### PR TITLE
Made OpenSSL a Required Package and Add Headers the Project Uses

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1307,12 +1307,12 @@ AC_LANG_POP([C++])
 #
 #   * nlassert
 #   * nlio
+#   * openssl
 #
 # The following are optional, depending on configuration:
 #
 #   * lwip
 #   * nlunit-test
-#   * openssl
 #   * nlfaultinjection
 #
 # Most of these are supplied "in package"; however, they may be also
@@ -1329,14 +1329,15 @@ AC_PATH_PROG([PKG_CONFIG],[pkg-config])
 # OpenSSL
 #
 
-NL_WITH_OPTIONAL_EXTERNAL_PACKAGE([OpenSSL],
+NL_WITH_REQUIRED_EXTERNAL_PACKAGE([OpenSSL],
     [OPENSSL],
     [openssl],
     [-lcrypto],
     [
         # Check for required OpenSSL headers.
 
-        AC_CHECK_HEADERS([openssl/aes.h] [openssl/bn.h] [openssl/crypto.h] [openssl/ec.h] [openssl/err.h] [openssl/evp.h] [openssl/sha.h],
+        AC_CHECK_HEADERS([openssl/aes.h] [openssl/bn.h] [openssl/crypto.h] [openssl/ec.h] [openssl/err.h] [openssl/evp.h] [openssl/hmac.h] [openssl/kdf.h] [openssl/rand.h] [openssl/sha.h] [openssl/srp.h],
+
             [],
             [
                 AC_MSG_ERROR(The OpenSSL header "$ac_header" is required but cannot be found.)


### PR DESCRIPTION
#### Problem
There is a discrepancy between the OpenSSL development package pulled in by the Docker build and the header files for OpenSSL that may or may not exist in a macOS or Linux system outside of Docker. This can cause latent, rather than up front, build failures for the latter environments.

 #### Summary of Changes
Changed OpenSSL from an optional to a required package.
Added OpenSSL headers additionally used by the project.

Fixes #252
