### PR TITLE
Add Docker packages and env variables for Git command completion

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,7 +22,9 @@ RUN apt-get -fy install git vim emacs sudo \
     lcov \
     shellcheck \
     gcc-multilib \
-    libfftw3-dev
+    libfftw3-dev \
+    git-core \
+    bash-completion
 
 RUN groupadd --gid $USER_GID $USERNAME
 RUN useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,5 +16,15 @@
 	// You can edit these settings after create using File > Preferences > Settings > Remote.
 	"settings": { 
 		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	"postCreateCommand": "source /usr/share/bash-completion/bash_completion",
+	"postCreateCommand": "source /etc/bash_completion.d/git-prompt ",
+
+	"remoteEnv": {
+		"GIT_PS1_SHOWDIRTYSTATE": "1",
+		"GIT_PS1_SHOWSTASHSTATE": "1",
+		"GIT_PS1_SHOWCOLORHINTS": "true",
+		"PROMPT_COMMAND": "${localEnv:PROMPT_COMMAND}"
 	}
 }

--- a/integrations/docker/images/chip-build/Dockerfile
+++ b/integrations/docker/images/chip-build/Dockerfile
@@ -19,7 +19,9 @@ RUN set -x \
     lcov \
     shellcheck \
     gcc-multilib \
-    libfftw3-dev
+    libfftw3-dev \
+    git-core \
+    bash-completion
 
 RUN mkdir -p /var/bsim
 WORKDIR /var/bsim


### PR DESCRIPTION
 #### Problem
There are some Git utilities that make it easier to work with Git. For example, command completion, command prompt integration etc. The Docker containers are missing the required packages and their integration.

 #### Summary of Changes
Added missing packages to `Dockerfile`. Updated `.devcontainer` to add missing bindings. 