### PR TITLE
Generalize name of BtpEngine module in BleLayer.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -821,13 +821,13 @@ AC_ARG_ENABLE(chipoble-test,
     ],
     [enable_chipoble_test=no])
 AC_MSG_RESULT(${enable_chipoble_test})
-AM_CONDITIONAL([CHIP_ENABLE_BTP_CODEC_TEST], [test "${enable_chipoble_test}" = "yes"])
+AM_CONDITIONAL([CHIP_ENABLE_BTP_TEST], [test "${enable_chipoble_test}" = "yes"])
 if test "${enable_chipoble_test}" = "yes"; then
-    CHIP_ENABLE_BTP_CODEC_TEST=1
+    CHIP_ENABLE_BTP_TEST=1
 else
-    CHIP_ENABLE_BTP_CODEC_TEST=0
+    CHIP_ENABLE_BTP_TEST=0
 fi
-AC_DEFINE_UNQUOTED([CHIP_ENABLE_BTP_CODEC_TEST],[${CHIP_ENABLE_BTP_CODEC_TEST}],[Define to 1 if you want to enable CHIPoBle Control Path and Throughput Test.])
+AC_DEFINE_UNQUOTED([CHIP_ENABLE_BTP_TEST],[${CHIP_ENABLE_BTP_TEST}],[Define to 1 if you want to enable CHIPoBle Control Path and Throughput Test.])
 #
 # Documentation
 #

--- a/configure.ac
+++ b/configure.ac
@@ -821,13 +821,13 @@ AC_ARG_ENABLE(chipoble-test,
     ],
     [enable_chipoble_test=no])
 AC_MSG_RESULT(${enable_chipoble_test})
-AM_CONDITIONAL([CHIP_ENABLE_BTP_TEST], [test "${enable_chipoble_test}" = "yes"])
+AM_CONDITIONAL([CHIP_ENABLE_CHIPOBLE_TEST], [test "${enable_chipoble_test}" = "yes"])
 if test "${enable_chipoble_test}" = "yes"; then
-    CHIP_ENABLE_BTP_TEST=1
+    CHIP_ENABLE_CHIPOBLE_TEST=1
 else
-    CHIP_ENABLE_BTP_TEST=0
+    CHIP_ENABLE_CHIPOBLE_TEST=0
 fi
-AC_DEFINE_UNQUOTED([CHIP_ENABLE_BTP_TEST],[${CHIP_ENABLE_BTP_TEST}],[Define to 1 if you want to enable CHIPoBle Control Path and Throughput Test.])
+AC_DEFINE_UNQUOTED([CHIP_ENABLE_CHIPOBLE_TEST],[${CHIP_ENABLE_CHIPOBLE_TEST}],[Define to 1 if you want to enable CHIPoBle Control Path and Throughput Test.])
 #
 # Documentation
 #

--- a/src/ble/BLEEndPoint.h
+++ b/src/ble/BLEEndPoint.h
@@ -31,9 +31,9 @@
 #include <system/SystemMutex.h>
 
 #include <ble/BleLayer.h>
