### PR TITLE
Add recursive thing

### DIFF
--- a/src/crypto/Makefile.am
+++ b/src/crypto/Makefile.am
@@ -44,4 +44,6 @@ dist_libChipCrypto_a_HEADERS                                 = \
     CHIPBase+CompilerAbstraction.h                             \
     $(NULL)
 
+$(RECURSIVE_TARGETS): $(lib_LIBRARIES)
+
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am


### PR DESCRIPTION
#### Problem
 `make check` fails on a clean tree because the tests in crypto/tests
  want the library in their parent directory

 #### Summary of Changes
 move .a making to before SUBDIR recursion