### PR TITLE
Ensure That the QRCode Library Is Built before Recursive Targets Are Run

### DIFF
--- a/src/setup_payload/Makefile.am
+++ b/src/setup_payload/Makefile.am
@@ -48,4 +48,6 @@ dist_libQrCode_a_HEADERS                                 = \
     QRCodeSetupPayloadParser.h                             \        
     $(NULL)
 
+$(RECURSIVE_TARGETS): $(lib_LIBRARIES)
+
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am


### PR DESCRIPTION
#### Problem
It is possible for recursive targets for the build system to attempt to run things in _tests_ before the QRCode library is built.

#### Summary of Changes
This adds a dependency on all recursive targets on the QRCode library.

Fixes #191 
