### PR TITLE
Missing crypto PAL layer #287

### DIFF
--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -24,11 +24,40 @@
 #define _CHIP_CRYPTO_PAL_H_
 
 #include <core/CHIPError.h>
+#include <stddef.h>
 
-CHIP_ERROR CHIP_aes_ccm_encrypt(unsigned char * plaintext, int plaintext_len, unsigned char * aad, int aad_len, unsigned char * key,
-                                unsigned char * iv, unsigned char * ciphertext, unsigned char * tag);
+/**
+ * @brief A function that implements 256-bit AES-CCM encryption
+ * @param plaintext Plaintext to encrypt
+ * @param plaintext_length Length of plain_text
+ * @param aad Additional authentication data
+ * @param aad_length Length of additional authentication data
+ * @param key Encryption key
+ * @param iv Initial vector
+ * @param iv_length Length of initial vector
+ * @param ciphertext Buffer to write ciphertext into. Caller must ensure this is large enough to hold the ciphertext
+ * @param tag Buffer to write tag into. Caller must ensure this is large enough to hold the tag
+ * */
+CHIP_ERROR CHIP_aes_ccm_256_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
+                                    size_t aad_length, const unsigned char * key, const unsigned char * iv, size_t iv_length,
+                                    unsigned char * ciphertext, unsigned char * tag);
 
-CHIP_ERROR CHIP_aes_ccm_decrypt(unsigned char * ciphertext, int ciphertext_len, unsigned char * aad, int aad_len,
-                                unsigned char * tag, unsigned char * key, unsigned char * iv, unsigned char * plaintext);
+/**
+ * @brief A function that implements 256-bit AES-CCM decryption
+ * @param ciphertext Ciphertext to decrypt
+ * @param ciphertext_length Length of ciphertext
+ * @param aad Additional authentical data.
+ * @param aad_length Length of additional authentication data
+ * @param tag Tag to use to decrypt
+ * @param tag_length Length of tag
+ * @param key Decryption key
+ * @param iv Initial vector
+ * @param iv_length Length of initial vector
+ * @param plaintext Buffer to write plaintext into
+ **/
+
+CHIP_ERROR CHIP_aes_ccm_256_decrypt(const unsigned char * ciphertext, size_t ciphertext_length, const unsigned char * aad,
+                                    size_t aad_length, const unsigned char * tag, size_t tag_length, const unsigned char * key,
+                                    const unsigned char * iv, size_t iv_length, unsigned char * plaintext);
 
 #endif

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -37,6 +37,7 @@
  * @param iv_length Length of initial vector
  * @param ciphertext Buffer to write ciphertext into. Caller must ensure this is large enough to hold the ciphertext
  * @param tag Buffer to write tag into. Caller must ensure this is large enough to hold the tag
+ * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  * */
 CHIP_ERROR CHIP_aes_ccm_256_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
                                     size_t aad_length, const unsigned char * key, const unsigned char * iv, size_t iv_length,
@@ -54,6 +55,7 @@ CHIP_ERROR CHIP_aes_ccm_256_encrypt(const unsigned char * plaintext, size_t plai
  * @param iv Initial vector
  * @param iv_length Length of initial vector
  * @param plaintext Buffer to write plaintext into
+ * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  **/
 
 CHIP_ERROR CHIP_aes_ccm_256_decrypt(const unsigned char * ciphertext, size_t ciphertext_length, const unsigned char * aad,

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -36,13 +36,14 @@
  * @param iv Initial vector
  * @param iv_length Length of initial vector
  * @param ciphertext Buffer to write ciphertext into. Caller must ensure this is large enough to hold the ciphertext
+ * @param ciphertext_length Length of generated ciphertext
  * @param tag Buffer to write tag into. Caller must ensure this is large enough to hold the tag
  * @param tag_length Expected length of tag
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  * */
 CHIP_ERROR CHIP_aes_ccm_256_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
                                     size_t aad_length, const unsigned char * key, const unsigned char * iv, size_t iv_length,
-                                    unsigned char * ciphertext, unsigned char * tag, size_t tag_length);
+                                    unsigned char * ciphertext, size_t &ciphertext_length, unsigned char * tag, size_t tag_length);
 
 /**
  * @brief A function that implements 256-bit AES-CCM decryption

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -37,11 +37,12 @@
  * @param iv_length Length of initial vector
  * @param ciphertext Buffer to write ciphertext into. Caller must ensure this is large enough to hold the ciphertext
  * @param tag Buffer to write tag into. Caller must ensure this is large enough to hold the tag
+ * @param tag_length Expected length of tag
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  * */
 CHIP_ERROR CHIP_aes_ccm_256_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
                                     size_t aad_length, const unsigned char * key, const unsigned char * iv, size_t iv_length,
