### PR TITLE
Adopt a Project-consistent Two-level #include Directive Name Pattern for the System Layer Library

### DIFF
--- a/src/inet/arpa-inet-compatibility.h
+++ b/src/inet/arpa-inet-compatibility.h
@@ -19,7 +19,7 @@
 #ifndef ARPA_INET_COMPATIBILITY_H
 #define ARPA_INET_COMPATIBILITY_H
 
-#include <SystemConfig.h>
+#include <system/SystemConfig.h>
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
 #include <arpa/inet.h>

--- a/src/system/SystemClock.cpp
+++ b/src/system/SystemClock.cpp
@@ -35,13 +35,13 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include <SystemConfig.h>
+#include <system/SystemConfig.h>
 
 #if !CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_TIME
 
-#include <SystemClock.h>
+#include <system/SystemClock.h>
 #include <support/CodeUtils.h>
-#include <SystemError.h>
+#include <system/SystemError.h>
 #include "SystemLayerPrivate.h"
 
 #if CHIP_SYSTEM_CONFIG_USE_POSIX_TIME_FUNCTS

--- a/src/system/SystemClock.h
+++ b/src/system/SystemClock.h
@@ -26,12 +26,12 @@
 #define SYSTEMTIME_H
 
 // Include configuration headers
-#include <SystemConfig.h>
+#include <system/SystemConfig.h>
 
 // Include dependent headers
 #include <support/DLLUtil.h>
 
