### PR TITLE
Updating GitHub workflow to use the same environment as the docker + vscode build

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -17,4 +17,5 @@ jobs:
           make -f Makefile-Standalone pretty-check
 
       - name: Run Build
-        run: ./bootstrap && make -f Makefile-Standalone distcheck
+#        run: ./bootstrap && make -f Makefile-Standalone distcheck
+        run: ./integrations/docker/docker_build.sh

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -17,5 +17,4 @@ jobs:
           make -f Makefile-Standalone pretty-check
 
       - name: Run Build
-#        run: ./bootstrap && make -f Makefile-Standalone distcheck
-        run: ./integrations/docker/docker_build.sh
+        run: ./integrations/docker/run_docker_build.sh

--- a/integrations/docker/images/chip-build/Dockerfile
+++ b/integrations/docker/images/chip-build/Dockerfile
@@ -1,6 +1,8 @@
 # start with Ubuntu 18.04LTS
 FROM ubuntu:bionic
 
+VOLUME "/var/source"
+
 # base build and check tools and libraries layer
 RUN set -x \
     && apt-get update \

--- a/integrations/docker/run_build.sh
+++ b/integrations/docker/run_build.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-./bootstrap -w make && mkdir -p build/default && (cd build/default && ../../configure --enable-coverage --enable-coverage-info) && make -C build/default distcheck
+./bootstrap && mkdir -p build/default && (cd build/default && ../../configure --enable-coverage --enable-coverage-info) && make -C build/default distcheck

--- a/integrations/docker/run_build.sh
+++ b/integrations/docker/run_build.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
+# Note: this needs to be run from the root directory presently. 
+# https://github.com/project-chip/connectedhomeip/issues/273
 
 ./bootstrap && mkdir -p build/default && (cd build/default && ../../configure --enable-coverage --enable-coverage-info) && make -C build/default distcheck

--- a/integrations/docker/run_build.sh
+++ b/integrations/docker/run_build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+./bootstrap && mkdir -p build/default && (cd build/default && ../../configure --enable-coverage --enable-coverage-info) && ./bootstrap -w make && make -C build/default distcheck

--- a/integrations/docker/run_build.sh
+++ b/integrations/docker/run_build.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-./bootstrap && mkdir -p build/default && (cd build/default && ../../configure --enable-coverage --enable-coverage-info) && ./bootstrap -w make && make -C build/default distcheck
+./bootstrap -w make && mkdir -p build/default && (cd build/default && ../../configure --enable-coverage --enable-coverage-info) && make -C build/default distcheck

--- a/integrations/docker/run_docker_build.sh
+++ b/integrations/docker/run_docker_build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+VERSION=$(cat integrations/docker/images/chip-build/version)
+ORGANIZATION="rwalkerapple"
+IMAGE="chip-build"
+TARGET_SOURCE_PATH="/var/source"
+
+docker run --rm -w $TARGET_SOURCE_PATH -v ${PWD}:$TARGET_SOURCE_PATH "$ORGANIZATION/$IMAGE:$VERSION" ./integrations/docker/run_build.sh

--- a/integrations/docker/run_docker_build.sh
+++ b/integrations/docker/run_docker_build.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Note: this needs to be run from the root directory presently. 
+# https://github.com/project-chip/connectedhomeip/issues/273
+
 set -e
 
 VERSION=$(cat integrations/docker/images/chip-build/version)


### PR DESCRIPTION
 #### Problem
The default GitHub ubuntu environment is different than our constrained build, which has been causing build confusions (some fail, some succeed). After this the VSCode + GitHub + docker local builds all will use the same build environment.

 #### Summary of Changes
Updating Docker build slightly, as well as moving GitHub workflows over to the docker build

