### PR TITLE
Base45 to a Set up payload

### DIFF
--- a/src/setup_payload/Base45.cpp
+++ b/src/setup_payload/Base45.cpp
@@ -29,11 +29,14 @@
 
 #include "Base45.h"
 
+#include <iostream>
+
 using namespace std;
 
 namespace chip {
 
 static const int kBase45ChunkLen = 3;
+static const int kBytesChunkLen  = 2;
 
 string base45Encode(const uint8_t * buf, size_t buf_len)
 {
@@ -46,7 +49,8 @@ string base45Encode(const uint8_t * buf, size_t buf_len)
 
     // eat little-endian uint16_ts from the byte array
     // encode as 3 base45 characters
-    while (buf_len >= 2)
+
+    while (buf_len >= kBytesChunkLen)
     {
         int next = buf[0] + buf[1] * 256;
 
@@ -55,8 +59,8 @@ string base45Encode(const uint8_t * buf, size_t buf_len)
             result += codes[next % radix];
             next /= radix;
         }
-        buf += 2;
-        buf_len -= 2;
+        buf += kBytesChunkLen;
+        buf_len -= kBytesChunkLen;
     }
     // handle leftover byte, if any
     if (buf_len != 0)
@@ -156,6 +160,7 @@ CHIP_ERROR base45Decode(string base45, vector<uint8_t> & result)
     //  base45 characters
     if (base45.length() % kBase45ChunkLen == 1)
     {
+        fprintf(stderr, "\nFailed decoding base45. Input was too short. %lu", base45.length());
         return CHIP_ERROR_INVALID_MESSAGE_LENGTH;
     }
     result.clear();

--- a/src/setup_payload/Base45.h
+++ b/src/setup_payload/Base45.h
@@ -36,7 +36,6 @@ namespace chip {
 CHIP_ERROR base45Decode(string base45, vector<uint8_t> & out);
 string base45Encode(const uint8_t * buf, size_t buf_len);
 
-
 } // namespace chip
 
 #endif /* _SETUP_CODE_UTILS_H_ */

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -37,6 +37,7 @@ static void populateBits(uint8_t * bits, int & offset, uint64_t input, size_t nu
     // do nothing in the case where we've overflowed. should never happen
     if (offset + numberOfBits > kTotalPayloadDataSizeInBits || input >= 1u << numberOfBits)
     {
+        fprintf(stderr, "Overflow while trying to generate a QR Code. Bailing.");
         return;
     }
 
@@ -86,7 +87,10 @@ string QRCodeSetupPayloadGenerator::payloadBinaryRepresentation()
         }
         return binary;
     }
-    return string();
+    else {
+        fprintf(stderr, "\nFailed encoding invalid payload\n");
+        return string();
+    }
 }
 
 string QRCodeSetupPayloadGenerator::payloadBase45Representation()
@@ -99,5 +103,8 @@ string QRCodeSetupPayloadGenerator::payloadBase45Representation()
 
         return base45Encode(bits, sizeof(bits) / sizeof(bits[0]));
     }
-    return string();
+    else {
+        fprintf(stderr, "\nFailed encoding invalid payload\n");
+        return string();
+    }
 }

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -87,7 +87,8 @@ string QRCodeSetupPayloadGenerator::payloadBinaryRepresentation()
         }
         return binary;
     }
-    else {
+    else
+    {
         fprintf(stderr, "\nFailed encoding invalid payload\n");
         return string();
     }
@@ -103,7 +104,8 @@ string QRCodeSetupPayloadGenerator::payloadBase45Representation()
 
         return base45Encode(bits, sizeof(bits) / sizeof(bits[0]));
     }
