### PR TITLE
Add / Migrate Missing Unit Tests for TLV

### DIFF
--- a/src/lib/core/CHIPCircularTLVBuffer.cpp
+++ b/src/lib/core/CHIPCircularTLVBuffer.cpp
@@ -1,0 +1,470 @@
+/*
+ *
+ *    Copyright (c) 2016-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements the circular buffer for TLV
+ *      elements. When used as the backing store for the TLVReader and
+ *      TLVWriter, those classes will work with the wraparound of data
+ *      within the buffer.  Additionally, the TLVWriter will be able
+ *      to continually add top-level TLV elements by evicting
+ *      pre-existing elements.
+ */
+
+#ifndef __STDC_LIMIT_MACROS
+#define __STDC_LIMIT_MACROS
+#endif
+#include <stdint.h>
+
+#include <core/CHIPCore.h>
+#include <core/CHIPEncoding.h>
+#include <core/CHIPTLV.h>
+#include <core/CHIPCircularTLVBuffer.h>
+
+#include <support/CodeUtils.h>
+
+namespace chip {
+namespace TLV {
+
+using namespace chip::Encoding;
+
+/**
+ * @brief
+ *   CHIPCircularTLVBuffer constructor
+ *
+ * @param[in] inBuffer       A pointer to the backing store for the queue
+ *
+ * @param[in] inBufferLength Length, in bytes, of the backing store
+ *
+ * @param[in] inHead         Initial point for the head.  The @a inHead pointer is must fall within the backing store for the circular buffer, i.e. within @a inBuffer and &(@a inBuffer[@a inBufferLength])
+ */
+CHIPCircularTLVBuffer::CHIPCircularTLVBuffer(uint8_t *inBuffer, size_t inBufferLength, uint8_t *inHead)
+{
+    mQueue = inBuffer;
+    mQueueSize = inBufferLength;
+    mQueueLength = 0;
+    mQueueHead = inHead;
+
+    mProcessEvictedElement = NULL;
+    mAppData = NULL;
+
+    // use common as opposed to unspecified, s.t. the reader that
+    // skips over the elements does not complain about implicit
+    // profile tags.
+    mImplicitProfileId = kCommonProfileId;
+}
+
+/**
+ * @brief
+ *   CHIPCircularTLVBuffer constructor
+ *
+ * @param[in] inBuffer       A pointer to the backing store for the queue
+ *
+ * @param[in] inBufferLength Length, in bytes, of the backing store
+ */
+CHIPCircularTLVBuffer::CHIPCircularTLVBuffer(uint8_t *inBuffer, size_t inBufferLength)
+{
+    mQueue = inBuffer;
+    mQueueSize = inBufferLength;
+    mQueueLength = 0;
+    mQueueHead = mQueue;
+
+    mProcessEvictedElement = NULL;
+    mAppData = NULL;
+
+    // use common as opposed to unspecified, s.t. the reader that
+    // skips over the elements does not complain about implicit
+    // profile tags.
+    mImplicitProfileId = kCommonProfileId;
+}
+
+
+/**
+ * @brief
+ *   Evicts the oldest top-level TLV element in the CHIPCircularTLVBuffer
+ *
+ * This function removes the oldest top level TLV element in the
+ * buffer.  The function will call the callback registered at
+ * #mProcessEvictedElement to process the element prior to removal.
+ * If the callback returns anything but #CHIP_NO_ERROR, the element
+ * is not removed.  Similarly, if any other error occurs -- no
+ * elements within the buffer, etc -- the underlying
+ * #CHIPCircularTLVBuffer remains unchanged.
+ *
+ *  @retval #CHIP_NO_ERROR On success.
+ *
+ *  @retval other          On any other error returned either by the callback
+ *                         or by the TLVReader.
+ *
+ */
+CHIP_ERROR CHIPCircularTLVBuffer::EvictHead(void)
+{
+    CircularTLVReader reader;
+    uint8_t *newHead;
+    size_t newLen;
+    CHIP_ERROR err;
+
+    // find the boundaries of an event to throw away
+    reader.Init(this);
+    reader.ImplicitProfileId = mImplicitProfileId;
+
+    // position the reader on the first element
+    err = reader.Next();
+    SuccessOrExit(err);
+
+    // skip to the next element
+    err = reader.Skip();
+    SuccessOrExit(err);
+
+    // record the state of the queue post-call
+    newLen  = mQueueLength - (reader.GetLengthRead());
+    newHead = const_cast<uint8_t *>(reader.GetReadPoint());
+
+    // if a custom handler is installed, give it a chance to
+    // process the element before we evict it from the buffer.
+    if (mProcessEvictedElement != NULL)
+    {
+        // Reinitialize the reader
+        reader.Init(this);
+        reader.ImplicitProfileId = mImplicitProfileId;
+
+        err = mProcessEvictedElement(*this, mAppData, reader);
+        SuccessOrExit(err);
+    }
+
+    // update queue state
+    mQueueLength = newLen;
+    mQueueHead = newHead;
+
+exit:
+    return err;
+}
+
+/**
+ * @brief
+ *   Get additional space for the TLVWriter.  In actuality, the
+ *   function evicts an element from the circular buffer, and adjusts
+ *   the head of this buffer queue
+ *
+ * @param[inout] ioWriter  TLVWriter calling this function
+ *
+ * @param[out] outBufStart The pointer to the new buffer
+ *
+ * @param[out] outBufLen   The available length for writing
+ *
+ * @retval #CHIP_NO_ERROR On success.
+ *
+ * @retval other           If the function was unable to elide a complete
+ *                         top-level TLV element.
+ */
+
+CHIP_ERROR CHIPCircularTLVBuffer::GetNewBuffer(TLVWriter& ioWriter, uint8_t *& outBufStart, uint32_t& outBufLen)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    uint8_t * tail = QueueTail();
+
+    if (mQueueLength >= mQueueSize) {
+        // Queue is out of space, need to evict an element
+        err = EvictHead();
+        SuccessOrExit(err);
+    }
+
+    // set the output values, returned buffer must be contiguous
+    outBufStart = tail;
+
+    if (tail >= mQueueHead)
+    {
+        outBufLen = mQueueSize - (tail - mQueue);
+    }
+    else
+    {
+        outBufLen = mQueueHead - tail;
+    }
+
+exit:
+    return err;
+}
+
+
+/**
+ * @brief
+ *   FinalizeBuffer adjust the `CHIPCircularTLVBuffer` state on
+ *   completion of output from the TLVWriter.  This function affects
+ *   the position of the queue tail.
+ *
+ * @param[inout] ioWriter TLVWriter calling this function
+ *
+ * @param[in] inBufStart pointer to the start of data (from `TLVWriter`
+ *                       perspective)
+ *
+ * @param[in] inBufLen   length of data in the buffer pointed to by
+ *                       `inbufStart`
+ *
+ * @retval #CHIP_NO_ERROR Unconditionally.
+ */
+
+CHIP_ERROR CHIPCircularTLVBuffer::FinalizeBuffer(TLVWriter& ioWriter, uint8_t *inBufStart, uint32_t inBufLen)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    uint8_t * tail = inBufStart + inBufLen;
+    if (inBufLen)
+    {
+        if (tail <= mQueueHead)
+        {
+            mQueueLength = mQueueSize + (tail - mQueueHead);
+        }
+        else
+        {
+            mQueueLength = tail - mQueueHead;
+        }
+    }
+    return err;
+}
+
+
+/**
+ * @brief
+ *   Get additional space for the TLVReader.
+ *
+ *  The storage provided by the CHIPCircularTLVBuffer may be
+ *  wraparound within the buffer.  This function provides us with an
+ *  ability to match the buffering of the circular buffer to the
+ *  TLVReader constraints.  The reader will read at most `mQueueSize`
+ *  bytes from the buffer.
+ *
+ * @param[in] ioReader        TLVReader calling this function.
+ *
+ * @param[inout] outBufStart  The reference to the data buffer.  On
+ *                            return, it is set to a value within this
+ *                            buffer.
+ *
+ * @param[out] outBufLen      On return, set to the number of continuous
+ *                            bytes that could be read out of the buffer.
+ *
+ * @retval #CHIP_NO_ERROR    Succeeds unconditionally.
+ */
+CHIP_ERROR CHIPCircularTLVBuffer::GetNextBuffer(TLVReader& ioReader, const uint8_t *& outBufStart, uint32_t & outBufLen)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    uint8_t * tail = QueueTail();
+    const uint8_t *readerStart = outBufStart;
+
+    if (readerStart == NULL)
+    {
+        outBufStart = mQueueHead;
+
+        if (outBufStart == mQueue + mQueueSize)
+        {
+            outBufStart = mQueue;
+        }
+    }
+    else if (readerStart >= (mQueue + mQueueSize))
+    {
+        outBufStart = mQueue;
+    }
+    else
+    {
+        outBufLen = 0;
+        return err;
+    }
+
+
+    if ((mQueueLength != 0) && (tail <= outBufStart))
+    {
+        // the buffer is non-empty and data wraps around the end
+        // point.  The returned buffer conceptually spans from
+        // outBufStart until the end of the underlying storage buffer
+        // (i.e. mQueue+mQueueSize).  This case tail == outBufStart
+        // indicates that the buffer is completely full
+        outBufLen = (mQueue + mQueueSize) - outBufStart;
+        if ((tail == outBufStart) && (readerStart != NULL))
+            outBufLen = 0;
+    }
+    else
+    {
+        // the buffer length is the distance between head and tail;
+        // tail is either strictly larger or the buffer is empty
+        outBufLen = tail - outBufStart;
+    }
+    return err;
+}
+
+
+/**
+ * @brief
+ *   A trampoline to fetch more space for the TLVWriter.
+ *
+ * @param[inout] ioWriter TLVWriter calling this function
+ *
+ * @param[inout] inBufHandle A handle to the `CircularTLVWriter` object
+ *
+ * @param[out] outBufStart The pointer to the new buffer
+ *
+ * @param[out] outBufLen   The available length for writing
+ *
+ * @retval #CHIP_NO_ERROR On success.
+ *
+ * @retval other           If the function was unable to elide a complete
+ *                         top-level TLV element.
+ */
+CHIP_ERROR CHIPCircularTLVBuffer::GetNewBufferFunct(TLVWriter& ioWriter, uintptr_t& inBufHandle, uint8_t *&outBufStart, uint32_t& outBufLen)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    CHIPCircularTLVBuffer *buf;
+
+    VerifyOrExit(inBufHandle != 0, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    buf = static_cast<CHIPCircularTLVBuffer *>((void *) inBufHandle);
+
+    err = buf->GetNewBuffer(ioWriter, outBufStart, outBufLen);
+
+exit:
+    return err;
+}
+
+
+/**
+ * @brief
+ *   A trampoline to CHIPCircularTLVBuffer::FinalizeBuffer
+ *
+ * @param[inout] ioWriter TLVWriter calling this function
+ *
+ * @param[inout] inBufHandle A handle to the `CircularTLVWriter` object
+ *
+ * @param[in] inBufStart pointer to the start of data (from `TLVWriter`
+ *                       perspective)
+ *
+ * @param[in] inBufLen   length of data in the buffer pointed to by
+ *                       `inbufStart`
+ *
+ * @retval #CHIP_NO_ERROR Unconditionally.
+ */
+CHIP_ERROR CHIPCircularTLVBuffer::FinalizeBufferFunct(TLVWriter& ioWriter, uintptr_t inBufHandle, uint8_t *inBufStart, uint32_t inBufLen)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    CHIPCircularTLVBuffer *buf;
+
+    VerifyOrExit(inBufHandle != 0, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    buf = static_cast<CHIPCircularTLVBuffer *>((void *) inBufHandle);
+
+    err = buf->FinalizeBuffer(ioWriter, inBufStart, inBufLen);
+
+exit:
+    return err;
+}
+
+
+/**
+ * @brief
+ *   A trampoline to CHIPCircularTLVBuffer::GetNextBuffer
+ *
+ * @param[inout] ioReader TLVReader calling this function
+ *
+ * @param[inout] inBufHandle A handle to the `CircularTLVWriter` object
+ *
+ * @param[inout] outBufStart  The reference to the data buffer.  On
+ *                            return, it is set to a value within this
+ *                            buffer.
+ *
+ * @param[out] outBufLen      On return, set to the number of continuous
+ *                            bytes that could be read out of the buffer.
+ *
+ * @retval #CHIP_NO_ERROR    Succeeds unconditionally.
+ */
+CHIP_ERROR CHIPCircularTLVBuffer::GetNextBufferFunct(TLVReader& ioReader, uintptr_t &inBufHandle, const uint8_t *&outBufStart, uint32_t &outBufLen)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    CHIPCircularTLVBuffer *buf;
+
+    VerifyOrExit(inBufHandle != 0, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    buf = static_cast<CHIPCircularTLVBuffer *>((void *) inBufHandle);
+
+    err = buf->GetNextBuffer(ioReader, outBufStart, outBufLen);
+
+exit:
+    return err;
+}
+
+/**
+ * @brief
+ *   Initializes a TLVWriter object to write from a single CHIPCircularTLVBuffer
+ *
+ * Writing begins at the last byte of the buffer.  The number of bytes
+ * to be written is not constrained by the underlying circular buffer:
+ * writing new elements to the buffer will kick out previous elements
+ * as long as an individual top-level TLV structure fits within the
+ * buffer.  For example, writing a 7-byte top-level boolean TLV into a
+ * 7 byte buffer will work indefinitely, but writing an 8-byte TLV
+ * structure will result in an error.
+ *
+ * @param[in]    buf   A pointer to a fully initialized CHIPCircularTLVBuffer
+ *
+ */
+void CircularTLVWriter::Init(CHIPCircularTLVBuffer *buf)
+{
+    mBufHandle = (uintptr_t) buf;
+    mLenWritten = 0;
+    mMaxLen = UINT32_MAX;
+    mContainerType = kTLVType_NotSpecified;
+    SetContainerOpen(false);
+    SetCloseContainerReserved(false);
+
+    ImplicitProfileId = kProfileIdNotSpecified;
+    GetNewBuffer = CHIPCircularTLVBuffer::GetNewBufferFunct;
+    FinalizeBuffer = CHIPCircularTLVBuffer::FinalizeBufferFunct;
+
+    GetNewBuffer(*this, mBufHandle, mBufStart, mRemainingLen);
+    mWritePoint = mBufStart;
+}
+
+/**
+ * @brief
+ *   Initializes a TLVReader object to read from a single CHIPCircularTLVBuffer
+ *
+ * Parsing begins at the start of the buffer (obtained by the
+ * buffer->Start() position) and continues until the end of the buffer
+ * Parsing may wraparound within the buffer (on any element).  At most
+ * buffer->GetQueueSize() bytes are read out.
+ *
+ * @param[in]    buf   A pointer to a fully initialized CHIPCircularTLVBuffer
+ *
+ */
+void CircularTLVReader::Init(CHIPCircularTLVBuffer *buf)
+{
+    uint32_t bufLen = 0;
+
+    mBufHandle = (uintptr_t) buf;
+    GetNextBuffer = CHIPCircularTLVBuffer::GetNextBufferFunct;
+    mLenRead = 0;
+    mReadPoint = NULL;
+    GetNextBuffer(*this, mBufHandle, mReadPoint, bufLen);
+    mBufEnd = mReadPoint + bufLen;
+    mMaxLen = buf->DataLength();
+    mControlByte = kTLVControlByte_NotSpecified;
+    mElemTag = AnonymousTag;
+    mElemLenOrVal = 0;
+    mContainerType = kTLVType_NotSpecified;
+    SetContainerOpen(false);
+    ImplicitProfileId = kProfileIdNotSpecified;
+    AppData = NULL;
+}
+
+} // namespace TLV
+} // namespace chip

--- a/src/lib/core/CHIPCircularTLVBuffer.cpp
+++ b/src/lib/core/CHIPCircularTLVBuffer.cpp
@@ -1,5 +1,6 @@
 /*
  *
+ *    Copyright (c) 2020 Project CHIP Authors
  *    Copyright (c) 2016-2017 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -51,17 +52,18 @@ using namespace chip::Encoding;
  *
  * @param[in] inBufferLength Length, in bytes, of the backing store
  *
- * @param[in] inHead         Initial point for the head.  The @a inHead pointer is must fall within the backing store for the circular buffer, i.e. within @a inBuffer and &(@a inBuffer[@a inBufferLength])
+ * @param[in] inHead         Initial point for the head.  The @a inHead pointer is must fall within the backing store for the
+ * circular buffer, i.e. within @a inBuffer and &(@a inBuffer[@a inBufferLength])
  */
