### PR TITLE
Build failure #176

### DIFF
--- a/src/setup_payload/Makefile.am
+++ b/src/setup_payload/Makefile.am
@@ -38,12 +38,14 @@ libQrCode_a_SOURCES                                       = \
     QRCodeSetupPayloadGenerator.cpp                         \
     SetupPayload.cpp                                        \
     Base45.cpp                                              \
+    QRCodeSetupPayloadParser.cpp                            \       
    $(NULL)
 
 dist_libQrCode_a_HEADERS                                 = \
     QRCodeSetupPayloadGenerator.h                          \
     SetupPayload.h                                         \
     Base45.h                                               \
+    QRCodeSetupPayloadParser.h                             \        
     $(NULL)
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am


### PR DESCRIPTION
 #### Problem
Build failure #176

Build was failing as two new files weren't in the Makefile.am
However it was passing locally for me at my desk as I was using the following -
`makefile -f Makefile-Standalone` to build
and
`makefile -f <pathToFolder>tests/` to test

The former was passing as it wasn't simply building those files. And the latter was fine as the tests import the `.cpp`


The GitHub build bot runs `./bootstrap && make -f Makefile-Standalone distcheck` and this was failing.
This change fixes the broken build.
Output from my local run
```
./bootstrap && make -f Makefile-Standalone distcheck
...
=======================================
chip- archives ready for distribution: 
chip-.tar.gz
=======================================
```


 #### Summary of Changes
Fix MakeFile.am

Fixes issue ##176
