### PR TITLE
Groom SetupPayload

### DIFF
--- a/src/setup_payload/Makefile.am
+++ b/src/setup_payload/Makefile.am
@@ -30,12 +30,9 @@ lib_LIBRARIES              = libQrCode.a
 libQrCode_adir             = $(includedir)/setup_payload
 
 libQrCode_a_CPPFLAGS                                      = \
-    -I$(top_srcdir)/src                                     \
-    -I$(top_srcdir)/src/include                             \
-    -I$(top_srcdir)/src/setup_payload                       \
     $(NULL)
 
-libQrCode_a_SOURCES =                                       \
+libQrCode_a_SOURCES                                       = \
     QRCodeSetupPayloadGenerator.cpp                         \
     SetupCodeUtils.cpp                                      \
     SetupPayload.cpp                                        \

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -71,7 +71,7 @@ string QRCodeSetupPayloadGenerator::payloadBinaryRepresentation()
 {
     if (mPayload.isValid())
     {
-        uint8_t bits[kTotalPayloadDataSizeInBits / 8] = { 0 };
+        uint8_t bits[kTotalPayloadDataSizeInBytes] = { 0 };
 
         generateBitSet(mPayload, bits);
 
@@ -93,7 +93,7 @@ string QRCodeSetupPayloadGenerator::payloadBase45Representation()
 {
     if (mPayload.isValid())
     {
-        uint8_t bits[kTotalPayloadDataSizeInBits / 8] = { 0 };
+        uint8_t bits[kTotalPayloadDataSizeInBytes] = { 0 };
 
         generateBitSet(mPayload, bits);
 

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -26,7 +26,6 @@
 #include "SetupCodeUtils.h"
 
 #include <iostream>
-
 #include <stdlib.h>
 
 using namespace chip;

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -26,164 +26,78 @@
 #include "SetupCodeUtils.h"
 
 #include <iostream>
-#include <vector>
 
 #include <stdlib.h>
 
 using namespace chip;
 using namespace std;
 
-void QRCodeSetupPayloadGenerator::resetBitSet()
+// Populates numberOfBits starting from LSB of input into bits, which is assumed to be zero-initialized
+void populateBits(uint8_t * bits, int & offset, uint64_t input, size_t numberOfBits)
 {
-    mPayloadBitsIndex = kTotalPayloadDataSizeInBits;
-    mPayloadBits.reset();
-}
-
-// Populates numberOfBits starting from LSB of input into mPayloadBits
-void QRCodeSetupPayloadGenerator::populateInteger(uint64_t input, size_t numberOfBits)
-{
-    if (mPayloadBitsIndex < numberOfBits || input >= 1 << numberOfBits)
+    if (offset + numberOfBits > kTotalPayloadDataSizeInBits || input >= 1 << numberOfBits)
     {
         abort();
     }
-    mPayloadBitsIndex -= numberOfBits;
-    int currentIndex = mPayloadBitsIndex;
 
-    int endIndex = currentIndex + (numberOfBits - 1);
-
-    while (currentIndex <= endIndex)
+    int index = offset;
+    offset += numberOfBits;
+    while (input != 0)
     {
-        input & 1 ? mPayloadBits.set(currentIndex) : mPayloadBits.reset(currentIndex);
-        currentIndex++;
-        input /= 2;
+        if (input & 1)
+        {
+            bits[index / 8] |= 1 << index % 8;
+        }
+        index++;
+        input >>= 1;
     }
 }
 
-void QRCodeSetupPayloadGenerator::populateVersion()
+void generateBitSet(SetupPayload & payload, uint8_t * bits)
 {
-    populateInteger(mPayload.version, kVersionFieldLengthInBits);
-}
+    int offset = 0;
 
-void QRCodeSetupPayloadGenerator::populateVendorID()
-{
-    populateInteger(mPayload.vendorID, kVendorIDFieldLengthInBits);
-}
-
-void QRCodeSetupPayloadGenerator::populateProductID()
-{
-    populateInteger(mPayload.productID, kProductIDFieldLengthInBits);
-}
-
-void QRCodeSetupPayloadGenerator::populateCustomFlowRequiredField()
-{
-    populateInteger(mPayload.requiresCustomFlow, kCustomFlowRequiredFieldLengthInBits);
-}
-
-void QRCodeSetupPayloadGenerator::populateRendezvousInfo()
-{
-    populateInteger(mPayload.rendezvousInformation, kRendezvousInfoFieldLengthInBits);
-}
-
-void QRCodeSetupPayloadGenerator::populateDiscriminator()
-{
-    populateInteger(mPayload.discriminator, kPayloadDiscriminatorFieldLengthInBits);
-}
-
-void QRCodeSetupPayloadGenerator::populateSetupPIN()
-{
-    populateInteger(mPayload.setUpPINCode, kSetupPINCodeFieldLengthInBits);
-}
-
-void QRCodeSetupPayloadGenerator::populateReservedField()
-{
-    populateInteger(0, kReservedFieldLengthInBits);
-}
-
-void QRCodeSetupPayloadGenerator::generateBitSet()
-{
-    resetBitSet();
-    populateVersion();
-    populateVendorID();
-    populateProductID();
-    populateCustomFlowRequiredField();
-    populateRendezvousInfo();
-    populateDiscriminator();
-    populateSetupPIN();
-    populateReservedField();
+    populateBits(bits, offset, payload.version, kVersionFieldLengthInBits);
+    populateBits(bits, offset, payload.vendorID, kVendorIDFieldLengthInBits);
+    populateBits(bits, offset, payload.productID, kProductIDFieldLengthInBits);
+    populateBits(bits, offset, payload.requiresCustomFlow, kCustomFlowRequiredFieldLengthInBits);
+    populateBits(bits, offset, payload.rendezvousInformation, kRendezvousInfoFieldLengthInBits);
+    populateBits(bits, offset, payload.discriminator, kPayloadDiscriminatorFieldLengthInBits);
+    populateBits(bits, offset, payload.setUpPINCode, kSetupPINCodeFieldLengthInBits);
+    populateBits(bits, offset, 0, kReservedFieldLengthInBits);
 }
 
 string QRCodeSetupPayloadGenerator::payloadBinaryRepresentation()
 {
     if (mPayload.isValid())
     {
-        generateBitSet();
-        return mPayloadBits.to_string();
+        uint8_t bits[kTotalPayloadDataSizeInBits / 8] = { 0 };
+
+        generateBitSet(mPayload, bits);
+
+        string binary;
+        for (int i = sizeof(bits) / sizeof(bits[0]) - 1; i >= 0; i--)
+        {
+            for (int j = 1 << 8; j != 0;)
+            {
+                j >>= 1;
+                binary += bits[i] & j ? "1" : "0";
+            }
+        }
+        return binary;
     }
     return string();
-}
-
-// This function assumes bits.size() % 8 == 0
-// TODO: Can this method be written in a more elegant way?
-vector<uint16_t> arrayFromBits(bitset<kTotalPayloadDataSizeInBits> bits)
-{
-    vector<uint16_t> resultVector;
-    size_t numberOfBits  = bits.size();
-    size_t numberOfBytes = numberOfBits / 8;
-    bool oddNumOfBytes   = (numberOfBytes % 2) ? true : false;
-
-    // Traversing in reverse, hence startIndex > endIndex
-    int endIndex   = 0;
-    int startIndex = bits.size() - 1;
-
-    /*
-    Every 2 bytes (16 bits) of binary source data are encoded to 3 characters of the Base-45 alphabet.
-    If an odd number of bytes are to be encoded, the remaining single byte will be encoded
-    to 2 characters of the Base-45 alphabet.
-    */
-    if (oddNumOfBytes)
-    {
-        endIndex = 8;
-    }
-
-    while (startIndex > endIndex)
-    {
-        int currentIntegerIndex = startIndex;
-        uint16_t result         = 0;
-        for (int i = currentIntegerIndex; i > currentIntegerIndex - 16; i--)
-        {
-            result = result << 1;
-            result = result | bits.test(i);
-        }
-        resultVector.push_back(result);
-        startIndex -= 16;
-    }
-
-    // If we have odd number of bytes append the last byte.
-    if (oddNumOfBytes)
-    {
-        uint16_t result = 0;
-        for (int i = 7; i >= 0; i--)
-        {
-            result = result << 1;
-            result = result & bits.test(i);
-        }
-        resultVector.push_back(result);
-    }
-    return resultVector;
 }
 
 string QRCodeSetupPayloadGenerator::payloadBase45Representation()
 {
     if (mPayload.isValid())
     {
-        generateBitSet();
-        vector<uint16_t> integerArray = arrayFromBits(mPayloadBits);
-        string result;
-        for (int idx = 0; idx < integerArray.size(); idx++)
-        {
-            result += base45EncodedString(integerArray[idx], 3);
-        }
-        return result;
+        uint8_t bits[kTotalPayloadDataSizeInBits / 8] = { 0 };
+
+        generateBitSet(mPayload, bits);
+
+        return base45Encode(bits, sizeof(bits) / sizeof(bits[0]));
     }
     return string();
 }

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -78,7 +78,7 @@ string QRCodeSetupPayloadGenerator::payloadBinaryRepresentation()
         string binary;
         for (int i = sizeof(bits) / sizeof(bits[0]) - 1; i >= 0; i--)
         {
-            for (int j = 1 << 8; j != 0;)
+            for (unsigned j = 1 << 8; j != 0;)
             {
                 j >>= 1;
                 binary += bits[i] & j ? "1" : "0";

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -32,7 +32,7 @@ using namespace chip;
 using namespace std;
 
 // Populates numberOfBits starting from LSB of input into bits, which is assumed to be zero-initialized
-void populateBits(uint8_t * bits, int & offset, uint64_t input, size_t numberOfBits)
+static void populateBits(uint8_t * bits, int & offset, uint64_t input, size_t numberOfBits)
 {
     if (offset + numberOfBits > kTotalPayloadDataSizeInBits || input >= 1 << numberOfBits)
     {
@@ -52,7 +52,7 @@ void populateBits(uint8_t * bits, int & offset, uint64_t input, size_t numberOfB
     }
 }
 
-void generateBitSet(SetupPayload & payload, uint8_t * bits)
+static void generateBitSet(SetupPayload & payload, uint8_t * bits)
 {
     int offset = 0;
 

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -34,9 +34,10 @@ using namespace std;
 // Populates numberOfBits starting from LSB of input into bits, which is assumed to be zero-initialized
 static void populateBits(uint8_t * bits, int & offset, uint64_t input, size_t numberOfBits)
 {
+    // do nothing in the case where we've overflowed. should never happen
     if (offset + numberOfBits > kTotalPayloadDataSizeInBits || input >= 1 << numberOfBits)
     {
-        abort();
+        return;
     }
 
     int index = offset;

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.h
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.h
@@ -41,22 +41,7 @@ namespace chip {
 class QRCodeSetupPayloadGenerator
 {
 private:
-    bitset<kTotalPayloadDataSizeInBits> mPayloadBits;
     SetupPayload mPayload;
-    // points to the current index within the bitset
-    int mPayloadBitsIndex;
-
-    void populateInteger(uint64_t input, size_t numberOfBits);
-    void populateVersion();
-    void populateVendorID();
-    void populateProductID();
-    void populateCustomFlowRequiredField();
-    void populateRendezvousInfo();
-    void populateDiscriminator();
-    void populateSetupPIN();
-    void populateReservedField();
-    void resetBitSet();
-    void generateBitSet();
 
 public:
     string payloadBinaryRepresentation();

--- a/src/setup_payload/SetupCodeUtils.cpp
+++ b/src/setup_payload/SetupCodeUtils.cpp
@@ -17,40 +17,150 @@
 
 /**
  *    @file
- *      This file implements converting an input into a Base45 String
+ *      This file implements converting an array of butes into a Base45 String
  *
  */
 
 #include "SetupCodeUtils.h"
 
-#include <string>
-#include <algorithm>
-
 using namespace std;
 
 namespace chip {
 
-char base45CharacterSet[45] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E',
-                                'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
-                                'U', 'V', 'W', 'X', 'Y', 'Z', ' ', '$', '%', '*', '+', '-', '.', '/', ':' };
-
-string base45EncodedString(uint64_t input, size_t minLength)
+string base45Encode(const uint8_t * buf, size_t buf_len)
 {
+    const char codes[] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E',
+                           'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
+                           'U', 'V', 'W', 'X', 'Y', 'Z', ' ', '$', '%', '*', '+', '-', '.', '/', ':' };
+
     string result;
-    int radix = 45;
-    do
-    {
-        char base45char = base45CharacterSet[input % radix];
-        result += base45char;
-        input = input / radix;
-    } while (input != 0);
+    int radix = sizeof(codes) / sizeof(codes[0]);
 
-    while (result.length() < minLength)
+    while (buf_len >= 2)
     {
-        result.append("0");
+        int next = buf[0] + buf[1] * 256;
+
+        for (int _ = 0; _ < 3; _++)
+        {
+            result += codes[next % radix];
+            next /= radix;
+        }
+        buf += 2;
+        buf_len -= 2;
     }
+    if (buf_len != 0)
+    {
+        int next = buf[0];
+        for (int _ = 0; _ < 2; _++)
+        {
+            result += codes[next % radix];
+            next /= radix;
+        }
+    }
+    return result;
+}
 
-    reverse(result.begin(), result.end());
+vector<uint8_t> base45Decode(string base45)
+{
+    // not long enough
+    if (base45.length() < 2)
+    {
+        return vector<uint8_t>();
+    }
+#define BOGUS 255
+    // subtract 32 from the charater, then index into this array, if possible
+    const uint8_t decodes[] = {
+        36,    // ' ', =32
+        BOGUS, // '!', =33
+        BOGUS, // '"', =34
+        BOGUS, // '#', =35
+        37,    // '$', =36
+        38,    // '%', =37
+        BOGUS, // '&', =38
+        BOGUS, // ''', =39
+        BOGUS, // '(', =40
+        BOGUS, // ')', =41
+        39,    // '*', =42
+        40,    // '+', =43
+        BOGUS, // ',', =44
+        41,    // '-', =45
+        42,    // '.', =46
+        43,    // '/', =47
+        0,     // '0', =48
+        1,     // '1', =49
+        2,     // '2', =50
+        3,     // '3', =51
+        4,     // '4', =52
+        5,     // '5', =53
+        6,     // '6', =54
+        7,     // '7', =55
+        8,     // '8', =56
+        9,     // '9', =57
+        44,    // ':', =58
+        BOGUS, // ';', =59
+        BOGUS, // '<', =50
+        BOGUS, // '=', =61
+        BOGUS, // '>', =62
+        BOGUS, // '?', =63
+        BOGUS, // '@', =64
+        10,    // 'A', =65
+        11,    // 'B', =66
+        12,    // 'C', =67
+        13,    // 'D', =68
+        14,    // 'E', =69
+        15,    // 'F', =70
+        16,    // 'G', =71
+        17,    // 'H', =72
+        18,    // 'I', =73
+        19,    // 'J', =74
+        20,    // 'K', =75
+        21,    // 'L', =76
+        22,    // 'M', =77
+        23,    // 'N', =78
+        24,    // 'O', =79
+        25,    // 'P', =80
+        26,    // 'Q', =81
+        27,    // 'R', =82
+        28,    // 'S', =83
+        29,    // 'T', =84
+        30,    // 'U', =85
+        31,    // 'V', =86
+        32,    // 'W', =87
+        33,    // 'X', =88
+        34,    // 'Y', =89
+        35,    // 'Z', =90
+    };
+    vector<uint8_t> result;
+
+#define DECODE_FAIL(c, v) ((c) < ' ' || (c) > 'Z' || ((v) = decodes[(c) - ' ']) == BOGUS)
+
+    for (int i = 0; base45.length() - i >= 3; i += 3)
+    {
+        uint8_t v0 = 0, v1 = 0, v2 = 0;
+
+        if (DECODE_FAIL(base45[i], v0) || DECODE_FAIL(base45[i + 1], v1) || DECODE_FAIL(base45[i + 2], v2))
+        {
+            return vector<uint8_t>();
+        }
+
+        uint16_t value = v0 + v1 * 45 + v2 * 45 * 45;
+
+        result.push_back(value & 255);
+        result.push_back(value / 255);
+    }
+    if (base45.length() % 3 == 2)
+    {
+        int i      = base45.length() - 2;
+        uint8_t v0 = 0, v1 = 0;
+        if (DECODE_FAIL(base45[i], v0) || DECODE_FAIL(base45[i + 1], v1))
+        {
+            return vector<uint8_t>();
+        }
+
+        uint8_t value = v0 + v1 * 45;
+
+        result.push_back(value);
+    }
     return result;
 }
 

--- a/src/setup_payload/SetupCodeUtils.cpp
+++ b/src/setup_payload/SetupCodeUtils.cpp
@@ -21,7 +21,7 @@
  *       the reverse.
  *
  *      The encoding chosen is: treat every 2 bytes of input data as a little-endian
- *        uint16_t, then div and mod hat into 3 base45 characters, with the least-significant
+ *        uint16_t, then div and mod that into 3 base45 characters, with the least-significant
  *        encoding bits in the first character of the resulting string.  If an odd
  *        number of bytes is encoded, 2 characters are used to encode the last byte.
  *

--- a/src/setup_payload/SetupCodeUtils.h
+++ b/src/setup_payload/SetupCodeUtils.h
@@ -23,14 +23,16 @@
 #ifndef _SETUP_CODE_UTILS_H_
 #define _SETUP_CODE_UTILS_H_
 
-#include <string>
 #include <stdint.h>
+#include <string>
+#include <vector>
 
 using namespace std;
 
 namespace chip {
 
-std::string base45EncodedString(uint64_t input, size_t minLength);
+vector<uint8_t> base45Decode(string base45);
+string base45Encode(const uint8_t * buf, size_t buf_len);
 
 } // namespace chip
 

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -41,6 +41,7 @@ const int kTotalPayloadDataSizeInBits =
     (kVersionFieldLengthInBits + kVendorIDFieldLengthInBits + kProductIDFieldLengthInBits + kCustomFlowRequiredFieldLengthInBits +
      kRendezvousInfoFieldLengthInBits + kPayloadDiscriminatorFieldLengthInBits + kSetupPINCodeFieldLengthInBits +
      kReservedFieldLengthInBits);
+const int kTotalPayloadDataSizeInBytes = (kTotalPayloadDataSizeInBits + 7) / 8;
 
 class SetupPayload
 {

--- a/src/setup_payload/tests/tests.cpp
+++ b/src/setup_payload/tests/tests.cpp
@@ -23,7 +23,6 @@
 
 #include "SetupPayload.cpp"
 #include "SetupCodeUtils.cpp"
-#include "SetupPayload.h"
 #include "QRCodeSetupPayloadGenerator.cpp"
 
 using namespace chip;
@@ -92,6 +91,9 @@ int testBase45()
         hello_world += (char) decoded[_];
     }
     surprises += EXPECT_EQ(hello_world, "Hello World!");
+
+    // short input
+    surprises += EXPECT_EQ(base45Decode("A0").size(), 1);
 
     // empty == empty
     surprises += EXPECT_EQ(base45Decode("").size(), 0);
@@ -165,6 +167,5 @@ int testSetupPayloadVerify()
 
 int main(int argc, char ** argv)
 {
-    printf("---Running Test--- tests from %s\n", __FILE__);
     return testBitsetLen() + testPayloadByteArrayRep() + testPayloadBase45Rep() + testBase45() + testSetupPayloadVerify();
 }

--- a/src/setup_payload/tests/tests.cpp
+++ b/src/setup_payload/tests/tests.cpp
@@ -29,9 +29,10 @@
 using namespace chip;
 using namespace std;
 
-void testPayloadByteArrayRep()
+#define EXPECT_EQ(x, y) ((x) != (y)) ? cerr << __FILE__ << ":" << __LINE__ << ":error EXPECT_EQ(" << x << ", " << y << ")\n", 1 : 0
+
+int testPayloadByteArrayRep()
 {
-    printf("---Running Test--- %s\n", __FUNCTION__);
     SetupPayload payload;
 
     payload.version               = 5;
@@ -43,16 +44,14 @@ void testPayloadByteArrayRep()
     payload.setUpPINCode          = 2048;
 
     QRCodeSetupPayloadGenerator generator(payload);
-    string result         = generator.payloadBinaryRepresentation();
-    string expectedResult = "101000000000000110000000000000000010000000011000000000000000000000010000"
-                            "00000000";
+    string result   = generator.payloadBinaryRepresentation();
+    string expected = "000000000000000000100000000000010000000000000000100000000000000000010000000000000011001010";
 
-    assert(result.compare(expectedResult) == 0);
+    return EXPECT_EQ(result, expected);
 }
 
-void testPayloadBase45Rep()
+int testPayloadBase45Rep()
 {
-    printf("---Running Test--- %s\n", __FUNCTION__);
     SetupPayload payload;
 
     payload.version               = 5;
@@ -64,30 +63,72 @@ void testPayloadBase45Rep()
     payload.setUpPINCode          = 2048;
 
     QRCodeSetupPayloadGenerator generator(payload);
-    string result         = generator.payloadBase45Representation();
-    string expectedResult = "KABG8842Q000211";
+    string result   = generator.payloadBase45Representation();
+    string expected = "B20800G00G8G000";
 
-    assert(result.compare(expectedResult) == 0);
+    return EXPECT_EQ(result, expected);
 }
 
-void testBase45Encoding()
+int testBase45()
 {
-    printf("---Running Test--- %s\n", __FUNCTION__);
-    uint16_t input        = 10;
-    string result         = base45EncodedString(input, 3);
-    string expectedResult = "00A";
-    assert(result.compare(expectedResult) == 0);
+    int surprises = 0;
+
+    uint8_t input[] = { 10, 10, 10 };
+
+    surprises += EXPECT_EQ(base45Encode(input, 0), "");
+
+    surprises += EXPECT_EQ(base45Encode(input, 1), "A0");
+
+    surprises += EXPECT_EQ(base45Encode(input, 2), "5C1");
+
+    surprises += EXPECT_EQ(base45Encode(input, 3), "5C1A0");
+
+    surprises += EXPECT_EQ(base45Encode((uint8_t *) "Hello World!", sizeof("Hello World!") - 1), "8 C VDN44I3E.VD/94");
+
+    vector<uint8_t> decoded = base45Decode("8 C VDN44I3E.VD/94");
+    string hello_world;
+    for (int _ = 0; _ < decoded.size(); _++)
+    {
+        hello_world += (char) decoded[_];
+    }
+    surprises += EXPECT_EQ(hello_world, "Hello World!");
+
+    // empty == empty
+    surprises += EXPECT_EQ(base45Decode("").size(), 0);
+    // too short
+    surprises += EXPECT_EQ(base45Decode("A").size(), 0);
+    // outside valid chars
+    surprises += EXPECT_EQ(base45Decode("0\x1").size(), 0);
+    surprises += EXPECT_EQ(base45Decode("\x10").size(), 0);
+    surprises += EXPECT_EQ(base45Decode("[0").size(), 0);
+    surprises += EXPECT_EQ(base45Decode("0[").size(), 0);
+
+    // BOGUS chars
+    surprises += EXPECT_EQ(base45Decode("!0").size(), 0);
+    surprises += EXPECT_EQ(base45Decode("\"0").size(), 0);
+    surprises += EXPECT_EQ(base45Decode("#0").size(), 0);
+    surprises += EXPECT_EQ(base45Decode("&0").size(), 0);
+    surprises += EXPECT_EQ(base45Decode("'0").size(), 0);
+    surprises += EXPECT_EQ(base45Decode("(0").size(), 0);
+    surprises += EXPECT_EQ(base45Decode(")0").size(), 0);
+    surprises += EXPECT_EQ(base45Decode(",0").size(), 0);
+    surprises += EXPECT_EQ(base45Decode(";0").size(), 0);
+    surprises += EXPECT_EQ(base45Decode("<0").size(), 0);
+    surprises += EXPECT_EQ(base45Decode("=0").size(), 0);
+    surprises += EXPECT_EQ(base45Decode(">0").size(), 0);
+    surprises += EXPECT_EQ(base45Decode("@0").size(), 0);
+
+    return surprises;
 }
 
-void testBitsetLen()
+int testBitsetLen()
 {
-    printf("---Running Test--- %s\n", __FUNCTION__);
-    assert(kTotalPayloadDataSizeInBits % 8 == 0);
+    return EXPECT_EQ(kTotalPayloadDataSizeInBits % 8, 0);
 }
 
-void testSetupPayloadVerify()
+int testSetupPayloadVerify()
 {
-    printf("---Running Test--- %s\n", __FUNCTION__);
+    int surprises = 0;
     SetupPayload payload;
 
     payload.version               = 5;
@@ -97,36 +138,33 @@ void testSetupPayloadVerify()
     payload.rendezvousInformation = 1;
     payload.discriminator         = 128;
     payload.setUpPINCode          = 2048;
-
-    assert(payload.isValid());
+    surprises += EXPECT_EQ(payload.isValid(), true);
 
     // test invalid version
     SetupPayload test_payload = payload;
     test_payload.version      = 2 << kVersionFieldLengthInBits;
-    assert(!test_payload.isValid());
+    surprises += EXPECT_EQ(test_payload.isValid(), false);
 
     // test invalid rendezvousInformation
     test_payload                       = payload;
     test_payload.rendezvousInformation = 3;
-    assert(!test_payload.isValid());
+    surprises += EXPECT_EQ(test_payload.isValid(), false);
 
     // test invalid discriminator
     test_payload               = payload;
     test_payload.discriminator = 2 << kPayloadDiscriminatorFieldLengthInBits;
-    assert(!test_payload.isValid());
+    surprises += EXPECT_EQ(test_payload.isValid(), false);
 
     // test invalid stetup PIN
     test_payload              = payload;
     test_payload.setUpPINCode = 2 << kSetupPINCodeFieldLengthInBits;
-    assert(!test_payload.isValid());
+    surprises += EXPECT_EQ(test_payload.isValid(), false);
+
+    return surprises;
 }
 
 int main(int argc, char ** argv)
 {
     printf("---Running Test--- tests from %s\n", __FILE__);
-    testBitsetLen();
-    testPayloadByteArrayRep();
-    testPayloadBase45Rep();
-    testBase45Encoding();
-    testSetupPayloadVerify();
+    return testBitsetLen() + testPayloadByteArrayRep() + testPayloadBase45Rep() + testBase45() + testSetupPayloadVerify();
 }


### PR DESCRIPTION
#### Problem
 SetupPayload's generation of the QRCode goes through 3 steps of
 re-ordering of the information in the in-memory struct, making it harder
 to verify correctness.

 #### Summary of Changes
* change encoding of the struct fields from from big-endian to little endian
    in the bitfieldn
* remove the code that changes from a bitfield to a reversed array of unit16s
* remove the reversal of the encoded string chunks
* add a base45 decoder (for fun and for testing)

The resulting base45 string is little-endian, least significant bits in
the first character of the string.