-    else {
+    else
+    {
         fprintf(stderr, "\nFailed encoding invalid payload\n");
         return string();
     }

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.h
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.h
@@ -29,7 +29,6 @@
 
 #include "SetupPayload.h"
 
-#include <bitset>
 #include <string>
 using namespace std;
 

--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -31,7 +31,7 @@ using namespace chip;
 using namespace std;
 
 // Populate numberOfBits into dest from buf starting at startIndex
-static uint64_t readBits(vector <uint8_t> buf, int &index, size_t numberOfBitsToRead)
+static uint64_t readBits(vector<uint8_t> buf, int & index, size_t numberOfBitsToRead)
 {
     uint64_t dest = 0;
     if (index + numberOfBitsToRead > buf.size() * 8 || numberOfBitsToRead > sizeof(uint64_t) * 8)
@@ -41,7 +41,7 @@ static uint64_t readBits(vector <uint8_t> buf, int &index, size_t numberOfBitsTo
         return 0;
     }
 
-    int currentIndex  = index;
+    int currentIndex = index;
     for (size_t bitsRead = 0; bitsRead < numberOfBitsToRead; bitsRead++)
     {
         if (buf[currentIndex / 8] & (1 << (currentIndex % 8)))
@@ -54,10 +54,12 @@ static uint64_t readBits(vector <uint8_t> buf, int &index, size_t numberOfBitsTo
     return dest;
 }
 
-SetupPayload QRCodeSetupPayloadParser::payload() 
+SetupPayload QRCodeSetupPayloadParser::payload()
 {
-    vector <uint8_t> buf = base45Decode(mBase45StringRepresentation);
-    if (buf.size() == 0) {
+    vector<uint8_t> buf = vector<uint8_t>();
+
+    if (CHIP_NO_ERROR != base45Decode(mBase45StringRepresentation, buf))
+    {
         fprintf(stderr, "Decoding of base45 string failed");
         return SetupPayload();
     }
@@ -65,14 +67,14 @@ SetupPayload QRCodeSetupPayloadParser::payload()
     SetupPayload payload;
 
     int indexToReadFrom = 0;
-    
-    payload.version = readBits(buf, indexToReadFrom, kVersionFieldLengthInBits);
-    payload.vendorID = readBits(buf, indexToReadFrom, kVendorIDFieldLengthInBits);
-    payload.productID = readBits(buf, indexToReadFrom, kProductIDFieldLengthInBits);
-    payload.requiresCustomFlow = readBits(buf, indexToReadFrom, kCustomFlowRequiredFieldLengthInBits);
+
+    payload.version               = readBits(buf, indexToReadFrom, kVersionFieldLengthInBits);
+    payload.vendorID              = readBits(buf, indexToReadFrom, kVendorIDFieldLengthInBits);
+    payload.productID             = readBits(buf, indexToReadFrom, kProductIDFieldLengthInBits);
+    payload.requiresCustomFlow    = readBits(buf, indexToReadFrom, kCustomFlowRequiredFieldLengthInBits);
     payload.rendezvousInformation = readBits(buf, indexToReadFrom, kRendezvousInfoFieldLengthInBits);
-    payload.discriminator = readBits(buf, indexToReadFrom, kPayloadDiscriminatorFieldLengthInBits);
-    payload.setUpPINCode = readBits(buf, indexToReadFrom, kSetupPINCodeFieldLengthInBits);
+    payload.discriminator         = readBits(buf, indexToReadFrom, kPayloadDiscriminatorFieldLengthInBits);
+    payload.setUpPINCode          = readBits(buf, indexToReadFrom, kSetupPINCodeFieldLengthInBits);
 
     return payload;
 }

--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  *
  *    <COPYRIGHT>
  *
@@ -34,7 +34,8 @@ using namespace std;
 static uint64_t readBits(vector <uint8_t> buf, int &index, size_t numberOfBitsToRead)
 {
     uint64_t dest = 0;
-    if (index + numberOfBitsToRead > buf.size() * 8 || numberOfBitsToRead > 64) {
+    if (index + numberOfBitsToRead > buf.size() * 8 || numberOfBitsToRead > sizeof(uint64_t) * 8)
+    {
         fprintf(stderr, "Error parsing QR code. startIndex %d numberOfBitsToLoad %zu buf_len %zu ", index, numberOfBitsToRead,
                 buf.size());
         return 0;

--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -22,7 +22,7 @@
  */
 
 #include "QRCodeSetupPayloadParser.h"
-#include "SetupCodeUtils.h"
+#include "Base45.h"
 
 #include <iostream>
 #include <vector>

--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -1,0 +1,77 @@
+/*
+ *
+ *    <COPYRIGHT>
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file describes a QRCode Setup Payload parser based on the
+ *      CHIP specification.
+ */
+
+#include "QRCodeSetupPayloadParser.h"
+#include "SetupCodeUtils.h"
+
+#include <iostream>
+#include <vector>
+
+using namespace chip;
+using namespace std;
+
+// Populate numberOfBits into dest from buf starting at startIndex
+static uint64_t readBits(vector <uint8_t> buf, int &index, size_t numberOfBitsToRead)
+{
+    uint64_t dest = 0;
+    if (index + numberOfBitsToRead > buf.size() * 8 || numberOfBitsToRead > 64) {
+        fprintf(stderr, "Error parsing QR code. startIndex %d numberOfBitsToLoad %zu buf_len %zu ", index, numberOfBitsToRead,
+                buf.size());
+        return 0;
+    }
+
+    int currentIndex  = index;
+    for (size_t bitsRead = 0; bitsRead < numberOfBitsToRead; bitsRead++)
+    {
+        if (buf[currentIndex / 8] & (1 << (currentIndex % 8)))
+        {
+            dest |= (1 << bitsRead);
+        }
+        currentIndex++;
+    }
+    index += numberOfBitsToRead;
+    return dest;
+}
+
+SetupPayload QRCodeSetupPayloadParser::payload() 
+{
+    vector <uint8_t> buf = base45Decode(mBase45StringRepresentation);
+    if (buf.size() == 0) {
+        fprintf(stderr, "Decoding of base45 string failed");
+        return SetupPayload();
+    }
+
+    SetupPayload payload;
+
+    int indexToReadFrom = 0;
+    
+    payload.version = readBits(buf, indexToReadFrom, kVersionFieldLengthInBits);
+    payload.vendorID = readBits(buf, indexToReadFrom, kVendorIDFieldLengthInBits);
+    payload.productID = readBits(buf, indexToReadFrom, kProductIDFieldLengthInBits);
+    payload.requiresCustomFlow = readBits(buf, indexToReadFrom, kCustomFlowRequiredFieldLengthInBits);
+    payload.rendezvousInformation = readBits(buf, indexToReadFrom, kRendezvousInfoFieldLengthInBits);
+    payload.discriminator = readBits(buf, indexToReadFrom, kPayloadDiscriminatorFieldLengthInBits);
+    payload.setUpPINCode = readBits(buf, indexToReadFrom, kSetupPINCodeFieldLengthInBits);
+
+    return payload;
+}

--- a/src/setup_payload/QRCodeSetupPayloadParser.h
+++ b/src/setup_payload/QRCodeSetupPayloadParser.h
@@ -1,4 +1,4 @@
-/*
+/**
  *
  *    <COPYRIGHT>
  *
@@ -29,6 +29,10 @@ using namespace std;
 namespace chip
 {
 
+/**
+ * @class QRCodeSetupPayloadParser
+ * A class that can be used to convert a base45 encoded payload to a SetupPayload object
+ * */
 class QRCodeSetupPayloadParser 
 {
     private:

--- a/src/setup_payload/QRCodeSetupPayloadParser.h
+++ b/src/setup_payload/QRCodeSetupPayloadParser.h
@@ -17,26 +17,26 @@
 
 /**
  *    @file
- *      Utility header to encode an input into a Base45 String
+ *      This file describes a QRCode Setup Payload parser based on the
+ *      CHIP specification.
  */
 
-#ifndef _SETUP_CODE_UTILS_H_
-#define _SETUP_CODE_UTILS_H_
+#include "SetupPayload.h"
 
-#include <core/CHIPError.h>
-
-#include <stdint.h>
 #include <string>
-#include <vector>
-
 using namespace std;
 
-namespace chip {
-// returns CHIP_NO_ERROR on successful decode
-CHIP_ERROR base45Decode(string base45, vector<uint8_t> & out);
-string base45Encode(const uint8_t * buf, size_t buf_len);
+namespace chip
+{
 
+class QRCodeSetupPayloadParser 
+{
+    private:
+        string mBase45StringRepresentation;
 
-} // namespace chip
+    public:
+        QRCodeSetupPayloadParser(string base45Representation) : mBase45StringRepresentation(base45Representation){};
+        SetupPayload payload();
+};
 
-#endif /* _SETUP_CODE_UTILS_H_ */
+}; // namespace chip

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -47,14 +47,23 @@ bool SetupPayload::isValid()
     {
         return false;
     }
-    // make sure the rendezvousInformation only uses allowed values
-    // i.e it must be > 0 and set to 1 or a power of 2.
-    uint16_t rezInfo = rendezvousInformation;
-    if (rezInfo == 0 || (rezInfo != 1 && (rezInfo & (rezInfo - 1)) != 0))
-    {
+
+    if (version == 0 && rendezvousInformation == 0 && discriminator == 0 && setUpPINCode == 0) {
         return false;
     }
+    
     return true;
+}
+
+bool SetupPayload::operator==(const SetupPayload& input)
+{
+    return this->version == input.version && \
+           this->vendorID == input.vendorID && \
+           this->productID == input.productID && \
+           this->requiresCustomFlow == input.requiresCustomFlow && \
+           this->rendezvousInformation == input.rendezvousInformation && \
+           this->discriminator == input.discriminator && \
+           this->setUpPINCode == input.setUpPINCode;
 }
 
 } // namespace chip

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -48,22 +48,19 @@ bool SetupPayload::isValid()
         return false;
     }
 
-    if (version == 0 && rendezvousInformation == 0 && discriminator == 0 && setUpPINCode == 0) {
+    if (version == 0 && rendezvousInformation == 0 && discriminator == 0 && setUpPINCode == 0)
+    {
         return false;
     }
-    
+
     return true;
 }
 
-bool SetupPayload::operator==(const SetupPayload& input)
+bool SetupPayload::operator==(const SetupPayload & input)
 {
-    return this->version == input.version && \
-           this->vendorID == input.vendorID && \
-           this->productID == input.productID && \
-           this->requiresCustomFlow == input.requiresCustomFlow && \
-           this->rendezvousInformation == input.rendezvousInformation && \
-           this->discriminator == input.discriminator && \
-           this->setUpPINCode == input.setUpPINCode;
+    return this->version == input.version && this->vendorID == input.vendorID && this->productID == input.productID &&
+        this->requiresCustomFlow == input.requiresCustomFlow && this->rendezvousInformation == input.rendezvousInformation &&
+        this->discriminator == input.discriminator && this->setUpPINCode == input.setUpPINCode;
 }
 
 } // namespace chip

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -25,6 +25,9 @@
 #define _SETUP_PAYLOAD_H_
 
 #include <stdint.h>
+#include <string>
+
+using namespace std;
 
 namespace chip {
 // TODO this shuould point to the spec
@@ -55,7 +58,11 @@ public:
     uint32_t setUpPINCode;
 
     // Test that the Setup Payload is within expected value ranges
+    SetupPayload() :
+        version(0), vendorID(0), productID(0), requiresCustomFlow(0), rendezvousInformation(0), discriminator(0), setUpPINCode(0){};
+    
     bool isValid();
+    bool operator==(const SetupPayload& input);
 };
 
 }; // namespace chip

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -60,9 +60,9 @@ public:
     // Test that the Setup Payload is within expected value ranges
     SetupPayload() :
         version(0), vendorID(0), productID(0), requiresCustomFlow(0), rendezvousInformation(0), discriminator(0), setUpPINCode(0){};
-    
+
     bool isValid();
-    bool operator==(const SetupPayload& input);
+    bool operator==(const SetupPayload & input);
 };
 
 }; // namespace chip

--- a/src/setup_payload/tests/Makefile.am
+++ b/src/setup_payload/tests/Makefile.am
@@ -70,7 +70,7 @@ TESTS_ENVIRONMENT                              = \
 # Source, compiler, and linker options for test programs.
 
 TestQrCode_LDADD                               = $(COMMON_LDADD)
-TestQrCode_SOURCES                             = tests.cpp
+TestQrCode_SOURCES                             = tests_qrcode.cpp
 
 if CHIP_BUILD_COVERAGE
 CLEANFILES                                     = $(wildcard *.gcda *.gcno)

--- a/src/setup_payload/tests/tests_qrcode.cpp
+++ b/src/setup_payload/tests/tests_qrcode.cpp
@@ -24,6 +24,7 @@
 #include "SetupPayload.cpp"
 #include "Base45.cpp"
 #include "QRCodeSetupPayloadGenerator.cpp"
+#include "QRCodeSetupPayloadParser.cpp"
 
 using namespace chip;
 using namespace std;
@@ -154,7 +155,7 @@ int testSetupPayloadVerify()
 
     // test invalid rendezvousInformation
     test_payload                       = payload;
-    test_payload.rendezvousInformation = 3;
+    test_payload.rendezvousInformation = 512;
     surprises += EXPECT_EQ(test_payload.isValid(), false);
 
     // test invalid discriminator
@@ -170,7 +171,94 @@ int testSetupPayloadVerify()
     return surprises;
 }
 
+int testInvalidQRCodePayload()
+{
+    int surprises                   = 0;
+    string invalidString            = "adas12AA";
+    QRCodeSetupPayloadParser parser = QRCodeSetupPayloadParser(invalidString);
+    SetupPayload payload            = parser.payload();
+
+    surprises = EXPECT_EQ(payload.isValid(), false);
+    return surprises;
+}
+
+int testPayloadEquality()
+{
+    SetupPayload payload;
+
+    payload.version               = 5;
+    payload.vendorID              = 12;
+    payload.productID             = 1;
+    payload.requiresCustomFlow    = 0;
+    payload.rendezvousInformation = 1;
+    payload.discriminator         = 128;
+    payload.setUpPINCode          = 2048;
+
+    SetupPayload equalPayload;
+    equalPayload.version                 = 5;
+    equalPayload.vendorID              = 12;
+    equalPayload.productID             = 1;
+    equalPayload.requiresCustomFlow      = 0;
+    equalPayload.rendezvousInformation = 1;
+    equalPayload.discriminator         = 128;
+    equalPayload.setUpPINCode          = 2048;
+
+    bool result = payload == equalPayload;
+    return EXPECT_EQ(result, true);
+}
+
+int testPayloadInEquality()
+{
+    SetupPayload payload;
+
+    payload.version               = 5;
+    payload.vendorID              = 12;
+    payload.productID             = 1;
+    payload.requiresCustomFlow    = 0;
+    payload.rendezvousInformation = 1;
+    payload.discriminator         = 128;
+    payload.setUpPINCode          = 2048;
+
+    SetupPayload unequalPayload;
+    unequalPayload.version               = 5;
+    unequalPayload.vendorID              = 12;
+    unequalPayload.productID             = 1;
+    unequalPayload.requiresCustomFlow    = 0;
+    unequalPayload.rendezvousInformation = 1;
+    unequalPayload.discriminator         = 28;
+    unequalPayload.setUpPINCode          = 121233;
+
+    bool result = payload == unequalPayload;
+    return EXPECT_EQ(result, false);
+}
+
+int testQRCodeToPayloadGeneration()
+{
+    int surprises = 0;
+    SetupPayload payload;
+    payload.version               = 3;
+    payload.vendorID              = 100;
+    payload.productID             = 12;
+    payload.requiresCustomFlow    = 1;
+    payload.rendezvousInformation = 4;
+    payload.discriminator         = 233;
+    payload.setUpPINCode          = 5221133;
+
+    
+    QRCodeSetupPayloadGenerator generator(payload);
+    string base45Rep = generator.payloadBase45Representation();
+    
+
+    QRCodeSetupPayloadParser parser(base45Rep);
+    SetupPayload resultingPayload = parser.payload();
+
+    bool result = payload == resultingPayload;
+    surprises += EXPECT_EQ(result, true);
+    return surprises;
+}
+
 int main(int argc, char ** argv)
 {
-    return testBitsetLen() + testPayloadByteArrayRep() + testPayloadBase45Rep() + testBase45() + testSetupPayloadVerify();
+    return testBitsetLen() + testPayloadByteArrayRep() + testPayloadBase45Rep() + testBase45() + testSetupPayloadVerify() +
+        testInvalidQRCodePayload() + testPayloadEquality() + testPayloadInEquality() + testQRCodeToPayloadGeneration();
 }

--- a/src/setup_payload/tests/tests_qrcode.cpp
+++ b/src/setup_payload/tests/tests_qrcode.cpp
@@ -195,10 +195,10 @@ int testPayloadEquality()
     payload.setUpPINCode          = 2048;
 
     SetupPayload equalPayload;
-    equalPayload.version                 = 5;
+    equalPayload.version               = 5;
     equalPayload.vendorID              = 12;
     equalPayload.productID             = 1;
-    equalPayload.requiresCustomFlow      = 0;
+    equalPayload.requiresCustomFlow    = 0;
     equalPayload.rendezvousInformation = 1;
     equalPayload.discriminator         = 128;
     equalPayload.setUpPINCode          = 2048;
@@ -244,10 +244,8 @@ int testQRCodeToPayloadGeneration()
     payload.discriminator         = 233;
     payload.setUpPINCode          = 5221133;
 
-    
     QRCodeSetupPayloadGenerator generator(payload);
     string base45Rep = generator.payloadBase45Representation();
-    
 
     QRCodeSetupPayloadParser parser(base45Rep);
     SetupPayload resultingPayload = parser.payload();


### PR DESCRIPTION
 #### Problem
QR code base45 string parser #145

 #### Summary of Changes
Add a new class `QRCodeSetupPayloadParser` that converts a `base45` string to a `SetupPayload` object

fixes #145 
