### PR TITLE
Restore license for lwip code

### DIFF
--- a/third_party/lwip/repo/lwip/src/core/ipv6/ip6_route_table.c
+++ b/third_party/lwip/repo/lwip/src/core/ipv6/ip6_route_table.c
@@ -5,7 +5,6 @@
  */
 
 /*
- * Copyright (c) 2020 Project CHIP Authors
  * Copyright (c) 2015 Nest Labs, Inc.
  * All rights reserved.
  *

--- a/third_party/lwip/repo/lwip/src/core/ipv6/ip6_route_table.c
+++ b/third_party/lwip/repo/lwip/src/core/ipv6/ip6_route_table.c
@@ -7,6 +7,35 @@
 /*
  * Copyright (c) 2020 Project CHIP Authors
  * Copyright (c) 2015 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * Author: Pradip De <pde@nestlabs.com>
+ *
+ *
+ * Please coordinate changes and requests with Pradip De
+ * <pde@nestlabs.com>
  */
 
 #include "lwip/opt.h"

--- a/third_party/lwip/repo/lwip/src/include/lwip/ip6_route_table.h
+++ b/third_party/lwip/repo/lwip/src/include/lwip/ip6_route_table.h
@@ -5,7 +5,6 @@
  */
 
 /*
- * Copyright (c) 2020 Project CHIP Authors
  * Copyright (c) 2015 Nest Labs, Inc.
  * All rights reserved.
  *

--- a/third_party/lwip/repo/lwip/src/include/lwip/ip6_route_table.h
+++ b/third_party/lwip/repo/lwip/src/include/lwip/ip6_route_table.h
@@ -7,6 +7,35 @@
 /*
  * Copyright (c) 2020 Project CHIP Authors
  * Copyright (c) 2015 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * Author: Pradip De <pde@nestlabs.com>
+ *
+ *
+ * Please coordinate changes and requests with Pradip De
+ * <pde@nestlabs.com>
  */
 
 #ifndef __LWIP_IP6_ROUTE_TABLE_H__


### PR DESCRIPTION
 #### Problem
When third_parry/lwip was brought over from openweave-core, the BSD license was stripped in some files, causing a triggered Copyright CHIP insertion

 #### Summary of Changes
Restored the stripped license information from third_party/LwIP source code. 

fixes #181 
