### PR TITLE
[system] Fix #274: issue with waking sockets from timers. 

### DIFF
--- a/src/system/SystemTimer.cpp
+++ b/src/system/SystemTimer.cpp
@@ -124,9 +124,7 @@ bool Timer::IsEarlierEpoch(const Timer::Epoch & inFirst, const Timer::Epoch & in
  */
 Error Timer::Start(uint32_t aDelayMilliseconds, OnCompleteFunct aOnComplete, void * aAppState)
 {
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
     Layer & lLayer = this->SystemLayer();
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
     CHIP_SYSTEM_FAULT_INJECT(FaultInjection::kFault_TimeoutImmediate, aDelayMilliseconds = 0);
 
@@ -171,6 +169,9 @@ Error Timer::Start(uint32_t aDelayMilliseconds, OnCompleteFunct aOnComplete, voi
         lTimer->mNextTimer = this;
     }
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+    lLayer.WakeSelect();
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
     return CHIP_SYSTEM_NO_ERROR;
 }


### PR DESCRIPTION
Fixes: #274

Calling `nl::Weave::System::Timer::Start` does not wake the Weave thread. 
This is arguably an understood limitation stemming from Weave
code being geared towards a single-threaded execution.  However, on a
number of platforms -- such as Java -- we admit to having pieces of
the Weave stack run within different threads but enclosed within the
correct lock around the Weave stack.  This results in issues where the
Java caller schedules a timer: the main Weave thread may be sleeping
in the event loop and does not adjust the wake time in response to the
new timer being scheduled.

The construction proposed herein parallels the semantics
`nl::Weave::System::Timer::Start` offers on LwIP systems and parallels
the semantics offered by `ScheduleWork`.

On systems where POSIX locking is already enabled, calling
`WakeSelect` from the layer's event loop does not actually involve a
write to a pipe, the wake is only invoked when the `Timer::Start` is
invoked from a different thread.

See: openweave/openweave-core#544
