### PR TITLE
Replace 'run_tests' with the More Familiar 'check' as the make Target

### DIFF
--- a/.yams/cpp_rules.min
+++ b/.yams/cpp_rules.min
@@ -53,7 +53,7 @@ endif
 	$(_@)$(CXX) $< -o $@ $(Module_Test_C_Flags) -L/usr/local/lib $($(*F)_FLAGS) $(GCOV_FLAGS)
 	@echo "Building tests <=  $<"
 
-run_tests: $(Tests_C_Exe) $(Tests_CPP_Exe)
+check: $(Tests_C_Exe) $(Tests_CPP_Exe)
 	@echo "Running tests <=  $<"
 	$(_@)$(foreach f,$^,$(VALGRIND) ./$(f);)
 ifneq ($(and $(GCOV),$(Tests_C_Files)),)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SUB_DIRS=src
 
-.PHONY: all clean run_tests
+.PHONY: all clean check
 
-all clean run_tests:
+all clean check:
 	git submodule update --init
 	$(foreach dir,$(SUB_DIRS), $(MAKE) $@ -C $(dir))

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-TOPTARGETS := all clean run_tests
+TOPTARGETS := all clean check
 
 SUBDIRS = lwip system lib/core lib/support ble inet
 

--- a/src/ble/Makefile
+++ b/src/ble/Makefile
@@ -1,9 +1,9 @@
 TOP_DIR = ../..
 Test_Dir = tests
 
-.PHONY: all clean run_tests
+.PHONY: all clean check
 
-all: libble.a run_tests
+all: libble.a check
 
 include $(TOP_DIR)/.yams/cpp_rules.min
 

--- a/src/inet/Makefile
+++ b/src/inet/Makefile
@@ -1,9 +1,9 @@
 TOP_DIR = ../..
 Test_Dir = tests
 
-.PHONY: all clean run_tests
+.PHONY: all clean check
 
-all: libnet.a run_tests
+all: libnet.a check
 
 include $(TOP_DIR)/.yams/cpp_rules.min
 

--- a/src/lib/core/Makefile
+++ b/src/lib/core/Makefile
@@ -1,9 +1,9 @@
 TOP_DIR = ../../..
 Test_Dir = tests
 
-.PHONY: all clean run_tests
+.PHONY: all clean check
 
-all: libcore.a run_tests
+all: libcore.a check
 
 include $(TOP_DIR)/.yams/cpp_rules.min
 

--- a/src/lib/support/Makefile
+++ b/src/lib/support/Makefile
@@ -1,9 +1,9 @@
 TOP_DIR = ../../..
 Test_Dir = tests
 
-.PHONY: all clean run_tests
+.PHONY: all clean check
 
-all: libsupport.a run_tests
+all: libsupport.a check
 
 include $(TOP_DIR)/.yams/cpp_rules.min
 

--- a/src/lwip/Makefile
+++ b/src/lwip/Makefile
@@ -3,7 +3,7 @@ Test_Dir = tests
 
 .PHONY: all
 
-all: liblwip.a run_tests
+all: liblwip.a check
 
 include $(TOP_DIR)/.yams/cpp_rules.min
 

--- a/src/system/Makefile
+++ b/src/system/Makefile
@@ -1,9 +1,9 @@
 TOP_DIR = ../..
 Test_Dir = tests
 
-.PHONY: all clean run_tests
+.PHONY: all clean check
 
-all: libSystemLayer.a run_tests
+all: libSystemLayer.a check
 
 include $(TOP_DIR)/.yams/cpp_rules.min
 


### PR DESCRIPTION
This replaces 'run_tests' with the more prevalent and familiar 'check' (at least in open source projects) as the make target for running unit and functional tests.