### PR TITLE
Fix casing for "chip" in comments

### DIFF
--- a/Makefile-Android
+++ b/Makefile-Android
@@ -389,7 +389,7 @@ endef # ABI_template
 
 .PHONY : all configure build stage check pretty lint pretty-check clean env-check help
 
-# Instantiate an ABI-specific set of rules to build chip for each target ABI.
+# Instantiate an ABI-specific set of rules to build CHIP for each target ABI.
 $(foreach abi,$(ANDROID_ABI),$(eval $(call ABI_template,$(abi))))
 
 all: stage

--- a/Makefile-Standalone
+++ b/Makefile-Standalone
@@ -15,7 +15,7 @@
 #
 
 #    Description:
-#      This file implements a glue makefile for building the Chip SDK
+#      This file implements a glue makefile for building the CHIP SDK
 #      for standalone desktop or server build host systems.
 #
 #      This is strictly a convenience makefile. Such systems can
@@ -103,9 +103,9 @@ endif
 # The variable OPENSSL can be used to override the above logic and specify a particular root
 # directory in which to find the OpenSSL headers and libraries.
 #
-# Setting OPENSSL=no or NO_OPENSSL=1 will cause OpenChip to be built without OpenSSL.  Note that
+# Setting OPENSSL=no or NO_OPENSSL=1 will cause CHIP to be built without OpenSSL.  Note that
 # building without OpenSSL automatically suppresses the building of various command line tools that
-# have a hard dependency on OpenSSL (e.g. the chip tool).
+# have a hard dependency on OpenSSL (e.g. the CHIP tool).
 
 ifeq ($(NO_OPENSSL),1)
 OPENSSL                         = no
@@ -238,7 +238,7 @@ AMFILES =                               \
 #
 # configure-arch <target>
 #
-# Configure the Chip SDK for the specified target.
+# Configure the CHIP SDK for the specified target.
 #
 #   target - The target to configure.
 #
@@ -255,7 +255,7 @@ endef # configure-target
 #
 # build-target <target>
 #
-# Build the Chip SDK intermediate build products for the specified
+# Build the CHIP SDK intermediate build products for the specified
 # target.
 #
 #   target - The target to build.
@@ -269,7 +269,7 @@ endef # build-target
 #
 # check-target <target>
 #
-# Check (run unit tests) the Chip SDK for the specified target.
+# Check (run unit tests) the CHIP SDK for the specified target.
 #
 #   target - The target to check.
 #
@@ -295,7 +295,7 @@ endef # distcheck-target
 #
 # coverage-target <target>
 #
-# Generate code coverage from unit tests for the Chip SDK for the
+# Generate code coverage from unit tests for the CHIP SDK for the
 # specified target.
 #
 #   target - The target to generate code coverage for.
@@ -309,7 +309,7 @@ endef # coverage-target
 #
 # stage-target <target>
 #
-# Stage (install) the Chip SDK final build products for the specified
+# Stage (install) the CHIP SDK final build products for the specified
 # target.
 #
 #   target - The target to stage.
@@ -324,7 +324,7 @@ endef # stage-target
 #
 # pretty-target <target>
 #
-# Prettyify the Chip SDK source code for the specified target.
+# Prettyify the CHIP SDK source code for the specified target.
 #
 #   target - The target to prettify.
 #
@@ -337,7 +337,7 @@ endef # pretty-target
 #
 # pretty-check-target <target>
 #
-# Pretty-check (lint) the Chip SDK source code for the specified
+# Pretty-check (lint) the CHIP SDK source code for the specified
 # target.
 #
 #   target - The target to pretty-check (lint).
@@ -352,7 +352,7 @@ endef # pretty-check-target
 # TARGET_template <target>
 #
 # Define macros, targets and rules to configure, build, and stage the
-# Chip SDK for a single target.
+# CHIP SDK for a single target.
 #
 #   target - The target to instantiate the template for.
 #
@@ -464,7 +464,7 @@ help:
 
 export HelpText
 define HelpText
-Simply type 'make -f $(firstword $(MAKEFILE_LIST))' to build Chip for the following 
+Simply type 'make -f $(firstword $(MAKEFILE_LIST))' to build CHIP for the following
 target:
 
     $(TargetTuple)
@@ -472,7 +472,7 @@ target:
 You may want or need to override the following make variables either on the 
 command line or in the environment: 
 
-  DEBUG=[1|0]             Enable/disable Chip debug code and logging (default: '$(DEBUG)').
+  DEBUG=[1|0]             Enable/disable CHIP debug code and logging (default: '$(DEBUG)').
 
   COVERAGE=[1|0]          Enable/disable generation of code coverage information 
                           (default: '$(COVERAGE)').
@@ -489,16 +489,16 @@ command line or in the environment:
                           include and lib subdirectories containing the necessary header 
                           and libraries. 
 
