### PR TITLE
Fix CHIP DeviceLayer Build and Link for EFR32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Build System
 .deps
 .dirstamp
+.DS_Store
 .local-version
 Makefile.in
 aclocal.m4
@@ -20,10 +21,8 @@ build/*
 !build/config/standalone/SystemProjectConfig.h
 !build/config/standalone/darwin/CHIPProjectConfig.h
 !build/config/standalone/no-openssl/CHIPProjectConfig.h
-!build/efr32/efr32-app.mk
-!build/efr32/efr32-chip.mk
-!build/nrf5/nrf5-app.mk
-!build/nrf5/nrf5-chip.mk
+!build/efr32/
+!build/nrf5/
 !build/scripts/gen-chip-version
 config.log
 config.status

--- a/build/efr32/efr32-app.mk
+++ b/build/efr32/efr32-app.mk
@@ -119,7 +119,7 @@ EXTRA_SRCS += \
     $(EFR32_SDK_ROOT)/platform/emdrv/nvm3/src/nvm3_default.c                                \
     $(EFR32_SDK_ROOT)/platform/emdrv/nvm3/src/nvm3_hal_flash.c                              \
     $(EFR32_SDK_ROOT)/platform/emdrv/sleep/src/sleep.c                                      \
-    $(EFR32_SDK_ROOT)/platform/base/hal/plugin/debug/rtt/SEGGER_RTT.c
+    $(EFR32_SDK_ROOT)/util/third_party/segger/systemview/SEGGER/SEGGER_RTT.c
 
 STD_INC_DIRS += \
     $(CHIP_ROOT)/src/include/platform/EFR32                                                 \
@@ -154,7 +154,8 @@ STD_INC_DIRS += \
     $(EFR32_SDK_ROOT)/platform/radio/rail_lib/hal                                           \
     $(EFR32_SDK_ROOT)/platform/radio/rail_lib/hal/efr32                                     \
     $(EFR32_SDK_ROOT)/platform/radio/rail_lib/plugin/pa-conversions                         \
-    $(EFR32_SDK_ROOT)/platform/base/hal/plugin/debug/rtt/   \
+    $(EFR32_SDK_ROOT)/util/third_party/segger/systemview/SEGGER                             \
+    $(EFR32_SDK_ROOT)/util/third_party/segger/systemview/Config/                            \
     $(EFR32_SDK_ROOT)/util/plugin/plugin-common/fem-control                                 \
     $(EFR32_SDK_ROOT)/util/third_party/mbedtls/sl_crypto/include
 

--- a/build/efr32/efr32-app.mk
+++ b/build/efr32/efr32-app.mk
@@ -76,7 +76,7 @@ ifndef FREERTOS_ROOT
 $(error ENVIRONMENT ERROR: FREERTOS_ROOT not set)
 endif
 
-
+uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 
 # Differentiate between boards
 # - BRD4304A / SLWSTK6000B / MGM12P Module / 2.4GHz@19dBm
@@ -119,15 +119,10 @@ EXTRA_SRCS += \
     $(EFR32_SDK_ROOT)/platform/emdrv/nvm3/src/nvm3_default.c                                \
     $(EFR32_SDK_ROOT)/platform/emdrv/nvm3/src/nvm3_hal_flash.c                              \
     $(EFR32_SDK_ROOT)/platform/emdrv/sleep/src/sleep.c                                      \
+    $(EFR32_SDK_ROOT)/platform/base/hal/plugin/debug/rtt/SEGGER_RTT.c
 
 STD_INC_DIRS += \
     $(CHIP_ROOT)/src/include/platform/EFR32                                                 \
-    $(OPENTHREAD_ROOT)/output/include                                                       \
-    $(OPENTHREAD_ROOT)/src/core/                                                            \
-    $(OPENTHREAD_ROOT)/third_party/jlink/SEGGER_RTT_V640/RTT                                \
-    $(OPENTHREAD_ROOT)/third_party/mbedtls                                                  \
-    $(OPENTHREAD_ROOT)/third_party/mbedtls/repo/include                                     \
-    $(OPENTHREAD_ROOT)/third_party/mbedtls/repo/include/mbedtls                             \
     $(FREERTOS_ROOT)/Source/include                                                         \
     $(FREERTOS_ROOT)/Source/portable/GCC/ARM_CM3                                            \
     $(EFR32_SDK_ROOT)                                                                       \
@@ -159,11 +154,9 @@ STD_INC_DIRS += \
     $(EFR32_SDK_ROOT)/platform/radio/rail_lib/hal                                           \
     $(EFR32_SDK_ROOT)/platform/radio/rail_lib/hal/efr32                                     \
     $(EFR32_SDK_ROOT)/platform/radio/rail_lib/plugin/pa-conversions                         \
+    $(EFR32_SDK_ROOT)/platform/base/hal/plugin/debug/rtt/   \
     $(EFR32_SDK_ROOT)/util/plugin/plugin-common/fem-control                                 \
-    $(EFR32_SDK_ROOT)/util/third_party/mbedtls/sl_crypto/include                            \
-    $(OPENTHREAD_ROOT)/examples/platforms/$(EFR32FAMILY)/                                   \
-    $(OPENTHREAD_ROOT)/examples/platforms/$(EFR32FAMILY)/$(BOARD_LC)                        \
-    $(OPENTHREAD_ROOT)/examples/platforms/$(EFR32FAMILY)/crypto
+    $(EFR32_SDK_ROOT)/util/third_party/mbedtls/sl_crypto/include
 
 ifeq ($(EFR32FAMILY), efr32mg12)
 STD_INC_DIRS += \
@@ -244,6 +237,8 @@ STD_LDFLAGS = \
     -ffunction-sections \
     -Wl,--gc-sections \
     -specs=nosys.specs \
+    $(foreach dir,$(LINKER_SCRIPT_INC_DIRS),-L$(dir)) \
+    -T$(LINKER_SCRIPT)
 
 ifeq ($(EFR32FAMILY), efr32mg21)
 STD_LDFLAGS += \
@@ -253,12 +248,14 @@ endif
 STD_LIBS = \
     -lc \
     -lstdc++ \
+    -lfreertos \
     -lnosys \
     -lm
 
 ifeq ($(EFR32FAMILY), efr32mg12)
 STD_LIBS += \
     $(EFR32_SDK_ROOT)/protocol/bluetooth/lib/EFR32MG12P/GCC/libbluetooth.a \
+    $(EFR32_SDK_ROOT)/protocol/bluetooth/lib/EFR32MG12P/GCC/libmbedtls.a \
     $(EFR32_SDK_ROOT)/platform/radio/rail_lib/autogen/librail_release/librail_multiprotocol_efr32xg12_gcc_release.a \
     $(EFR32_SDK_ROOT)/platform/emdrv/nvm3/lib/libnvm3_CM4_gcc.a
 else
@@ -277,11 +274,27 @@ STD_DEFINES = \
 
 STD_COMPILE_PREREQUISITES =
 
+STD_LINK_PREREQUISITES += $(OUTPUT_DIR)/freertos/libfreertos.a
+
 DEFINE_FLAGS = $(foreach def,$(STD_DEFINES) $(DEFINES),-D$(def))
 
 INC_FLAGS = $(foreach dir,$(INC_DIRS) $(STD_INC_DIRS),-I$(dir))
 
 LINKER_SCRIPT_INC_DIRS = $(PROJECT_ROOT) $(OUTPUT_DIR)/freertos
+
+# Default EFR32 linker script defines a section at top of Flash for NVM3 support.
+ifeq ($(EFR32FAMILY), efr32mg12)
+ifndef LINKER_SCRIPT
+LINKER_SCRIPT = $(APP)-MG12P.ld
+endif
+else
+ifeq ($(EFR32FAMILY), efr32mg21)
+ifndef LINKER_SCRIPT
+LINKER_SCRIPT = $(APP)-MG21.ld
+endif
+endif
+endif
+
 
 # ==================================================
 # Toolchain and external utilities / files
@@ -308,8 +321,11 @@ ifneq (, $(shell which ccache))
 CCACHE = ccache
 endif
 
+ifeq ($(uname_S),Darwin)
+COMMANDER = $(EFR32_TOOLS_ROOT)/developer/adapter_packs/commander/Commander.app/Contents/MacOS/commander
+else
 COMMANDER = $(EFR32_TOOLS_ROOT)/developer/adapter_packs/commander/commander
-
+endif
 
 # ==================================================
 # Build options

--- a/build/efr32/efr32-chip.mk
+++ b/build/efr32/efr32-chip.mk
@@ -153,7 +153,7 @@ STD_LDFLAGS += -L$(CHIP_OUTPUT_DIR)/lib
 # Add CHIP libraries to standard libraries list.
 STD_LIBS += \
     -lDeviceLayer \
-    -lchip \
+    -lCHIP \
     -lInetLayer \
     -lnlfaultinjection \
     -lSystemLayer \
@@ -167,7 +167,7 @@ STD_COMPILE_PREREQUISITES += install-chip
 # Add the CHIP libraries as prerequisites for linking the application.
 STD_LINK_PREREQUISITES += \
     $(CHIP_OUTPUT_DIR)/lib/libDeviceLayer.a \
-    $(CHIP_OUTPUT_DIR)/lib/libchip.a \
+    $(CHIP_OUTPUT_DIR)/lib/libCHIP.a \
     $(CHIP_OUTPUT_DIR)/lib/libInetLayer.a \
     $(CHIP_OUTPUT_DIR)/lib/libnlfaultinjection.a \
     $(CHIP_OUTPUT_DIR)/lib/libSystemLayer.a \

--- a/build/efr32/efr32-chip.mk
+++ b/build/efr32/efr32-chip.mk
@@ -101,7 +101,6 @@ CHIP_CONFIGURE_OPTIONS = \
     --with-lwip=internal \
     --with-lwip-target=efr32 \
     --with-inet-endpoint="tcp udp" \
-    --with-openssl=no \
     --with-logging-style=external \
     --with-chip-project-includes=$(CHIP_PROJECT_CONFIG) \
     --with-chip-system-project-includes=$(CHIP_PROJECT_CONFIG) \

--- a/build/efr32/efr32-freertos.mk
+++ b/build/efr32/efr32-freertos.mk
@@ -1,0 +1,152 @@
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#    Copyright (c) 2020 Google LLC.
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+#
+#   @file
+#         Component makefile for incorporating FreeRTOS into an EFR32
+#         application.
+#
+
+#
+#   This makefile is intended to work in conjunction with the efr32-app.mk
+#   makefile to build the OpenWeave example applications on Silicon Labs platforms.
+#   EFR32 applications should include this file in their top level Makefile
+#   along with the other makefiles in this directory.  E.g.:
+#
+#       PROJECT_ROOT = $(realpath .)
+#
+#       BUILD_SUPPORT_DIR = $(PROJECT_ROOT)/third_party/openweave-core/build/efr32
+#
+#       include $(BUILD_SUPPORT_DIR)/efr32-app.mk
+#       include $(BUILD_SUPPORT_DIR)/efr32-openweave.mk
+#       include $(BUILD_SUPPORT_DIR)/efr32-openthread.mk
+#       include $(BUILD_SUPPORT_DIR)/efr32-freertos.mk
+#
+#       PROJECT_ROOT := $(realpath .)
+#
+#       APP := openweave-efr32-bringup
+#
+#       SRCS = \
+#           $(PROJECT_ROOT)/main.cpp \
+#           ...
+#
+#       $(call GenerateBuildRules)
+#
+
+ifeq ($(EFR32FAMILY), efr32mg12)
+  FREERTOS_TARGET = ARM_CM3
+else
+ifeq ($(EFR32FAMILY), efr32mg21)
+  FREERTOS_TARGET = ARM_CM4F
+endif
+endif
+
+FREERTOS_OUTPUT_DIR = $(OUTPUT_DIR)/freertos
+FREERTOS_LIB_DIR = $(FREERTOS_OUTPUT_DIR)
+
+STD_LDFLAGS += \
+    -L$(FREERTOS_LIB_DIR)
+
+STD_INC_DIRS += \
+    $(FREERTOS_ROOT)/Source/include/
+
+$(FREERTOS_OUTPUT_DIR)/croutine.c.o : $(FREERTOS_ROOT)/Source/croutine.c $(FREERTOSCONFIG_DIR)/FreeRTOSConfig.h
+	$(NO_ECHO) $(CCACHE) $(CC) -c  $(STD_CFLAGS) $(CFLAGS) $(DEBUG_FLAGS) $(OPT_FLAGS) $(DEFINE_FLAGS) $(INC_FLAGS) $(FREERTOS_ROOT)/Source/croutine.c -o $(FREERTOS_OUTPUT_DIR)/croutine.c.o
+
+$(FREERTOS_OUTPUT_DIR)/list.c.o     : $(FREERTOS_ROOT)/Source/list.c $(FREERTOSCONFIG_DIR)/FreeRTOSConfig.h
+	$(NO_ECHO) $(CCACHE) $(CC) -c  $(STD_CFLAGS) $(CFLAGS) $(DEBUG_FLAGS) $(OPT_FLAGS) $(DEFINE_FLAGS) $(INC_FLAGS) $(FREERTOS_ROOT)/Source/list.c -o $(FREERTOS_OUTPUT_DIR)/list.c.o
+
+$(FREERTOS_OUTPUT_DIR)/queue.c.o    : $(FREERTOS_ROOT)/Source/queue.c $(FREERTOSCONFIG_DIR)/FreeRTOSConfig.h
+	$(NO_ECHO) $(CCACHE) $(CC) -c  $(STD_CFLAGS) $(CFLAGS) $(DEBUG_FLAGS) $(OPT_FLAGS) $(DEFINE_FLAGS) $(INC_FLAGS) $(FREERTOS_ROOT)/Source/queue.c -o $(FREERTOS_OUTPUT_DIR)/queue.c.o
+
+$(FREERTOS_OUTPUT_DIR)/event_groups.c.o    : $(FREERTOS_ROOT)/Source/event_groups.c $(FREERTOSCONFIG_DIR)/FreeRTOSConfig.h
+	$(NO_ECHO) $(CCACHE) $(CC) -c  $(STD_CFLAGS) $(CFLAGS) $(DEBUG_FLAGS) $(OPT_FLAGS) $(DEFINE_FLAGS) $(INC_FLAGS) $(FREERTOS_ROOT)/Source/event_groups.c -o $(FREERTOS_OUTPUT_DIR)/event_groups.c.o
+
+$(FREERTOS_OUTPUT_DIR)/tasks.c.o    : $(FREERTOS_ROOT)/Source/tasks.c $(FREERTOSCONFIG_DIR)/FreeRTOSConfig.h
+	$(NO_ECHO) $(CCACHE) $(CC) -c  $(STD_CFLAGS) $(CFLAGS) $(DEBUG_FLAGS) $(OPT_FLAGS) $(DEFINE_FLAGS) $(INC_FLAGS) $(FREERTOS_ROOT)/Source/tasks.c -o $(FREERTOS_OUTPUT_DIR)/tasks.c.o
+
+$(FREERTOS_OUTPUT_DIR)/timers.c.o   : $(FREERTOS_ROOT)/Source/timers.c $(FREERTOSCONFIG_DIR)/FreeRTOSConfig.h
+	$(NO_ECHO) $(CCACHE) $(CC) -c  $(STD_CFLAGS) $(CFLAGS) $(DEBUG_FLAGS) $(OPT_FLAGS) $(DEFINE_FLAGS) $(INC_FLAGS) $(FREERTOS_ROOT)/Source/timers.c -o $(FREERTOS_OUTPUT_DIR)/timers.c.o
+
+$(FREERTOS_OUTPUT_DIR)/port.c.o     : $(FREERTOS_ROOT)/Source/portable/GCC/$(FREERTOS_TARGET)/port.c $(FREERTOSCONFIG_DIR)/FreeRTOSConfig.h
+	$(NO_ECHO) $(CCACHE) $(CC) -c  $(STD_CFLAGS) $(CFLAGS) $(DEBUG_FLAGS) $(OPT_FLAGS) $(DEFINE_FLAGS) $(INC_FLAGS) $(FREERTOS_ROOT)/Source/portable/GCC/$(FREERTOS_TARGET)/port.c -o $(FREERTOS_OUTPUT_DIR)/port.c.o
+
+$(FREERTOS_OUTPUT_DIR)/heap_3.c.o     : $(FREERTOS_ROOT)/Source/portable/MemMang/heap_3.c $(FREERTOSCONFIG_DIR)/FreeRTOSConfig.h
+	$(NO_ECHO) $(CCACHE) $(CC) -c  $(STD_CFLAGS) $(CFLAGS) $(DEBUG_FLAGS) $(OPT_FLAGS) $(DEFINE_FLAGS) $(INC_FLAGS) $(FREERTOS_ROOT)/Source/portable/MemMang/heap_3.c -o $(FREERTOS_OUTPUT_DIR)/heap_3.c.o
+
+FREERTOS_OBJECTS := \
+    $(FREERTOS_OUTPUT_DIR)/croutine.c.o \
+    $(FREERTOS_OUTPUT_DIR)/list.c.o \
+    $(FREERTOS_OUTPUT_DIR)/queue.c.o \
+    $(FREERTOS_OUTPUT_DIR)/event_groups.c.o \
+    $(FREERTOS_OUTPUT_DIR)/tasks.c.o \
+    $(FREERTOS_OUTPUT_DIR)/timers.c.o \
+    $(FREERTOS_OUTPUT_DIR)/port.c.o \
+    $(FREERTOS_OUTPUT_DIR)/heap_3.c.o
+
+
+# Add FreeRTOSBuildRules to the list of late-bound build rules that
+# will be evaluated when GenerateBuildRules is called.
+LATE_BOUND_RULES += FreeRTOSBuildRules
+
+# Rules for configuring, building and installing FreeRTOS from source.
+define FreeRTOSBuildRules
+
+$(FREERTOS_LIB_DIR)/libfreertos.a : $(FREERTOS_OUTPUT_DIR) $(FREERTOS_LIB_DIR) $(FREERTOS_OBJECTS)
+	@echo "$(HDR_PREFIX)AR $(FREERTOS_LIB_DIR)/libfreertos.a"
+	$(NO_ECHO)$(AR) rcs $(FREERTOS_LIB_DIR)/libfreertos.a $(FREERTOS_OBJECTS)
+
+.phony: $(FREERTOS_OUTPUT_DIR)
+$(FREERTOS_OUTPUT_DIR) :
+	@echo "$(HDR_PREFIX)MKDIR $@"
+	$(NO_ECHO)mkdir -p $(FREERTOS_OUTPUT_DIR)
+
+.phony: build-freertos
+build-freertos : $(FREERTOS_LIB_DIR)/libfreertos.a
+
+.phony: install-freertos
+install-freertos : $(FREERTOS_OUTPUT_DIR)
+	@echo "$(HDR_PREFIX)CP $(FREERTOS_OUTPUT_DIR)"
+	$(NO_ECHO)cp -r $(FREERTOS_ROOT)/Source/include $(FREERTOS_OUTPUT_DIR)/
+
+.phony: clean-freertos
+clean-freertos :
+	@echo "$(HDR_PREFIX)RM $(FREERTOS_OUTPUT_DIR)"
+	$(NO_ECHO)rm -rf $(FREERTOS_OUTPUT_DIR)
+
+endef
+
+
+# ==================================================
+# FreeRTOS-specific help definitions
+# ==================================================
+
+define TargetHelp +=
+
+  build-freertos        Build the FreeRTOS library.
+
+  install-freertos      Install FreeRTOS library and headers in
+                        build output directory for use by application.
+
+  clean-freertos        Clean all build outputs produced by the FreeRTOS
+                        build process.
+endef
+
+
+
+

--- a/src/include/platform/EFR32/freertos_bluetooth.h
+++ b/src/include/platform/EFR32/freertos_bluetooth.h
@@ -2,6 +2,7 @@
  *
  *    Copyright (c) 2020 Project CHIP Authors
  *    Copyright (c) 2020 Google LLC.
+ *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/include/platform/internal/GenericPlatformManagerImpl.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.ipp
@@ -55,17 +55,17 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack(void)
     // Arrange for Device Layer errors to be translated to text.
     RegisterDeviceLayerErrorFormatter();
 
-    // Initialize the source used by CHIP to get secure random data.
-    err = InitEntropy();
-    SuccessOrExit(err);
+    // TODO Initialize the source used by CHIP to get secure random data.
+    // err = InitEntropy();
+    // SuccessOrExit(err);
 
-    // Initialize the Configuration Manager object.
-    err = ConfigurationMgr().Init();
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(DeviceLayer, "Configuration Manager initialization failed: %s", ErrorStr(err));
-    }
-    SuccessOrExit(err);
+    // TODO Initialize the Configuration Manager object.
+    // err = ConfigurationMgr().Init();
+    // if (err != CHIP_NO_ERROR)
+    // {
+    //     ChipLogError(DeviceLayer, "Configuration Manager initialization failed: %s", ErrorStr(err));
+    // }
+    // SuccessOrExit(err);
 
     // Initialize the CHIP system layer.
     new (&SystemLayer) System::Layer();
@@ -85,27 +85,27 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack(void)
     }
     SuccessOrExit(err);
 
-    // Perform dynamic configuration of the core CHIP objects based on stored settings.
+    // TODO Perform dynamic configuration of the core CHIP objects based on stored settings.
     //
     // NB: In general, initialization of Device Layer objects should happen *after* this call
     // as their initialization methods may rely on the proper initialization of the core
     // objects.
     //
-    err = ConfigurationMgr().ConfigureChipStack();
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(DeviceLayer, "ConfigureChipStack failed: %s", ErrorStr(err));
-    }
-    SuccessOrExit(err);
+    // err = ConfigurationMgr().ConfigureChipStack();
+    // if (err != CHIP_NO_ERROR)
+    // {
+    //     ChipLogError(DeviceLayer, "ConfigureChipStack failed: %s", ErrorStr(err));
+    // }
+    // SuccessOrExit(err);
 
-    // Initialize the BLE manager.
+    //TODO Initialize the BLE manager.
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
-    err = BLEMgr().Init();
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(DeviceLayer, "BLEManager initialization failed: %s", ErrorStr(err));
-    }
-    SuccessOrExit(err);
+    // err = BLEMgr().Init();
+    // if (err != CHIP_NO_ERROR)
+    // {
+    //     ChipLogError(DeviceLayer, "BLEManager initialization failed: %s", ErrorStr(err));
+    // }
+    // SuccessOrExit(err);
 #endif
 
     // Initialize the Connectivity Manager object.
@@ -116,30 +116,30 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack(void)
     }
     SuccessOrExit(err);
 
-    // Initialize CHIP Event Logging.
-    err = InitChipEventLogging();
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(DeviceLayer, "Event Logging initialization failed: %s", ErrorStr(err));
-    }
+    // TODO Initialize CHIP Event Logging.
+    // err = InitChipEventLogging();
+    // if (err != CHIP_NO_ERROR)
+    // {
+    //     ChipLogError(DeviceLayer, "Event Logging initialization failed: %s", ErrorStr(err));
+    // }
+    // SuccessOrExit(err);
+
+    // TODO Initialize the Time Sync Manager object.
+    // err = TimeSyncMgr().Init();
+    // if (err != CHIP_NO_ERROR)
+    // {
+    //     ChipLogError(DeviceLayer, "Time Sync Manager initialization failed: %s", ErrorStr(err));
+    // }
     SuccessOrExit(err);
 
-    // Initialize the Time Sync Manager object.
-    err = TimeSyncMgr().Init();
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(DeviceLayer, "Time Sync Manager initialization failed: %s", ErrorStr(err));
-    }
-    SuccessOrExit(err);
-
-    // Initialize the Software Update Manager object.
+    // TODO Initialize the Software Update Manager object.
 #if CHIP_DEVICE_CONFIG_ENABLE_SOFTWARE_UPDATE_MANAGER
-    err = SoftwareUpdateMgr().Init();
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(DeviceLayer, "Software Update Manager initialization failed: %s", ErrorStr(err));
-    }
-    SuccessOrExit(err);
+    // err = SoftwareUpdateMgr().Init();
+    // if (err != CHIP_NO_ERROR)
+    // {
+    //     ChipLogError(DeviceLayer, "Software Update Manager initialization failed: %s", ErrorStr(err));
+    // }
+    // SuccessOrExit(err);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_SOFTWARE_UPDATE_MANAGER
 
 exit:
@@ -280,7 +280,7 @@ void GenericPlatformManagerImpl<ImplClass>::DispatchEventToDeviceLayer(const Chi
     ThreadStackMgr().OnPlatformEvent(event);
 #endif
     ConnectivityMgr().OnPlatformEvent(event);
-    TimeSyncMgr().OnPlatformEvent(event);
+    // TimeSyncMgr().OnPlatformEvent(event);
 }
 
 template<class ImplClass>

--- a/src/include/platform/internal/GenericPlatformManagerImpl.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.ipp
@@ -235,7 +235,6 @@ void GenericPlatformManagerImpl<ImplClass>::DispatchEventToDeviceLayer(const Chi
     ThreadStackMgr().OnPlatformEvent(event);
 #endif
     ConnectivityMgr().OnPlatformEvent(event);
-    // TimeSyncMgr().OnPlatformEvent(event);
 }
 
 template<class ImplClass>

--- a/src/include/platform/internal/GenericPlatformManagerImpl.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.ipp
@@ -56,16 +56,8 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack(void)
     RegisterDeviceLayerErrorFormatter();
 
     // TODO Initialize the source used by CHIP to get secure random data.
-    // err = InitEntropy();
-    // SuccessOrExit(err);
 
     // TODO Initialize the Configuration Manager object.
-    // err = ConfigurationMgr().Init();
-    // if (err != CHIP_NO_ERROR)
-    // {
-    //     ChipLogError(DeviceLayer, "Configuration Manager initialization failed: %s", ErrorStr(err));
-    // }
-    // SuccessOrExit(err);
 
     // Initialize the CHIP system layer.
     new (&SystemLayer) System::Layer();
@@ -86,27 +78,8 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack(void)
     SuccessOrExit(err);
 
     // TODO Perform dynamic configuration of the core CHIP objects based on stored settings.
-    //
-    // NB: In general, initialization of Device Layer objects should happen *after* this call
-    // as their initialization methods may rely on the proper initialization of the core
-    // objects.
-    //
-    // err = ConfigurationMgr().ConfigureChipStack();
-    // if (err != CHIP_NO_ERROR)
-    // {
-    //     ChipLogError(DeviceLayer, "ConfigureChipStack failed: %s", ErrorStr(err));
-    // }
-    // SuccessOrExit(err);
 
-    //TODO Initialize the BLE manager.
-#if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
-    // err = BLEMgr().Init();
-    // if (err != CHIP_NO_ERROR)
-    // {
-    //     ChipLogError(DeviceLayer, "BLEManager initialization failed: %s", ErrorStr(err));
-    // }
-    // SuccessOrExit(err);
-#endif
+    // TODO Initialize the BLE manager.
 
     // Initialize the Connectivity Manager object.
     err = ConnectivityMgr().Init();
@@ -117,30 +90,12 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack(void)
     SuccessOrExit(err);
 
     // TODO Initialize CHIP Event Logging.
-    // err = InitChipEventLogging();
-    // if (err != CHIP_NO_ERROR)
-    // {
-    //     ChipLogError(DeviceLayer, "Event Logging initialization failed: %s", ErrorStr(err));
-    // }
-    // SuccessOrExit(err);
 
     // TODO Initialize the Time Sync Manager object.
-    // err = TimeSyncMgr().Init();
-    // if (err != CHIP_NO_ERROR)
-    // {
-    //     ChipLogError(DeviceLayer, "Time Sync Manager initialization failed: %s", ErrorStr(err));
-    // }
+
     SuccessOrExit(err);
 
     // TODO Initialize the Software Update Manager object.
-#if CHIP_DEVICE_CONFIG_ENABLE_SOFTWARE_UPDATE_MANAGER
-    // err = SoftwareUpdateMgr().Init();
-    // if (err != CHIP_NO_ERROR)
-    // {
-    //     ChipLogError(DeviceLayer, "Software Update Manager initialization failed: %s", ErrorStr(err));
-    // }
-    // SuccessOrExit(err);
-#endif // CHIP_DEVICE_CONFIG_ENABLE_SOFTWARE_UPDATE_MANAGER
 
 exit:
     return err;

--- a/src/platform/EFR32/Logging.cpp
+++ b/src/platform/EFR32/Logging.cpp
@@ -48,6 +48,10 @@
 #define LOG_RTT_BUFFER_SIZE 256
 #endif
 
+// FreeRTOS includes
+#include "SEGGER_RTT.h"
+#include "SEGGER_RTT_Conf.h"
+
 #define LOG_ERROR "<error > "
 #define LOG_WARN "<warn  > "
 #define LOG_INFO "<info  > "
@@ -171,7 +175,7 @@ void Log(uint8_t module, uint8_t category, const char *aFormat, ...)
         char   formattedMsg[CHIP_DEVICE_CONFIG_LOG_MESSAGE_MAX_SIZE];
         size_t formattedMsgLen;
 
-        constexpr size_t maxPrefixLen = nlChipLoggingModuleNameLen + 3;
+        constexpr size_t maxPrefixLen = ChipLoggingModuleNameLen + 3;
         static_assert(sizeof(formattedMsg) > maxPrefixLen);
 
         switch (category)

--- a/src/platform/EFR32/freertos_bluetooth.c
+++ b/src/platform/EFR32/freertos_bluetooth.c
@@ -2,6 +2,7 @@
  *
  *    Copyright (c) 2020 Project CHIP Authors
  *    Copyright (c) 2020 Google LLC.
+ *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/platform/GeneralUtils.cpp
+++ b/src/platform/GeneralUtils.cpp
@@ -1,0 +1,129 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2018 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          General utility functions available on all platforms.
+ */
+
+#include <platform/internal/CHIPDeviceLayerInternal.h>
+#include <support/CodeUtils.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+CHIP_ERROR ParseCompilerDateStr(const char * dateStr, uint16_t & year, uint8_t & month, uint8_t & dayOfMonth)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    char monthStr[4];
+    const char * p;
+    char* endptr;
+
+    static const char months[] = "JanFebMarAprMayJunJulAugSepOctNovDec";
+
+    VerifyOrExit(strlen(dateStr) == 11, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    memcpy(monthStr, dateStr, 3);
+    monthStr[3] = 0;
+
+    p = strstr(months, monthStr);
+    VerifyOrExit(p != NULL, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    month = ((p - months) / 3) + 1;
+
+    dayOfMonth = strtoul(dateStr + 4, &endptr, 10);
+    VerifyOrExit(endptr == dateStr + 6, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    year = strtoul(dateStr + 7, &endptr, 10);
+    VerifyOrExit(endptr == dateStr + 11, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR Parse24HourTimeStr(const char * timeStr, uint8_t & hour, uint8_t & minute, uint8_t & second)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    char * p;
+
+    VerifyOrExit(strlen(timeStr) == 8, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    hour = strtoul(timeStr, &p, 10);
+    VerifyOrExit(p == timeStr + 2, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    minute = strtoul(timeStr + 3, &p, 10);
+    VerifyOrExit(p == timeStr + 5, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    second = strtoul(timeStr + 6, &p, 10);
+    VerifyOrExit(p == timeStr + 8, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+exit:
+    return err;
+}
+
+/**
+ * Register a text error formatter for Device Layer errors.
+ */
+void RegisterDeviceLayerErrorFormatter(void)
+{
+    static ErrorFormatter sDeviceLayerErrorFormatter =
+    {
+        FormatDeviceLayerError,
+        NULL
+    };
+
+    RegisterErrorFormatter(&sDeviceLayerErrorFormatter);
+}
+
+/**
+ * Given Device Layer error, returns a human-readable NULL-terminated C string
+ * describing the error.
+ *
+ * @param[in] buf                   Buffer into which the error string will be placed.
+ * @param[in] bufSize               Size of the supplied buffer in bytes.
+ * @param[in] err                   The error to be described.
+ *
+ * @return true                     If a descriptions string was written into the supplied buffer.
+ * @return false                    If the supplied error was not a Device Layer error.
+ *
+ */
+bool FormatDeviceLayerError(char * buf, uint16_t bufSize, int32_t err)
+{
+    const char * desc = NULL;
+
+    if (err < CHIP_DEVICE_ERROR_MIN || err > CHIP_DEVICE_ERROR_MAX)
+    {
+        return false;
+    }
+
+#if !CHIP_CONFIG_SHORT_ERROR_STR
+    switch (err)
+    {
+    case CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND        : desc = "Config not found"; break;
+    case CHIP_DEVICE_ERROR_NOT_SERVICE_PROVISIONED : desc = "Not service provisioned"; break;
+    }
+#endif // !CHIP_CONFIG_SHORT_ERROR_STR
+
+    FormatError(buf, bufSize, "Device Layer", err, desc);
+
+    return true;
+}
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/Globals.cpp
+++ b/src/platform/Globals.cpp
@@ -1,0 +1,35 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2018 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <platform/internal/CHIPDeviceLayerInternal.h>
+#include <platform/internal/BLEManager.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+chip::System::Layer SystemLayer;
+chip::Inet::InetLayer InetLayer;
+
+namespace Internal {
+
+const char * const TAG = "CHIP[DL]";
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/Makefile.am
+++ b/src/platform/Makefile.am
@@ -86,6 +86,10 @@ libDeviceLayer_a_CPPFLAGS               = \
 
 libDeviceLayer_a_SOURCES                = \
     PersistedStorage.cpp                  \
+    SystemEventSupport.cpp                \
+    SystemTimerSupport.cpp                \
+    GeneralUtils.cpp                      \
+    Globals.cpp                           \
     $(NULL)
 
 if CHIP_DEVICE_LAYER_TARGET_NRF5

--- a/src/platform/SystemEventSupport.cpp
+++ b/src/platform/SystemEventSupport.cpp
@@ -1,0 +1,66 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2018 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Provides implementations of the CHIP System Layer platform
+ *          event functions that are suitable for use on all platforms.
+ */
+
+#include <platform/internal/CHIPDeviceLayerInternal.h>
+#include <platform/PlatformManager.h>
+
+namespace chip {
+namespace System {
+namespace Platform {
+namespace Layer {
+
+using namespace ::chip::DeviceLayer;
+
+System::Error PostEvent(System::Layer & aLayer, void * aContext, System::Object & aTarget, System::EventType aType, uintptr_t aArgument)
+{
+    ChipDeviceEvent event;
+    event.Type = DeviceEventType::kChipSystemLayerEvent;
+    event.ChipSystemLayerEvent.Type = aType;
+    event.ChipSystemLayerEvent.Target = &aTarget;
+    event.ChipSystemLayerEvent.Argument = aArgument;
+
+    PlatformMgr().PostEvent(&event);
+
+    return CHIP_SYSTEM_NO_ERROR;
+}
+
+System::Error DispatchEvents(Layer & aLayer, void * aContext)
+{
+    PlatformMgr().RunEventLoop();
+
+    return CHIP_SYSTEM_NO_ERROR;
+}
+
+System::Error DispatchEvent(System::Layer & aLayer, void * aContext, const ChipDeviceEvent * aEvent)
+{
+    PlatformMgr().DispatchEvent(aEvent);
+
+    return CHIP_SYSTEM_NO_ERROR;
+}
+
+} // namespace Layer
+} // namespace Platform
+} // namespace System
+} // namespace chip

--- a/src/platform/SystemTimerSupport.cpp
+++ b/src/platform/SystemTimerSupport.cpp
@@ -1,0 +1,44 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2018 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Provides implementations of the CHIP System Layer platform
+ *          timer functions that are suitable for use on all platforms.
+ */
+
+#include <platform/internal/CHIPDeviceLayerInternal.h>
+#include <platform/PlatformManager.h>
+
+namespace chip {
+namespace System {
+namespace Platform {
+namespace Layer {
+
+using namespace ::chip::DeviceLayer;
+
+System::Error StartTimer(System::Layer & aLayer, void * aContext, uint32_t aMilliseconds)
+{
+    return PlatformMgr().StartChipTimer(aMilliseconds);
+}
+
+} // namespace Layer
+} // namespace Platform
+} // namespace System
+} // namespace chip


### PR DESCRIPTION
 #### Problem

Fixed issues linking with CHIP since there is still some missing functionality.
 
 #### Summary of Changes

- Updated helper mk files for building external demos with CHIP support
- Pulled in files needed to build and link with DeviceLayer
- Removed `with-openssl=no` from the efr32-chip.mk (**needs a tracking issue**)
- Gutted `InitChipStack()` since most Impl classes are unavailable and link fails (**needs issues for all the commented out code - possibly duplicate issues**)

Filed Issues to track: #295 #290 #291 