-CHIPCircularTLVBuffer::CHIPCircularTLVBuffer(uint8_t *inBuffer, size_t inBufferLength, uint8_t *inHead)
+CHIPCircularTLVBuffer::CHIPCircularTLVBuffer(uint8_t * inBuffer, size_t inBufferLength, uint8_t * inHead)
 {
-    mQueue = inBuffer;
-    mQueueSize = inBufferLength;
+    mQueue       = inBuffer;
+    mQueueSize   = inBufferLength;
     mQueueLength = 0;
-    mQueueHead = inHead;
+    mQueueHead   = inHead;
 
     mProcessEvictedElement = NULL;
-    mAppData = NULL;
+    mAppData               = NULL;
 
     // use common as opposed to unspecified, s.t. the reader that
     // skips over the elements does not complain about implicit
@@ -77,22 +79,21 @@ CHIPCircularTLVBuffer::CHIPCircularTLVBuffer(uint8_t *inBuffer, size_t inBufferL
  *
  * @param[in] inBufferLength Length, in bytes, of the backing store
  */
-CHIPCircularTLVBuffer::CHIPCircularTLVBuffer(uint8_t *inBuffer, size_t inBufferLength)
+CHIPCircularTLVBuffer::CHIPCircularTLVBuffer(uint8_t * inBuffer, size_t inBufferLength)
 {
-    mQueue = inBuffer;
-    mQueueSize = inBufferLength;
+    mQueue       = inBuffer;
+    mQueueSize   = inBufferLength;
     mQueueLength = 0;
-    mQueueHead = mQueue;
+    mQueueHead   = mQueue;
 
     mProcessEvictedElement = NULL;
-    mAppData = NULL;
+    mAppData               = NULL;
 
     // use common as opposed to unspecified, s.t. the reader that
     // skips over the elements does not complain about implicit
     // profile tags.
     mImplicitProfileId = kCommonProfileId;
 }
-
 
 /**
  * @brief
@@ -115,7 +116,7 @@ CHIPCircularTLVBuffer::CHIPCircularTLVBuffer(uint8_t *inBuffer, size_t inBufferL
 CHIP_ERROR CHIPCircularTLVBuffer::EvictHead(void)
 {
     CircularTLVReader reader;
-    uint8_t *newHead;
+    uint8_t * newHead;
     size_t newLen;
     CHIP_ERROR err;
 
@@ -149,7 +150,7 @@ CHIP_ERROR CHIPCircularTLVBuffer::EvictHead(void)
 
     // update queue state
     mQueueLength = newLen;
-    mQueueHead = newHead;
+    mQueueHead   = newHead;
 
 exit:
     return err;
@@ -173,12 +174,13 @@ exit:
  *                         top-level TLV element.
  */
 
-CHIP_ERROR CHIPCircularTLVBuffer::GetNewBuffer(TLVWriter& ioWriter, uint8_t *& outBufStart, uint32_t& outBufLen)
+CHIP_ERROR CHIPCircularTLVBuffer::GetNewBuffer(TLVWriter & ioWriter, uint8_t *& outBufStart, uint32_t & outBufLen)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint8_t * tail = QueueTail();
 
-    if (mQueueLength >= mQueueSize) {
+    if (mQueueLength >= mQueueSize)
+    {
         // Queue is out of space, need to evict an element
         err = EvictHead();
         SuccessOrExit(err);
@@ -200,7 +202,6 @@ exit:
     return err;
 }
 
-
 /**
  * @brief
  *   FinalizeBuffer adjust the `CHIPCircularTLVBuffer` state on
@@ -218,7 +219,7 @@ exit:
  * @retval #CHIP_NO_ERROR Unconditionally.
  */
 
-CHIP_ERROR CHIPCircularTLVBuffer::FinalizeBuffer(TLVWriter& ioWriter, uint8_t *inBufStart, uint32_t inBufLen)
+CHIP_ERROR CHIPCircularTLVBuffer::FinalizeBuffer(TLVWriter & ioWriter, uint8_t * inBufStart, uint32_t inBufLen)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint8_t * tail = inBufStart + inBufLen;
@@ -235,7 +236,6 @@ CHIP_ERROR CHIPCircularTLVBuffer::FinalizeBuffer(TLVWriter& ioWriter, uint8_t *i
     }
     return err;
 }
-
 
 /**
  * @brief
@@ -258,11 +258,11 @@ CHIP_ERROR CHIPCircularTLVBuffer::FinalizeBuffer(TLVWriter& ioWriter, uint8_t *i
  *
  * @retval #CHIP_NO_ERROR    Succeeds unconditionally.
  */
-CHIP_ERROR CHIPCircularTLVBuffer::GetNextBuffer(TLVReader& ioReader, const uint8_t *& outBufStart, uint32_t & outBufLen)
+CHIP_ERROR CHIPCircularTLVBuffer::GetNextBuffer(TLVReader & ioReader, const uint8_t *& outBufStart, uint32_t & outBufLen)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    uint8_t * tail = QueueTail();
-    const uint8_t *readerStart = outBufStart;
+    CHIP_ERROR err              = CHIP_NO_ERROR;
+    uint8_t * tail              = QueueTail();
+    const uint8_t * readerStart = outBufStart;
 
     if (readerStart == NULL)
     {
@@ -282,7 +282,6 @@ CHIP_ERROR CHIPCircularTLVBuffer::GetNextBuffer(TLVReader& ioReader, const uint8
         outBufLen = 0;
         return err;
     }
-
 
     if ((mQueueLength != 0) && (tail <= outBufStart))
     {
@@ -304,7 +303,6 @@ CHIP_ERROR CHIPCircularTLVBuffer::GetNextBuffer(TLVReader& ioReader, const uint8
     return err;
 }
 
-
 /**
  * @brief
  *   A trampoline to fetch more space for the TLVWriter.
@@ -322,10 +320,11 @@ CHIP_ERROR CHIPCircularTLVBuffer::GetNextBuffer(TLVReader& ioReader, const uint8
  * @retval other           If the function was unable to elide a complete
  *                         top-level TLV element.
  */
-CHIP_ERROR CHIPCircularTLVBuffer::GetNewBufferFunct(TLVWriter& ioWriter, uintptr_t& inBufHandle, uint8_t *&outBufStart, uint32_t& outBufLen)
+CHIP_ERROR CHIPCircularTLVBuffer::GetNewBufferFunct(TLVWriter & ioWriter, uintptr_t & inBufHandle, uint8_t *& outBufStart,
+                                                    uint32_t & outBufLen)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    CHIPCircularTLVBuffer *buf;
+    CHIPCircularTLVBuffer * buf;
 
     VerifyOrExit(inBufHandle != 0, err = CHIP_ERROR_INVALID_ARGUMENT);
 
@@ -336,7 +335,6 @@ CHIP_ERROR CHIPCircularTLVBuffer::GetNewBufferFunct(TLVWriter& ioWriter, uintptr
 exit:
     return err;
 }
-
 
 /**
  * @brief
@@ -354,10 +352,11 @@ exit:
  *
  * @retval #CHIP_NO_ERROR Unconditionally.
  */
-CHIP_ERROR CHIPCircularTLVBuffer::FinalizeBufferFunct(TLVWriter& ioWriter, uintptr_t inBufHandle, uint8_t *inBufStart, uint32_t inBufLen)
+CHIP_ERROR CHIPCircularTLVBuffer::FinalizeBufferFunct(TLVWriter & ioWriter, uintptr_t inBufHandle, uint8_t * inBufStart,
+                                                      uint32_t inBufLen)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    CHIPCircularTLVBuffer *buf;
+    CHIPCircularTLVBuffer * buf;
 
     VerifyOrExit(inBufHandle != 0, err = CHIP_ERROR_INVALID_ARGUMENT);
 
@@ -368,7 +367,6 @@ CHIP_ERROR CHIPCircularTLVBuffer::FinalizeBufferFunct(TLVWriter& ioWriter, uintp
 exit:
     return err;
 }
-
 
 /**
  * @brief
@@ -387,10 +385,11 @@ exit:
  *
  * @retval #CHIP_NO_ERROR    Succeeds unconditionally.
  */
-CHIP_ERROR CHIPCircularTLVBuffer::GetNextBufferFunct(TLVReader& ioReader, uintptr_t &inBufHandle, const uint8_t *&outBufStart, uint32_t &outBufLen)
+CHIP_ERROR CHIPCircularTLVBuffer::GetNextBufferFunct(TLVReader & ioReader, uintptr_t & inBufHandle, const uint8_t *& outBufStart,
+                                                     uint32_t & outBufLen)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    CHIPCircularTLVBuffer *buf;
+    CHIPCircularTLVBuffer * buf;
 
     VerifyOrExit(inBufHandle != 0, err = CHIP_ERROR_INVALID_ARGUMENT);
 
@@ -417,18 +416,18 @@ exit:
  * @param[in]    buf   A pointer to a fully initialized CHIPCircularTLVBuffer
  *
  */
-void CircularTLVWriter::Init(CHIPCircularTLVBuffer *buf)
+void CircularTLVWriter::Init(CHIPCircularTLVBuffer * buf)
 {
-    mBufHandle = (uintptr_t) buf;
-    mLenWritten = 0;
-    mMaxLen = UINT32_MAX;
+    mBufHandle     = (uintptr_t) buf;
+    mLenWritten    = 0;
+    mMaxLen        = UINT32_MAX;
     mContainerType = kTLVType_NotSpecified;
     SetContainerOpen(false);
     SetCloseContainerReserved(false);
 
     ImplicitProfileId = kProfileIdNotSpecified;
-    GetNewBuffer = CHIPCircularTLVBuffer::GetNewBufferFunct;
-    FinalizeBuffer = CHIPCircularTLVBuffer::FinalizeBufferFunct;
+    GetNewBuffer      = CHIPCircularTLVBuffer::GetNewBufferFunct;
+    FinalizeBuffer    = CHIPCircularTLVBuffer::FinalizeBufferFunct;
 
     GetNewBuffer(*this, mBufHandle, mBufStart, mRemainingLen);
     mWritePoint = mBufStart;
@@ -446,24 +445,24 @@ void CircularTLVWriter::Init(CHIPCircularTLVBuffer *buf)
  * @param[in]    buf   A pointer to a fully initialized CHIPCircularTLVBuffer
  *
  */
-void CircularTLVReader::Init(CHIPCircularTLVBuffer *buf)
+void CircularTLVReader::Init(CHIPCircularTLVBuffer * buf)
 {
     uint32_t bufLen = 0;
 
-    mBufHandle = (uintptr_t) buf;
+    mBufHandle    = (uintptr_t) buf;
     GetNextBuffer = CHIPCircularTLVBuffer::GetNextBufferFunct;
-    mLenRead = 0;
-    mReadPoint = NULL;
+    mLenRead      = 0;
+    mReadPoint    = NULL;
     GetNextBuffer(*this, mBufHandle, mReadPoint, bufLen);
-    mBufEnd = mReadPoint + bufLen;
-    mMaxLen = buf->DataLength();
-    mControlByte = kTLVControlByte_NotSpecified;
-    mElemTag = AnonymousTag;
-    mElemLenOrVal = 0;
+    mBufEnd        = mReadPoint + bufLen;
+    mMaxLen        = buf->DataLength();
+    mControlByte   = kTLVControlByte_NotSpecified;
+    mElemTag       = AnonymousTag;
+    mElemLenOrVal  = 0;
     mContainerType = kTLVType_NotSpecified;
     SetContainerOpen(false);
     ImplicitProfileId = kProfileIdNotSpecified;
-    AppData = NULL;
+    AppData           = NULL;
 }
 
 } // namespace TLV

--- a/src/lib/core/CHIPCircularTLVBuffer.h
+++ b/src/lib/core/CHIPCircularTLVBuffer.h
@@ -1,0 +1,151 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2016-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *  @file
+ *      This file defines the circular buffer for TLV
+ *      elements. When used as the backing store for the TLVReader and
+ *      TLVWriter, those classes will work with the wraparound of data
+ *      within the buffer.  Additionally, the TLVWriter will be able
+ *      to continually add top-level TLV elements by evicting
+ *      pre-existing elements.
+ */
+
+#ifndef CHIP_CIRCULAR_TLV_BUFFER_H_
+#define CHIP_CIRCULAR_TLV_BUFFER_H_
+
+#include <stdlib.h>
+
+#include <support/DLLUtil.h>
+
+#include <core/CHIPError.h>
+#include <core/CHIPTLVTags.h>
+#include <core/CHIPTLVTypes.h>
+#include <core/CHIPTLV.h>
+
+namespace chip {
+namespace TLV {
+
+/**
+ * @class CHIPCircularTLVBuffer
+ *
+ * @brief
+ *    CHIPCircularTLVBuffer provides circular storage for the
+ *    chip::TLV::TLVWriter and chip::TLVTLVReader.  chip::TLV::TLVWriter is able to write an
+ *    unbounded number of TLV entries to the CHIPCircularTLVBuffer
+ *    as long as each individual TLV entry fits entirely within the
+ *    provided storage.  The chip::TLV::TLVReader will read at most the size of
+ *    the buffer, but will accommodate the wraparound within the
+ *    buffer.
+ *
+ */
+class DLL_EXPORT CHIPCircularTLVBuffer
+{
+public:
+    CHIPCircularTLVBuffer(uint8_t *inBuffer, size_t inBufferLength);
+    CHIPCircularTLVBuffer(uint8_t *inBuffer, size_t inBufferLength, uint8_t *inHead);
+
+    CHIP_ERROR GetNewBuffer(TLVWriter& ioWriter, uint8_t *& outBufStart, uint32_t& outBufLen);
+    CHIP_ERROR FinalizeBuffer(TLVWriter& ioWriter, uint8_t *inBufStart, uint32_t inBufLen);
+    CHIP_ERROR GetNextBuffer(TLVReader& ioReader, const uint8_t *& outBufStart, uint32_t& outBufLen);
+
+    inline uint8_t *QueueHead(void) const { return mQueueHead; };
+    inline uint8_t *QueueTail(void) const { return mQueue + (((mQueueHead-mQueue) + mQueueLength) % mQueueSize); };
+    inline size_t DataLength(void) const { return mQueueLength; };
+    inline size_t AvailableDataLength(void) const { return mQueueSize - mQueueLength; };
+    inline size_t GetQueueSize(void) const { return mQueueSize; };
+    inline uint8_t *GetQueue(void) const { return mQueue; };
+
+    CHIP_ERROR EvictHead(void);
+
+    static CHIP_ERROR GetNewBufferFunct(TLVWriter& ioWriter, uintptr_t& inBufHandle, uint8_t *& outBufStart, uint32_t& outBufLen);
+    static CHIP_ERROR FinalizeBufferFunct(TLVWriter& ioWriter, uintptr_t inBufHandle, uint8_t *inBufStart, uint32_t inBufLen);
+    static CHIP_ERROR GetNextBufferFunct(TLVReader& ioReader, uintptr_t &inBufHandle, const uint8_t *& outBufStart, uint32_t& outBufLen);
+
+    /**
+     *  @typedef CHIP_ERROR (*ProcessEvictedElementFunct)(CHIPCircularTLVBuffer &inBuffer, void * inAppData, TLVReader &inReader)
+     *
+     *  A function that is called to process a TLV element prior to it
+     *  being evicted from the chip::TLV::CHIPCircularTLVBuffer
+     *
+     *  Functions of this type are used to process a TLV element about
+     *  to be evicted from the buffer.  The function will be given a
+     *  chip::TLV::TLVReader positioned on the element about to be deleted, as
+     *  well as void * context where the user may have provided
+     *  additional environment for the callback.  If the function
+     *  processed the element successfully, it must return
+     *  #CHIP_NO_ERROR ; this signifies to the CHIPCircularTLVBuffer
+     *  that the element may be safely evicted.  Any other return
+     *  value is treated as an error and will prevent the
+     *  #CHIPCircularTLVBuffer from evicting the element under
+     *  consideration.
+     *
+     *  Note: This callback may be used to force
+     *  CHIPCircularTLVBuffer to not evict the element.  This may be
+     *  useful in a number of circumstances, when it is desired to
+     *  have an underlying circular buffer, but not to override any
+     *  elements within it.
+     *
+     *  @param[in] inBuffer  A reference to the buffer from which the
+     *                       eviction takes place
+     *
+     *  @param[in] inAppData A pointer to the user-provided structure
+     *                       containing additional context for this
+     *                       callback
+     *
+     *  @param[in] inReader  A TLVReader positioned at the element to
+     *                       be evicted.
+     *
+     *  @retval #CHIP_NO_ERROR On success. Element will be evicted.
+     *
+     *  @retval other        An error has occurred during the event
+     *                       processing.  The element stays in the
+     *                       buffer.  The write function that
+     *                       triggered this element eviction will
+     *                       fail.
+     */
+    typedef CHIP_ERROR (*ProcessEvictedElementFunct)(CHIPCircularTLVBuffer &inBuffer, void * inAppData, TLVReader &inReader);
+
+    uint32_t mImplicitProfileId;
+    void * mAppData; /**< An optional, user supplied context to be used with the callback processing the evicted element. */
+    ProcessEvictedElementFunct mProcessEvictedElement; /**< An optional, user-supplied callback that processes the element prior to evicting it from the circular buffer.  See the ProcessEvictedElementFunct type definition on additional information on implementing the mProcessEvictedElement function. */
+
+private:
+    uint8_t *mQueue;
+    size_t mQueueSize;
+    uint8_t *mQueueHead;
+    size_t mQueueLength;
+};
+
+class DLL_EXPORT CircularTLVReader : public TLVReader
+{
+public:
+    void Init(CHIPCircularTLVBuffer *buf);
+};
+
+class DLL_EXPORT CircularTLVWriter : public TLVWriter
+{
+public:
+    void Init(CHIPCircularTLVBuffer *buf);
+};
+
+} // namespace TLV
+} // namespace chip
+
+#endif //CHIP_CIRCULAR_TLV_BUFFER_H_

--- a/src/lib/core/CHIPTLV.h
+++ b/src/lib/core/CHIPTLV.h
@@ -25,16 +25,16 @@
  *      more compact over the wire.
  */
 
-#ifndef CHIPTLV_H_
-#define CHIPTLV_H_
+#ifndef CHIP_TLV_H_
+#define CHIP_TLV_H_
 
 #include <stdlib.h>
 #include <stdarg.h>
 
 #include <support/DLLUtil.h>
 #include <core/CHIPError.h>
-#include "core/CHIPTLVTags.h"
-#include "core/CHIPTLVTypes.h"
+#include <core/CHIPTLVTags.h>
+#include <core/CHIPTLVTypes.h>
 
 // forward declaration of the PacketBuffer class used within the header.
 namespace chip {
@@ -463,4 +463,4 @@ private:
 } // namespace TLV
 } // namespace chip
 
-#endif /* CHIPTLV_H_ */
+#endif /* CHIP_TLV_H_ */

--- a/src/lib/core/CHIPTLVData.hpp
+++ b/src/lib/core/CHIPTLVData.hpp
@@ -27,60 +27,61 @@
  */
 
 
-#ifndef CHIPTLVDATA_H_
-#define CHIPTLVDATA_H_
+#ifndef CHIP_TLV_DATA_H_
+#define CHIP_TLV_DATA_H_
 
 #include <stdint.h>
-#include <CHIPTLV.h>
+
+#include <core/CHIPTLV.h>
 
 /*
  *  @brief Integral truncate L to the least significant 32-bit
  *
  *  @note Integral truncate would take the least significant bits, regardless of hardware endianness.
  */
-#define CHIPTLV_GetLower32From64(v)  ((uint32_t)(((uint64_t)(v) >>  0) & 0xFFFFFFFFUL))
+#define CHIP_TLV_GetLower32From64(v)  ((uint32_t)(((uint64_t)(v) >>  0) & 0xFFFFFFFFUL))
 
 /*
  *  @brief Integral truncate argument X to the next least significant 32-bit
  *
  *  @note Right bit shift gets rid of the least significant bits, regardless of hardware endianness.
  */
-#define CHIPTLV_GetUpper32From64(v)  ((uint32_t)(((uint64_t)(v) >> 32) & 0xFFFFFFFFUL))
+#define CHIP_TLV_GetUpper32From64(v)  ((uint32_t)(((uint64_t)(v) >> 32) & 0xFFFFFFFFUL))
 
 /*
  *  @brief Integral truncate L to the least significant 16-bit
  *
  *  @note Integral truncate would take the least significant bits, regardless of hardware endianness.
  */
-#define CHIPTLV_GetLower16From32(v)  ((uint16_t)(((uint32_t)(v) >>  0) & 0xFFFFU))
+#define CHIP_TLV_GetLower16From32(v)  ((uint16_t)(((uint32_t)(v) >>  0) & 0xFFFFU))
 
 /*
  *  @brief Integral truncate argument X to the next least significant 16-bit
  *
  *  @note Right bit shift gets rid of the least significant bits, regardless of hardware endianness.
  */
-#define CHIPTLV_GetUpper16From32(v)  ((uint16_t)(((uint32_t)(v) >> 16) & 0xFFFFU))
+#define CHIP_TLV_GetUpper16From32(v)  ((uint16_t)(((uint32_t)(v) >> 16) & 0xFFFFU))
 
 /*
  *  @brief Integral truncate L to the least significant 8-bit
  *
  *  @note Integral truncate would take the least significant bits, regardless of hardware endianness.
  */
-#define CHIPTLV_GetLower8From16(v)   ((uint8_t)(((uint16_t)(v) >> 0) & 0xFFU))
+#define CHIP_TLV_GetLower8From16(v)   ((uint8_t)(((uint16_t)(v) >> 0) & 0xFFU))
 
 /*
  *  @brief Integral truncate argument X to the next least significant 8-bit
  *
  *  @note Right bit shift gets rid of the least significant bits, regardless of hardware endianness.
  */
-#define CHIPTLV_GetUpper8From16(v)   ((uint8_t)(((uint16_t)(v) >> 8) & 0xFFU))
+#define CHIP_TLV_GetUpper8From16(v)   ((uint8_t)(((uint16_t)(v) >> 8) & 0xFFU))
 
 /*
  *  @brief Integral truncate argument v to 8-bit
  *
  *  @note Integral truncate would take the least significant bits, regardless of hardware endianness.
  */
-#define CHIPTLV_Serialize8(v) ((uint8_t)(v))
+#define CHIP_TLV_Serialize8(v) ((uint8_t)(v))
 
 /*
  *  @brief Integral truncate argument v to 16-bit, and then serialize it using CHIP standard Little Endian order
@@ -88,60 +89,60 @@
  *  @note Integral truncate would preserve the least significant bits, regardless of hardware endianness.
  *     Right bit shift gets rid of the least significant bits, regardless of hardware endianness.
  */
-#define CHIPTLV_Serialize16(v) CHIPTLV_GetLower8From16(v), CHIPTLV_GetUpper8From16(v)
+#define CHIP_TLV_Serialize16(v) CHIP_TLV_GetLower8From16(v), CHIP_TLV_GetUpper8From16(v)
 
 /*
  *  @brief Integral truncate argument v to 32-bit, and then serialize it using CHIP standard Little Endian order
  */
-#define CHIPTLV_Serialize32(v) CHIPTLV_Serialize16(CHIPTLV_GetLower16From32(v)), CHIPTLV_Serialize16(CHIPTLV_GetUpper16From32(v))
+#define CHIP_TLV_Serialize32(v) CHIP_TLV_Serialize16(CHIP_TLV_GetLower16From32(v)), CHIP_TLV_Serialize16(CHIP_TLV_GetUpper16From32(v))
 
 /*
  *  @brief Integral truncate argument v to 64-bit, and then serialize it using CHIP standard Little Endian order
  */
-#define CHIPTLV_Serialize64(v) CHIPTLV_Serialize32(CHIPTLV_GetLower32From64(v)), CHIPTLV_Serialize32(CHIPTLV_GetUpper32From64(v))
+#define CHIP_TLV_Serialize64(v) CHIP_TLV_Serialize32(CHIP_TLV_GetLower32From64(v)), CHIP_TLV_Serialize32(CHIP_TLV_GetUpper32From64(v))
 
 /*
  *  @brief Specifies an anonymous TLV element, which doesn't have any tag
  */
-#define CHIPTLV_TAG_ANONYMOUS CHIP::TLV::kTLVTagControl_Anonymous
+#define CHIP_TLV_TAG_ANONYMOUS chip::TLV::kTLVTagControl_Anonymous
 
 /*
  *  @brief Specifies a TLV element with a context-specific tag
  *  @param Tag      The context-specific tag for this TLV element. Would be truncated to 8 bits.
  */
-#define CHIPTLV_TAG_CONTEXT_SPECIFIC(Tag) CHIP::TLV::kTLVTagControl_ContextSpecific, CHIPTLV_Serialize8(Tag)
+#define CHIP_TLV_TAG_CONTEXT_SPECIFIC(Tag) chip::TLV::kTLVTagControl_ContextSpecific, CHIP_TLV_Serialize8(Tag)
 
 /*
  *  @brief Specifies a TLV element with a Common Profile tag
  *  @param Tag      The tag for this TLV element, defined under Common Profile.
  *                  Would be truncated to 16 bites.
  */
-#define CHIPTLV_TAG_COMMON_PROFILE_2Bytes(Tag) \
-    CHIP::TLV::kTLVTagControl_CommonProfile_2Bytes, CHIPTLV_Serialize16(Tag)
+#define CHIP_TLV_TAG_COMMON_PROFILE_2Bytes(Tag) \
+    chip::TLV::kTLVTagControl_CommonProfile_2Bytes, CHIP_TLV_Serialize16(Tag)
 
 /*
  *  @brief Specifies a TLV element with a Common Profile tag
  *  @param Tag      The tag for this TLV element, defined under Common Profile.
  *                  Would be truncated to 32 bites.
  */
-#define CHIPTLV_TAG_COMMON_PROFILE_4Bytes(Tag) \
-    CHIP::TLV::kTLVTagControl_CommonProfile_4Bytes, CHIPTLV_Serialize32(Tag)
+#define CHIP_TLV_TAG_COMMON_PROFILE_4Bytes(Tag) \
+    chip::TLV::kTLVTagControl_CommonProfile_4Bytes, CHIP_TLV_Serialize32(Tag)
 
 /*
  *  @brief Specifies a TLV element with an Implicit Profile tag
  *  @param Tag      The tag for this TLV element, defined under the current implicit profile.
  *                  Would be truncated to 16 bits.
  */
-#define CHIPTLV_TAG_IMPLICIT_PROFILE_2Bytes(Tag) \
-    CHIP::TLV::kTLVTagControl_ImplicitProfile_2Bytes, CHIPTLV_Serialize16(Tag)
+#define CHIP_TLV_TAG_IMPLICIT_PROFILE_2Bytes(Tag) \
+    chip::TLV::kTLVTagControl_ImplicitProfile_2Bytes, CHIP_TLV_Serialize16(Tag)
 
 /*
  *  @brief Specifies a TLV element with an Implicit Profile tag
  *  @param Tag      The tag for this TLV element, defined under the current implicit profile.
  *                  Would be truncated to 32 bits.
  */
-#define CHIPTLV_TAG_IMPLICIT_PROFILE_4Bytes(Tag) \
-    CHIP::TLV::kTLVTagControl_ImplicitProfile_4Bytes, CHIPTLV_Serialize32(Tag)
+#define CHIP_TLV_TAG_IMPLICIT_PROFILE_4Bytes(Tag) \
+    chip::TLV::kTLVTagControl_ImplicitProfile_4Bytes, CHIP_TLV_Serialize32(Tag)
 
 /*
  *  @brief Specifies a TLV element with a Fully Qualified tag
@@ -149,8 +150,8 @@
  *  @param Tag          The tag for this TLV element, defined under ProfileId.
  *                      Would be truncated to 16 bits.
  */
-#define CHIPTLV_TAG_FULLY_QUALIFIED_6Bytes(ProfileId, Tag) \
-    CHIP::TLV::kTLVTagControl_FullyQualified_6Bytes, CHIPTLV_Serialize16(ProfileId >> 16), CHIPTLV_Serialize16(ProfileId), CHIPTLV_Serialize16(Tag)
+#define CHIP_TLV_TAG_FULLY_QUALIFIED_6Bytes(ProfileId, Tag) \
+    chip::TLV::kTLVTagControl_FullyQualified_6Bytes, CHIP_TLV_Serialize16(ProfileId >> 16), CHIP_TLV_Serialize16(ProfileId), CHIP_TLV_Serialize16(Tag)
 
 /*
  *  @brief Specifies a TLV element with a Fully Qualified tag
@@ -158,242 +159,242 @@
  *  @param Tag          The tag for this TLV element, defined under ProfileId.
  *                      Would be truncated to 32 bits.
  */
-#define CHIPTLV_TAG_FULLY_QUALIFIED_8Bytes(ProfileId, Tag) \
-    CHIP::TLV::kTLVTagControl_FullyQualified_8Bytes, CHIPTLV_Serialize16(ProfileId >> 16), CHIPTLV_Serialize16(ProfileId), CHIPTLV_Serialize32(Tag)
+#define CHIP_TLV_TAG_FULLY_QUALIFIED_8Bytes(ProfileId, Tag) \
+    chip::TLV::kTLVTagControl_FullyQualified_8Bytes, CHIP_TLV_Serialize16(ProfileId >> 16), CHIP_TLV_Serialize16(ProfileId), CHIP_TLV_Serialize32(Tag)
 
 /*
  *  @brief Specifies a NULL TLV element, which has just the tag but no value
- *  @param TagSpec      Should be filled with macros begin with CHIPTLV_TAG_
+ *  @param TagSpec      Should be filled with macros begin with CHIP_TLV_TAG_
  */
-#define CHIPTLV_NULL(TagSpec) CHIP::TLV::kTLVElementType_Null | TagSpec
+#define CHIP_TLV_NULL(TagSpec) chip::TLV::kTLVElementType_Null | TagSpec
 
 /*
  *  @brief Specifies a Structure TLV element, marking the beginning of a Structure
- *  @param TagSpec      Should be filled with macros begin with CHIPTLV_TAG_
+ *  @param TagSpec      Should be filled with macros begin with CHIP_TLV_TAG_
  */
-#define CHIPTLV_STRUCTURE(TagSpec) CHIP::TLV::kTLVElementType_Structure | TagSpec
+#define CHIP_TLV_STRUCTURE(TagSpec) chip::TLV::kTLVElementType_Structure | TagSpec
 
 /*
  *  @brief Specifies a Array TLV element, marking the beginning of an Array
- *  @param TagSpec      Should be filled with macros begin with CHIPTLV_TAG_
+ *  @param TagSpec      Should be filled with macros begin with CHIP_TLV_TAG_
  */
-#define CHIPTLV_ARRAY(TagSpec) CHIP::TLV::kTLVElementType_Array | TagSpec
+#define CHIP_TLV_ARRAY(TagSpec) chip::TLV::kTLVElementType_Array | TagSpec
 
 /*
  *  @brief Specifies a Path TLV element, marking the beginning of a Path
- *  @param TagSpec      Should be filled with macros begin with CHIPTLV_TAG_
+ *  @param TagSpec      Should be filled with macros begin with CHIP_TLV_TAG_
  */
-#define CHIPTLV_PATH(TagSpec) CHIP::TLV::kTLVElementType_Path | TagSpec
+#define CHIP_TLV_PATH(TagSpec) chip::TLV::kTLVElementType_Path | TagSpec
 
 /*
  *  @brief Specifies a Boolean TLV element, which can be either true or false
- *  @param TagSpec      Should be filled with macros begin with CHIPTLV_TAG_
+ *  @param TagSpec      Should be filled with macros begin with CHIP_TLV_TAG_
  *  @param Value        Should be either true or false
  */
-#define CHIPTLV_BOOL(TagSpec, Value) \
-    ((Value) ? CHIP::TLV::kTLVElementType_BooleanTrue : CHIP::TLV::kTLVElementType_BooleanFalse) | TagSpec
+#define CHIP_TLV_BOOL(TagSpec, Value) \
+    ((Value) ? chip::TLV::kTLVElementType_BooleanTrue : chip::TLV::kTLVElementType_BooleanFalse) | TagSpec
 
 /**
  *  @brief
  *    Specifies a Single Precision Floating Point TLV element, marking the beginning of 32-bit data
  *
- *  @param TagSpec      Should be filled with macros beginning with CHIPTLV_TAG_
+ *  @param TagSpec      Should be filled with macros beginning with CHIP_TLV_TAG_
  *
  *  @param ...          Bytes representing the floating point value to serialize
  */
-#define CHIPTLV_FLOAT32(TagSpec, ...) \
-    CHIP::TLV::kTLVElementType_FloatingPointNumber32 | TagSpec, ## __VA_ARGS__
+#define CHIP_TLV_FLOAT32(TagSpec, ...) \
+    chip::TLV::kTLVElementType_FloatingPointNumber32 | TagSpec, ## __VA_ARGS__
 
 /**
  *  @brief
  *    Specifies a Double Precision Floating Point TLV element, marking the beginning of 64-bit data
  *
- *  @param TagSpec      Should be filled with macros begin with CHIPTLV_TAG_
+ *  @param TagSpec      Should be filled with macros begin with CHIP_TLV_TAG_
  *
  *  @param ...          Bytes representing the floating point value to serialize
  */
-#define CHIPTLV_FLOAT64(TagSpec, ...) \
-    CHIP::TLV::kTLVElementType_FloatingPointNumber64 | TagSpec, ## __VA_ARGS__
+#define CHIP_TLV_FLOAT64(TagSpec, ...) \
+    chip::TLV::kTLVElementType_FloatingPointNumber64 | TagSpec, ## __VA_ARGS__
 
 /*
  *  @brief Specifies a EndOfContainer TLV element, marking the end of a Structure, Array, or Path
  */
-#define CHIPTLV_END_OF_CONTAINER CHIP::TLV::kTLVElementType_EndOfContainer | CHIP::TLV::kTLVTagControl_Anonymous
+#define CHIP_TLV_END_OF_CONTAINER chip::TLV::kTLVElementType_EndOfContainer | chip::TLV::kTLVTagControl_Anonymous
 
 /*
  *  @brief Specifies a EndOfContainer TLV element, marking the end of a Structure, Array, or Path
  */
-#define CHIPTLV_END_OF_STRUCTURE CHIPTLV_END_OF_CONTAINER
+#define CHIP_TLV_END_OF_STRUCTURE CHIP_TLV_END_OF_CONTAINER
 
 /*
  *  @brief Specifies a EndOfContainer TLV element, marking the end of a Structure, Array, or Path
  */
-#define CHIPTLV_END_OF_ARRAY CHIPTLV_END_OF_CONTAINER
+#define CHIP_TLV_END_OF_ARRAY CHIP_TLV_END_OF_CONTAINER
 
 /*
  *  @brief Specifies a EndOfContainer TLV element, marking the end of a Structure, Array, or Path
  */
-#define CHIPTLV_END_OF_PATH CHIPTLV_END_OF_CONTAINER
+#define CHIP_TLV_END_OF_PATH CHIP_TLV_END_OF_CONTAINER
 
 
 /*
  *  @brief Specifies an 8-bit Signed Integer TLV element
- *  @param TagSpec      Should be filled with macros begin with CHIPTLV_TAG_
+ *  @param TagSpec      Should be filled with macros begin with CHIP_TLV_TAG_
  *  @param Value        Would be first converted to int8_t, and then serialized
  */
-#define CHIPTLV_INT8(TagSpec, Value) CHIP::TLV::kTLVElementType_Int8 | TagSpec, CHIPTLV_Serialize8(int8_t(Value))
+#define CHIP_TLV_INT8(TagSpec, Value) chip::TLV::kTLVElementType_Int8 | TagSpec, CHIP_TLV_Serialize8(int8_t(Value))
 
 /*
  *  @brief Specifies a 16-bit Signed Integer TLV element
- *  @param TagSpec      Should be filled with macros begin with CHIPTLV_TAG_
+ *  @param TagSpec      Should be filled with macros begin with CHIP_TLV_TAG_
  *  @param Value        Would be first converted to int16_t, and then serialized
  */
-#define CHIPTLV_INT16(TagSpec, Value) CHIP::TLV::kTLVElementType_Int16 | TagSpec, CHIPTLV_Serialize16(int16_t(Value))
+#define CHIP_TLV_INT16(TagSpec, Value) chip::TLV::kTLVElementType_Int16 | TagSpec, CHIP_TLV_Serialize16(int16_t(Value))
 
 /*
  *  @brief Specifies a 32-bit Signed Integer TLV element
- *  @param TagSpec      Should be filled with macros begin with CHIPTLV_TAG_
+ *  @param TagSpec      Should be filled with macros begin with CHIP_TLV_TAG_
  *  @param Value        Would be first converted to int32_t, and then serialized
  */
-#define CHIPTLV_INT32(TagSpec, Value) CHIP::TLV::kTLVElementType_Int32 | TagSpec, CHIPTLV_Serialize32(int32_t(Value))
+#define CHIP_TLV_INT32(TagSpec, Value) chip::TLV::kTLVElementType_Int32 | TagSpec, CHIP_TLV_Serialize32(int32_t(Value))
 
 /*
  *  @brief Specifies a 32-bit Signed Integer TLV element
- *  @param TagSpec      Should be filled with macros begin with CHIPTLV_TAG_
+ *  @param TagSpec      Should be filled with macros begin with CHIP_TLV_TAG_
  *  @param Value        Would be first converted to int64_t, and then serialized
  */
-#define CHIPTLV_INT64(TagSpec, Value) CHIP::TLV::kTLVElementType_Int64 | TagSpec, CHIPTLV_Serialize64(int64_t(Value))
+#define CHIP_TLV_INT64(TagSpec, Value) chip::TLV::kTLVElementType_Int64 | TagSpec, CHIP_TLV_Serialize64(int64_t(Value))
 
 /*
  *  @brief Specifies an 8-bit Unsigned Integer TLV element
- *  @param TagSpec      Should be filled with macros begin with CHIPTLV_TAG_
+ *  @param TagSpec      Should be filled with macros begin with CHIP_TLV_TAG_
  *  @param Value        Would be first converted to (uint8_t), and then serialized
  */
-#define CHIPTLV_UINT8(TagSpec, Value) CHIP::TLV::kTLVElementType_UInt8 | TagSpec, CHIPTLV_Serialize8((uint8_t)(Value))
+#define CHIP_TLV_UINT8(TagSpec, Value) chip::TLV::kTLVElementType_UInt8 | TagSpec, CHIP_TLV_Serialize8((uint8_t)(Value))
 
 /*
  *  @brief Specifies a 16-bit Unsigned Integer TLV element
- *  @param TagSpec      Should be filled with macros begin with CHIPTLV_TAG_
+ *  @param TagSpec      Should be filled with macros begin with CHIP_TLV_TAG_
  *  @param Value        Would be first converted to (uint16_t), and then serialized
  */
-#define CHIPTLV_UINT16(TagSpec, Value) CHIP::TLV::kTLVElementType_UInt16 | TagSpec, CHIPTLV_Serialize16((uint16_t)(Value))
+#define CHIP_TLV_UINT16(TagSpec, Value) chip::TLV::kTLVElementType_UInt16 | TagSpec, CHIP_TLV_Serialize16((uint16_t)(Value))
 
 /*
  *  @brief Specifies a 32-bit Unsigned Integer TLV element
- *  @param TagSpec      Should be filled with macros begin with CHIPTLV_TAG_
+ *  @param TagSpec      Should be filled with macros begin with CHIP_TLV_TAG_
  *  @param Value        Would be first converted to (uint32_t), and then serialized
  */
-#define CHIPTLV_UINT32(TagSpec, Value) CHIP::TLV::kTLVElementType_UInt32 | TagSpec, CHIPTLV_Serialize32((uint32_t)(Value))
+#define CHIP_TLV_UINT32(TagSpec, Value) chip::TLV::kTLVElementType_UInt32 | TagSpec, CHIP_TLV_Serialize32((uint32_t)(Value))
 
 /*
  *  @brief Specifies a 64-bit Unsigned Integer TLV element
- *  @param TagSpec      Should be filled with macros begin with CHIPTLV_TAG_
+ *  @param TagSpec      Should be filled with macros begin with CHIP_TLV_TAG_
  *  @param Value        Would be first converted to (uint64_t), and then serialized
  */
-#define CHIPTLV_UINT64(TagSpec, Value) CHIP::TLV::kTLVElementType_UInt64 | TagSpec, CHIPTLV_Serialize64((uint64_t)(Value))
+#define CHIP_TLV_UINT64(TagSpec, Value) chip::TLV::kTLVElementType_UInt64 | TagSpec, CHIP_TLV_Serialize64((uint64_t)(Value))
 
 /**
  *  @brief
  *    Specifies an UTF8 String TLV element, marking the beginning of String data
  *
- *  @param TagSpec              Should be filled with macros begin with CHIPTLV_TAG_
+ *  @param TagSpec              Should be filled with macros begin with CHIP_TLV_TAG_
  *
  *  @param StringLength         Number of bytes in this string, must be less than 0x100
  *
  *  @param ...                  Bytes representing the string characters to serialize
  */
-#define CHIPTLV_UTF8_STRING_1ByteLength(TagSpec, StringLength, ...) \
-    CHIP::TLV::kTLVElementType_UTF8String_1ByteLength | TagSpec, CHIPTLV_Serialize8((uint8_t)(StringLength)), ## __VA_ARGS__
+#define CHIP_TLV_UTF8_STRING_1ByteLength(TagSpec, StringLength, ...) \
+    chip::TLV::kTLVElementType_UTF8String_1ByteLength | TagSpec, CHIP_TLV_Serialize8((uint8_t)(StringLength)), ## __VA_ARGS__
 
 /**
  *  @brief
  *    Specifies an UTF8 String TLV element, marking the beginning of String data
  *
- *  @param TagSpec              Should be filled with macros begin with CHIPTLV_TAG_
+ *  @param TagSpec              Should be filled with macros begin with CHIP_TLV_TAG_
  *
  *  @param StringLength         Number of bytes in this string, must be less than 0x10000
  *
  *  @param ...                  Bytes representing the string characters to serialize
  */
-#define CHIPTLV_UTF8_STRING_2ByteLength(TagSpec, StringLength, ...) \
-    CHIP::TLV::kTLVElementType_UTF8String_2ByteLength | TagSpec, CHIPTLV_Serialize16((uint16_t)(StringLength)), ## __VA_ARGS__
+#define CHIP_TLV_UTF8_STRING_2ByteLength(TagSpec, StringLength, ...) \
+    chip::TLV::kTLVElementType_UTF8String_2ByteLength | TagSpec, CHIP_TLV_Serialize16((uint16_t)(StringLength)), ## __VA_ARGS__
 
 /**
  *  @brief
  *    Specifies an UTF8 String TLV element, marking the beginning of String data
  *
- *  @param TagSpec              Should be filled with macros begin with CHIPTLV_TAG_
+ *  @param TagSpec              Should be filled with macros begin with CHIP_TLV_TAG_
  *
  *  @param StringLength         Number of bytes in this string, must be less than 0x100000000
  *
  *  @param ...                  Bytes representing the string characters to serialize
  */
-#define CHIPTLV_UTF8_STRING_4ByteLength(TagSpec, StringLength, ...) \
-    CHIP::TLV::kTLVElementType_UTF8String_4ByteLength | TagSpec, CHIPTLV_Serialize32((uint32_t)(StringLength)), ## __VA_ARGS__
+#define CHIP_TLV_UTF8_STRING_4ByteLength(TagSpec, StringLength, ...) \
+    chip::TLV::kTLVElementType_UTF8String_4ByteLength | TagSpec, CHIP_TLV_Serialize32((uint32_t)(StringLength)), ## __VA_ARGS__
 
 /**
  *  @brief
  *    Specifies an UTF8 String TLV element, marking the beginning of String data
  *
- *  @param TagSpec              Should be filled with macros begin with CHIPTLV_TAG_
+ *  @param TagSpec              Should be filled with macros begin with CHIP_TLV_TAG_
  *
  *  @param StringLength         Number of bytes in this string, must be less than 0x10000000000000000
  *
  *  @param ...                  Bytes representing the string characters to serialize
  */
-#define CHIPTLV_UTF8_STRING_8ByteLength(TagSpec, StringLength, ...) \
-    CHIP::TLV::kTLVElementType_UTF8String_8ByteLength | TagSpec, CHIPTLV_Serialize64((uint64_t)(StringLength)), ## __VA_ARGS__
+#define CHIP_TLV_UTF8_STRING_8ByteLength(TagSpec, StringLength, ...) \
+    chip::TLV::kTLVElementType_UTF8String_8ByteLength | TagSpec, CHIP_TLV_Serialize64((uint64_t)(StringLength)), ## __VA_ARGS__
 
 /**
  *  @brief
  *    Specifies a BYTE String TLV element, marking the beginning of String data
  *
- *  @param TagSpec              Should be filled with macros begin with CHIPTLV_TAG_
+ *  @param TagSpec              Should be filled with macros begin with CHIP_TLV_TAG_
  *
  *  @param StringLength         Number of bytes in this string, must be less than 0x100
  *
  *  @param ...                  Bytes to serialize
  */
-#define CHIPTLV_BYTE_STRING_1ByteLength(TagSpec, StringLength, ...) \
-    CHIP::TLV::kTLVElementType_ByteString_1ByteLength | TagSpec, CHIPTLV_Serialize8((uint8_t)(StringLength)), ## __VA_ARGS__
+#define CHIP_TLV_BYTE_STRING_1ByteLength(TagSpec, StringLength, ...) \
+    chip::TLV::kTLVElementType_ByteString_1ByteLength | TagSpec, CHIP_TLV_Serialize8((uint8_t)(StringLength)), ## __VA_ARGS__
 
 /**
  *  @brief
  *    Specifies a BYTE String TLV element, marking the beginning of String data
  *
- *  @param TagSpec              Should be filled with macros begin with CHIPTLV_TAG_
+ *  @param TagSpec              Should be filled with macros begin with CHIP_TLV_TAG_
  *
  *  @param StringLength         Number of bytes in this string, must be less than 0x10000
  *
  *  @param ...                  Bytes to serialize
  */
-#define CHIPTLV_BYTE_STRING_2ByteLength(TagSpec, StringLength, ...) \
-    CHIP::TLV::kTLVElementType_ByteString_2ByteLength | TagSpec, CHIPTLV_Serialize16((uint16_t)(StringLength)), ## __VA_ARGS__
+#define CHIP_TLV_BYTE_STRING_2ByteLength(TagSpec, StringLength, ...) \
+    chip::TLV::kTLVElementType_ByteString_2ByteLength | TagSpec, CHIP_TLV_Serialize16((uint16_t)(StringLength)), ## __VA_ARGS__
 
 /**
  *  @brief
  *    Specifies a BYTE String TLV element, marking the beginning of String data
  *
- *  @param TagSpec              Should be filled with macros begin with CHIPTLV_TAG_
+ *  @param TagSpec              Should be filled with macros begin with CHIP_TLV_TAG_
  *
  *  @param StringLength         Number of bytes in this string, must be less than 0x100000000
  *
  *  @param ...                  Bytes to serialize
  */
-#define CHIPTLV_BYTE_STRING_4ByteLength(TagSpec, StringLength, ...) \
-    CHIP::TLV::kTLVElementType_ByteString_4ByteLength | TagSpec, CHIPTLV_Serialize32((uint32_t)(StringLength)), ## __VA_ARGS__
+#define CHIP_TLV_BYTE_STRING_4ByteLength(TagSpec, StringLength, ...) \
+    chip::TLV::kTLVElementType_ByteString_4ByteLength | TagSpec, CHIP_TLV_Serialize32((uint32_t)(StringLength)), ## __VA_ARGS__
 
 /**
  *  @brief
  *    Specifies a BYTE String TLV element, marking the beginning of String data
  *
- *  @param TagSpec              Should be filled with macros begin with CHIPTLV_TAG_
+ *  @param TagSpec              Should be filled with macros begin with CHIP_TLV_TAG_
  *
  *  @param StringLength         Number of bytes in this string, must be less than 0x10000000000000000
  *
  *  @param ...                  Bytes to serialize
  */
-#define CHIPTLV_BYTE_STRING_8ByteLength(TagSpec, StringLength, ...) \
-    CHIP::TLV::kTLVElementType_ByteString_8ByteLength | TagSpec, CHIPTLV_Serialize64((uint64_t)(StringLength)), ## __VA_ARGS__
+#define CHIP_TLV_BYTE_STRING_8ByteLength(TagSpec, StringLength, ...) \
+    chip::TLV::kTLVElementType_ByteString_8ByteLength | TagSpec, CHIP_TLV_Serialize64((uint64_t)(StringLength)), ## __VA_ARGS__
 
 #endif /* CHIPTLVDATA_H_ */

--- a/src/lib/core/CHIPTLVDebug.hpp
+++ b/src/lib/core/CHIPTLVDebug.hpp
@@ -29,8 +29,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <CHIPError.h>
-#include <CHIPTLV.h>
+#include <core/CHIPError.h>
+#include <core/CHIPTLV.h>
 
 namespace chip {
 

--- a/src/lib/core/CHIPTLVUtilities.hpp
+++ b/src/lib/core/CHIPTLVUtilities.hpp
@@ -29,8 +29,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <CHIPError.h>
-#include <CHIPTLV.h>
+#include <core/CHIPError.h>
+#include <core/CHIPTLV.h>
 
 namespace chip {
 

--- a/src/lib/core/CoreLayer.am
+++ b/src/lib/core/CoreLayer.am
@@ -24,6 +24,7 @@
 #
 
 CHIP_BUILD_CORE_LAYER_SOURCE_FILES                        = \
+    core/CHIPCircularTLVBuffer.cpp                          \
     core/CHIPError.cpp                                      \
     core/CHIPTLVDebug.cpp                                   \
     core/CHIPTLVReader.cpp                                  \
@@ -34,6 +35,7 @@ CHIP_BUILD_CORE_LAYER_SOURCE_FILES                        = \
     $(NULL)
 
 CHIP_BUILD_CORE_LAYER_HEADER_FILES                        = \
+    core/CHIPCircularTLVBuffer.h                            \
     core/CHIPConfig.h                                       \
     core/CHIPCore.h                                         \
     core/CHIPEncoding.h                                     \

--- a/src/lib/core/tests/Makefile.am
+++ b/src/lib/core/tests/Makefile.am
@@ -64,6 +64,7 @@ COMMON_LDADD                                          = \
 
 check_PROGRAMS                                        = \
     TestCHIPErrorStr                                    \
+    TestCHIPTLV                                         \
     $(NULL)
 
 # Test applications and scripts that should be built and run when the
@@ -83,6 +84,9 @@ TESTS_ENVIRONMENT                                     = \
 
 TestCHIPErrorStr_SOURCES                              = TestCHIPErrorStr.cpp
 TestCHIPErrorStr_LDADD                                = $(COMMON_LDADD)
+
+TestCHIPTLV_SOURCES                                   = TestCHIPTLV.cpp
+TestCHIPTLV_LDADD                                     = $(COMMON_LDADD)
 
 if CHIP_BUILD_COVERAGE
 CLEANFILES                                            = $(wildcard *.gcda *.gcno)

--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -19,7 +19,7 @@
 
 /**
  *    @file
- *      This file implements unit tests for the Weave TLV implementation.
+ *      This file implements unit tests for the CHIP TLV implementation.
  *
  */
 
@@ -1458,9 +1458,9 @@ exit:
 }
 
 /**
- *  Test Weave TLV Utilities
+ *  Test CHIP TLV Utilities
  */
-void CheckWeaveTLVUtilities(nlTestSuite *inSuite, void *inContext)
+void CheckCHIPTLVUtilities(nlTestSuite *inSuite, void *inContext)
 {
     uint8_t buf[2048];
     TLVWriter writer;
@@ -1551,9 +1551,9 @@ void CheckWeaveTLVUtilities(nlTestSuite *inSuite, void *inContext)
 }
 
 /**
- *  Test Weave TLV Empty Find
+ *  Test CHIP TLV Empty Find
  */
-void CheckWeaveTLVEmptyFind(nlTestSuite *inSuite, void *inContext)
+void CheckCHIPTLVEmptyFind(nlTestSuite *inSuite, void *inContext)
 {
     uint8_t buf[30];
     TLVWriter writer;
@@ -2282,7 +2282,7 @@ void CheckCircularTLVBufferEdge(nlTestSuite *inSuite, void *inContext)
     TestEnd<TLVReader>(inSuite, reader);
 
 }
-void CheckWeaveTLVPutStringF(nlTestSuite *inSuite, void *inContext)
+void CheckCHIPTLVPutStringF(nlTestSuite *inSuite, void *inContext)
 {
     const size_t bufsize = 24;
     char strBuffer[bufsize];
@@ -2312,7 +2312,7 @@ void CheckWeaveTLVPutStringF(nlTestSuite *inSuite, void *inContext)
     NL_TEST_ASSERT(inSuite, strncmp(valStr, strBuffer, 256) == 0);
 }
 
-void CheckWeaveTLVPutStringFCircular(nlTestSuite *inSuite, void *inContext)
+void CheckCHIPTLVPutStringFCircular(nlTestSuite *inSuite, void *inContext)
 {
     const size_t bufsize = 40;
     char strBuffer[bufsize];
@@ -2377,7 +2377,7 @@ void CheckWeaveTLVPutStringFCircular(nlTestSuite *inSuite, void *inContext)
     NL_TEST_ASSERT(inSuite, strncmp(valStr, strBuffer, bufsize) == 0);
 }
 
-void CheckWeaveTLVSkipCircular(nlTestSuite *inSuite, void * inContext)
+void CheckCHIPTLVSkipCircular(nlTestSuite *inSuite, void * inContext)
 {
     const size_t bufsize = 40; // large enough s.t. 2 elements fit, 3rd causes eviction
     uint8_t backingStore[bufsize];
@@ -2492,9 +2492,9 @@ void CheckStrictAliasing(nlTestSuite *inSuite, void *inContext)
 }
 
 /**
- *  Test Weave TLV Writer Copy Container
+ *  Test CHIP TLV Writer Copy Container
  */
-void TestWeaveTLVWriterCopyContainer(nlTestSuite *inSuite)
+void TestCHIPTLVWriterCopyContainer(nlTestSuite *inSuite)
 {
     uint8_t buf[2048];
 
@@ -2539,9 +2539,9 @@ void TestWeaveTLVWriterCopyContainer(nlTestSuite *inSuite)
 }
 
 /**
- *  Test Weave TLV Writer Copy Element
+ *  Test CHIP TLV Writer Copy Element
  */
-void TestWeaveTLVWriterCopyElement(nlTestSuite *inSuite)
+void TestCHIPTLVWriterCopyElement(nlTestSuite *inSuite)
 {
     CHIP_ERROR err;
     uint8_t expectedBuf[2048], testBuf[2048];
@@ -2672,9 +2672,9 @@ void PreserveSizeWrite(nlTestSuite *inSuite, TLVWriter& writer, bool preserveSiz
 }
 
 /**
- *  Test Weave TLV Writer with Preserve Size
+ *  Test CHIP TLV Writer with Preserve Size
  */
-void TestWeaveTLVWriterPreserveSize(nlTestSuite *inSuite)
+void TestCHIPTLVWriterPreserveSize(nlTestSuite *inSuite)
 {
     uint8_t buf[2048];
     TLVWriter writer;
@@ -2689,9 +2689,9 @@ void TestWeaveTLVWriterPreserveSize(nlTestSuite *inSuite)
 }
 
 /**
- *  Test error handling of Weave TLV Writer
+ *  Test error handling of CHIP TLV Writer
  */
-void TestWeaveTLVWriterErrorHandling(nlTestSuite *inSuite)
+void TestCHIPTLVWriterErrorHandling(nlTestSuite *inSuite)
 {
     CHIP_ERROR err;
     uint8_t buf[2048];
@@ -2737,17 +2737,17 @@ void TestWeaveTLVWriterErrorHandling(nlTestSuite *inSuite)
 }
 
 /**
- *  Test Weave TLV Writer
+ *  Test CHIP TLV Writer
  */
-void CheckWeaveTLVWriter(nlTestSuite *inSuite, void *inContext)
+void CheckCHIPTLVWriter(nlTestSuite *inSuite, void *inContext)
 {
-    TestWeaveTLVWriterCopyContainer(inSuite);
+    TestCHIPTLVWriterCopyContainer(inSuite);
 
-    TestWeaveTLVWriterCopyElement(inSuite);
+    TestCHIPTLVWriterCopyElement(inSuite);
 
-    TestWeaveTLVWriterPreserveSize(inSuite);
+    TestCHIPTLVWriterPreserveSize(inSuite);
 
-    TestWeaveTLVWriterErrorHandling(inSuite);
+    TestCHIPTLVWriterErrorHandling(inSuite);
 }
 
 void SkipNonContainer(nlTestSuite *inSuite)
@@ -2808,9 +2808,9 @@ void NextContainer(nlTestSuite *inSuite)
 }
 
 /**
- *  Test Weave TLV Reader Skip functions
+ *  Test CHIP TLV Reader Skip functions
  */
-void TestWeaveTLVReaderSkip(nlTestSuite *inSuite)
+void TestCHIPTLVReaderSkip(nlTestSuite *inSuite)
 {
     SkipNonContainer(inSuite);
 
@@ -2820,9 +2820,9 @@ void TestWeaveTLVReaderSkip(nlTestSuite *inSuite)
 }
 
 /**
- *  Test Weave TLV Reader Dup functions
+ *  Test CHIP TLV Reader Dup functions
  */
-void TestWeaveTLVReaderDup(nlTestSuite *inSuite)
+void TestCHIPTLVReaderDup(nlTestSuite *inSuite)
 {
     TLVReader reader;
 
@@ -2940,9 +2940,9 @@ void TestWeaveTLVReaderDup(nlTestSuite *inSuite)
     TestEnd<TLVReader>(inSuite, reader);
 }
 /**
- *  Test error handling of Weave TLV Reader
+ *  Test error handling of CHIP TLV Reader
  */
-void TestWeaveTLVReaderErrorHandling(nlTestSuite *inSuite)
+void TestCHIPTLVReaderErrorHandling(nlTestSuite *inSuite)
 {
     CHIP_ERROR err;
     uint8_t buf[2048];
@@ -3003,9 +3003,9 @@ void TestWeaveTLVReaderErrorHandling(nlTestSuite *inSuite)
     free((void *)data);
 }
 /**
- *  Test Weave TLV Reader in a use case
+ *  Test CHIP TLV Reader in a use case
  */
-void TestWeaveTLVReaderInPractice(nlTestSuite *inSuite)
+void TestCHIPTLVReaderInPractice(nlTestSuite *inSuite)
 {
     uint8_t buf[2048];
     TLVWriter writer;
@@ -3031,7 +3031,7 @@ void TestWeaveTLVReaderInPractice(nlTestSuite *inSuite)
     TestGet<TLVReader, double>(inSuite, reader, kTLVType_FloatingPointNumber, ProfileTag(TestProfile_1, 4000000000ULL), (float) 1.0);
 }
 
-void TestWeaveTLVReader_NextOverContainer_ProcessElement(nlTestSuite *inSuite, TLVReader& reader, void *context)
+void TestCHIPTLVReader_NextOverContainer_ProcessElement(nlTestSuite *inSuite, TLVReader& reader, void *context)
 {
     CHIP_ERROR err, nextRes1, nextRes2;
     TLVType outerContainerType;
@@ -3064,19 +3064,19 @@ void TestWeaveTLVReader_NextOverContainer_ProcessElement(nlTestSuite *inSuite, T
 }
 
 /**
- * Test using Weave TLV Reader Next() method to skip over containers.
+ * Test using CHIP TLV Reader Next() method to skip over containers.
  */
-void TestWeaveTLVReader_NextOverContainer(nlTestSuite *inSuite)
+void TestCHIPTLVReader_NextOverContainer(nlTestSuite *inSuite)
 {
     TLVReader reader;
 
     reader.Init(Encoding1, sizeof(Encoding1));
     reader.ImplicitProfileId = TestProfile_2;
 
-    ForEachElement(inSuite, reader, NULL, TestWeaveTLVReader_NextOverContainer_ProcessElement);
+    ForEachElement(inSuite, reader, NULL, TestCHIPTLVReader_NextOverContainer_ProcessElement);
 }
 
-void TestWeaveTLVReader_SkipOverContainer_ProcessElement(nlTestSuite *inSuite, TLVReader& reader, void *context)
+void TestCHIPTLVReader_SkipOverContainer_ProcessElement(nlTestSuite *inSuite, TLVReader& reader, void *context)
 {
     CHIP_ERROR err;
     TLVType outerContainerType;
@@ -3106,38 +3106,38 @@ void TestWeaveTLVReader_SkipOverContainer_ProcessElement(nlTestSuite *inSuite, T
 }
 
 /**
- * Test using Weave TLV Reader Skip() method to skip over containers.
+ * Test using CHIP TLV Reader Skip() method to skip over containers.
  */
-void TestWeaveTLVReader_SkipOverContainer(nlTestSuite *inSuite)
+void TestCHIPTLVReader_SkipOverContainer(nlTestSuite *inSuite)
 {
     TLVReader reader;
 
     reader.Init(Encoding1, sizeof(Encoding1));
     reader.ImplicitProfileId = TestProfile_2;
 
-    ForEachElement(inSuite, reader, NULL, TestWeaveTLVReader_SkipOverContainer_ProcessElement);
+    ForEachElement(inSuite, reader, NULL, TestCHIPTLVReader_SkipOverContainer_ProcessElement);
 }
 
 /**
- *  Test Weave TLV Reader
+ *  Test CHIP TLV Reader
  */
-void CheckWeaveTLVReader(nlTestSuite *inSuite, void *inContext)
+void CheckCHIPTLVReader(nlTestSuite *inSuite, void *inContext)
 {
-    TestWeaveTLVReaderSkip(inSuite);
+    TestCHIPTLVReaderSkip(inSuite);
 
-    TestWeaveTLVReaderDup(inSuite);
+    TestCHIPTLVReaderDup(inSuite);
 
-    TestWeaveTLVReaderErrorHandling(inSuite);
+    TestCHIPTLVReaderErrorHandling(inSuite);
 
-    TestWeaveTLVReaderInPractice(inSuite);
+    TestCHIPTLVReaderInPractice(inSuite);
 
-    TestWeaveTLVReader_NextOverContainer(inSuite);
+    TestCHIPTLVReader_NextOverContainer(inSuite);
 
-    TestWeaveTLVReader_SkipOverContainer(inSuite);
+    TestCHIPTLVReader_SkipOverContainer(inSuite);
 }
 
 /**
- *  Test Weave TLV Items
+ *  Test CHIP TLV Items
  */
 static void TestItems(nlTestSuite *inSuite, void *inContext)
 {
@@ -3224,7 +3224,7 @@ static void TestItems(nlTestSuite *inSuite, void *inContext)
 }
 
 /**
- *  Test Weave TLV Containers
+ *  Test CHIP TLV Containers
  */
 static void TestContainers(nlTestSuite *inSuite, void *inContext)
 {
@@ -3258,18 +3258,18 @@ static void TestContainers(nlTestSuite *inSuite, void *inContext)
 }
 
 /**
- *  Test Weave TLV Basics
+ *  Test CHIP TLV Basics
  */
-static void CheckWeaveTLVBasics(nlTestSuite *inSuite, void *inContext)
+static void CheckCHIPTLVBasics(nlTestSuite *inSuite, void *inContext)
 {
     TestItems(inSuite, inContext);
     TestContainers(inSuite, inContext);
 }
 
 /**
- *  Test Weave TLV Updater
+ *  Test CHIP TLV Updater
  */
-static void CheckWeaveUpdater(nlTestSuite *inSuite, void *inContext)
+static void CheckCHIPUpdater(nlTestSuite *inSuite, void *inContext)
 {
     WriteAppendReadTest0(inSuite);
 
@@ -3485,6 +3485,260 @@ static void CheckCloseContainerReserve(nlTestSuite *inSuite, void *inContext)
     }
 }
 
+static CHIP_ERROR ReadFuzzedEncoding1(nlTestSuite *inSuite, TLVReader& reader)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+#define FUZZ_CHECK_VAL(TYPE, VAL)                                       \
+    do {                                                                \
+        TYPE val;                                                       \
+        err = reader.Get(val);                                          \
+        SuccessOrExit(err);                                             \
+        VerifyOrExit(val == (VAL), err = CHIP_ERROR_INVALID_ARGUMENT); \
+    } while (0)
+
+#define FUZZ_CHECK_STRING(VAL)                                                              \
+    do {                                                                                    \
+        char buf[sizeof(VAL)];                                                              \
+        VerifyOrExit(reader.GetLength() == strlen(VAL), err = CHIP_ERROR_INVALID_ADDRESS); \
+        err = reader.GetString(buf, sizeof(buf));                                           \
+        SuccessOrExit(err);                                                                 \
+        VerifyOrExit(strcmp(buf, (VAL)) == 0, err = CHIP_ERROR_INVALID_ADDRESS);           \
+    } while (0)
+
+    err = reader.Next(kTLVType_Structure, ProfileTag(TestProfile_1, 1));
+    SuccessOrExit(err);
+
+    {
+        TLVType outerContainer1Type;
+
+        err = reader.EnterContainer(outerContainer1Type);
+        SuccessOrExit(err);
+
+        err = reader.Next(kTLVType_Boolean, ProfileTag(TestProfile_1, 2));
+        SuccessOrExit(err);
+
+        FUZZ_CHECK_VAL(bool, true);
+
+        err = reader.Next(kTLVType_Boolean, ProfileTag(TestProfile_2, 2));
+        SuccessOrExit(err);
+
+        FUZZ_CHECK_VAL(bool, false);
+
+        err = reader.Next(kTLVType_Array, ContextTag(0));
+        SuccessOrExit(err);
+
+        {
+            TLVType outerContainer2Type;
+
+            err = reader.EnterContainer(outerContainer2Type);
+            SuccessOrExit(err);
+
+            err = reader.Next(kTLVType_SignedInteger, AnonymousTag);
+            SuccessOrExit(err);
+
+            FUZZ_CHECK_VAL(int8_t, 42);
+            FUZZ_CHECK_VAL(int16_t, 42);
+            FUZZ_CHECK_VAL(int32_t, 42);
+            FUZZ_CHECK_VAL(int64_t, 42);
+            FUZZ_CHECK_VAL(uint8_t, 42);
+            FUZZ_CHECK_VAL(uint16_t, 42);
+            FUZZ_CHECK_VAL(uint32_t, 42);
+            FUZZ_CHECK_VAL(uint64_t, 42);
+
+            err = reader.Next(kTLVType_SignedInteger, AnonymousTag);
+            SuccessOrExit(err);
+
+            FUZZ_CHECK_VAL(int8_t, -17);
+            FUZZ_CHECK_VAL(int16_t, -17);
+            FUZZ_CHECK_VAL(int32_t, -17);
+            FUZZ_CHECK_VAL(int64_t, -17);
+
+            err = reader.Next(kTLVType_SignedInteger, AnonymousTag);
+            SuccessOrExit(err);
+
+            FUZZ_CHECK_VAL(int32_t, -170000);
+            FUZZ_CHECK_VAL(int64_t, -170000);
+
+            err = reader.Next(kTLVType_UnsignedInteger, AnonymousTag);
+            SuccessOrExit(err);
+
+            FUZZ_CHECK_VAL(int64_t, 40000000000ULL);
+            FUZZ_CHECK_VAL(uint64_t, 40000000000ULL);
+
+            err = reader.Next(kTLVType_Structure, AnonymousTag);
+            SuccessOrExit(err);
+
+            {
+                TLVType outerContainer3Type;
+
+                err = reader.EnterContainer(outerContainer3Type);
+                SuccessOrExit(err);
+
+                err = reader.ExitContainer(outerContainer3Type);
+                SuccessOrExit(err);
+            }
+
+            err = reader.Next(kTLVType_Path, AnonymousTag);
+            SuccessOrExit(err);
+
+            {
+                TLVType outerContainer3Type;
+
+                err = reader.EnterContainer(outerContainer3Type);
+                SuccessOrExit(err);
+
+                err = reader.Next(kTLVType_Null, ProfileTag(TestProfile_1, 17));
+                SuccessOrExit(err);
+
+                err = reader.Next(kTLVType_Null, ProfileTag(TestProfile_2, 900000));
+                SuccessOrExit(err);
+
+                err = reader.Next(kTLVType_Structure, ProfileTag(TestProfile_2, 4000000000ULL));
+                SuccessOrExit(err);
+
+                {
+                    TLVType outerContainer4Type;
+
+                    err = reader.EnterContainer(outerContainer4Type);
+                    SuccessOrExit(err);
+
+                    err = reader.Next(kTLVType_UTF8String, CommonTag(70000));
+                    SuccessOrExit(err);
+
+                    FUZZ_CHECK_STRING(sLargeString);
+
+                    err = reader.ExitContainer(outerContainer4Type);
+                    SuccessOrExit(err);
+                }
+
+                err = reader.ExitContainer(outerContainer3Type);
+                SuccessOrExit(err);
+            }
+
+            err = reader.ExitContainer(outerContainer2Type);
+            SuccessOrExit(err);
+        }
+
+        err = reader.Next(kTLVType_UTF8String, ProfileTag(TestProfile_1, 5));
+        SuccessOrExit(err);
+
+        FUZZ_CHECK_STRING("This is a test");
+
+        err = reader.Next(kTLVType_FloatingPointNumber, ProfileTag(TestProfile_2, 65535));
+        SuccessOrExit(err);
+
+        FUZZ_CHECK_VAL(double, (float)17.9);
+
+        err = reader.Next(kTLVType_FloatingPointNumber, ProfileTag(TestProfile_2, 65536));
+        SuccessOrExit(err);
+
+        FUZZ_CHECK_VAL(double, (double)17.9);
+
+        err = reader.ExitContainer(outerContainer1Type);
+        SuccessOrExit(err);
+    }
+
+    err = reader.Next();
+    if (err == CHIP_END_OF_TLV)
+        err = CHIP_NO_ERROR;
+
+exit:
+    return err;
+}
+
+static uint32_t sFuzzTestDurationSecs = 5;
+static uint8_t  sFixedFuzzMask = 0;
+
+static void TLVReaderFuzzTest(nlTestSuite *inSuite, void *inContext)
+{
+    time_t now, endTime;
+    uint8_t fuzzedData[sizeof(Encoding1)];
+
+    // clang-format off
+    static uint8_t sFixedFuzzVals[] =
+    {
+        0x00,
+        0x01,
+        0xFF,
+        0x20, // 1-byte signed integer with context tag
+        0x21, // 2-byte signed integer with context tag
+        0x22, // 4-byte signed integer with context tag
+        0x23, // 8-byte signed integer with context tag
+        0x24, // 1-byte unsigned integer with context tag
+        0x25, // 1-byte unsigned integer with context tag
+        0x26, // 1-byte unsigned integer with context tag
+        0x27, // 1-byte unsigned integer with context tag
+        0x28, // Boolean false with context tag
+        0x29, // Boolean true with context tag
+        0x27, // UTF-8 string with 1-byte length and context tag
+        0x30, // Byte string with 1-byte length and context tag
+        0x35, // Structure with context tag
+        0x36, // Array with context tag
+        0x18, // End of container
+    };
+    // clang-format on
+
+    memcpy(fuzzedData, Encoding1, sizeof(fuzzedData));
+
+    time(&now);
+    endTime = now + sFuzzTestDurationSecs + 1;
+
+    srand(now);
+
+    size_t m = 0;
+    while (true)
+    {
+        for (size_t i = 0; i < sizeof(fuzzedData); i++)
+        {
+            uint8_t origVal = fuzzedData[i];
+
+            if (m < sizeof(sFixedFuzzVals))
+            {
+                if (origVal == sFixedFuzzVals[m])
+                    continue;
+
+                fuzzedData[i] = sFixedFuzzVals[m];
+            }
+
+            else
+            {
+                uint8_t fuzzMask = sFixedFuzzMask;
+                while (fuzzMask == 0)
+                    fuzzMask = GetRandU8();
+
+                fuzzedData[i] ^= fuzzMask;
+            }
+
+            TLVReader reader;
+            reader.Init(fuzzedData, sizeof(fuzzedData));
+            reader.ImplicitProfileId = TestProfile_2;
+
+            CHIP_ERROR readRes = ReadFuzzedEncoding1(inSuite, reader);
+            NL_TEST_ASSERT(inSuite, readRes != CHIP_NO_ERROR);
+
+            if (readRes == CHIP_NO_ERROR)
+            {
+                printf("Unexpected success of fuzz test: offset %u, original value 0x%02X, mutated value 0x%02X\n",
+                       (unsigned)i, (unsigned)origVal, (unsigned)fuzzedData[i]);
+                ExitNow();
+            }
+
+            time(&now);
+            if (now >= endTime)
+                ExitNow();
+
+            fuzzedData[i] = origVal;
+        }
+
+       if (m < sizeof(sFixedFuzzVals))
+            m++;
+    }
+
+exit:
+    return;
+}
+
 // Test Suite
 
 /**
@@ -3499,20 +3753,21 @@ static const nlTest sTests[] =
     NL_TEST_DEF("Pretty Print Test",                   CheckPrettyPrinter),
     NL_TEST_DEF("Data Macro Test",                     CheckDataMacro),
     NL_TEST_DEF("Strict Aliasing Test",                CheckStrictAliasing),
-    NL_TEST_DEF("Weave TLV Basics",                    CheckWeaveTLVBasics),
-    NL_TEST_DEF("Weave TLV Writer",                    CheckWeaveTLVWriter),
-    NL_TEST_DEF("Weave TLV Reader",                    CheckWeaveTLVReader),
-    NL_TEST_DEF("Weave TLV Utilities",                 CheckWeaveTLVUtilities),
-    NL_TEST_DEF("Weave TLV Updater",                   CheckWeaveUpdater),
-    NL_TEST_DEF("Weave TLV Empty Find",                CheckWeaveTLVEmptyFind),
-    NL_TEST_DEF("Weave Circular TLV buffer, simple",   CheckCircularTLVBufferSimple),
-    NL_TEST_DEF("Weave Circular TLV buffer, mid-buffer start", CheckCircularTLVBufferStartMidway),
-    NL_TEST_DEF("Weave Circular TLV buffer, straddle", CheckCircularTLVBufferEvictStraddlingEvent),
-    NL_TEST_DEF("Weave Circular TLV buffer, edge",     CheckCircularTLVBufferEdge),
-    NL_TEST_DEF("Weave TLV Printf",                    CheckWeaveTLVPutStringF),
-    NL_TEST_DEF("Weave TLV Printf, Circular TLV buf",  CheckWeaveTLVPutStringFCircular),
-    NL_TEST_DEF("Weave TLV Skip non-contiguous",       CheckWeaveTLVSkipCircular),
-    NL_TEST_DEF("Weave TLV Check reserve",             CheckCloseContainerReserve),
+    NL_TEST_DEF("CHIP TLV Basics",                     CheckCHIPTLVBasics),
+    NL_TEST_DEF("CHIP TLV Writer",                     CheckCHIPTLVWriter),
+    NL_TEST_DEF("CHIP TLV Reader",                     CheckCHIPTLVReader),
+    NL_TEST_DEF("CHIP TLV Utilities",                  CheckCHIPTLVUtilities),
+    NL_TEST_DEF("CHIP TLV Updater",                    CheckCHIPUpdater),
+    NL_TEST_DEF("CHIP TLV Empty Find",                 CheckCHIPTLVEmptyFind),
+    NL_TEST_DEF("CHIP Circular TLV buffer, simple",    CheckCircularTLVBufferSimple),
+    NL_TEST_DEF("CHIP Circular TLV buffer, mid-buffer start", CheckCircularTLVBufferStartMidway),
+    NL_TEST_DEF("CHIP Circular TLV buffer, straddle",  CheckCircularTLVBufferEvictStraddlingEvent),
+    NL_TEST_DEF("CHIP Circular TLV buffer, edge",      CheckCircularTLVBufferEdge),
+    NL_TEST_DEF("CHIP TLV Printf",                     CheckCHIPTLVPutStringF),
+    NL_TEST_DEF("CHIP TLV Printf, Circular TLV buf",   CheckCHIPTLVPutStringFCircular),
+    NL_TEST_DEF("CHIP TLV Skip non-contiguous",        CheckCHIPTLVSkipCircular),
+    NL_TEST_DEF("CHIP TLV Check reserve",              CheckCloseContainerReserve),
+    NL_TEST_DEF("CHIP TLV Reader Fuzz Test",           TLVReaderFuzzTest),
 
     NL_TEST_SENTINEL()
 };

--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -41,22 +41,24 @@ using namespace chip::TLV;
 
 enum
 {
-    TestProfile_1				= 0xAABBCCDD,
-    TestProfile_2				= 0x11223344
+    TestProfile_1 = 0xAABBCCDD,
+    TestProfile_2 = 0x11223344
 };
 
+// clang-format off
 static const char sLargeString [] =
     "START..."
     "!123456789ABCDEF@123456789ABCDEF#123456789ABCDEF$123456789ABCDEF%123456789ABCDEF^123456789ABCDEF&123456789ABCDEF*123456789ABCDEF"
     "01234567(9ABCDEF01234567)9ABCDEF01234567-9ABCDEF01234567=9ABCDEF01234567[9ABCDEF01234567]9ABCDEF01234567;9ABCDEF01234567'9ABCDEF"
     "...END";
+// clang-format on
 
 void Abort()
 {
     abort();
 }
 
-void TestAndOpenContainer(nlTestSuite *inSuite, TLVReader& reader, TLVType type, uint64_t tag, TLVReader& containerReader)
+void TestAndOpenContainer(nlTestSuite * inSuite, TLVReader & reader, TLVType type, uint64_t tag, TLVReader & containerReader)
 {
     NL_TEST_ASSERT(inSuite, reader.GetType() == type);
     NL_TEST_ASSERT(inSuite, reader.GetTag() == tag);
@@ -68,8 +70,8 @@ void TestAndOpenContainer(nlTestSuite *inSuite, TLVReader& reader, TLVType type,
     NL_TEST_ASSERT(inSuite, containerReader.GetContainerType() == type);
 }
 
-template<class T>
-void TestAndEnterContainer(nlTestSuite *inSuite, T& t, TLVType type, uint64_t tag, TLVType& outerContainerType)
+template <class T>
+void TestAndEnterContainer(nlTestSuite * inSuite, T & t, TLVType type, uint64_t tag, TLVType & outerContainerType)
 {
     NL_TEST_ASSERT(inSuite, t.GetType() == type);
     NL_TEST_ASSERT(inSuite, t.GetTag() == tag);
@@ -84,27 +86,27 @@ void TestAndEnterContainer(nlTestSuite *inSuite, T& t, TLVType type, uint64_t ta
     NL_TEST_ASSERT(inSuite, t.GetContainerType() == type);
 }
 
-template<class T>
-void TestNext(nlTestSuite *inSuite, T& t)
+template <class T>
+void TestNext(nlTestSuite * inSuite, T & t)
 {
     CHIP_ERROR err = t.Next();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
-void TestSkip(nlTestSuite *inSuite, TLVReader& reader)
+void TestSkip(nlTestSuite * inSuite, TLVReader & reader)
 {
     CHIP_ERROR err = reader.Skip();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
-void TestMove(nlTestSuite *inSuite, TLVUpdater& updater)
+void TestMove(nlTestSuite * inSuite, TLVUpdater & updater)
 {
     CHIP_ERROR err = updater.Move();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
-template<class T>
-void TestEnd(nlTestSuite *inSuite, T& t)
+template <class T>
+void TestEnd(nlTestSuite * inSuite, T & t)
 {
     CHIP_ERROR err;
 
@@ -112,7 +114,7 @@ void TestEnd(nlTestSuite *inSuite, T& t)
     NL_TEST_ASSERT(inSuite, err == CHIP_END_OF_TLV);
 }
 
-void TestEndAndCloseContainer(nlTestSuite *inSuite, TLVReader& reader, TLVReader& containerReader)
+void TestEndAndCloseContainer(nlTestSuite * inSuite, TLVReader & reader, TLVReader & containerReader)
 {
     CHIP_ERROR err;
 
@@ -122,8 +124,8 @@ void TestEndAndCloseContainer(nlTestSuite *inSuite, TLVReader& reader, TLVReader
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
-template<class T>
-void TestEndAndExitContainer(nlTestSuite *inSuite, T& t, TLVType outerContainerType)
+template <class T>
+void TestEndAndExitContainer(nlTestSuite * inSuite, T & t, TLVType outerContainerType)
 {
     CHIP_ERROR err;
 
@@ -135,8 +137,8 @@ void TestEndAndExitContainer(nlTestSuite *inSuite, T& t, TLVType outerContainerT
     NL_TEST_ASSERT(inSuite, t.GetContainerType() == outerContainerType);
 }
 
-template<class S, class T>
-void TestGet(nlTestSuite *inSuite, S& s, TLVType type, uint64_t tag, T expectedVal)
+template <class S, class T>
+void TestGet(nlTestSuite * inSuite, S & s, TLVType type, uint64_t tag, T expectedVal)
 {
     NL_TEST_ASSERT(inSuite, s.GetType() == type);
     NL_TEST_ASSERT(inSuite, s.GetTag() == tag);
@@ -149,7 +151,8 @@ void TestGet(nlTestSuite *inSuite, S& s, TLVType type, uint64_t tag, T expectedV
     NL_TEST_ASSERT(inSuite, val == expectedVal);
 }
 
-void ForEachElement(nlTestSuite *inSuite, TLVReader& reader, void *context, void (*cb)(nlTestSuite *inSuite, TLVReader& reader, void *context))
+void ForEachElement(nlTestSuite * inSuite, TLVReader & reader, void * context,
+                    void (*cb)(nlTestSuite * inSuite, TLVReader & reader, void * context))
 {
     CHIP_ERROR err;
 
@@ -188,20 +191,19 @@ void ForEachElement(nlTestSuite *inSuite, TLVReader& reader, void *context, void
 
 struct TestTLVContext
 {
-    nlTestSuite *mSuite;
+    nlTestSuite * mSuite;
     int mEvictionCount;
     int mEvictedBytes;
 };
 
-
-void TestNull(nlTestSuite *inSuite, TLVReader& reader, uint64_t tag)
+void TestNull(nlTestSuite * inSuite, TLVReader & reader, uint64_t tag)
 {
     NL_TEST_ASSERT(inSuite, reader.GetType() == kTLVType_Null);
     NL_TEST_ASSERT(inSuite, reader.GetTag() == tag);
     NL_TEST_ASSERT(inSuite, reader.GetLength() == 0);
 }
 
-void TestString(nlTestSuite *inSuite, TLVReader& reader, uint64_t tag, const char *expectedVal)
+void TestString(nlTestSuite * inSuite, TLVReader & reader, uint64_t tag, const char * expectedVal)
 {
     NL_TEST_ASSERT(inSuite, reader.GetType() == kTLVType_UTF8String);
     NL_TEST_ASSERT(inSuite, reader.GetTag() == tag);
@@ -209,7 +211,7 @@ void TestString(nlTestSuite *inSuite, TLVReader& reader, uint64_t tag, const cha
     uint32_t expectedLen = strlen(expectedVal);
     NL_TEST_ASSERT(inSuite, reader.GetLength() == expectedLen);
 
-    char *val = (char *)malloc(expectedLen + 1);
+    char * val = (char *) malloc(expectedLen + 1);
 
     CHIP_ERROR err = reader.GetString(val, expectedLen + 1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -219,7 +221,7 @@ void TestString(nlTestSuite *inSuite, TLVReader& reader, uint64_t tag, const cha
     free(val);
 }
 
-void TestDupString(nlTestSuite *inSuite, TLVReader& reader, uint64_t tag, const char *expectedVal)
+void TestDupString(nlTestSuite * inSuite, TLVReader & reader, uint64_t tag, const char * expectedVal)
 {
     NL_TEST_ASSERT(inSuite, reader.GetType() == kTLVType_UTF8String);
     NL_TEST_ASSERT(inSuite, reader.GetTag() == tag);
@@ -227,7 +229,7 @@ void TestDupString(nlTestSuite *inSuite, TLVReader& reader, uint64_t tag, const 
     uint32_t expectedLen = strlen(expectedVal);
     NL_TEST_ASSERT(inSuite, reader.GetLength() == expectedLen);
 
-    char *val = (char *)malloc(expectedLen + 1);
+    char * val = (char *) malloc(expectedLen + 1);
 
     CHIP_ERROR err = reader.DupString(val);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -237,14 +239,14 @@ void TestDupString(nlTestSuite *inSuite, TLVReader& reader, uint64_t tag, const 
     free(val);
 }
 
-void TestDupBytes(nlTestSuite *inSuite, TLVReader& reader, uint64_t tag, const uint8_t *expectedVal, uint32_t expectedLen)
+void TestDupBytes(nlTestSuite * inSuite, TLVReader & reader, uint64_t tag, const uint8_t * expectedVal, uint32_t expectedLen)
 {
     NL_TEST_ASSERT(inSuite, reader.GetType() == kTLVType_UTF8String);
     NL_TEST_ASSERT(inSuite, reader.GetTag() == tag);
 
     NL_TEST_ASSERT(inSuite, reader.GetLength() == expectedLen);
 
-    uint8_t *val = (uint8_t *)malloc(expectedLen);
+    uint8_t * val  = (uint8_t *) malloc(expectedLen);
     CHIP_ERROR err = reader.DupBytes(val, expectedLen);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
@@ -253,7 +255,7 @@ void TestDupBytes(nlTestSuite *inSuite, TLVReader& reader, uint64_t tag, const u
     free(val);
 }
 
-void TestBufferContents(nlTestSuite *inSuite, PacketBuffer *buf, const uint8_t *expectedVal, uint32_t expectedLen)
+void TestBufferContents(nlTestSuite * inSuite, PacketBuffer * buf, const uint8_t * expectedVal, uint32_t expectedLen)
 {
     while (buf != NULL)
     {
@@ -271,6 +273,7 @@ void TestBufferContents(nlTestSuite *inSuite, PacketBuffer *buf, const uint8_t *
     NL_TEST_ASSERT(inSuite, expectedLen == 0);
 }
 
+// clang-format off
 static const uint8_t Encoding1[] =
 {
     0xD5, 0xBB, 0xAA, 0xDD, 0xCC, 0x01, 0x00, 0xC9, 0xBB, 0xAA, 0xDD, 0xCC, 0x02, 0x00, 0x88, 0x02,
@@ -299,7 +302,9 @@ static const uint8_t Encoding1[] =
     0x8A, 0xFF, 0xFF, 0x33, 0x33, 0x8f, 0x41,
     0xAB, 0x00, 0x00, 0x01, 0x00, 0x66, 0x66, 0x66, 0x66, 0x66, 0xE6, 0x31, 0x40, 0x18
 };
+// clang-format on
 
+// clang-format off
 static const uint8_t Encoding1_DataMacro [] =
 {
     CHIP_TLV_STRUCTURE(CHIP_TLV_TAG_FULLY_QUALIFIED_6Bytes(TestProfile_1, 1)),
@@ -346,8 +351,9 @@ static const uint8_t Encoding1_DataMacro [] =
             0x66, 0x66, 0x66, 0x66, 0x66, 0xE6, 0x31, 0x40), // (double)17.9
     CHIP_TLV_END_OF_CONTAINER
 };
+// clang-format on
 
-void WriteEncoding1(nlTestSuite *inSuite, TLVWriter& writer)
+void WriteEncoding1(nlTestSuite * inSuite, TLVWriter & writer)
 {
     CHIP_ERROR err;
     TLVWriter writer2;
@@ -425,10 +431,10 @@ void WriteEncoding1(nlTestSuite *inSuite, TLVWriter& writer)
     err = writer2.PutString(ProfileTag(TestProfile_1, 5), "This is a test");
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = writer2.Put(ProfileTag(TestProfile_2, 65535), (float)17.9);
+    err = writer2.Put(ProfileTag(TestProfile_2, 65535), (float) 17.9);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = writer2.Put(ProfileTag(TestProfile_2, 65536), (double)17.9);
+    err = writer2.Put(ProfileTag(TestProfile_2, 65536), (double) 17.9);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     err = writer.CloseContainer(writer2);
@@ -438,7 +444,7 @@ void WriteEncoding1(nlTestSuite *inSuite, TLVWriter& writer)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
-void WriteEmptyEncoding(nlTestSuite *inSuite, TLVWriter& writer)
+void WriteEmptyEncoding(nlTestSuite * inSuite, TLVWriter & writer)
 {
     CHIP_ERROR err;
     TLVWriter writer2;
@@ -463,7 +469,7 @@ void WriteEmptyEncoding(nlTestSuite *inSuite, TLVWriter& writer)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
-void ReadEncoding1(nlTestSuite *inSuite, TLVReader& reader)
+void ReadEncoding1(nlTestSuite * inSuite, TLVReader & reader)
 {
     TestNext<TLVReader>(inSuite, reader);
 
@@ -545,7 +551,8 @@ void ReadEncoding1(nlTestSuite *inSuite, TLVReader& reader)
                 {
                     TLVType outerContainerType;
 
-                    TestAndEnterContainer<TLVReader>(inSuite, reader5, kTLVType_Structure, ProfileTag(TestProfile_2, 4000000000ULL), outerContainerType);
+                    TestAndEnterContainer<TLVReader>(inSuite, reader5, kTLVType_Structure, ProfileTag(TestProfile_2, 4000000000ULL),
+                                                     outerContainerType);
 
                     TestNext<TLVReader>(inSuite, reader5);
 
@@ -566,11 +573,11 @@ void ReadEncoding1(nlTestSuite *inSuite, TLVReader& reader)
 
         TestNext<TLVReader>(inSuite, reader2);
 
-        TestGet<TLVReader, double>(inSuite, reader2, kTLVType_FloatingPointNumber, ProfileTag(TestProfile_2, 65535), (float)17.9);
+        TestGet<TLVReader, double>(inSuite, reader2, kTLVType_FloatingPointNumber, ProfileTag(TestProfile_2, 65535), (float) 17.9);
 
         TestNext<TLVReader>(inSuite, reader2);
 
-        TestGet<TLVReader, double>(inSuite, reader2, kTLVType_FloatingPointNumber, ProfileTag(TestProfile_2, 65536), (double)17.9);
+        TestGet<TLVReader, double>(inSuite, reader2, kTLVType_FloatingPointNumber, ProfileTag(TestProfile_2, 65536), (double) 17.9);
 
         TestEndAndCloseContainer(inSuite, reader, reader2);
     }
@@ -578,7 +585,7 @@ void ReadEncoding1(nlTestSuite *inSuite, TLVReader& reader)
     TestEnd<TLVReader>(inSuite, reader);
 }
 
-void WriteEncoding2(nlTestSuite *inSuite, TLVWriter& writer)
+void WriteEncoding2(nlTestSuite * inSuite, TLVWriter & writer)
 {
     CHIP_ERROR err;
 
@@ -618,7 +625,7 @@ void WriteEncoding2(nlTestSuite *inSuite, TLVWriter& writer)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
-void WriteEncoding3(nlTestSuite *inSuite, TLVWriter& writer)
+void WriteEncoding3(nlTestSuite * inSuite, TLVWriter & writer)
 {
     CHIP_ERROR err;
 
@@ -639,7 +646,7 @@ void WriteEncoding3(nlTestSuite *inSuite, TLVWriter& writer)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
-void ReadEncoding3(nlTestSuite *inSuite, TLVReader& reader)
+void ReadEncoding3(nlTestSuite * inSuite, TLVReader & reader)
 {
     TLVReader reader2;
 
@@ -651,7 +658,7 @@ void ReadEncoding3(nlTestSuite *inSuite, TLVReader& reader)
 
     TestEndAndCloseContainer(inSuite, reader, reader2);
 }
-
+// clang-format off
 static const uint8_t Encoding5_DataMacro [] =
 {
     CHIP_TLV_STRUCTURE(CHIP_TLV_TAG_FULLY_QUALIFIED_6Bytes(TestProfile_1, 1)),
@@ -676,8 +683,9 @@ static const uint8_t Encoding5_DataMacro [] =
         CHIP_TLV_BOOL(CHIP_TLV_TAG_FULLY_QUALIFIED_6Bytes(TestProfile_1, 2), true),
     CHIP_TLV_END_OF_CONTAINER,
 };
+// clang-format on
 
-void WriteEncoding5(nlTestSuite *inSuite, TLVWriter& writer)
+void WriteEncoding5(nlTestSuite * inSuite, TLVWriter & writer)
 {
     CHIP_ERROR err;
 
@@ -769,7 +777,7 @@ void WriteEncoding5(nlTestSuite *inSuite, TLVWriter& writer)
  * <TestProfile_1, 1, kTLVType_Structure, <TestProfile_1, 2, true> <TestProfile_2, 2, false> >,
  * <TestProfile_2, 1, kTLVType_Structure, <TestProfile_2, 2, false> <TestProfile_1, 2, true> >
  */
-void AppendEncoding2(nlTestSuite *inSuite, uint8_t *buf, uint32_t dataLen, uint32_t maxLen, uint32_t& updatedLen)
+void AppendEncoding2(nlTestSuite * inSuite, uint8_t * buf, uint32_t dataLen, uint32_t maxLen, uint32_t & updatedLen)
 {
     CHIP_ERROR err;
 
@@ -883,7 +891,8 @@ void AppendEncoding2(nlTestSuite *inSuite, uint8_t *buf, uint32_t dataLen, uint3
  * <TestProfile_1, 1, kTLVType_Structure, <TestProfile_1, 2, true> <TestProfile_2, 2, false> >,
  * <TestProfile_2, 1, kTLVType_Structure, <TestProfile_2, 2, false> <TestProfile_1, 2, true> >
  */
-void FindAppendEncoding2(nlTestSuite *inSuite, uint8_t *buf, uint32_t dataLen, uint32_t maxLen, uint32_t& updatedLen, bool findContainer)
+void FindAppendEncoding2(nlTestSuite * inSuite, uint8_t * buf, uint32_t dataLen, uint32_t maxLen, uint32_t & updatedLen,
+                         bool findContainer)
 {
     CHIP_ERROR err;
 
@@ -905,7 +914,8 @@ void FindAppendEncoding2(nlTestSuite *inSuite, uint8_t *buf, uint32_t dataLen, u
         err = tagReader.EnterContainer(outerContainerType);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        do {
+        do
+        {
             err = tagReader.Next();
         } while (err != CHIP_END_OF_TLV);
 
@@ -1002,7 +1012,7 @@ void FindAppendEncoding2(nlTestSuite *inSuite, uint8_t *buf, uint32_t dataLen, u
     updatedLen = updater.GetLengthWritten();
 }
 
-void AppendEncoding3(nlTestSuite *inSuite, uint8_t *buf, uint32_t dataLen, uint32_t maxLen, uint32_t& updatedLen)
+void AppendEncoding3(nlTestSuite * inSuite, uint8_t * buf, uint32_t dataLen, uint32_t maxLen, uint32_t & updatedLen)
 {
     CHIP_ERROR err;
 
@@ -1041,7 +1051,7 @@ void AppendEncoding3(nlTestSuite *inSuite, uint8_t *buf, uint32_t dataLen, uint3
     updatedLen = updater.GetLengthWritten();
 }
 
-void AppendEncoding4(nlTestSuite *inSuite, uint8_t *buf, uint32_t dataLen, uint32_t maxLen, uint32_t& updatedLen)
+void AppendEncoding4(nlTestSuite * inSuite, uint8_t * buf, uint32_t dataLen, uint32_t maxLen, uint32_t & updatedLen)
 {
     CHIP_ERROR err;
 
@@ -1074,7 +1084,7 @@ void AppendEncoding4(nlTestSuite *inSuite, uint8_t *buf, uint32_t dataLen, uint3
     updatedLen = updater.GetLengthWritten();
 }
 
-void DeleteEncoding5(nlTestSuite *inSuite, uint8_t *buf, uint32_t dataLen, uint32_t maxLen, uint32_t& updatedLen)
+void DeleteEncoding5(nlTestSuite * inSuite, uint8_t * buf, uint32_t dataLen, uint32_t maxLen, uint32_t & updatedLen)
 {
     CHIP_ERROR err;
 
@@ -1147,7 +1157,7 @@ void DeleteEncoding5(nlTestSuite *inSuite, uint8_t *buf, uint32_t dataLen, uint3
     updatedLen = updater.GetLengthWritten();
 }
 
-void ReadAppendedEncoding2(nlTestSuite *inSuite, TLVReader& reader)
+void ReadAppendedEncoding2(nlTestSuite * inSuite, TLVReader & reader)
 {
     TestNext<TLVReader>(inSuite, reader);
 
@@ -1232,7 +1242,7 @@ void ReadAppendedEncoding2(nlTestSuite *inSuite, TLVReader& reader)
     TestEnd<TLVReader>(inSuite, reader);
 }
 
-void ReadAppendedEncoding3(nlTestSuite *inSuite, TLVReader& reader)
+void ReadAppendedEncoding3(nlTestSuite * inSuite, TLVReader & reader)
 {
     TestNext<TLVReader>(inSuite, reader);
 
@@ -1255,7 +1265,7 @@ void ReadAppendedEncoding3(nlTestSuite *inSuite, TLVReader& reader)
     TestEnd<TLVReader>(inSuite, reader);
 }
 
-void ReadAppendedEncoding4(nlTestSuite *inSuite, TLVReader& reader)
+void ReadAppendedEncoding4(nlTestSuite * inSuite, TLVReader & reader)
 {
     TestNext<TLVReader>(inSuite, reader);
 
@@ -1274,7 +1284,7 @@ void ReadAppendedEncoding4(nlTestSuite *inSuite, TLVReader& reader)
     TestEnd<TLVReader>(inSuite, reader);
 }
 
-void ReadDeletedEncoding5(nlTestSuite *inSuite, TLVReader& reader)
+void ReadDeletedEncoding5(nlTestSuite * inSuite, TLVReader & reader)
 {
     TestNext<TLVReader>(inSuite, reader);
 
@@ -1318,7 +1328,7 @@ void ReadDeletedEncoding5(nlTestSuite *inSuite, TLVReader& reader)
 /**
  *  Test Simple Write and Reader
  */
-void CheckSimpleWriteRead(nlTestSuite *inSuite, void *inContext)
+void CheckSimpleWriteRead(nlTestSuite * inSuite, void * inContext)
 {
     uint8_t buf[2048];
     TLVWriter writer;
@@ -1350,7 +1360,6 @@ void CheckSimpleWriteRead(nlTestSuite *inSuite, void *inContext)
     ReadEncoding1(inSuite, reader);
 }
 
-
 /**
  *  Log the specified message in the form of @a aFormat.
  *
@@ -1362,7 +1371,7 @@ void CheckSimpleWriteRead(nlTestSuite *inSuite, void *inContext)
  *                           to the format specifiers in @a aFormat.
  *
  */
-void SimpleDumpWriter(const char *aFormat, ...)
+void SimpleDumpWriter(const char * aFormat, ...)
 {
     va_list args;
 
@@ -1376,7 +1385,7 @@ void SimpleDumpWriter(const char *aFormat, ...)
 /**
  *  Test Pretty Printer
  */
-void CheckPrettyPrinter(nlTestSuite *inSuite, void *inContext)
+void CheckPrettyPrinter(nlTestSuite * inSuite, void * inContext)
 {
     uint8_t buf[2048];
     TLVWriter writer;
@@ -1400,7 +1409,7 @@ void CheckPrettyPrinter(nlTestSuite *inSuite, void *inContext)
 /**
  *  Test Data Macros
  */
-void CheckDataMacro(nlTestSuite *inSuite, void *inContext)
+void CheckDataMacro(nlTestSuite * inSuite, void * inContext)
 {
     NL_TEST_ASSERT(inSuite, sizeof(Encoding1_DataMacro) == sizeof(Encoding1));
     NL_TEST_ASSERT(inSuite, memcmp(Encoding1, Encoding1_DataMacro, sizeof(Encoding1)) == 0);
@@ -1416,16 +1425,16 @@ void CheckDataMacro(nlTestSuite *inSuite, void *inContext)
     NL_TEST_ASSERT(inSuite, memcmp(buf, Encoding5_DataMacro, encodedLen) == 0);
 }
 
-static CHIP_ERROR NullIterateHandler(const TLVReader &aReader, size_t aDepth, void *aContext)
+static CHIP_ERROR NullIterateHandler(const TLVReader & aReader, size_t aDepth, void * aContext)
 {
-    (void)aReader;
-    (void)aDepth;
-    (void)aContext;
+    (void) aReader;
+    (void) aDepth;
+    (void) aContext;
 
     return CHIP_NO_ERROR;
 }
 
-static CHIP_ERROR FindContainerWithElement(const TLVReader &aReader, size_t aDepth, void *aContext)
+static CHIP_ERROR FindContainerWithElement(const TLVReader & aReader, size_t aDepth, void * aContext)
 {
     TLVReader reader;
     TLVReader result;
@@ -1460,7 +1469,7 @@ exit:
 /**
  *  Test CHIP TLV Utilities
  */
-void CheckCHIPTLVUtilities(nlTestSuite *inSuite, void *inContext)
+void CheckCHIPTLVUtilities(nlTestSuite * inSuite, void * inContext)
 {
     uint8_t buf[2048];
     TLVWriter writer;
@@ -1513,19 +1522,19 @@ void CheckCHIPTLVUtilities(nlTestSuite *inSuite, void *inContext)
         // position the reader on the first element
         reader1.Next();
         uint64_t tag = ProfileTag(TestProfile_1, 1);
-        err = chip::TLV::Utilities::Find(reader1, FindContainerWithElement, &tag, tagReader, false);
+        err          = chip::TLV::Utilities::Find(reader1, FindContainerWithElement, &tag, tagReader, false);
         NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_TLV_TAG_NOT_FOUND);
 
         tag = ProfileTag(TestProfile_2, 2);
         err = chip::TLV::Utilities::Find(reader1, FindContainerWithElement, &tag, tagReader, false);
-        NL_TEST_ASSERT(inSuite, err ==  CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, tagReader.GetType() == kTLVType_Structure);
         NL_TEST_ASSERT(inSuite, tagReader.GetTag() == ProfileTag(TestProfile_1, 1));
 
         // Position the reader on the second element
         reader1.Next();
         err = chip::TLV::Utilities::Find(reader1, FindContainerWithElement, &tag, tagReader, false);
-        NL_TEST_ASSERT(inSuite, err ==  CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, tagReader.GetType() == kTLVType_Structure);
         NL_TEST_ASSERT(inSuite, tagReader.GetTag() == ProfileTag(TestProfile_2, 1));
     }
@@ -1553,7 +1562,7 @@ void CheckCHIPTLVUtilities(nlTestSuite *inSuite, void *inContext)
 /**
  *  Test CHIP TLV Empty Find
  */
-void CheckCHIPTLVEmptyFind(nlTestSuite *inSuite, void *inContext)
+void CheckCHIPTLVEmptyFind(nlTestSuite * inSuite, void * inContext)
 {
     uint8_t buf[30];
     TLVWriter writer;
@@ -1576,6 +1585,7 @@ void CheckCHIPTLVEmptyFind(nlTestSuite *inSuite, void *inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
+// clang-format off
 uint8_t Encoding2[] =
 {
     // Container 1
@@ -1613,8 +1623,9 @@ uint8_t AppendedEncoding2[] =
         0xC9, 0xBB, 0xAA, 0xDD, 0xCC, 0x02, 0x00,
     0x18
 };
+// clang-format on
 
-void WriteAppendReadTest0(nlTestSuite *inSuite)
+void WriteAppendReadTest0(nlTestSuite * inSuite)
 {
     uint8_t buf[74];
     uint32_t updatedLen;
@@ -1666,7 +1677,7 @@ void WriteAppendReadTest0(nlTestSuite *inSuite)
     ReadAppendedEncoding2(inSuite, reader);
 }
 
-void WriteFindAppendReadTest(nlTestSuite *inSuite, bool findContainer)
+void WriteFindAppendReadTest(nlTestSuite * inSuite, bool findContainer)
 {
     uint8_t buf[74];
     uint32_t updatedLen;
@@ -1718,6 +1729,7 @@ void WriteFindAppendReadTest(nlTestSuite *inSuite, bool findContainer)
     ReadAppendedEncoding2(inSuite, reader);
 }
 
+// clang-format off
 uint8_t Encoding3[] =
 {
     // Container 1
@@ -1734,8 +1746,9 @@ uint8_t AppendedEncoding3[] =
         0x89, 0x02, 0x00,
     0x18
 };
+// clang-format on
 
-void WriteAppendReadTest1(nlTestSuite *inSuite)
+void WriteAppendReadTest1(nlTestSuite * inSuite)
 {
     uint8_t buf[14];
     uint32_t updatedLen;
@@ -1787,6 +1800,7 @@ void WriteAppendReadTest1(nlTestSuite *inSuite)
     ReadAppendedEncoding3(inSuite, reader);
 }
 
+// clang-format off
 uint8_t AppendedEncoding4[] =
 {
     // Container 1
@@ -1794,8 +1808,9 @@ uint8_t AppendedEncoding4[] =
         0x88, 0x02, 0x00,
     0x18,
 };
+// clang-format on
 
-void AppendReadTest(nlTestSuite *inSuite)
+void AppendReadTest(nlTestSuite * inSuite)
 {
     uint8_t buf[11];
     uint32_t updatedLen;
@@ -1837,6 +1852,7 @@ void AppendReadTest(nlTestSuite *inSuite)
     ReadAppendedEncoding4(inSuite, reader);
 }
 
+// clang-format off
 uint8_t Encoding5[] =
 {
     // Container 1
@@ -1874,8 +1890,9 @@ uint8_t DeletedEncoding5[] =
         0xC9, 0xBB, 0xAA, 0xDD, 0xCC, 0x02, 0x00,
     0x18
 };
+// clang-format on
 
-void WriteDeleteReadTest(nlTestSuite *inSuite)
+void WriteDeleteReadTest(nlTestSuite * inSuite)
 {
     uint8_t buf[74];
     uint32_t updatedLen;
@@ -1918,9 +1935,9 @@ void WriteDeleteReadTest(nlTestSuite *inSuite)
 /**
  *  Test Packet Buffer
  */
-void CheckPacketBuffer(nlTestSuite *inSuite, void *inContext)
+void CheckPacketBuffer(nlTestSuite * inSuite, void * inContext)
 {
-    PacketBuffer *buf = PacketBuffer::New(0);
+    PacketBuffer * buf = PacketBuffer::New(0);
     TLVWriter writer;
     TLVReader reader;
 
@@ -1944,9 +1961,9 @@ void CheckPacketBuffer(nlTestSuite *inSuite, void *inContext)
     PacketBuffer::Free(buf);
 }
 
-CHIP_ERROR CountEvictedMembers(CHIPCircularTLVBuffer &inBuffer, void * inAppData, TLVReader &inReader)
+CHIP_ERROR CountEvictedMembers(CHIPCircularTLVBuffer & inBuffer, void * inAppData, TLVReader & inReader)
 {
-    TestTLVContext *context = static_cast<TestTLVContext *>(inAppData);
+    TestTLVContext * context = static_cast<TestTLVContext *>(inAppData);
     CHIP_ERROR err;
 
     // "Process" the first element in the reader
@@ -1962,7 +1979,7 @@ CHIP_ERROR CountEvictedMembers(CHIPCircularTLVBuffer &inBuffer, void * inAppData
     return CHIP_NO_ERROR;
 }
 
-void CheckCircularTLVBufferSimple(nlTestSuite *inSuite, void *inContext)
+void CheckCircularTLVBufferSimple(nlTestSuite * inSuite, void * inContext)
 {
     // Write 40 bytes as 4 separate events into a 30 byte buffer.  On
     // completion of the test, the buffer should contain 2 elements
@@ -1972,16 +1989,16 @@ void CheckCircularTLVBufferSimple(nlTestSuite *inSuite, void *inContext)
     uint8_t backingStore[30];
     CircularTLVWriter writer;
     CircularTLVReader reader;
-    TestTLVContext *context = static_cast<TestTLVContext *>(inContext);
+    TestTLVContext * context = static_cast<TestTLVContext *>(inContext);
     CHIPCircularTLVBuffer buffer(backingStore, 30);
     writer.Init(&buffer);
     writer.ImplicitProfileId = TestProfile_2;
 
     context->mEvictionCount = 0;
-    context->mEvictedBytes = 0;
+    context->mEvictedBytes  = 0;
 
     buffer.mProcessEvictedElement = CountEvictedMembers;
-    buffer.mAppData = inContext;
+    buffer.mAppData               = inContext;
 
     writer.PutBoolean(ProfileTag(TestProfile_1, 2), true);
 
@@ -1994,7 +2011,7 @@ void CheckCircularTLVBufferSimple(nlTestSuite *inSuite, void *inContext)
     NL_TEST_ASSERT(inSuite, context->mEvictionCount == 2);
     NL_TEST_ASSERT(inSuite, context->mEvictedBytes == 18);
     NL_TEST_ASSERT(inSuite, buffer.DataLength() == 22);
-    NL_TEST_ASSERT(inSuite, (buffer.DataLength() + context->mEvictedBytes) ==  writer.GetLengthWritten());
+    NL_TEST_ASSERT(inSuite, (buffer.DataLength() + context->mEvictedBytes) == writer.GetLengthWritten());
 
     // At this point the buffer should contain 2 instances of Encoding3.
     reader.Init(&buffer);
@@ -2012,7 +2029,7 @@ void CheckCircularTLVBufferSimple(nlTestSuite *inSuite, void *inContext)
     TestEnd<TLVReader>(inSuite, reader);
 }
 
-void CheckCircularTLVBufferStartMidway(nlTestSuite *inSuite, void *inContext)
+void CheckCircularTLVBufferStartMidway(nlTestSuite * inSuite, void * inContext)
 {
     // Write 40 bytes as 4 separate events into a 30 byte buffer.  On
     // completion of the test, the buffer should contain 2 elements
@@ -2022,16 +2039,16 @@ void CheckCircularTLVBufferStartMidway(nlTestSuite *inSuite, void *inContext)
     uint8_t backingStore[30];
     CircularTLVWriter writer;
     CircularTLVReader reader;
-    TestTLVContext *context = static_cast<TestTLVContext *>(inContext);
+    TestTLVContext * context = static_cast<TestTLVContext *>(inContext);
     CHIPCircularTLVBuffer buffer(backingStore, 30, &(backingStore[15]));
     writer.Init(&buffer);
     writer.ImplicitProfileId = TestProfile_2;
 
     context->mEvictionCount = 0;
-    context->mEvictedBytes = 0;
+    context->mEvictedBytes  = 0;
 
     buffer.mProcessEvictedElement = CountEvictedMembers;
-    buffer.mAppData = inContext;
+    buffer.mAppData               = inContext;
 
     writer.PutBoolean(ProfileTag(TestProfile_1, 2), true);
 
@@ -2044,7 +2061,7 @@ void CheckCircularTLVBufferStartMidway(nlTestSuite *inSuite, void *inContext)
     NL_TEST_ASSERT(inSuite, context->mEvictionCount == 2);
     NL_TEST_ASSERT(inSuite, context->mEvictedBytes == 18);
     NL_TEST_ASSERT(inSuite, buffer.DataLength() == 22);
-    NL_TEST_ASSERT(inSuite, (buffer.DataLength() + context->mEvictedBytes) ==  writer.GetLengthWritten());
+    NL_TEST_ASSERT(inSuite, (buffer.DataLength() + context->mEvictedBytes) == writer.GetLengthWritten());
 
     // At this point the buffer should contain 2 instances of Encoding3.
     reader.Init(&buffer);
@@ -2062,7 +2079,7 @@ void CheckCircularTLVBufferStartMidway(nlTestSuite *inSuite, void *inContext)
     TestEnd<TLVReader>(inSuite, reader);
 }
 
-void CheckCircularTLVBufferEvictStraddlingEvent(nlTestSuite *inSuite, void *inContext)
+void CheckCircularTLVBufferEvictStraddlingEvent(nlTestSuite * inSuite, void * inContext)
 {
     // Write 95 bytes to the buffer as 9 different TLV elements: 1
     // 7-byte element and 8 11-byte elements.
@@ -2070,7 +2087,7 @@ void CheckCircularTLVBufferEvictStraddlingEvent(nlTestSuite *inSuite, void *inCo
     // and 7 elements should have been evicted in the last call to
     // WriteEncoding.
 
-    TestTLVContext *context = static_cast<TestTLVContext *>(inContext);
+    TestTLVContext * context = static_cast<TestTLVContext *>(inContext);
     uint8_t backingStore[30];
     CircularTLVWriter writer;
     CircularTLVReader reader;
@@ -2079,10 +2096,10 @@ void CheckCircularTLVBufferEvictStraddlingEvent(nlTestSuite *inSuite, void *inCo
     writer.ImplicitProfileId = TestProfile_2;
 
     context->mEvictionCount = 0;
-    context->mEvictedBytes = 0;
+    context->mEvictedBytes  = 0;
 
     buffer.mProcessEvictedElement = CountEvictedMembers;
-    buffer.mAppData = inContext;
+    buffer.mAppData               = inContext;
 
     writer.PutBoolean(ProfileTag(TestProfile_1, 2), true);
 
@@ -2103,9 +2120,11 @@ void CheckCircularTLVBufferEvictStraddlingEvent(nlTestSuite *inSuite, void *inCo
 
     WriteEncoding3(inSuite, writer);
 
-    NL_TEST_ASSERT(inSuite, writer.GetLengthWritten() == (8 * 11 + 7)); // 8 writes of Encoding3 (11 bytes each) and 7 bytes for the initial boolean.
+    NL_TEST_ASSERT(inSuite,
+                   writer.GetLengthWritten() ==
+                       (8 * 11 + 7)); // 8 writes of Encoding3 (11 bytes each) and 7 bytes for the initial boolean.
     NL_TEST_ASSERT(inSuite, buffer.DataLength() == 22);
-    NL_TEST_ASSERT(inSuite, (buffer.DataLength() + context->mEvictedBytes) ==  writer.GetLengthWritten());
+    NL_TEST_ASSERT(inSuite, (buffer.DataLength() + context->mEvictedBytes) == writer.GetLengthWritten());
     NL_TEST_ASSERT(inSuite, context->mEvictionCount == 7);
 
     // At this point the buffer should contain 2 instances of Encoding3.
@@ -2124,9 +2143,9 @@ void CheckCircularTLVBufferEvictStraddlingEvent(nlTestSuite *inSuite, void *inCo
     TestEnd<TLVReader>(inSuite, reader);
 }
 
-void CheckCircularTLVBufferEdge(nlTestSuite *inSuite, void *inContext)
+void CheckCircularTLVBufferEdge(nlTestSuite * inSuite, void * inContext)
 {
-    TestTLVContext *context = static_cast<TestTLVContext *>(inContext);
+    TestTLVContext * context = static_cast<TestTLVContext *>(inContext);
     CHIP_ERROR err;
     uint8_t backingStore[7];
     uint8_t backingStore1[14];
@@ -2140,10 +2159,10 @@ void CheckCircularTLVBufferEdge(nlTestSuite *inSuite, void *inContext)
     writer.ImplicitProfileId = TestProfile_2;
 
     context->mEvictionCount = 0;
-    context->mEvictedBytes = 0;
+    context->mEvictedBytes  = 0;
 
     buffer.mProcessEvictedElement = CountEvictedMembers;
-    buffer.mAppData = inContext;
+    buffer.mAppData               = inContext;
 
     // Test eviction for an element that fits in the underlying buffer exactly
     err = writer.PutBoolean(ProfileTag(TestProfile_1, 2), true);
@@ -2202,15 +2221,14 @@ void CheckCircularTLVBufferEdge(nlTestSuite *inSuite, void *inContext)
         TestEnd<TLVReader>(inSuite, reader);
     }
 
-
     writer.Init(&buffer1);
     writer.ImplicitProfileId = TestProfile_2;
 
     context->mEvictionCount = 0;
-    context->mEvictedBytes = 0;
+    context->mEvictedBytes  = 0;
 
     buffer1.mProcessEvictedElement = CountEvictedMembers;
-    buffer1.mAppData = inContext;
+    buffer1.mAppData               = inContext;
 
     // Two elements fit in the buffer exactly
     err = writer.PutBoolean(ProfileTag(TestProfile_1, 2), true);
@@ -2280,9 +2298,8 @@ void CheckCircularTLVBufferEdge(nlTestSuite *inSuite, void *inContext)
     reader.ImplicitProfileId = TestProfile_2;
 
     TestEnd<TLVReader>(inSuite, reader);
-
 }
-void CheckCHIPTLVPutStringF(nlTestSuite *inSuite, void *inContext)
+void CheckCHIPTLVPutStringF(nlTestSuite * inSuite, void * inContext)
 {
     const size_t bufsize = 24;
     char strBuffer[bufsize];
@@ -2290,7 +2307,7 @@ void CheckCHIPTLVPutStringF(nlTestSuite *inSuite, void *inContext)
     uint8_t backingStore[bufsize];
     TLVWriter writer;
     TLVReader reader;
-    size_t num = 1;
+    size_t num     = 1;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     writer.Init(backingStore, bufsize);
@@ -2312,7 +2329,7 @@ void CheckCHIPTLVPutStringF(nlTestSuite *inSuite, void *inContext)
     NL_TEST_ASSERT(inSuite, strncmp(valStr, strBuffer, 256) == 0);
 }
 
-void CheckCHIPTLVPutStringFCircular(nlTestSuite *inSuite, void *inContext)
+void CheckCHIPTLVPutStringFCircular(nlTestSuite * inSuite, void * inContext)
 {
     const size_t bufsize = 40;
     char strBuffer[bufsize];
@@ -2321,7 +2338,7 @@ void CheckCHIPTLVPutStringFCircular(nlTestSuite *inSuite, void *inContext)
     CircularTLVWriter writer;
     CircularTLVReader reader;
     CHIPCircularTLVBuffer buffer(backingStore, bufsize);
-    size_t num = 1;
+    size_t num     = 1;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     // Initial test: Verify that a straight printf works as expected into continuous buffer.
@@ -2343,7 +2360,7 @@ void CheckCHIPTLVPutStringFCircular(nlTestSuite *inSuite, void *inContext)
 
     reader.Init(&buffer);
 
-    //Skip over the initial element
+    // Skip over the initial element
     err = reader.Next();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
@@ -2377,7 +2394,7 @@ void CheckCHIPTLVPutStringFCircular(nlTestSuite *inSuite, void *inContext)
     NL_TEST_ASSERT(inSuite, strncmp(valStr, strBuffer, bufsize) == 0);
 }
 
-void CheckCHIPTLVSkipCircular(nlTestSuite *inSuite, void * inContext)
+void CheckCHIPTLVSkipCircular(nlTestSuite * inSuite, void * inContext)
 {
     const size_t bufsize = 40; // large enough s.t. 2 elements fit, 3rd causes eviction
     uint8_t backingStore[bufsize];
@@ -2412,30 +2429,29 @@ void CheckCHIPTLVSkipCircular(nlTestSuite *inSuite, void * inContext)
 
     err = reader.Skip(); // // Test that the buf ptr is handled correctly within the ReadData() function.
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
 }
 
 /**
  *  Test Buffer Overflow
  */
-void CheckBufferOverflow(nlTestSuite *inSuite, void *inContext)
+void CheckBufferOverflow(nlTestSuite * inSuite, void * inContext)
 {
     TLVWriter writer;
     TLVReader reader;
 
-    PacketBuffer *buf = PacketBuffer::New(0);
+    PacketBuffer * buf  = PacketBuffer::New(0);
     uint16_t maxDataLen = buf->MaxDataLength();
-    uint16_t reserve = (sizeof(Encoding1) < maxDataLen) ? (maxDataLen - sizeof(Encoding1)) + 2 : 0;
+    uint16_t reserve    = (sizeof(Encoding1) < maxDataLen) ? (maxDataLen - sizeof(Encoding1)) + 2 : 0;
 
     // Repeatedly write and read a TLV encoding to a chain of PacketBuffers. Use progressively larger
     // and larger amounts of space in the first buffer to force the encoding/decoding to overlap the
     // end of the buffer and the beginning of the next.
-    for ( ; reserve < maxDataLen; reserve++)
+    for (; reserve < maxDataLen; reserve++)
     {
         buf->SetStart(buf->Start() + reserve);
 
         writer.Init(buf);
-        writer.GetNewBuffer = TLVWriter::GetNewPacketBuffer;
+        writer.GetNewBuffer      = TLVWriter::GetNewPacketBuffer;
         writer.ImplicitProfileId = TestProfile_2;
 
         WriteEncoding1(inSuite, writer);
@@ -2463,6 +2479,7 @@ void CheckBufferOverflow(nlTestSuite *inSuite, void *inContext)
  * The issue has been spotted on debug builds.
  *
  */
+// clang-format off
 static const uint8_t sIdentifyResponseBuf[] =
 {
     0xD5, 0x00, 0x00, 0x0E, 0x00, 0x01, 0x00, 0x25,
@@ -2473,13 +2490,14 @@ static const uint8_t sIdentifyResponseBuf[] =
     0x2C, 0x09, 0x06, 0x31, 0x2E, 0x34, 0x72, 0x63,
     0x35, 0x24, 0x0C, 0x01, 0x18,
 };
+// clang-format on
 
 static const uint32_t kIdentifyResponseLen = 53;
 
-void CheckStrictAliasing(nlTestSuite *inSuite, void *inContext)
+void CheckStrictAliasing(nlTestSuite * inSuite, void * inContext)
 {
     const uint32_t kProfile_Id = 0x0000000e;
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    CHIP_ERROR err             = CHIP_NO_ERROR;
     TLVReader reader;
 
     reader.Init(sIdentifyResponseBuf, kIdentifyResponseLen);
@@ -2494,7 +2512,7 @@ void CheckStrictAliasing(nlTestSuite *inSuite, void *inContext)
 /**
  *  Test CHIP TLV Writer Copy Container
  */
-void TestCHIPTLVWriterCopyContainer(nlTestSuite *inSuite)
+void TestCHIPTLVWriterCopyContainer(nlTestSuite * inSuite)
 {
     uint8_t buf[2048];
 
@@ -2534,21 +2552,23 @@ void TestCHIPTLVWriterCopyContainer(nlTestSuite *inSuite)
 
         int memcmpRes = memcmp(buf, Encoding1, encodedLen);
         NL_TEST_ASSERT(inSuite, memcmpRes == 0);
-
     }
 }
 
 /**
  *  Test CHIP TLV Writer Copy Element
  */
-void TestCHIPTLVWriterCopyElement(nlTestSuite *inSuite)
+void TestCHIPTLVWriterCopyElement(nlTestSuite * inSuite)
 {
     CHIP_ERROR err;
     uint8_t expectedBuf[2048], testBuf[2048];
     uint32_t expectedLen, testLen;
     TLVWriter writer;
     TLVType outerContainerType;
-    enum { kRepeatCount = 3 };
+    enum
+    {
+        kRepeatCount = 3
+    };
 
     writer.Init(expectedBuf, sizeof(expectedBuf));
     writer.ImplicitProfileId = TestProfile_2;
@@ -2567,7 +2587,7 @@ void TestCHIPTLVWriterCopyElement(nlTestSuite *inSuite)
     err = writer.Finalize();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    expectedLen= writer.GetLengthWritten();
+    expectedLen = writer.GetLengthWritten();
 
     writer.Init(testBuf, sizeof(testBuf));
     writer.ImplicitProfileId = TestProfile_2;
@@ -2602,7 +2622,7 @@ void TestCHIPTLVWriterCopyElement(nlTestSuite *inSuite)
     NL_TEST_ASSERT(inSuite, memcmpRes == 0);
 }
 
-void PreserveSizeWrite(nlTestSuite *inSuite, TLVWriter& writer, bool preserveSize)
+void PreserveSizeWrite(nlTestSuite * inSuite, TLVWriter & writer, bool preserveSize)
 {
     CHIP_ERROR err;
     TLVWriter writer2;
@@ -2674,7 +2694,7 @@ void PreserveSizeWrite(nlTestSuite *inSuite, TLVWriter& writer, bool preserveSiz
 /**
  *  Test CHIP TLV Writer with Preserve Size
  */
-void TestCHIPTLVWriterPreserveSize(nlTestSuite *inSuite)
+void TestCHIPTLVWriterPreserveSize(nlTestSuite * inSuite)
 {
     uint8_t buf[2048];
     TLVWriter writer;
@@ -2691,7 +2711,7 @@ void TestCHIPTLVWriterPreserveSize(nlTestSuite *inSuite)
 /**
  *  Test error handling of CHIP TLV Writer
  */
-void TestCHIPTLVWriterErrorHandling(nlTestSuite *inSuite)
+void TestCHIPTLVWriterErrorHandling(nlTestSuite * inSuite)
 {
     CHIP_ERROR err;
     uint8_t buf[2048];
@@ -2726,20 +2746,21 @@ void TestCHIPTLVWriterErrorHandling(nlTestSuite *inSuite)
 
     // EndContainer()
     outerContainerType = kTLVType_Boolean;
-    err = writer.EndContainer(outerContainerType);
+    err                = writer.EndContainer(outerContainerType);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
 
     // PutPreEncodedContainer()
     TLVReader reader;
     reader.Init(buf, 2048);
-    err = writer.PutPreEncodedContainer(ProfileTag(TestProfile_2, 4000000000ULL), kTLVType_Boolean, reader.GetReadPoint(), reader.GetRemainingLength());
+    err = writer.PutPreEncodedContainer(ProfileTag(TestProfile_2, 4000000000ULL), kTLVType_Boolean, reader.GetReadPoint(),
+                                        reader.GetRemainingLength());
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
 }
 
 /**
  *  Test CHIP TLV Writer
  */
-void CheckCHIPTLVWriter(nlTestSuite *inSuite, void *inContext)
+void CheckCHIPTLVWriter(nlTestSuite * inSuite, void * inContext)
 {
     TestCHIPTLVWriterCopyContainer(inSuite);
 
@@ -2750,11 +2771,11 @@ void CheckCHIPTLVWriter(nlTestSuite *inSuite, void *inContext)
     TestCHIPTLVWriterErrorHandling(inSuite);
 }
 
-void SkipNonContainer(nlTestSuite *inSuite)
+void SkipNonContainer(nlTestSuite * inSuite)
 {
     TLVReader reader;
-    const uint8_t *readpoint1 = NULL;
-    const uint8_t *readpoint2 = NULL;
+    const uint8_t * readpoint1 = NULL;
+    const uint8_t * readpoint2 = NULL;
 
     reader.Init(Encoding1, sizeof(Encoding1));
     reader.ImplicitProfileId = TestProfile_2;
@@ -2771,11 +2792,11 @@ void SkipNonContainer(nlTestSuite *inSuite)
     NL_TEST_ASSERT(inSuite, readpoint1 == readpoint2);
 }
 
-void SkipContainer(nlTestSuite *inSuite)
+void SkipContainer(nlTestSuite * inSuite)
 {
     TLVReader reader;
-    const uint8_t *readpoint1 = NULL;
-    const uint8_t *readpoint2 = NULL;
+    const uint8_t * readpoint1 = NULL;
+    const uint8_t * readpoint2 = NULL;
 
     reader.Init(Encoding1, sizeof(Encoding1));
     reader.ImplicitProfileId = TestProfile_2;
@@ -2794,7 +2815,7 @@ void SkipContainer(nlTestSuite *inSuite)
     NL_TEST_ASSERT(inSuite, readpoint1 == readpoint2);
 }
 
-void NextContainer(nlTestSuite *inSuite)
+void NextContainer(nlTestSuite * inSuite)
 {
     TLVReader reader;
 
@@ -2810,7 +2831,7 @@ void NextContainer(nlTestSuite *inSuite)
 /**
  *  Test CHIP TLV Reader Skip functions
  */
-void TestCHIPTLVReaderSkip(nlTestSuite *inSuite)
+void TestCHIPTLVReaderSkip(nlTestSuite * inSuite)
 {
     SkipNonContainer(inSuite);
 
@@ -2822,7 +2843,7 @@ void TestCHIPTLVReaderSkip(nlTestSuite *inSuite)
 /**
  *  Test CHIP TLV Reader Dup functions
  */
-void TestCHIPTLVReaderDup(nlTestSuite *inSuite)
+void TestCHIPTLVReaderDup(nlTestSuite * inSuite)
 {
     TLVReader reader;
 
@@ -2907,7 +2928,8 @@ void TestCHIPTLVReaderDup(nlTestSuite *inSuite)
                 {
                     TLVType outerContainerType;
 
-                    TestAndEnterContainer<TLVReader>(inSuite, reader5, kTLVType_Structure, ProfileTag(TestProfile_2, 4000000000ULL), outerContainerType);
+                    TestAndEnterContainer<TLVReader>(inSuite, reader5, kTLVType_Structure, ProfileTag(TestProfile_2, 4000000000ULL),
+                                                     outerContainerType);
 
                     TestNext<TLVReader>(inSuite, reader5);
 
@@ -2924,15 +2946,15 @@ void TestCHIPTLVReaderDup(nlTestSuite *inSuite)
 
         TestNext<TLVReader>(inSuite, reader2);
 
-        TestDupBytes(inSuite, reader2, ProfileTag(TestProfile_1, 5), (uint8_t *)("This is a test"), 14);
+        TestDupBytes(inSuite, reader2, ProfileTag(TestProfile_1, 5), (uint8_t *) ("This is a test"), 14);
 
         TestNext<TLVReader>(inSuite, reader2);
 
-        TestGet<TLVReader, double>(inSuite, reader2, kTLVType_FloatingPointNumber, ProfileTag(TestProfile_2, 65535), (float)17.9);
+        TestGet<TLVReader, double>(inSuite, reader2, kTLVType_FloatingPointNumber, ProfileTag(TestProfile_2, 65535), (float) 17.9);
 
         TestNext<TLVReader>(inSuite, reader2);
 
-        TestGet<TLVReader, double>(inSuite, reader2, kTLVType_FloatingPointNumber, ProfileTag(TestProfile_2, 65536), (double)17.9);
+        TestGet<TLVReader, double>(inSuite, reader2, kTLVType_FloatingPointNumber, ProfileTag(TestProfile_2, 65536), (double) 17.9);
 
         TestEndAndCloseContainer(inSuite, reader, reader2);
     }
@@ -2942,7 +2964,7 @@ void TestCHIPTLVReaderDup(nlTestSuite *inSuite)
 /**
  *  Test error handling of CHIP TLV Reader
  */
-void TestCHIPTLVReaderErrorHandling(nlTestSuite *inSuite)
+void TestCHIPTLVReaderErrorHandling(nlTestSuite * inSuite)
 {
     CHIP_ERROR err;
     uint8_t buf[2048];
@@ -2987,25 +3009,25 @@ void TestCHIPTLVReaderErrorHandling(nlTestSuite *inSuite)
 
     // EnterContainer()
     TLVType outerContainerType = kTLVType_Boolean;
-    err = reader.EnterContainer(outerContainerType);
+    err                        = reader.EnterContainer(outerContainerType);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
 
     // DupString()
-    char *str = (char *)malloc(16);
-    err = reader.DupString(str);
+    char * str = (char *) malloc(16);
+    err        = reader.DupString(str);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_WRONG_TLV_TYPE);
     free(str);
 
     // GetDataPtr()
-    const uint8_t *data = (uint8_t *)malloc(16);
-    err = reader.GetDataPtr(data);
+    const uint8_t * data = (uint8_t *) malloc(16);
+    err                  = reader.GetDataPtr(data);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_WRONG_TLV_TYPE);
-    free((void *)data);
+    free((void *) data);
 }
 /**
  *  Test CHIP TLV Reader in a use case
  */
-void TestCHIPTLVReaderInPractice(nlTestSuite *inSuite)
+void TestCHIPTLVReaderInPractice(nlTestSuite * inSuite)
 {
     uint8_t buf[2048];
     TLVWriter writer;
@@ -3020,7 +3042,8 @@ void TestCHIPTLVReaderInPractice(nlTestSuite *inSuite)
 
     TestNext<TLVReader>(inSuite, reader);
 
-    TestGet<TLVReader, int64_t>(inSuite, reader, kTLVType_SignedInteger, ProfileTag(TestProfile_1, 4000000000ULL), (int64_t) 40000000000ULL);
+    TestGet<TLVReader, int64_t>(inSuite, reader, kTLVType_SignedInteger, ProfileTag(TestProfile_1, 4000000000ULL),
+                                (int64_t) 40000000000ULL);
 
     TestNext<TLVReader>(inSuite, reader);
 
@@ -3028,10 +3051,11 @@ void TestCHIPTLVReaderInPractice(nlTestSuite *inSuite)
 
     TestNext<TLVReader>(inSuite, reader);
 
-    TestGet<TLVReader, double>(inSuite, reader, kTLVType_FloatingPointNumber, ProfileTag(TestProfile_1, 4000000000ULL), (float) 1.0);
+    TestGet<TLVReader, double>(inSuite, reader, kTLVType_FloatingPointNumber, ProfileTag(TestProfile_1, 4000000000ULL),
+                               (float) 1.0);
 }
 
-void TestCHIPTLVReader_NextOverContainer_ProcessElement(nlTestSuite *inSuite, TLVReader& reader, void *context)
+void TestCHIPTLVReader_NextOverContainer_ProcessElement(nlTestSuite * inSuite, TLVReader & reader, void * context)
 {
     CHIP_ERROR err, nextRes1, nextRes2;
     TLVType outerContainerType;
@@ -3066,7 +3090,7 @@ void TestCHIPTLVReader_NextOverContainer_ProcessElement(nlTestSuite *inSuite, TL
 /**
  * Test using CHIP TLV Reader Next() method to skip over containers.
  */
-void TestCHIPTLVReader_NextOverContainer(nlTestSuite *inSuite)
+void TestCHIPTLVReader_NextOverContainer(nlTestSuite * inSuite)
 {
     TLVReader reader;
 
@@ -3076,7 +3100,7 @@ void TestCHIPTLVReader_NextOverContainer(nlTestSuite *inSuite)
     ForEachElement(inSuite, reader, NULL, TestCHIPTLVReader_NextOverContainer_ProcessElement);
 }
 
-void TestCHIPTLVReader_SkipOverContainer_ProcessElement(nlTestSuite *inSuite, TLVReader& reader, void *context)
+void TestCHIPTLVReader_SkipOverContainer_ProcessElement(nlTestSuite * inSuite, TLVReader & reader, void * context)
 {
     CHIP_ERROR err;
     TLVType outerContainerType;
@@ -3108,7 +3132,7 @@ void TestCHIPTLVReader_SkipOverContainer_ProcessElement(nlTestSuite *inSuite, TL
 /**
  * Test using CHIP TLV Reader Skip() method to skip over containers.
  */
-void TestCHIPTLVReader_SkipOverContainer(nlTestSuite *inSuite)
+void TestCHIPTLVReader_SkipOverContainer(nlTestSuite * inSuite)
 {
     TLVReader reader;
 
@@ -3121,7 +3145,7 @@ void TestCHIPTLVReader_SkipOverContainer(nlTestSuite *inSuite)
 /**
  *  Test CHIP TLV Reader
  */
-void CheckCHIPTLVReader(nlTestSuite *inSuite, void *inContext)
+void CheckCHIPTLVReader(nlTestSuite * inSuite, void * inContext)
 {
     TestCHIPTLVReaderSkip(inSuite);
 
@@ -3139,7 +3163,7 @@ void CheckCHIPTLVReader(nlTestSuite *inSuite, void *inContext)
 /**
  *  Test CHIP TLV Items
  */
-static void TestItems(nlTestSuite *inSuite, void *inContext)
+static void TestItems(nlTestSuite * inSuite, void * inContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -3226,7 +3250,7 @@ static void TestItems(nlTestSuite *inSuite, void *inContext)
 /**
  *  Test CHIP TLV Containers
  */
-static void TestContainers(nlTestSuite *inSuite, void *inContext)
+static void TestContainers(nlTestSuite * inSuite, void * inContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     TLVWriter writer;
@@ -3260,7 +3284,7 @@ static void TestContainers(nlTestSuite *inSuite, void *inContext)
 /**
  *  Test CHIP TLV Basics
  */
-static void CheckCHIPTLVBasics(nlTestSuite *inSuite, void *inContext)
+static void CheckCHIPTLVBasics(nlTestSuite * inSuite, void * inContext)
 {
     TestItems(inSuite, inContext);
     TestContainers(inSuite, inContext);
@@ -3269,7 +3293,7 @@ static void CheckCHIPTLVBasics(nlTestSuite *inSuite, void *inContext)
 /**
  *  Test CHIP TLV Updater
  */
-static void CheckCHIPUpdater(nlTestSuite *inSuite, void *inContext)
+static void CheckCHIPUpdater(nlTestSuite * inSuite, void * inContext)
 {
     WriteAppendReadTest0(inSuite);
 
@@ -3277,7 +3301,7 @@ static void CheckCHIPUpdater(nlTestSuite *inSuite, void *inContext)
 
     WriteFindAppendReadTest(inSuite, false); // Find an element
 
-    WriteFindAppendReadTest(inSuite, true);  // Find a container
+    WriteFindAppendReadTest(inSuite, true); // Find a container
 
     AppendReadTest(inSuite);
 
@@ -3291,16 +3315,16 @@ static void CheckCHIPUpdater(nlTestSuite *inSuite, void *inContext)
 class OptimisticTLVWriter : public TLVWriter
 {
 public:
-    void Init(uint8_t *buf, uint32_t maxLen);
+    void Init(uint8_t * buf, uint32_t maxLen);
 };
 
-void OptimisticTLVWriter::Init(uint8_t *buf, uint32_t maxLen)
+void OptimisticTLVWriter::Init(uint8_t * buf, uint32_t maxLen)
 {
     TLVWriter::Init(buf, maxLen);
     SetCloseContainerReserved(false);
 }
 
-static void CheckCloseContainerReserve(nlTestSuite *inSuite, void *inContext)
+static void CheckCloseContainerReserve(nlTestSuite * inSuite, void * inContext)
 {
     // We are writing the structure looking like:
     //
@@ -3485,25 +3509,27 @@ static void CheckCloseContainerReserve(nlTestSuite *inSuite, void *inContext)
     }
 }
 
-static CHIP_ERROR ReadFuzzedEncoding1(nlTestSuite *inSuite, TLVReader& reader)
+static CHIP_ERROR ReadFuzzedEncoding1(nlTestSuite * inSuite, TLVReader & reader)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-#define FUZZ_CHECK_VAL(TYPE, VAL)                                       \
-    do {                                                                \
-        TYPE val;                                                       \
-        err = reader.Get(val);                                          \
-        SuccessOrExit(err);                                             \
-        VerifyOrExit(val == (VAL), err = CHIP_ERROR_INVALID_ARGUMENT); \
+#define FUZZ_CHECK_VAL(TYPE, VAL)                                                                                                  \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        TYPE val;                                                                                                                  \
+        err = reader.Get(val);                                                                                                     \
+        SuccessOrExit(err);                                                                                                        \
+        VerifyOrExit(val == (VAL), err = CHIP_ERROR_INVALID_ARGUMENT);                                                             \
     } while (0)
 
-#define FUZZ_CHECK_STRING(VAL)                                                              \
-    do {                                                                                    \
-        char buf[sizeof(VAL)];                                                              \
-        VerifyOrExit(reader.GetLength() == strlen(VAL), err = CHIP_ERROR_INVALID_ADDRESS); \
-        err = reader.GetString(buf, sizeof(buf));                                           \
-        SuccessOrExit(err);                                                                 \
-        VerifyOrExit(strcmp(buf, (VAL)) == 0, err = CHIP_ERROR_INVALID_ADDRESS);           \
+#define FUZZ_CHECK_STRING(VAL)                                                                                                     \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        char buf[sizeof(VAL)];                                                                                                     \
+        VerifyOrExit(reader.GetLength() == strlen(VAL), err = CHIP_ERROR_INVALID_ADDRESS);                                         \
+        err = reader.GetString(buf, sizeof(buf));                                                                                  \
+        SuccessOrExit(err);                                                                                                        \
+        VerifyOrExit(strcmp(buf, (VAL)) == 0, err = CHIP_ERROR_INVALID_ADDRESS);                                                   \
     } while (0)
 
     err = reader.Next(kTLVType_Structure, ProfileTag(TestProfile_1, 1));
@@ -3628,12 +3654,12 @@ static CHIP_ERROR ReadFuzzedEncoding1(nlTestSuite *inSuite, TLVReader& reader)
         err = reader.Next(kTLVType_FloatingPointNumber, ProfileTag(TestProfile_2, 65535));
         SuccessOrExit(err);
 
-        FUZZ_CHECK_VAL(double, (float)17.9);
+        FUZZ_CHECK_VAL(double, (float) 17.9);
 
         err = reader.Next(kTLVType_FloatingPointNumber, ProfileTag(TestProfile_2, 65536));
         SuccessOrExit(err);
 
-        FUZZ_CHECK_VAL(double, (double)17.9);
+        FUZZ_CHECK_VAL(double, (double) 17.9);
 
         err = reader.ExitContainer(outerContainer1Type);
         SuccessOrExit(err);
@@ -3648,9 +3674,9 @@ exit:
 }
 
 static uint32_t sFuzzTestDurationSecs = 5;
-static uint8_t  sFixedFuzzMask = 0;
+static uint8_t sFixedFuzzMask         = 0;
 
-static void TLVReaderFuzzTest(nlTestSuite *inSuite, void *inContext)
+static void TLVReaderFuzzTest(nlTestSuite * inSuite, void * inContext)
 {
     time_t now, endTime;
     uint8_t fuzzedData[sizeof(Encoding1)];
@@ -3719,8 +3745,8 @@ static void TLVReaderFuzzTest(nlTestSuite *inSuite, void *inContext)
 
             if (readRes == CHIP_NO_ERROR)
             {
-                printf("Unexpected success of fuzz test: offset %u, original value 0x%02X, mutated value 0x%02X\n",
-                       (unsigned)i, (unsigned)origVal, (unsigned)fuzzedData[i]);
+                printf("Unexpected success of fuzz test: offset %u, original value 0x%02X, mutated value 0x%02X\n", (unsigned) i,
+                       (unsigned) origVal, (unsigned) fuzzedData[i]);
                 ExitNow();
             }
 
@@ -3731,7 +3757,7 @@ static void TLVReaderFuzzTest(nlTestSuite *inSuite, void *inContext)
             fuzzedData[i] = origVal;
         }
 
-       if (m < sizeof(sFixedFuzzVals))
+        if (m < sizeof(sFixedFuzzVals))
             m++;
     }
 
@@ -3776,7 +3802,7 @@ static const nlTest sTests[] =
 /**
  *  Main
  */
-int main(int argc, char *argv[])
+int main(int argc, char * argv[])
 {
     // clang-format off
     nlTestSuite theSuite =

--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -1,0 +1,3546 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements unit tests for the Weave TLV implementation.
+ *
+ */
+
+#include <nlbyteorder.h>
+#include <nlunit-test.h>
+
+#include <core/CHIPCircularTLVBuffer.h>
+#include <core/CHIPCore.h>
+#include <core/CHIPTLV.h>
+#include <core/CHIPTLVData.hpp>
+#include <core/CHIPTLVDebug.hpp>
+#include <core/CHIPTLVUtilities.hpp>
+
+#include <support/CodeUtils.h>
+#include <support/RandUtils.h>
+
+using namespace chip;
+using namespace chip::TLV;
+
+enum
+{
+    TestProfile_1				= 0xAABBCCDD,
+    TestProfile_2				= 0x11223344
+};
+
+static const char sLargeString [] =
+    "START..."
+    "!123456789ABCDEF@123456789ABCDEF#123456789ABCDEF$123456789ABCDEF%123456789ABCDEF^123456789ABCDEF&123456789ABCDEF*123456789ABCDEF"
+    "01234567(9ABCDEF01234567)9ABCDEF01234567-9ABCDEF01234567=9ABCDEF01234567[9ABCDEF01234567]9ABCDEF01234567;9ABCDEF01234567'9ABCDEF"
+    "...END";
+
+void Abort()
+{
+    abort();
+}
+
+void TestAndOpenContainer(nlTestSuite *inSuite, TLVReader& reader, TLVType type, uint64_t tag, TLVReader& containerReader)
+{
+    NL_TEST_ASSERT(inSuite, reader.GetType() == type);
+    NL_TEST_ASSERT(inSuite, reader.GetTag() == tag);
+    NL_TEST_ASSERT(inSuite, reader.GetLength() == 0);
+
+    CHIP_ERROR err = reader.OpenContainer(containerReader);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, containerReader.GetContainerType() == type);
+}
+
+template<class T>
+void TestAndEnterContainer(nlTestSuite *inSuite, T& t, TLVType type, uint64_t tag, TLVType& outerContainerType)
+{
+    NL_TEST_ASSERT(inSuite, t.GetType() == type);
+    NL_TEST_ASSERT(inSuite, t.GetTag() == tag);
+    NL_TEST_ASSERT(inSuite, t.GetLength() == 0);
+
+    TLVType expectedContainerType = t.GetContainerType();
+
+    CHIP_ERROR err = t.EnterContainer(outerContainerType);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, outerContainerType == expectedContainerType);
+    NL_TEST_ASSERT(inSuite, t.GetContainerType() == type);
+}
+
+template<class T>
+void TestNext(nlTestSuite *inSuite, T& t)
+{
+    CHIP_ERROR err = t.Next();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+}
+
+void TestSkip(nlTestSuite *inSuite, TLVReader& reader)
+{
+    CHIP_ERROR err = reader.Skip();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+}
+
+void TestMove(nlTestSuite *inSuite, TLVUpdater& updater)
+{
+    CHIP_ERROR err = updater.Move();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+}
+
+template<class T>
+void TestEnd(nlTestSuite *inSuite, T& t)
+{
+    CHIP_ERROR err;
+
+    err = t.Next();
+    NL_TEST_ASSERT(inSuite, err == CHIP_END_OF_TLV);
+}
+
+void TestEndAndCloseContainer(nlTestSuite *inSuite, TLVReader& reader, TLVReader& containerReader)
+{
+    CHIP_ERROR err;
+
+    TestEnd<TLVReader>(inSuite, containerReader);
+
+    err = reader.CloseContainer(containerReader);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+}
+
+template<class T>
+void TestEndAndExitContainer(nlTestSuite *inSuite, T& t, TLVType outerContainerType)
+{
+    CHIP_ERROR err;
+
+    TestEnd<T>(inSuite, t);
+
+    err = t.ExitContainer(outerContainerType);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, t.GetContainerType() == outerContainerType);
+}
+
+template<class S, class T>
+void TestGet(nlTestSuite *inSuite, S& s, TLVType type, uint64_t tag, T expectedVal)
+{
+    NL_TEST_ASSERT(inSuite, s.GetType() == type);
+    NL_TEST_ASSERT(inSuite, s.GetTag() == tag);
+    NL_TEST_ASSERT(inSuite, s.GetLength() == 0);
+
+    T val;
+    CHIP_ERROR err = s.Get(val);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, val == expectedVal);
+}
+
+void ForEachElement(nlTestSuite *inSuite, TLVReader& reader, void *context, void (*cb)(nlTestSuite *inSuite, TLVReader& reader, void *context))
+{
+    CHIP_ERROR err;
+
+    while (true)
+    {
+        err = reader.Next();
+        if (err == CHIP_END_OF_TLV)
+        {
+            return;
+        }
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        if (cb != NULL)
+        {
+            cb(inSuite, reader, context);
+        }
+
+        if (TLVTypeIsContainer(reader.GetType()))
+        {
+            TLVType outerContainerType;
+
+            err = reader.EnterContainer(outerContainerType);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+            ForEachElement(inSuite, reader, context, cb);
+
+            err = reader.ExitContainer(outerContainerType);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        }
+    }
+}
+
+/**
+ * context
+ */
+
+struct TestTLVContext
+{
+    nlTestSuite *mSuite;
+    int mEvictionCount;
+    int mEvictedBytes;
+};
+
+
+void TestNull(nlTestSuite *inSuite, TLVReader& reader, uint64_t tag)
+{
+    NL_TEST_ASSERT(inSuite, reader.GetType() == kTLVType_Null);
+    NL_TEST_ASSERT(inSuite, reader.GetTag() == tag);
+    NL_TEST_ASSERT(inSuite, reader.GetLength() == 0);
+}
+
+void TestString(nlTestSuite *inSuite, TLVReader& reader, uint64_t tag, const char *expectedVal)
+{
+    NL_TEST_ASSERT(inSuite, reader.GetType() == kTLVType_UTF8String);
+    NL_TEST_ASSERT(inSuite, reader.GetTag() == tag);
+
+    uint32_t expectedLen = strlen(expectedVal);
+    NL_TEST_ASSERT(inSuite, reader.GetLength() == expectedLen);
+
+    char *val = (char *)malloc(expectedLen + 1);
+
+    CHIP_ERROR err = reader.GetString(val, expectedLen + 1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, memcmp(val, expectedVal, expectedLen + 1) == 0);
+
+    free(val);
+}
+
+void TestDupString(nlTestSuite *inSuite, TLVReader& reader, uint64_t tag, const char *expectedVal)
+{
+    NL_TEST_ASSERT(inSuite, reader.GetType() == kTLVType_UTF8String);
+    NL_TEST_ASSERT(inSuite, reader.GetTag() == tag);
+
+    uint32_t expectedLen = strlen(expectedVal);
+    NL_TEST_ASSERT(inSuite, reader.GetLength() == expectedLen);
+
+    char *val = (char *)malloc(expectedLen + 1);
+
+    CHIP_ERROR err = reader.DupString(val);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, memcmp(val, expectedVal, expectedLen + 1) == 0);
+
+    free(val);
+}
+
+void TestDupBytes(nlTestSuite *inSuite, TLVReader& reader, uint64_t tag, const uint8_t *expectedVal, uint32_t expectedLen)
+{
+    NL_TEST_ASSERT(inSuite, reader.GetType() == kTLVType_UTF8String);
+    NL_TEST_ASSERT(inSuite, reader.GetTag() == tag);
+
+    NL_TEST_ASSERT(inSuite, reader.GetLength() == expectedLen);
+
+    uint8_t *val = (uint8_t *)malloc(expectedLen);
+    CHIP_ERROR err = reader.DupBytes(val, expectedLen);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, memcmp(val, expectedVal, expectedLen) == 0);
+
+    free(val);
+}
+
+void TestBufferContents(nlTestSuite *inSuite, PacketBuffer *buf, const uint8_t *expectedVal, uint32_t expectedLen)
+{
+    while (buf != NULL)
+    {
+        uint16_t len = buf->DataLength();
+        NL_TEST_ASSERT(inSuite, len <= expectedLen);
+
+        NL_TEST_ASSERT(inSuite, memcmp(buf->Start(), expectedVal, len) == 0);
+
+        expectedVal += len;
+        expectedLen -= len;
+
+        buf = buf->Next();
+    }
+
+    NL_TEST_ASSERT(inSuite, expectedLen == 0);
+}
+
+static const uint8_t Encoding1[] =
+{
+    0xD5, 0xBB, 0xAA, 0xDD, 0xCC, 0x01, 0x00, 0xC9, 0xBB, 0xAA, 0xDD, 0xCC, 0x02, 0x00, 0x88, 0x02,
+    0x00, 0x36, 0x00, 0x00, 0x2A, 0x00, 0xEF, 0x02, 0xF0, 0x67, 0xFD, 0xFF, 0x07, 0x00, 0x90, 0x2F,
+    0x50, 0x09, 0x00, 0x00, 0x00, 0x15, 0x18, 0x17, 0xD4, 0xBB, 0xAA, 0xDD, 0xCC, 0x11, 0x00, 0xB4,
+    0xA0, 0xBB, 0x0D, 0x00, 0xB5, 0x00, 0x28, 0x6B, 0xEE, 0x6D, 0x70, 0x11, 0x01, 0x00, 0x0E, 0x01,
+    0x53, 0x54, 0x41, 0x52, 0x54, 0x2E, 0x2E, 0x2E, 0x21, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+    0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x40, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+    0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x23, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+    0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x24, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+    0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x25, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+    0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x5E, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+    0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x26, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+    0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x2A, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+    0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+    0x28, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+    0x29, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+    0x2D, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+    0x3D, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+    0x5B, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+    0x5D, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+    0x3B, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+    0x27, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x2E, 0x2E, 0x2E, 0x45, 0x4E, 0x44, 0x18, 0x18,
+    0x18, 0xCC, 0xBB, 0xAA, 0xDD, 0xCC, 0x05, 0x00, 0x0E, 0x54, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73,
+    0x20, 0x61, 0x20, 0x74, 0x65, 0x73, 0x74,
+    0x8A, 0xFF, 0xFF, 0x33, 0x33, 0x8f, 0x41,
+    0xAB, 0x00, 0x00, 0x01, 0x00, 0x66, 0x66, 0x66, 0x66, 0x66, 0xE6, 0x31, 0x40, 0x18
+};
+
+static const uint8_t Encoding1_DataMacro [] =
+{
+    CHIP_TLV_STRUCTURE(CHIP_TLV_TAG_FULLY_QUALIFIED_6Bytes(TestProfile_1, 1)),
+        CHIP_TLV_BOOL(CHIP_TLV_TAG_FULLY_QUALIFIED_6Bytes(TestProfile_1, 2), true),
+        CHIP_TLV_BOOL(CHIP_TLV_TAG_IMPLICIT_PROFILE_2Bytes(2), false),
+        CHIP_TLV_ARRAY(CHIP_TLV_TAG_CONTEXT_SPECIFIC(0)),
+            CHIP_TLV_INT8(CHIP_TLV_TAG_ANONYMOUS, 42),
+            CHIP_TLV_INT8(CHIP_TLV_TAG_ANONYMOUS, -17),
+            CHIP_TLV_INT32(CHIP_TLV_TAG_ANONYMOUS, -170000),
+            CHIP_TLV_UINT64(CHIP_TLV_TAG_ANONYMOUS, 40000000000ULL),
+            CHIP_TLV_STRUCTURE(CHIP_TLV_TAG_ANONYMOUS),
+            CHIP_TLV_END_OF_CONTAINER,
+            CHIP_TLV_PATH(CHIP_TLV_TAG_ANONYMOUS),
+                CHIP_TLV_NULL(CHIP_TLV_TAG_FULLY_QUALIFIED_6Bytes(TestProfile_1, 17)),
+                CHIP_TLV_NULL(CHIP_TLV_TAG_IMPLICIT_PROFILE_4Bytes(900000)),
+                CHIP_TLV_STRUCTURE(CHIP_TLV_TAG_IMPLICIT_PROFILE_4Bytes(4000000000ULL)),
+                    CHIP_TLV_UTF8_STRING_2ByteLength(CHIP_TLV_TAG_COMMON_PROFILE_4Bytes(70000), sizeof(sLargeString) - 1,
+                    'S', 'T', 'A', 'R', 'T', '.', '.', '.',
+                    '!', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', '@',
+                    '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', '#', '1',
+                    '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', '$', '1', '2',
+                    '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', '%', '1', '2', '3',
+                    '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', '^', '1', '2', '3', '4',
+                    '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', '&', '1', '2', '3', '4', '5',
+                    '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', '*', '1', '2', '3', '4', '5', '6',
+                    '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
+                    '0', '1', '2', '3', '4', '5', '6', '7', '(', '9', 'A', 'B', 'C', 'D', 'E', 'F', '0',
+                    '1', '2', '3', '4', '5', '6', '7', ')', '9', 'A', 'B', 'C', 'D', 'E', 'F', '0', '1',
+                    '2', '3', '4', '5', '6', '7', '-', '9', 'A', 'B', 'C', 'D', 'E', 'F', '0', '1', '2',
+                    '3', '4', '5', '6', '7', '=', '9', 'A', 'B', 'C', 'D', 'E', 'F', '0', '1', '2', '3',
+                    '4', '5', '6', '7', '[', '9', 'A', 'B', 'C', 'D', 'E', 'F', '0', '1', '2', '3', '4',
+                    '5', '6', '7', ']', '9', 'A', 'B', 'C', 'D', 'E', 'F', '0', '1', '2', '3', '4', '5',
+                    '6', '7', ';', '9', 'A', 'B', 'C', 'D', 'E', 'F', '0', '1', '2', '3', '4', '5', '6',
+                    '7', '\'', '9', 'A', 'B', 'C', 'D', 'E', 'F',
+                    '.', '.', '.', 'E', 'N', 'D'),
+                CHIP_TLV_END_OF_CONTAINER,
+            CHIP_TLV_END_OF_CONTAINER,
+        CHIP_TLV_END_OF_CONTAINER,
+        CHIP_TLV_UTF8_STRING_1ByteLength(CHIP_TLV_TAG_FULLY_QUALIFIED_6Bytes(TestProfile_1, 5), sizeof("This is a test") - 1,
+            'T', 'h', 'i', 's', ' ', 'i', 's', ' ', 'a', ' ', 't', 'e', 's', 't'),
+        CHIP_TLV_FLOAT32(CHIP_TLV_TAG_IMPLICIT_PROFILE_2Bytes(65535),
+            0x33, 0x33, 0x8f, 0x41), // (float)17.9
+        CHIP_TLV_FLOAT64(CHIP_TLV_TAG_IMPLICIT_PROFILE_4Bytes(65536),
+            0x66, 0x66, 0x66, 0x66, 0x66, 0xE6, 0x31, 0x40), // (double)17.9
+    CHIP_TLV_END_OF_CONTAINER
+};
+
+void WriteEncoding1(nlTestSuite *inSuite, TLVWriter& writer)
+{
+    CHIP_ERROR err;
+    TLVWriter writer2;
+
+    err = writer.OpenContainer(ProfileTag(TestProfile_1, 1), kTLVType_Structure, writer2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer2.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer2.PutBoolean(ProfileTag(TestProfile_2, 2), false);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    {
+        TLVWriter writer3;
+
+        err = writer2.OpenContainer(ContextTag(0), kTLVType_Array, writer3);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer3.Put(AnonymousTag, 42);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer3.Put(AnonymousTag, -17);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer3.Put(AnonymousTag, -170000);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer3.Put(AnonymousTag, (uint64_t) 40000000000ULL);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        {
+            TLVWriter writer4;
+
+            err = writer3.OpenContainer(AnonymousTag, kTLVType_Structure, writer4);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+            err = writer3.CloseContainer(writer4);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        }
+
+        {
+            TLVWriter writer5;
+
+            err = writer3.OpenContainer(AnonymousTag, kTLVType_Path, writer5);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+            err = writer5.PutNull(ProfileTag(TestProfile_1, 17));
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+            err = writer5.PutNull(ProfileTag(TestProfile_2, 900000));
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+            {
+                TLVType outerContainerType;
+
+                err = writer5.StartContainer(ProfileTag(TestProfile_2, 4000000000ULL), kTLVType_Structure, outerContainerType);
+                NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+                err = writer5.PutString(CommonTag(70000), sLargeString);
+                NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+                err = writer5.EndContainer(outerContainerType);
+                NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+            }
+
+            err = writer3.CloseContainer(writer5);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        }
+
+        err = writer2.CloseContainer(writer3);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    }
+
+    err = writer2.PutString(ProfileTag(TestProfile_1, 5), "This is a test");
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer2.Put(ProfileTag(TestProfile_2, 65535), (float)17.9);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer2.Put(ProfileTag(TestProfile_2, 65536), (double)17.9);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.CloseContainer(writer2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Finalize();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+}
+
+void WriteEmptyEncoding(nlTestSuite *inSuite, TLVWriter& writer)
+{
+    CHIP_ERROR err;
+    TLVWriter writer2;
+
+    err = writer.OpenContainer(ProfileTag(TestProfile_1, 1), kTLVType_Structure, writer2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    {
+        TLVWriter writer3;
+
+        err = writer2.OpenContainer(ProfileTag(TestProfile_1, 256), kTLVType_Array, writer3);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer2.CloseContainer(writer3);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    }
+
+    err = writer.CloseContainer(writer2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Finalize();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+}
+
+void ReadEncoding1(nlTestSuite *inSuite, TLVReader& reader)
+{
+    TestNext<TLVReader>(inSuite, reader);
+
+    {
+        TLVReader reader2;
+
+        TestAndOpenContainer(inSuite, reader, kTLVType_Structure, ProfileTag(TestProfile_1, 1), reader2);
+
+        TestNext<TLVReader>(inSuite, reader2);
+
+        TestGet<TLVReader, bool>(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
+
+        TestNext<TLVReader>(inSuite, reader2);
+
+        TestGet<TLVReader, bool>(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
+
+        TestNext<TLVReader>(inSuite, reader2);
+
+        {
+            TLVReader reader3;
+
+            TestAndOpenContainer(inSuite, reader2, kTLVType_Array, ContextTag(0), reader3);
+
+            TestNext<TLVReader>(inSuite, reader3);
+
+            TestGet<TLVReader, int8_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
+            TestGet<TLVReader, int16_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
+            TestGet<TLVReader, int32_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
+            TestGet<TLVReader, int64_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
+            TestGet<TLVReader, uint8_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
+            TestGet<TLVReader, uint16_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
+            TestGet<TLVReader, uint32_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
+            TestGet<TLVReader, uint64_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
+
+            TestNext<TLVReader>(inSuite, reader3);
+
+            TestGet<TLVReader, int8_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, -17);
+            TestGet<TLVReader, int16_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, -17);
+            TestGet<TLVReader, int32_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, -17);
+            TestGet<TLVReader, int64_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, -17);
+
+            TestNext<TLVReader>(inSuite, reader3);
+
+            TestGet<TLVReader, int32_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, -170000);
+            TestGet<TLVReader, int64_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, -170000);
+
+            TestNext<TLVReader>(inSuite, reader3);
+
+            TestGet<TLVReader, int64_t>(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag, 40000000000ULL);
+            TestGet<TLVReader, uint64_t>(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag, 40000000000ULL);
+
+            TestNext<TLVReader>(inSuite, reader3);
+
+            {
+                TLVReader reader4;
+
+                TestAndOpenContainer(inSuite, reader3, kTLVType_Structure, AnonymousTag, reader4);
+
+                TestEndAndCloseContainer(inSuite, reader3, reader4);
+            }
+
+            TestNext<TLVReader>(inSuite, reader3);
+
+            {
+                TLVReader reader5;
+
+                TestAndOpenContainer(inSuite, reader3, kTLVType_Path, AnonymousTag, reader5);
+
+                TestNext<TLVReader>(inSuite, reader5);
+
+                TestNull(inSuite, reader5, ProfileTag(TestProfile_1, 17));
+
+                TestNext<TLVReader>(inSuite, reader5);
+
+                TestNull(inSuite, reader5, ProfileTag(TestProfile_2, 900000));
+
+                TestNext<TLVReader>(inSuite, reader5);
+
+                {
+                    TLVType outerContainerType;
+
+                    TestAndEnterContainer<TLVReader>(inSuite, reader5, kTLVType_Structure, ProfileTag(TestProfile_2, 4000000000ULL), outerContainerType);
+
+                    TestNext<TLVReader>(inSuite, reader5);
+
+                    TestString(inSuite, reader5, CommonTag(70000), sLargeString);
+
+                    TestEndAndExitContainer<TLVReader>(inSuite, reader5, outerContainerType);
+                }
+
+                TestEndAndCloseContainer(inSuite, reader3, reader5);
+            }
+
+            TestEndAndCloseContainer(inSuite, reader2, reader3);
+        }
+
+        TestNext<TLVReader>(inSuite, reader2);
+
+        TestString(inSuite, reader2, ProfileTag(TestProfile_1, 5), "This is a test");
+
+        TestNext<TLVReader>(inSuite, reader2);
+
+        TestGet<TLVReader, double>(inSuite, reader2, kTLVType_FloatingPointNumber, ProfileTag(TestProfile_2, 65535), (float)17.9);
+
+        TestNext<TLVReader>(inSuite, reader2);
+
+        TestGet<TLVReader, double>(inSuite, reader2, kTLVType_FloatingPointNumber, ProfileTag(TestProfile_2, 65536), (double)17.9);
+
+        TestEndAndCloseContainer(inSuite, reader, reader2);
+    }
+
+    TestEnd<TLVReader>(inSuite, reader);
+}
+
+void WriteEncoding2(nlTestSuite *inSuite, TLVWriter& writer)
+{
+    CHIP_ERROR err;
+
+    { // Container 1
+        TLVWriter writer1;
+
+        err = writer.OpenContainer(ProfileTag(TestProfile_1, 1), kTLVType_Structure, writer1);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer1.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer1.PutBoolean(ProfileTag(TestProfile_2, 2), false);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer.CloseContainer(writer1);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    }
+
+    { // Container 2
+        TLVWriter writer1;
+
+        err = writer.OpenContainer(ProfileTag(TestProfile_2, 1), kTLVType_Structure, writer1);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer1.PutBoolean(ProfileTag(TestProfile_2, 2), false);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer1.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer.CloseContainer(writer1);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    }
+
+    err = writer.Finalize();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+}
+
+void WriteEncoding3(nlTestSuite *inSuite, TLVWriter& writer)
+{
+    CHIP_ERROR err;
+
+    { // Container 1
+        TLVWriter writer1;
+
+        err = writer.OpenContainer(ProfileTag(TestProfile_1, 1), kTLVType_Structure, writer1);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer1.PutBoolean(ProfileTag(TestProfile_2, 2), false);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer.CloseContainer(writer1);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    }
+
+    err = writer.Finalize();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+}
+
+void ReadEncoding3(nlTestSuite *inSuite, TLVReader& reader)
+{
+    TLVReader reader2;
+
+    TestAndOpenContainer(inSuite, reader, kTLVType_Structure, ProfileTag(TestProfile_1, 1), reader2);
+
+    TestNext<TLVReader>(inSuite, reader2);
+
+    TestGet<TLVReader, bool>(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
+
+    TestEndAndCloseContainer(inSuite, reader, reader2);
+}
+
+static const uint8_t Encoding5_DataMacro [] =
+{
+    CHIP_TLV_STRUCTURE(CHIP_TLV_TAG_FULLY_QUALIFIED_6Bytes(TestProfile_1, 1)),
+        CHIP_TLV_BOOL(CHIP_TLV_TAG_FULLY_QUALIFIED_6Bytes(TestProfile_1, 2), true),
+        CHIP_TLV_BOOL(CHIP_TLV_TAG_IMPLICIT_PROFILE_2Bytes(2), false),
+        CHIP_TLV_BOOL(CHIP_TLV_TAG_FULLY_QUALIFIED_6Bytes(TestProfile_1, 2), false),
+        CHIP_TLV_BOOL(CHIP_TLV_TAG_IMPLICIT_PROFILE_2Bytes(2), true),
+
+        CHIP_TLV_STRUCTURE(CHIP_TLV_TAG_FULLY_QUALIFIED_6Bytes(TestProfile_1, 1)),
+            CHIP_TLV_BOOL(CHIP_TLV_TAG_FULLY_QUALIFIED_6Bytes(TestProfile_1, 2), true),
+            CHIP_TLV_BOOL(CHIP_TLV_TAG_IMPLICIT_PROFILE_2Bytes(2), false),
+        CHIP_TLV_END_OF_CONTAINER,
+
+        CHIP_TLV_STRUCTURE(CHIP_TLV_TAG_IMPLICIT_PROFILE_2Bytes(1)),
+            CHIP_TLV_BOOL(CHIP_TLV_TAG_IMPLICIT_PROFILE_2Bytes(2), false),
+            CHIP_TLV_BOOL(CHIP_TLV_TAG_FULLY_QUALIFIED_6Bytes(TestProfile_1, 2), true),
+        CHIP_TLV_END_OF_CONTAINER,
+    CHIP_TLV_END_OF_CONTAINER,
+
+    CHIP_TLV_STRUCTURE(CHIP_TLV_TAG_IMPLICIT_PROFILE_2Bytes(1)),
+        CHIP_TLV_BOOL(CHIP_TLV_TAG_IMPLICIT_PROFILE_2Bytes(2), false),
+        CHIP_TLV_BOOL(CHIP_TLV_TAG_FULLY_QUALIFIED_6Bytes(TestProfile_1, 2), true),
+    CHIP_TLV_END_OF_CONTAINER,
+};
+
+void WriteEncoding5(nlTestSuite *inSuite, TLVWriter& writer)
+{
+    CHIP_ERROR err;
+
+    { // Container 1
+        TLVWriter writer1;
+
+        err = writer.OpenContainer(ProfileTag(TestProfile_1, 1), kTLVType_Structure, writer1);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer1.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer1.PutBoolean(ProfileTag(TestProfile_2, 2), false);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer1.PutBoolean(ProfileTag(TestProfile_1, 2), false);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer1.PutBoolean(ProfileTag(TestProfile_2, 2), true);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        { // Inner Container 1
+            TLVWriter writer2;
+
+            err = writer1.OpenContainer(ProfileTag(TestProfile_1, 1), kTLVType_Structure, writer2);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+            err = writer2.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+            err = writer2.PutBoolean(ProfileTag(TestProfile_2, 2), false);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+            err = writer1.CloseContainer(writer2);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        }
+
+        { // Inner Container 2
+            TLVWriter writer2;
+
+            err = writer1.OpenContainer(ProfileTag(TestProfile_2, 1), kTLVType_Structure, writer2);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+            err = writer2.PutBoolean(ProfileTag(TestProfile_2, 2), false);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+            err = writer2.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+            err = writer1.CloseContainer(writer2);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        }
+
+        err = writer.CloseContainer(writer1);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    }
+
+    { // Container 2
+        TLVWriter writer1;
+
+        err = writer.OpenContainer(ProfileTag(TestProfile_2, 1), kTLVType_Structure, writer1);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer1.PutBoolean(ProfileTag(TestProfile_2, 2), false);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer1.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer.CloseContainer(writer1);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    }
+
+    err = writer.Finalize();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+}
+
+/**
+ * AppendEncoding2()
+ *
+ * This function appends two boolean types and two container types to the first
+ * container.
+ *
+ * The boolean types are-
+ * <TestProfile_1, 2, false>
+ * <TestProfile_2, 2, true>
+ *
+ * The two new container types are-
+ * <TestProfile_1, 1, kTLVType_Structure, <TestProfile_1, 2, true> <TestProfile_2, 2, false> >,
+ * <TestProfile_2, 1, kTLVType_Structure, <TestProfile_2, 2, false> <TestProfile_1, 2, true> >
+ */
+void AppendEncoding2(nlTestSuite *inSuite, uint8_t *buf, uint32_t dataLen, uint32_t maxLen, uint32_t& updatedLen)
+{
+    CHIP_ERROR err;
+
+    TLVUpdater updater;
+
+    err = updater.Init(buf, dataLen, maxLen);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    updater.SetImplicitProfileId(TestProfile_2);
+
+    TestNext<TLVUpdater>(inSuite, updater);
+
+    {
+        TLVType outerContainerType;
+
+        TestAndEnterContainer<TLVUpdater>(inSuite, updater, kTLVType_Structure, ProfileTag(TestProfile_1, 1), outerContainerType);
+
+        TestNext<TLVUpdater>(inSuite, updater);
+
+        // Move the element without modification
+        TestMove(inSuite, updater);
+
+        TestNext<TLVUpdater>(inSuite, updater);
+
+        // Read and copy the element with/without modification
+        TestGet<TLVUpdater, bool>(inSuite, updater, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
+        err = updater.PutBoolean(ProfileTag(TestProfile_2, 2), false);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        // TestEnd and add data at the end of the container
+        TestEnd<TLVUpdater>(inSuite, updater);
+
+        // Put new values in the encoding using the updater
+        // Add <TestProfile_1, 2, false>
+        err = updater.PutBoolean(ProfileTag(TestProfile_1, 2), false);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        // Add <TestProfile_2, 2, true>
+        err = updater.PutBoolean(ProfileTag(TestProfile_2, 2), true);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        // Add a new container
+        {
+            TLVType outerContainerType1;
+
+            err = updater.StartContainer(ProfileTag(TestProfile_1, 1), kTLVType_Structure, outerContainerType1);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+            // Add <TestProfile_1, 2, true>
+            err = updater.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+            // Add <TestProfile_1, 2, true>
+            err = updater.PutBoolean(ProfileTag(TestProfile_2, 2), false);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+            // Close the container
+            err = updater.EndContainer(outerContainerType1);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        }
+
+        // Add another new container
+        {
+            TLVType outerContainerType1;
+
+            err = updater.StartContainer(ProfileTag(TestProfile_2, 1), kTLVType_Structure, outerContainerType1);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+            // Add <TestProfile_2, 2, false>
+            err = updater.PutBoolean(ProfileTag(TestProfile_2, 2), false);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+            // Add <TestProfile_1, 2, true>
+            err = updater.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+            // Close the container
+            err = updater.EndContainer(outerContainerType1);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        }
+
+        TestEndAndExitContainer<TLVUpdater>(inSuite, updater, outerContainerType);
+    }
+
+    TestNext<TLVUpdater>(inSuite, updater);
+
+    // Move the container unmodified
+    TestMove(inSuite, updater);
+
+    TestEnd<TLVUpdater>(inSuite, updater);
+
+    err = updater.Finalize();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    updatedLen = updater.GetLengthWritten();
+}
+
+/**
+ * FindAppendEncoding2()
+ *
+ * This function appends two boolean types and two container types to the first
+ * container. It is very similar to AppendEncoding2() above except for the fact
+ * that it uses TLVUtilities::Find() to find the element of interest before
+ * appending new data.
+ *
+ * The boolean types are-
+ * <TestProfile_1, 2, false>
+ * <TestProfile_2, 2, true>
+ *
+ * The two new container types are-
+ * <TestProfile_1, 1, kTLVType_Structure, <TestProfile_1, 2, true> <TestProfile_2, 2, false> >,
+ * <TestProfile_2, 1, kTLVType_Structure, <TestProfile_2, 2, false> <TestProfile_1, 2, true> >
+ */
+void FindAppendEncoding2(nlTestSuite *inSuite, uint8_t *buf, uint32_t dataLen, uint32_t maxLen, uint32_t& updatedLen, bool findContainer)
+{
+    CHIP_ERROR err;
+
+    TLVReader reader;
+    TLVUpdater updater;
+
+    // Initialize a reader
+    reader.Init(buf, dataLen);
+    reader.ImplicitProfileId = TestProfile_2;
+
+    if (findContainer)
+    {
+        // Find the container
+        TLVReader tagReader;
+        TLVType outerContainerType;
+        err = chip::TLV::Utilities::Find(reader, ProfileTag(TestProfile_1, 1), tagReader);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = tagReader.EnterContainer(outerContainerType);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        do {
+            err = tagReader.Next();
+        } while (err != CHIP_END_OF_TLV);
+
+        TestEnd<TLVReader>(inSuite, tagReader);
+
+        // Init a TLVUpdater using the TLVReader
+        err = updater.Init(tagReader, maxLen - dataLen);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    }
+    else
+    {
+        // Find
+        TLVReader tagReader;
+        err = chip::TLV::Utilities::Find(reader, ProfileTag(TestProfile_2, 2), tagReader);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        // Test Find(recurse = true)
+        TLVReader tagReader2;
+        err = chip::TLV::Utilities::Find(reader, ProfileTag(TestProfile_2, 2), tagReader2, true);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        //
+        // Test Find(recurse = false)
+        TLVReader tagReader3;
+        err = chip::TLV::Utilities::Find(reader, ProfileTag(TestProfile_2, 2), tagReader3, false);
+        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_TLV_TAG_NOT_FOUND);
+
+        // Init a TLVUpdater using the TLVReader
+        err = updater.Init(tagReader, maxLen - dataLen);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        TestNext<TLVUpdater>(inSuite, updater);
+
+        // Move the element without modification
+        TestMove(inSuite, updater);
+    }
+
+    // Put new values in the encoding using the updater
+    // Add <TestProfile_1, 2, false>
+    err = updater.PutBoolean(ProfileTag(TestProfile_1, 2), false);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    // Add <TestProfile_2, 2, true>
+    err = updater.PutBoolean(ProfileTag(TestProfile_2, 2), true);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    // Add a new container
+    {
+        TLVType outerContainerType1;
+
+        err = updater.StartContainer(ProfileTag(TestProfile_1, 1), kTLVType_Structure, outerContainerType1);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        // Add <TestProfile_1, 2, true>
+        err = updater.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        // Add <TestProfile_1, 2, true>
+        err = updater.PutBoolean(ProfileTag(TestProfile_2, 2), false);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        // Close the container
+        err = updater.EndContainer(outerContainerType1);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    }
+
+    // Add another new container
+    {
+        TLVType outerContainerType1;
+
+        err = updater.StartContainer(ProfileTag(TestProfile_2, 1), kTLVType_Structure, outerContainerType1);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        // Add <TestProfile_2, 2, false>
+        err = updater.PutBoolean(ProfileTag(TestProfile_2, 2), false);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        // Add <TestProfile_1, 2, true>
+        err = updater.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        // Close the container
+        err = updater.EndContainer(outerContainerType1);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    }
+
+    // Move everything else unmodified
+    updater.MoveUntilEnd();
+
+    TestEnd<TLVUpdater>(inSuite, updater);
+
+    err = updater.Finalize();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    updatedLen = updater.GetLengthWritten();
+}
+
+void AppendEncoding3(nlTestSuite *inSuite, uint8_t *buf, uint32_t dataLen, uint32_t maxLen, uint32_t& updatedLen)
+{
+    CHIP_ERROR err;
+
+    TLVUpdater updater;
+
+    err = updater.Init(buf, dataLen, maxLen);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    updater.SetImplicitProfileId(TestProfile_2);
+
+    TestNext<TLVUpdater>(inSuite, updater);
+
+    {
+        TLVType outerContainerType;
+
+        TestAndEnterContainer<TLVUpdater>(inSuite, updater, kTLVType_Structure, ProfileTag(TestProfile_1, 1), outerContainerType);
+
+        TestNext<TLVUpdater>(inSuite, updater);
+
+        // Move the element without modification
+        TestMove(inSuite, updater);
+
+        // Put new value in the encoding using the updater
+        // Add <TestProfile_2, 2, true>
+        err = updater.PutBoolean(ProfileTag(TestProfile_2, 2), true);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        TestEndAndExitContainer<TLVUpdater>(inSuite, updater, outerContainerType);
+    }
+
+    TestEnd<TLVUpdater>(inSuite, updater);
+
+    err = updater.Finalize();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    updatedLen = updater.GetLengthWritten();
+}
+
+void AppendEncoding4(nlTestSuite *inSuite, uint8_t *buf, uint32_t dataLen, uint32_t maxLen, uint32_t& updatedLen)
+{
+    CHIP_ERROR err;
+
+    TLVUpdater updater;
+
+    err = updater.Init(buf, dataLen, maxLen);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    updater.SetImplicitProfileId(TestProfile_2);
+
+    // Add a new container
+    {
+        TLVType outerContainerType;
+
+        err = updater.StartContainer(ProfileTag(TestProfile_1, 1), kTLVType_Structure, outerContainerType);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        // Add <TestProfile_1, 2, true>
+        err = updater.PutBoolean(ProfileTag(TestProfile_2, 2), false);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        // Close the container
+        err = updater.EndContainer(outerContainerType);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    }
+
+    err = updater.Finalize();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    updatedLen = updater.GetLengthWritten();
+}
+
+void DeleteEncoding5(nlTestSuite *inSuite, uint8_t *buf, uint32_t dataLen, uint32_t maxLen, uint32_t& updatedLen)
+{
+    CHIP_ERROR err;
+
+    TLVUpdater updater;
+
+    err = updater.Init(buf, dataLen, maxLen);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    updater.SetImplicitProfileId(TestProfile_2);
+
+    TestNext<TLVUpdater>(inSuite, updater);
+
+    {
+        TLVType outerContainerType;
+
+        TestAndEnterContainer<TLVUpdater>(inSuite, updater, kTLVType_Structure, ProfileTag(TestProfile_1, 1), outerContainerType);
+
+        TestNext<TLVUpdater>(inSuite, updater);
+
+        TestMove(inSuite, updater);
+
+        TestNext<TLVUpdater>(inSuite, updater);
+
+        TestMove(inSuite, updater);
+
+        TestNext<TLVUpdater>(inSuite, updater);
+
+        // Get the value to inspect and skip writing it
+        TestGet<TLVUpdater, bool>(inSuite, updater, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), false);
+
+        TestNext<TLVUpdater>(inSuite, updater);
+
+        // Skip the next boolean type and don't copy by doing nothing
+
+        TestNext<TLVUpdater>(inSuite, updater);
+
+        // Read ahead into the next container and decide whether to skip or
+        // not based on elements in the container
+        {
+            TLVReader reader;
+            TLVType containerType;
+
+            updater.GetReader(reader);
+
+            TestAndEnterContainer<TLVReader>(inSuite, reader, kTLVType_Structure, ProfileTag(TestProfile_1, 1), containerType);
+
+            TestNext<TLVReader>(inSuite, reader);
+
+            // If the container's first element has the tag <TestProfile_1, 2>
+            // skip the whole container, and if NOT copy the container
+            if (reader.GetTag() != ProfileTag(TestProfile_1, 2))
+                TestMove(inSuite, updater);
+        }
+
+        TestNext<TLVUpdater>(inSuite, updater);
+
+        // Skip the next container and don't copy by doing nothing
+
+        TestEndAndExitContainer<TLVUpdater>(inSuite, updater, outerContainerType);
+    }
+
+    // Move everything else unmodified
+    updater.MoveUntilEnd();
+
+    TestEnd<TLVUpdater>(inSuite, updater);
+
+    err = updater.Finalize();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    updatedLen = updater.GetLengthWritten();
+}
+
+void ReadAppendedEncoding2(nlTestSuite *inSuite, TLVReader& reader)
+{
+    TestNext<TLVReader>(inSuite, reader);
+
+    { // Container 1
+        TLVReader reader1;
+
+        TestAndOpenContainer(inSuite, reader, kTLVType_Structure, ProfileTag(TestProfile_1, 1), reader1);
+
+        TestNext<TLVReader>(inSuite, reader1);
+
+        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
+
+        TestNext<TLVReader>(inSuite, reader1);
+
+        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
+
+        TestNext<TLVReader>(inSuite, reader1);
+
+        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), false);
+
+        TestNext<TLVReader>(inSuite, reader1);
+
+        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), true);
+
+        TestNext<TLVReader>(inSuite, reader1);
+
+        {
+            TLVReader reader2;
+
+            TestAndOpenContainer(inSuite, reader1, kTLVType_Structure, ProfileTag(TestProfile_1, 1), reader2);
+
+            TestNext<TLVReader>(inSuite, reader2);
+
+            TestGet<TLVReader, bool>(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
+
+            TestNext<TLVReader>(inSuite, reader2);
+
+            TestGet<TLVReader, bool>(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
+
+            TestEndAndCloseContainer(inSuite, reader1, reader2);
+        }
+
+        TestNext<TLVReader>(inSuite, reader1);
+
+        {
+            TLVReader reader2;
+
+            TestAndOpenContainer(inSuite, reader1, kTLVType_Structure, ProfileTag(TestProfile_2, 1), reader2);
+
+            TestNext<TLVReader>(inSuite, reader2);
+
+            TestGet<TLVReader, bool>(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
+
+            TestNext<TLVReader>(inSuite, reader2);
+
+            TestGet<TLVReader, bool>(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
+
+            TestEndAndCloseContainer(inSuite, reader1, reader2);
+        }
+
+        TestEndAndCloseContainer(inSuite, reader, reader1);
+    }
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    { // Container 2
+        TLVReader reader1;
+
+        TestAndOpenContainer(inSuite, reader, kTLVType_Structure, ProfileTag(TestProfile_2, 1), reader1);
+
+        TestNext<TLVReader>(inSuite, reader1);
+
+        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
+
+        TestNext<TLVReader>(inSuite, reader1);
+
+        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
+
+        TestEndAndCloseContainer(inSuite, reader, reader1);
+    }
+
+    TestEnd<TLVReader>(inSuite, reader);
+}
+
+void ReadAppendedEncoding3(nlTestSuite *inSuite, TLVReader& reader)
+{
+    TestNext<TLVReader>(inSuite, reader);
+
+    { // Container 1
+        TLVReader reader1;
+
+        TestAndOpenContainer(inSuite, reader, kTLVType_Structure, ProfileTag(TestProfile_1, 1), reader1);
+
+        TestNext<TLVReader>(inSuite, reader1);
+
+        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
+
+        TestNext<TLVReader>(inSuite, reader1);
+
+        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), true);
+
+        TestEndAndCloseContainer(inSuite, reader, reader1);
+    }
+
+    TestEnd<TLVReader>(inSuite, reader);
+}
+
+void ReadAppendedEncoding4(nlTestSuite *inSuite, TLVReader& reader)
+{
+    TestNext<TLVReader>(inSuite, reader);
+
+    { // Container 1
+        TLVReader reader1;
+
+        TestAndOpenContainer(inSuite, reader, kTLVType_Structure, ProfileTag(TestProfile_1, 1), reader1);
+
+        TestNext<TLVReader>(inSuite, reader1);
+
+        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
+
+        TestEndAndCloseContainer(inSuite, reader, reader1);
+    }
+
+    TestEnd<TLVReader>(inSuite, reader);
+}
+
+void ReadDeletedEncoding5(nlTestSuite *inSuite, TLVReader& reader)
+{
+    TestNext<TLVReader>(inSuite, reader);
+
+    { // Container 1
+        TLVReader reader1;
+
+        TestAndOpenContainer(inSuite, reader, kTLVType_Structure, ProfileTag(TestProfile_1, 1), reader1);
+
+        TestNext<TLVReader>(inSuite, reader1);
+
+        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
+
+        TestNext<TLVReader>(inSuite, reader1);
+
+        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
+
+        TestEndAndCloseContainer(inSuite, reader, reader1);
+    }
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    { // Container 2
+        TLVReader reader1;
+
+        TestAndOpenContainer(inSuite, reader, kTLVType_Structure, ProfileTag(TestProfile_2, 1), reader1);
+
+        TestNext<TLVReader>(inSuite, reader1);
+
+        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
+
+        TestNext<TLVReader>(inSuite, reader1);
+
+        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
+
+        TestEndAndCloseContainer(inSuite, reader, reader1);
+    }
+
+    TestEnd<TLVReader>(inSuite, reader);
+}
+
+/**
+ *  Test Simple Write and Reader
+ */
+void CheckSimpleWriteRead(nlTestSuite *inSuite, void *inContext)
+{
+    uint8_t buf[2048];
+    TLVWriter writer;
+    TLVReader reader;
+
+    writer.Init(buf, sizeof(buf));
+    writer.ImplicitProfileId = TestProfile_2;
+
+    WriteEncoding1(inSuite, writer);
+
+    uint32_t encodedLen = writer.GetLengthWritten();
+
+#ifdef DUMP_ENCODING
+    for (uint32_t i = 0; i < encodedLen; i++)
+    {
+        if (i != 0 && i % 16 == 0)
+            printf("\n");
+        printf("0x%02X, ", buf[i]);
+    }
+    printf("\n");
+#endif
+
+    NL_TEST_ASSERT(inSuite, encodedLen == sizeof(Encoding1));
+    NL_TEST_ASSERT(inSuite, memcmp(buf, Encoding1, encodedLen) == 0);
+
+    reader.Init(buf, encodedLen);
+    reader.ImplicitProfileId = TestProfile_2;
+
+    ReadEncoding1(inSuite, reader);
+}
+
+
+/**
+ *  Log the specified message in the form of @a aFormat.
+ *
+ *  @param[in]     aFormat   A pointer to a NULL-terminated C string with
+ *                           C Standard Library-style format specifiers
+ *                           containing the log message to be formatted and
+ *                           logged.
+ *  @param[in]     ...       An argument list whose elements should correspond
+ *                           to the format specifiers in @a aFormat.
+ *
+ */
+void SimpleDumpWriter(const char *aFormat, ...)
+{
+    va_list args;
+
+    va_start(args, aFormat);
+
+    vprintf(aFormat, args);
+
+    va_end(args);
+}
+
+/**
+ *  Test Pretty Printer
+ */
+void CheckPrettyPrinter(nlTestSuite *inSuite, void *inContext)
+{
+    uint8_t buf[2048];
+    TLVWriter writer;
+    TLVReader reader;
+
+    writer.Init(buf, sizeof(buf));
+    writer.ImplicitProfileId = TestProfile_2;
+
+    WriteEncoding1(inSuite, writer);
+
+    uint32_t encodedLen = writer.GetLengthWritten();
+
+    NL_TEST_ASSERT(inSuite, encodedLen == sizeof(Encoding1));
+    NL_TEST_ASSERT(inSuite, memcmp(buf, Encoding1, encodedLen) == 0);
+
+    reader.Init(buf, encodedLen);
+    reader.ImplicitProfileId = TestProfile_2;
+    chip::TLV::Debug::Dump(reader, SimpleDumpWriter);
+}
+
+/**
+ *  Test Data Macros
+ */
+void CheckDataMacro(nlTestSuite *inSuite, void *inContext)
+{
+    NL_TEST_ASSERT(inSuite, sizeof(Encoding1_DataMacro) == sizeof(Encoding1));
+    NL_TEST_ASSERT(inSuite, memcmp(Encoding1, Encoding1_DataMacro, sizeof(Encoding1)) == 0);
+
+    uint8_t buf[2048];
+    TLVWriter writer;
+    writer.Init(buf, sizeof(buf));
+    writer.ImplicitProfileId = TestProfile_2;
+    WriteEncoding5(inSuite, writer);
+    uint32_t encodedLen = writer.GetLengthWritten();
+
+    NL_TEST_ASSERT(inSuite, sizeof(Encoding5_DataMacro) == encodedLen);
+    NL_TEST_ASSERT(inSuite, memcmp(buf, Encoding5_DataMacro, encodedLen) == 0);
+}
+
+static CHIP_ERROR NullIterateHandler(const TLVReader &aReader, size_t aDepth, void *aContext)
+{
+    (void)aReader;
+    (void)aDepth;
+    (void)aContext;
+
+    return CHIP_NO_ERROR;
+}
+
+static CHIP_ERROR FindContainerWithElement(const TLVReader &aReader, size_t aDepth, void *aContext)
+{
+    TLVReader reader;
+    TLVReader result;
+    uint64_t * tag = static_cast<uint64_t *>(aContext);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    TLVType containerType;
+
+    reader.Init(aReader);
+
+    if (TLVTypeIsContainer(reader.GetType()))
+    {
+        err = reader.EnterContainer(containerType);
+        SuccessOrExit(err);
+
+        err = chip::TLV::Utilities::Find(reader, *tag, result, false);
+
+        // Map a successful find (CHIP_NO_ERROR) onto a signal that the element has been found.
+        if (err == CHIP_NO_ERROR)
+        {
+            err = CHIP_ERROR_MAX;
+        }
+        // Map a failed find attempt to NO_ERROR
+        else if (err == CHIP_ERROR_TLV_TAG_NOT_FOUND)
+        {
+            err = CHIP_NO_ERROR;
+        }
+    }
+exit:
+    return err;
+}
+
+/**
+ *  Test Weave TLV Utilities
+ */
+void CheckWeaveTLVUtilities(nlTestSuite *inSuite, void *inContext)
+{
+    uint8_t buf[2048];
+    TLVWriter writer;
+    TLVReader reader, reader1;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    writer.Init(buf, sizeof(buf));
+    writer.ImplicitProfileId = TestProfile_2;
+
+    WriteEncoding1(inSuite, writer);
+
+    uint32_t encodedLen = writer.GetLengthWritten();
+
+    NL_TEST_ASSERT(inSuite, encodedLen == sizeof(Encoding1));
+    NL_TEST_ASSERT(inSuite, memcmp(buf, Encoding1, encodedLen) == 0);
+
+    reader.Init(buf, encodedLen);
+    reader.ImplicitProfileId = TestProfile_2;
+
+    reader1.Init(reader);
+    err = reader1.Next();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    // Find a tag
+    TLVReader tagReader;
+    err = chip::TLV::Utilities::Find(reader, ProfileTag(TestProfile_2, 65536), tagReader);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    // Find with reader positioned "on" the element of interest
+    err = chip::TLV::Utilities::Find(reader1, ProfileTag(TestProfile_1, 1), tagReader);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    // Find a tag that's not present
+    err = chip::TLV::Utilities::Find(reader, ProfileTag(TestProfile_2, 1024), tagReader);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_TLV_TAG_NOT_FOUND);
+
+    // Find with a predicate
+    {
+        uint8_t buf1[74];
+
+        writer.Init(buf1, sizeof(buf1));
+        writer.ImplicitProfileId = TestProfile_2;
+
+        WriteEncoding2(inSuite, writer);
+
+        // Initialize a reader
+        reader1.Init(buf1, writer.GetLengthWritten());
+        reader1.ImplicitProfileId = TestProfile_2;
+
+        // position the reader on the first element
+        reader1.Next();
+        uint64_t tag = ProfileTag(TestProfile_1, 1);
+        err = chip::TLV::Utilities::Find(reader1, FindContainerWithElement, &tag, tagReader, false);
+        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_TLV_TAG_NOT_FOUND);
+
+        tag = ProfileTag(TestProfile_2, 2);
+        err = chip::TLV::Utilities::Find(reader1, FindContainerWithElement, &tag, tagReader, false);
+        NL_TEST_ASSERT(inSuite, err ==  CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, tagReader.GetType() == kTLVType_Structure);
+        NL_TEST_ASSERT(inSuite, tagReader.GetTag() == ProfileTag(TestProfile_1, 1));
+
+        // Position the reader on the second element
+        reader1.Next();
+        err = chip::TLV::Utilities::Find(reader1, FindContainerWithElement, &tag, tagReader, false);
+        NL_TEST_ASSERT(inSuite, err ==  CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, tagReader.GetType() == kTLVType_Structure);
+        NL_TEST_ASSERT(inSuite, tagReader.GetTag() == ProfileTag(TestProfile_2, 1));
+    }
+
+    // Count
+    size_t count;
+    const size_t expectedCount = 17;
+    reader1.Init(reader);
+    reader1.Next();
+
+    err = chip::TLV::Utilities::Count(reader, count);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, count == expectedCount);
+
+    // Count with reader already positioned "on" the first element in the encoding
+    err = chip::TLV::Utilities::Count(reader1, count);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, count == expectedCount);
+
+    // Iterate
+    err = chip::TLV::Utilities::Iterate(reader, NullIterateHandler, NULL);
+    NL_TEST_ASSERT(inSuite, err == CHIP_END_OF_TLV);
+}
+
+/**
+ *  Test Weave TLV Empty Find
+ */
+void CheckWeaveTLVEmptyFind(nlTestSuite *inSuite, void *inContext)
+{
+    uint8_t buf[30];
+    TLVWriter writer;
+    TLVReader reader;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    writer.Init(buf, sizeof(buf));
+    writer.ImplicitProfileId = TestProfile_2;
+
+    WriteEmptyEncoding(inSuite, writer);
+
+    uint32_t encodedLen = writer.GetLengthWritten();
+
+    reader.Init(buf, encodedLen);
+    reader.ImplicitProfileId = TestProfile_2;
+
+    // Find the empty container
+    TLVReader tagReader;
+    err = chip::TLV::Utilities::Find(reader, ProfileTag(TestProfile_1, 256), tagReader);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+}
+
+uint8_t Encoding2[] =
+{
+    // Container 1
+    0xD5, 0xBB, 0xAA, 0xDD, 0xCC, 0x01, 0x00,
+        0xC9, 0xBB, 0xAA, 0xDD, 0xCC, 0x02, 0x00,
+        0x88, 0x02, 0x00,
+    0x18,
+    // Container 2
+    0x95, 0x01, 0x00,
+        0x88, 0x02, 0x00,
+        0xC9, 0xBB, 0xAA, 0xDD, 0xCC, 0x02, 0x00,
+    0x18
+};
+
+uint8_t AppendedEncoding2[] =
+{
+    // Container 1
+    0xD5, 0xBB, 0xAA, 0xDD, 0xCC, 0x01, 0x00,
+        0xC9, 0xBB, 0xAA, 0xDD, 0xCC, 0x02, 0x00,
+        0x88, 0x02, 0x00,
+        0xC8, 0xBB, 0xAA, 0xDD, 0xCC, 0x02, 0x00,
+        0x89, 0x02, 0x00,
+        0xD5, 0xBB, 0xAA, 0xDD, 0xCC, 0x01, 0x00,
+            0xC9, 0xBB, 0xAA, 0xDD, 0xCC, 0x02, 0x00,
+            0x88, 0x02, 0x00,
+        0x18,
+        0x95, 0x01, 0x00,
+            0x88, 0x02, 0x00,
+            0xC9, 0xBB, 0xAA, 0xDD, 0xCC, 0x02, 0x00,
+        0x18,
+    0x18,
+    // Container 2
+    0x95, 0x01, 0x00,
+        0x88, 0x02, 0x00,
+        0xC9, 0xBB, 0xAA, 0xDD, 0xCC, 0x02, 0x00,
+    0x18
+};
+
+void WriteAppendReadTest0(nlTestSuite *inSuite)
+{
+    uint8_t buf[74];
+    uint32_t updatedLen;
+
+    TLVWriter writer;
+    TLVReader reader;
+
+    writer.Init(buf, sizeof(buf));
+    writer.ImplicitProfileId = TestProfile_2;
+
+    WriteEncoding2(inSuite, writer);
+
+    uint32_t encodedLen = writer.GetLengthWritten();
+
+#ifdef DUMP_ENCODING
+    printf("Initial encoding:\n");
+    for (uint32_t i = 0; i < encodedLen; i++)
+    {
+        if (i != 0 && i % 16 == 0)
+            printf("\n");
+        printf("0x%02X, ", buf[i]);
+    }
+    printf("\n");
+#endif
+
+    NL_TEST_ASSERT(inSuite, encodedLen == sizeof(Encoding2));
+    NL_TEST_ASSERT(inSuite, memcmp(buf, Encoding2, encodedLen) == 0);
+
+    // Append new data into encoding
+    AppendEncoding2(inSuite, buf, encodedLen, sizeof(buf), updatedLen);
+
+#ifdef DUMP_ENCODING
+    printf("Updated encoding:\n");
+    for (uint32_t i = 0; i < updatedLen; i++)
+    {
+        if (i != 0 && i % 16 == 0)
+            printf("\n");
+        printf("0x%02X, ", buf[i]);
+    }
+    printf("\n");
+#endif
+
+    NL_TEST_ASSERT(inSuite, updatedLen == sizeof(AppendedEncoding2));
+    NL_TEST_ASSERT(inSuite, memcmp(buf, AppendedEncoding2, updatedLen) == 0);
+
+    reader.Init(buf, updatedLen);
+    reader.ImplicitProfileId = TestProfile_2;
+
+    ReadAppendedEncoding2(inSuite, reader);
+}
+
+void WriteFindAppendReadTest(nlTestSuite *inSuite, bool findContainer)
+{
+    uint8_t buf[74];
+    uint32_t updatedLen;
+
+    TLVWriter writer;
+    TLVReader reader;
+
+    writer.Init(buf, sizeof(buf));
+    writer.ImplicitProfileId = TestProfile_2;
+
+    WriteEncoding2(inSuite, writer);
+
+    uint32_t encodedLen = writer.GetLengthWritten();
+
+#ifdef DUMP_ENCODING
+    printf("Initial encoding:\n");
+    for (uint32_t i = 0; i < encodedLen; i++)
+    {
+        if (i != 0 && i % 16 == 0)
+            printf("\n");
+        printf("0x%02X, ", buf[i]);
+    }
+    printf("\n");
+#endif
+
+    NL_TEST_ASSERT(inSuite, encodedLen == sizeof(Encoding2));
+    NL_TEST_ASSERT(inSuite, memcmp(buf, Encoding2, encodedLen) == 0);
+
+    // Append new data into encoding
+    FindAppendEncoding2(inSuite, buf, encodedLen, sizeof(buf), updatedLen, findContainer);
+
+#ifdef DUMP_ENCODING
+    printf("Updated encoding:\n");
+    for (uint32_t i = 0; i < updatedLen; i++)
+    {
+        if (i != 0 && i % 16 == 0)
+            printf("\n");
+        printf("0x%02X, ", buf[i]);
+    }
+    printf("\n");
+#endif
+
+    NL_TEST_ASSERT(inSuite, updatedLen == sizeof(AppendedEncoding2));
+    NL_TEST_ASSERT(inSuite, memcmp(buf, AppendedEncoding2, updatedLen) == 0);
+
+    reader.Init(buf, updatedLen);
+    reader.ImplicitProfileId = TestProfile_2;
+
+    ReadAppendedEncoding2(inSuite, reader);
+}
+
+uint8_t Encoding3[] =
+{
+    // Container 1
+    0xD5, 0xBB, 0xAA, 0xDD, 0xCC, 0x01, 0x00,
+        0x88, 0x02, 0x00,
+    0x18,
+};
+
+uint8_t AppendedEncoding3[] =
+{
+    // Container 1
+    0xD5, 0xBB, 0xAA, 0xDD, 0xCC, 0x01, 0x00,
+        0x88, 0x02, 0x00,
+        0x89, 0x02, 0x00,
+    0x18
+};
+
+void WriteAppendReadTest1(nlTestSuite *inSuite)
+{
+    uint8_t buf[14];
+    uint32_t updatedLen;
+
+    TLVWriter writer;
+    TLVReader reader;
+
+    writer.Init(buf, sizeof(buf));
+    writer.ImplicitProfileId = TestProfile_2;
+
+    WriteEncoding3(inSuite, writer);
+
+    uint32_t encodedLen = writer.GetLengthWritten();
+
+#ifdef DUMP_ENCODING
+    printf("Initial encoding:\n");
+    for (uint32_t i = 0; i < encodedLen; i++)
+    {
+        if (i != 0 && i % 16 == 0)
+            printf("\n");
+        printf("0x%02X, ", buf[i]);
+    }
+    printf("\n");
+#endif
+
+    NL_TEST_ASSERT(inSuite, encodedLen == sizeof(Encoding3));
+    NL_TEST_ASSERT(inSuite, memcmp(buf, Encoding3, encodedLen) == 0);
+
+    // Append new data into encoding
+    AppendEncoding3(inSuite, buf, encodedLen, sizeof(buf), updatedLen);
+
+#ifdef DUMP_ENCODING
+    printf("Updated encoding:\n");
+    for (uint32_t i = 0; i < updatedLen; i++)
+    {
+        if (i != 0 && i % 16 == 0)
+            printf("\n");
+        printf("0x%02X, ", buf[i]);
+    }
+    printf("\n");
+#endif
+
+    NL_TEST_ASSERT(inSuite, updatedLen == sizeof(AppendedEncoding3));
+    NL_TEST_ASSERT(inSuite, memcmp(buf, AppendedEncoding3, updatedLen) == 0);
+
+    reader.Init(buf, updatedLen);
+    reader.ImplicitProfileId = TestProfile_2;
+
+    ReadAppendedEncoding3(inSuite, reader);
+}
+
+uint8_t AppendedEncoding4[] =
+{
+    // Container 1
+    0xD5, 0xBB, 0xAA, 0xDD, 0xCC, 0x01, 0x00,
+        0x88, 0x02, 0x00,
+    0x18,
+};
+
+void AppendReadTest(nlTestSuite *inSuite)
+{
+    uint8_t buf[11];
+    uint32_t updatedLen;
+
+    memset(buf, 0, sizeof(buf));
+
+#ifdef DUMP_ENCODING
+    printf("Initial encoding:\n");
+    for (uint32_t i = 0; i < sizeof(buf); i++)
+    {
+        if (i != 0 && i % 16 == 0)
+            printf("\n");
+        printf("0x%02X, ", buf[i]);
+    }
+    printf("\n");
+#endif
+
+    // Append new data to encoding
+    AppendEncoding4(inSuite, buf, 0, sizeof(buf), updatedLen);
+
+#ifdef DUMP_ENCODING
+    printf("Updated encoding:\n");
+    for (uint32_t i = 0; i < updatedLen; i++)
+    {
+        if (i != 0 && i % 16 == 0)
+            printf("\n");
+        printf("0x%02X, ", buf[i]);
+    }
+    printf("\n");
+#endif
+
+    NL_TEST_ASSERT(inSuite, updatedLen == sizeof(AppendedEncoding4));
+    NL_TEST_ASSERT(inSuite, memcmp(buf, AppendedEncoding4, updatedLen) == 0);
+
+    TLVReader reader;
+    reader.Init(buf, updatedLen);
+    reader.ImplicitProfileId = TestProfile_2;
+
+    ReadAppendedEncoding4(inSuite, reader);
+}
+
+uint8_t Encoding5[] =
+{
+    // Container 1
+    0xD5, 0xBB, 0xAA, 0xDD, 0xCC, 0x01, 0x00,
+        0xC9, 0xBB, 0xAA, 0xDD, 0xCC, 0x02, 0x00,
+        0x88, 0x02, 0x00,
+        0xC8, 0xBB, 0xAA, 0xDD, 0xCC, 0x02, 0x00,
+        0x89, 0x02, 0x00,
+        0xD5, 0xBB, 0xAA, 0xDD, 0xCC, 0x01, 0x00,
+            0xC9, 0xBB, 0xAA, 0xDD, 0xCC, 0x02, 0x00,
+            0x88, 0x02, 0x00,
+        0x18,
+        0x95, 0x01, 0x00,
+            0x88, 0x02, 0x00,
+            0xC9, 0xBB, 0xAA, 0xDD, 0xCC, 0x02, 0x00,
+        0x18,
+    0x18,
+    // Container 2
+    0x95, 0x01, 0x00,
+        0x88, 0x02, 0x00,
+        0xC9, 0xBB, 0xAA, 0xDD, 0xCC, 0x02, 0x00,
+    0x18
+};
+
+uint8_t DeletedEncoding5[] =
+{
+    // Container 1
+    0xD5, 0xBB, 0xAA, 0xDD, 0xCC, 0x01, 0x00,
+        0xC9, 0xBB, 0xAA, 0xDD, 0xCC, 0x02, 0x00,
+        0x88, 0x02, 0x00,
+    0x18,
+    // Container 2
+    0x95, 0x01, 0x00,
+        0x88, 0x02, 0x00,
+        0xC9, 0xBB, 0xAA, 0xDD, 0xCC, 0x02, 0x00,
+    0x18
+};
+
+void WriteDeleteReadTest(nlTestSuite *inSuite)
+{
+    uint8_t buf[74];
+    uint32_t updatedLen;
+
+    TLVWriter writer;
+    TLVReader reader;
+
+    writer.Init(buf, sizeof(buf));
+    writer.ImplicitProfileId = TestProfile_2;
+
+    WriteEncoding5(inSuite, writer);
+
+    uint32_t encodedLen = writer.GetLengthWritten();
+
+#ifdef DUMP_ENCODING
+    for (uint32_t i = 0; i < encodedLen; i++)
+    {
+        if (i != 0 && i % 16 == 0)
+            printf("\n");
+        printf("0x%02X, ", buf[i]);
+    }
+    printf("\n");
+#endif
+
+    NL_TEST_ASSERT(inSuite, encodedLen == sizeof(Encoding5));
+    NL_TEST_ASSERT(inSuite, memcmp(buf, Encoding5, encodedLen) == 0);
+
+    // Delete some elements from the encoding
+    DeleteEncoding5(inSuite, buf, encodedLen, sizeof(buf), updatedLen);
+
+    NL_TEST_ASSERT(inSuite, updatedLen == sizeof(DeletedEncoding5));
+    NL_TEST_ASSERT(inSuite, memcmp(buf, DeletedEncoding5, updatedLen) == 0);
+
+    reader.Init(buf, updatedLen);
+    reader.ImplicitProfileId = TestProfile_2;
+
+    ReadDeletedEncoding5(inSuite, reader);
+}
+
+/**
+ *  Test Packet Buffer
+ */
+void CheckPacketBuffer(nlTestSuite *inSuite, void *inContext)
+{
+    PacketBuffer *buf = PacketBuffer::New(0);
+    TLVWriter writer;
+    TLVReader reader;
+
+    writer.Init(buf);
+    writer.ImplicitProfileId = TestProfile_2;
+
+    WriteEncoding1(inSuite, writer);
+
+    TestBufferContents(inSuite, buf, Encoding1, sizeof(Encoding1));
+
+    reader.Init(buf);
+    reader.ImplicitProfileId = TestProfile_2;
+
+    ReadEncoding1(inSuite, reader);
+
+    reader.Init(buf, buf->MaxDataLength(), false);
+    reader.ImplicitProfileId = TestProfile_2;
+
+    ReadEncoding1(inSuite, reader);
+
+    PacketBuffer::Free(buf);
+}
+
+CHIP_ERROR CountEvictedMembers(CHIPCircularTLVBuffer &inBuffer, void * inAppData, TLVReader &inReader)
+{
+    TestTLVContext *context = static_cast<TestTLVContext *>(inAppData);
+    CHIP_ERROR err;
+
+    // "Process" the first element in the reader
+    err = inReader.Next();
+    NL_TEST_ASSERT(context->mSuite, err == CHIP_NO_ERROR);
+
+    err = inReader.Skip();
+    NL_TEST_ASSERT(context->mSuite, err == CHIP_NO_ERROR);
+
+    context->mEvictionCount++;
+    context->mEvictedBytes += inReader.GetLengthRead();
+
+    return CHIP_NO_ERROR;
+}
+
+void CheckCircularTLVBufferSimple(nlTestSuite *inSuite, void *inContext)
+{
+    // Write 40 bytes as 4 separate events into a 30 byte buffer.  On
+    // completion of the test, the buffer should contain 2 elements
+    // and 2 elements should have been evicted in the last call to
+    // WriteEncoding.
+
+    uint8_t backingStore[30];
+    CircularTLVWriter writer;
+    CircularTLVReader reader;
+    TestTLVContext *context = static_cast<TestTLVContext *>(inContext);
+    CHIPCircularTLVBuffer buffer(backingStore, 30);
+    writer.Init(&buffer);
+    writer.ImplicitProfileId = TestProfile_2;
+
+    context->mEvictionCount = 0;
+    context->mEvictedBytes = 0;
+
+    buffer.mProcessEvictedElement = CountEvictedMembers;
+    buffer.mAppData = inContext;
+
+    writer.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+
+    WriteEncoding3(inSuite, writer);
+
+    WriteEncoding3(inSuite, writer);
+
+    WriteEncoding3(inSuite, writer);
+
+    NL_TEST_ASSERT(inSuite, context->mEvictionCount == 2);
+    NL_TEST_ASSERT(inSuite, context->mEvictedBytes == 18);
+    NL_TEST_ASSERT(inSuite, buffer.DataLength() == 22);
+    NL_TEST_ASSERT(inSuite, (buffer.DataLength() + context->mEvictedBytes) ==  writer.GetLengthWritten());
+
+    // At this point the buffer should contain 2 instances of Encoding3.
+    reader.Init(&buffer);
+    reader.ImplicitProfileId = TestProfile_2;
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    ReadEncoding3(inSuite, reader);
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    ReadEncoding3(inSuite, reader);
+
+    // Check that the reader is out of data
+    TestEnd<TLVReader>(inSuite, reader);
+}
+
+void CheckCircularTLVBufferStartMidway(nlTestSuite *inSuite, void *inContext)
+{
+    // Write 40 bytes as 4 separate events into a 30 byte buffer.  On
+    // completion of the test, the buffer should contain 2 elements
+    // and 2 elements should have been evicted in the last call to
+    // WriteEncoding.
+
+    uint8_t backingStore[30];
+    CircularTLVWriter writer;
+    CircularTLVReader reader;
+    TestTLVContext *context = static_cast<TestTLVContext *>(inContext);
+    CHIPCircularTLVBuffer buffer(backingStore, 30, &(backingStore[15]));
+    writer.Init(&buffer);
+    writer.ImplicitProfileId = TestProfile_2;
+
+    context->mEvictionCount = 0;
+    context->mEvictedBytes = 0;
+
+    buffer.mProcessEvictedElement = CountEvictedMembers;
+    buffer.mAppData = inContext;
+
+    writer.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+
+    WriteEncoding3(inSuite, writer);
+
+    WriteEncoding3(inSuite, writer);
+
+    WriteEncoding3(inSuite, writer);
+
+    NL_TEST_ASSERT(inSuite, context->mEvictionCount == 2);
+    NL_TEST_ASSERT(inSuite, context->mEvictedBytes == 18);
+    NL_TEST_ASSERT(inSuite, buffer.DataLength() == 22);
+    NL_TEST_ASSERT(inSuite, (buffer.DataLength() + context->mEvictedBytes) ==  writer.GetLengthWritten());
+
+    // At this point the buffer should contain 2 instances of Encoding3.
+    reader.Init(&buffer);
+    reader.ImplicitProfileId = TestProfile_2;
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    ReadEncoding3(inSuite, reader);
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    ReadEncoding3(inSuite, reader);
+
+    // Check that the reader is out of data
+    TestEnd<TLVReader>(inSuite, reader);
+}
+
+void CheckCircularTLVBufferEvictStraddlingEvent(nlTestSuite *inSuite, void *inContext)
+{
+    // Write 95 bytes to the buffer as 9 different TLV elements: 1
+    // 7-byte element and 8 11-byte elements.
+    // On completion of the test, the buffer should contain 2 elements
+    // and 7 elements should have been evicted in the last call to
+    // WriteEncoding.
+
+    TestTLVContext *context = static_cast<TestTLVContext *>(inContext);
+    uint8_t backingStore[30];
+    CircularTLVWriter writer;
+    CircularTLVReader reader;
+    CHIPCircularTLVBuffer buffer(backingStore, 30);
+    writer.Init(&buffer);
+    writer.ImplicitProfileId = TestProfile_2;
+
+    context->mEvictionCount = 0;
+    context->mEvictedBytes = 0;
+
+    buffer.mProcessEvictedElement = CountEvictedMembers;
+    buffer.mAppData = inContext;
+
+    writer.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+
+    WriteEncoding3(inSuite, writer);
+
+    WriteEncoding3(inSuite, writer);
+
+    WriteEncoding3(inSuite, writer);
+
+    WriteEncoding3(inSuite, writer);
+
+    // the write below will evict an element that straddles the buffer boundary.
+    WriteEncoding3(inSuite, writer);
+
+    WriteEncoding3(inSuite, writer);
+
+    WriteEncoding3(inSuite, writer);
+
+    WriteEncoding3(inSuite, writer);
+
+    NL_TEST_ASSERT(inSuite, writer.GetLengthWritten() == (8 * 11 + 7)); // 8 writes of Encoding3 (11 bytes each) and 7 bytes for the initial boolean.
+    NL_TEST_ASSERT(inSuite, buffer.DataLength() == 22);
+    NL_TEST_ASSERT(inSuite, (buffer.DataLength() + context->mEvictedBytes) ==  writer.GetLengthWritten());
+    NL_TEST_ASSERT(inSuite, context->mEvictionCount == 7);
+
+    // At this point the buffer should contain 2 instances of Encoding3.
+    reader.Init(&buffer);
+    reader.ImplicitProfileId = TestProfile_2;
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    ReadEncoding3(inSuite, reader);
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    ReadEncoding3(inSuite, reader);
+
+    // Check that the reader is out of data
+    TestEnd<TLVReader>(inSuite, reader);
+}
+
+void CheckCircularTLVBufferEdge(nlTestSuite *inSuite, void *inContext)
+{
+    TestTLVContext *context = static_cast<TestTLVContext *>(inContext);
+    CHIP_ERROR err;
+    uint8_t backingStore[7];
+    uint8_t backingStore1[14];
+    CircularTLVWriter writer;
+    CircularTLVReader reader;
+    TLVWriter writer1;
+
+    CHIPCircularTLVBuffer buffer(backingStore, sizeof(backingStore));
+    CHIPCircularTLVBuffer buffer1(backingStore1, sizeof(backingStore1));
+    writer.Init(&buffer);
+    writer.ImplicitProfileId = TestProfile_2;
+
+    context->mEvictionCount = 0;
+    context->mEvictedBytes = 0;
+
+    buffer.mProcessEvictedElement = CountEvictedMembers;
+    buffer.mAppData = inContext;
+
+    // Test eviction for an element that fits in the underlying buffer exactly
+    err = writer.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.PutBoolean(ProfileTag(TestProfile_1, 2), false);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Finalize();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    // At this point the buffer should contain only the boolean we just wrote
+    reader.Init(&buffer);
+    reader.ImplicitProfileId = TestProfile_2;
+
+    TestNext<TLVReader>(inSuite, reader);
+    TestGet<TLVReader, bool>(inSuite, reader, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), false);
+
+    // Check that the reader is out of data
+    TestEnd<TLVReader>(inSuite, reader);
+
+    // verify that an element larger than the underlying buffer fails out.
+    err = writer.OpenContainer(ProfileTag(TestProfile_1, 1), kTLVType_Structure, writer1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer1.PutBoolean(ProfileTag(TestProfile_2, 2), false);
+    NL_TEST_ASSERT(inSuite, err == CHIP_END_OF_TLV);
+
+    // Verify reader correctness
+
+    // Write an element that takes half of the buffer, and evict it.
+    // Do it 2 times, so we test what happens when the head is at the
+    // middle and at the end of the buffer but the buffer is empty.
+    int i = 0;
+    for (i = 0; i < 2; i++)
+    {
+        writer.Init(&buffer1);
+        writer.ImplicitProfileId = TestProfile_2;
+
+        err = writer.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer.Finalize();
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        reader.Init(&buffer1);
+        reader.ImplicitProfileId = TestProfile_2;
+
+        TestNext<TLVReader>(inSuite, reader);
+        TestGet<TLVReader, bool>(inSuite, reader, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
+        TestEnd<TLVReader>(inSuite, reader);
+
+        buffer1.EvictHead();
+
+        reader.Init(&buffer1);
+        reader.ImplicitProfileId = TestProfile_2;
+        TestEnd<TLVReader>(inSuite, reader);
+    }
+
+
+    writer.Init(&buffer1);
+    writer.ImplicitProfileId = TestProfile_2;
+
+    context->mEvictionCount = 0;
+    context->mEvictedBytes = 0;
+
+    buffer1.mProcessEvictedElement = CountEvictedMembers;
+    buffer1.mAppData = inContext;
+
+    // Two elements fit in the buffer exactly
+    err = writer.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.PutBoolean(ProfileTag(TestProfile_1, 2), false);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Finalize();
+
+    // Verify that we can read out two elements from the buffer
+    reader.Init(&buffer1);
+    reader.ImplicitProfileId = TestProfile_2;
+
+    TestNext<TLVReader>(inSuite, reader);
+    TestGet<TLVReader, bool>(inSuite, reader, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
+
+    TestNext<TLVReader>(inSuite, reader);
+    TestGet<TLVReader, bool>(inSuite, reader, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), false);
+
+    TestEnd<TLVReader>(inSuite, reader);
+
+    // Check that the eviction works as expected
+
+    buffer1.EvictHead();
+
+    // At this point the buffer should contain only the second boolean
+    reader.Init(&buffer1);
+    reader.ImplicitProfileId = TestProfile_2;
+
+    TestNext<TLVReader>(inSuite, reader);
+    TestGet<TLVReader, bool>(inSuite, reader, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), false);
+
+    // Check that the reader is out of data
+    TestEnd<TLVReader>(inSuite, reader);
+
+    // Write another boolean, verify that the buffer is full and contains two booleans
+
+    writer.Init(&buffer1);
+    writer.ImplicitProfileId = TestProfile_2;
+
+    err = writer.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Finalize();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    // Verify that we can read out two elements from the buffer
+    reader.Init(&buffer1);
+    reader.ImplicitProfileId = TestProfile_2;
+
+    TestNext<TLVReader>(inSuite, reader);
+    TestGet<TLVReader, bool>(inSuite, reader, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), false);
+
+    TestNext<TLVReader>(inSuite, reader);
+    TestGet<TLVReader, bool>(inSuite, reader, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
+
+    TestEnd<TLVReader>(inSuite, reader);
+
+    // Evict the elements from the buffer, verfiy that we have an
+    // empty reader on our hands
+
+    buffer1.EvictHead();
+    buffer1.EvictHead();
+
+    reader.Init(&buffer1);
+    reader.ImplicitProfileId = TestProfile_2;
+
+    TestEnd<TLVReader>(inSuite, reader);
+
+}
+void CheckWeaveTLVPutStringF(nlTestSuite *inSuite, void *inContext)
+{
+    const size_t bufsize = 24;
+    char strBuffer[bufsize];
+    char valStr[bufsize];
+    uint8_t backingStore[bufsize];
+    TLVWriter writer;
+    TLVReader reader;
+    size_t num = 1;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    writer.Init(backingStore, bufsize);
+    snprintf(strBuffer, sizeof(strBuffer), "Sample string %zu", num);
+
+    err = writer.PutStringF(ProfileTag(TestProfile_1, 1), "Sample string %zu", num);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Finalize();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    reader.Init(backingStore, writer.GetLengthWritten());
+    err = reader.Next();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = reader.GetString(valStr, 256);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, strncmp(valStr, strBuffer, 256) == 0);
+}
+
+void CheckWeaveTLVPutStringFCircular(nlTestSuite *inSuite, void *inContext)
+{
+    const size_t bufsize = 40;
+    char strBuffer[bufsize];
+    char valStr[bufsize];
+    uint8_t backingStore[bufsize];
+    CircularTLVWriter writer;
+    CircularTLVReader reader;
+    CHIPCircularTLVBuffer buffer(backingStore, bufsize);
+    size_t num = 1;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    // Initial test: Verify that a straight printf works as expected into continuous buffer.
+
+    writer.Init(&buffer);
+    snprintf(strBuffer, sizeof(strBuffer), "Sample string %zu", num);
+
+    err = writer.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Finalize();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.PutStringF(ProfileTag(TestProfile_1, 1), "Sample string %zu", num);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Finalize();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    reader.Init(&buffer);
+
+    //Skip over the initial element
+    err = reader.Next();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = reader.Next();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = reader.GetString(valStr, bufsize);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, strncmp(valStr, strBuffer, bufsize) == 0);
+
+    // Verify that the PutStringF will handle correctly the case with the discontinuous buffer
+    // This print will both stradle the boundary of the buffer and displace the previous two elements.
+    num = 2;
+
+    snprintf(strBuffer, sizeof(strBuffer), "Sample string %zu", num);
+
+    err = writer.PutStringF(ProfileTag(TestProfile_1, 1), "Sample string %zu", num);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Finalize();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    reader.Init(&buffer);
+    err = reader.Next();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = reader.GetString(valStr, bufsize);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, strncmp(valStr, strBuffer, bufsize) == 0);
+}
+
+void CheckWeaveTLVSkipCircular(nlTestSuite *inSuite, void * inContext)
+{
+    const size_t bufsize = 40; // large enough s.t. 2 elements fit, 3rd causes eviction
+    uint8_t backingStore[bufsize];
+    char testString[] = "Sample string"; // 13 characters, without the trailing NULL, add 3 bytes for anon tag
+    // Any pair of reader and writer would work here, either PacketBuffer based or CircularTLV based.
+    CircularTLVWriter writer;
+    CircularTLVReader reader;
+    CHIPCircularTLVBuffer buffer(backingStore, bufsize);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    writer.Init(&buffer);
+
+    err = writer.PutString(AnonymousTag, testString);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.PutString(AnonymousTag, testString);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.PutString(AnonymousTag, testString); // This event straddles the boundary
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.PutString(AnonymousTag, testString); // This one does not.
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Finalize();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    reader.Init(&buffer);
+
+    err = reader.Next(); // position the reader at the straddling element
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = reader.Skip(); // // Test that the buf ptr is handled correctly within the ReadData() function.
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+}
+
+/**
+ *  Test Buffer Overflow
+ */
+void CheckBufferOverflow(nlTestSuite *inSuite, void *inContext)
+{
+    TLVWriter writer;
+    TLVReader reader;
+
+    PacketBuffer *buf = PacketBuffer::New(0);
+    uint16_t maxDataLen = buf->MaxDataLength();
+    uint16_t reserve = (sizeof(Encoding1) < maxDataLen) ? (maxDataLen - sizeof(Encoding1)) + 2 : 0;
+
+    // Repeatedly write and read a TLV encoding to a chain of PacketBuffers. Use progressively larger
+    // and larger amounts of space in the first buffer to force the encoding/decoding to overlap the
+    // end of the buffer and the beginning of the next.
+    for ( ; reserve < maxDataLen; reserve++)
+    {
+        buf->SetStart(buf->Start() + reserve);
+
+        writer.Init(buf);
+        writer.GetNewBuffer = TLVWriter::GetNewPacketBuffer;
+        writer.ImplicitProfileId = TestProfile_2;
+
+        WriteEncoding1(inSuite, writer);
+
+        TestBufferContents(inSuite, buf, Encoding1, sizeof(Encoding1));
+
+        reader.Init(buf, 0xFFFFFFFFUL, true);
+        reader.ImplicitProfileId = TestProfile_2;
+
+        ReadEncoding1(inSuite, reader);
+
+        PacketBuffer::Free(buf);
+
+        buf = PacketBuffer::New(0);
+    }
+}
+
+/**
+ * Test case to verify the correctness of TLVReader::GetTag()
+ *
+ * TLVReader::GetTag() does not return the correct tag value when the
+ * the compiler optimization level contains strict aliasing. In the below
+ * example, the returned tag value would be 0xe, instead of 0xe00000001.
+ *
+ * The issue has been spotted on debug builds.
+ *
+ */
+static const uint8_t sIdentifyResponseBuf[] =
+{
+    0xD5, 0x00, 0x00, 0x0E, 0x00, 0x01, 0x00, 0x25,
+    0x00, 0x5A, 0x23, 0x24, 0x01, 0x07, 0x24, 0x02,
+    0x05, 0x25, 0x03, 0x22, 0x1E, 0x2C, 0x04, 0x10,
+    0x30, 0x34, 0x41, 0x41, 0x30, 0x31, 0x41, 0x43,
+    0x32, 0x33, 0x31, 0x34, 0x30, 0x30, 0x4C, 0x50,
+    0x2C, 0x09, 0x06, 0x31, 0x2E, 0x34, 0x72, 0x63,
+    0x35, 0x24, 0x0C, 0x01, 0x18,
+};
+
+static const uint32_t kIdentifyResponseLen = 53;
+
+void CheckStrictAliasing(nlTestSuite *inSuite, void *inContext)
+{
+    const uint32_t kProfile_Id = 0x0000000e;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    TLVReader reader;
+
+    reader.Init(sIdentifyResponseBuf, kIdentifyResponseLen);
+    reader.ImplicitProfileId = kProfile_Id;
+
+    err = reader.Next();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, reader.GetTag() == 0xe00000001);
+}
+
+/**
+ *  Test Weave TLV Writer Copy Container
+ */
+void TestWeaveTLVWriterCopyContainer(nlTestSuite *inSuite)
+{
+    uint8_t buf[2048];
+
+    {
+        TLVWriter writer;
+        TLVReader reader;
+
+        reader.Init(Encoding1, sizeof(Encoding1));
+        reader.ImplicitProfileId = TestProfile_2;
+
+        TestNext<TLVReader>(inSuite, reader);
+
+        writer.Init(buf, sizeof(buf));
+        writer.ImplicitProfileId = TestProfile_2;
+
+        CHIP_ERROR err = writer.CopyContainer(reader);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        uint32_t encodedLen = writer.GetLengthWritten();
+        NL_TEST_ASSERT(inSuite, encodedLen == sizeof(Encoding1));
+
+        int memcmpRes = memcmp(buf, Encoding1, encodedLen);
+        NL_TEST_ASSERT(inSuite, memcmpRes == 0);
+    }
+
+    {
+        TLVWriter writer;
+
+        writer.Init(buf, sizeof(buf));
+        writer.ImplicitProfileId = TestProfile_2;
+
+        CHIP_ERROR err = writer.CopyContainer(ProfileTag(TestProfile_1, 1), Encoding1, sizeof(Encoding1));
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        uint32_t encodedLen = writer.GetLengthWritten();
+        NL_TEST_ASSERT(inSuite, encodedLen == sizeof(Encoding1));
+
+        int memcmpRes = memcmp(buf, Encoding1, encodedLen);
+        NL_TEST_ASSERT(inSuite, memcmpRes == 0);
+
+    }
+}
+
+/**
+ *  Test Weave TLV Writer Copy Element
+ */
+void TestWeaveTLVWriterCopyElement(nlTestSuite *inSuite)
+{
+    CHIP_ERROR err;
+    uint8_t expectedBuf[2048], testBuf[2048];
+    uint32_t expectedLen, testLen;
+    TLVWriter writer;
+    TLVType outerContainerType;
+    enum { kRepeatCount = 3 };
+
+    writer.Init(expectedBuf, sizeof(expectedBuf));
+    writer.ImplicitProfileId = TestProfile_2;
+
+    err = writer.StartContainer(AnonymousTag, kTLVType_Structure, outerContainerType);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    for (int i = 0; i < kRepeatCount; i++)
+    {
+        WriteEncoding1(inSuite, writer);
+    }
+
+    err = writer.EndContainer(outerContainerType);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Finalize();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    expectedLen= writer.GetLengthWritten();
+
+    writer.Init(testBuf, sizeof(testBuf));
+    writer.ImplicitProfileId = TestProfile_2;
+
+    err = writer.StartContainer(AnonymousTag, kTLVType_Structure, outerContainerType);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    for (int i = 0; i < kRepeatCount; i++)
+    {
+        TLVReader reader;
+
+        reader.Init(Encoding1, sizeof(Encoding1));
+        reader.ImplicitProfileId = TestProfile_2;
+
+        TestNext<TLVReader>(inSuite, reader);
+
+        err = writer.CopyElement(reader);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    }
+
+    err = writer.EndContainer(outerContainerType);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Finalize();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    testLen = writer.GetLengthWritten();
+
+    NL_TEST_ASSERT(inSuite, testLen == expectedLen);
+
+    int memcmpRes = memcmp(testBuf, expectedBuf, testLen);
+    NL_TEST_ASSERT(inSuite, memcmpRes == 0);
+}
+
+void PreserveSizeWrite(nlTestSuite *inSuite, TLVWriter& writer, bool preserveSize)
+{
+    CHIP_ERROR err;
+    TLVWriter writer2;
+
+    // kTLVTagControl_FullyQualified_8Bytes
+    err = writer.Put(ProfileTag(TestProfile_1, 4000000000ULL), (int64_t) 40000000000ULL, true);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Put(ProfileTag(TestProfile_1, 4000000000ULL), (int16_t) 12345, true);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Put(ProfileTag(TestProfile_1, 4000000000ULL), (float) 1.0);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.OpenContainer(ProfileTag(TestProfile_1, 1), kTLVType_Structure, writer2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    {
+        TLVWriter writer3;
+
+        err = writer2.OpenContainer(ContextTag(0), kTLVType_Array, writer3);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer3.Put(AnonymousTag, (uint8_t) 42, preserveSize);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer3.Put(AnonymousTag, (uint16_t) 42, preserveSize);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer3.Put(AnonymousTag, (uint32_t) 42, preserveSize);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer3.Put(AnonymousTag, (uint64_t) 40000000000ULL, preserveSize);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer3.Put(AnonymousTag, (int8_t) -17, preserveSize);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer3.Put(AnonymousTag, (int16_t) -17, preserveSize);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer3.Put(AnonymousTag, (int32_t) -170000, preserveSize);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer3.Put(AnonymousTag, (int64_t) -170000, preserveSize);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        // the below cases are for full coverage of PUTs
+        err = writer3.Put(AnonymousTag, (uint64_t) 65535, false);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer3.Put(AnonymousTag, (int64_t) 32767, false);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer3.Put(AnonymousTag, (int64_t) 40000000000ULL, false);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer2.CloseContainer(writer3);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    }
+
+    err = writer.CloseContainer(writer2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Finalize();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+}
+
+/**
+ *  Test Weave TLV Writer with Preserve Size
+ */
+void TestWeaveTLVWriterPreserveSize(nlTestSuite *inSuite)
+{
+    uint8_t buf[2048];
+    TLVWriter writer;
+
+    writer.Init(buf, sizeof(buf));
+    writer.ImplicitProfileId = TestProfile_2;
+
+    PreserveSizeWrite(inSuite, writer, true);
+
+    uint32_t encodedLen = writer.GetLengthWritten();
+    NL_TEST_ASSERT(inSuite, encodedLen == 105);
+}
+
+/**
+ *  Test error handling of Weave TLV Writer
+ */
+void TestWeaveTLVWriterErrorHandling(nlTestSuite *inSuite)
+{
+    CHIP_ERROR err;
+    uint8_t buf[2048];
+    TLVWriter writer, writer2, writer3;
+
+    writer.Init(buf, sizeof(buf));
+    writer.ImplicitProfileId = TestProfile_2;
+
+    // OpenContainer() for non-container
+    err = writer.OpenContainer(ProfileTag(TestProfile_1, 1), kTLVType_Boolean, writer2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_WRONG_TLV_TYPE);
+
+    // CloseContainer() for non-container
+    err = writer.CloseContainer(writer2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
+
+    // OpenContainer() failure
+    err = writer.OpenContainer(ProfileTag(TestProfile_1, 1), kTLVType_Structure, writer2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer2.OpenContainer(ProfileTag(TestProfile_1, 1), kTLVType_Structure, writer3);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    // CloseContainer() failure
+    err = writer.CloseContainer(writer2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_TLV_CONTAINER_OPEN);
+
+    // StartContainer()
+    TLVType outerContainerType;
+    err = writer.StartContainer(ProfileTag(TestProfile_2, 4000000000ULL), kTLVType_Boolean, outerContainerType);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_WRONG_TLV_TYPE);
+
+    // EndContainer()
+    outerContainerType = kTLVType_Boolean;
+    err = writer.EndContainer(outerContainerType);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
+
+    // PutPreEncodedContainer()
+    TLVReader reader;
+    reader.Init(buf, 2048);
+    err = writer.PutPreEncodedContainer(ProfileTag(TestProfile_2, 4000000000ULL), kTLVType_Boolean, reader.GetReadPoint(), reader.GetRemainingLength());
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
+}
+
+/**
+ *  Test Weave TLV Writer
+ */
+void CheckWeaveTLVWriter(nlTestSuite *inSuite, void *inContext)
+{
+    TestWeaveTLVWriterCopyContainer(inSuite);
+
+    TestWeaveTLVWriterCopyElement(inSuite);
+
+    TestWeaveTLVWriterPreserveSize(inSuite);
+
+    TestWeaveTLVWriterErrorHandling(inSuite);
+}
+
+void SkipNonContainer(nlTestSuite *inSuite)
+{
+    TLVReader reader;
+    const uint8_t *readpoint1 = NULL;
+    const uint8_t *readpoint2 = NULL;
+
+    reader.Init(Encoding1, sizeof(Encoding1));
+    reader.ImplicitProfileId = TestProfile_2;
+
+    TestSkip(inSuite, reader);
+
+    readpoint1 = reader.GetReadPoint();
+
+    // Skip again, to check the operation is idempotent
+    TestSkip(inSuite, reader);
+
+    readpoint2 = reader.GetReadPoint();
+
+    NL_TEST_ASSERT(inSuite, readpoint1 == readpoint2);
+}
+
+void SkipContainer(nlTestSuite *inSuite)
+{
+    TLVReader reader;
+    const uint8_t *readpoint1 = NULL;
+    const uint8_t *readpoint2 = NULL;
+
+    reader.Init(Encoding1, sizeof(Encoding1));
+    reader.ImplicitProfileId = TestProfile_2;
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    TestSkip(inSuite, reader);
+
+    readpoint1 = reader.GetReadPoint();
+
+    // Skip again, to check the operation is idempotent
+    TestSkip(inSuite, reader);
+
+    readpoint2 = reader.GetReadPoint();
+
+    NL_TEST_ASSERT(inSuite, readpoint1 == readpoint2);
+}
+
+void NextContainer(nlTestSuite *inSuite)
+{
+    TLVReader reader;
+
+    reader.Init(Encoding1, sizeof(Encoding1));
+    reader.ImplicitProfileId = TestProfile_2;
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    CHIP_ERROR err = reader.Next();
+    NL_TEST_ASSERT(inSuite, err == CHIP_END_OF_TLV);
+}
+
+/**
+ *  Test Weave TLV Reader Skip functions
+ */
+void TestWeaveTLVReaderSkip(nlTestSuite *inSuite)
+{
+    SkipNonContainer(inSuite);
+
+    SkipContainer(inSuite);
+
+    NextContainer(inSuite);
+}
+
+/**
+ *  Test Weave TLV Reader Dup functions
+ */
+void TestWeaveTLVReaderDup(nlTestSuite *inSuite)
+{
+    TLVReader reader;
+
+    reader.Init(Encoding1, sizeof(Encoding1));
+    reader.ImplicitProfileId = TestProfile_2;
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    {
+        TLVReader reader2;
+
+        TestAndOpenContainer(inSuite, reader, kTLVType_Structure, ProfileTag(TestProfile_1, 1), reader2);
+
+        TestNext<TLVReader>(inSuite, reader2);
+
+        TestGet<TLVReader, bool>(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
+
+        TestNext<TLVReader>(inSuite, reader2);
+
+        TestGet<TLVReader, bool>(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
+
+        TestNext<TLVReader>(inSuite, reader2);
+
+        {
+            TLVReader reader3;
+
+            TestAndOpenContainer(inSuite, reader2, kTLVType_Array, ContextTag(0), reader3);
+
+            TestNext<TLVReader>(inSuite, reader3);
+
+            TestGet<TLVReader, int8_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
+            TestGet<TLVReader, int16_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
+            TestGet<TLVReader, int32_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
+            TestGet<TLVReader, int64_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
+            TestGet<TLVReader, uint32_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
+            TestGet<TLVReader, uint64_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
+
+            TestNext<TLVReader>(inSuite, reader3);
+
+            TestGet<TLVReader, int8_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, -17);
+            TestGet<TLVReader, int16_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, -17);
+            TestGet<TLVReader, int32_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, -17);
+            TestGet<TLVReader, int64_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, -17);
+
+            TestNext<TLVReader>(inSuite, reader3);
+
+            TestGet<TLVReader, int32_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, -170000);
+            TestGet<TLVReader, int64_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, -170000);
+
+            TestNext<TLVReader>(inSuite, reader3);
+
+            TestGet<TLVReader, int64_t>(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag, 40000000000ULL);
+            TestGet<TLVReader, uint64_t>(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag, 40000000000ULL);
+
+            TestNext<TLVReader>(inSuite, reader3);
+
+            {
+                TLVReader reader4;
+
+                TestAndOpenContainer(inSuite, reader3, kTLVType_Structure, AnonymousTag, reader4);
+
+                TestEndAndCloseContainer(inSuite, reader3, reader4);
+            }
+
+            TestNext<TLVReader>(inSuite, reader3);
+
+            {
+                TLVReader reader5;
+
+                TestAndOpenContainer(inSuite, reader3, kTLVType_Path, AnonymousTag, reader5);
+
+                TestNext<TLVReader>(inSuite, reader5);
+
+                TestNull(inSuite, reader5, ProfileTag(TestProfile_1, 17));
+
+                TestNext<TLVReader>(inSuite, reader5);
+
+                TestNull(inSuite, reader5, ProfileTag(TestProfile_2, 900000));
+
+                TestNext<TLVReader>(inSuite, reader5);
+
+                {
+                    TLVType outerContainerType;
+
+                    TestAndEnterContainer<TLVReader>(inSuite, reader5, kTLVType_Structure, ProfileTag(TestProfile_2, 4000000000ULL), outerContainerType);
+
+                    TestNext<TLVReader>(inSuite, reader5);
+
+                    TestDupString(inSuite, reader5, CommonTag(70000), sLargeString);
+
+                    TestEndAndExitContainer<TLVReader>(inSuite, reader5, outerContainerType);
+                }
+
+                TestEndAndCloseContainer(inSuite, reader3, reader5);
+            }
+
+            TestEndAndCloseContainer(inSuite, reader2, reader3);
+        }
+
+        TestNext<TLVReader>(inSuite, reader2);
+
+        TestDupBytes(inSuite, reader2, ProfileTag(TestProfile_1, 5), (uint8_t *)("This is a test"), 14);
+
+        TestNext<TLVReader>(inSuite, reader2);
+
+        TestGet<TLVReader, double>(inSuite, reader2, kTLVType_FloatingPointNumber, ProfileTag(TestProfile_2, 65535), (float)17.9);
+
+        TestNext<TLVReader>(inSuite, reader2);
+
+        TestGet<TLVReader, double>(inSuite, reader2, kTLVType_FloatingPointNumber, ProfileTag(TestProfile_2, 65536), (double)17.9);
+
+        TestEndAndCloseContainer(inSuite, reader, reader2);
+    }
+
+    TestEnd<TLVReader>(inSuite, reader);
+}
+/**
+ *  Test error handling of Weave TLV Reader
+ */
+void TestWeaveTLVReaderErrorHandling(nlTestSuite *inSuite)
+{
+    CHIP_ERROR err;
+    uint8_t buf[2048];
+    TLVReader reader;
+
+    reader.Init(buf, sizeof(buf));
+    reader.ImplicitProfileId = TestProfile_2;
+
+    // Get(bool&)
+    bool val;
+    err = reader.Get(val);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_WRONG_TLV_TYPE);
+
+    // Get(double&)
+    double numD;
+    err = reader.Get(numD);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_WRONG_TLV_TYPE);
+
+    // Get(uint64_t&)
+    uint64_t num;
+    err = reader.Get(num);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_WRONG_TLV_TYPE);
+
+    // GetBytes()
+    uint8_t bBuf[16];
+    err = reader.GetBytes(bBuf, sizeof(bBuf));
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_WRONG_TLV_TYPE);
+
+    // GetString()
+    char sBuf[16];
+    err = reader.GetString(sBuf, sizeof(sBuf));
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_WRONG_TLV_TYPE);
+
+    // OpenContainer()
+    TLVReader reader2;
+    err = reader.OpenContainer(reader2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
+
+    // CloseContainer()
+    err = reader.CloseContainer(reader2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
+
+    // EnterContainer()
+    TLVType outerContainerType = kTLVType_Boolean;
+    err = reader.EnterContainer(outerContainerType);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
+
+    // DupString()
+    char *str = (char *)malloc(16);
+    err = reader.DupString(str);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_WRONG_TLV_TYPE);
+    free(str);
+
+    // GetDataPtr()
+    const uint8_t *data = (uint8_t *)malloc(16);
+    err = reader.GetDataPtr(data);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_WRONG_TLV_TYPE);
+    free((void *)data);
+}
+/**
+ *  Test Weave TLV Reader in a use case
+ */
+void TestWeaveTLVReaderInPractice(nlTestSuite *inSuite)
+{
+    uint8_t buf[2048];
+    TLVWriter writer;
+    TLVReader reader;
+
+    writer.Init(buf, sizeof(buf));
+    writer.ImplicitProfileId = TestProfile_2;
+
+    PreserveSizeWrite(inSuite, writer, true);
+
+    reader.Init(buf, sizeof(buf));
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    TestGet<TLVReader, int64_t>(inSuite, reader, kTLVType_SignedInteger, ProfileTag(TestProfile_1, 4000000000ULL), (int64_t) 40000000000ULL);
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    TestGet<TLVReader, int64_t>(inSuite, reader, kTLVType_SignedInteger, ProfileTag(TestProfile_1, 4000000000ULL), (int16_t) 12345);
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    TestGet<TLVReader, double>(inSuite, reader, kTLVType_FloatingPointNumber, ProfileTag(TestProfile_1, 4000000000ULL), (float) 1.0);
+}
+
+void TestWeaveTLVReader_NextOverContainer_ProcessElement(nlTestSuite *inSuite, TLVReader& reader, void *context)
+{
+    CHIP_ERROR err, nextRes1, nextRes2;
+    TLVType outerContainerType;
+
+    // If the current element is a container...
+    if (TLVTypeIsContainer(reader.GetType()))
+    {
+        // Make two copies of the reader
+        TLVReader readerClone1 = reader;
+        TLVReader readerClone2 = reader;
+
+        // Manually advance one of the readers to the element immediately after the container (if any).
+        err = readerClone1.EnterContainer(outerContainerType);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        ForEachElement(inSuite, readerClone1, NULL, NULL);
+        err = readerClone1.ExitContainer(outerContainerType);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        nextRes1 = readerClone1.Next();
+        NL_TEST_ASSERT(inSuite, nextRes1 == CHIP_NO_ERROR || nextRes1 == CHIP_END_OF_TLV);
+
+        // For the other reader, skip over the entire container using the Next() method.
+        nextRes2 = readerClone2.Next();
+        NL_TEST_ASSERT(inSuite, nextRes2 == CHIP_NO_ERROR || nextRes2 == CHIP_END_OF_TLV);
+
+        // Verify the two readers end up in the same state/position.
+        NL_TEST_ASSERT(inSuite, nextRes1 == nextRes2);
+        NL_TEST_ASSERT(inSuite, readerClone1.GetType() == readerClone2.GetType());
+        NL_TEST_ASSERT(inSuite, readerClone1.GetReadPoint() == readerClone2.GetReadPoint());
+    }
+}
+
+/**
+ * Test using Weave TLV Reader Next() method to skip over containers.
+ */
+void TestWeaveTLVReader_NextOverContainer(nlTestSuite *inSuite)
+{
+    TLVReader reader;
+
+    reader.Init(Encoding1, sizeof(Encoding1));
+    reader.ImplicitProfileId = TestProfile_2;
+
+    ForEachElement(inSuite, reader, NULL, TestWeaveTLVReader_NextOverContainer_ProcessElement);
+}
+
+void TestWeaveTLVReader_SkipOverContainer_ProcessElement(nlTestSuite *inSuite, TLVReader& reader, void *context)
+{
+    CHIP_ERROR err;
+    TLVType outerContainerType;
+
+    // If the current element is a container...
+    if (TLVTypeIsContainer(reader.GetType()))
+    {
+        // Make two copies of the reader
+        TLVReader readerClone1 = reader;
+        TLVReader readerClone2 = reader;
+
+        // Manually advance one of the readers to immediately after the container.
+        err = readerClone1.EnterContainer(outerContainerType);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        ForEachElement(inSuite, readerClone1, NULL, NULL);
+        err = readerClone1.ExitContainer(outerContainerType);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        // For the other reader, skip over the entire container using the Skip() method.
+        err = readerClone2.Skip();
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        // Verify the two readers end up in the same state/position.
+        NL_TEST_ASSERT(inSuite, readerClone1.GetType() == readerClone2.GetType());
+        NL_TEST_ASSERT(inSuite, readerClone1.GetReadPoint() == readerClone2.GetReadPoint());
+    }
+}
+
+/**
+ * Test using Weave TLV Reader Skip() method to skip over containers.
+ */
+void TestWeaveTLVReader_SkipOverContainer(nlTestSuite *inSuite)
+{
+    TLVReader reader;
+
+    reader.Init(Encoding1, sizeof(Encoding1));
+    reader.ImplicitProfileId = TestProfile_2;
+
+    ForEachElement(inSuite, reader, NULL, TestWeaveTLVReader_SkipOverContainer_ProcessElement);
+}
+
+/**
+ *  Test Weave TLV Reader
+ */
+void CheckWeaveTLVReader(nlTestSuite *inSuite, void *inContext)
+{
+    TestWeaveTLVReaderSkip(inSuite);
+
+    TestWeaveTLVReaderDup(inSuite);
+
+    TestWeaveTLVReaderErrorHandling(inSuite);
+
+    TestWeaveTLVReaderInPractice(inSuite);
+
+    TestWeaveTLVReader_NextOverContainer(inSuite);
+
+    TestWeaveTLVReader_SkipOverContainer(inSuite);
+}
+
+/**
+ *  Test Weave TLV Items
+ */
+static void TestItems(nlTestSuite *inSuite, void *inContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    uint8_t sBuffer[256];
+
+    TLVWriter writer;
+    writer.Init(sBuffer, sizeof(sBuffer));
+
+    TLVWriter writer2;
+    err = writer.OpenContainer(AnonymousTag, kTLVType_Array, writer2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    {
+        err = writer2.PutBoolean(AnonymousTag, true);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer2.Put(AnonymousTag, static_cast<int8_t>(-1));
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer2.Put(AnonymousTag, static_cast<int16_t>(-2));
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer2.Put(AnonymousTag, static_cast<int32_t>(-3));
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer2.Put(AnonymousTag, static_cast<int64_t>(-4));
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer2.Put(AnonymousTag, static_cast<float>(-5.5));
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer2.Put(AnonymousTag, static_cast<double>(-3.14159265358979323846));
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    }
+
+    err = writer.CloseContainer(writer2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.OpenContainer(AnonymousTag, kTLVType_Array, writer2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    {
+        err = writer2.PutBoolean(AnonymousTag, false);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer2.Put(AnonymousTag, static_cast<int8_t>(1));
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer2.Put(AnonymousTag, static_cast<int16_t>(2));
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer2.Put(AnonymousTag, static_cast<int32_t>(3));
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer2.Put(AnonymousTag, static_cast<int64_t>(4));
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer2.Put(AnonymousTag, static_cast<uint8_t>(5));
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer2.Put(AnonymousTag, static_cast<uint16_t>(6));
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer2.Put(AnonymousTag, static_cast<uint32_t>(7));
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer2.Put(AnonymousTag, static_cast<uint64_t>(8));
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer2.Put(AnonymousTag, static_cast<float>(9.9));
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer2.Put(AnonymousTag, static_cast<double>(3.14159265358979323846));
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    }
+
+    err = writer.CloseContainer(writer2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Finalize();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+}
+
+/**
+ *  Test Weave TLV Containers
+ */
+static void TestContainers(nlTestSuite *inSuite, void *inContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    TLVWriter writer;
+
+    uint8_t sBuffer[256];
+    writer.Init(sBuffer, sizeof(sBuffer));
+
+    TLVWriter writer2;
+    err = writer.OpenContainer(AnonymousTag, kTLVType_Array, writer2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    TLVType type = writer2.GetContainerType();
+    NL_TEST_ASSERT(inSuite, type == kTLVType_Array);
+
+    err = writer.CloseContainer(writer2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.OpenContainer(AnonymousTag, kTLVType_Structure, writer2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    type = writer2.GetContainerType();
+    NL_TEST_ASSERT(inSuite, type == kTLVType_Structure);
+
+    err = writer.CloseContainer(writer2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Finalize();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+}
+
+/**
+ *  Test Weave TLV Basics
+ */
+static void CheckWeaveTLVBasics(nlTestSuite *inSuite, void *inContext)
+{
+    TestItems(inSuite, inContext);
+    TestContainers(inSuite, inContext);
+}
+
+/**
+ *  Test Weave TLV Updater
+ */
+static void CheckWeaveUpdater(nlTestSuite *inSuite, void *inContext)
+{
+    WriteAppendReadTest0(inSuite);
+
+    WriteAppendReadTest1(inSuite);
+
+    WriteFindAppendReadTest(inSuite, false); // Find an element
+
+    WriteFindAppendReadTest(inSuite, true);  // Find a container
+
+    AppendReadTest(inSuite);
+
+    WriteDeleteReadTest(inSuite);
+}
+
+/**
+ * Test TLV CloseContainer symbol reservations
+ */
+
+class OptimisticTLVWriter : public TLVWriter
+{
+public:
+    void Init(uint8_t *buf, uint32_t maxLen);
+};
+
+void OptimisticTLVWriter::Init(uint8_t *buf, uint32_t maxLen)
+{
+    TLVWriter::Init(buf, maxLen);
+    SetCloseContainerReserved(false);
+}
+
+static void CheckCloseContainerReserve(nlTestSuite *inSuite, void *inContext)
+{
+    // We are writing the structure looking like:
+    //
+    // [{TestProfile_1:2: true}]
+    //
+    // the above should consume 11 bytes in the TLV encoding. The
+    // chosen buffer is too small for that, this test verifies that we
+    // fail in the right places in the code.  With the standard
+    // TLVWriter, we now make provisions to reserve the space for the
+    // CloseContainer tag in the OpenContainer call.  As a result, we
+    // expect to error out when we attempt to write out the value for
+    // the TestProfile_1:2 tag.  In contrast, the
+    // `OptimisticTLVWriter` implements the earlier TLVWriter behavior
+    // and fails out in the last CloseContainer call.  The error
+    // caught there is different because we run up against the mMaxLen
+    // rather than mRemainingLen check.
+
+    uint8_t buf[10];
+    uint8_t buf1[7];
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    TLVWriter writer1;
+    OptimisticTLVWriter writer2;
+    TLVWriter innerWriter1, innerWriter2;
+    TLVType container1, container2;
+
+    writer1.Init(buf, sizeof(buf));
+
+    err = writer1.OpenContainer(AnonymousTag, kTLVType_Array, innerWriter1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = innerWriter1.OpenContainer(AnonymousTag, kTLVType_Structure, innerWriter2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = innerWriter2.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    err = innerWriter1.CloseContainer(innerWriter2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer1.CloseContainer(innerWriter1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    writer2.Init(buf, sizeof(buf));
+
+    err = writer2.OpenContainer(AnonymousTag, kTLVType_Array, innerWriter1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = innerWriter1.OpenContainer(AnonymousTag, kTLVType_Structure, innerWriter2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = innerWriter2.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = innerWriter1.CloseContainer(innerWriter2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer2.CloseContainer(innerWriter1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    // test the same scheme works on the Start/End container
+
+    writer1.Init(buf, sizeof(buf));
+
+    err = writer1.StartContainer(AnonymousTag, kTLVType_Array, container1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer1.StartContainer(AnonymousTag, kTLVType_Structure, container2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer1.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    err = writer1.EndContainer(container2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer1.EndContainer(container1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    writer2.Init(buf, sizeof(buf));
+
+    err = writer2.StartContainer(AnonymousTag, kTLVType_Array, container1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer2.StartContainer(AnonymousTag, kTLVType_Structure, container2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer2.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer2.EndContainer(container2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer2.EndContainer(container1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    // Test that the reservations work for the empty containers
+
+    writer1.Init(buf1, sizeof(buf1));
+    err = writer1.OpenContainer(ProfileTag(TestProfile_1, 2), kTLVType_Structure, innerWriter1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    err = writer1.CloseContainer(innerWriter1);
+    NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
+
+    writer2.Init(buf1, sizeof(buf1));
+    err = writer2.OpenContainer(ProfileTag(TestProfile_1, 2), kTLVType_Structure, innerWriter1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer2.CloseContainer(innerWriter1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    writer1.Init(buf1, sizeof(buf1));
+
+    err = writer1.StartContainer(ProfileTag(TestProfile_1, 2), kTLVType_Structure, container1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    err = writer1.EndContainer(container1);
+    NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
+
+    writer2.Init(buf1, sizeof(buf1));
+
+    err = writer2.StartContainer(ProfileTag(TestProfile_1, 2), kTLVType_Structure, container1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer2.EndContainer(container1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    // Test that the reservations work if the writer has a maxLen of 0.
+
+    writer1.Init(buf1, 0);
+
+    err = writer1.OpenContainer(ProfileTag(TestProfile_1, 2), kTLVType_Structure, innerWriter1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    err = writer1.StartContainer(AnonymousTag, kTLVType_Array, container1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    // Test again all cases from 0 to the length of buf1
+
+    for (size_t maxLen = 0; maxLen <= sizeof(buf); maxLen++)
+    {
+        // Open/CloseContainer
+
+        writer1.Init(buf, maxLen);
+
+        err = writer1.OpenContainer(AnonymousTag, kTLVType_Array, innerWriter1);
+
+        if (err == CHIP_NO_ERROR)
+            err = innerWriter1.OpenContainer(AnonymousTag, kTLVType_Structure, innerWriter2);
+
+        if (err == CHIP_NO_ERROR)
+            err = innerWriter2.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+
+        if (err == CHIP_NO_ERROR)
+            err = innerWriter1.CloseContainer(innerWriter2);
+
+        if (err == CHIP_NO_ERROR)
+            err = writer1.CloseContainer(innerWriter1);
+
+        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_BUFFER_TOO_SMALL);
+
+        // Start/EndContainer
+
+        writer1.Init(buf, maxLen);
+
+        if (err == CHIP_NO_ERROR)
+            err = writer1.StartContainer(AnonymousTag, kTLVType_Array, container1);
+
+        if (err == CHIP_NO_ERROR)
+            err = writer1.StartContainer(AnonymousTag, kTLVType_Structure, container2);
+
+        if (err == CHIP_NO_ERROR)
+            err = writer1.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+
+        if (err == CHIP_NO_ERROR)
+            err = writer1.EndContainer(container2);
+
+        if (err == CHIP_NO_ERROR)
+            err = writer1.EndContainer(container1);
+
+        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_BUFFER_TOO_SMALL);
+    }
+}
+
+// Test Suite
+
+/**
+ *  Test Suite that lists all the test functions.
+ */
+// clang-format off
+static const nlTest sTests[] =
+{
+    NL_TEST_DEF("Simple Write Read Test",              CheckSimpleWriteRead),
+    NL_TEST_DEF("Inet Buffer Test",                    CheckPacketBuffer),
+    NL_TEST_DEF("Buffer Overflow Test",                CheckBufferOverflow),
+    NL_TEST_DEF("Pretty Print Test",                   CheckPrettyPrinter),
+    NL_TEST_DEF("Data Macro Test",                     CheckDataMacro),
+    NL_TEST_DEF("Strict Aliasing Test",                CheckStrictAliasing),
+    NL_TEST_DEF("Weave TLV Basics",                    CheckWeaveTLVBasics),
+    NL_TEST_DEF("Weave TLV Writer",                    CheckWeaveTLVWriter),
+    NL_TEST_DEF("Weave TLV Reader",                    CheckWeaveTLVReader),
+    NL_TEST_DEF("Weave TLV Utilities",                 CheckWeaveTLVUtilities),
+    NL_TEST_DEF("Weave TLV Updater",                   CheckWeaveUpdater),
+    NL_TEST_DEF("Weave TLV Empty Find",                CheckWeaveTLVEmptyFind),
+    NL_TEST_DEF("Weave Circular TLV buffer, simple",   CheckCircularTLVBufferSimple),
+    NL_TEST_DEF("Weave Circular TLV buffer, mid-buffer start", CheckCircularTLVBufferStartMidway),
+    NL_TEST_DEF("Weave Circular TLV buffer, straddle", CheckCircularTLVBufferEvictStraddlingEvent),
+    NL_TEST_DEF("Weave Circular TLV buffer, edge",     CheckCircularTLVBufferEdge),
+    NL_TEST_DEF("Weave TLV Printf",                    CheckWeaveTLVPutStringF),
+    NL_TEST_DEF("Weave TLV Printf, Circular TLV buf",  CheckWeaveTLVPutStringFCircular),
+    NL_TEST_DEF("Weave TLV Skip non-contiguous",       CheckWeaveTLVSkipCircular),
+    NL_TEST_DEF("Weave TLV Check reserve",             CheckCloseContainerReserve),
+
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+/**
+ *  Main
+ */
+int main(int argc, char *argv[])
+{
+    // clang-format off
+    nlTestSuite theSuite =
+    {
+        "chip-tlv",
+        &sTests[0],
+        NULL,
+        NULL
+    };
+    // clang-format on
+    TestTLVContext context;
+
+    context.mSuite = &theSuite;
+
+    // Generate machine-readable, comma-separated value (CSV) output.
+    nl_test_set_output_style(OUTPUT_CSV);
+
+    // Run test suit against one context
+    nlTestRunner(&theSuite, &context);
+
+    return nlTestRunnerStats(&theSuite);
+}


### PR DESCRIPTION
#### Problem
The TLV facility is missing unit tests.

#### Summary of Changes
This adds / imports / migrates unit tests from openweave-core.

Fixes #238
