### PR TITLE
Move devcontainer to connectedhomeip/chip-build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,41 +1,7 @@
-# start with Ubuntu 18.04LTS
-FROM ubuntu:bionic
+# All tools required for compilation belong in chip-build, forms "truth" for CHIP build tooling
+FROM connectedhomeip/chip-build
 
-# base build and check tools and libraries layer
-RUN set -x \
-    && apt-get update \
-    && apt-get install -fy \
-    git \
-    curl \
-    jq \
-    make \
-    autoconf \
-    automake \
-    libtool \
-    pkg-config \
-    g++ \
-    clang-9 \
-    clang-format-9 \
-    clang-tidy-9 \
-    lcov \
-    shellcheck \
-    libssl-dev
-
-# BabbleSim layer
-RUN set -x \
-    && apt-get install -fy \
-    gcc-multilib \
-    libfftw3-dev \
-    && (mkdir -p /var/bsim \
-    && cd /var/bsim \
-    && curl https://storage.googleapis.com/git-repo-downloads/repo > ./repo  && chmod a+x ./repo \
-    && ./repo init -u https://github.com/BabbleSim/manifest.git -m everything.xml -b v1.0.3 --depth=1 \
-    && ./repo sync \
-    && make everything -j 8)
-
-# above is same as "FROM connectedhomeip/chip-build"
-
-# development environment stuff, command line helpers, etc.
+# This Dockerfile contains things useful for an interactive development environment
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID


### PR DESCRIPTION
#### Problem
 Tooling for builds is duplicated across Dockerfiles, presents a maintenance burden

 #### Summary of Changes
 Build devcontainer's docker image FROM connectedhomeip/chip-build

 Note: needs rebase once #282 lands