### PR TITLE
Corrected a Typo from Issue #227

### DIFF
--- a/src/lib/core/tests/TestCHIPErrorStr.cpp
+++ b/src/lib/core/tests/TestCHIPErrorStr.cpp
@@ -234,7 +234,7 @@ static int32_t sContext[] =
 
 static const size_t kTestElements = sizeof(sContext) / sizeof(sContext[0]);
 
-static void CheckCHIPErrorStr(nlTestSuite * inSuite, void * inContext)
+static void CheckCoreErrorStr(nlTestSuite * inSuite, void * inContext)
 {
     // Register the layer error formatter
 


### PR DESCRIPTION
#### Problem
There was a typo in the merge from issue #227 that did not get pushed and, therefore, merged.

#### Summary of Changes
Fix the typo.

Fixes #227