-#include <SystemError.h>
+#include <system/SystemError.h>
 
 namespace chip {
 namespace System {

--- a/src/system/SystemError.cpp
+++ b/src/system/SystemError.cpp
@@ -27,7 +27,7 @@
 #include <stddef.h>
 
 // Include module header
-#include <SystemError.h>
+#include <system/SystemError.h>
 
 // Include common private header
 #include "SystemLayerPrivate.h"

--- a/src/system/SystemError.h
+++ b/src/system/SystemError.h
@@ -33,7 +33,7 @@
 #define SYSTEMERROR_H
 
 // Include headers
-#include <SystemConfig.h>
+#include <system/SystemConfig.h>
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 #include <lwip/err.h>

--- a/src/system/SystemEvent.h
+++ b/src/system/SystemEvent.h
@@ -26,7 +26,7 @@
 #define SYSTEMEVENT_H
 
 // Include headers
-#include <SystemConfig.h>
+#include <system/SystemConfig.h>
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 

--- a/src/system/SystemFaultInjection.cpp
+++ b/src/system/SystemFaultInjection.cpp
@@ -23,7 +23,7 @@
 
 #include <string.h>
 #include <nlassert.h>
-#include <SystemFaultInjection.h>
+#include <system/SystemFaultInjection.h>
 
 #if CHIP_SYSTEM_CONFIG_TEST
 

--- a/src/system/SystemFaultInjection.h
+++ b/src/system/SystemFaultInjection.h
@@ -24,7 +24,7 @@
 #ifndef SYSTEMFAULTINJECTION_H
 #define SYSTEMFAULTINJECTION_H
 
-#include <SystemConfig.h>
+#include <system/SystemConfig.h>
 
 #if CHIP_SYSTEM_CONFIG_TEST && CHIP_WITH_NLFAULTINJECTION
 

--- a/src/system/SystemLayer.cpp
+++ b/src/system/SystemLayer.cpp
@@ -23,14 +23,14 @@
  */
 
 // Include module header
-#include <SystemLayer.h>
+#include <system/SystemLayer.h>
 
 // Include common private header
 #include "SystemLayerPrivate.h"
 
 // Include local headers
-#include <SystemClock.h>
-#include <SystemTimer.h>
+#include <system/SystemClock.h>
+#include <system/SystemTimer.h>
 
 // Include additional CHIP headers
 #include <support/logging/CHIPLogging.h>

--- a/src/system/SystemLayer.h
+++ b/src/system/SystemLayer.h
@@ -27,7 +27,7 @@
 #define SYSTEMLAYER_H
 
 // Include configuration headers
-#include <SystemConfig.h>
+#include <system/SystemConfig.h>
 
 // Include dependent headers
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
@@ -40,9 +40,9 @@
 
 #include <support/DLLUtil.h>
 
-#include <SystemError.h>
-#include <SystemObject.h>
-#include <SystemEvent.h>
+#include <system/SystemError.h>
+#include <system/SystemObject.h>
+#include <system/SystemEvent.h>
 
 #if CHIP_SYSTEM_CONFIG_PROVIDE_OBSOLESCENT_INTERFACES
 

--- a/src/system/SystemLayerPrivate.h
+++ b/src/system/SystemLayerPrivate.h
@@ -24,15 +24,15 @@
 #ifndef SYSTEMLAYERPRIVATE_H
 #define SYSTEMLAYERPRIVATE_H
 
-#include <SystemConfig.h>
+#include <system/SystemConfig.h>
 
 //
 // Common definitions for the LwIP configuration
 //
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 
-#include "lwip/init.h"
-#include "lwip/stats.h"
+#include <lwip/init.h>
+#include <lwip/stats.h>
 
 // To use LwIP 1.x, some additional definitions are required here.
 #if LWIP_VERSION_MAJOR < 2

--- a/src/system/SystemMutex.cpp
+++ b/src/system/SystemMutex.cpp
@@ -23,7 +23,7 @@
  */
 
 // Include module header
-#include <SystemMutex.h>
+#include <system/SystemMutex.h>
 
 // Include common private header
 #include "SystemLayerPrivate.h"

--- a/src/system/SystemMutex.h
+++ b/src/system/SystemMutex.h
@@ -26,10 +26,10 @@
 #define SYSTEMMUTEX_H
 
 // Include configuration headers
-#include <SystemConfig.h>
+#include <system/SystemConfig.h>
 
 // Include dependent headers
-#include <SystemError.h>
+#include <system/SystemError.h>
 
 #include <support/DLLUtil.h>
 

--- a/src/system/SystemObject.cpp
+++ b/src/system/SystemObject.cpp
@@ -23,13 +23,13 @@
  */
 
 // Include module header
-#include <SystemObject.h>
+#include <system/SystemObject.h>
 
 // Include common private header
 #include "SystemLayerPrivate.h"
 
 // Include local headers
-#include <SystemLayer.h>
+#include <system/SystemLayer.h>
 #include <support/CodeUtils.h>
 
 // Include local headers

--- a/src/system/SystemObject.h
+++ b/src/system/SystemObject.h
@@ -30,7 +30,7 @@
 #define SYSTEMOBJECT_H
 
 // Include configuration headers
-#include <SystemConfig.h>
+#include <system/SystemConfig.h>
 
 // Include dependent headers
 #include <stddef.h>
@@ -39,8 +39,8 @@
 
 #include <support/DLLUtil.h>
 
-#include <SystemError.h>
-#include <SystemStats.h>
+#include <system/SystemError.h>
+#include <system/SystemStats.h>
 
 #ifndef SYSTEM_OBJECT_HWM_TEST_HOOK
 #define SYSTEM_OBJECT_HWM_TEST_HOOK()

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -27,14 +27,14 @@
 #define SYSTEMPACKETBUFFER_H
 
 // Include configuration header
-#include <SystemConfig.h>
+#include <system/SystemConfig.h>
 
 // Include dependent headers
 #include <stddef.h>
 
 #include "support/DLLUtil.h"
 
-#include "system/SystemAlignSize.h"
+#include <system/SystemAlignSize.h>
 #include <system/SystemError.h>
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP

--- a/src/system/SystemStats.cpp
+++ b/src/system/SystemStats.cpp
@@ -26,10 +26,10 @@
 #include "SystemLayerPrivate.h"
 
 // Include local headers
-#include <SystemTimer.h>
+#include <system/SystemTimer.h>
 
 // Include module header
-#include <SystemStats.h>
+#include <system/SystemStats.h>
 
 #include <string.h>
 

--- a/src/system/SystemTimer.cpp
+++ b/src/system/SystemTimer.cpp
@@ -24,7 +24,7 @@
  */
 
 // Include module header
-#include <SystemTimer.h>
+#include <system/SystemTimer.h>
 
 // Include common private header
 #include "SystemLayerPrivate.h"
@@ -32,9 +32,9 @@
 // Include local headers
 #include <string.h>
 
-#include <SystemError.h>
-#include <SystemLayer.h>
-#include <SystemFaultInjection.h>
+#include <system/SystemError.h>
+#include <system/SystemLayer.h>
+#include <system/SystemFaultInjection.h>
 
 #include <support/CodeUtils.h>
 

--- a/src/system/SystemTimer.h
+++ b/src/system/SystemTimer.h
@@ -27,15 +27,15 @@
 #define SYSTEMTIMER_H
 
 // Include configuration headers
-#include <SystemConfig.h>
+#include <system/SystemConfig.h>
 
 // Include dependent headers
 #include <support/DLLUtil.h>
 
-#include <SystemClock.h>
-#include <SystemError.h>
-#include <SystemObject.h>
-#include <SystemStats.h>
+#include <system/SystemClock.h>
+#include <system/SystemError.h>
+#include <system/SystemObject.h>
+#include <system/SystemStats.h>
 
 #if CHIP_SYSTEM_CONFIG_PROVIDE_OBSOLESCENT_INTERFACES
 


### PR DESCRIPTION
#### Problem
Currently most of the system layer library headers do not follow a two-level include name pattern used by the rest of the project.

#### Summary of Changes
Adopts a two-level #include directive name pattern for system layer library headers.

Fixes #220 
