### PR TITLE
Remove unnecessary tabs in Makefiles

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -118,6 +118,9 @@ Instead, do this:
 Use backticks for `inline code`. This includes file paths and file or binary names.
 
 
+### Makefiles
+
+Use `tabs` only where strictly necessary. For example, Avoid using tabs to align line breaks.
 
 Supported keywords:
 

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -118,6 +118,7 @@ Instead, do this:
 Use backticks for `inline code`. This includes file paths and file or binary names.
 
 
+
 Supported keywords:
 
 Keyword | Description

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -118,10 +118,6 @@ Instead, do this:
 Use backticks for `inline code`. This includes file paths and file or binary names.
 
 
-### Makefiles
-
-Use `tabs` only where strictly necessary. For example, Avoid using tabs to align line breaks.
-
 Supported keywords:
 
 Keyword | Description

--- a/docs/style/STYLE_MAKEFILES.md
+++ b/docs/style/STYLE_MAKEFILES.md
@@ -1,0 +1,3 @@
+# CHIP Makefile Style Guide
+
+Use `tabs` only where strictly necessary. For example, Avoid using `tabs` to align line breaks.

--- a/src/lib/core/Makefile
+++ b/src/lib/core/Makefile
@@ -7,25 +7,25 @@ all: libcore.a run_tests
 
 include $(TOP_DIR)/.yams/cpp_rules.min
 
-Module_Includes = 	\
-	-I. 											\
-	-I$(TOP_DIR)/src		 						\
-	-I$(TOP_DIR)/src/include 						\
-	-I$(TOP_DIR)/src/lib/ 							\
-	-I$(TOP_DIR)/src/system 						\
-	-I$(TOP_DIR)/build/config/standalone/			\
-	-I$(TOP_DIR)/third_party/nlio/repo/include  	\
-	-I$(TOP_DIR)/third_party/nlassert/repo/include  \
+Module_Includes = \
+	-I. \
+	-I$(TOP_DIR)/src \
+	-I$(TOP_DIR)/src/include \
+	-I$(TOP_DIR)/src/lib/ \
+	-I$(TOP_DIR)/src/system \
+	-I$(TOP_DIR)/build/config/standalone/ \
+	-I$(TOP_DIR)/third_party/nlio/repo/include \
+	-I$(TOP_DIR)/third_party/nlassert/repo/include
 
 Module_Test_Includes = $(Module_Includes)
 
 CPP_Files = \
-	CHIPError.cpp			\
-	CHIPTLVWriter.cpp		\
-	CHIPTLVReader.cpp 		\
-	CHIPTLVUtilities.cpp	\
-	CHIPTLVUpdater.cpp		\
-	CHIPTLVDebug.cpp		\
+	CHIPError.cpp \
+	CHIPTLVWriter.cpp \
+	CHIPTLVReader.cpp \
+	CHIPTLVUtilities.cpp \
+	CHIPTLVUpdater.cpp \
+	CHIPTLVDebug.cpp
 
 libcore.a: $(CPP_Objects)
 	ar rvs $@ $^

--- a/src/lib/support/Makefile
+++ b/src/lib/support/Makefile
@@ -7,7 +7,7 @@ all: libsupport.a run_tests
 
 include $(TOP_DIR)/.yams/cpp_rules.min
 
-Module_Includes = 	\
+Module_Includes = \
 	-I. \
 	-I$(TOP_DIR)/src/include \
 	-I$(TOP_DIR)/src/lib \

--- a/src/system/Makefile
+++ b/src/system/Makefile
@@ -7,27 +7,27 @@ all: libSystemLayer.a run_tests
 
 include $(TOP_DIR)/.yams/cpp_rules.min
 
-Module_Includes = 	\
+Module_Includes = \
 				-I. \
-				-I$(TOP_DIR)/src									\
-				-I$(TOP_DIR)/src/include 							\
-				-I$(TOP_DIR)/src/lib/ 								\
-				-I$(TOP_DIR)/build/config/standalone/				\
-				-I$(TOP_DIR)/third_party/nlassert/repo/include/		\
-				-I$(TOP_DIR)/src/lib/core							\
+				-I$(TOP_DIR)/src \
+				-I$(TOP_DIR)/src/include \
+				-I$(TOP_DIR)/src/lib \
+				-I$(TOP_DIR)/build/config/standalone \
+				-I$(TOP_DIR)/third_party/nlassert/repo/include \
+				-I$(TOP_DIR)/src/lib/core \
 
 
 Module_Test_Includes = $(Module_Includes)
 
 CPP_Files = \
-	SystemMutex.cpp 			\
-	SystemError.cpp 			\
-	SystemClock.cpp 			\
-	SystemObject.cpp 			\
-	SystemStats.cpp 			\
-	SystemTimer.cpp 			\
-	SystemLayer.cpp				\
-	SystemFaultInjection.cpp 	\
+	SystemMutex.cpp \
+	SystemError.cpp \
+	SystemClock.cpp \
+	SystemObject.cpp \
+	SystemStats.cpp \
+	SystemTimer.cpp \
+	SystemLayer.cpp \
+	SystemFaultInjection.cpp \
 	SystemPacketBuffer.cpp
 
 libSystemLayer.a: $(CPP_Objects)


### PR DESCRIPTION
Removed unnecessary tabs being used to align line breaks


@rwalker-apple 