### PR TITLE
Removed Unneeded Top-level Unit Test Project Subdirectory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,7 +171,6 @@ CHIP considers there to be a few different types of pull requests:
 ### Prior to review, all changes require:
 - [GitHub Workflows](../.github/workflows) pass 
 - [Certification Tests](tests/certification/README.md) pass 
-- [Unit Tests](tests/unit/README.md) pass
 - [Fuzz Tests](tests/fuzz/README.md) pass
 - [Integration Tests](tests/integration/README.md) pass
 - Linting passes
@@ -204,7 +203,6 @@ your development branch and update.
 * Passes [Review Requirements](#review-requirements)
 * [GitHub Workflows](../.github/workflows) pass 
 * [Certification Tests](tests/certification/README.md) pass 
-* [Unit Tests](tests/unit/README.md) pass
 * [Fuzz Tests](tests/fuzz/README.md) pass
 * [Integration Tests](tests/integration/README.md) pass
 * Linting passes

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -1,1 +1,0 @@
-## Unit Test Suites


### PR DESCRIPTION
 #### Problem
This addresses GitHub issue #166.

 #### Summary of Changes
This removes the top-level _tests/unit_ directory, no longer needed by the project.

Fixes #166
