### PR TITLE
Import the Missing ErrorStr.cpp Source File

### DIFF
--- a/src/lib/core/CHIPError.cpp
+++ b/src/lib/core/CHIPError.cpp
@@ -29,6 +29,16 @@
 namespace chip {
 
 /**
+ * Register a text error formatter for CHIP core errors.
+ */
+void RegisterCHIPLayerErrorFormatter(void)
+{
+    static ErrorFormatter sCHIPErrorFormatter = { FormatCHIPError, NULL };
+
+    RegisterErrorFormatter(&sCHIPErrorFormatter);
+}
+
+/**
  * Given a CHIP error, returns a human-readable NULL-terminated C string
  * describing the error.
  *

--- a/src/lib/core/CHIPError.h
+++ b/src/lib/core/CHIPError.h
@@ -1741,6 +1741,7 @@ typedef CHIP_CONFIG_ERROR_TYPE CHIP_ERROR;
 
 namespace chip {
 
+extern void RegisterCHIPLayerErrorFormatter(void);
 extern bool FormatCHIPError(char * buf, uint16_t bufSize, int32_t err);
 
 } // namespace chip

--- a/src/lib/support/ErrorStr.cpp
+++ b/src/lib/support/ErrorStr.cpp
@@ -1,0 +1,159 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements functions to translate error codes used
+ *      throughout the CHIP package into human-readable strings.
+ *
+ */
+
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
+#include <inttypes.h>
+#include <stdio.h>
+
+#include <core/CHIPCore.h>
+#include <support/CodeUtils.h>
+
+namespace chip {
+
+/**
+ * Static buffer to store the formatted error string.
+ */
+static char sErrorStr[CHIP_CONFIG_ERROR_STR_SIZE];
+
+/**
+ * Linked-list of error formatter functions.
+ */
+static const ErrorFormatter * sErrorFormatterList = NULL;
+
+/**
+ * This routine returns a human-readable NULL-terminated C string
+ * describing the provided error.
+ *
+ * @param[in] err                      The error for format and describe.
+ *
+ * @return A pointer to a NULL-terminated C string describing the
+ *         provided error.
+ */
+DLL_EXPORT const char * ErrorStr(int32_t err)
+{
+    if (err == 0)
+    {
+        return "No Error";
+    }
+
+    // Search the registered error formatter for one that will format the given
+    // error code.
+    for (const ErrorFormatter * errFormatter = sErrorFormatterList;
+         errFormatter != NULL;
+         errFormatter = errFormatter->Next)
+    {
+        if (errFormatter->FormatError(sErrorStr, sizeof(sErrorStr), err))
+        {
+            return sErrorStr;
+        }
+    }
+
+    // Use a default formatting if no formatter found.
+    FormatError(sErrorStr, sizeof(sErrorStr), NULL, err, NULL);
+    return sErrorStr;
+}
+
+/**
+ * Add a new error formatter function to the global list of error formatters.
+ *
+ * @param[in] errFormatter             An ErrorFormatter structure containing a
+ *                                     pointer to the new error function.  Note
+ *                                     that a pointer to the supplied ErrorFormatter
+ *                                     structure will be retained by the function.
+ *                                     Thus the memory for the structure must
+ *                                     remain reserved.
+ */
+DLL_EXPORT void RegisterErrorFormatter(ErrorFormatter * errFormatter)
+{
+    // Do nothing if a formatter with the same format function is already in the list.
+    for (const ErrorFormatter * existingFormatter = sErrorFormatterList;
+         existingFormatter != NULL;
+         existingFormatter = existingFormatter->Next)
+    {
+        if (existingFormatter->FormatError == errFormatter->FormatError)
+        {
+            return;
+        }
+    }
+
+    // Add the formatter to the global list.
+    errFormatter->Next = sErrorFormatterList;
+    sErrorFormatterList = errFormatter;
+}
+
+
+#if !CHIP_CONFIG_CUSTOM_ERROR_FORMATTER
+
+/**
+ * Generates a human-readable NULL-terminated C string describing the provided error.
+ *
+ * @param[in] buf                   Buffer into which the error string will be placed.
+ * @param[in] bufSize               Size of the supplied buffer in bytes.
+ * @param[in] subsys                A short string describing the subsystem that originated
+ *                                  the error, or NULL if the origin of the error is
+ *                                  unknown/unavailable.  This string should be 10
+ *                                  characters or less.
+ * @param[in] err                   The error to be formatted.
+ * @param[in] desc                  A string describing the cause or meaning of the error,
+ *                                  or NULL if no such information is available.
+ */
+DLL_EXPORT void FormatError(char * buf, uint16_t bufSize, const char * subsys, int32_t err, const char * desc)
+{
+#if CHIP_CONFIG_SHORT_ERROR_STR
+
+    if (subsys == NULL)
+    {
+        (void)snprintf(buf, bufSize, "Error " CHIP_CONFIG_SHORT_FORM_ERROR_VALUE_FORMAT, err);
+    }
+    else
+    {
+        (void)snprintf(buf, bufSize, "Error %s:" CHIP_CONFIG_SHORT_FORM_ERROR_VALUE_FORMAT, subsys, err);
+    }
+
+#else // CHIP_CONFIG_SHORT_ERROR_STR
+
+    int len = 0;
+
+    if (subsys != NULL)
+    {
+        len = snprintf(buf, bufSize, "%s ", subsys);
+    }
+
+    len += snprintf(buf + len, bufSize - len, "Error %" PRId32 " (0x%08" PRIX32 ")", err, (uint32_t)err);
+
+    if (desc != NULL)
+    {
+        (void)snprintf(buf + len, bufSize - len, ": %s", desc);
+    }
+
+#endif // CHIP_CONFIG_SHORT_ERROR_STR
+}
+
+#endif // CHIP_CONFIG_CUSTOM_ERROR_FORMATTER
+
+} // namespace chip

--- a/src/lib/support/ErrorStr.cpp
+++ b/src/lib/support/ErrorStr.cpp
@@ -63,9 +63,7 @@ DLL_EXPORT const char * ErrorStr(int32_t err)
 
     // Search the registered error formatter for one that will format the given
     // error code.
-    for (const ErrorFormatter * errFormatter = sErrorFormatterList;
-         errFormatter != NULL;
-         errFormatter = errFormatter->Next)
+    for (const ErrorFormatter * errFormatter = sErrorFormatterList; errFormatter != NULL; errFormatter = errFormatter->Next)
     {
         if (errFormatter->FormatError(sErrorStr, sizeof(sErrorStr), err))
         {
@@ -91,9 +89,8 @@ DLL_EXPORT const char * ErrorStr(int32_t err)
 DLL_EXPORT void RegisterErrorFormatter(ErrorFormatter * errFormatter)
 {
     // Do nothing if a formatter with the same format function is already in the list.
-    for (const ErrorFormatter * existingFormatter = sErrorFormatterList;
-         existingFormatter != NULL;
-         existingFormatter = existingFormatter->Next)
+    for (const ErrorFormatter * existingFormatter = sErrorFormatterList; existingFormatter != NULL;
+         existingFormatter                        = existingFormatter->Next)
     {
         if (existingFormatter->FormatError == errFormatter->FormatError)
         {
@@ -102,10 +99,9 @@ DLL_EXPORT void RegisterErrorFormatter(ErrorFormatter * errFormatter)
     }
 
     // Add the formatter to the global list.
-    errFormatter->Next = sErrorFormatterList;
+    errFormatter->Next  = sErrorFormatterList;
     sErrorFormatterList = errFormatter;
 }
-
 
 #if !CHIP_CONFIG_CUSTOM_ERROR_FORMATTER
 
@@ -128,11 +124,11 @@ DLL_EXPORT void FormatError(char * buf, uint16_t bufSize, const char * subsys, i
 
     if (subsys == NULL)
     {
-        (void)snprintf(buf, bufSize, "Error " CHIP_CONFIG_SHORT_FORM_ERROR_VALUE_FORMAT, err);
+        (void) snprintf(buf, bufSize, "Error " CHIP_CONFIG_SHORT_FORM_ERROR_VALUE_FORMAT, err);
     }
     else
     {
-        (void)snprintf(buf, bufSize, "Error %s:" CHIP_CONFIG_SHORT_FORM_ERROR_VALUE_FORMAT, subsys, err);
+        (void) snprintf(buf, bufSize, "Error %s:" CHIP_CONFIG_SHORT_FORM_ERROR_VALUE_FORMAT, subsys, err);
     }
 
 #else // CHIP_CONFIG_SHORT_ERROR_STR
@@ -144,11 +140,11 @@ DLL_EXPORT void FormatError(char * buf, uint16_t bufSize, const char * subsys, i
         len = snprintf(buf, bufSize, "%s ", subsys);
     }
 
-    len += snprintf(buf + len, bufSize - len, "Error %" PRId32 " (0x%08" PRIX32 ")", err, (uint32_t)err);
+    len += snprintf(buf + len, bufSize - len, "Error %" PRId32 " (0x%08" PRIX32 ")", err, (uint32_t) err);
 
     if (desc != NULL)
     {
-        (void)snprintf(buf + len, bufSize - len, ": %s", desc);
+        (void) snprintf(buf + len, bufSize - len, ": %s", desc);
     }
 
 #endif // CHIP_CONFIG_SHORT_ERROR_STR

--- a/src/lib/support/SupportLayer.am
+++ b/src/lib/support/SupportLayer.am
@@ -26,6 +26,7 @@ CHIP_BUILD_SUPPORT_LAYER_SOURCE_FILES                     = \
     support/Base64.cpp                                      \
     support/CHIPFaultInjection.cpp                          \
     support/logging/CHIPLogging.cpp                         \
+    support/ErrorStr.cpp                                    \
     support/FibonacciUtils.cpp                              \
     support/RandUtils.cpp                                   \
     $(NULL)


### PR DESCRIPTION
 #### Problem
This adds the missing ErrorStr.cpp source file and its associated symbols to resolve a link-time error for unit tests and create a dependency on those symbols.

 #### Summary of Changes
This imports ErrorStr.cpp and applies a small refactoring to eliminate a circular dependency between the CHIP core library and the support library.

Fixes #192 
