### PR TITLE
Fix code coverage reporting during build process

### DIFF
--- a/.yams/cpp_rules.min
+++ b/.yams/cpp_rules.min
@@ -48,35 +48,34 @@ $(Test_Dir)/%_q: $(Test_Dir)/%.c
 ifdef CLANG_FORMAT
 	@$(CLANG_FORMAT) $<
 endif
-	@$(CC) $< -o $@ $(Module_Test_C_Flags) -L/usr/local/lib $($(*F)_FLAGS) -fprofile-arcs -ftest-coverage -fprofile-dir="$(Test_Dir)"
+	@$(CC) $< -o $@ $(Module_Test_C_Flags) -L/usr/local/lib $($(*F)_FLAGS) -fprofile-arcs -ftest-coverage
 ifdef CPPCHECK
 	@$(CPPCHECK) $(Module_Test_Includes) $($(*F)_Inc_FLAGS) $<
 endif
-	@mv $(*F).gc* $(Test_Dir)
 	@echo "Building tests <=  $<"
 
 $(Test_Dir)/%_q: $(Test_Dir)/%.cpp
 ifdef CLANG_FORMAT
 	@$(CLANG_FORMAT) $<
 endif
-	@$(CXX) $< -o $@ $(Module_Test_C_Flags) -L/usr/local/lib $($(*F)_FLAGS) -fprofile-arcs -ftest-coverage -fprofile-dir="$(Test_Dir)"
+	@$(CXX) $< -o $@ $(Module_Test_C_Flags) -L/usr/local/lib $($(*F)_FLAGS) -fprofile-arcs -ftest-coverage
 ifdef CPPCHECK
 	@$(CPPCHECK) $(Module_Test_Includes) $($(*F)_Inc_FLAGS) $<
 endif
-	@mv $(*F).gc* $(Test_Dir)
 	@echo "Building tests <=  $<"
 
 run_tests: $(Tests_C_Exe) $(Tests_CPP_Exe)
 	@echo "Running tests <=  $<"
 	@$(foreach f,$^,$(VALGRIND) ./$(f);)
 ifneq ($(and $(GCOV),$(Tests_C_Files)),)
-	@$(GCOV) $(Tests_C_Files)
+	@$(GCOV) $(notdir $(Tests_C_Files))
 endif
 ifneq ($(and $(GCOV),$(Tests_CPP_Files)),)
-	@$(GCOV) $(Tests_CPP_Files)
+	@$(GCOV) $(notdir $(Tests_C_Files))
 endif
 
 my_clean:
 	@rm -f $(C_Objects) $(CPP_Objects)
+	@rm -f *.gcda *.gcno *.gcov
 	@rm -f $(Tests_C_Exe) $(Tests_CPP_Exe) $(Test_Dir)/*.gcda $(Test_Dir)/*.gcno $(Test_Dir)/*.gcov
 	@rm -rf $(Test_Dir)/*.dSYM

--- a/.yams/cpp_rules.min
+++ b/.yams/cpp_rules.min
@@ -71,7 +71,7 @@ ifneq ($(and $(GCOV),$(Tests_C_Files)),)
 	@$(GCOV) $(notdir $(Tests_C_Files))
 endif
 ifneq ($(and $(GCOV),$(Tests_CPP_Files)),)
-	@$(GCOV) $(notdir $(Tests_C_Files))
+	@$(GCOV) $(notdir $(Tests_CPP_Files))
 endif
 
 my_clean:


### PR DESCRIPTION
Some versions of `clang` do not support `-fprofile-dir` option. Due to this, the `gcno` files were not mapping to the correct source code. The coverage report was always showing 0 code coverage.

Removed the option, and reworked the rules to pick the correct source code for coverage reporting.