### PR TITLE
Allow bootstrap to be run from anywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 Makefile.in
 aclocal.m4
 autom4te.cache
+output/
 build/*
 !build/autoconf/m4/nl_with_lwip.m4
 !build/config/standalone/CHIPProjectConfig.h

--- a/bootstrap
+++ b/bootstrap
@@ -27,10 +27,6 @@
 
 nlbuild_autotools_stem="third_party/nlbuild-autotools/repo"
 
-# Establish some key directories
+srcdir=$(cd $(dirname "${0}") && pwd)
 
-srcdir="$(dirname "${0}")"
-abs_srcdir="$(cd "${srcdir}" && pwd)"
-abs_top_srcdir="${abs_srcdir}"
-
-exec "${srcdir}/${nlbuild_autotools_stem}/scripts/bootstrap" -I "${abs_top_srcdir}/${nlbuild_autotools_stem}" "${@}"
+(cd "${srcdir}" && exec "${srcdir}/${nlbuild_autotools_stem}/scripts/bootstrap" -I "${srcdir}/${nlbuild_autotools_stem}" "${@}")


### PR DESCRIPTION
#### Problem
 running bootstrap from anywhere but // doesn't work

 #### Summary of Changes
 fix up bootstrap to accommodate this use case:

```
 $ ./bootstrap && (cd build/foo && ../../configure)
 $ cd src/setup_payload
 dev: <edit code, makefiles, etc.>
 $ ../../bootstrap -w  && make -C ../../build/foo/src/setup_payload check
 <goto dev>

```

