### PR TITLE
Add support for platform layer to build

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,6 +22,15 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
+MAYBE_PLATFORM_SUBDIRS          = \
+    $(NULL)
+
+if CONFIG_DEVICE_LAYER
+MAYBE_PLATFORM_SUBDIRS         += \
+    platform                      \
+    $(NULL)
+endif # CONFIG_DEVICE_LAYER
+
 # Always package (e.g. for 'make dist') these subdirectories.
 
 DIST_SUBDIRS                      = \
@@ -31,6 +40,7 @@ DIST_SUBDIRS                      = \
     lwip                            \
     setup_payload                   \
     system                          \
+    $(MAYBE_PLATFORM_SUBDIRS)       \
     $(NULL)
 
 # Always build (e.g. for 'make all') these subdirectories.
@@ -41,6 +51,7 @@ SUBDIRS                           = \
     lwip                            \
     setup_payload                   \
     system                          \
+    $(MAYBE_PLATFORM_SUBDIRS)       \
     $(NULL)
 
 if CONFIG_NETWORK_LAYER_BLE


### PR DESCRIPTION
 #### Problem
Platform Layer is not included in any top level Makefiles and so is never invoked.
 #### Summary of Changes
Add support to optionally include the platform layer in a build.

