### PR TITLE
Fix EFR32 DeviceLayer build

### DIFF
--- a/src/lib/support/Makefile.am
+++ b/src/lib/support/Makefile.am
@@ -33,6 +33,7 @@ lib_LIBRARIES                       = libSupportLayer.a
 libSupportLayer_a_CPPFLAGS          = \
     -I$(top_srcdir)/src               \
     -I$(top_srcdir)/src/lib           \
+    -I$(top_srcdir)/src/include       \
     $(NULL)
 
 libSupportLayer_a_SOURCES           = $(CHIP_BUILD_SUPPORT_LAYER_SOURCE_FILES)


### PR DESCRIPTION
 #### Problem
EFR32 DeviceLayer isn't building because of a missing header dependency.
 #### Summary of Changes
Add the include directive. 