### PR TITLE
Renamed instances and files of WoBLE to CHIPoBLE

### DIFF
--- a/src/ble/BLEEndPoint.cpp
+++ b/src/ble/BLEEndPoint.cpp
@@ -19,7 +19,7 @@
  *    @file
  *      This file implements a Bluetooth Low Energy (BLE) connection
  *      endpoint abstraction for the byte-streaming,
- *      connection-oriented chip over Bluetooth Low Energy (WoBLE)
+ *      connection-oriented chip over Bluetooth Low Energy (CHIPoBLE)
  *      Bluetooth Transport Protocol (BTP).
  *
  */
@@ -41,9 +41,9 @@
 
 #include <ble/BLEEndPoint.h>
 #include <ble/BleLayer.h>
-#include <ble/WoBle.h>
-#if CHIP_ENABLE_WOBLE_TEST
-#include "WoBleTest.h"
+#include <ble/CHIPoBLE.h>
+#if CHIP_ENABLE_CHIPOBLE_TEST
+#include "CHIPoBLETest.h"
 #endif
 
 // clang-format off
@@ -221,8 +221,8 @@ void BLEEndPoint::HandleSubscribeReceived()
     VerifyOrExit(mSendQueue != NULL, err = BLE_ERROR_INCORRECT_STATE);
 
     // Send BTP capabilities response to peripheral via GATT indication.
-#if CHIP_ENABLE_WOBLE_TEST
-    VerifyOrExit(mWoBle.PopPacketTag(mSendQueue) == kType_Data, err = BLE_ERROR_INVALID_BTP_HEADER_FLAGS);
+#if CHIP_ENABLE_CHIPOBLE_TEST
+    VerifyOrExit(mCHIPoBLE.PopPacketTag(mSendQueue) == kType_Data, err = BLE_ERROR_INVALID_BTP_HEADER_FLAGS);
 #endif
     if (!SendIndication(mSendQueue))
     {
@@ -306,7 +306,7 @@ void BLEEndPoint::Abort()
     OnConnectComplete  = NULL;
     OnConnectionClosed = NULL;
     OnMessageReceived  = NULL;
-#if CHIP_ENABLE_WOBLE_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     OnCommandReceived = NULL;
 #endif
 
@@ -319,7 +319,7 @@ void BLEEndPoint::Close()
     OnConnectComplete  = NULL;
     OnConnectionClosed = NULL;
     OnMessageReceived  = NULL;
-#if CHIP_ENABLE_WOBLE_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     OnCommandReceived = NULL;
 #endif
 
@@ -346,7 +346,7 @@ void BLEEndPoint::DoClose(uint8_t flags, BLE_ERROR err)
         }
 
         // If transmit buffer is empty or a transmission abort was specified...
-        if (mWoBle.TxState() == WoBle::kState_Idle || (flags & kBleCloseFlag_AbortTransmission))
+        if (mCHIPoBLE.TxState() == CHIPoBLE::kState_Idle || (flags & kBleCloseFlag_AbortTransmission))
         {
             FinalizeClose(oldState, flags, err);
         }
