### PR TITLE
fix trailing whitespace

### DIFF
--- a/src/setup_payload/Makefile.am
+++ b/src/setup_payload/Makefile.am
@@ -38,14 +38,14 @@ libQrCode_a_SOURCES                                       = \
     QRCodeSetupPayloadGenerator.cpp                         \
     SetupPayload.cpp                                        \
     Base45.cpp                                              \
-    QRCodeSetupPayloadParser.cpp                            \       
+    QRCodeSetupPayloadParser.cpp                            \
    $(NULL)
 
 dist_libQrCode_a_HEADERS                                 = \
     QRCodeSetupPayloadGenerator.h                          \
     SetupPayload.h                                         \
     Base45.h                                               \
-    QRCodeSetupPayloadParser.h                             \        
+    QRCodeSetupPayloadParser.h                             \
     $(NULL)
 
 $(RECURSIVE_TARGETS): $(lib_LIBRARIES)


### PR DESCRIPTION
#### Problem
 trailing whitespace after line continuation causes warnings to be emitted by automake

 #### Summary of Changes
 removed trailing whitespace