### PR TITLE
Ensure Content under Top-level tests Is Tracked for the Project Distribution

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 #
-#    <COPYRIGHT>
+#    Copyright (c) 2020 Project CHIP Authors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ AM_MAKEFLAGS                             = --no-print-directory
 SUBDIRS                                  = \
     third_party                            \
     src                                    \
+    tests                                  \
     $(NULL)
 
 PRETTY_SUBDIRS                           = \

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 #
-#    <COPYRIGHT>
+#    Copyright (c) 2020 Project CHIP Authors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -1810,6 +1810,7 @@ src/setup_payload/tests/Makefile
 src/inet/Makefile
 src/lib/Makefile
 src/platform/Makefile
+tests/Makefile
 ])
 
 #

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,0 +1,42 @@
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+
+#
+#    Description:
+#      This file is the GNU automake template for the Project CHIP
+#      tests directory.
+#
+
+include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
+
+EXTRA_DIST                                   = \
+    integration/README.md                      \
+    docs/README.md                             \
+    fuzz/README.md                             \
+    certification/README.md                    \
+    $(NULL)
+
+# Always package (e.g. for 'make dist') these subdirectories.
+
+DIST_SUBDIRS                                 = \
+    $(NULL)
+
+# Always build (e.g. for 'make all') these subdirectories.
+
+SUBDIRS                                      = \
+    $(NULL)
+
+include $(abs_top_nlbuild_autotools_dir)/automake/post.am


### PR DESCRIPTION
 #### Problem
Several README.md files underneath the top-level _tests_ directory are not tracked and included in the project distribution when 'make dist' is invoked.

 #### Summary of Changes
This adds the following content to the project distribution:

* tests/integration/README.md
* tests/docs/README.md
* tests/fuzz/README.md
* tests/certification/README.md

Fixes #167