### PR TITLE
Ignore Build-system-generated Files Created by 'bootstrap'.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,25 @@
 *.gcda
 *.gcov
 *_q*
+
+# Build System
+aclocal.m4
+autom4te.cache
+build/autoconf/compile
+build/autoconf/config.guess
+build/autoconf/config.sub
+build/autoconf/depcomp
+build/autoconf/install-sh
+build/autoconf/ltmain.sh
+build/autoconf/m4/libtool.m4
+build/autoconf/m4/ltoptions.m4
+build/autoconf/m4/ltsugar.m4
+build/autoconf/m4/ltversion.m4
+build/autoconf/m4/lt~obsolete.m4
+build/autoconf/missing
+build/autoconf/test-driver
+config.log
+config.status
+configure
+Makefile.in
+src/include/BuildConfig.h.in


### PR DESCRIPTION
This pull request updates _.gitignore_ to ignore files generated by the build system following bootstrap.