-#include <ble/CHIPoBle.h>
-#if CHIP_ENABLE_CHIPOBLE_TEST
-#include <ble/CHIPoBleTest.h>
+#include <ble/BtpEngine.h>
+#if CHIP_ENABLE_BTP_TEST
+#include <ble/BtpEngineTest.h>
 #endif
 
 namespace chip {
@@ -50,16 +50,16 @@ enum
 // Forward declarations
 class BleLayer;
 class BleEndPointPool;
-#if CHIP_ENABLE_CHIPOBLE_TEST
-class CHIPoBleTest;
+#if CHIP_ENABLE_BTP_TEST
+class BtpEngineTest;
 #endif
 
 class DLL_EXPORT BLEEndPoint : public BleLayerObject
 {
     friend class BleLayer;
     friend class BleEndPointPool;
-#if CHIP_ENABLE_CHIPOBLE_TEST
-    friend class CHIPoBleTest;
+#if CHIP_ENABLE_BTP_TEST
+    friend class BtpEngineTest;
 #endif
 
 public:
@@ -87,11 +87,11 @@ public:
     typedef void (*OnConnectionClosedFunct)(BLEEndPoint * endPoint, BLE_ERROR err);
     OnConnectionClosedFunct OnConnectionClosed;
 
-#if CHIP_ENABLE_CHIPOBLE_TEST
+#if CHIP_ENABLE_BTP_TEST
     typedef void (*OnCommandReceivedFunct)(BLEEndPoint * endPoint, PacketBuffer * msg);
     OnCommandReceivedFunct OnCommandReceived;
     inline void SetOnCommandReceivedCB(OnCommandReceivedFunct cb) { OnCommandReceived = cb; };
-    CHIPoBleTest mCHIPoBleTest;
+    BtpEngineTest mBtpEngineTest;
     inline void SetTxWindowSize(uint8_t size) { mRemoteReceiveWindowSize = size; };
     inline void SetRxWindowSize(uint8_t size) { mReceiveWindowMaxSize = size; };
 #endif
@@ -126,7 +126,7 @@ private:
         kTimerState_AckReceivedTimerRunning       = 0x04, // Ack received timer running due to unacked sent fragment.
         kTimerState_SendAckTimerRunning           = 0x08, // Send ack timer running; indicates pending ack to send.
         kTimerState_UnsubscribeTimerRunning       = 0x10, // Unsubscribe completion timer running.
-#if CHIP_ENABLE_CHIPOBLE_TEST
+#if CHIP_ENABLE_BTP_TEST
         kTimerState_UnderTestTimerRunnung = 0x80 // running throughput Tx test
 #endif
     };
@@ -136,7 +136,7 @@ private:
     // modify the state of the underlying BLE connection.
     BLE_CONNECTION_OBJECT mConnObj;
 
-    // Queue of outgoing messages to send when current CHIPoBle transmission completes.
+    // Queue of outgoing messages to send when current BtpEngine transmission completes.
     //
     // Re-used during connection setup to cache capabilities request and response payloads; payloads are freed when
     // connection is established.
@@ -146,14 +146,14 @@ private:
     // progress.
     PacketBuffer * mAckToSend;
 
-    CHIPoBle mCHIPoBle;
+    BtpEngine mBtpEngine;
     BleRole mRole;
     uint8_t mConnStateFlags;
     uint8_t mTimerStateFlags;
     SequenceNumber_t mLocalReceiveWindowSize;
     SequenceNumber_t mRemoteReceiveWindowSize;
     SequenceNumber_t mReceiveWindowMaxSize;
-#if CHIP_ENABLE_CHIPOBLE_TEST
+#if CHIP_ENABLE_BTP_TEST
     chip::System::Mutex mTxQueueMutex; // For MT-safe Tx queuing
 #endif
 
@@ -216,10 +216,10 @@ private:
     void FinalizeClose(uint8_t state, uint8_t flags, BLE_ERROR err);
     void ReleaseBleConnection(void);
     void Free(void);
-    void FreeCHIPoBle(void);
+    void FreeBtpEngine(void);
 
-    // Mutex lock on Tx queue. Used only in CHIPoBle test build for now.
-#if CHIP_ENABLE_CHIPOBLE_TEST
+    // Mutex lock on Tx queue. Used only in BtpEngine test build for now.
+#if CHIP_ENABLE_BTP_TEST
     inline void QueueTxLock() { mTxQueueMutex.Lock(); };
     inline void QueueTxUnlock() { mTxQueueMutex.Unlock(); };
 #else

--- a/src/ble/BLEEndPoint.h
+++ b/src/ble/BLEEndPoint.h
@@ -32,7 +32,7 @@
 
 #include <ble/BleLayer.h>
 #include <ble/BtpEngine.h>
-#if CHIP_ENABLE_BTP_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
 #include <ble/BtpEngineTest.h>
 #endif
 
@@ -50,7 +50,7 @@ enum
 // Forward declarations
 class BleLayer;
 class BleEndPointPool;
-#if CHIP_ENABLE_BTP_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
 class BtpEngineTest;
 #endif
 
@@ -58,7 +58,7 @@ class DLL_EXPORT BLEEndPoint : public BleLayerObject
 {
     friend class BleLayer;
     friend class BleEndPointPool;
-#if CHIP_ENABLE_BTP_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     friend class BtpEngineTest;
 #endif
 
@@ -87,7 +87,7 @@ public:
     typedef void (*OnConnectionClosedFunct)(BLEEndPoint * endPoint, BLE_ERROR err);
     OnConnectionClosedFunct OnConnectionClosed;
 
-#if CHIP_ENABLE_BTP_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     typedef void (*OnCommandReceivedFunct)(BLEEndPoint * endPoint, PacketBuffer * msg);
     OnCommandReceivedFunct OnCommandReceived;
     inline void SetOnCommandReceivedCB(OnCommandReceivedFunct cb) { OnCommandReceived = cb; };
@@ -126,7 +126,7 @@ private:
         kTimerState_AckReceivedTimerRunning       = 0x04, // Ack received timer running due to unacked sent fragment.
         kTimerState_SendAckTimerRunning           = 0x08, // Send ack timer running; indicates pending ack to send.
         kTimerState_UnsubscribeTimerRunning       = 0x10, // Unsubscribe completion timer running.
-#if CHIP_ENABLE_BTP_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
         kTimerState_UnderTestTimerRunnung = 0x80 // running throughput Tx test
 #endif
     };
@@ -153,7 +153,7 @@ private:
     SequenceNumber_t mLocalReceiveWindowSize;
     SequenceNumber_t mRemoteReceiveWindowSize;
     SequenceNumber_t mReceiveWindowMaxSize;
-#if CHIP_ENABLE_BTP_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     chip::System::Mutex mTxQueueMutex; // For MT-safe Tx queuing
 #endif
 
@@ -219,7 +219,7 @@ private:
     void FreeBtpEngine(void);
 
     // Mutex lock on Tx queue. Used only in BtpEngine test build for now.
-#if CHIP_ENABLE_BTP_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     inline void QueueTxLock() { mTxQueueMutex.Lock(); };
     inline void QueueTxUnlock() { mTxQueueMutex.Unlock(); };
 #else

--- a/src/ble/Ble.h
+++ b/src/ble/Ble.h
@@ -35,7 +35,7 @@
 #include <ble/BleLayer.h>
 #include <ble/BlePlatformDelegate.h>
 #include <ble/BleUUID.h>
-#include <ble/CHIPoBle.h>
+#include <ble/BtpEngine.h>
 
 /**
  *   @namespace Ble

--- a/src/ble/BleLayer.am
+++ b/src/ble/BleLayer.am
@@ -29,7 +29,7 @@ CHIP_BUILD_BLE_LAYER_SOURCE_FILES                         = \
     @top_builddir@/src/ble/BleLayer.cpp                     \
     @top_builddir@/src/ble/BleUUID.cpp                      \
     @top_builddir@/src/ble/BLEEndPoint.cpp                  \
-    @top_builddir@/src/ble/CHIPoBle.cpp                     \
+    @top_builddir@/src/ble/BtpEngine.cpp                     \
     $(NULL)
 
 CHIP_BUILD_BLE_LAYER_HEADER_FILES                         = \
@@ -42,5 +42,5 @@ CHIP_BUILD_BLE_LAYER_HEADER_FILES                         = \
     BleLayer.h                                              \
     BlePlatformDelegate.h                                   \
     BleUUID.h                                               \
-    CHIPoBle.h                                              \
+    BtpEngine.h                                              \
     $(NULL)

--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -321,7 +321,7 @@ BLE_ERROR BleLayer::Init(BlePlatformDelegate * platformDelegate, BleApplicationD
 
     mState = kState_Initialized;
 
-#if CHIP_ENABLE_BTP_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     mTestBleEndPoint = NULL;
 #endif
 
@@ -383,7 +383,7 @@ BLE_ERROR BleLayer::NewBleEndPoint(BLEEndPoint ** retEndPoint, BLE_CONNECTION_OB
 
     (*retEndPoint)->Init(this, connObj, role, autoClose);
 
-#if CHIP_ENABLE_BTP_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     mTestBleEndPoint = *retEndPoint;
 #endif
 

--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -321,7 +321,7 @@ BLE_ERROR BleLayer::Init(BlePlatformDelegate * platformDelegate, BleApplicationD
 
     mState = kState_Initialized;
 
-#if CHIP_ENABLE_CHIPOBLE_TEST
+#if CHIP_ENABLE_BTP_TEST
     mTestBleEndPoint = NULL;
 #endif
 
@@ -383,7 +383,7 @@ BLE_ERROR BleLayer::NewBleEndPoint(BLEEndPoint ** retEndPoint, BLE_CONNECTION_OB
 
     (*retEndPoint)->Init(this, connObj, role, autoClose);
 
-#if CHIP_ENABLE_CHIPOBLE_TEST
+#if CHIP_ENABLE_BTP_TEST
     mTestBleEndPoint = *retEndPoint;
 #endif
 

--- a/src/ble/BleLayer.h
+++ b/src/ble/BleLayer.h
@@ -99,7 +99,7 @@ typedef enum
 typedef enum
 {
     kBleTransportProtocolVersion_None = 0,
-    kBleTransportProtocolVersion_V1   = 1, // Prototype CHIPoBle version without ACKs or flow-control.
+    kBleTransportProtocolVersion_V1   = 1, // Prototype BtpEngine version without ACKs or flow-control.
     kBleTransportProtocolVersion_V2   = 2, // First CHIPoBLE version with ACKs and flow-control.
     kBleTransportProtocolVersion_V3   = 3  // First CHIPoBLE version with asymetric fragement sizes.
 } BleTransportProtocolVersion;
@@ -230,8 +230,8 @@ public:
 class DLL_EXPORT BleLayer
 {
     friend class BLEEndPoint;
-#if CHIP_ENABLE_CHIPOBLE_TEST
-    friend class CHIPoBleTest;
+#if CHIP_ENABLE_BTP_TEST
+    friend class BtpEngineTest;
 #endif
 
 public:
@@ -330,7 +330,7 @@ public:
      *   err = BLE_ERROR_APP_CLOSED_CONNECTION to prevent the leak of this chipConnection and its end point object. */
     void HandleConnectionError(BLE_CONNECTION_OBJECT connObj, BLE_ERROR err);
 
-#if CHIP_ENABLE_CHIPOBLE_TEST
+#if CHIP_ENABLE_BTP_TEST
     BLEEndPoint * mTestBleEndPoint;
 #endif
 

--- a/src/ble/BleLayer.h
+++ b/src/ble/BleLayer.h
@@ -99,9 +99,9 @@ typedef enum
 typedef enum
 {
     kBleTransportProtocolVersion_None = 0,
-    kBleTransportProtocolVersion_V1   = 1, // Prototype BtpEngine version without ACKs or flow-control.
-    kBleTransportProtocolVersion_V2   = 2, // First CHIPoBLE version with ACKs and flow-control.
-    kBleTransportProtocolVersion_V3   = 3  // First CHIPoBLE version with asymetric fragement sizes.
+    kBleTransportProtocolVersion_V1   = 1, // Prototype BTP version without ACKs or flow-control.
+    kBleTransportProtocolVersion_V2   = 2, // First BTP version with ACKs and flow-control.
+    kBleTransportProtocolVersion_V3   = 3  // First BTP version with asymetric fragement sizes.
 } BleTransportProtocolVersion;
 
 class BleLayerObject
@@ -230,7 +230,7 @@ public:
 class DLL_EXPORT BleLayer
 {
     friend class BLEEndPoint;
-#if CHIP_ENABLE_BTP_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     friend class BtpEngineTest;
 #endif
 
@@ -330,7 +330,7 @@ public:
      *   err = BLE_ERROR_APP_CLOSED_CONNECTION to prevent the leak of this chipConnection and its end point object. */
     void HandleConnectionError(BLE_CONNECTION_OBJECT connObj, BLE_ERROR err);
 
-#if CHIP_ENABLE_BTP_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     BLEEndPoint * mTestBleEndPoint;
 #endif
 

--- a/src/ble/BtpEngine.cpp
+++ b/src/ble/BtpEngine.cpp
@@ -30,7 +30,7 @@
 #if CONFIG_NETWORK_LAYER_BLE
 
 #include <ble/BtpEngine.h>
-#if CHIP_ENABLE_BTP_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
 #include <ble/BtpEngineTest.h>
 #endif
 
@@ -109,7 +109,7 @@ BLE_ERROR BtpEngine::Init(void * an_app_state, bool expect_first_ack)
     mTxPacketCount         = 0;
     mTxNewestUnackedSeqNum = 0;
     mTxOldestUnackedSeqNum = 0;
-#if CHIP_ENABLE_BTP_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     mTxPacketType = kType_Data; // Default BtpEngine Data packet
     mRxPacketType = kType_Data; // Default BtpEngine Data packet
 #endif
@@ -273,7 +273,7 @@ BLE_ERROR BtpEngine::HandleCharacteristicReceived(PacketBuffer * data, SequenceN
 
     // Get header flags, always in first byte.
     rx_flags = characteristic[cursor++];
-#if CHIP_ENABLE_BTP_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     if (GetFlag(rx_flags, kHeaderFlag_CommandMessage))
         SetRxPacketType(kType_Control);
     else
@@ -484,7 +484,7 @@ bool BtpEngine::HandleCharacteristicSend(PacketBuffer * data, bool send_ack)
 
         characteristic[0] = kHeaderFlag_StartMessage;
 
-#if CHIP_ENABLE_BTP_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
         if (TxPacketType() == kType_Control)
             SetFlag(characteristic[0], kHeaderFlag_CommandMessage, true);
 #endif
@@ -537,7 +537,7 @@ bool BtpEngine::HandleCharacteristicSend(PacketBuffer * data, bool send_ack)
 
         characteristic[0] = kHeaderFlag_ContinueMessage;
 
-#if CHIP_ENABLE_BTP_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
         if (TxPacketType() == kType_Control)
             SetFlag(characteristic[0], kHeaderFlag_CommandMessage, true);
 #endif

--- a/src/ble/BtpEngine.h
+++ b/src/ble/BtpEngine.h
@@ -25,8 +25,8 @@
  *
  */
 
-#ifndef CHIPOBLE_H_
-#define CHIPOBLE_H_
+#ifndef BTP_ENGINE_H_
+#define BTP_ENGINE_H_
 
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS
@@ -46,10 +46,10 @@ namespace Ble {
 
 using ::chip::System::PacketBuffer;
 
-typedef uint8_t SequenceNumber_t; // If type changed from uint8_t, adjust assumptions in CHIPoBle::IsValidAck and
+typedef uint8_t SequenceNumber_t; // If type changed from uint8_t, adjust assumptions in BtpEngine::IsValidAck and
                                   // BLEEndPoint::AdjustReceiveWindow.
 
-#if CHIP_ENABLE_CHIPOBLE_TEST
+#if CHIP_ENABLE_BTP_TEST
 class BLEEndPoint;
 #endif
 
@@ -58,11 +58,11 @@ typedef enum
 {
     kType_Data    = 0, // Default 0 for data
     kType_Control = 1,
-} PacketType_t; // CHIPoBle packet types
+} PacketType_t; // BtpEngine packet types
 
-class CHIPoBle
+class BtpEngine
 {
-#if CHIP_ENABLE_CHIPOBLE_TEST
+#if CHIP_ENABLE_BTP_TEST
     friend class BLEEndPoint;
 #endif
 
@@ -82,7 +82,7 @@ public:
         kHeaderFlag_ContinueMessage = 0x02,
         kHeaderFlag_EndMessage      = 0x04,
         kHeaderFlag_FragmentAck     = 0x08,
-#if CHIP_ENABLE_CHIPOBLE_TEST
+#if CHIP_ENABLE_BTP_TEST
         kHeaderFlag_CommandMessage = 0x10,
 #endif
     }; // Masks for BTP fragment header flag bits.
@@ -92,8 +92,8 @@ public:
 
 public:
     // Public functions:
-    CHIPoBle(void){};
-    ~CHIPoBle(void){};
+    BtpEngine(void){};
+    ~BtpEngine(void){};
 
     BLE_ERROR Init(void * an_app_state, bool expect_first_ack);
 
@@ -113,7 +113,7 @@ public:
 
     inline State_t RxState(void) { return mRxState; }
     inline State_t TxState(void) { return mTxState; }
-#if CHIP_ENABLE_CHIPOBLE_TEST
+#if CHIP_ENABLE_BTP_TEST
     inline PacketType_t SetTxPacketType(PacketType_t type) { return (mTxPacketType = type); };
     inline PacketType_t SetRxPacketType(PacketType_t type) { return (mRxPacketType = type); };
     inline PacketType_t TxPacketType() { return mTxPacketType; };
@@ -135,7 +135,7 @@ public:
         p->SetStart(p->Start() + sizeof(type));
         return type;
     };
-#endif // CHIP_ENABLE_CHIPOBLE_TEST
+#endif // CHIP_ENABLE_BTP_TEST
 
     bool HasUnackedData(void) const;
 
@@ -154,7 +154,7 @@ public:
 
 private:
     // Private data members:
-#if CHIP_ENABLE_CHIPOBLE_TEST
+#if CHIP_ENABLE_BTP_TEST
     PacketType_t mTxPacketType;
     PacketType_t mRxPacketType;
     SequenceNumber_t mTxPacketSeq;
@@ -192,4 +192,4 @@ private:
 } /* namespace Ble */
 } /* namespace chip */
 
