### PR TITLE
Added Missing Files from the Project Tree That Were Causing 'make distcheck' to Fail

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -52,6 +52,10 @@ EXTRA_DIST                               = \
     bootstrap                              \
     bootstrap-configure                    \
     repos.conf                             \
+    $(srcdir)/build/autoconf               \
+    $(srcdir)/build/config                 \
+    $(srcdir)/build/efr32                  \
+    $(srcdir)/build/nrf5                   \
     $(NULL)
 
 BUILT_SOURCES                            = \


### PR DESCRIPTION
#### Problem
The top-of-tree master builds are failing against 'make distcheck'.

#### Summary of Changes
Added missing files from the project tree that were causing 'make distcheck' to fail.

Fixes #240
