### PR TITLE
Use the project-chip fork of shellcheck

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: shellcheck
         id: shellcheck
-        uses: ludeeus/actions-shellcheck@0.1.0
+        uses: project-chip/actions-shellcheck@0.1.0
         env:
           EXCLUDE_DIRS: third_party

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: shellcheck
         id: shellcheck
-        uses: project-chip/actions-shellcheck@0.1.0
+        uses: project-chip/action-shellcheck@master
         env:
           EXCLUDE_DIRS: third_party

--- a/integrations/clang/clang-format-check.sh
+++ b/integrations/clang/clang-format-check.sh
@@ -6,20 +6,21 @@
 # replacements.
 #
 
+# shellcheck disable=SC2120
 die() {
-    echo " *** ERROR: " $*
+    echo " *** ERROR: $*"
     exit 1
 }
 
 # from `man diff`:
 # Exit status is 0 if inputs are the same, 1 if different, 2 if trouble.
 
-$(dirname "$0")/clang-format.sh -style=file $@  | diff -u $@ - || die
+"$(dirname "$0")"/clang-format.sh -style=file "$@"  | diff -u "$@" - || die "diffs exist"
 
 for arg; do true; done
 file=$arg
-[ -n "$(tail -c1 $file)" ] && {
-    echo " *** ERROR: Missing EOF newline: " $file
+[[ -n "$(tail -c1 "$file")" ]] && {
+    echo " *** ERROR: Missing EOF newline: $file"
     exit 1
 }
 

--- a/integrations/clang/clang-format.sh
+++ b/integrations/clang/clang-format.sh
@@ -2,14 +2,15 @@
 
 CLANG_FORMAT_VERSION="clang-format version 9.0"
 
+# shellcheck disable=SC2120
 die() {
-    echo " *** ERROR: " $*
+    echo " *** ERROR: $*"
     exit 1
 }
 
-if which clang-format-6.0 > /dev/null; then
+if command -v clang-format-6.0 > /dev/null; then
     alias clang-format=clang-format-9.0
-elif which clang-format > /dev/null; then
+elif command -v clang-format > /dev/null; then
     case "$(clang-format --version)" in
         "$CLANG_FORMAT_VERSION"*)
             ;;
@@ -21,7 +22,7 @@ else
     die "clang-format 9.0 required"
 fi
 
-clang-format $@ || die
+clang-format "$@" || die "format failed"
 
 # ensure EOF newline
 REPLACE=no
@@ -36,8 +37,8 @@ done
 
 file=$arg
 
-[ $REPLACE != yes ] || {
-    [ -n "$(tail -c1 $file)" ] && echo >> $file
+[[ $REPLACE != yes ]] || {
+    [[ -n "$(tail -c1 "$file")" ]] && echo >> "$file"
 }
 
 exit 0


### PR DESCRIPTION
#### Problem
 shellcheck doesn't support excluding directories that might be imports,
 e.g in the chip repo, we don't audit third_party

 #### Summary of Changes
 * take advantage of project-chip's fork of shellcheck
 * fix scripts that run afoul of the check