-#endif /* CHIPOBLE_H_ */
+#endif /* BTP_ENGINE_H_ */

--- a/src/ble/BtpEngine.h
+++ b/src/ble/BtpEngine.h
@@ -49,7 +49,7 @@ using ::chip::System::PacketBuffer;
 typedef uint8_t SequenceNumber_t; // If type changed from uint8_t, adjust assumptions in BtpEngine::IsValidAck and
                                   // BLEEndPoint::AdjustReceiveWindow.
 
-#if CHIP_ENABLE_BTP_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
 class BLEEndPoint;
 #endif
 
@@ -58,11 +58,11 @@ typedef enum
 {
     kType_Data    = 0, // Default 0 for data
     kType_Control = 1,
-} PacketType_t; // BtpEngine packet types
+} PacketType_t; // BTP packet types
 
 class BtpEngine
 {
-#if CHIP_ENABLE_BTP_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     friend class BLEEndPoint;
 #endif
 
@@ -82,7 +82,7 @@ public:
         kHeaderFlag_ContinueMessage = 0x02,
         kHeaderFlag_EndMessage      = 0x04,
         kHeaderFlag_FragmentAck     = 0x08,
-#if CHIP_ENABLE_BTP_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
         kHeaderFlag_CommandMessage = 0x10,
 #endif
     }; // Masks for BTP fragment header flag bits.
