### PR TITLE
Update clang integration for clang 9

### DIFF
--- a/integrations/clang/clang-format.sh
+++ b/integrations/clang/clang-format.sh
@@ -7,8 +7,8 @@ die() {
     exit 1
 }
 
-if command -v clang-format-6.0 > /dev/null; then
-    alias clang-format=clang-format-9.0
+if command -v clang-format-9 > /dev/null; then
+    alias clang-format=clang-format-9
 elif command -v clang-format > /dev/null; then
     case "$(clang-format --version)" in
         "$CLANG_FORMAT_VERSION"*)


### PR DESCRIPTION
#### Problem
 clang.sh aliases to the wrong clang-format

 #### Summary of Changes
 fix the alias