-  OPENSSL=internal        Build the internal copy of OpenSSL as part of the OpenChip
+  OPENSSL=internal        Build the internal copy of OpenSSL as part of the CHIP
                           build.
 
   OPENSSL=no              Build an alternate configuration that does not depend
   NO_OPENSSL=1            on the use of OpenSSL (default: '$(NO_OPENSSL)'.  Note
                           that the various command line tools that depend on
-                          OpenSSL (e.g., the chip tool) will not be built in
+                          OpenSSL (e.g., the CHIP tool) will not be built in
                           this configuration.
 
-  TUNNEL_FAILOVER=[1|0]   Enable/disabled support for redundant VPN to the Chip service 
+  TUNNEL_FAILOVER=[1|0]   Enable/disabled support for redundant VPN to the CHIP service
                           (default: '$(TUNNEL_FAILOVER)').
 
   I686TARGET=[1|0]        Enable/disable building a 32-bit target.  Requires a properly

--- a/Makefile-iOS
+++ b/Makefile-iOS
@@ -16,7 +16,7 @@
 
 #
 #    Description:
-#      This file implements a glue makefile for building the Chip SDK
+#      This file implements a glue makefile for building the CHIP SDK
 #      for iOS devices and simulators for multiple architectures.
 #
 
@@ -230,7 +230,7 @@ AMFILES =                                                \
 #
 # configure-arch <arch>
 #
-# Configure the Chip SDK for the specified architecture.
+# Configure the CHIP SDK for the specified architecture.
 #
 #   arch - The architecture to configure.
 #
@@ -290,7 +290,7 @@ endef # configure-arch
 #
 # build-arch <arch>
 #
-# Build the Chip SDK intermediate build products for the specified
+# Build the CHIP SDK intermediate build products for the specified
 # architecture.
 #
 #   arch - The architecture to build.
@@ -304,7 +304,7 @@ endef # build-arch
 #
 # stage-arch <arch>
 #
-# Stage (install) the Chip SDK final build products for the specified
+# Stage (install) the CHIP SDK final build products for the specified
 # architecture.
 #
 #   arch - The architecture to stage.
@@ -319,7 +319,7 @@ endef # stage-arch
 #
 # pretty-arch <arch>
 #
-# Prettyify the Chip SDK source code for the specified architecture.
+# Prettyify the CHIP SDK source code for the specified architecture.
 #
 #   arch - The architecture to prettify.
 #
@@ -332,7 +332,7 @@ endef # pretty-arch
 #
 # pretty-check-arch <arch>
 #
-# Pretty-check (lint) the Chip SDK source code for the specified
+# Pretty-check (lint) the CHIP SDK source code for the specified
 # architecture.
 #
 #   arch - The architecture to pretty-check (lint).
@@ -364,7 +364,7 @@ endef # combine-archs
 # ARCH_template <arch>
 #
 # Define macros, targets and rules to configure, build, and stage the
-# Chip SDK for a single architecture.
+# CHIP SDK for a single architecture.
 #
 #   arch - The architecture to instantiate the template for.
 #
@@ -525,7 +525,7 @@ clean:
 	@$(RM_F) -r $(CLEAN_DIRS)
 
 help:
-	$(ECHO) "Simply type 'make -f $(firstword $(MAKEFILE_LIST))' to build Chip for iOS for the following "
+	$(ECHO) "Simply type 'make -f $(firstword $(MAKEFILE_LIST))' to build CHIP for iOS for the following "
 	$(ECHO) "architectures: "
 	$(ECHO) ""
 	$(ECHO) "    $(ARCHS)"
@@ -537,10 +537,10 @@ help:
 	$(ECHO) "You may want or need to override the following make variables either on the "
 	$(ECHO) "command line or in the environment: "
 	$(ECHO) ""
-	$(ECHO) "  DEBUG                   Enable Chip debug code and logging (default: '$(DEBUG)')."
-	$(ECHO) "  ENABLE_TARGETED_LISTEN  Enable Chip support for listening on particular "
+	$(ECHO) "  DEBUG                   Enable CHIP debug code and logging (default: '$(DEBUG)')."
+	$(ECHO) "  ENABLE_TARGETED_LISTEN  Enable CHIP support for listening on particular "
 	$(ECHO) "                          addresses or interfaces. This allows testing multiple "
-	$(ECHO) "                          instances of the Chip stack running on a single host "
+	$(ECHO) "                          instances of the CHIP stack running on a single host "
 	$(ECHO) "                          '(default: $(ENABLE_TARGETED_LISTEN)')."
 	$(ECHO) "  OPENSSL_DIR             Specify an alternate OpenSSL installation (default: "
 	$(ECHO) "                          '$(OPENSSL_DIR)'). For example, if OpenSSL libraries are "

--- a/build/nrf5/nrf5-chip.mk
+++ b/build/nrf5/nrf5-chip.mk
@@ -16,13 +16,13 @@
 
 #
 #   @file
-#         Component makefile for incorporating Chip into an nRF5
+#         Component makefile for incorporating CHIP into an nRF5
 #         application.
 #
 
 #
 #   This makefile is intended to work in conjunction with the nrf5-app.mk
-#   makefile to build the Chip example applications on Nordic platforms. 
+#   makefile to build the CHIP example applications on Nordic platforms.
 #   nRF5 applications should include this file in their top level Makefile
 #   after including nrf5-app.mk.  E.g.:
 #
@@ -48,24 +48,24 @@
 # General settings
 # ==================================================
 
-# Location of Chip source tree
+# Location of CHIP source tree
 CHIP_ROOT ?= $(PROJECT_ROOT)/third_party/connectedhomeip
 
-# Archtecture for which Chip will be built.
+# Archtecture for which CHIP will be built.
 CHIP_HOST_ARCH := armv7-unknown-linux-gnu
 
-# Directory into which the Chip build system will place its output. 	
+# Directory into which the CHIP build system will place its output.
 CHIP_OUTPUT_DIR = $(OUTPUT_DIR)/chip
 
 # An optional file containing application-specific configuration overrides.
 CHIP_PROJECT_CONFIG = $(wildcard $(PROJECT_ROOT)/CHIPProjectConfig.h)
 
-# Architcture on which Chip is being built.
+# Architcture on which CHIP is being built.
 CHIP_BUILD_ARCH = $(shell $(CHIP_ROOT)/third_party/nlbuild-autotools/repo/third_party/autoconf/config.guess | sed -e 's/[[:digit:].]*$$//g')
 
 
 # ==================================================
-# Compilation flags specific to building Chip
+# Compilation flags specific to building CHIP
 # ==================================================
 
 CHIP_CPPFLAGS = $(STD_CFLAGS) $(CFLAGS) $(DEBUG_FLAGS) $(OPT_FLAGS) $(DEFINE_FLAGS) $(INC_FLAGS) 
@@ -82,7 +82,7 @@ DoubleQuoteStr = $(QuoteChar)$(subst $(QuoteChar),\$(QuoteChar),$(subst \,\\,$(1
 
 
 # ==================================================
-# Chip configuration options
+# CHIP configuration options
 # ==================================================
 
 CHIP_CONFIGURE_OPTIONS = \
@@ -125,10 +125,10 @@ endif
 
 # ==================================================
 # Adjustments to standard build settings to 
-#   incorporate Chip
+#   incorporate CHIP
 # ==================================================
 
-# Add Chip-specific paths to the standard include directories.
+# Add CHIP-specific paths to the standard include directories.
 STD_INC_DIRS += \
     $(CHIP_OUTPUT_DIR)/include \
     $(CHIP_OUTPUT_DIR)/src/include \
@@ -139,10 +139,10 @@ STD_INC_DIRS += \
 	$(CHIP_ROOT)/src/lwip/nrf5 \
 	$(CHIP_ROOT)/src/lwip/freertos
 
-# Add the location of Chip libraries to application link action.
+# Add the location of CHIP libraries to application link action.
 STD_LDFLAGS += -L$(CHIP_OUTPUT_DIR)/lib
 
-# Add Chip libraries to standard libraries list. 
+# Add CHIP libraries to standard libraries list.
 STD_LIBS += \
     -lDeviceLayer \
 	-lInetLayer \
@@ -150,12 +150,12 @@ STD_LIBS += \
 	-lSystemLayer \
 	-llwip
 
-# Add the appropriate Chip target as a prerequisite to all application
-# compilation targets to ensure that Chip gets built and its header
+# Add the appropriate CHIP target as a prerequisite to all application
+# compilation targets to ensure that CHIP gets built and its header
 # files installed prior to compiling any dependent source files.
 STD_COMPILE_PREREQUISITES += install-chip
 
-# Add the Chip libraries as prerequisites for linking the application.
+# Add the CHIP libraries as prerequisites for linking the application.
 STD_LINK_PREREQUISITES += \
     $(CHIP_OUTPUT_DIR)/lib/libDeviceLayer.a \
 	$(CHIP_OUTPUT_DIR)/lib/libInetLayer.a \
@@ -165,14 +165,14 @@ STD_LINK_PREREQUISITES += \
 
 
 # ==================================================
-# Late-bound build rules for Chip
+# Late-bound build rules for CHIP
 # ==================================================
 
 # Add ChipBuildRules to the list of late-bound build rules that
 # will be evaluated when GenerateBuildRules is called. 
 LATE_BOUND_RULES += ChipBuildRules
 
-# Rules for configuring, building and installing Chip.
+# Rules for configuring, building and installing CHIP.
 define ChipBuildRules
 
 .PHONY : config-chip .check-config-chip build-chip install-chip clean-chip
@@ -216,19 +216,19 @@ endef
 
 
 # ==================================================
-# Chip-specific help definitions
+# CHIP-specific help definitions
 # ==================================================
 
 define TargetHelp +=
 
 
-  config-chip          Run the Chip configure script.
+  config-chip          Run the CHIP configure script.
   
-  build-chip           Build the Chip libraries.
+  build-chip           Build the CHIP libraries.
   
-  install-chip         Install Chip libraries and headers in 
+  install-chip         Install CHIP libraries and headers in
                         build output directory for use by application.
   
-  clean-chip           Clean all build outputs produced by the Chip
+  clean-chip           Clean all build outputs produced by the CHIP
                         build process.
 endef

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -117,6 +117,9 @@ Instead, do this:
 
 Use backticks for `inline code`. This includes file paths and file or binary names.
 
+### Code Comments
+
+Use uppercase `CHIP` in comments, as it is an acronym.
 
 
 Supported keywords:

--- a/src/ble/BLEEndPoint.cpp
+++ b/src/ble/BLEEndPoint.cpp
@@ -19,7 +19,7 @@
  *    @file
  *      This file implements a Bluetooth Low Energy (BLE) connection
  *      endpoint abstraction for the byte-streaming,
- *      connection-oriented chip over Bluetooth Low Energy (CHIPoBLE)
+ *      connection-oriented CHIP over Bluetooth Low Energy (CHIPoBLE)
  *      Bluetooth Transport Protocol (BTP).
  *
  */
@@ -201,10 +201,10 @@ BLE_ERROR BLEEndPoint::HandleReceiveConnectionComplete()
     StopReceiveConnectionTimer();
 
     // We've successfully completed the BLE transport protocol handshake, so let the application know we're open for business.
-    if (mBle->OnchipBleConnectReceived != NULL)
+    if (mBle->OnChipBleConnectReceived != NULL)
     {
         // Indicate BLE transport protocol connection received to next-higher layer.
-        mBle->OnchipBleConnectReceived(this);
+        mBle->OnChipBleConnectReceived(this);
     }
     else
     {
@@ -484,7 +484,7 @@ void BLEEndPoint::ReleaseBleConnection()
 void BLEEndPoint::Free()
 {
     // Release BLE connection. Will close connection if AutoClose enabled for this end point. Otherwise, informs
-    // application that chip is done with this BLE connection, and application makes decision about whether to close
+    // application that CHIP is done with this BLE connection, and application makes decision about whether to close
     // and clean up or retain connection.
     ReleaseBleConnection();
 
@@ -1517,7 +1517,7 @@ exit:
 
 bool BLEEndPoint::SendWrite(PacketBuffer * buf)
 {
-    // Add reference to message fragment for duration of platform's GATT write attempt. chip retains partial
+    // Add reference to message fragment for duration of platform's GATT write attempt. CHIP retains partial
     // ownership of message fragment's PacketBuffer, since this is the same buffer as that of the whole message, just
     // with a fragmenter-modified payload offset and data length. Buffer must be decref'd (i.e. PacketBuffer::Free'd) by
     // platform when BLE GATT operation completes.
@@ -1530,7 +1530,7 @@ bool BLEEndPoint::SendWrite(PacketBuffer * buf)
 
 bool BLEEndPoint::SendIndication(PacketBuffer * buf)
 {
-    // Add reference to message fragment for duration of platform's GATT indication attempt. chip retains partial
+    // Add reference to message fragment for duration of platform's GATT indication attempt. CHIP retains partial
     // ownership of message fragment's PacketBuffer, since this is the same buffer as that of the whole message, just
     // with a fragmenter-modified payload offset and data length. Buffer must be decref'd (i.e. PacketBuffer::Free'd) by
     // platform when BLE GATT operation completes.

--- a/src/ble/BLEEndPoint.h
+++ b/src/ble/BLEEndPoint.h
@@ -19,7 +19,7 @@
  *    @file
  *      This file defines a Bluetooth Low Energy (BLE) connection
  *      endpoint abstraction for the byte-streaming,
- *      connection-oriented chip over Bluetooth Low Energy (CHIPoBLE)
+ *      connection-oriented CHIP over Bluetooth Low Energy (CHIPoBLE)
  *      Bluetooth Transport Protocol (BTP).
  *
  */
@@ -73,7 +73,7 @@ public:
         kState_Connected  = 3,
         kState_Closing    = 4,
         kState_Closed     = 5
-    } mState; // [READ-ONLY] End point connection state. Refers to state of chip over
+    } mState; // [READ-ONLY] End point connection state. Refers to state of CHIP over
               // BLE transport protocol connection, not of underlying BLE connection.
 
     // Public function pointers:

--- a/src/ble/BleApplicationDelegate.h
+++ b/src/ble/BleApplicationDelegate.h
@@ -35,8 +35,8 @@ namespace Ble {
 class DLL_EXPORT BleApplicationDelegate
 {
 public:
-    // chip calls this function once it closes the last BLEEndPoint associated with a BLE given connection object.
-    // A call to this function means chip no longer cares about the state of the given BLE connection.
+    // CHIP calls this function once it closes the last BLEEndPoint associated with a BLE given connection object.
+    // A call to this function means CHIP no longer cares about the state of the given BLE connection.
     // The application can use this callback to e.g. close the underlying BLE conection if it is no longer needed,
     // decrement the connection's refcount if it has one, or perform any other sort of cleanup as desired.
     virtual void NotifyChipConnectionClosed(BLE_CONNECTION_OBJECT connObj) = 0;

--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -18,31 +18,31 @@
 /**
  *    @file
  *      This file implements objects which provide an abstraction layer between
- *      a platform's Bluetooth Low Energy (BLE) implementation and the chip
+ *      a platform's Bluetooth Low Energy (BLE) implementation and the CHIP
  *      stack.
  *
  *      The BleLayer obect accepts BLE data and control input from the
  *      application via a functional interface. It performs the fragmentation
- *      and reassembly required to transmit chip message via a BLE GATT
- *      characteristic interface, and drives incoming messages up the chip
+ *      and reassembly required to transmit CHIP message via a BLE GATT
+ *      characteristic interface, and drives incoming messages up the CHIP
  *      stack.
  *
  *      During initialization, the BleLayer object requires a pointer to the
  *      platform's implementation of the BlePlatformDelegate and
  *      BleApplicationDelegate objects.
  *
- *      The BlePlatformDelegate provides the chip stack with an interface
+ *      The BlePlatformDelegate provides the CHIP stack with an interface
  *      by which to form and cancel GATT subscriptions, read and write
  *      GATT characteristic values, send GATT characteristic notifications,
  *      respond to GATT read requests, and close BLE connections.
  *
- *      The BleApplicationDelegate provides a mechanism for chip to inform
+ *      The BleApplicationDelegate provides a mechanism for CHIP to inform
  *      the application when it has finished using a given BLE connection,
  *      i.e when the chipConnection object wrapping this connection has
  *      closed. This allows the application to either close the BLE connection
- *      or continue to keep it open for non-chip purposes.
+ *      or continue to keep it open for non-CHIP purposes.
  *
- *      To enable chip over BLE for a new platform, the application developer
+ *      To enable CHIP over BLE for a new platform, the application developer
  *      must provide an implementation for both delegates, provides points to
  *      instances of these delegates on startup, and ensure that the
  *      application calls the necessary BleLayer functions when appropriate to
@@ -156,11 +156,11 @@ static BleEndPointPool sBLEEndPointPool;
 
 // UUIDs used internally by BleLayer:
 
-const chipBleUUID BleLayer::CHIP_BLE_CHAR_1_ID = { { // 18EE2EF5-263D-4559-959F-4F9C429F9D11
+const ChipBleUUID BleLayer::CHIP_BLE_CHAR_1_ID = { { // 18EE2EF5-263D-4559-959F-4F9C429F9D11
                                                      0x18, 0xEE, 0x2E, 0xF5, 0x26, 0x3D, 0x45, 0x59, 0x95, 0x9F, 0x4F, 0x9C, 0x42,
                                                      0x9F, 0x9D, 0x11 } };
 
-const chipBleUUID BleLayer::CHIP_BLE_CHAR_2_ID = { { // 18EE2EF5-263D-4559-959F-4F9C429F9D12
+const ChipBleUUID BleLayer::CHIP_BLE_CHAR_2_ID = { { // 18EE2EF5-263D-4559-959F-4F9C429F9D12
                                                      0x18, 0xEE, 0x2E, 0xF5, 0x26, 0x3D, 0x45, 0x59, 0x95, 0x9F, 0x4F, 0x9C, 0x42,
                                                      0x9F, 0x9D, 0x12 } };
 
@@ -389,7 +389,7 @@ BLE_ERROR BleLayer::NewBleEndPoint(BLEEndPoint ** retEndPoint, BLE_CONNECTION_OB
     return BLE_NO_ERROR;
 }
 
-// Handle remote central's initiation of chip over BLE protocol handshake.
+// Handle remote central's initiation of CHIP over BLE protocol handshake.
 BLE_ERROR BleLayer::HandleBleTransportConnectionInitiated(BLE_CONNECTION_OBJECT connObj, PacketBuffer * pBuf)
 {
     BLE_ERROR err             = BLE_NO_ERROR;
@@ -421,13 +421,13 @@ exit:
 
     if (err != BLE_NO_ERROR)
     {
-        ChipLogError(Ble, "HandlechipConnectionReceived failed, err = %d", err);
+        ChipLogError(Ble, "HandleChipConnectionReceived failed, err = %d", err);
     }
 
     return err;
 }
 
-bool BleLayer::HandleWriteReceived(BLE_CONNECTION_OBJECT connObj, const chipBleUUID * svcId, const chipBleUUID * charId,
+bool BleLayer::HandleWriteReceived(BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId,
                                    PacketBuffer * pBuf)
 {
     if (!UUIDsMatch(&CHIP_BLE_SVC_ID, svcId))
@@ -480,7 +480,7 @@ exit:
     return true;
 }
 
-bool BleLayer::HandleIndicationReceived(BLE_CONNECTION_OBJECT connObj, const chipBleUUID * svcId, const chipBleUUID * charId,
+bool BleLayer::HandleIndicationReceived(BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId,
                                         PacketBuffer * pBuf)
 {
     if (!UUIDsMatch(&CHIP_BLE_SVC_ID, svcId))
@@ -527,7 +527,7 @@ exit:
     return true;
 }
 
-bool BleLayer::HandleWriteConfirmation(BLE_CONNECTION_OBJECT connObj, const chipBleUUID * svcId, const chipBleUUID * charId)
+bool BleLayer::HandleWriteConfirmation(BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId)
 {
     if (!UUIDsMatch(&CHIP_BLE_SVC_ID, svcId))
     {
@@ -546,7 +546,7 @@ bool BleLayer::HandleWriteConfirmation(BLE_CONNECTION_OBJECT connObj, const chip
     return true;
 }
 
-bool BleLayer::HandleIndicationConfirmation(BLE_CONNECTION_OBJECT connObj, const chipBleUUID * svcId, const chipBleUUID * charId)
+bool BleLayer::HandleIndicationConfirmation(BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId)
 {
     if (!UUIDsMatch(&CHIP_BLE_SVC_ID, svcId))
     {
@@ -585,7 +585,7 @@ void BleLayer::HandleAckReceived(BLE_CONNECTION_OBJECT connObj)
     }
 }
 
-bool BleLayer::HandleSubscribeReceived(BLE_CONNECTION_OBJECT connObj, const chipBleUUID * svcId, const chipBleUUID * charId)
+bool BleLayer::HandleSubscribeReceived(BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId)
 {
     if (!UUIDsMatch(&CHIP_BLE_SVC_ID, svcId))
     {
@@ -610,7 +610,7 @@ bool BleLayer::HandleSubscribeReceived(BLE_CONNECTION_OBJECT connObj, const chip
     return true;
 }
 
-bool BleLayer::HandleSubscribeComplete(BLE_CONNECTION_OBJECT connObj, const chipBleUUID * svcId, const chipBleUUID * charId)
+bool BleLayer::HandleSubscribeComplete(BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId)
 {
     if (!UUIDsMatch(&CHIP_BLE_SVC_ID, svcId))
     {
@@ -634,7 +634,7 @@ bool BleLayer::HandleSubscribeComplete(BLE_CONNECTION_OBJECT connObj, const chip
     return true;
 }
 
-bool BleLayer::HandleUnsubscribeReceived(BLE_CONNECTION_OBJECT connObj, const chipBleUUID * svcId, const chipBleUUID * charId)
+bool BleLayer::HandleUnsubscribeReceived(BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId)
 {
     if (!UUIDsMatch(&CHIP_BLE_SVC_ID, svcId))
     {
@@ -659,7 +659,7 @@ bool BleLayer::HandleUnsubscribeReceived(BLE_CONNECTION_OBJECT connObj, const ch
     return true;
 }
 
-bool BleLayer::HandleUnsubscribeComplete(BLE_CONNECTION_OBJECT connObj, const chipBleUUID * svcId, const chipBleUUID * charId)
+bool BleLayer::HandleUnsubscribeComplete(BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId)
 {
     if (!UUIDsMatch(&CHIP_BLE_SVC_ID, svcId))
     {

--- a/src/ble/BleLayer.h
+++ b/src/ble/BleLayer.h
@@ -18,25 +18,25 @@
 /**
  *    @file
  *      This file defines objects that provide an abstraction layer between a
- *      platform's Bluetooth Low Energy (BLE) implementation and the chip
+ *      platform's Bluetooth Low Energy (BLE) implementation and the CHIP
  *      stack.
  *
  *      The BleLayer obect accepts BLE data and control input from the
  *      application via a functional interface. It performs the fragmentation
- *      and reassembly required to transmit chip message via a BLE GATT
- *      characteristic interface, and drives incoming messages up the chip
+ *      and reassembly required to transmit CHIP message via a BLE GATT
+ *      characteristic interface, and drives incoming messages up the CHIP
  *      stack.
  *
  *      During initialization, the BleLayer object requires a pointer to the
  *      platform's implementation of the BleAdapter object. This object is
- *      defined but not implemented by the chip stack, and provides the
+ *      defined but not implemented by the CHIP stack, and provides the
  *      BleLayer with a functional interface to drive outgoing GATT
  *      characteristic writes and indications. It also provides a mechanism
- *      for chip to inform the application when it has finished using a given
+ *      for CHIP to inform the application when it has finished using a given
  *      BLE connection, i.e., when the chipConnection object wrapping this
  *      connection has closed.
  *
- *      To enable chip over BLE for a new platform, the application developer
+ *      To enable CHIP over BLE for a new platform, the application developer
  *      must implement the BleAdapter class for their platform, pass it to the
  *      BleLayer on startup, pass a pointer to this BleLayer to their instance
  *      of chipMessageLayer, and ensure that the application calls the
@@ -75,7 +75,7 @@ using ::chip::System::PacketBuffer;
  *  @def NUM_SUPPORTED_PROTOCOL_VERSIONS
  *
  *  Number of unsigned 4-bit representations of supported transport protocol
- *  versions encapsulated in a BleTransportCapabilitiesRequest. Defined by chip
+ *  versions encapsulated in a BleTransportCapabilitiesRequest. Defined by CHIP
  *  over BLE protocol specification.
  */
 #define NUM_SUPPORTED_PROTOCOL_VERSIONS 8
@@ -94,7 +94,7 @@ typedef enum
     kBleRole_Peripheral = 1
 } BleRole;
 
-/// Enum defining versions of chip over BLE transport protocol.
+/// Enum defining versions of CHIP over BLE transport protocol.
 typedef enum
 {
     kBleTransportProtocolVersion_None = 0,
@@ -244,7 +244,7 @@ public:
     void * mAppState;
 
     typedef void (*BleConnectionReceivedFunct)(BLEEndPoint * newEndPoint);
-    BleConnectionReceivedFunct OnchipBleConnectReceived;
+    BleConnectionReceivedFunct OnChipBleConnectReceived;
 
 public:
     // Public functions:
@@ -268,64 +268,64 @@ public:
     /**< Platform interface functions:
 
      *   Calling conventions:
-     *     chip takes ownership of PacketBuffers received through these functions,
+     *     CHIP takes ownership of PacketBuffers received through these functions,
      *     and will free them or pass ownership up the stack.
      *
      *     Beyond each call, no guarantees are provided as to the lifetime of UUID arguments.
      *
-     *     A 'true' return value means the chip stack successfully handled the
-     *     corresponding message or state indication. 'false' means the chip stack either
-     *     failed or chose not to handle this. In case of 'false,' the chip stack will not
+     *     A 'true' return value means the CHIP stack successfully handled the
+     *     corresponding message or state indication. 'false' means the CHIP stack either
+     *     failed or chose not to handle this. In case of 'false,' the CHIP stack will not
      *     have freed or taken ownership of any PacketBuffer arguments. This contract allows the
-     *     platform to pass BLE events to chip without needing to know which characteristics
-     *     chip cares about.
+     *     platform to pass BLE events to CHIP without needing to know which characteristics
+     *     CHIP cares about.
 
-     *     Platform must call this function when a GATT subscription has been established to any chip service
+     *     Platform must call this function when a GATT subscription has been established to any CHIP service
      *     charateristic.
      *
-     *     If this function returns true, chip has accepted the BLE connection and wrapped it
-     *     in a chipConnection object. If chip accepts a BLE connection, the platform MUST
-     *     notify chip if the subscription is canceled or the underlying BLE connection is
+     *     If this function returns true, CHIP has accepted the BLE connection and wrapped it
+     *     in a chipConnection object. If CHIP accepts a BLE connection, the platform MUST
+     *     notify CHIP if the subscription is canceled or the underlying BLE connection is
      *     closed, or the associated chipConnection will never be closed or freed. */
-    bool HandleSubscribeReceived(BLE_CONNECTION_OBJECT connObj, const chipBleUUID * svcId, const chipBleUUID * charId);
+    bool HandleSubscribeReceived(BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId);
 
     /// Call when a GATT subscribe request succeeds.
-    bool HandleSubscribeComplete(BLE_CONNECTION_OBJECT connObj, const chipBleUUID * svcId, const chipBleUUID * charId);
+    bool HandleSubscribeComplete(BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId);
 
-    /**< Platform must call this function when a GATT unsubscribe is requested on any chip
-     *   service charateristic, that is, when an existing GATT subscription on a chip service
+    /**< Platform must call this function when a GATT unsubscribe is requested on any CHIP
+     *   service charateristic, that is, when an existing GATT subscription on a CHIP service
      *   characteristic is canceled. */
-    bool HandleUnsubscribeReceived(BLE_CONNECTION_OBJECT connObj, const chipBleUUID * svcId, const chipBleUUID * charId);
+    bool HandleUnsubscribeReceived(BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId);
 
     /// Call when a GATT unsubscribe request succeeds.
-    bool HandleUnsubscribeComplete(BLE_CONNECTION_OBJECT connObj, const chipBleUUID * svcId, const chipBleUUID * charId);
+    bool HandleUnsubscribeComplete(BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId);
 
     /// Call when a GATT write request is received.
-    bool HandleWriteReceived(BLE_CONNECTION_OBJECT connObj, const chipBleUUID * svcId, const chipBleUUID * charId,
+    bool HandleWriteReceived(BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId,
                              PacketBuffer * pBuf);
 
     /// Call when a GATT indication is received.
-    bool HandleIndicationReceived(BLE_CONNECTION_OBJECT connObj, const chipBleUUID * svcId, const chipBleUUID * charId,
+    bool HandleIndicationReceived(BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId,
                                   PacketBuffer * pBuf);
 
     /// Call when an outstanding GATT write request receives a positive receipt confirmation.
-    bool HandleWriteConfirmation(BLE_CONNECTION_OBJECT connObj, const chipBleUUID * svcId, const chipBleUUID * charId);
+    bool HandleWriteConfirmation(BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId);
 
     /// Call when an oustanding GATT indication receives a positive receipt confirmation.
-    bool HandleIndicationConfirmation(BLE_CONNECTION_OBJECT connObj, const chipBleUUID * svcId, const chipBleUUID * charId);
+    bool HandleIndicationConfirmation(BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId);
 
     /// Call when a GATT read request is received.
-    bool HandleReadReceived(BLE_CONNECTION_OBJECT connObj, BLE_READ_REQUEST_CONTEXT requestContext, const chipBleUUID * svcId,
-                            const chipBleUUID * charId);
+    bool HandleReadReceived(BLE_CONNECTION_OBJECT connObj, BLE_READ_REQUEST_CONTEXT requestContext, const ChipBleUUID * svcId,
+                            const ChipBleUUID * charId);
 
     /**< Platform must call this function when any previous operation undertaken by the BleLayer via BleAdapter
      *   fails, such as a characteristic write request or subscribe attempt, or when a BLE connection is closed.
      *
-     *   In most cases, this will prompt chip to close the associated chipConnection and notify that platform that
+     *   In most cases, this will prompt CHIP to close the associated chipConnection and notify that platform that
      *   it has abandoned the underlying BLE connection.
      *
      *   NOTE: if the application explicitly closes a BLE connection with an associated chipConnection such that
-     *   the BLE connection close will not generate an upcall to chip, HandleConnectionError must be called with
+     *   the BLE connection close will not generate an upcall to CHIP, HandleConnectionError must be called with
      *   err = BLE_ERROR_APP_CLOSED_CONNECTION to prevent the leak of this chipConnection and its end point object. */
     void HandleConnectionError(BLE_CONNECTION_OBJECT connObj, BLE_ERROR err);
 
@@ -336,10 +336,10 @@ public:
 private:
     // Private data members:
 
-    // UUID of chip service characteristic used for central writes.
-    static const chipBleUUID CHIP_BLE_CHAR_1_ID;
-    // UUID of chip service characteristic used for peripheral indications.
-    static const chipBleUUID CHIP_BLE_CHAR_2_ID;
+    // UUID of CHIP service characteristic used for central writes.
+    static const ChipBleUUID CHIP_BLE_CHAR_1_ID;
+    // UUID of CHIP service characteristic used for peripheral indications.
+    static const ChipBleUUID CHIP_BLE_CHAR_2_ID;
 
     BlePlatformDelegate * mPlatformDelegate;
     BleApplicationDelegate * mApplicationDelegate;

--- a/src/ble/BlePlatformDelegate.h
+++ b/src/ble/BlePlatformDelegate.h
@@ -43,11 +43,11 @@ public:
     // Following APIs must be implemented by platform:
 
     // Subscribe to updates and indications on the specfied characteristic
-    virtual bool SubscribeCharacteristic(BLE_CONNECTION_OBJECT connObj, const chipBleUUID * svcId, const chipBleUUID * charId) = 0;
+    virtual bool SubscribeCharacteristic(BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId) = 0;
 
     // Unsubscribe from updates and indications on the specified characteristic
-    virtual bool UnsubscribeCharacteristic(BLE_CONNECTION_OBJECT connObj, const chipBleUUID * svcId,
-                                           const chipBleUUID * charId) = 0;
+    virtual bool UnsubscribeCharacteristic(BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId,
+                                           const ChipBleUUID * charId) = 0;
 
     // Close the underlying BLE connection.
     virtual bool CloseConnection(BLE_CONNECTION_OBJECT connObj) = 0;
@@ -56,8 +56,8 @@ public:
     virtual uint16_t GetMTU(BLE_CONNECTION_OBJECT connObj) const = 0;
 
     // Data path calling convention:
-    //   The chip stack retains partial ownership of pBufs sent via the below functions. These buffers are freed by
-    //   chip after either they're acknowledged by the peer's BLE controller, or chip shuts down the pBuf's
+    //   The CHIP stack retains partial ownership of pBufs sent via the below functions. These buffers are freed by
+    //   CHIP after either they're acknowledged by the peer's BLE controller, or CHIP shuts down the pBuf's
     //   associated BLEEndPoint.
     //
     //   For its part, the platform MUST call PacketBuffer::Free on each pBuf it receives via a Send* function once it no
@@ -74,20 +74,20 @@ public:
     //   If a Send* function returns false, it must release its reference to pBuf prior to return.
 
     // Send GATT characteristic indication request
-    virtual bool SendIndication(BLE_CONNECTION_OBJECT connObj, const chipBleUUID * svcId, const chipBleUUID * charId,
+    virtual bool SendIndication(BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId,
                                 PacketBuffer * pBuf) = 0;
 
     // Send GATT characteristic write request
-    virtual bool SendWriteRequest(BLE_CONNECTION_OBJECT connObj, const chipBleUUID * svcId, const chipBleUUID * charId,
+    virtual bool SendWriteRequest(BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId,
                                   PacketBuffer * pBuf) = 0;
 
     // Send GATT characteristic read request
-    virtual bool SendReadRequest(BLE_CONNECTION_OBJECT connObj, const chipBleUUID * svcId, const chipBleUUID * charId,
+    virtual bool SendReadRequest(BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId,
                                  PacketBuffer * pBuf) = 0;
 
     // Send response to remote host's GATT chacteristic read response
-    virtual bool SendReadResponse(BLE_CONNECTION_OBJECT connObj, BLE_READ_REQUEST_CONTEXT requestContext, const chipBleUUID * svcId,
-                                  const chipBleUUID * charId) = 0;
+    virtual bool SendReadResponse(BLE_CONNECTION_OBJECT connObj, BLE_READ_REQUEST_CONTEXT requestContext, const ChipBleUUID * svcId,
+                                  const ChipBleUUID * charId) = 0;
 };
 
 } /* namespace Ble */

--- a/src/ble/BleUUID.cpp
+++ b/src/ble/BleUUID.cpp
@@ -26,11 +26,11 @@
 namespace chip {
 namespace Ble {
 
-const chipBleUUID CHIP_BLE_SVC_ID = { { // 0000FEAF-0000-1000-8000-00805F9B34FB
+const ChipBleUUID CHIP_BLE_SVC_ID = { { // 0000FEAF-0000-1000-8000-00805F9B34FB
                                         0x00, 0x00, 0xFE, 0xAF, 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0x80, 0x5F, 0x9B, 0x34,
                                         0xFB } };
 
-bool UUIDsMatch(const chipBleUUID * idOne, const chipBleUUID * idTwo)
+bool UUIDsMatch(const ChipBleUUID * idOne, const ChipBleUUID * idTwo)
 {
     if ((idOne == NULL) || (idTwo == NULL))
     {

--- a/src/ble/BleUUID.h
+++ b/src/ble/BleUUID.h
@@ -29,12 +29,12 @@ namespace Ble {
 typedef struct
 {
     uint8_t bytes[16];
-} chipBleUUID;
+} ChipBleUUID;
 
 // UUID of CHIP BLE service. Exposed for use in scan filter.
-extern const chipBleUUID CHIP_BLE_SVC_ID;
+extern const ChipBleUUID CHIP_BLE_SVC_ID;
 
-bool UUIDsMatch(const chipBleUUID * idOne, const chipBleUUID * idTwo);
+bool UUIDsMatch(const ChipBleUUID * idOne, const ChipBleUUID * idTwo);
 
 } /* namespace Ble */
 } /* namespace chip */

--- a/src/include/platform/EFR32/BlePlatformConfig.h
+++ b/src/include/platform/EFR32/BlePlatformConfig.h
@@ -17,7 +17,7 @@
 
 /**
  *    @file
- *          Platform-specific configuration overrides for the OpenChip BLE
+ *          Platform-specific configuration overrides for the CHIP BLE
  *          Layer on EFR32 platforms using the Silicon Labs SDK.
  *
  */

--- a/src/include/platform/EFR32/CHIPPlatformConfig.h
+++ b/src/include/platform/EFR32/CHIPPlatformConfig.h
@@ -17,7 +17,7 @@
 
 /**
  *    @file
- *          Platform-specific configuration overrides for OpenChip on
+ *          Platform-specific configuration overrides for CHIP on
  *          Silcon Labs EFR32 platforms.
  */
 
@@ -61,7 +61,7 @@
 #define CHIP_CONFIG_HASH_IMPLEMENTATION_MBEDTLS 0
 #define CHIP_CONFIG_HASH_IMPLEMENTATION_PLATFORM 0
 
-// FIXME: EFR32 set to MBED-TLS (But this is third-party repo in OpenChip, not SDK)
+// FIXME: EFR32 set to MBED-TLS (But this is third-party repo in CHIP, not SDK)
 
 #define CHIP_CONFIG_AES_IMPLEMENTATION_OPENSSL 0
 #define CHIP_CONFIG_AES_IMPLEMENTATION_AESNI 0

--- a/src/include/platform/EFR32/EFR32Config.h
+++ b/src/include/platform/EFR32/EFR32Config.h
@@ -64,7 +64,7 @@ public:
 
     using Key = uint32_t;
 
-    // NVM3 key base offsets used by the OpenChip Device Layer.
+    // NVM3 key base offsets used by the CHIP Device Layer.
     static constexpr uint8_t kChipFactory_KeyBase =
         0xA2; // Persistent config values set at manufacturing time. Retained during factory reset.
     static constexpr uint8_t kChipConfig_KeyBase =
@@ -81,7 +81,7 @@ public:
     static constexpr Key kConfigKey_ManufacturingDate    = EFR32ConfigKey(kChipFactory_KeyBase, 0x04);
     static constexpr Key kConfigKey_PairingCode          = EFR32ConfigKey(kChipFactory_KeyBase, 0x05);
     static constexpr Key kConfigKey_MfrDeviceICACerts    = EFR32ConfigKey(kChipFactory_KeyBase, 0x06);
-    // Chip Config Keys
+    // CHIP Config Keys
     static constexpr Key kConfigKey_FabricId             = EFR32ConfigKey(kChipConfig_KeyBase, 0x00);
     static constexpr Key kConfigKey_ServiceConfig        = EFR32ConfigKey(kChipConfig_KeyBase, 0x01);
     static constexpr Key kConfigKey_PairedAccountId      = EFR32ConfigKey(kChipConfig_KeyBase, 0x02);

--- a/src/include/platform/EFR32/InetPlatformConfig.h
+++ b/src/include/platform/EFR32/InetPlatformConfig.h
@@ -17,7 +17,7 @@
 
 /**
  *    @file
- *          Platform-specific configuration overrides for the OpenChip Inet
+ *          Platform-specific configuration overrides for the CHIP Inet
  *          Layer on EFR32 platforms using the Silicon Labs SDK.
  *
  */

--- a/src/include/platform/EFR32/SystemPlatformConfig.h
+++ b/src/include/platform/EFR32/SystemPlatformConfig.h
@@ -17,7 +17,7 @@
 
 /**
  *    @file
- *          Platform-specific configuration overrides for the OpenChip System
+ *          Platform-specific configuration overrides for the CHIP System
  *          Layer on Silcon Labs EFR32 Platforms.
  *
  */

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -922,8 +922,8 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_ComputeProvisioningHash(
     //     DDDDddddddddddddddddCCCCcccc…ccccIIIIiiii…iiiiKKKKkkkk…kkkkPPPPpppppp
     //
     // Where:
-    //     dddddddddddddddd is the Chip node id for the device, encoded as a string of 16 uppercase hex digits.
-    //     cccc…cccc is the device Chip certificate, in base-64 format.
+    //     dddddddddddddddd is the CHIP node id for the device, encoded as a string of 16 uppercase hex digits.
+    //     cccc…cccc is the device CHIP certificate, in base-64 format.
     //     iiii…iiii is the device intermediate CA certificates, in base-64 format (if provisioned).
     //     kkkk…kkkk is the device private key, in base-64 format.
     //     pppppp is the device pairing code, as ASCII characters.

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.ipp
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.ipp
@@ -104,15 +104,15 @@ void GenericConnectivityManagerImpl_Thread<ImplClass>::UpdateServiceConnectivity
 {
     bool haveServiceConnectivity = false;
 
-    // Evaluate whether there is connectivity to the chip service subnet via the Thread network.
+    // Evaluate whether there is connectivity to the CHIP service subnet via the Thread network.
     //
     // If the device is a member of a fabric, then service connectivity is assessed by checking if the
-    // local Thread stack has a route to the chip service subnet.  This route will typically be a /48
-    // chip ULA route that has been advertised by one or more chip border router devices in the Thread
-    // network.  If no such route exists, then it is likely that there are no functioning chip border
+    // local Thread stack has a route to the CHIP service subnet.  This route will typically be a /48
+    // CHIP ULA route that has been advertised by one or more CHIP border router devices in the Thread
+    // network.  If no such route exists, then it is likely that there are no functioning CHIP border
     // routers, and thus no route to the service via Thread.
     //
-    // If the device is NOT a member of a fabric, then there can be no chip service connectivity via Thread.
+    // If the device is NOT a member of a fabric, then there can be no CHIP service connectivity via Thread.
     //
     if (FabricState.FabricId != kFabricIdNotSpecified)
     {

--- a/src/include/platform/internal/GenericPlatformManagerImpl.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.ipp
@@ -51,7 +51,7 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack(void)
     // Arrange for Device Layer errors to be translated to text.
     RegisterDeviceLayerErrorFormatter();
 
-    // Initialize the source used by chip to get secure random data.
+    // Initialize the source used by CHIP to get secure random data.
     err = InitEntropy();
     SuccessOrExit(err);
 
@@ -63,7 +63,7 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack(void)
     }
     SuccessOrExit(err);
 
-    // Initialize the chip system layer.
+    // Initialize the CHIP system layer.
     new (&SystemLayer) System::Layer();
     err = SystemLayer.Init(NULL);
     if (err != CHIP_SYSTEM_NO_ERROR)
@@ -72,7 +72,7 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack(void)
     }
     SuccessOrExit(err);
 
-    // Initialize the chip Inet layer.
+    // Initialize the CHIP Inet layer.
     new (&InetLayer) Inet::InetLayer();
     err = InetLayer.Init(SystemLayer, NULL);
     if (err != INET_NO_ERROR)
@@ -93,7 +93,7 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack(void)
 #endif
     }
 
-    // Perform dynamic configuration of the core chip objects based on stored settings.
+    // Perform dynamic configuration of the core CHIP objects based on stored settings.
     //
     // NB: In general, initialization of Device Layer objects should happen *after* this call
     // as their initialization methods may rely on the proper initialization of the core
@@ -124,7 +124,7 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack(void)
     }
     SuccessOrExit(err);
 
-    // Initialize chip Event Logging.
+    // Initialize CHIP Event Logging.
     err = InitChipEventLogging();
     if (err != CHIP_NO_ERROR)
     {
@@ -228,7 +228,7 @@ void GenericPlatformManagerImpl<ImplClass>::_DispatchEvent(const ChipDeviceEvent
         break;
 
     case DeviceEventType::kChipSystemLayerEvent:
-        // If the event is a chip System or Inet Layer event, deliver it to the SystemLayer event handler.
+        // If the event is a CHIP System or Inet Layer event, deliver it to the SystemLayer event handler.
         Impl()->DispatchEventToSystemLayer(event);
         break;
 
@@ -272,7 +272,7 @@ void GenericPlatformManagerImpl<ImplClass>::DispatchEventToSystemLayer(const Chi
                                   event->ChipSystemLayerEvent.Argument);
     if (err != CHIP_SYSTEM_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Error handling chip System Layer event (type %d): %s",
+        ChipLogError(DeviceLayer, "Error handling CHIP System Layer event (type %d): %s",
                 event->Type, ErrorStr(err));
     }
 }

--- a/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
@@ -53,14 +53,14 @@ CHIP_ERROR GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_InitChipStack(void)
     mChipStackLock = xSemaphoreCreateMutex();
     if (mChipStackLock == NULL)
     {
-        ChipLogError(DeviceLayer, "Failed to create chip stack lock");
+        ChipLogError(DeviceLayer, "Failed to create CHIP stack lock");
         ExitNow(err = CHIP_ERROR_NO_MEMORY);
     }
 
     mChipEventQueue = xQueueCreate(CHIP_DEVICE_CONFIG_MAX_EVENT_QUEUE_SIZE, sizeof(ChipDeviceEvent));
     if (mChipEventQueue == NULL)
     {
-        ChipLogError(DeviceLayer, "Failed to allocate chip event queue");
+        ChipLogError(DeviceLayer, "Failed to allocate CHIP event queue");
         ExitNow(err = CHIP_ERROR_NO_MEMORY);
     }
 
@@ -97,7 +97,7 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_PostEvent(const ChipDevice
     {
         if (!xQueueSend(mChipEventQueue, event, 1))
         {
-            ChipLogError(DeviceLayer, "Failed to post event to chip Platform event queue");
+            ChipLogError(DeviceLayer, "Failed to post event to CHIP Platform event queue");
         }
     }
 }
@@ -113,14 +113,14 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_RunEventLoop(void)
     // Capture the task handle.
     mEventLoopTask = xTaskGetCurrentTaskHandle();
 
-    // Lock the chip stack.
+    // Lock the CHIP stack.
     Impl()->LockChipStack();
 
     while (true)
     {
         TickType_t waitTime;
 
-        // If one or more chip timers are active...
+        // If one or more CHIP timers are active...
         if (mChipTimerActive)
         {
             // Adjust the base time and remaining duration for the next scheduled timer based on the
@@ -137,7 +137,7 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_RunEventLoop(void)
                 err = SystemLayer.HandlePlatformTimer();
                 if (err != CHIP_SYSTEM_NO_ERROR)
                 {
-                    ChipLogError(DeviceLayer, "Error handling chip timers: %s", ErrorStr(err));
+                    ChipLogError(DeviceLayer, "Error handling CHIP timers: %s", ErrorStr(err));
                 }
 
                 // When processing the event queue below, do not wait if the queue is empty.  Instead
@@ -153,19 +153,19 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_RunEventLoop(void)
             }
         }
 
-        // Otherwise no chip timers are active, so wait indefinitely for an event to arrive on the event
+        // Otherwise no CHIP timers are active, so wait indefinitely for an event to arrive on the event
         // queue.
         else
         {
             waitTime = portMAX_DELAY;
         }
 
-        // Unlock the chip stack, allowing other threads to enter chip while the event loop thread is sleeping.
+        // Unlock the CHIP stack, allowing other threads to enter CHIP while the event loop thread is sleeping.
         Impl()->UnlockChipStack();
 
         BaseType_t eventReceived = xQueueReceive(mChipEventQueue, &event, waitTime);
 
-        // Lock the chip stack.
+        // Lock the CHIP stack.
         Impl()->LockChipStack();
 
         // If an event was received, dispatch it.  Continue receiving events from the queue and
@@ -197,7 +197,7 @@ CHIP_ERROR GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_StartEventLoopTask(v
 template<class ImplClass>
 void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::EventLoopTaskMain(void * arg)
 {
-    ChipLogDetail(DeviceLayer, "chip task running");
+    ChipLogDetail(DeviceLayer, "CHIP task running");
     static_cast<GenericPlatformManagerImpl_FreeRTOS<ImplClass>*>(arg)->Impl()->RunEventLoop();
 }
 
@@ -230,7 +230,7 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::PostEventFromISR(const Chip
     {
         if (!xQueueSendFromISR(mChipEventQueue, event, &yieldRequired))
         {
-            ChipLogError(DeviceLayer, "Failed to post event to chip Platform event queue");
+            ChipLogError(DeviceLayer, "Failed to post event to CHIP Platform event queue");
         }
     }
 }

--- a/src/include/platform/internal/GenericSoftwareUpdateManagerImpl.ipp
+++ b/src/include/platform/internal/GenericSoftwareUpdateManagerImpl.ipp
@@ -202,7 +202,7 @@ CHIP_ERROR GenericSoftwareUpdateManagerImpl<ImplClass>::PrepareQuery(void)
     err = imageQuery.version.init((uint8_t) firmwareRevLen, firmwareRev);
     SuccessOrExit(err);
 
-    // Locale is an optional field in the chip software update protocol. If one is not provided by the application,
+    // Locale is an optional field in the CHIP software update protocol. If one is not provided by the application,
     // then skip over and move to the next field.
     if (outParam.PrepareQuery.DesiredLocale != NULL)
     {
@@ -213,7 +213,7 @@ CHIP_ERROR GenericSoftwareUpdateManagerImpl<ImplClass>::PrepareQuery(void)
         ev.SetLocalePresent();
     }
 
-    // Package specification is an option field in the chip software update protocol. If one is not
+    // Package specification is an option field in the CHIP software update protocol. If one is not
     // provided by the application, skip and move to the next field.
     if (outParam.PrepareQuery.PackageSpecification != NULL)
     {
@@ -496,7 +496,7 @@ void GenericSoftwareUpdateManagerImpl<ImplClass>::HandleResponse(ExchangeContext
     self->mExchangeCtx = NULL;
 
     // We expect to receive one of two possible responses:
-    // 1. An ImageQueryResponse message under the chip software update profile indicating
+    // 1. An ImageQueryResponse message under the CHIP software update profile indicating
     //    an update might be available or
     // 2. A StatusReport indicating no software update available or a problem with the query.
     //

--- a/src/include/platform/nRF5/nRF5Config.h
+++ b/src/include/platform/nRF5/nRF5Config.h
@@ -64,7 +64,7 @@ public:
     static constexpr uint16_t kFDSRecordKeyMin                  = 0x0001; /**< Minimum value that can be used for a FDS record key (per Nordic SDK) */
     static constexpr uint16_t kFDSRecordKeyMax                  = 0xBFFF; /**< Maximum value that can be used for a FDS record key (per Nordic SDK) */
 
-    // FDS file ids used by the Openchip Device Layer
+    // FDS file ids used by the CHIP Device Layer
     static constexpr uint16_t kFileId_ChipFactory              = 0x235A; /**< FDS file containing persistent config values set at manufacturing time.
                                                                            *   Retained during factory reset. */
     static constexpr uint16_t kFileId_ChipConfig               = 0x235B; /**< FDS file containing dynamic config values set at runtime.
@@ -97,12 +97,12 @@ public:
     static constexpr Key kConfigKey_OperationalDeviceICACerts   = NRF5ConfigKey(kFileId_ChipConfig,  0x0013);
     static constexpr Key kConfigKey_OperationalDevicePrivateKey = NRF5ConfigKey(kFileId_ChipConfig,  0x0014);
 
-    // Range of FDS record keys used to store chip persisted counter values.
+    // Range of FDS record keys used to store CHIP persisted counter values.
     static constexpr uint16_t kPersistedCounterRecordKeyBase    = kFDSRecordKeyMin;
-                                                                          /**< Base record key for records containing chip persisted counter values.
-                                                                           *   The chip counter id is added to this value to form the FDS record key.*/
+                                                                          /**< Base record key for records containing CHIP persisted counter values.
+                                                                           *   The CHIP counter id is added to this value to form the FDS record key.*/
     static constexpr uint16_t kPersistedCounterRecordKeyMax     = kFDSRecordKeyMax;
-                                                                          /**< Max record key for records containing chip persisted counter values. */
+                                                                          /**< Max record key for records containing CHIP persisted counter values. */
 
     static CHIP_ERROR Init(void);
 

--- a/src/inet/AsyncDNSResolverSockets.cpp
+++ b/src/inet/AsyncDNSResolverSockets.cpp
@@ -95,7 +95,7 @@ INET_ERROR AsyncDNSResolverSockets::Shutdown(void)
 
     AsyncMutexUnlock();
 
-    // Have the chip thread join the thread pool for asynchronous DNS resolution.
+    // Have the CHIP thread join the thread pool for asynchronous DNS resolution.
     for (int i = 0; i < INET_CONFIG_DNS_ASYNC_MAX_THREAD_COUNT; i++)
     {
         pthreadErr = pthread_join(mAsyncDNSThreadHandle[i], NULL);
@@ -309,10 +309,10 @@ void AsyncDNSResolverSockets::DNSResultEventHandler(chip::System::Layer * aLayer
 
 void AsyncDNSResolverSockets::NotifyChipThread(DNSResolver * resolver)
 {
-    // Post work item via Timer Event for the chip thread
+    // Post work item via Timer Event for the CHIP thread
     chip::System::Layer & lSystemLayer = resolver->SystemLayer();
 
-    ChipLogDetail(Inet, "Posting DNS completion event to chip thread.");
+    ChipLogDetail(Inet, "Posting DNS completion event to CHIP thread.");
     lSystemLayer.ScheduleWork(AsyncDNSResolverSockets::DNSResultEventHandler, resolver);
 }
 

--- a/src/inet/TCPEndPoint.cpp
+++ b/src/inet/TCPEndPoint.cpp
@@ -193,14 +193,14 @@ INET_ERROR TCPEndPoint::Bind(IPAddressType addrType, IPAddress addr, uint16_t po
 
 #ifdef SO_REUSEPORT
         // Enable SO_REUSEPORT.  This permits coexistence between an
-        // untargetted chip client and other services that listen on
-        // a chip port on a specific address (such as a chip client
+        // untargetted CHIP client and other services that listen on
+        // a CHIP port on a specific address (such as a CHIP client
         // with TARGETTED_LISTEN or TCP proxying services).  Note that
         // one of the costs of this implementation is the
         // non-deterministic connection dispatch when multple clients
         // listen on the address wih the same degreee of selectivity,
-        // e.g. two untargetted-listen chip clients, or two
-        // targetted-listen chip clients with the same node id.
+        // e.g. two untargetted-listen CHIP clients, or two
+        // targetted-listen CHIP clients with the same node id.
 
         if (setsockopt(mSocket, SOL_SOCKET, SO_REUSEPORT, &n, sizeof(n)) != 0)
         {
@@ -408,7 +408,7 @@ INET_ERROR TCPEndPoint::Connect(IPAddress addr, uint16_t port, InterfaceId intf)
                 return res;
 
             // Attempt to bind to the interface using SO_BINDTODEVICE which requires privileged access.
-            // If the permission is denied(EACCES) because chip is running in a context
+            // If the permission is denied(EACCES) because CHIP is running in a context
             // that does not have privileged access, choose a source address on the
             // interface to bind the connetion to.
             int r = setsockopt(mSocket, SOL_SOCKET, SO_BINDTODEVICE, (void *) &ifr, sizeof(ifr));

--- a/src/inet/TunEndPoint.cpp
+++ b/src/inet/TunEndPoint.cpp
@@ -128,7 +128,7 @@ void TunEndPoint::Close(void)
     {
 
         // For LwIP, we do not remove the netif as it would have
-        // an impact on the interface iterator in chip which
+        // an impact on the interface iterator in CHIP which
         // might lose reference to a particular netif index that
         // it might be holding on to.
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
@@ -171,7 +171,7 @@ void TunEndPoint::Free()
  * @note
  *  This method performs a couple of minimal sanity checks on the packet to
  *  be sure it is IP version 6 then dispatches it for encapsulation in a
- *  chip tunneling message.
+ *  CHIP tunneling message.
  *
  * @param[in]   message     the IPv6 packet to send.
  *
@@ -553,7 +553,7 @@ err_t TunEndPoint::LwIPPostToInetEventQ(struct netif * netif, struct pbuf * p)
     PacketBuffer * buf                 = PacketBuffer::NewWithAvailableSize(p->tot_len);
 
     // Starting off with a reserved size of the default CHIP_SYSTEM_CONFIG_HEADER_RESERVE_SIZE
-    // which allows for adding the chip header and the underlying transport and IP headers
+    // which allows for adding the CHIP header and the underlying transport and IP headers
     // encapsulating this tunneled packet.
 
     VerifyOrExit(buf != NULL, lwipErr = ERR_MEM);

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -21,7 +21,7 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
-# Pull in the sources that comprise the Chip library.
+# Pull in the sources that comprise the CHIP library.
 
 include ../system/SystemLayer.am
 include ../inet/InetLayer.am

--- a/src/lib/support/CHIPFaultInjection.cpp
+++ b/src/lib/support/CHIPFaultInjection.cpp
@@ -17,7 +17,7 @@
 
 /**
  *    @file
- *      Implementation of the fault-injection utilities for chip.
+ *      Implementation of the fault-injection utilities for CHIP.
  */
 
 #include <string.h>
@@ -33,7 +33,7 @@ namespace FaultInjection {
 static nl::FaultInjection::Record sFaultRecordArray[kFault_NumItems];
 static int32_t sFault_WDMNotificationSize_Arguments[1];
 static int32_t sFault_FuzzExchangeHeader_Arguments[1];
-static class nl::FaultInjection::Manager schipFaultInMgr;
+static class nl::FaultInjection::Manager sChipFaultInMgr;
 static const nl::FaultInjection::Name sManagerName  = "chip";
 static const nl::FaultInjection::Name sFaultNames[] = {
     "AllocExchangeContext",
@@ -88,9 +88,9 @@ static const nl::FaultInjection::Name sFaultNames[] = {
  */
 nl::FaultInjection::Manager & GetManager(void)
 {
-    if (0 == schipFaultInMgr.GetNumFaults())
+    if (0 == sChipFaultInMgr.GetNumFaults())
     {
-        schipFaultInMgr.Init(kFault_NumItems, sFaultRecordArray, sManagerName, sFaultNames);
+        sChipFaultInMgr.Init(kFault_NumItems, sFaultRecordArray, sManagerName, sFaultNames);
         memset(&sFault_WDMNotificationSize_Arguments, 0, sizeof(sFault_WDMNotificationSize_Arguments));
         sFaultRecordArray[kFault_WDM_NotificationSize].mArguments = sFault_WDMNotificationSize_Arguments;
         sFaultRecordArray[kFault_WDM_NotificationSize].mLengthOfArguments =
@@ -101,11 +101,11 @@ nl::FaultInjection::Manager & GetManager(void)
         sFaultRecordArray[kFault_FuzzExchangeHeaderTx].mLengthOfArguments =
             static_cast<uint8_t>(sizeof(sFault_FuzzExchangeHeader_Arguments) / sizeof(sFault_FuzzExchangeHeader_Arguments[0]));
     }
-    return schipFaultInMgr;
+    return sChipFaultInMgr;
 }
 
 /**
- * Fuzz a byte of a chip Exchange Header
+ * Fuzz a byte of a CHIP Exchange Header
  *
  * @param[in] p     Pointer to the encoded Exchange Header
  * @param[in] arg   An index from 0 to (CHIP_FAULT_INJECTION_NUM_FUZZ_VALUES * 5 -1)
@@ -113,7 +113,7 @@ nl::FaultInjection::Manager & GetManager(void)
  */
 DLL_EXPORT void FuzzExchangeHeader(uint8_t * p, int32_t arg)
 {
-    // chip is little endian; this function alters the
+    // CHIP is little endian; this function alters the
     // least significant byte of the header fields.
     const uint8_t offsets[] = {
         0, // flags and version

--- a/src/platform/EFR32/BLEManagerImpl.cpp
+++ b/src/platform/EFR32/BLEManagerImpl.cpp
@@ -128,7 +128,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
     CHIP_ERROR err;
     errorcode_t ret;
 
-    // Initialize the Chip BleLayer.
+    // Initialize the CHIP BleLayer.
     err = BleLayer::Init(this, this, &SystemLayer);
     SuccessOrExit(err);
 
@@ -193,7 +193,7 @@ void BLEManagerImpl::bluetoothStackEventHandler(void *p_arg)
             flags &= ~BLUETOOTH_EVENT_FLAG_EVT_WAITING;
             xEventGroupClearBits(bluetooth_event_flags, BLUETOOTH_EVENT_FLAG_EVT_WAITING);
 
-            // As this is running in a separate thread, we need to block Chip from operating,
+            // As this is running in a separate thread, we need to block CHIP from operating,
             // until the events are handled.
             PlatformMgr().LockChipStack();
 
@@ -785,7 +785,7 @@ void BLEManagerImpl::HandleTXCharCCCDWrite(volatile struct gecko_cmd_packet *evt
         if (!bleConnState->subscribed)
         {
             bleConnState->subscribed = 1;
-            // Post an event to the Chip queue to process either a WoBLE Subscribe or Unsubscribe based on
+            // Post an event to the CHIP queue to process either a WoBLE Subscribe or Unsubscribe based on
             // whether the client is enabling or disabling indications.
             {
                 event.Type                 = DeviceEventType::kWoBLESubscribe;
@@ -827,7 +827,7 @@ void BLEManagerImpl::HandleRXCharWrite(volatile struct gecko_cmd_packet *evt)
                    "Write request/command received for WoBLE RX characteristic (con %" PRIu16 ", len %" PRIu16 ")",
                    evt->data.evt_gatt_server_user_write_request.connection, buf->DataLength());
 
-    // Post an event to the Chip queue to deliver the data into the Chip stack.
+    // Post an event to the CHIP queue to deliver the data into the CHIP stack.
     {
         ChipDeviceEvent event;
         event.Type                     = DeviceEventType::kWoBLEWriteReceived;

--- a/src/platform/EFR32/ConfigurationManagerImpl.cpp
+++ b/src/platform/EFR32/ConfigurationManagerImpl.cpp
@@ -37,7 +37,7 @@ using namespace ::chip::DeviceLayer::Internal;
 
 namespace {
 
-// Singleton instance of Chip Group Key Store.
+// Singleton instance of CHIP Group Key Store.
 GroupKeyStoreImpl gGroupKeyStore;
 
 } // unnamed namespace
@@ -104,7 +104,7 @@ CHIP_ERROR ConfigurationManagerImpl::_ReadPersistedStorageValue(
     ::chip::Platform::PersistedStorage::Key persistedStorageKey,
     uint32_t &                                   value)
 {
-    // This method reads Chip Persisted Counter type nvm3 objects.
+    // This method reads CHIP Persisted Counter type nvm3 objects.
     // (where persistedStorageKey represents an index to the counter).
     CHIP_ERROR err;
 
@@ -123,7 +123,7 @@ CHIP_ERROR ConfigurationManagerImpl::_WritePersistedStorageValue(
     ::chip::Platform::PersistedStorage::Key persistedStorageKey,
     uint32_t                                     value)
 {
-    // This method reads Chip Persisted Counter type nvm3 objects.
+    // This method reads CHIP Persisted Counter type nvm3 objects.
     // (where persistedStorageKey represents an index to the counter).
     CHIP_ERROR err;
 

--- a/src/platform/EFR32/EFR32Config.cpp
+++ b/src/platform/EFR32/EFR32Config.cpp
@@ -46,7 +46,7 @@ namespace Internal {
     static nvm3_CacheEntry_t name##_cache[cacheSize];                   \
     static uint8_t           name##_nvm[nvmSize] SL_ATTRIBUTE_SECTION(STRINGIZE(name##_section))
 
-// Local version of SDK macro (allows Chip to configure the maximum nvm3 object size and headroom).
+// Local version of SDK macro (allows CHIP to configure the maximum nvm3 object size and headroom).
 #define CHIP_NVM3_DEFINE_SECTION_INIT_DATA(name, maxObjectSize, repackHeadroom) \
     static nvm3_Init_t name = {                                                  \
         (nvm3_HalPtr_t)name##_nvm,                                               \
@@ -514,7 +514,7 @@ CHIP_ERROR EFR32Config::FactoryResetConfig(void)
 
     CHIP_ERROR err;
 
-    // Iterate over all the Chip Config nvm3 records and delete each one...
+    // Iterate over all the CHIP Config nvm3 records and delete each one...
     err = ForEachRecord(kMinConfigKey_ChipConfig, kMaxConfigKey_ChipConfig, false,
                         [](const Key &nvm3Key, const size_t &length) -> CHIP_ERROR {
                             CHIP_ERROR err2;
@@ -609,7 +609,7 @@ exit:
 
 bool EFR32Config::ValidConfigKey(Key key)
 {
-    // Returns true if the key is in the valid Chip Config nvm3 key range.
+    // Returns true if the key is in the valid CHIP Config nvm3 key range.
 
     if ((key >= kMinConfigKey_ChipFactory) && (key <= kMaxConfigKey_ChipCounter))
     {

--- a/src/platform/EFR32/GroupKeyStoreImpl.cpp
+++ b/src/platform/EFR32/GroupKeyStoreImpl.cpp
@@ -17,7 +17,7 @@
 
 /**
  *    @file
- *          Provides an implementation of the Chip GroupKeyStore interface
+ *          Provides an implementation of the CHIP GroupKeyStore interface
  *          for platforms based on the Silicon Labs SDK.
  */
 
@@ -47,7 +47,7 @@ CHIP_ERROR GroupKeyStoreImpl::RetrieveGroupKey(uint32_t keyId, ChipGroupKey &key
                             // Read the nvm3 obj binary data data into the buffer.
                             err2 = ReadConfigValueBin(nvm3Key, buf, sizeof(buf), keyLen);
 
-                            // Decode the Chip key id for the current key.
+                            // Decode the CHIP key id for the current key.
                             err2 = DecodeGroupKeyId(buf, keyLen, curKeyId);
                             SuccessOrExit(err2);
 
@@ -176,7 +176,7 @@ CHIP_ERROR GroupKeyStoreImpl::DeleteGroupKey(uint32_t keyId)
                             err2 = ReadConfigValueBin(nvm3Key, buf, sizeof(buf), keyLen);
                             SuccessOrExit(err2);
 
-                            // Decode the Chip key id for the current group key.
+                            // Decode the CHIP key id for the current group key.
                             err2 = DecodeGroupKeyId(buf, keyLen, curKeyId);
                             SuccessOrExit(err2);
 
@@ -226,7 +226,7 @@ CHIP_ERROR GroupKeyStoreImpl::DeleteGroupKeysOfAType(uint32_t keyType)
                             err2 = ReadConfigValueBin(nvm3Key, buf, sizeof(buf), keyLen);
                             SuccessOrExit(err2);
 
-                            // Decode the Chip key id for the current group key.
+                            // Decode the CHIP key id for the current group key.
                             err2 = DecodeGroupKeyId(buf, keyLen, curKeyId);
                             SuccessOrExit(err2);
 
@@ -266,7 +266,7 @@ CHIP_ERROR GroupKeyStoreImpl::EnumerateGroupKeys(uint32_t  keyType,
             err2 = ReadConfigValueBin(nvm3Key, buf, sizeof(buf), keyLen);
             SuccessOrExit(err2);
 
-            // Decode the Chip key id for the current group key.
+            // Decode the CHIP key id for the current group key.
             err2 = DecodeGroupKeyId(buf, keyLen, curKeyId);
             SuccessOrExit(err2);
 

--- a/src/platform/EFR32/Logging.cpp
+++ b/src/platform/EFR32/Logging.cpp
@@ -17,7 +17,7 @@
 
 /**
  *    @file
- *          Provides implementations for the OpenChip and LwIP logging
+ *          Provides implementations for the CHIP and LwIP logging
  *          functions on Silicon Labs EFR32 platforms.
  *
  *          Logging should be initialized by a call to efr32LogInit().  A
@@ -161,7 +161,7 @@ namespace chip {
 namespace Logging {
 
 /**
- * OpenChip log output function.
+ * CHIP log output function.
  */
 void Log(uint8_t module, uint8_t category, const char *aFormat, ...)
 {

--- a/src/platform/nRF5/BLEManagerImpl.cpp
+++ b/src/platform/nRF5/BLEManagerImpl.cpp
@@ -93,7 +93,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
         mSubscribedConIds[i] = BLE_CONNECTION_UNINITIALIZED;
     }
 
-    // Initialize the chip BleLayer.
+    // Initialize the CHIP BleLayer.
     err = BleLayer::Init(this, this, &SystemLayer);
     SuccessOrExit(err);
 
@@ -394,7 +394,7 @@ void BLEManagerImpl::DriveBLEState(void)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    // Perform any initialization actions that must occur after the chip task is running.
+    // Perform any initialization actions that must occur after the CHIP task is running.
     if (!GetFlag(mFlags, kFlag_AsyncInitCompleted))
     {
         SetFlag(mFlags, kFlag_AsyncInitCompleted);
@@ -520,7 +520,7 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
 
 #endif // CHIP_PROGRESS_LOGGING
 
-    // Configure an "advertising set" in the BLE soft device with the data and parameters for chip advertising.
+    // Configure an "advertising set" in the BLE soft device with the data and parameters for CHIP advertising.
     // If the advertising set doesn't exist, this call will create it and return its handle.
     err = sd_ble_gap_adv_set_configure(&mAdvHandle, &gapAdvData, &gapAdvParams);
     if (err != CHIP_NO_ERROR)
@@ -619,7 +619,7 @@ CHIP_ERROR BLEManagerImpl::EncodeAdvertisingData(ble_gap_adv_data_t & gapAdvData
     err = ble_advdata_encode(&advData, mAdvDataBuf, &gapAdvData.adv_data.len);
     SuccessOrExit(err);
 
-    // Initialize the chip BLE Device Identification Information block that will be sent as payload
+    // Initialize the CHIP BLE Device Identification Information block that will be sent as payload
     // within the BLE service advertisement data.
     err = ConfigurationMgr().GetBLEDeviceIdentificationInfo(deviceIdInfo);
     SuccessOrExit(err);
@@ -764,7 +764,7 @@ void BLEManagerImpl::SoftDeviceBLEEventCallback(const ble_evt_t * bleEvent, void
             memcpy(buf->Start(), bleEvent->evt.gatts_evt.params.write.data, valLen);
             buf->SetDataLength(valLen);
 
-            // Arrange to post a CHIPoBLERXWriteEvent event to the chip queue.
+            // Arrange to post a CHIPoBLERXWriteEvent event to the CHIP queue.
             event.Type = DeviceEventType::kCHIPoBLERXCharWriteEvent;
             event.Platform.RXCharWriteEvent.ConId = bleEvent->evt.gatts_evt.conn_handle;
             event.Platform.RXCharWriteEvent.WriteArgs = bleEvent->evt.gatts_evt.params.write;
@@ -783,10 +783,10 @@ void BLEManagerImpl::SoftDeviceBLEEventCallback(const ble_evt_t * bleEvent, void
         // Ignore any events that are larger than a particular size.
         //
         // With the exception of GATT write events to the CHIPoBLE RX characteristic, which are handled above,
-        // all BLE events that chip is interested are of a limited size, roughly equal to sizeof(ble_evt_t)
+        // all BLE events that CHIP is interested are of a limited size, roughly equal to sizeof(ble_evt_t)
         // plus a couple of bytes of payload data.  Any event that is larger than this size and not handled
         // above must represent an event related to some *other* user of the BLE SoftDevice and therefore
-        // can be safely ignored by chip.
+        // can be safely ignored by CHIP.
         VerifyOrExit(bleEvent->header.evt_len <= sizeof(event.Platform.SoftDeviceBLEEvent), /**/);
 
         // Ignore any write event for anything *other* than the CHIPoBLE TX CCCD value.
@@ -798,7 +798,7 @@ void BLEManagerImpl::SoftDeviceBLEEventCallback(const ble_evt_t * bleEvent, void
         memcpy(&event.Platform.SoftDeviceBLEEvent.EventData, bleEvent, bleEvent->header.evt_len);
     }
 
-    // Post the event to the chip queue.
+    // Post the event to the CHIP queue.
 #if (NRF_SDH_DISPATCH_MODEL == NRF_SDH_DISPATCH_MODEL_INTERRUPT)
     BaseType_t yieldRequired;
     PlatformMgrImpl().PostEventFromISR(&event, yieldRequired);

--- a/src/platform/nRF5/ConfigurationManagerImpl.cpp
+++ b/src/platform/nRF5/ConfigurationManagerImpl.cpp
@@ -43,7 +43,7 @@ using namespace ::chip::DeviceLayer::Internal;
 
 namespace {
 
-// Singleton instance of chip Group Key Store.
+// Singleton instance of CHIP Group Key Store.
 GroupKeyStoreImpl gGroupKeyStore;
 
 } // unnamed namespace

--- a/src/platform/nRF5/ConnectivityManagerImpl.cpp
+++ b/src/platform/nRF5/ConnectivityManagerImpl.cpp
@@ -65,7 +65,7 @@ CHIP_ERROR ConnectivityManagerImpl::_Init()
     GenericConnectivityManagerImpl_Thread<ConnectivityManagerImpl>::_Init();
 #endif
 
-    // Initialize the chip Addressing and Routing Module.
+    // Initialize the CHIP Addressing and Routing Module.
     err = Warm::Init(FabricState);
     SuccessOrExit(err);
 

--- a/src/platform/nRF5/GroupKeyStoreImpl.cpp
+++ b/src/platform/nRF5/GroupKeyStoreImpl.cpp
@@ -17,7 +17,7 @@
 
 /**
  *    @file
- *          Provides an implementation of the chip GroupKeyStore interface
+ *          Provides an implementation of the CHIP GroupKeyStore interface
  *          for platforms based on the Nordic nRF5 SDK.
  */
 
@@ -44,7 +44,7 @@ CHIP_ERROR GroupKeyStoreImpl::RetrieveGroupKey(uint32_t keyId, ChipGroupKey & ke
                   uint32_t curKeyId;
                   CHIP_ERROR err2 = CHIP_NO_ERROR;
 
-                  // Decode the chip key id for the current key.
+                  // Decode the CHIP key id for the current key.
                   err2 = DecodeGroupKeyId((const uint8_t *)rec.p_data, rec.p_header->length_words * kFDSWordSize, curKeyId);
                   SuccessOrExit(err2);
 
@@ -158,7 +158,7 @@ CHIP_ERROR GroupKeyStoreImpl::DeleteGroupKey(uint32_t keyId)
                   uint32_t curKeyId;
                   CHIP_ERROR err2;
 
-                  // Decode the chip key id for the current group key.
+                  // Decode the CHIP key id for the current group key.
                   err2 = DecodeGroupKeyId((const uint8_t *)rec.p_data, rec.p_header->length_words * kFDSWordSize, curKeyId);
                   SuccessOrExit(err2);
 
@@ -191,7 +191,7 @@ CHIP_ERROR GroupKeyStoreImpl::DeleteGroupKeysOfAType(uint32_t keyType)
                   uint32_t curKeyId;
                   CHIP_ERROR err2;
 
-                  // Decode the chip key id for the current group key.
+                  // Decode the CHIP key id for the current group key.
                   err2 = DecodeGroupKeyId((const uint8_t *)rec.p_data, rec.p_header->length_words * kFDSWordSize, curKeyId);
                   SuccessOrExit(err2);
 
@@ -228,7 +228,7 @@ CHIP_ERROR GroupKeyStoreImpl::EnumerateGroupKeys(uint32_t keyType, uint32_t * ke
                   uint32_t curKeyId;
                   CHIP_ERROR err2 = CHIP_NO_ERROR;
 
-                  // Decode the chip key id for the current key.
+                  // Decode the CHIP key id for the current key.
                   err2 = DecodeGroupKeyId((const uint8_t *)rec.p_data, rec.p_header->length_words * kFDSWordSize, curKeyId);
                   SuccessOrExit(err2);
 

--- a/src/platform/nRF5/nRF5Config.cpp
+++ b/src/platform/nRF5/nRF5Config.cpp
@@ -712,7 +712,7 @@ void NRF5Config::HandleFDSEvent(const fds_evt_t * fdsEvent)
     // Mark the operation as complete.
     sActiveAsyncOp = NULL;
 
-    // Signal the chip thread that the operation has completed.
+    // Signal the CHIP thread that the operation has completed.
 #if defined(SOFTDEVICE_PRESENT) && SOFTDEVICE_PRESENT
 
     // When using the Nodic SoftDevice, HandleFDSEvent() is called in a SoftDevice interrupt


### PR DESCRIPTION
 #### Problem
Code has mixed use of `Chip`, `CHIP` and `chip` in the comments

 #### Summary of Changes
Use `CHIP` in comments.