@@ -354,8 +354,8 @@ void BLEEndPoint::DoClose(uint8_t flags, BLE_ERROR err)
         {
             // Wait for send queue and fragmenter's tx buffer to become empty, to ensure all pending messages have been
             // sent. Only free end point and tell platform it can throw away the underlying BLE connection once all
-            // pending messages have been sent and acknowledged by the remote WoBLE stack, or once the remote stack
-            // closes the WoBLE connection.
+            // pending messages have been sent and acknowledged by the remote CHIPoBLE stack, or once the remote stack
+            // closes the CHIPoBLE connection.
             //
             // In so doing, BLEEndPoint attempts to emulate the level of reliability afforded by TCPEndPoint and TCP
             // sockets in general with a typical default SO_LINGER option. That said, there is no hard guarantee that
@@ -381,9 +381,9 @@ void BLEEndPoint::FinalizeClose(uint8_t oldState, uint8_t flags, BLE_ERROR err)
     mSendQueue = NULL;
     QueueTxUnlock();
 
-#if CHIP_ENABLE_WOBLE_TEST
-    PacketBuffer::Free(mWoBleTest.mCommandReceiveQueue);
-    mWoBleTest.mCommandReceiveQueue = NULL;
+#if CHIP_ENABLE_CHIPOBLE_TEST
+    PacketBuffer::Free(mCHIPoBLETest.mCommandReceiveQueue);
+    mCHIPoBLETest.mCommandReceiveQueue = NULL;
 #endif
 
     // Fire application's close callback if we haven't already, and it's not suppressed.
@@ -411,7 +411,7 @@ void BLEEndPoint::FinalizeClose(uint8_t oldState, uint8_t flags, BLE_ERROR err)
             // we're really sure the unsubscribe request has been sent.
             if (!mBle->mPlatformDelegate->UnsubscribeCharacteristic(mConnObj, &CHIP_BLE_SVC_ID, &mBle->CHIP_BLE_CHAR_2_ID))
             {
-                chipLogError(Ble, "WoBle unsub failed");
+                chipLogError(Ble, "CHIPoBLE unsub failed");
 
                 // If unsubscribe fails, release BLE connection and free end point immediately.
                 Free();
@@ -488,7 +488,7 @@ void BLEEndPoint::Free()
     ReleaseBleConnection();
 
     // Clear fragmentation and reassembly engine's Tx and Rx buffers. Counters will be reset by next engine init.
-    FreeWoBle();
+    FreeCHIPoBLE();
 
     // Clear pending ack buffer, if any.
     PacketBuffer::Free(mAckToSend);
@@ -499,8 +499,8 @@ void BLEEndPoint::Free()
     StopAckReceivedTimer();
     StopSendAckTimer();
     StopUnsubscribeTimer();
-#if CHIP_ENABLE_WOBLE_TEST
-    mWoBleTest.StopTestTimer();
+#if CHIP_ENABLE_CHIPOBLE_TEST
+    mCHIPoBLETest.StopTestTimer();
     // Clear callback
     OnCommandReceived = NULL;
 #endif
@@ -517,18 +517,18 @@ void BLEEndPoint::Free()
     Release();
 }
 
-void BLEEndPoint::FreeWoBle()
+void BLEEndPoint::FreeCHIPoBLE()
 {
     PacketBuffer * buf;
 
     // Free transmit disassembly buffer
-    buf = mWoBle.TxPacket();
-    mWoBle.ClearTxPacket();
+    buf = mCHIPoBLE.TxPacket();
+    mCHIPoBLE.ClearTxPacket();
     PacketBuffer::Free(buf);
 
     // Free receive reassembly buffer
-    buf = mWoBle.RxPacket();
-    mWoBle.ClearRxPacket();
+    buf = mCHIPoBLE.RxPacket();
+    mCHIPoBLE.ClearRxPacket();
     PacketBuffer::Free(buf);
 }
 
@@ -555,24 +555,24 @@ BLE_ERROR BLEEndPoint::Init(BleLayer * bleLayer, BLE_CONNECTION_OBJECT connObj, 
     // If central, periperal's handshake indication 'ack's write sent by central to kick off the BTP handshake.
     expectInitialAck = (role == kBleRole_Peripheral);
 
-    err = mWoBle.Init(this, expectInitialAck);
+    err = mCHIPoBLE.Init(this, expectInitialAck);
     if (err != BLE_NO_ERROR)
     {
-        chipLogError(Ble, "WoBle init failed");
+        chipLogError(Ble, "CHIPoBLE init failed");
         ExitNow();
     }
 
-#if CHIP_ENABLE_WOBLE_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     err = (BLE_ERROR) mTxQueueMutex.Init(mTxQueueMutex);
     if (err != BLE_NO_ERROR)
     {
         chipLogError(Ble, "%s: Mutex init failed", __FUNCTION__);
         ExitNow();
     }
-    err = mWoBleTest.Init(this);
+    err = mCHIPoBLETest.Init(this);
     if (err != BLE_NO_ERROR)
     {
-        chipLogError(Ble, "WoBleTest init failed");
+        chipLogError(Ble, "CHIPoBLETest init failed");
         ExitNow();
     }
 #endif
@@ -643,9 +643,9 @@ BLE_ERROR BLEEndPoint::SendCharacteristic(PacketBuffer * buf)
  */
 void BLEEndPoint::QueueTx(PacketBuffer * data, PacketType_t type)
 {
-#if CHIP_ENABLE_WOBLE_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     chipLogDebugBleEndPoint(Ble, "%s: data->%p, type %d, len %d", __FUNCTION__, data, type, data->DataLength());
-    mWoBle.PushPacketTag(data, type);
+    mCHIPoBLE.PushPacketTag(data, type);
 #endif
 
     QueueTxLock();
@@ -728,7 +728,7 @@ bool BLEEndPoint::PrepareNextFragment(PacketBuffer * data, bool & sentAck)
         sentAck = false;
     }
 
-    return mWoBle.HandleCharacteristicSend(data, sentAck);
+    return mCHIPoBLE.HandleCharacteristicSend(data, sentAck);
 }
 
 BLE_ERROR BLEEndPoint::SendNextMessage()
@@ -738,7 +738,7 @@ BLE_ERROR BLEEndPoint::SendNextMessage()
 
     // Get the first queued packet to send
     QueueTxLock();
-#if CHIP_ENABLE_WOBLE_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     // Return if tx queue is empty
     // Note: DetachTail() does not check an empty queue
     if (mSendQueue == NULL)
@@ -752,19 +752,19 @@ BLE_ERROR BLEEndPoint::SendNextMessage()
     mSendQueue          = mSendQueue->DetachTail();
     QueueTxUnlock();
 
-#if CHIP_ENABLE_WOBLE_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     // Get and consume the packet tag in message buffer
-    PacketType_t type = mWoBle.PopPacketTag(data);
-    mWoBle.SetTxPacketType(type);
-    mWoBleTest.DoTxTiming(data, WOBLE_TX_START);
+    PacketType_t type = mCHIPoBLE.PopPacketTag(data);
+    mCHIPoBLE.SetTxPacketType(type);
+    mCHIPoBLETest.DoTxTiming(data, CHIPOBLE_TX_START);
 #endif
 
     // Hand whole message payload to the fragmenter.
-    VerifyOrExit(PrepareNextFragment(data, sentAck), err = BLE_ERROR_WOBLE_PROTOCOL_ABORT);
+    VerifyOrExit(PrepareNextFragment(data, sentAck), err = BLE_ERROR_CHIPOBLE_PROTOCOL_ABORT);
     data = NULL; // Ownership passed to fragmenter's tx buf on PrepareNextFragment success.
 
     // Send first message fragment over the air.
-    CHIP_FAULT_INJECT(chip::FaultInjection::kFault_WOBLESend,
+    CHIP_FAULT_INJECT(chip::FaultInjection::kFault_CHIPoBLESend,
             {
                 if (mRole == kBleRole_Central)
                 {
@@ -775,7 +775,7 @@ BLE_ERROR BLEEndPoint::SendNextMessage()
                 ExitNow();
             }
             );
-    err = SendCharacteristic(mWoBle.TxPacket());
+    err = SendCharacteristic(mCHIPoBLE.TxPacket());
     SuccessOrExit(err);
 
     if (sentAck)
@@ -806,13 +806,13 @@ BLE_ERROR BLEEndPoint::ContinueMessageSend()
     {
         // Log BTP error
         chipLogError(Ble, "btp fragmenter error on send!");
-        mWoBle.LogState();
+        mCHIPoBLE.LogState();
 
-        err = BLE_ERROR_WOBLE_PROTOCOL_ABORT;
+        err = BLE_ERROR_CHIPOBLE_PROTOCOL_ABORT;
         ExitNow();
     }
 
-    err = SendCharacteristic(mWoBle.TxPacket());
+    err = SendCharacteristic(mCHIPoBLE.TxPacket());
     SuccessOrExit(err);
 
     if (sentAck)
@@ -929,7 +929,7 @@ BLE_ERROR BLEEndPoint::HandleFragmentConfirmationReceived()
     // the stand-alone ack, and also the case where a window size < the immediate ack threshold was detected in
     // Receive(), but the stand-alone ack was deferred due to a pending outbound message fragment.
     if (mLocalReceiveWindowSize <= BLE_CONFIG_IMMEDIATE_ACK_WINDOW_THRESHOLD &&
-        !(mSendQueue != NULL || mWoBle.TxState() == WoBle::kState_InProgress) )
+        !(mSendQueue != NULL || mCHIPoBLE.TxState() == CHIPoBLE::kState_InProgress) )
     {
         err = DriveStandAloneAck(); // Encode stand-alone ack and drive sending.
         SuccessOrExit(err);
@@ -996,7 +996,7 @@ BLE_ERROR BLEEndPoint::DoSendStandAloneAck()
     chipLogDebugBleEndPoint(Ble, "entered DoSendStandAloneAck; sending stand-alone ack");
 
     // Encode and transmit stand-alone ack.
-    mWoBle.EncodeStandAloneAck(mAckToSend);
+    mCHIPoBLE.EncodeStandAloneAck(mAckToSend);
     BLE_ERROR err = SendCharacteristic(mAckToSend);
     SuccessOrExit(err);
 
@@ -1055,7 +1055,7 @@ BLE_ERROR BLEEndPoint::DriveSending()
         err = DoSendStandAloneAck();
         SuccessOrExit(err);
     }
-    else if (mWoBle.TxState() == WoBle::kState_Idle) // Else send next message fragment, if any.
+    else if (mCHIPoBLE.TxState() == CHIPoBLE::kState_Idle) // Else send next message fragment, if any.
     {
         // Fragmenter's idle, let's see what's in the send queue...
         if (mSendQueue != NULL)
@@ -1069,20 +1069,20 @@ BLE_ERROR BLEEndPoint::DriveSending()
             // Nothing to send!
         }
     }
-    else if (mWoBle.TxState() == WoBle::kState_InProgress)
+    else if (mCHIPoBLE.TxState() == CHIPoBLE::kState_InProgress)
     {
         // Send next fragment of message currently held by fragmenter.
         err = ContinueMessageSend();
         SuccessOrExit(err);
     }
-    else if (mWoBle.TxState() == WoBle::kState_Complete)
+    else if (mCHIPoBLE.TxState() == CHIPoBLE::kState_Complete)
     {
         // Clear fragmenter's pointer to sent message buffer and reset its Tx state.
-        PacketBuffer * sentBuf = mWoBle.TxPacket();
-#if CHIP_ENABLE_WOBLE_TEST
-        mWoBleTest.DoTxTiming(sentBuf, WOBLE_TX_DONE);
-#endif // CHIP_ENABLE_WOBLE_TEST
-        mWoBle.ClearTxPacket();
+        PacketBuffer * sentBuf = mCHIPoBLE.TxPacket();
+#if CHIP_ENABLE_CHIPOBLE_TEST
+        mCHIPoBLETest.DoTxTiming(sentBuf, CHIPOBLE_TX_DONE);
+#endif // CHIP_ENABLE_CHIPOBLE_TEST
+        mCHIPoBLE.ClearTxPacket();
 
         // Free sent buffer.
         PacketBuffer::Free(sentBuf);
@@ -1094,7 +1094,7 @@ BLE_ERROR BLEEndPoint::DriveSending()
             err = SendNextMessage();
             SuccessOrExit(err);
         }
-        else if (mState == kState_Closing && !mWoBle.ExpectingAck()) // and mSendQueue is NULL, per above...
+        else if (mState == kState_Closing && !mCHIPoBLE.ExpectingAck()) // and mSendQueue is NULL, per above...
         {
             // If end point closing, got last ack, and got out-of-order confirmation for last send, finalize close.
             FinalizeClose(mState, kBleCloseFlag_SuppressCallback, BLE_NO_ERROR);
@@ -1142,12 +1142,12 @@ BLE_ERROR BLEEndPoint::HandleCapabilitiesRequestReceived(PacketBuffer * data)
     if (mtu > 0) // If one or both device knows connection's MTU...
     {
         resp.mFragmentSize =
-            chip::min(static_cast<uint16_t>(mtu - 3), WoBle::sMaxFragmentSize); // Reserve 3 bytes of MTU for ATT header.
+            chip::min(static_cast<uint16_t>(mtu - 3), CHIPoBLE::sMaxFragmentSize); // Reserve 3 bytes of MTU for ATT header.
     }
     else // Else, if neither device knows MTU...
     {
-        chipLogProgress(Ble, "cannot determine ATT MTU; selecting default fragment size = %u", WoBle::sDefaultFragmentSize);
-        resp.mFragmentSize = WoBle::sDefaultFragmentSize;
+        chipLogProgress(Ble, "cannot determine ATT MTU; selecting default fragment size = %u", CHIPoBLE::sDefaultFragmentSize);
+        resp.mFragmentSize = CHIPoBLE::sDefaultFragmentSize;
     }
 
     // Select local and remote max receive window size based on local resources available for both incoming writes AND
@@ -1174,15 +1174,15 @@ BLE_ERROR BLEEndPoint::HandleCapabilitiesRequestReceived(PacketBuffer * data)
              (resp.mSelectedProtocolVersion == kBleTransportProtocolVersion_V2))
     {
         // Set Rx and Tx fragment sizes to the same value
-        mWoBle.SetRxFragmentSize(resp.mFragmentSize);
-        mWoBle.SetTxFragmentSize(resp.mFragmentSize);
+        mCHIPoBLE.SetRxFragmentSize(resp.mFragmentSize);
+        mCHIPoBLE.SetTxFragmentSize(resp.mFragmentSize);
     }
     else // resp.SelectedProtocolVersion >= kBleTransportProtocolVersion_V3
     {
         // This is the peripheral, so set Rx fragment size, and leave Tx at default
-        mWoBle.SetRxFragmentSize(resp.mFragmentSize);
+        mCHIPoBLE.SetRxFragmentSize(resp.mFragmentSize);
     }
-    chipLogProgress(Ble, "using BTP fragment sizes rx %d / tx %d.", mWoBle.GetRxFragmentSize(), mWoBle.GetTxFragmentSize());
+    chipLogProgress(Ble, "using BTP fragment sizes rx %d / tx %d.", mCHIPoBLE.GetRxFragmentSize(), mCHIPoBLE.GetTxFragmentSize());
 
     err = resp.Encode(responseBuf);
     SuccessOrExit(err);
@@ -1232,21 +1232,21 @@ BLE_ERROR BLEEndPoint::HandleCapabilitiesResponseReceived(PacketBuffer * data)
         ExitNow();
     }
 
