### PR TITLE
Be careful with snprintf

### DIFF
--- a/src/lib/support/ErrorStr.cpp
+++ b/src/lib/support/ErrorStr.cpp
@@ -133,19 +133,22 @@ DLL_EXPORT void FormatError(char * buf, uint16_t bufSize, const char * subsys, i
 
 #else // CHIP_CONFIG_SHORT_ERROR_STR
 
-    int len = 0;
+    const char * subsysSep = " ";
+    const char * descSep   = ": ";
 
-    if (subsys != NULL)
+    if (subsys == NULL)
     {
-        len = snprintf(buf, bufSize, "%s ", subsys);
+        subsys    = "";
+        subsysSep = "";
+    }
+    if (desc == NULL)
+    {
+        desc    = "";
+        descSep = "";
     }
 
-    len += snprintf(buf + len, bufSize - len, "Error %" PRId32 " (0x%08" PRIX32 ")", err, (uint32_t) err);
-
-    if (desc != NULL)
-    {
-        (void) snprintf(buf + len, bufSize - len, ": %s", desc);
-    }
+    (void) snprintf(buf, bufSize, "%s%sError %" PRId32 " (0x%08" PRIX32 ")%s%s", subsys, subsysSep, err, (uint32_t) err, descSep,
+                    desc);
 
 #endif // CHIP_CONFIG_SHORT_ERROR_STR
 }


### PR DESCRIPTION
#### Problem
 ErrStr puts too much stock in snprintf's behavior and return value,
 and may as a result may index outside the bounds of the output buffer

 consider:
 http://www.cplusplus.com/reference/cstdio/snprintf/
 http://www.cplusplus.com/reference/cstdio/snprintf/


 #### Summary of Changes
 restructure to be able to safely ignore sprintf's return value