### PR TITLE
Rename WoBLE to CHIPoBLE in nRF5 platform code

### DIFF
--- a/src/platform/nRF5/ConnectivityManagerImpl.cpp
+++ b/src/platform/nRF5/ConnectivityManagerImpl.cpp
@@ -29,7 +29,7 @@
 #include <support/logging/CHIPLogging.h>
 #include <support/CodeUtils.h>
 
-#if CHIP_DEVICE_CONFIG_ENABLE_WOBLE
+#if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 #include <platform/internal/GenericConnectivityManagerImpl_BLE.ipp>
 #endif
 

--- a/src/platform/nRF5/ThreadStackManagerImpl.cpp
+++ b/src/platform/nRF5/ThreadStackManagerImpl.cpp
@@ -64,17 +64,17 @@ bool ThreadStackManagerImpl::IsInitialized()
     return sInstance.mThreadStackLock != NULL;
 }
 
-void ThreadStackManagerImpl::_OnWoBLEAdvertisingStart(void)
+void ThreadStackManagerImpl::_OnCHIPoBLEAdvertisingStart(void)
 {
     // If Thread-over-BLE is enabled, ensure that ToBLE advertising is stopped before
-    // starting WoBLE advertising.  This is accomplished by disabling the OpenThread
+    // starting CHIPoBLE advertising.  This is accomplished by disabling the OpenThread
     // IPv6 interface via a call to otIp6SetEnabled(false).
     //
     // On platforms where there is no native support for simultaneous BLE advertising
     // (e.g. Nordic’s SoftDevice), it is necessary to coordinate between the different
     // advertising modes a CHIP device may employ.  This arises in particular when a
-    // device supports both WoBLE and ToBLE, each of which requires a separate advertising
-    // regime.  The OnWoBLEAdvertisingStart()/OnWoBLEAdvertisingStop() methods handle
+    // device supports both CHIPoBLE and ToBLE, each of which requires a separate advertising
+    // regime.  The OnCHIPoBLEAdvertisingStart()/OnCHIPoBLEAdvertisingStop() methods handle
     // the switching between the two modes.
     //
 #if OPENTHREAD_CONFIG_ENABLE_TOBLE
@@ -84,10 +84,10 @@ void ThreadStackManagerImpl::_OnWoBLEAdvertisingStart(void)
 #endif
 }
 
-void ThreadStackManagerImpl::_OnWoBLEAdvertisingStop(void)
+void ThreadStackManagerImpl::_OnCHIPoBLEAdvertisingStop(void)
 {
     // If Thread-over-BLE is enabled, and a Thread provision exists, ensure that ToBLE
-    // advertising is re-activated once WoBLE advertising stops.
+    // advertising is re-activated once CHIPoBLE advertising stops.
     //
 #if OPENTHREAD_CONFIG_ENABLE_TOBLE
     LockThreadStack();


### PR DESCRIPTION
 #### Problem
Some code in nRF5 platform still has reference to WoBLE

 #### Summary of Changes
Renamed to CHIPoBLE.
