### PR TITLE
Update BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -74,9 +74,13 @@ make -f Makefile-Standalone
 # From top of clean tree
 ./bootstrap
 
-mkdir out
-cd out
-../configure
+mkdir build/<CONFIG>
+cd build/<CONFIG>
+../../configure <CONFIG ARGUMENTS>
+```
+Where `<CONFIG>` is something that describes what configuration (as described by `<CONFIG ARGUMENTS>`
+of the tree you're planning to build, or simply `out` if you're not feeling creative.
+```
 
 # Build libraries
 make


### PR DESCRIPTION
 #### Problem
 BUILDING.md recommends `out` as a build output directory, which leads to questions like "why isn't `out/` in .gitignore?"

 #### Summary of Changes
move recommended output to build/..., try to shed a bit more light on custom builds

may help address #143