-    // Set fragment size as minimum of (reported ATT MTU, WoBLE characteristic size)
-    resp.mFragmentSize = chip::min(resp.mFragmentSize, WoBle::sMaxFragmentSize);
+    // Set fragment size as minimum of (reported ATT MTU, CHIPoBLE characteristic size)
+    resp.mFragmentSize = chip::min(resp.mFragmentSize, CHIPoBLE::sMaxFragmentSize);
 
     if ((resp.mSelectedProtocolVersion == kBleTransportProtocolVersion_V1) ||
         (resp.mSelectedProtocolVersion == kBleTransportProtocolVersion_V2))
     {
-        mWoBle.SetRxFragmentSize(resp.mFragmentSize);
-        mWoBle.SetTxFragmentSize(resp.mFragmentSize);
+        mCHIPoBLE.SetRxFragmentSize(resp.mFragmentSize);
+        mCHIPoBLE.SetTxFragmentSize(resp.mFragmentSize);
     }
     else // resp.SelectedProtocolVersion >= kBleTransportProtocolVersion_V3
     {
         // This is the central, so set Tx fragement size, and leave Rx at default.
-        mWoBle.SetTxFragmentSize(resp.mFragmentSize);
+        mCHIPoBLE.SetTxFragmentSize(resp.mFragmentSize);
     }
-    chipLogProgress(Ble, "using BTP fragment sizes rx %d / tx %d.", mWoBle.GetRxFragmentSize(), mWoBle.GetTxFragmentSize());
+    chipLogProgress(Ble, "using BTP fragment sizes rx %d / tx %d.", mCHIPoBLE.GetRxFragmentSize(), mCHIPoBLE.GetTxFragmentSize());
 
     // Select local and remote max receive window size based on local resources available for both incoming indications
     // AND GATT confirmations.
@@ -1313,14 +1313,14 @@ BLE_ERROR BLEEndPoint::Receive(PacketBuffer * data)
     uint8_t closeFlags           = kBleCloseFlag_AbortTransmission;
     bool didReceiveAck           = false;
 