@@ -113,7 +113,7 @@ public:
 
     inline State_t RxState(void) { return mRxState; }
     inline State_t TxState(void) { return mTxState; }
-#if CHIP_ENABLE_BTP_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     inline PacketType_t SetTxPacketType(PacketType_t type) { return (mTxPacketType = type); };
     inline PacketType_t SetRxPacketType(PacketType_t type) { return (mRxPacketType = type); };
     inline PacketType_t TxPacketType() { return mTxPacketType; };
@@ -135,7 +135,7 @@ public:
         p->SetStart(p->Start() + sizeof(type));
         return type;
     };
-#endif // CHIP_ENABLE_BTP_TEST
+#endif // CHIP_ENABLE_CHIPOBLE_TEST
 
     bool HasUnackedData(void) const;
 
@@ -154,7 +154,7 @@ public:
 
 private:
     // Private data members:
-#if CHIP_ENABLE_BTP_TEST
+#if CHIP_ENABLE_CHIPOBLE_TEST
     PacketType_t mTxPacketType;
     PacketType_t mRxPacketType;
     SequenceNumber_t mTxPacketSeq;


### PR DESCRIPTION
The name of the CHIPoBle module is misleading.  

The code actually implements generalized encoding/decoding of BTP (Bluetooth Transport Protocol) packets.

As such, this PR renames the module to BtpEngine for clarity. 
