### PR TITLE
Fix build warnings

### DIFF
--- a/third_party/lwip/repo/lwip/src/core/memp.c
+++ b/third_party/lwip/repo/lwip/src/core/memp.c
@@ -118,6 +118,8 @@ _Static_assert ((PBUF_CUSTOM_POOL_IDX_START > PBUF_CUSTOM_POOL_IDX_END), "PBUF_C
 #define MEMP_PBUF_POOL_HIGHWATERMARK(type) (type)
 #endif
 
+#define sys_profile_interval_set_pbuf_highwatermark(...)
+
 #if MEMP_SANITY_CHECK && !MEMP_MEM_MALLOC
 /**
  * Check that memp-lists don't form a circle, using "Floyd's cycle-finding algorithm".

--- a/third_party/lwip/repo/lwip/src/core/udp.c
+++ b/third_party/lwip/repo/lwip/src/core/udp.c
@@ -866,7 +866,7 @@ udp_sendto_if_src_chksum(struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *d
   LWIP_DEBUGF(UDP_DEBUG, ("udp_send: UDP checksum 0x%04"X16_F"\n", lwip_ntohs(udphdr->chksum)));
   LWIP_DEBUGF(UDP_DEBUG, ("udp_send: ip_output_if (,,,,0x%02"X16_F",)\n", (u16_t)ip_proto));
   /* output to IP */
-  netif_apply_pcb(netif, pcb);
+  netif_apply_pcb(netif, (struct ip_pcb*) pcb);
   err = ip_output_if_src(q, src_ip, dst_ip, ttl, pcb->tos, ip_proto, netif);
   netif_apply_pcb(netif, NULL);
 #if LWIP_MANAGEMENT_CHANNEL


### PR DESCRIPTION
Fix the following build warnings

```
../../third_party/lwip/repo/lwip/src/core/memp.c: In function 'memp_malloc':
../../third_party/lwip/repo/lwip/src/core/memp.c:489:7: warning: implicit declaration of function 'sys_profile_interval_set_pbuf_highwatermark' [-Wimplicit-function-declaration]
       sys_profile_interval_set_pbuf_highwatermark((u32_t)(*num_used_pool_ptr), MEMP_PBUF_POOL_HIGHWATERMARK(type));
```

```
../../third_party/lwip/repo/lwip/src/core/udp.c: In function 'udp_sendto_if_src':
../../third_party/lwip/repo/lwip/src/core/udp.c:869:26: warning: passing argument 2 of 'netif_apply_pcb' from incompatible pointer type [-Wincompatible-pointer-types]
   netif_apply_pcb(netif, pcb);
```

Fixes: #33 