-                                    unsigned char * ciphertext, unsigned char * tag);
+                                    unsigned char * ciphertext, unsigned char * tag, size_t tag_length);
 
 /**
  * @brief A function that implements 256-bit AES-CCM decryption

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -36,14 +36,13 @@
  * @param iv Initial vector
  * @param iv_length Length of initial vector
  * @param ciphertext Buffer to write ciphertext into. Caller must ensure this is large enough to hold the ciphertext
- * @param ciphertext_length Length of generated ciphertext
  * @param tag Buffer to write tag into. Caller must ensure this is large enough to hold the tag
  * @param tag_length Expected length of tag
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  * */
 CHIP_ERROR CHIP_aes_ccm_256_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
                                     size_t aad_length, const unsigned char * key, const unsigned char * iv, size_t iv_length,
-                                    unsigned char * ciphertext, size_t &ciphertext_length, unsigned char * tag, size_t tag_length);
+                                    unsigned char * ciphertext, unsigned char * tag, size_t tag_length);
 
 /**
  * @brief A function that implements 256-bit AES-CCM decryption

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -1,0 +1,34 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Header that exposes the platform agnostic CHIP crypto primitives
+ */
+
+#ifndef _CHIP_CRYPTO_PAL_H_
+#define _CHIP_CRYPTO_PAL_H_
+
+#include <core/CHIPError.h>
+
+CHIP_ERROR CHIP_aes_ccm_encrypt(unsigned char * plaintext, int plaintext_len, unsigned char * aad, int aad_len, unsigned char * key,
+                                unsigned char * iv, unsigned char * ciphertext, unsigned char * tag);
+
+CHIP_ERROR CHIP_aes_ccm_decrypt(unsigned char * ciphertext, int ciphertext_len, unsigned char * aad, int aad_len,
+                                unsigned char * tag, unsigned char * key, unsigned char * iv, unsigned char * plaintext);
+
+#endif

--- a/src/crypto/CHIPCryptoPALOpenSSL.c
+++ b/src/crypto/CHIPCryptoPALOpenSSL.c
@@ -22,15 +22,17 @@
 
 #include "CHIPCryptoPAL.h"
 
-int CHIP_aes_ccm_encrypt(unsigned char * plaintext, int plaintext_len, unsigned char * aad, int aad_len, unsigned char * key,
-                         unsigned char * iv, unsigned char * ciphertext, unsigned char * tag)
+CHIP_ERROR CHIP_aes_ccm_256_encrypt(const unsigned char * plaintext, size_t plaintext_len, const unsigned char * aad,
+                                    size_t aad_len, const unsigned char * key, const unsigned char * iv, size_t iv_length,
+                                    unsigned char * ciphertext, unsigned char * tag)
 {
     // TODO: Need to implement openSSL based AES-CCM #256
     return CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE;
 }
 
