### PR TITLE
Fix shellcheck (should also resurrect Tidy)

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,4 +1,4 @@
-name: shellcheck
+name: Shellcheck
 
 on: [pull_request]
 
@@ -11,7 +11,5 @@ jobs:
       - name: shellcheck
         id: shellcheck
         uses: ludeeus/actions-shellcheck@0.1.0
-        with:
-          repo-token: ${{ github.token }}
         env:
           EXCLUDE_DIRS: third_party


### PR DESCRIPTION
### Problem
  GitHub workflow names need to have an initial capital letter, apparently,
  or need to differ from the list of jobs inside. Without the initial capital letter,
  the workflow is ignored or actions parsing halts, not sure which.

  ### Changes
  * capitalize shellcheck's "name:"
  * remove unnecessary repo token argument (copy pasta)