-#if CHIP_ENABLE_WOBLE_TEST
-    if (mWoBle.IsCommandPacket(data))
+#if CHIP_ENABLE_CHIPOBLE_TEST
+    if (mCHIPoBLE.IsCommandPacket(data))
     {
         chipLogDebugBleEndPoint(Ble, "%s: Received Control frame: Flags %x", __FUNCTION__, *(data->Start()));
     }
     else
 #endif
-    { // This is a special handling on the first Woble data packet, the CapabilitiesRequest.
+    { // This is a special handling on the first CHIPoBLE data packet, the CapabilitiesRequest.
         // Suppress error logging if peer's send overlaps with our unsubscribe on final close.
         if (IsUnsubscribePending())
         {
@@ -1377,15 +1377,15 @@ BLE_ERROR BLEEndPoint::Receive(PacketBuffer * data)
         ExitNow();
     }
 
-    chipLogDebugBleEndPoint(Ble, "woble about to rx characteristic, state before:");
-    mWoBle.LogStateDebug();
+    chipLogDebugBleEndPoint(Ble, "CHIPoBLE about to rx characteristic, state before:");
+    mCHIPoBLE.LogStateDebug();
 
     // Pass received packet into BTP protocol engine.
-    err  = mWoBle.HandleCharacteristicReceived(data, receivedAck, didReceiveAck);
+    err  = mCHIPoBLE.HandleCharacteristicReceived(data, receivedAck, didReceiveAck);
     data = NULL; // Buffer consumed by protocol engine; either freed or added to message reassembly area.
 
-    chipLogDebugBleEndPoint(Ble, "woble rx'd characteristic, state after:");
-    mWoBle.LogStateDebug();
+    chipLogDebugBleEndPoint(Ble, "CHIPoBLE rx'd characteristic, state after:");
+    mCHIPoBLE.LogStateDebug();
 
     SuccessOrExit(err);
 
@@ -1399,12 +1399,12 @@ BLE_ERROR BLEEndPoint::Receive(PacketBuffer * data)
         chipLogDebugBleEndPoint(Ble, "got btp ack = %u", receivedAck);
 
         // If ack was rx'd for neweset unacked sent fragment, stop ack received timer.
-        if (!mWoBle.ExpectingAck())
+        if (!mCHIPoBLE.ExpectingAck())
         {
             chipLogDebugBleEndPoint(Ble, "got ack for last outstanding fragment");
             StopAckReceivedTimer();
 
-            if (mState == kState_Closing && mSendQueue == NULL && mWoBle.TxState() == WoBle::kState_Idle)
+            if (mState == kState_Closing && mSendQueue == NULL && mCHIPoBLE.TxState() == CHIPoBLE::kState_Idle)
             {
                 // If end point closing, got confirmation for last send, and waiting for last ack, finalize close.
                 FinalizeClose(mState, kBleCloseFlag_SuppressCallback, BLE_NO_ERROR);
@@ -1420,12 +1420,12 @@ BLE_ERROR BLEEndPoint::Receive(PacketBuffer * data)
 
         chipLogDebugBleEndPoint(Ble, "about to adjust remote rx window; got ack num = %u, newest unacked sent seq num = %u, \
                 old window size = %u, max window size = %u",
-                                 receivedAck, mWoBle.GetNewestUnackedSentSequenceNumber(), mRemoteReceiveWindowSize,
+                                 receivedAck, mCHIPoBLE.GetNewestUnackedSentSequenceNumber(), mRemoteReceiveWindowSize,
                                  mReceiveWindowMaxSize);
 
         // Open remote device's receive window according to sequence number it just acknowledged.
         mRemoteReceiveWindowSize =
-            AdjustRemoteReceiveWindow(receivedAck, mReceiveWindowMaxSize, mWoBle.GetNewestUnackedSentSequenceNumber());
+            AdjustRemoteReceiveWindow(receivedAck, mReceiveWindowMaxSize, mCHIPoBLE.GetNewestUnackedSentSequenceNumber());
 
         chipLogDebugBleEndPoint(Ble, "adjusted remote rx window, new size = %u", mRemoteReceiveWindowSize);
 
@@ -1447,7 +1447,7 @@ BLE_ERROR BLEEndPoint::Receive(PacketBuffer * data)
     //
     // If any GATT operation is in flight that is NOT a stand-alone ack, the window size will be checked against
     // this threshold again when the GATT operation is confirmed.
-    if (mWoBle.HasUnackedData())
+    if (mCHIPoBLE.HasUnackedData())
     {
         if (mLocalReceiveWindowSize <= BLE_CONFIG_IMMEDIATE_ACK_WINDOW_THRESHOLD &&
             !GetFlag(mConnStateFlags, kConnState_GattOperationInFlight))
@@ -1467,22 +1467,22 @@ BLE_ERROR BLEEndPoint::Receive(PacketBuffer * data)
     }
 
     // If we've reassembled a whole message...
-    if (mWoBle.RxState() == WoBle::kState_Complete)
+    if (mCHIPoBLE.RxState() == CHIPoBLE::kState_Complete)
     {
         // Take ownership of message PacketBuffer
-        PacketBuffer * full_packet = mWoBle.RxPacket();
-        mWoBle.ClearRxPacket();
+        PacketBuffer * full_packet = mCHIPoBLE.RxPacket();
+        mCHIPoBLE.ClearRxPacket();
 
         chipLogDebugBleEndPoint(Ble, "reassembled whole msg, len = %d", full_packet->DataLength());
 
-#if CHIP_ENABLE_WOBLE_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
         // If we have a control message received callback, and end point is not closing...
-        if (mWoBle.RxPacketType() == kType_Control && OnCommandReceived && mState != kState_Closing)
+        if (mCHIPoBLE.RxPacketType() == kType_Control && OnCommandReceived && mState != kState_Closing)
         {
             chipLogDebugBleEndPoint(Ble, "%s: calling OnCommandReceived, seq# %u, len = %u, type %u", __FUNCTION__, receivedAck,
-                                     full_packet->DataLength(), mWoBle.RxPacketType());
+                                     full_packet->DataLength(), mCHIPoBLE.RxPacketType());
             // Pass received control message up the stack.
-            mWoBle.SetRxPacketSeq(receivedAck);
+            mCHIPoBLE.SetRxPacketSeq(receivedAck);
             OnCommandReceived(this, full_packet);
         }
         else
@@ -1700,7 +1700,7 @@ void BLEEndPoint::HandleAckReceivedTimeout(chip::System::Layer * systemLayer, vo
     if (GetFlag(ep->mTimerStateFlags, kTimerState_AckReceivedTimerRunning))
     {
         chipLogError(Ble, "ack recv timeout, closing ep %p", ep);
-        ep->mWoBle.LogStateDebug();
+        ep->mCHIPoBLE.LogStateDebug();
         SetFlag(ep->mTimerStateFlags, kTimerState_AckReceivedTimerRunning, false);
         ep->DoClose(kBleCloseFlag_AbortTransmission, BLE_ERROR_FRAGMENT_ACK_TIMED_OUT);
     }

--- a/src/ble/BLEEndPoint.h
+++ b/src/ble/BLEEndPoint.h
@@ -19,7 +19,7 @@
  *    @file
  *      This file defines a Bluetooth Low Energy (BLE) connection
  *      endpoint abstraction for the byte-streaming,
- *      connection-oriented chip over Bluetooth Low Energy (WoBLE)
+ *      connection-oriented chip over Bluetooth Low Energy (CHIPoBLE)
  *      Bluetooth Transport Protocol (BTP).
  *
  */
@@ -30,9 +30,9 @@
 #include <system/SystemMutex.h>
 
 #include <ble/BleLayer.h>
-#include <ble/WoBle.h>
-#if CHIP_ENABLE_WOBLE_TEST
-#include <ble/WoBleTest.h>
+#include <ble/CHIPoBLE.h>
+#if CHIP_ENABLE_CHIPOBLE_TEST
+#include <ble/CHIPoBLETest.h>
 #endif
 
 namespace chip {
@@ -49,16 +49,16 @@ enum
 // Forward declarations
 class BleLayer;
 class BleEndPointPool;
-#if CHIP_ENABLE_WOBLE_TEST
-class WoBleTest;
+#if CHIP_ENABLE_CHIPOBLE_TEST
+class CHIPoBLETest;
 #endif
 
 class DLL_EXPORT BLEEndPoint : public BleLayerObject
 {
     friend class BleLayer;
     friend class BleEndPointPool;
-#if CHIP_ENABLE_WOBLE_TEST
-    friend class WoBleTest;
+#if CHIP_ENABLE_CHIPOBLE_TEST
+    friend class CHIPoBLETest;
 #endif
 
 public:
@@ -86,11 +86,11 @@ public:
     typedef void (*OnConnectionClosedFunct)(BLEEndPoint * endPoint, BLE_ERROR err);
     OnConnectionClosedFunct OnConnectionClosed;
 
-#if CHIP_ENABLE_WOBLE_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     typedef void (*OnCommandReceivedFunct)(BLEEndPoint * endPoint, PacketBuffer * msg);
     OnCommandReceivedFunct OnCommandReceived;
     inline void SetOnCommandReceivedCB(OnCommandReceivedFunct cb) { OnCommandReceived = cb; };
-    WoBleTest mWoBleTest;
+    CHIPoBLETest mCHIPoBLETest;
     inline void SetTxWindowSize(uint8_t size) { mRemoteReceiveWindowSize = size; };
     inline void SetRxWindowSize(uint8_t size) { mReceiveWindowMaxSize = size; };
 #endif
@@ -125,7 +125,7 @@ private:
         kTimerState_AckReceivedTimerRunning       = 0x04, // Ack received timer running due to unacked sent fragment.
         kTimerState_SendAckTimerRunning           = 0x08, // Send ack timer running; indicates pending ack to send.
         kTimerState_UnsubscribeTimerRunning       = 0x10, // Unsubscribe completion timer running.
-#if CHIP_ENABLE_WOBLE_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
         kTimerState_UnderTestTimerRunnung = 0x80 // running throughput Tx test
 #endif
     };
@@ -135,7 +135,7 @@ private:
     // modify the state of the underlying BLE connection.
     BLE_CONNECTION_OBJECT mConnObj;
 
-    // Queue of outgoing messages to send when current WoBle transmission completes.
+    // Queue of outgoing messages to send when current CHIPoBLE transmission completes.
     //
     // Re-used during connection setup to cache capabilities request and response payloads; payloads are freed when
     // connection is established.
@@ -145,14 +145,14 @@ private:
     // progress.
     PacketBuffer * mAckToSend;
 
-    WoBle mWoBle;
+    CHIPoBLE mCHIPoBLE;
     BleRole mRole;
     uint8_t mConnStateFlags;
     uint8_t mTimerStateFlags;
     SequenceNumber_t mLocalReceiveWindowSize;
     SequenceNumber_t mRemoteReceiveWindowSize;
     SequenceNumber_t mReceiveWindowMaxSize;
-#if CHIP_ENABLE_WOBLE_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     chip::System::Mutex mTxQueueMutex; // For MT-safe Tx queuing
 #endif
 
@@ -215,10 +215,10 @@ private:
     void FinalizeClose(uint8_t state, uint8_t flags, BLE_ERROR err);
     void ReleaseBleConnection(void);
     void Free(void);
-    void FreeWoBle(void);
+    void FreeCHIPoBLE(void);
 
-    // Mutex lock on Tx queue. Used only in WoBle test build for now.
-#if CHIP_ENABLE_WOBLE_TEST
+    // Mutex lock on Tx queue. Used only in CHIPoBLE test build for now.
+#if CHIP_ENABLE_CHIPOBLE_TEST
     inline void QueueTxLock() { mTxQueueMutex.Lock(); };
     inline void QueueTxUnlock() { mTxQueueMutex.Unlock(); };
 #else

--- a/src/ble/Ble.h
+++ b/src/ble/Ble.h
@@ -34,7 +34,7 @@
 #include <ble/BleLayer.h>
 #include <ble/BlePlatformDelegate.h>
 #include <ble/BleUUID.h>
-#include <ble/WoBle.h>
+#include <ble/CHIPoBLE.h>
 
 /**
  *   @namespace Ble

--- a/src/ble/BleError.cpp
+++ b/src/ble/BleError.cpp
@@ -70,7 +70,7 @@ bool FormatBleLayerError(char * buf, uint16_t bufSize, int32_t err)
     case BLE_ERROR_GATT_WRITE_FAILED                            : desc = "GATT write characteristic operation failed"; break;
     case BLE_ERROR_GATT_INDICATE_FAILED                         : desc = "GATT indicate characteristic operation failed"; break;
     case BLE_ERROR_NOT_IMPLEMENTED                              : desc = "Not implemented"; break;
-    case BLE_ERROR_WOBLE_PROTOCOL_ABORT                         : desc = "BLE transport protocol fired abort"; break;
+    case BLE_ERROR_CHIPOBLE_PROTOCOL_ABORT                         : desc = "BLE transport protocol fired abort"; break;
     case BLE_ERROR_REMOTE_DEVICE_DISCONNECTED                   : desc = "Remote device closed BLE connection"; break;
     case BLE_ERROR_APP_CLOSED_CONNECTION                        : desc = "Application closed BLE connection"; break;
     case BLE_ERROR_OUTBOUND_MESSAGE_TOO_BIG                     : desc = "Outbound message too big"; break;

--- a/src/ble/BleError.h
+++ b/src/ble/BleError.h
@@ -195,13 +195,13 @@ typedef BLE_CONFIG_ERROR_TYPE BLE_ERROR;
  */
 
 /**
- *  @def BLE_ERROR_WOBLE_PROTOCOL_ABORT
+ *  @def BLE_ERROR_CHIPOBLE_PROTOCOL_ABORT
  *
  *  @brief
  *    A BLE Transport Protocol (BTP) error was encountered.
  *
  */
-#define BLE_ERROR_WOBLE_PROTOCOL_ABORT                     _BLE_ERROR(11)
+#define BLE_ERROR_CHIPOBLE_PROTOCOL_ABORT                     _BLE_ERROR(11)
 
 /**
  *  @def BLE_ERROR_REMOTE_DEVICE_DISCONNECTED

--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -320,7 +320,7 @@ BLE_ERROR BleLayer::Init(BlePlatformDelegate * platformDelegate, BleApplicationD
 
     mState = kState_Initialized;
 
-#if CHIP_ENABLE_WOBLE_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     mTestBleEndPoint = NULL;
 #endif
 
@@ -382,7 +382,7 @@ BLE_ERROR BleLayer::NewBleEndPoint(BLEEndPoint ** retEndPoint, BLE_CONNECTION_OB
 
     (*retEndPoint)->Init(this, connObj, role, autoClose);
 
-#if CHIP_ENABLE_WOBLE_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     mTestBleEndPoint = *retEndPoint;
 #endif
 

--- a/src/ble/BleLayer.h
+++ b/src/ble/BleLayer.h
@@ -98,9 +98,9 @@ typedef enum
 typedef enum
 {
     kBleTransportProtocolVersion_None = 0,
-    kBleTransportProtocolVersion_V1   = 1, // Prototype WoBLe version without ACKs or flow-control.
-    kBleTransportProtocolVersion_V2   = 2, // First WoBLE version with ACKs and flow-control.
-    kBleTransportProtocolVersion_V3   = 3  // First WoBLE version with asymetric fragement sizes.
+    kBleTransportProtocolVersion_V1   = 1, // Prototype CHIPoBLE version without ACKs or flow-control.
+    kBleTransportProtocolVersion_V2   = 2, // First CHIPoBLE version with ACKs and flow-control.
+    kBleTransportProtocolVersion_V3   = 3  // First CHIPoBLE version with asymetric fragement sizes.
 } BleTransportProtocolVersion;
 
 class BleLayerObject
@@ -229,8 +229,8 @@ public:
 class DLL_EXPORT BleLayer
 {
     friend class BLEEndPoint;
-#if CHIP_ENABLE_WOBLE_TEST
-    friend class WoBleTest;
+#if CHIP_ENABLE_CHIPOBLE_TEST
+    friend class CHIPoBLETest;
 #endif
 
 public:
@@ -330,7 +330,7 @@ public:
      *   err = BLE_ERROR_APP_CLOSED_CONNECTION to prevent the leak of this chipConnection and its end point object. */
     void HandleConnectionError(BLE_CONNECTION_OBJECT connObj, BLE_ERROR err);
 
-#if CHIP_ENABLE_WOBLE_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     BLEEndPoint * mTestBleEndPoint;
 #endif
 

--- a/src/ble/CHIPoBLE.h
+++ b/src/ble/CHIPoBLE.h
@@ -17,15 +17,15 @@
 
 /**
  *    @file
- *      This file defines types and an object for the chip over
- *      Bluetooth Low Energy (WoBLE) byte-stream, connection-oriented
+ *      This file defines types and an object for the CHIP over
+ *      Bluetooth Low Energy (ChipoBLE) byte-stream, connection-oriented
  *      adaptation of chip for point-to-point Bluetooth Low Energy
  *      (BLE) links.
  *
  */
 
-#ifndef WOBLE_H_
-#define WOBLE_H_
+#ifndef CHIPOBLE_H_
+#define CHIPOBLE_H_
 
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS
@@ -44,10 +44,10 @@ namespace Ble {
 
 using ::chip::System::PacketBuffer;
 
-typedef uint8_t SequenceNumber_t; // If type changed from uint8_t, adjust assumptions in WoBle::IsValidAck and
+typedef uint8_t SequenceNumber_t; // If type changed from uint8_t, adjust assumptions in CHIPoBLE::IsValidAck and
                                   // BLEEndPoint::AdjustReceiveWindow.
 
-#if CHIP_ENABLE_WOBLE_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
 class BLEEndPoint;
 #endif
 
@@ -56,11 +56,11 @@ typedef enum
 {
     kType_Data    = 0, // Default 0 for data
     kType_Control = 1,
-} PacketType_t; // WoBle packet types
+} PacketType_t; // CHIPoBLE packet types
 
-class WoBle
+class CHIPoBLE
 {
-#if CHIP_ENABLE_WOBLE_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     friend class BLEEndPoint;
 #endif
 
@@ -80,7 +80,7 @@ public:
         kHeaderFlag_ContinueMessage = 0x02,
         kHeaderFlag_EndMessage      = 0x04,
         kHeaderFlag_FragmentAck     = 0x08,
-#if CHIP_ENABLE_WOBLE_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
         kHeaderFlag_CommandMessage = 0x10,
 #endif
     }; // Masks for BTP fragment header flag bits.
@@ -90,8 +90,8 @@ public:
 
 public:
     // Public functions:
-    WoBle(void) { };
-    ~WoBle(void) { };
+    CHIPoBLE(void) { };
+    ~CHIPoBLE(void) { };
 
     BLE_ERROR Init(void * an_app_state, bool expect_first_ack);
 
@@ -111,7 +111,7 @@ public:
 
     inline State_t RxState(void) { return mRxState; }
     inline State_t TxState(void) { return mTxState; }
-#if CHIP_ENABLE_WOBLE_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     inline PacketType_t SetTxPacketType(PacketType_t type) { return (mTxPacketType = type); };
     inline PacketType_t SetRxPacketType(PacketType_t type) { return (mRxPacketType = type); };
     inline PacketType_t TxPacketType() { return mTxPacketType; };
@@ -133,7 +133,7 @@ public:
         p->SetStart(p->Start() + sizeof(type));
         return type;
     };
-#endif // CHIP_ENABLE_WOBLE_TEST
+#endif // CHIP_ENABLE_CHIPOBLE_TEST
 
     bool HasUnackedData(void) const;
 
@@ -152,7 +152,7 @@ public:
 
 private:
     // Private data members:
-#if CHIP_ENABLE_WOBLE_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     PacketType_t mTxPacketType;
     PacketType_t mRxPacketType;
     SequenceNumber_t mTxPacketSeq;
@@ -190,4 +190,4 @@ private:
 } /* namespace Ble */
 } /* namespace chip */
 
-#endif /* WOBLE_H_ */
+#endif /* CHIPOBLE_H_ */

--- a/src/ble/Makefile
+++ b/src/ble/Makefile
@@ -25,7 +25,7 @@ CPP_Files = \
 	BleError.cpp \
 	BleLayer.cpp \
 	BleUUID.cpp \
-	WoBle.cpp
+	CHIPoBLE.cpp
 
 libble.a: $(CPP_Objects)
 	ar rvs $@ $^

--- a/src/include/BuildConfig.h
+++ b/src/include/BuildConfig.h
@@ -7,7 +7,7 @@
 /* Path to BLE platform config header file */
 /* #undef BLE_PLATFORM_CONFIG_INCLUDE */
 
-/* Define to 1 if you want to enable WoBle over bluez. */
+/* Define to 1 if you want to enable CHIPoBLE over bluez. */
 #define CONFIG_BLE_PLATFORM_BLUEZ 0
 
 /* Define to 1 if you want to use the CHIP Device Layer. */
@@ -426,9 +426,9 @@
 /* Path to CHIP Device Layer platform config header file */
 /* #undef CHIP_DEVICE_PROJECT_CONFIG_INCLUDE */
 
-/* Define to 1 if you want to enable WoBle Control Path and Throughput Test.
+/* Define to 1 if you want to enable CHIPoBLE Control Path and Throughput Test.
    */
-#define CHIP_ENABLE_WOBLE_TEST 0
+#define CHIP_ENABLE_CHIPOBLE_TEST 0
 
 /* Define to 1 if support for fuzzing enabled */
 /* #undef CHIP_FUZZING_ENABLED */

--- a/src/lib/support/CHIPFaultInjection.cpp
+++ b/src/lib/support/CHIPFaultInjection.cpp
@@ -79,7 +79,7 @@ static const FaultInjection::Name sFaultNames[] = {
     "TunnelPacketDropByPolicy",
 #endif // CHIP_CONFIG_ENABLE_TUNNELING
 #if CONFIG_NETWORK_LAYER_BLE
-    "WOBLESend",
+    "CHIPoBLESend",
 #endif // CONFIG_NETWORK_LAYER_BLE
 };
 

--- a/src/lib/support/CHIPFaultInjection.h
+++ b/src/lib/support/CHIPFaultInjection.h
@@ -94,7 +94,7 @@ typedef enum
     kFault_TunnelPacketDropByPolicy,            /**< Trigger an explicit drop of the packet as if done by an application policy */
 #endif // CHIP_CONFIG_ENABLE_TUNNELING
 #if CONFIG_NETWORK_LAYER_BLE
-    kFault_WOBLESend,                           /**< Inject a GATT error when sending the first fragment of a chip message over BLE */
+    kFault_CHIPoBLESend,                        /**< Inject a GATT error when sending the first fragment of a chip message over BLE */
 #endif // CONFIG_NETWORK_LAYER_BLE
     kFault_NumItems,
 } Id;

--- a/src/platform/include/CHIPDeviceConfig.h
+++ b/src/platform/include/CHIPDeviceConfig.h
@@ -313,35 +313,35 @@
 #define CHIP_DEVICE_CONFIG_LWIP_WIFI_AP_IF_NAME "ap"
 #endif
 
-// -------------------- BLE/WoBLE Configuration --------------------
+// -------------------- BLE/CHIPoBLE Configuration --------------------
 
 /**
- * CHIP_DEVICE_CONFIG_ENABLE_WOBLE
+ * CHIP_DEVICE_CONFIG_ENABLE_CHIPoBLE
  *
- * Enable support for chip-over-BLE (WoBLE).
+ * Enable support for CHIP-over-BLE (CHIPoBLE).
  */
-#ifndef CHIP_DEVICE_CONFIG_ENABLE_WOBLE
-#define CHIP_DEVICE_CONFIG_ENABLE_WOBLE 1
+#ifndef CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+#define CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE 1
 #endif
 
 /**
- * CHIP_DEVICE_CONFIG_SINGLE_WOBLE_CONNECTION
+ * CHIP_DEVICE_CONFIG_SINGLE_CHIPOBLE_CONNECTION
  *
- * Limit support for chip-over-BLE (WoBLE) to a single connection.
- * When set, WoBLE advertisements will stop while a WoBLE connection is active.
+ * Limit support for CHIP-over-BLE (CHIPoBLE) to a single connection.
+ * When set, CHIPoBLE advertisements will stop while a CHIPoBLE connection is active.
  */
-#ifndef CHIP_DEVICE_CONFIG_WOBLE_SINGLE_CONNECTION
-#define CHIP_DEVICE_CONFIG_WOBLE_SINGLE_CONNECTION 0
+#ifndef CHIP_DEVICE_CONFIG_CHIPOBLE_SINGLE_CONNECTION
+#define CHIP_DEVICE_CONFIG_CHIPOBLE_SINGLE_CONNECTION 0
 #endif
 
 /**
- * CHIP_DEVICE_CONFIG_WOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
+ * CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
  *
- * Automatically disable WoBLE advertising when the device transitions to a fully
+ * Automatically disable CHIPoBLE advertising when the device transitions to a fully
  * provisioned state.
  */
-#ifndef CHIP_DEVICE_CONFIG_WOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
-#define CHIP_DEVICE_CONFIG_WOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED 0
+#ifndef CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
+#define CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED 0
 #endif
 
 /**
@@ -351,7 +351,7 @@
  * consists of the final two bytes of the device's chip node id in hex.
  *
  * NOTE: The device layer limits the total length of a device name to 16 characters.
- * However, due to other data sent in WoBLE advertise packets, the device name
+ * However, due to other data sent in CHIPoBLE advertise packets, the device name
  * may need to be shorter.
  */
 #ifndef CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX

--- a/src/platform/include/CHIPDeviceEvent.h
+++ b/src/platform/include/CHIPDeviceEvent.h
@@ -168,11 +168,11 @@ enum PublicEventTypes
     kSessionEstablished,
 
     /**
-     * WoBLE Connection Established
+     * CHIPoBLE Connection Established
      *
-     * Signals that an external entity has established a new WoBLE connection with the device.
+     * Signals that an external entity has established a new CHIPoBLE connection with the device.
      */
-    kWoBLEConnectionEstablished,
+    kCHIPoBLEConnectionEstablished,
 
     /**
      * Thread State Change
@@ -189,11 +189,11 @@ enum PublicEventTypes
     kThreadInterfaceStateChange,
 
     /**
-     * chip-over-BLE (WoBLE) Advertising Change
+     * chip-over-BLE (CHIPoBLE) Advertising Change
      *
-     * Signals that the state of WoBLE advertising has changed.
+     * Signals that the state of CHIPoBLE advertising has changed.
      */
-    kWoBLEAdvertisingChange,
+    kCHIPoBLEAdvertisingChange,
 };
 
 /**
@@ -208,11 +208,11 @@ enum InternalEventTypes
     kNoOp,
     kCallWorkFunct,
     kChipSystemLayerEvent,
-    kWoBLESubscribe,
-    kWoBLEUnsubscribe,
-    kWoBLEWriteReceived,
-    kWoBLEIndicateConfirm,
-    kWoBLEConnectionError,
+    kCHIPoBLESubscribe,
+    kCHIPoBLEUnsubscribe,
+    kCHIPoBLEWriteReceived,
+    kCHIPoBLEIndicateConfirm,
+    kCHIPoBLEConnectionError,
 };
 
 static_assert(kEventTypeNotSet == 0, "kEventTypeNotSet must be defined as 0");
@@ -359,25 +359,25 @@ struct ChipDeviceEvent final
         struct
         {
             BLE_CONNECTION_OBJECT ConId;
-        } WoBLESubscribe;
+        } CHIPoBLESubscribe;
         struct
         {
             BLE_CONNECTION_OBJECT ConId;
-        } WoBLEUnsubscribe;
+        } CHIPoBLEUnsubscribe;
         struct
         {
             BLE_CONNECTION_OBJECT ConId;
             PacketBuffer * Data;
-        } WoBLEWriteReceived;
+        } CHIPoBLEWriteReceived;
         struct
         {
             BLE_CONNECTION_OBJECT ConId;
-        } WoBLEIndicateConfirm;
+        } CHIPoBLEIndicateConfirm;
         struct
         {
             BLE_CONNECTION_OBJECT ConId;
             CHIP_ERROR Reason;
-        } WoBLEConnectionError;
+        } CHIPoBLEConnectionError;
         struct
         {
             bool RoleChanged : 1;
@@ -392,7 +392,7 @@ struct ChipDeviceEvent final
         struct
         {
             ActivityChange Result;
-        } WoBLEAdvertisingChange;
+        } CHIPoBLEAdvertisingChange;
     };
 
     void Clear() { memset(this, 0, sizeof(*this)); }

--- a/src/platform/include/ConnectivityManager.h
+++ b/src/platform/include/ConnectivityManager.h
@@ -79,11 +79,11 @@ public:
         kServiceTunnelMode_Enabled                  = 2,
     };
 
-    enum WoBLEServiceMode
+    enum CHIPoBLEServiceMode
     {
-        kWoBLEServiceMode_NotSupported              = 0,
-        kWoBLEServiceMode_Enabled                   = 1,
-        kWoBLEServiceMode_Disabled                  = 2,
+        kCHIPoBLEServiceMode_NotSupported              = 0,
+        kCHIPoBLEServiceMode_Enabled                   = 1,
+        kCHIPoBLEServiceMode_Disabled                  = 2,
     };
 
     enum ThreadDeviceType
@@ -148,9 +148,9 @@ public:
     // Service connectivity methods
     bool HaveServiceConnectivity(void);
 
-    // WoBLE service methods
-    WoBLEServiceMode GetWoBLEServiceMode(void);
-    CHIP_ERROR SetWoBLEServiceMode(WoBLEServiceMode val);
+    // CHIPoBLE service methods
+    CHIPoBLEServiceMode GetCHIPoBLEServiceMode(void);
+    CHIP_ERROR SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool IsBLEAdvertisingEnabled(void);
     CHIP_ERROR SetBLEAdvertisingEnabled(bool val);
     bool IsBLEFastAdvertisingEnabled(void);
@@ -170,7 +170,7 @@ public:
     static const char * WiFiStationModeToStr(WiFiStationMode mode);
     static const char * WiFiAPModeToStr(WiFiAPMode mode);
     static const char * ServiceTunnelModeToStr(ServiceTunnelMode mode);
-    static const char * WoBLEServiceModeToStr(WoBLEServiceMode mode);
+    static const char * CHIPoBLEServiceModeToStr(CHIPoBLEServiceMode mode);
 
 private:
 
@@ -446,14 +446,14 @@ inline bool ConnectivityManager::HaveServiceConnectivityViaThread(void)
     return static_cast<ImplClass*>(this)->_HaveServiceConnectivityViaThread();
 }
 
-inline ConnectivityManager::WoBLEServiceMode ConnectivityManager::GetWoBLEServiceMode(void)
+inline ConnectivityManager::CHIPoBLEServiceMode ConnectivityManager::GetCHIPoBLEServiceMode(void)
 {
-    return static_cast<ImplClass*>(this)->_GetWoBLEServiceMode();
+    return static_cast<ImplClass*>(this)->_GetCHIPoBLEServiceMode();
 }
 
-inline CHIP_ERROR ConnectivityManager::SetWoBLEServiceMode(WoBLEServiceMode val)
+inline CHIP_ERROR ConnectivityManager::SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val)
 {
-    return static_cast<ImplClass*>(this)->_SetWoBLEServiceMode(val);
+    return static_cast<ImplClass*>(this)->_SetCHIPoBLEServiceMode(val);
 }
 
 inline bool ConnectivityManager::IsBLEAdvertisingEnabled(void)
@@ -531,9 +531,9 @@ inline const char * ConnectivityManager::ServiceTunnelModeToStr(ServiceTunnelMod
     return ImplClass::_ServiceTunnelModeToStr(mode);
 }
 
-inline const char * ConnectivityManager::WoBLEServiceModeToStr(WoBLEServiceMode mode)
+inline const char * ConnectivityManager::CHIPoBLEServiceModeToStr(CHIPoBLEServiceMode mode)
 {
-    return ImplClass::_WoBLEServiceModeToStr(mode);
+    return ImplClass::_CHIPoBLEServiceModeToStr(mode);
 }
 
 inline CHIP_ERROR ConnectivityManager::Init(void)

--- a/src/platform/include/ThreadStackManager.h
+++ b/src/platform/include/ThreadStackManager.h
@@ -97,8 +97,8 @@ private:
     CHIP_ERROR SetThreadPollingConfig(const ConnectivityManager::ThreadPollingConfig & pollingConfig);
     bool HaveMeshConnectivity(void);
     void OnMessageLayerActivityChanged(bool messageLayerIsActive);
-    void OnWoBLEAdvertisingStart(void);
-    void OnWoBLEAdvertisingStop(void);
+    void OnCHIPoBLEAdvertisingStart(void);
+    void OnCHIPoBLEAdvertisingStop(void);
 
 protected:
 
@@ -252,14 +252,14 @@ inline void ThreadStackManager::OnMessageLayerActivityChanged(bool messageLayerI
     return static_cast<ImplClass*>(this)->_OnMessageLayerActivityChanged(messageLayerIsActive);
 }
 
-inline void ThreadStackManager::OnWoBLEAdvertisingStart(void)
+inline void ThreadStackManager::OnCHIPoBLEAdvertisingStart(void)
 {
-    static_cast<ImplClass*>(this)->_OnWoBLEAdvertisingStart();
+    static_cast<ImplClass*>(this)->_OnCHIPoBLEAdvertisingStart();
 }
 
-inline void ThreadStackManager::OnWoBLEAdvertisingStop(void)
+inline void ThreadStackManager::OnCHIPoBLEAdvertisingStop(void)
 {
-    static_cast<ImplClass*>(this)->_OnWoBLEAdvertisingStop();
+    static_cast<ImplClass*>(this)->_OnCHIPoBLEAdvertisingStop();
 }
 
 inline CHIP_ERROR ThreadStackManager::GetAndLogThreadStatsCounters(void)


### PR DESCRIPTION
This cleans up several lingering instances of the tree of WoBLE (in various capitalizations) to CHIPoBLE (in various capitalizations) across both files and symbols.