### PR TITLE
Running make does not build platform

### DIFF
--- a/build/nrf5/nrf5-chip.mk
+++ b/build/nrf5/nrf5-chip.mk
@@ -133,7 +133,6 @@ STD_INC_DIRS += \
     $(CHIP_OUTPUT_DIR)/include \
     $(CHIP_OUTPUT_DIR)/src/include \
     $(CHIP_ROOT)/src/include \
-    $(CHIP_ROOT)/src/adaptations/device-layer/trait-support \
     $(CHIP_ROOT)/third_party/lwip/repo/lwip/src/include \
     $(CHIP_ROOT)/src/lwip \
 	$(CHIP_ROOT)/src/lwip/nrf5 \

--- a/configure.ac
+++ b/configure.ac
@@ -1809,6 +1809,7 @@ src/setup_payload/Makefile
 src/setup_payload/tests/Makefile
 src/inet/Makefile
 src/lib/Makefile
+src/platform/Makefile
 ])
 
 #


### PR DESCRIPTION
 #### Problem
`configure.ac` didn't have platform's makefile in config file list. So it was not including it in the builds.

 #### Summary of Changes
Updated the file list. Also removed some stale references from nRF5 makefile.