-int CHIP_aes_ccm_decrypt(unsigned char * ciphertext, int ciphertext_len, unsigned char * aad, int aad_len, unsigned char * tag,
-                         unsigned char * key, unsigned char * iv, unsigned char * plaintext);
+CHIP_ERROR CHIP_aes_ccm_256_decrypt(const unsigned char * ciphertext, size_t ciphertext_len, const unsigned char * aad,
+                                    size_t aad_len, const unsigned char * tag, size_t tag_length, const unsigned char * key,
+                                    const unsigned char * iv, size_t iv_length, unsigned char * plaintext)
 {
     // TODO: Need to implement openSSL based AES-CCM #256
     return CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE;

--- a/src/crypto/CHIPCryptoPALOpenSSL.c
+++ b/src/crypto/CHIPCryptoPALOpenSSL.c
@@ -24,7 +24,7 @@
 
 CHIP_ERROR CHIP_aes_ccm_256_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
                                     size_t aad_length, const unsigned char * key, const unsigned char * iv, size_t iv_length,
-                                    unsigned char * ciphertext, unsigned char * tag, size_t tag_length)
+                                    unsigned char * ciphertext, size_t & ciphertext_length, unsigned char * tag, size_t tag_length)
 {
     // TODO: Need to implement openSSL based AES-CCM #256
     return CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE;

--- a/src/crypto/CHIPCryptoPALOpenSSL.c
+++ b/src/crypto/CHIPCryptoPALOpenSSL.c
@@ -24,7 +24,7 @@
 
 CHIP_ERROR CHIP_aes_ccm_256_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
                                     size_t aad_length, const unsigned char * key, const unsigned char * iv, size_t iv_length,
-                                    unsigned char * ciphertext, size_t & ciphertext_length, unsigned char * tag, size_t tag_length)
+                                    unsigned char * ciphertext, unsigned char * tag, size_t tag_length)
 {
     // TODO: Need to implement openSSL based AES-CCM #256
     return CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE;

--- a/src/crypto/CHIPCryptoPALOpenSSL.c
+++ b/src/crypto/CHIPCryptoPALOpenSSL.c
@@ -22,9 +22,9 @@
 
 #include "CHIPCryptoPAL.h"
 
-CHIP_ERROR CHIP_aes_ccm_256_encrypt(const unsigned char * plaintext, size_t plaintext_len, const unsigned char * aad,
-                                    size_t aad_len, const unsigned char * key, const unsigned char * iv, size_t iv_length,
-                                    unsigned char * ciphertext, unsigned char * tag)
+CHIP_ERROR CHIP_aes_ccm_256_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
+                                    size_t aad_length, const unsigned char * key, const unsigned char * iv, size_t iv_length,
+                                    unsigned char * ciphertext, unsigned char * tag, size_t tag_length)
 {
     // TODO: Need to implement openSSL based AES-CCM #256
     return CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE;

--- a/src/crypto/CHIPCryptoPALOpenSSL.c
+++ b/src/crypto/CHIPCryptoPALOpenSSL.c
@@ -1,0 +1,37 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      openSSL based implementation of CHIP crypto primitives
+ */
+
+#include "CHIPCryptoPAL.h"
+
+int CHIP_aes_ccm_encrypt(unsigned char * plaintext, int plaintext_len, unsigned char * aad, int aad_len, unsigned char * key,
+                         unsigned char * iv, unsigned char * ciphertext, unsigned char * tag)
+{
+    // TODO: Need to implement openSSL based AES-CCM #256
+    return CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE;
+}
+
+int CHIP_aes_ccm_decrypt(unsigned char * ciphertext, int ciphertext_len, unsigned char * aad, int aad_len, unsigned char * tag,
+                         unsigned char * key, unsigned char * iv, unsigned char * plaintext);
+{
+    // TODO: Need to implement openSSL based AES-CCM #256
+    return CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE;
+}

--- a/src/crypto/CHIPCryptoPALmbedTLS.c
+++ b/src/crypto/CHIPCryptoPALmbedTLS.c
@@ -24,7 +24,7 @@
 
 CHIP_ERROR CHIP_aes_ccm_256_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
                                     size_t aad_length, const unsigned char * key, const unsigned char * iv, size_t iv_length,
-                                    unsigned char * ciphertext, size_t & ciphertext_length, unsigned char * tag, size_t tag_length)
+                                    unsigned char * ciphertext, unsigned char * tag, size_t tag_length)
 {
     // TODO: Need mbedTLS based implementation for AES-CCM #264
     return CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE;

--- a/src/crypto/CHIPCryptoPALmbedTLS.c
+++ b/src/crypto/CHIPCryptoPALmbedTLS.c
@@ -1,0 +1,37 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      mbedTLS based implementation of CHIP crypto primitives
+ */
+
+#include "CHIPCryptoPAL.h"
+
+int CHIP_aes_ccm_encrypt(unsigned char * plaintext, int plaintext_len, unsigned char * aad, int aad_len, unsigned char * key,
+                         unsigned char * iv, unsigned char * ciphertext, unsigned char * tag)
+{
+    // TODO: Need mbedTLS based implementation for AES-CCM #264
+    return CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE;
+}
+
+int CHIP_aes_ccm_decrypt(unsigned char * ciphertext, int ciphertext_len, unsigned char * aad, int aad_len, unsigned char * tag,
+                         unsigned char * key, unsigned char * iv, unsigned char * plaintext);
+{
+    // TODO: Need mbedTLS based implementation for AES-CCM #264
+    return CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE;
+}

--- a/src/crypto/CHIPCryptoPALmbedTLS.c
+++ b/src/crypto/CHIPCryptoPALmbedTLS.c
@@ -24,7 +24,7 @@
 
 CHIP_ERROR CHIP_aes_ccm_256_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
                                     size_t aad_length, const unsigned char * key, const unsigned char * iv, size_t iv_length,
-                                    unsigned char * ciphertext, unsigned char * tag, size_t tag_length)
+                                    unsigned char * ciphertext, size_t & ciphertext_length, unsigned char * tag, size_t tag_length)
 {
     // TODO: Need mbedTLS based implementation for AES-CCM #264
     return CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE;

--- a/src/crypto/CHIPCryptoPALmbedTLS.c
+++ b/src/crypto/CHIPCryptoPALmbedTLS.c
@@ -22,9 +22,9 @@
 
 #include "CHIPCryptoPAL.h"
 
-CHIP_ERROR CHIP_aes_ccm_256_encrypt(const unsigned char * plaintext, size_t plaintext_len, const unsigned char * aad,
-                                    size_t aad_len, const unsigned char * key, const unsigned char * iv, size_t iv_length,
-                                    unsigned char * ciphertext, unsigned char * tag)
+CHIP_ERROR CHIP_aes_ccm_256_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
+                                    size_t aad_length, const unsigned char * key, const unsigned char * iv, size_t iv_length,
+                                    unsigned char * ciphertext, unsigned char * tag, size_t tag_length)
 {
     // TODO: Need mbedTLS based implementation for AES-CCM #264
     return CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE;

--- a/src/crypto/CHIPCryptoPALmbedTLS.c
+++ b/src/crypto/CHIPCryptoPALmbedTLS.c
@@ -22,15 +22,17 @@
 
 #include "CHIPCryptoPAL.h"
 
-int CHIP_aes_ccm_encrypt(unsigned char * plaintext, int plaintext_len, unsigned char * aad, int aad_len, unsigned char * key,
-                         unsigned char * iv, unsigned char * ciphertext, unsigned char * tag)
+CHIP_ERROR CHIP_aes_ccm_256_encrypt(const unsigned char * plaintext, size_t plaintext_len, const unsigned char * aad,
+                                    size_t aad_len, const unsigned char * key, const unsigned char * iv, size_t iv_length,
+                                    unsigned char * ciphertext, unsigned char * tag)
 {
     // TODO: Need mbedTLS based implementation for AES-CCM #264
     return CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE;
 }
 
-int CHIP_aes_ccm_decrypt(unsigned char * ciphertext, int ciphertext_len, unsigned char * aad, int aad_len, unsigned char * tag,
-                         unsigned char * key, unsigned char * iv, unsigned char * plaintext);
+CHIP_ERROR CHIP_aes_ccm_256_decrypt(const unsigned char * ciphertext, size_t ciphertext_len, const unsigned char * aad,
+                                    size_t aad_len, const unsigned char * tag, size_t tag_length, const unsigned char * key,
+                                    const unsigned char * iv, size_t iv_length, unsigned char * plaintext)
 {
     // TODO: Need mbedTLS based implementation for AES-CCM #264
     return CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE;

--- a/src/crypto/Makefile.am
+++ b/src/crypto/Makefile.am
@@ -42,6 +42,7 @@ libChipCrypto_a_SOURCES                                       = \
 dist_libChipCrypto_a_HEADERS                                 = \
     CHIPCrypto.h                                               \
     CHIPBase+CompilerAbstraction.h                             \
+    CHIPCryptoPAL.h                                            \
     $(NULL)
 
 $(RECURSIVE_TARGETS): $(lib_LIBRARIES)


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/issues/287

 #### Problem
We will have two implementations (`openSSL` and `mbedTLS`) of the crypto primitives for CHIP. 
This diff lays out the structure of the header and implementation files of the same. 
The crypto primitive interfaces will be defined in `src/crypto/CHIPCryptoPAL.h`. The `openSSL` implementation will be in `src/crypto/CHIPCryptoPALOpenSSL.c` and the `mbedTLS` implementation will be in `src/crypto/CHIPCryptoPALmbedTLS.c`

This diff does not implement any of the functions yet. This is just so that we have a common file structure of which we can parallelly implement the two stacks.

Also in this diff I am not compiling any of the .c files. I will start doing that once they are actually implemented and also when I figure out how to selectively build one of them based on the target platform. 

fixes Missing crypto PAL layer #287