### PR TITLE
Add / Import Missing Tests for Inet Buffer, EndPoint, and Timer

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -55,12 +55,12 @@ endif # CONFIG_DEVICE_LAYER
 
 DIST_SUBDIRS                      = \
     include                         \
+    system                          \
     $(BLE_SUBDIRS)                  \
     inet                            \
     lib                             \
     lwip                            \
     setup_payload                   \
-    system                          \
     crypto                          \
     $(PLATFORM_SUBDIRS)             \
     $(NULL)
@@ -70,12 +70,12 @@ DIST_SUBDIRS                      = \
 SUBDIRS                           = \
     include                         \
     lib/support                     \
+    system                          \
     $(MAYBE_BLE_SUBDIRS)            \
     inet                            \
     lib                             \
     lwip                            \
     setup_payload                   \
-    system                          \
     crypto                          \
     $(MAYBE_PLATFORM_SUBDIRS)       \
     $(NULL)

--- a/src/inet/tests/Makefile.am
+++ b/src/inet/tests/Makefile.am
@@ -35,12 +35,16 @@ noinst_HEADERS                                        = \
 EXTRA_DIST                                            = \
     $(NULL)
 
+noinst_LIBRARIES                                      = \
+    $(NULL)
+
 if CHIP_BUILD_TESTS
 # C preprocessor option flags that will apply to all compiled objects in this
 # makefile.
 
 AM_CPPFLAGS                                           = \
     -I$(top_srcdir)/src                                 \
+    -I$(top_srcdir)/src/include                         \
     -I$(top_srcdir)/src/lib                             \
     $(LWIP_CPPFLAGS)                                    \
     $(SOCKETS_CPPFLAGS)                                 \
@@ -49,6 +53,7 @@ AM_CPPFLAGS                                           = \
 
 CHIP_LDADD                                            = \
     $(top_builddir)/src/inet/libInetLayer.a             \
+    $(top_builddir)/src/system/libSystemLayer.a         \
     $(top_builddir)/src/lib/support/libSupportLayer.a   \
     $(NULL)
 
@@ -64,6 +69,7 @@ COMMON_LDADD                                          = \
 
 check_PROGRAMS                                        = \
     TestInetAddress                                     \
+    TestInetBuffer                                      \
     TestInetErrorStr                                    \
     $(NULL)
 
@@ -85,7 +91,12 @@ TESTS_ENVIRONMENT                                     = \
 TestInetAddress_SOURCES                               = TestInetAddress.cpp
 TestInetAddress_LDADD                                 = $(COMMON_LDADD)
 
-TestInetErrorStr_SOURCES                              = TestInetErrorStr.cpp
+TestInetBuffer_SOURCES                                = TestInetBuffer.cpp      \
+                                                        $(NULL)
+TestInetBuffer_LDADD                                  = $(COMMON_LDADD)
+
+TestInetErrorStr_SOURCES                              = TestInetErrorStr.cpp    \
+                                                        $(NULL)
 TestInetErrorStr_LDADD                                = $(COMMON_LDADD)
 
 if CHIP_BUILD_COVERAGE

--- a/src/inet/tests/Makefile.am
+++ b/src/inet/tests/Makefile.am
@@ -71,6 +71,7 @@ check_PROGRAMS                                        = \
     TestInetAddress                                     \
     TestInetBuffer                                      \
     TestInetErrorStr                                    \
+    TestInetTimer                                       \
     $(NULL)
 
 # Test applications and scripts that should be built and run when the
@@ -98,6 +99,10 @@ TestInetBuffer_LDADD                                  = $(COMMON_LDADD)
 TestInetErrorStr_SOURCES                              = TestInetErrorStr.cpp    \
                                                         $(NULL)
 TestInetErrorStr_LDADD                                = $(COMMON_LDADD)
+
+TestInetTimer_SOURCES                                 = TestInetTimer.cpp       \
+                                                        $(NULL)
+TestInetTimer_LDADD                                   = $(COMMON_LDADD)
 
 if CHIP_BUILD_COVERAGE
 CLEANFILES                                            = $(wildcard *.gcda *.gcno)

--- a/src/inet/tests/Makefile.am
+++ b/src/inet/tests/Makefile.am
@@ -27,6 +27,8 @@ include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 # since they are not part of the package.
 #
 noinst_HEADERS                                        = \
+    TestInetCommon.h                                    \
+    TestInetCommonOptions.h                             \
     $(NULL)
 
 #
@@ -36,6 +38,7 @@ EXTRA_DIST                                            = \
     $(NULL)
 
 noinst_LIBRARIES                                      = \
+    libTestInetCommon.a                                 \
     $(NULL)
 
 if CHIP_BUILD_TESTS
@@ -49,6 +52,11 @@ AM_CPPFLAGS                                           = \
     $(LWIP_CPPFLAGS)                                    \
     $(SOCKETS_CPPFLAGS)                                 \
     $(PTHREAD_CFLAGS)                                   \
+    $(NULL)
+
+libTestInetCommon_a_SOURCES                           = \
+    TestInetCommon.cpp                                  \
+    TestInetCommonOptions.cpp                           \
     $(NULL)
 
 CHIP_LDADD                                            = \
@@ -70,6 +78,7 @@ COMMON_LDADD                                          = \
 check_PROGRAMS                                        = \
     TestInetAddress                                     \
     TestInetBuffer                                      \
+    TestInetEndPoint                                    \
     TestInetErrorStr                                    \
     TestInetTimer                                       \
     $(NULL)
@@ -95,6 +104,10 @@ TestInetAddress_LDADD                                 = $(COMMON_LDADD)
 TestInetBuffer_SOURCES                                = TestInetBuffer.cpp      \
                                                         $(NULL)
 TestInetBuffer_LDADD                                  = $(COMMON_LDADD)
+
+TestInetEndPoint_SOURCES                              = TestInetEndPoint.cpp    \
+                                                        $(NULL)
+TestInetEndPoint_LDADD                                = libTestInetCommon.a $(COMMON_LDADD)
 
 TestInetErrorStr_SOURCES                              = TestInetErrorStr.cpp    \
                                                         $(NULL)

--- a/src/inet/tests/Makefile.am
+++ b/src/inet/tests/Makefile.am
@@ -73,12 +73,28 @@ COMMON_LDADD                                          = \
     $(PTHREAD_CFLAGS) $(PTHREAD_LIBS)                   \
     $(NULL)
 
+# Test executables that should be built but not installed and should
+# always be built to ensure overall "build sanity".
+#
+# These will NOT be part of the externally-consumable binary SDK.
+#
+# XXX - At this point TestInetEndPoint is stranded here until a
+#       solution for enabling IPv6 on Linux containers for Docker on macOS
+#       can be resolved as that test involves executing APIs that
+#       exercise bind, listen, connect, accept, etc. on IPv4 and IPv6 IP end
+#       points. When that issue has been resolved, move that test to
+#       check_PROGRAMS.
+
+noinst_PROGRAMS                                       = \
+    TestInetEndPoint                                    \
+    $(NULL)
+
+
 # Test applications that should be run when the 'check' target is run.
 
 check_PROGRAMS                                        = \
     TestInetAddress                                     \
     TestInetBuffer                                      \
-    TestInetEndPoint                                    \
     TestInetErrorStr                                    \
     TestInetTimer                                       \
     $(NULL)

--- a/src/inet/tests/TestInetBuffer.cpp
+++ b/src/inet/tests/TestInetBuffer.cpp
@@ -1,0 +1,1170 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2015-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a unit test suite for
+ *      <tt>chip::Inet::InetBuffer</tt>, a class that provides
+ *      structure for network buffer management.
+ *
+ */
+
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
+#ifndef __STDC_LIMIT_MACROS
+#define __STDC_LIMIT_MACROS
+#endif
+
+#include <stdint.h>
+
+#include <inet/InetConfig.h>
+
+#if INET_CONFIG_PROVIDE_OBSOLESCENT_INTERFACES
+
+#include <string.h>
+
+#include <inet/InetBuffer.h>
+
+#include <nlunit-test.h>
+
+//#include "ToolCommon.h"
+
+#define MEM_ALIGN_SIZE(SZ, ALIGN) (((SZ) + (ALIGN) -1) & ~((ALIGN) -1))
+#if INET_LWIP
+#define INET_BUF_SIZE LWIP_MEM_ALIGN_SIZE(PBUF_POOL_BUFSIZE)
+#define INET_BUF_HEADER_SIZE LWIP_MEM_ALIGN_SIZE(sizeof(struct pbuf))
+#else
+#define INET_BUF_SIZE CHIP_SYSTEM_PACKETBUFFER_SIZE
+#define INET_BUF_HEADER_SIZE MEM_ALIGN_SIZE(sizeof(InetBuffer), 4)
+#endif
+
+#define INET_TO_PBUF(x) (static_cast<struct pbuf *>(static_cast<void *>(x)))
+#define PBUF_TO_INET(x) (static_cast<InetBuffer *>(static_cast<void *>(x)))
+
+using namespace chip::Inet;
+
+// Test input vector format.
+
+struct TestContext
+{
+    uint16_t init_len;
+    uint16_t reserved_size;
+    uint8_t * start_buffer;
+    uint8_t * end_buffer;
+    uint8_t * payload_ptr;
+    struct pbuf * buf;
+};
+
+// Test input data.
+
+static struct TestContext sContext[] = { { 0, 0, NULL, NULL, NULL, NULL },
+                                         { 0, 10, NULL, NULL, NULL, NULL },
+                                         { 0, 128, NULL, NULL, NULL, NULL },
+                                         { 0, CHIP_SYSTEM_PACKETBUFFER_SIZE, NULL, NULL, NULL, NULL },
+                                         { 0, INET_BUF_SIZE, NULL, NULL, NULL, NULL } };
+
+static const uint16_t sLengths[] = { 0, 1, 10, 128, INET_BUF_SIZE, UINT16_MAX };
+
+// Number of test context examples.
+static const size_t kTestElements = sizeof(sContext) / sizeof(struct TestContext);
+static const size_t kTestLengths  = sizeof(sLengths) / sizeof(uint16_t);
+
+// Utility functions.
+
+/**
+ *  Free allocated test buffer memory.
+ */
+static void BufferFree(struct TestContext * theContext)
+{
+    if (theContext->buf != NULL)
+    {
+        InetBuffer::Free(PBUF_TO_INET(theContext->buf));
+    }
+}
+
+/**
+ *  Allocate memory for a test buffer and configure according to test context.
+ */
+static void BufferAlloc(struct TestContext * theContext)
+{
+    if (theContext->buf == NULL)
+    {
+        theContext->buf = INET_TO_PBUF(InetBuffer::New(0));
+    }
+
+    if (theContext->buf == NULL)
+    {
+        fprintf(stderr, "Failed to allocate %zuB memory: %s\n", ((size_t) INET_BUF_SIZE), strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    memset(theContext->buf, 0, INET_BUF_SIZE);
+
+    theContext->start_buffer = reinterpret_cast<uint8_t *>(theContext->buf);
+    theContext->end_buffer   = reinterpret_cast<uint8_t *>(theContext->buf) + INET_BUF_SIZE;
+
+    if (INET_BUF_HEADER_SIZE + theContext->reserved_size > INET_BUF_SIZE)
+    {
+        theContext->payload_ptr = (theContext->start_buffer + INET_BUF_SIZE);
+    }
+    else
+    {
+        theContext->payload_ptr = (theContext->start_buffer + INET_BUF_HEADER_SIZE + theContext->reserved_size);
+    }
+}
+
+/**
+ *  Setup buffer layout as it is used by InetBuffer class.
+ */
+static InetBuffer * PrepareTestBuffer(struct TestContext * theContext)
+{
+    BufferAlloc(theContext);
+
+    theContext->buf->next    = NULL;
+    theContext->buf->payload = theContext->payload_ptr;
+    theContext->buf->ref     = 1;
+    theContext->buf->len     = theContext->init_len;
+    theContext->buf->tot_len = theContext->init_len;
+#if INET_LWIP
+    theContext->buf->type = PBUF_POOL;
+#endif
+
+    return reinterpret_cast<InetBuffer *>(theContext->buf);
+}
+
+// Test functions invoked from the suite.
+
+/**
+ *  Test InetBuffer::Start() function.
+ */
+static void CheckStart(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * theContext = (struct TestContext *) (inContext);
+
+    for (size_t ith = 0; ith < kTestElements; ith++)
+    {
+        InetBuffer * buffer = PrepareTestBuffer(theContext);
+
+        NL_TEST_ASSERT(inSuite, buffer->Start() == theContext->payload_ptr);
+
+        theContext++;
+    }
+}
+
+/**
+ *  Test InetBuffer::SetStart() function.
+ *
+ *  Description: For every buffer-configuration from inContext, create a
+ *               buffer's instance according to the configuration. Next,
+ *               for any offset value from start_offset[], pass it to the
+ *               buffer's instance through SetStart method. Then, verify that
+ *               the beginning of the buffer has been correctly internally
+ *               adjusted according to the offset value passed into the
+ *               SetStart() method.
+ */
+static void CheckSetStart(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * theContext = (struct TestContext *) (inContext);
+
+    for (size_t ith = 0; ith < kTestElements; ith++)
+    {
+        const int start_offset[] = { -static_cast<int>(INET_BUF_SIZE), -128, -1, 0, 1, 128, static_cast<int>(INET_BUF_SIZE) };
+
+        for (size_t s = 0; s < sizeof(start_offset) / sizeof(int); s++)
+        {
+            uint8_t * test_start   = theContext->payload_ptr + start_offset[s];
+            uint8_t * verify_start = test_start;
+            InetBuffer * buffer    = PrepareTestBuffer(theContext);
+
+            buffer->SetStart(test_start);
+
+            if (verify_start <= theContext->start_buffer + INET_BUF_HEADER_SIZE)
+            {
+                // Set start before valid payload beginning.
+                verify_start = theContext->start_buffer + INET_BUF_HEADER_SIZE;
+            }
+
+            if (verify_start >= theContext->end_buffer)
+            {
+                // Set start after valid payload beginning.
+                verify_start = theContext->end_buffer;
+            }
+
+            NL_TEST_ASSERT(inSuite, theContext->buf->payload == verify_start);
+
+            if ((verify_start - theContext->payload_ptr) > theContext->init_len)
+            {
+                // Set start to the beginning of payload, right after buffer's header.
+                NL_TEST_ASSERT(inSuite, theContext->buf->len == 0);
+            }
+            else
+            {
+                // Set start to somewhere between the end of the buffer's
+                // header and the end of payload.
+                NL_TEST_ASSERT(inSuite, theContext->buf->len == (theContext->init_len - (verify_start - theContext->payload_ptr)));
+            }
+        }
+        theContext++;
+    }
+}
+
+/**
+ *  Test InetBuffer::DataLength() function.
+ */
+static void CheckDataLength(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * theContext = (struct TestContext *) (inContext);
+
+    for (size_t ith = 0; ith < kTestElements; ith++)
+    {
+        InetBuffer * buffer = PrepareTestBuffer(theContext);
+
+        NL_TEST_ASSERT(inSuite, buffer->DataLength() == theContext->buf->len);
+
+        theContext++;
+    }
+}
+
+/**
+ *  Test InetBuffer::SetDataLength() function.
+ *
+ *  Description: Take two initial configurations of InetBuffer from
+ *               inContext and create two InetBuffer instances based on those
+ *               configurations. For any two buffers, call SetDataLength with
+ *               different value from sLength[]. If two buffers are created with
+ *               the same configuration, test SetDataLength on one buffer,
+ *               without specifying the head of the buffer chain. Otherwise,
+ *               test SetDataLength with one buffer being down the chain and the
+ *               other one being passed as the head of the chain. After calling
+ *               the method verify that data lenghts were correctly adjusted.
+ */
+static void CheckSetDataLength(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * theFirstContext = static_cast<struct TestContext *>(inContext);
+
+    for (size_t ith = 0; ith < kTestElements; ith++)
+    {
+        struct TestContext * theSecondContext = static_cast<struct TestContext *>(inContext);
+
+        for (size_t jth = 0; jth < kTestElements; jth++)
+        {
+            for (size_t n = 0; n < kTestLengths; n++)
+            {
+                InetBuffer * buffer_1 = PrepareTestBuffer(theFirstContext);
+                InetBuffer * buffer_2 = PrepareTestBuffer(theSecondContext);
+
+                if (theFirstContext == theSecondContext)
+                {
+                    // headOfChain (the second arg) is NULL
+                    buffer_2->SetDataLength(sLengths[n], NULL);
+
+                    if (sLengths[n] > (theSecondContext->end_buffer - theSecondContext->payload_ptr))
+                    {
+                        NL_TEST_ASSERT(
+                            inSuite, theSecondContext->buf->len == (theSecondContext->end_buffer - theSecondContext->payload_ptr));
+                        NL_TEST_ASSERT(inSuite,
+                                       theSecondContext->buf->tot_len ==
+                                           (theSecondContext->end_buffer - theSecondContext->payload_ptr));
+                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->next == NULL);
+                    }
+                    else
+                    {
+                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->len == sLengths[n]);
+                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->tot_len == sLengths[n]);
+                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->next == NULL);
+                    }
+                }
+                else
+                {
+                    // headOfChain (the second arg) is buffer_1
+                    buffer_2->SetDataLength(sLengths[n], buffer_1);
+
+                    if (sLengths[n] > (theSecondContext->end_buffer - theSecondContext->payload_ptr))
+                    {
+                        NL_TEST_ASSERT(
+                            inSuite, theSecondContext->buf->len == (theSecondContext->end_buffer - theSecondContext->payload_ptr));
+                        NL_TEST_ASSERT(inSuite,
+                                       theSecondContext->buf->tot_len ==
+                                           (theSecondContext->end_buffer - theSecondContext->payload_ptr));
+                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->next == NULL);
+
+                        NL_TEST_ASSERT(inSuite,
+                                       theFirstContext->buf->tot_len ==
+                                           (theFirstContext->init_len +
+                                            static_cast<int32_t>(theSecondContext->end_buffer - theSecondContext->payload_ptr) -
+                                            static_cast<int32_t>(theSecondContext->init_len)));
+                    }
+                    else
+                    {
+                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->len == sLengths[n]);
+                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->tot_len == sLengths[n]);
+                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->next == NULL);
+
+                        NL_TEST_ASSERT(inSuite,
+                                       theFirstContext->buf->tot_len ==
+                                           (theFirstContext->init_len + static_cast<int32_t>(sLengths[n]) -
+                                            static_cast<int32_t>(theSecondContext->init_len)));
+                    }
+                }
+            }
+
+            theSecondContext++;
+        }
+
+        theFirstContext++;
+    }
+}
+
+/**
+ *  Test InetBuffer::TotalLength() function.
+ */
+static void CheckTotalLength(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * theContext = (struct TestContext *) (inContext);
+
+    for (size_t ith = 0; ith < kTestElements; ith++)
+    {
+        InetBuffer * buffer = PrepareTestBuffer(theContext);
+
+        NL_TEST_ASSERT(inSuite, buffer->TotalLength() == theContext->init_len);
+
+        theContext++;
+    }
+}
+
+/**
+ *  Test InetBuffer::MaxDataLength() function.
+ */
+static void CheckMaxDataLength(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * theContext = (struct TestContext *) (inContext);
+
+    for (size_t ith = 0; ith < kTestElements; ith++)
+    {
+        InetBuffer * buffer = PrepareTestBuffer(theContext);
+
+        NL_TEST_ASSERT(inSuite, buffer->MaxDataLength() == (theContext->end_buffer - theContext->payload_ptr));
+
+        theContext++;
+    }
+}
+
+/**
+ *  Test InetBuffer::AvailableDataLength() function.
+ */
+static void CheckAvailableDataLength(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * theContext = (struct TestContext *) (inContext);
+
+    for (size_t ith = 0; ith < kTestElements; ith++)
+    {
+        InetBuffer * buffer = PrepareTestBuffer(theContext);
+
+        NL_TEST_ASSERT(
+            inSuite, buffer->AvailableDataLength() == ((theContext->end_buffer - theContext->payload_ptr) - theContext->init_len));
+
+        theContext++;
+    }
+}
+
+/**
+ *  Test InetBuffer::ReservedSize() function.
+ */
+static void CheckReservedSize(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * theContext = (struct TestContext *) (inContext);
+
+    for (size_t ith = 0; ith < kTestElements; ith++)
+    {
+        InetBuffer * buffer = PrepareTestBuffer(theContext);
+
+        if (INET_BUF_HEADER_SIZE + theContext->reserved_size > INET_BUF_SIZE)
+        {
+            NL_TEST_ASSERT(inSuite, buffer->ReservedSize() == (INET_BUF_SIZE - INET_BUF_HEADER_SIZE));
+        }
+        else
+        {
+            NL_TEST_ASSERT(inSuite, buffer->ReservedSize() == theContext->reserved_size);
+        }
+
+        theContext++;
+    }
+}
+
+/**
+ *  Test InetBuffer::AddToEnd() function.
+ *
+ *  Description: Take three initial configurations of InetBuffer from
+ *               inContext, create three InetBuffers based on those
+ *               configurations and then link those buffers together with
+ *               InetBuffer:AddToEnd(). Then, assert that after connecting
+ *               buffers together, their internal states are correctly updated.
+ *               This test function tests linking any combination of three
+ *               buffer-configurations passed within inContext.
+ */
+static void CheckAddToEnd(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * theFirstContext = static_cast<struct TestContext *>(inContext);
+
+    for (size_t ith = 0; ith < kTestElements; ith++)
+    {
+        struct TestContext * theSecondContext = static_cast<struct TestContext *>(inContext);
+
+        for (size_t jth = 0; jth < kTestElements; jth++)
+        {
+            struct TestContext * theThirdContext = static_cast<struct TestContext *>(inContext);
+
+            for (size_t kth = 0; kth < kTestElements; kth++)
+            {
+                InetBuffer * buffer_1 = NULL;
+                InetBuffer * buffer_2 = NULL;
+                InetBuffer * buffer_3 = NULL;
+
+                if (theFirstContext == theSecondContext || theFirstContext == theThirdContext ||
+                    theSecondContext == theThirdContext)
+                {
+                    theThirdContext++;
+                    continue;
+                }
+
+                buffer_1 = PrepareTestBuffer(theFirstContext);
+                buffer_2 = PrepareTestBuffer(theSecondContext);
+                buffer_3 = PrepareTestBuffer(theThirdContext);
+
+                buffer_1->AddToEnd(buffer_2);
+
+                NL_TEST_ASSERT(inSuite, theFirstContext->buf->tot_len == (theFirstContext->init_len + theSecondContext->init_len));
+                NL_TEST_ASSERT(inSuite, theFirstContext->buf->next == theSecondContext->buf);
+                NL_TEST_ASSERT(inSuite, theSecondContext->buf->next == NULL);
+
+                NL_TEST_ASSERT(inSuite, theThirdContext->buf->next == NULL);
+
+                buffer_1->AddToEnd(buffer_3);
+
+                NL_TEST_ASSERT(inSuite,
+                               theFirstContext->buf->tot_len ==
+                                   (theFirstContext->init_len + theSecondContext->init_len + theThirdContext->init_len));
+                NL_TEST_ASSERT(inSuite, theFirstContext->buf->next == theSecondContext->buf);
+                NL_TEST_ASSERT(inSuite, theSecondContext->buf->next == theThirdContext->buf);
+                NL_TEST_ASSERT(inSuite, theThirdContext->buf->next == NULL);
+
+                theThirdContext++;
+            }
+
+            theSecondContext++;
+        }
+
+        theFirstContext++;
+    }
+}
+
+/**
+ *  Test InetBuffer::DetachTail() function.
+ *
+ *  Description: Take two initial configurations of InetBuffer from
+ *               inContext and create two InetBuffer instances based on those
+ *               configurations. Next, link those buffers together, with the first
+ *               buffer instance pointing to the second one. Then, call DetachTail()
+ *               on the first buffer to unlink the second buffer. After the call,
+ *               verify correct internal state of the first buffer.
+ */
+static void CheckDetachTail(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * theFirstContext = static_cast<struct TestContext *>(inContext);
+
+    for (size_t ith = 0; ith < kTestElements; ith++)
+    {
+        struct TestContext * theSecondContext = static_cast<struct TestContext *>(inContext);
+
+        for (size_t jth = 0; jth < kTestElements; jth++)
+        {
+            InetBuffer * buffer_1 = PrepareTestBuffer(theFirstContext);
+            InetBuffer * buffer_2 = PrepareTestBuffer(theSecondContext);
+            InetBuffer * returned = NULL;
+
+            if (theFirstContext != theSecondContext)
+            {
+                theFirstContext->buf->next = theSecondContext->buf;
+                theFirstContext->buf->tot_len += theSecondContext->init_len;
+            }
+
+            returned = buffer_1->DetachTail();
+
+            NL_TEST_ASSERT(inSuite, theFirstContext->buf->next == NULL);
+            NL_TEST_ASSERT(inSuite, theFirstContext->buf->tot_len == theFirstContext->init_len);
+
+            if (theFirstContext != theSecondContext)
+            {
+                NL_TEST_ASSERT(inSuite, returned == buffer_2);
+            }
+
+            theSecondContext++;
+        }
+
+        theFirstContext++;
+    }
+}
+
+/**
+ *  Test InetBuffer::CompactHead() function.
+ *
+ *  Description: Take two initial configurations of InetBuffer from
+ *               inContext and create two InetBuffer instances based on those
+ *               configurations. Next, set both buffers' data length to any
+ *               combination of values from sLengths[] and link those buffers
+ *               into a chain. Then, call CompactHead() on the first buffer in
+ *               the chain. After calling the method, verify correctly adjusted
+ *               state of the first buffer.
+ */
+static void CheckCompactHead(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * theFirstContext = static_cast<struct TestContext *>(inContext);
+
+    for (size_t ith = 0; ith < kTestElements; ith++)
+    {
+        struct TestContext * theSecondContext = static_cast<struct TestContext *>(inContext);
+
+        for (size_t jth = 0; jth < kTestElements; jth++)
+        {
+            // start with various initial length for the first buffer
+            for (size_t k = 0; k < kTestLengths; k++)
+            {
+                // start with various initial length for the second buffer
+                for (size_t l = 0; l < kTestLengths; l++)
+                {
+                    InetBuffer * buffer_1 = PrepareTestBuffer(theFirstContext);
+                    InetBuffer * buffer_2 = PrepareTestBuffer(theSecondContext);
+                    uint16_t len1         = 0;
+                    uint16_t len2         = 0;
+
+                    buffer_1->SetDataLength(sLengths[k], buffer_1);
+                    len1 = buffer_1->DataLength();
+
+                    if (theFirstContext != theSecondContext)
+                    {
+                        theFirstContext->buf->next = theSecondContext->buf;
+
+                        // Add various lengths to the second buffer
+                        buffer_2->SetDataLength(sLengths[l], buffer_1);
+                        len2 = buffer_2->DataLength();
+                    }
+
+                    buffer_1->CompactHead();
+
+                    NL_TEST_ASSERT(inSuite,
+                                   theFirstContext->buf->payload == (theFirstContext->start_buffer + INET_BUF_HEADER_SIZE));
+
+                    /* verify length of the first buffer */
+                    if (theFirstContext == theSecondContext)
+                    {
+                        NL_TEST_ASSERT(inSuite, theFirstContext->buf->tot_len == len1);
+                    }
+                    else if (theFirstContext->buf->tot_len > buffer_1->MaxDataLength())
+                    {
+                        NL_TEST_ASSERT(inSuite, theFirstContext->buf->len == buffer_1->MaxDataLength());
+                        NL_TEST_ASSERT(inSuite,
+                                       theSecondContext->buf->len == theFirstContext->buf->tot_len - buffer_1->MaxDataLength());
+                    }
+                    else
+                    {
+                        NL_TEST_ASSERT(inSuite, theFirstContext->buf->len == theFirstContext->buf->tot_len);
+                        if (len1 >= buffer_1->MaxDataLength() && len2 == 0)
+                        {
+                            /* make sure the second buffer is not freed */
+                            NL_TEST_ASSERT(inSuite, theFirstContext->buf->next == theSecondContext->buf);
+                        }
+                        else
+                        {
+                            /* make sure the second buffer is freed */
+                            NL_TEST_ASSERT(inSuite, theFirstContext->buf->next == NULL);
+                            theSecondContext->buf = NULL;
+                        }
+                    }
+                }
+            }
+            theSecondContext++;
+        }
+
+        theFirstContext++;
+    }
+}
+
+/**
+ *  Test InetBuffer::ConsumeHead() function.
+ *
+ *  Description: For every buffer-configuration from inContext, create a
+ *               buffer's instance according to the configuration. Next,
+ *               for any value from sLengths[], pass it to the buffer's
+ *               instance through ConsumeHead() method. Then, verify that
+ *               the internal state of the buffer has been correctly
+ *               adjusted according to the value passed into the method.
+ */
+static void CheckConsumeHead(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * theContext = (struct TestContext *) (inContext);
+
+    for (size_t ith = 0; ith < kTestElements; ith++)
+    {
+        for (size_t n = 0; n < kTestLengths; n++)
+        {
+            InetBuffer * buffer = PrepareTestBuffer(theContext);
+
+            buffer->ConsumeHead(sLengths[n]);
+
+            if (sLengths[n] > theContext->init_len)
+            {
+                NL_TEST_ASSERT(inSuite, theContext->buf->payload == (theContext->payload_ptr + theContext->init_len));
+                NL_TEST_ASSERT(inSuite, theContext->buf->len == 0);
+                NL_TEST_ASSERT(inSuite, theContext->buf->tot_len == 0);
+            }
+            else
+            {
+                NL_TEST_ASSERT(inSuite, theContext->buf->payload == (theContext->payload_ptr + sLengths[n]));
+                NL_TEST_ASSERT(inSuite, theContext->buf->len == (theContext->buf->len - sLengths[n]));
+                NL_TEST_ASSERT(inSuite, theContext->buf->tot_len == (theContext->buf->tot_len - sLengths[n]));
+            }
+
+            if (theContext->buf->ref == 0)
+            {
+                theContext->buf = NULL;
+            }
+        }
+
+        theContext++;
+    }
+}
+
+/**
+ *  Test InetBuffer::Consume() function.
+ *
+ *  Description: Take two different initial configurations of InetBuffer from
+ *               inContext and create two InetBuffer instances based on those
+ *               configurations. Next, set both buffers' data length to any
+ *               combination of values from sLengths[]  and link those buffers
+ *               into a chain. Then, call Consume() on the first buffer in
+ *               the chain with all values from sLengths[]. After calling the
+ *               method, verify correctly adjusted the state of the first
+ *               buffer and appropriate return pointer from the method's call.
+ */
+static void CheckConsume(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * theFirstContext = static_cast<struct TestContext *>(inContext);
+
+    for (size_t ith = 0; ith < kTestElements; ith++)
+    {
+        struct TestContext * theSecondContext = static_cast<struct TestContext *>(inContext);
+
+        for (size_t jth = 0; jth < kTestElements; jth++)
+        {
+            // consume various amounts of memory
+            for (size_t c = 0; c < kTestLengths; c++)
+            {
+                // start with various initial length for the first buffer
+                for (size_t k = 0; k < kTestLengths; k++)
+                {
+                    // start with various initial length for the second buffer
+                    for (size_t l = 0; l < kTestLengths; l++)
+                    {
+                        InetBuffer * buffer_1;
+                        InetBuffer * buffer_2;
+                        InetBuffer * returned;
+                        uint16_t buf_1_len = 0;
+                        uint16_t buf_2_len = 0;
+
+                        if (theFirstContext == theSecondContext)
+                        {
+                            continue;
+                        }
+
+                        buffer_1 = PrepareTestBuffer(theFirstContext);
+                        buffer_2 = PrepareTestBuffer(theSecondContext);
+
+                        theFirstContext->buf->next = theSecondContext->buf;
+
+                        // Add various lengths to buffers
+                        buffer_1->SetDataLength(sLengths[k], buffer_1);
+                        buffer_2->SetDataLength(sLengths[l], buffer_1);
+
+                        buf_1_len = theFirstContext->buf->len;
+                        buf_2_len = theSecondContext->buf->len;
+
+                        returned = buffer_1->Consume(sLengths[c]);
+
+                        if (sLengths[c] == 0)
+                        {
+                            NL_TEST_ASSERT(inSuite, returned == buffer_1);
+                            continue;
+                        }
+
+                        if (sLengths[c] < buf_1_len)
+                        {
+                            NL_TEST_ASSERT(inSuite, returned == buffer_1);
+                        }
+                        else if ((sLengths[c] >= buf_1_len) &&
+                                 ((sLengths[c] < buf_1_len + buf_2_len) ||
+                                  ((sLengths[c] == buf_1_len + buf_2_len) && buf_2_len == 0)))
+                        {
+                            NL_TEST_ASSERT(inSuite, returned == buffer_2);
+                            theFirstContext->buf = NULL;
+                        }
+                        else if (sLengths[c] >= (buf_1_len + buf_2_len))
+                        {
+                            NL_TEST_ASSERT(inSuite, returned == NULL);
+                            theFirstContext->buf  = NULL;
+                            theSecondContext->buf = NULL;
+                        }
+                    }
+                }
+            }
+
+            theSecondContext++;
+        }
+
+        theFirstContext++;
+    }
+}
+
+/**
+ *  Test InetBuffer::EnsureReservedSize() function.
+ *
+ *  Description: For every buffer-configuration from inContext, create a
+ *               buffer's instance according to the configuration. Next,
+ *               manually specify how much space is reserved in the buffer.
+ *               Then, verify that EnsureReservedSize() method correctly
+ *               retrieves the amount of the reserved space.
+ */
+static void CheckEnsureReservedSize(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * theContext = (struct TestContext *) (inContext);
+
+    for (size_t ith = 0; ith < kTestElements; ith++)
+    {
+        for (size_t n = 0; n < kTestLengths; n++)
+        {
+            InetBuffer * buffer    = PrepareTestBuffer(theContext);
+            uint16_t reserved_size = theContext->reserved_size;
+
+            if (INET_BUF_HEADER_SIZE + theContext->reserved_size > INET_BUF_SIZE)
+            {
+                reserved_size = INET_BUF_SIZE - INET_BUF_HEADER_SIZE;
+            }
+
+            if (sLengths[n] <= reserved_size)
+            {
+                NL_TEST_ASSERT(inSuite, buffer->EnsureReservedSize(sLengths[n]) == true);
+                continue;
+            }
+
+            if ((sLengths[n] + theContext->init_len) > (INET_BUF_SIZE - INET_BUF_HEADER_SIZE))
+            {
+                NL_TEST_ASSERT(inSuite, buffer->EnsureReservedSize(sLengths[n]) == false);
+                continue;
+            }
+
+            NL_TEST_ASSERT(inSuite, buffer->EnsureReservedSize(sLengths[n]) == true);
+            NL_TEST_ASSERT(inSuite, theContext->buf->payload == (theContext->payload_ptr + sLengths[n] - reserved_size));
+        }
+
+        theContext++;
+    }
+}
+
+/**
+ *  Test InetBuffer::AlignPayload() function.
+ *
+ *  Description: For every buffer-configuration from inContext, create a
+ *               buffer's instance according to the configuration. Next,
+ *               manually specify how much space is reserved and the
+ *               required payload shift. Then, verify that AlignPayload()
+ *               method correctly aligns the payload start pointer.
+ */
+static void CheckAlignPayload(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * theContext = (struct TestContext *) (inContext);
+
+    for (size_t ith = 0; ith < kTestElements; ith++)
+    {
+        for (size_t n = 0; n < kTestLengths - 1; n++)
+        {
+            InetBuffer * buffer = PrepareTestBuffer(theContext);
+
+            if (sLengths[n] == 0)
+            {
+                NL_TEST_ASSERT(inSuite, buffer->AlignPayload(sLengths[n]) == false);
+                continue;
+            }
+
+            uint16_t reserved_size = theContext->reserved_size;
+            if (INET_BUF_HEADER_SIZE + theContext->reserved_size > INET_BUF_SIZE)
+            {
+                reserved_size = INET_BUF_SIZE - INET_BUF_HEADER_SIZE;
+            }
+
+            uint16_t payload_offset = (unsigned long) buffer->Start() % sLengths[n];
+            uint16_t payload_shift  = 0;
+            if (payload_offset > 0)
+                payload_shift = sLengths[n] - payload_offset;
+
+            if (payload_shift <= INET_BUF_SIZE - INET_BUF_HEADER_SIZE - reserved_size)
+            {
+                NL_TEST_ASSERT(inSuite, buffer->AlignPayload(sLengths[n]) == true);
+                NL_TEST_ASSERT(inSuite, ((unsigned long) buffer->Start() % sLengths[n]) == 0);
+            }
+            else
+            {
+                NL_TEST_ASSERT(inSuite, buffer->AlignPayload(sLengths[n]) == false);
+            }
+        }
+
+        theContext++;
+    }
+}
+
+/**
+ *  Test InetBuffer::Next() function.
+ */
+static void CheckNext(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * theFirstContext = static_cast<struct TestContext *>(inContext);
+
+    for (size_t ith = 0; ith < kTestElements; ith++)
+    {
+        struct TestContext * theSecondContext = static_cast<struct TestContext *>(inContext);
+
+        for (size_t jth = 0; jth < kTestElements; jth++)
+        {
+            InetBuffer * buffer_1 = PrepareTestBuffer(theFirstContext);
+            InetBuffer * buffer_2 = PrepareTestBuffer(theSecondContext);
+
+            if (theFirstContext != theSecondContext)
+            {
+                theFirstContext->buf->next = theSecondContext->buf;
+
+                NL_TEST_ASSERT(inSuite, buffer_1->Next() == buffer_2);
+            }
+            else
+            {
+                NL_TEST_ASSERT(inSuite, buffer_1->Next() == NULL);
+            }
+
+            NL_TEST_ASSERT(inSuite, buffer_2->Next() == NULL);
+            theSecondContext++;
+        }
+
+        theFirstContext++;
+    }
+}
+
+/**
+ *  Test InetBuffer::AddRef() function.
+ */
+static void CheckAddRef(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * theContext = (struct TestContext *) (inContext);
+
+    for (size_t ith = 0; ith < kTestElements; ith++)
+    {
+        InetBuffer * buffer = PrepareTestBuffer(theContext);
+        buffer->AddRef();
+
+        NL_TEST_ASSERT(inSuite, theContext->buf->ref == 2);
+
+        theContext++;
+    }
+}
+
+/**
+ *  Test InetBuffer::New() and InetBuffer::Free() functions.
+ *
+ *  Description: For every buffer-configuration from inContext, create a
+ *               buffer's instance using New() method. Then, verify that
+ *               when the size of the reserved space passed to New() is
+ *               greater than INET_BUF_SIZE - INET_BUF_HEADER_SIZE, the method
+ *               returns NULL. Otherwise, check for correctness of initializing
+ *               the new buffer's internal state. Finally, free the buffer.
+ */
+static void CheckNewAndFree(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * theContext = (struct TestContext *) (inContext);
+    InetBuffer * buffer;
+
+    for (size_t ith = 0; ith < kTestElements; ith++)
+    {
+        struct pbuf * pb = NULL;
+
+        buffer = InetBuffer::New(theContext->reserved_size);
+
+        if (theContext->reserved_size + INET_BUF_HEADER_SIZE > INET_BUF_SIZE)
+        {
+            NL_TEST_ASSERT(inSuite, buffer == NULL);
+            theContext++;
+            continue;
+        }
+
+        NL_TEST_ASSERT(inSuite, buffer != NULL);
+
+        if (buffer != NULL)
+        {
+            pb = INET_TO_PBUF(buffer);
+
+            NL_TEST_ASSERT(inSuite, pb->len == 0);
+            NL_TEST_ASSERT(inSuite, pb->tot_len == 0);
+            NL_TEST_ASSERT(inSuite, pb->next == NULL);
+            NL_TEST_ASSERT(inSuite, pb->ref == 1);
+        }
+
+        InetBuffer::Free(buffer);
+
+        theContext++;
+    }
+
+    // Use the rest of the buffer space
+    do
+    {
+        buffer = InetBuffer::New();
+    } while (buffer != NULL);
+}
+
+/**
+ *  Test InetBuffer::Free() function.
+ *
+ *  Description: Take two different initial configurations of InetBuffer from
+ *               inContext and create two InetBuffer instances based on those
+ *               configurations. Next, chain two buffers together and set each
+ *               buffer's reference count to one of the values from
+ *               init_ret_count[]. Then, call Free() on the first buffer in
+ *               the chain and verify correctly adjusted states of the two
+ *               buffers.
+ */
+static void CheckFree(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * theFirstContext = static_cast<struct TestContext *>(inContext);
+
+    for (size_t ith = 0; ith < kTestElements; ith++)
+    {
+        struct TestContext * theSecondContext = static_cast<struct TestContext *>(inContext);
+
+        for (size_t jth = 0; jth < kTestElements; jth++)
+        {
+            const uint16_t init_ref_count[] = { 1, 2, 3 };
+            const int refs                  = sizeof(init_ref_count) / sizeof(uint16_t);
+
+            // start with various buffer ref counts
+            for (size_t r = 0; r < refs; r++)
+            {
+                InetBuffer * buffer_1;
+
+                if (theFirstContext == theSecondContext)
+                {
+                    continue;
+                }
+
+                buffer_1 = PrepareTestBuffer(theFirstContext);
+                (void) PrepareTestBuffer(theSecondContext);
+
+                theFirstContext->buf->next = theSecondContext->buf;
+
+                // Add various buffer ref counts
+                theFirstContext->buf->ref  = init_ref_count[r];
+                theSecondContext->buf->ref = init_ref_count[(r + 1) % refs];
+
+                InetBuffer::Free(buffer_1);
+
+                NL_TEST_ASSERT(inSuite, theFirstContext->buf->ref == (init_ref_count[r] - 1));
+
+                if (init_ref_count[r] == 1)
+                {
+                    NL_TEST_ASSERT(inSuite, theSecondContext->buf->ref == (init_ref_count[(r + 1) % refs] - 1));
+                }
+                else
+                {
+                    NL_TEST_ASSERT(inSuite, theSecondContext->buf->ref == (init_ref_count[(r + 1) % refs]));
+                }
+
+                if (init_ref_count[r] > 1)
+                {
+                    NL_TEST_ASSERT(inSuite, theFirstContext->buf->next == theSecondContext->buf);
+                }
+
+                if (theFirstContext->buf->ref == 0)
+                {
+                    theFirstContext->buf = NULL;
+                }
+
+                if (theSecondContext->buf->ref == 0)
+                {
+                    theSecondContext->buf = NULL;
+                }
+            }
+
+            theSecondContext++;
+        }
+
+        theFirstContext++;
+    }
+}
+
+/**
+ *  Test InetBuffer::FreeHead() function.
+ *
+ *  Description: Take two different initial configurations of InetBuffer from
+ *               inContext and create two InetBuffer instances based on those
+ *               configurations. Next, chain two buffers together. Then, call
+ *               FreeHead() on the first buffer in the chain and verify that
+ *               the method returned pointer to the second buffer.
+ */
+static void CheckFreeHead(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * theFirstContext = static_cast<struct TestContext *>(inContext);
+
+    for (size_t ith = 0; ith < kTestElements; ith++)
+    {
+        struct TestContext * theSecondContext = static_cast<struct TestContext *>(inContext);
+
+        for (size_t jth = 0; jth < kTestElements; jth++)
+        {
+            InetBuffer * buffer_1;
+            InetBuffer * buffer_2;
+            InetBuffer * returned = NULL;
+
+            if (theFirstContext == theSecondContext)
+            {
+                continue;
+            }
+
+            buffer_1 = PrepareTestBuffer(theFirstContext);
+            buffer_2 = PrepareTestBuffer(theSecondContext);
+
+            theFirstContext->buf->next = theSecondContext->buf;
+
+            returned = InetBuffer::FreeHead(buffer_1);
+
+            NL_TEST_ASSERT(inSuite, returned == buffer_2);
+
+            theFirstContext->buf = NULL;
+            theSecondContext++;
+        }
+
+        theFirstContext++;
+    }
+}
+
+/**
+ *  Test InetBuffer::BuildFreeList() function.
+ */
+static void CheckBuildFreeList(nlTestSuite * inSuite, void * inContext)
+{
+    // BuildFreeList() is a private method called automatically.
+    (void) inSuite;
+    (void) inContext;
+}
+
+// Test Suite
+
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+static const nlTest sTests[] = { NL_TEST_DEF("InetBuffer::Start", CheckStart),
+                                 NL_TEST_DEF("InetBuffer::SetStart", CheckSetStart),
+                                 NL_TEST_DEF("InetBuffer::DataLength", CheckDataLength),
+                                 NL_TEST_DEF("InetBuffer::SetDataLength", CheckSetDataLength),
+                                 NL_TEST_DEF("InetBuffer::TotalLength", CheckTotalLength),
+                                 NL_TEST_DEF("InetBuffer::MaxDataLength", CheckMaxDataLength),
+                                 NL_TEST_DEF("InetBuffer::AvailableDataLength", CheckAvailableDataLength),
+                                 NL_TEST_DEF("InetBuffer::ReservedSize", CheckReservedSize),
+                                 NL_TEST_DEF("InetBuffer::AddToEnd", CheckAddToEnd),
+                                 NL_TEST_DEF("InetBuffer::DetachTail", CheckDetachTail),
+                                 NL_TEST_DEF("InetBuffer::CompactHead", CheckCompactHead),
+                                 NL_TEST_DEF("InetBuffer::ConsumeHead", CheckConsumeHead),
+                                 NL_TEST_DEF("InetBuffer::Consume", CheckConsume),
+                                 NL_TEST_DEF("InetBuffer::EnsureReservedSize", CheckEnsureReservedSize),
+                                 NL_TEST_DEF("InetBuffer::AlignPayload", CheckAlignPayload),
+                                 NL_TEST_DEF("InetBuffer::Next", CheckNext),
+                                 NL_TEST_DEF("InetBuffer::AddRef", CheckAddRef),
+                                 NL_TEST_DEF("InetBuffer::New & InetBuffer::Free", CheckNewAndFree),
+                                 NL_TEST_DEF("InetBuffer::Free", CheckFree),
+                                 NL_TEST_DEF("InetBuffer::FreeHead", CheckFreeHead),
+                                 NL_TEST_DEF("InetBuffer::BuildFreeList", CheckBuildFreeList),
+                                 NL_TEST_SENTINEL() };
+
+/**
+ *  Set up the test suite.
+ *  This is a work-around to initiate InetBuffer protected class instance's
+ *  data and set it to a known state, before an instance is created.
+ */
+static int TestSetup(void * inContext)
+{
+    struct TestContext * theContext = (struct TestContext *) (inContext);
+
+    for (size_t ith = 0; ith < kTestElements; ith++)
+    {
+        BufferAlloc(theContext);
+
+        theContext++;
+    }
+
+    return (SUCCESS);
+}
+
+/**
+ *  Tear down the test suite.
+ *  Free memory reserved at TestSetup.
+ */
+static int TestTeardown(void * inContext)
+{
+    struct TestContext * theContext = (struct TestContext *) (inContext);
+
+    for (size_t ith = 0; ith < kTestElements; ith++)
+    {
+        BufferFree(theContext);
+
+        theContext++;
+    }
+
+    return (SUCCESS);
+}
+
+int main(void)
+{
+    nlTestSuite theSuite = { "inet-buffer", &sTests[0], TestSetup, TestTeardown };
+
+    // Init lwip
+#if INET_LWIP
+    tcpip_init(NULL, NULL);
+#endif
+
+    // Generate machine-readable, comma-separated value (CSV) output.
+    nl_test_set_output_style(OUTPUT_CSV);
+
+    // Run test suit againt one context.
+    nlTestRunner(&theSuite, &sContext);
+
+    return nlTestRunnerStats(&theSuite);
+}
+
+#else // !INET_CONFIG_PROVIDE_OBSOLESCENT_INTERFACES
+
+int main(void)
+{
+    return 0;
+}
+
+#endif // !INET_CONFIG_PROVIDE_OBSOLESCENT_INTERFACES

--- a/src/inet/tests/TestInetCommon.cpp
+++ b/src/inet/tests/TestInetCommon.cpp
@@ -1,0 +1,532 @@
+/*
+ *
+ *    Copyright (c) Project CHIP Authors
+ *    Copyright (c) 2013-2018 Nest Labs, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements constants, globals and interfaces common
+ *      to and used by all Inet layer library test applications and tools.
+ *
+ *      NOTE: These do not comprise a public part of the CHIP API and
+ *            are subject to change without notice.
+ *
+ */
+
+#ifndef __STDC_LIMIT_MACROS
+#define __STDC_LIMIT_MACROS
+#endif
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
+#include "TestInetCommon.h"
+
+#include <new>
+#include <vector>
+
+#include <inttypes.h>
+#include <stdint.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <system/SystemTimer.h>
+#include <system/SystemFaultInjection.h>
+#include <support/CHIPFaultInjection.h>
+#include <inet/InetFaultInjection.h>
+
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+#include <lwip/dns.h>
+#include <lwip/netif.h>
+#include <lwip/sys.h>
+#include <lwip/tcpip.h>
+#include <netif/etharp.h>
+
+#include "TapAddrAutoconf.h"
+#include "TapInterface.h"
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+#include <arpa/inet.h>
+#include <sys/select.h>
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+
+using namespace chip;
+
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+static sys_mbox * sLwIPEventQueue     = NULL;
+static unsigned int sLwIPAcquireCount = 0;
+
+static void AcquireLwIP(void)
+{
+    if (sLwIPAcquireCount++ == 0)
+    {
+        sys_mbox_new(&sLwIPEventQueue, 100);
+    }
+}
+
+static void ReleaseLwIP(void)
+{
+    if (sLwIPAcquireCount > 0 && --sLwIPAcquireCount == 0)
+    {
+        tcpip_finish(NULL, NULL);
+    }
+}
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+
+System::Layer gSystemLayer;
+
+Inet::InetLayer gInet;
+
+#if CHIP_SYSTEM_CONFIG_USE_LWIP && !CHIP_SYSTEM_CONFIG_USE_SOCKETS
+static std::vector<TapInterface> sTapIFs;
+static std::vector<struct netif> sNetIFs; // interface to filter
+#endif                                    // CHIP_SYSTEM_CONFIG_USE_LWIP && !CHIP_SYSTEM_CONFIG_USE_SOCKETS
+
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+
+static bool NetworkIsReady();
+static void OnLwIPInitComplete(void * arg);
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+
+char gDefaultTapDeviceName[32];
+
+static void ExitOnSIGUSR1Handler(int signum)
+{
+    // exit() allows us a slightly better clean up (gcov data) than SIGINT's exit
+    exit(0);
+}
+
+// We set a hook to exit when we receive SIGUSR1, SIGTERM or SIGHUP
+void SetSIGUSR1Handler(void)
+{
+    SetSignalHandler(ExitOnSIGUSR1Handler);
+}
+
+void SetSignalHandler(SignalHandler handler)
+{
+    struct sigaction sa;
+    int signals[] = { SIGUSR1 };
+    size_t i;
+
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = handler;
+
+    for (i = 0; i < sizeof(signals) / sizeof(signals[0]); i++)
+    {
+        if (sigaction(signals[i], &sa, NULL) == -1)
+        {
+            perror("Can't catch signal");
+            exit(1);
+        }
+    }
+}
+
+void InitSystemLayer()
+{
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+    AcquireLwIP();
+
+    gSystemLayer.Init(sLwIPEventQueue);
+#else  // !CHIP_SYSTEM_CONFIG_USE_LWIP
+    gSystemLayer.Init(NULL);
+#endif // !CHIP_SYSTEM_CONFIG_USE_LWIP
+}
+
+void ShutdownSystemLayer()
+{
+    gSystemLayer.Shutdown();
+
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+    ReleaseLwIP();
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+}
+
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+static void PrintNetworkState()
+{
+    char intfName[10];
+
+    for (size_t j = 0; j < gNetworkOptions.TapDeviceName.size(); j++)
+    {
+        struct netif * netIF = &(sNetIFs[j]);
+        TapInterface * tapIF = &(sTapIFs[j]);
+
+        GetInterfaceName(netIF, intfName, sizeof(intfName));
+
+        printf("LwIP interface ready\n");
+        printf("  Interface Name: %s\n", intfName);
+        printf("  Tap Device: %s\n", gNetworkOptions.TapDeviceName[j]);
+        printf("  MAC address: %02x:%02x:%02x:%02x:%02x:%02x\n", tapIF->macAddr[0], tapIF->macAddr[1], tapIF->macAddr[2],
+               tapIF->macAddr[3], tapIF->macAddr[4], tapIF->macAddr[5]);
+#if INET_CONFIG_ENABLE_IPV4
+        printf("  IPv4 Address: %s\n", ipaddr_ntoa(&(netIF->ip_addr)));
+        printf("  IPv4 Mask: %s\n", ipaddr_ntoa(&(netIF->netmask)));
+        printf("  IPv4 Gateway: %s\n", ipaddr_ntoa(&(netIF->gw)));
+#endif // INET_CONFIG_ENABLE_IPV4
+        for (int i = 0; i < LWIP_IPV6_NUM_ADDRESSES; i++)
+        {
+            if (!ip6_addr_isany(netif_ip6_addr(netIF, i)))
+            {
+                printf("  IPv6 address: %s, 0x%02x\n", ip6addr_ntoa(netif_ip6_addr(netIF, i)), netif_ip6_addr_state(netIF, i));
+            }
+        }
+    }
+#if INET_CONFIG_ENABLE_DNS_RESOLVER
+    char dnsServerAddrStr[DNS_MAX_NAME_LENGTH];
+    printf("  DNS Server: %s\n", gNetworkOptions.DNSServerAddr.ToString(dnsServerAddrStr, sizeof(dnsServerAddrStr)));
+#endif // INET_CONFIG_ENABLE_DNS_RESOLVER
+}
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+
+void InitNetwork()
+{
+    void * lContext = NULL;
+
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+
+    tcpip_init(NULL, NULL);
+
+#else // !CHIP_SYSTEM_CONFIG_USE_SOCKETS
+
+    // If an tap device name hasn't been specified, derive one from the IPv6 interface id.
+
+    if (gNetworkOptions.TapDeviceName.empty())
+    {
+        for (size_t j = 0; j < gNetworkOptions.LocalIPv6Addr.size(); j++)
+        {
+            uint64_t iid    = gNetworkOptions.LocalIPv6Addr[j].InterfaceId();
+            char * tap_name = (char *) malloc(sizeof(gDefaultTapDeviceName));
+            snprintf(tap_name, sizeof(gDefaultTapDeviceName), "chip-dev-%" PRIx64, iid & 0xFFFF);
+            tap_name[sizeof(gDefaultTapDeviceName) - 1] = 0;
+            gNetworkOptions.TapDeviceName.push_back(tap_name);
+        }
+    }
+
+    err_t lwipErr;
+
+    sTapIFs.clear();
+    sNetIFs.clear();
+
+    for (size_t j = 0; j < gNetworkOptions.TapDeviceName.size(); j++)
+    {
+        TapInterface tapIF;
+        struct netif netIF;
+
+        sTapIFs.push_back(tapIF);
+        sNetIFs.push_back(netIF);
+    }
+
+    for (size_t j = 0; j < gNetworkOptions.TapDeviceName.size(); j++)
+    {
+        lwipErr = TapInterface_Init(&(sTapIFs[j]), gNetworkOptions.TapDeviceName[j], NULL);
+        if (lwipErr != ERR_OK)
+        {
+            printf("Failed to initialize tap device %s: %s\n", gNetworkOptions.TapDeviceName[j],
+                   ErrorStr(System::MapErrorLwIP(lwipErr)));
+            exit(EXIT_FAILURE);
+        }
+    }
+    tcpip_init(OnLwIPInitComplete, NULL);
+
+    // Lock LwIP stack
+    LOCK_TCPIP_CORE();
+
+    for (size_t j = 0; j < gNetworkOptions.TapDeviceName.size(); j++)
+    {
+        std::vector<char *> addrsVec;
+
+        addrsVec.clear();
+
+        if (gNetworkOptions.TapUseSystemConfig)
+        {
+            CollectTapAddresses(addrsVec, gNetworkOptions.TapDeviceName[j]);
+        }
+
+#if INET_CONFIG_ENABLE_IPV4
+
+        IPAddress ip4Addr = (j < gNetworkOptions.LocalIPv4Addr.size()) ? gNetworkOptions.LocalIPv4Addr[j] : IPAddress::Any;
+        for (size_t n = 0; n < addrsVec.size(); n++)
+        {
+            IPAddress auto_addr;
+            if (IPAddress::FromString(addrsVec[n], auto_addr) && auto_addr.IsIPv4())
+            {
+                ip4Addr = auto_addr;
+            }
+        }
+
+        IPAddress ip4Gateway = (j < gNetworkOptions.IPv4GatewayAddr.size()) ? gNetworkOptions.IPv4GatewayAddr[j] : IPAddress::Any;
+
+        {
+#if LWIP_VERSION_MAJOR > 1
+            ip4_addr_t ip4AddrLwIP, ip4NetmaskLwIP, ip4GatewayLwIP;
+#else  // LWIP_VERSION_MAJOR <= 1
+            ip_addr_t ip4AddrLwIP, ip4NetmaskLwIP, ip4GatewayLwIP;
+#endif // LWIP_VERSION_MAJOR <= 1
+
+            ip4AddrLwIP = ip4Addr.ToIPv4();
+            IP4_ADDR(&ip4NetmaskLwIP, 255, 255, 255, 0);
+            ip4GatewayLwIP = ip4Gateway.ToIPv4();
+            netif_add(&(netIFs[j]), &ip4AddrLwIP, &ip4NetmaskLwIP, &ip4GatewayLwIP, &(sTapIFs[j]), TapInterface_SetupNetif,
+                      tcpip_input);
+        }
+
+#endif // INET_CONFIG_ENABLE_IPV4
+
+        netif_create_ip6_linklocal_address(&(netIFs[j]), 1);
+
+        if (j < gNetworkOptions.LocalIPv6Addr.size())
+        {
+            ip6_addr_t ip6addr = gNetworkOptions.LocalIPv6Addr[j].ToIPv6();
+            s8_t index;
+            netif_add_ip6_address_with_route(&(netIFs[j]), &ip6addr, 64, &index);
+            // add ipv6 route for ipv6 address
+            if (j < gNetworkOptions.IPv6GatewayAddr.size())
+            {
+                static ip6_addr_t br_ip6_addr = gNetworkOptions.IPv6GatewayAddr[j].ToIPv6();
+                struct ip6_prefix ip6_prefix;
+                ip6_prefix.addr       = Inet::IPAddress::Any.ToIPv6();
+                ip6_prefix.prefix_len = 0;
+                ip6_add_route_entry(&ip6_prefix, &netIFs[j], &br_ip6_addr, NULL);
+            }
+            if (index >= 0)
+            {
+                netif_ip6_addr_set_state(&(netIFs[j]), index, IP6_ADDR_PREFERRED);
+            }
+        }
+        for (size_t n = 0; n < addrsVec.size(); n++)
+        {
+            IPAddress auto_addr;
+            if (IPAddress::FromString(addrsVec[n], auto_addr) && !auto_addr.IsIPv4())
+            {
+                ip6_addr_t ip6addr = auto_addr.ToIPv6();
+                s8_t index;
+                if (auto_addr.IsIPv6LinkLocal())
+                    continue; // skip over the LLA addresses, LwIP is aready adding those
+                if (auto_addr.IsIPv6Multicast())
+                    continue; // skip over the multicast addresses from host for now.
+                netif_add_ip6_address_with_route(&(netIFs[j]), &ip6addr, 64, &index);
+                if (index >= 0)
+                {
+                    netif_ip6_addr_set_state(&(netIFs[j]), index, IP6_ADDR_PREFERRED);
+                }
+            }
+        }
+
+        netif_set_up(&(netIFs[j]));
+        netif_set_link_up(&(netIFs[j]));
+    }
+
+    netif_set_default(&(netIFs[0]));
+    // UnLock LwIP stack
+
+    UNLOCK_TCPIP_CORE();
+
+    while (!NetworkIsReady())
+    {
+        struct timeval lSleepTime;
+        lSleepTime.tv_sec  = 0;
+        lSleepTime.tv_usec = 100000;
+        ServiceEvents(lSleepTime);
+    }
+
+    // FIXME: this is kinda nasty :(
+    // Force new IP address to be ready, bypassing duplicate detection.
+
+    for (size_t j = 0; j < gNetworkOptions.TapDeviceName.size(); j++)
+    {
+        if (j < gNetworkOptions.LocalIPv6Addr.size())
+        {
+            netif_ip6_addr_set_state(&(netIFs[j]), 2, 0x30);
+        }
+        else
+        {
+            netif_ip6_addr_set_state(&(netIFs[j]), 1, 0x30);
+        }
+    }
+
+#if INET_CONFIG_ENABLE_DNS_RESOLVER
+    if (gNetworkOptions.DNSServerAddr != IPAddress::Any)
+    {
+#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
+        ip_addr_t dnsServerAddr = gNetworkOptions.DNSServerAddr.ToLwIPAddr();
+#else // LWIP_VERSION_MAJOR <= 1
+#if INET_CONFIG_ENABLE_IPV4
+        ip_addr_t dnsServerAddr = gNetworkOptions.DNSServerAddr.ToIPv4();
+#else // !INET_CONFIG_ENABLE_IPV4
+#error "No support for DNS Resolver without IPv4!"
+#endif // !INET_CONFIG_ENABLE_IPV4
+#endif // LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
+
+        dns_setserver(0, &dnsServerAddr);
+    }
+#endif // INET_CONFIG_ENABLE_DNS_RESOLVER
+
+    PrintNetworkState();
+
+#endif // !CHIP_SYSTEM_CONFIG_USE_SOCKETS
+
+    AcquireLwIP();
+    lContext = sLwIPEventQueue;
+
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+
+    gInet.Init(gSystemLayer, lContext);
+}
+
+void ServiceEvents(struct ::timeval & aSleepTime)
+{
+    static bool printed = false;
+
+    if (!printed)
+    {
+#if CHIP_SYSTEM_CONFIG_USE_LWIP && !CHIP_SYSTEM_CONFIG_USE_SOCKETS
+        if (NetworkIsReady())
+#endif
+        {
+            printf("Weave Node ready to service events; PID: %d; PPID: %d\n", getpid(), getppid());
+            fflush(stdout);
+            printed = true;
+        }
+    }
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+    fd_set readFDs, writeFDs, exceptFDs;
+    int numFDs = 0;
+
+    FD_ZERO(&readFDs);
+    FD_ZERO(&writeFDs);
+    FD_ZERO(&exceptFDs);
+
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+    if (gSystemLayer.State() == System::kLayerState_Initialized)
+        gSystemLayer.PrepareSelect(numFDs, &readFDs, &writeFDs, &exceptFDs, aSleepTime);
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
+
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+    if (gInet.State == InetLayer::kState_Initialized)
+        gInet.PrepareSelect(numFDs, &readFDs, &writeFDs, &exceptFDs, aSleepTime);
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
+
+    int selectRes = select(numFDs, &readFDs, &writeFDs, &exceptFDs, &aSleepTime);
+    if (selectRes < 0)
+    {
+        printf("select failed: %s\n", ErrorStr(System::MapErrorPOSIX(errno)));
+        return;
+    }
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
+
+    if (gSystemLayer.State() == System::kLayerState_Initialized)
+    {
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+        static uint32_t sRemainingSystemLayerEventDelay = 0;
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+
+        gSystemLayer.HandleSelectResult(selectRes, &readFDs, &writeFDs, &exceptFDs);
+
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
+
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+        if (gSystemLayer.State() == System::kLayerState_Initialized)
+        {
+            if (sRemainingSystemLayerEventDelay == 0)
+            {
+                gSystemLayer.DispatchEvents();
+                sRemainingSystemLayerEventDelay = gNetworkOptions.EventDelay;
+            }
+            else
+                sRemainingSystemLayerEventDelay--;
+
+            // TODO: Currently timers are delayed by aSleepTime above. A improved solution would have a mechanism to reduce
+            // aSleepTime according to the next timer.
+
+            gSystemLayer.HandlePlatformTimer();
+        }
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+    }
+
+#if CHIP_SYSTEM_CONFIG_USE_LWIP && !CHIP_SYSTEM_CONFIG_USE_SOCKETS
+    TapInterface_Select(&(sTapIFs[0]), &(sNetIFs[0]), aSleepTime, gNetworkOptions.TapDeviceName.size());
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP && !CHIP_SYSTEM_CONFIG_USE_SOCKETS
+
+    if (gInet.State == InetLayer::kState_Initialized)
+    {
+#if INET_CONFIG_PROVIDE_OBSOLESCENT_INTERFACES && CHIP_SYSTEM_CONFIG_USE_LWIP
+        static uint32_t sRemainingInetLayerEventDelay = 0;
+#endif // INET_CONFIG_PROVIDE_OBSOLESCENT_INTERFACES && CHIP_SYSTEM_CONFIG_USE_LWIP
+
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+
+        gInet.HandleSelectResult(selectRes, &readFDs, &writeFDs, &exceptFDs);
+
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
+
+#if INET_CONFIG_PROVIDE_OBSOLESCENT_INTERFACES && CHIP_SYSTEM_CONFIG_USE_LWIP
+        if (gInet.State == InetLayer::kState_Initialized)
+        {
+            if (sRemainingInetLayerEventDelay == 0)
+            {
+                gInet.DispatchEvents();
+                sRemainingInetLayerEventDelay = gNetworkOptions.EventDelay;
+            }
+            else
+                sRemainingInetLayerEventDelay--;
+
+            // TODO: Currently timers are delayed by aSleepTime above. A improved solution would have a mechanism to reduce
+            // aSleepTime according to the next timer.
+
+            gInet.HandlePlatformTimer();
+        }
+#endif // INET_CONFIG_PROVIDE_OBSOLESCENT_INTERFACES && CHIP_SYSTEM_CONFIG_USE_LWIP
+    }
+}
+
+#if CHIP_SYSTEM_CONFIG_USE_LWIP && !CHIP_SYSTEM_CONFIG_USE_SOCKETS
+static bool NetworkIsReady()
+{
+    bool ready = true;
+
+    for (size_t j = 0; j < gNetworkOptions.TapDeviceName.size(); j++)
+    {
+        for (int i = 0; i < LWIP_IPV6_NUM_ADDRESSES; i++)
+        {
+            if (!ip6_addr_isany(netif_ip6_addr(&(netIFs[j]), i)) && ip6_addr_istentative(netif_ip6_addr_state(&(netIFs[j]), i)))
+            {
+                ready = false;
+                break;
+            }
+        }
+    }
+    return ready;
+}
+
+static void OnLwIPInitComplete(void * arg)
+{
+    printf("Waiting for addresses assignment...\n");
+}
+
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP && !CHIP_SYSTEM_CONFIG_USE_SOCKETS
+
+void ShutdownNetwork()
+{
+    gInet.Shutdown();
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+    ReleaseLwIP();
+#endif
+}

--- a/src/inet/tests/TestInetCommon.cpp
+++ b/src/inet/tests/TestInetCommon.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *    Copyright (c) 2013-2018 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,8 +18,9 @@
 
 /**
  *    @file
- *      This file implements constants, globals and interfaces common
- *      to and used by all Inet layer library test applications and tools.
+ *      This file implements constants, globals and interfaces common to
+ *      and used by all CHP Inet layer library test applications and
+ *      tools.
  *
  *      NOTE: These do not comprise a public part of the CHIP API and
  *            are subject to change without notice.
@@ -399,7 +400,7 @@ void ServiceEvents(struct ::timeval & aSleepTime)
         if (NetworkIsReady())
 #endif
         {
-            printf("Weave Node ready to service events; PID: %d; PPID: %d\n", getpid(), getppid());
+            printf("CHIP node ready to service events; PID: %d; PPID: %d\n", getpid(), getppid());
             fflush(stdout);
             printed = true;
         }

--- a/src/inet/tests/TestInetCommon.h
+++ b/src/inet/tests/TestInetCommon.h
@@ -1,0 +1,81 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines constants, globals and interfaces common to
+ *      and used by all Weave test applications and tools.
+ *
+ *      NOTE: These do not comprise a public part of the Weave API and
+ *            are subject to change without notice.
+ *
+ */
+
+#ifndef CHIP_TEST_INET_COMMON_H_
+#define CHIP_TEST_INET_COMMON_H_
+
+#ifndef __STDC_LIMIT_MACROS
+#define __STDC_LIMIT_MACROS
+#endif
+
+#include <ctype.h>
+#include <errno.h>
+#include <limits.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include <sys/time.h>
+
+#include <nlfaultinjection.hpp>
+
+#include <inet/InetLayer.h>
+#include <support/CodeUtils.h>
+#include <support/ErrorStr.h>
+#include <system/SystemLayer.h>
+
+#include "TestInetCommonOptions.h"
+
+#define CHIP_TOOL_COPYRIGHT "Copyright (c) 2020 Project CHIP Authors\nAll rights reserved.\n"
+
+extern chip::System::Layer gSystemLayer;
+
+extern chip::Inet::InetLayer gInet;
+
+extern void SetSIGUSR1Handler(void);
+extern void InitSystemLayer(void);
+extern void ShutdownSystemLayer(void);
+
+typedef void (*SignalHandler)(int signum);
+
+extern void SetSignalHandler(SignalHandler handler);
+
+extern void InitNetwork(void);
+extern void ServiceEvents(struct ::timeval & aSleepTime);
+extern void ShutdownNetwork(void);
+
+inline static void ServiceNetwork(struct ::timeval &aSleepTime)
+{
+    ServiceEvents(aSleepTime);
+}
+
+#endif /* CHIP_TEST_INET_COMMON_H_ */

--- a/src/inet/tests/TestInetCommon.h
+++ b/src/inet/tests/TestInetCommon.h
@@ -20,9 +20,10 @@
 /**
  *    @file
  *      This file defines constants, globals and interfaces common to
- *      and used by all Weave test applications and tools.
+ *      and used by all CHP Inet layer library test applications and
+ *      tools.
  *
- *      NOTE: These do not comprise a public part of the Weave API and
+ *      NOTE: These do not comprise a public part of the CHIP API and
  *            are subject to change without notice.
  *
  */
@@ -73,7 +74,7 @@ extern void InitNetwork(void);
 extern void ServiceEvents(struct ::timeval & aSleepTime);
 extern void ShutdownNetwork(void);
 
-inline static void ServiceNetwork(struct ::timeval &aSleepTime)
+inline static void ServiceNetwork(struct ::timeval & aSleepTime)
 {
     ServiceEvents(aSleepTime);
 }

--- a/src/inet/tests/TestInetCommonOptions.cpp
+++ b/src/inet/tests/TestInetCommonOptions.cpp
@@ -1,0 +1,293 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Common command-line option handling code for test applications.
+ *
+ */
+
+#ifndef __STDC_LIMIT_MACROS
+#define __STDC_LIMIT_MACROS
+#endif
+#define __STDC_FORMAT_MACROS
+
+#include "TestInetCommonOptions.h"
+
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include <system/SystemFaultInjection.h>
+#include <support/CHIPFaultInjection.h>
+#include <inet/InetFaultInjection.h>
+
+using namespace chip;
+using namespace chip::ArgParser;
+using namespace chip::Inet;
+
+// Global Variables
+
+NetworkOptions gNetworkOptions;
+FaultInjectionOptions gFaultInjectionOptions;
+
+NetworkOptions::NetworkOptions()
+{
+    static OptionDef optionDefs[] = {
+        { "local-addr", kArgumentRequired, 'a' },
+        { "node-addr", kArgumentRequired, kToolCommonOpt_NodeAddr }, /* alias for local-addr */
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+        { "tap-device", kArgumentRequired, kToolCommonOpt_TapDevice },
+        { "ipv4-gateway", kArgumentRequired, kToolCommonOpt_IPv4GatewayAddr },
+        { "ipv6-gateway", kArgumentRequired, kToolCommonOpt_IPv6GatewayAddr },
+        { "dns-server", kArgumentRequired, 'X' },
+        { "debug-lwip", kNoArgument, kToolCommonOpt_DebugLwIP },
+        { "event-delay", kArgumentRequired, kToolCommonOpt_EventDelay },
+        { "tap-system-config", kNoArgument, kToolCommonOpt_TapInterfaceConfig },
+#endif
+        {}
+    };
+    OptionDefs = optionDefs;
+
+    HelpGroupName = "NETWORK OPTIONS";
+
+    OptionHelp = "  -a, --local-addr, --node-addr <ip-addr>\n"
+                 "       Local address for the node.\n"
+                 "\n"
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+                 "  --tap-device <tap-dev-name>\n"
+                 "       TAP device name for LwIP hosted OS usage. Defaults to weave-dev-<node-id>.\n"
+                 "\n"
+                 "  --ipv4-gateway <ip-addr>\n"
+                 "       Address of default IPv4 gateway.\n"
+                 "\n"
+                 "  --ipv6-gateway <ip-addr>\n"
+                 "       Address of default IPv6 gateway.\n"
+                 "\n"
+                 "  -X, --dns-server <ip-addr>\n"
+                 "       IPv4 address of local DNS server.\n"
+                 "\n"
+                 "  --debug-lwip\n"
+                 "       Enable LwIP debug messages.\n"
+                 "\n"
+                 "  --event-delay <int>\n"
+                 "       Delay event processing by specified number of iterations. Defaults to 0.\n"
+                 "\n"
+                 "  --tap-system-config\n"
+                 "       Use configuration on each of the Linux TAP interfaces to configure LwIP's interfaces.\n"
+                 "\n"
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+        ;
+
+    // Defaults.
+    LocalIPv4Addr.clear();
+    LocalIPv6Addr.clear();
+
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+    TapDeviceName.clear();
+    LwIPDebugFlags = 0;
+    EventDelay     = 0;
+    IPv4GatewayAddr.clear();
+    IPv6GatewayAddr.clear();
+    DNSServerAddr      = Inet::IPAddress::Any;
+    TapUseSystemConfig = false;
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+}
+
+bool NetworkOptions::HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg)
+{
+    Inet::IPAddress localAddr;
+
+    switch (id)
+    {
+    case 'a':
+    case kToolCommonOpt_NodeAddr:
+        if (!ParseIPAddress(arg, localAddr))
+        {
+            PrintArgError("%s: Invalid value specified for local IP address: %s\n", progName, arg);
+            return false;
+        }
+#if INET_CONFIG_ENABLE_IPV4
+        if (localAddr.IsIPv4())
+        {
+            LocalIPv4Addr.push_back(localAddr);
+        }
+        else
+        {
+            LocalIPv6Addr.push_back(localAddr);
+        }
+#else  // INET_CONFIG_ENABLE_IPV4
+        LocalIPv6Addr.push_back(localAddr);
+#endif // INET_CONFIG_ENABLE_IPV4
+        break;
+
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+    case 'X':
+        if (!ParseIPAddress(arg, DNSServerAddr))
+        {
+            PrintArgError("%s: Invalid value specified for DNS server address: %s\n", progName, arg);
+            return false;
+        }
+        break;
+    case kToolCommonOpt_TapDevice:
+        TapDeviceName.push_back(arg);
+        break;
+
+    case kToolCommonOpt_IPv4GatewayAddr: {
+        if (!ParseIPAddress(arg, localAddr) || !localAddr.IsIPv4())
+        {
+            PrintArgError("%s: Invalid value specified for IPv4 gateway address: %s\n", progName, arg);
+            return false;
+        }
+        IPv4GatewayAddr.push_back(localAddr);
+    }
+    break;
+
+    case kToolCommonOpt_IPv6GatewayAddr: {
+        if (!ParseIPAddress(arg, localAddr))
+        {
+            PrintArgError("%s: Invalid value specified for IPv6 gateway address: %s\n", progName, arg);
+            return false;
+        }
+        IPv6GatewayAddr.push_back(localAddr);
+    }
+    break;
+
+    case kToolCommonOpt_DebugLwIP:
+#if defined(LWIP_DEBUG)
+        gLwIP_DebugFlags = (LWIP_DBG_ON | LWIP_DBG_TRACE | LWIP_DBG_STATE | LWIP_DBG_FRESH | LWIP_DBG_HALT);
+#endif
+        break;
+    case kToolCommonOpt_EventDelay:
+        if (!ParseInt(arg, EventDelay))
+        {
+            PrintArgError("%s: Invalid value specified for event delay: %s\n", progName, arg);
+            return false;
+        }
+        break;
+
+    case kToolCommonOpt_TapInterfaceConfig:
+        TapUseSystemConfig = true;
+        break;
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+
+    default:
+        PrintArgError("%s: INTERNAL ERROR: Unhandled option: %s\n", progName, name);
+        return false;
+    }
+
+    return true;
+}
+
+FaultInjectionOptions::FaultInjectionOptions()
+{
+    static OptionDef optionDefs[] = {
+#if CHIP_CONFIG_TEST || CHIP_SYSTEM_CONFIG_TEST || INET_CONFIG_TEST
+        { "faults", kArgumentRequired, kToolCommonOpt_FaultInjection },
+        { "iterations", kArgumentRequired, kToolCommonOpt_FaultTestIterations },
+        { "debug-resource-usage", kNoArgument, kToolCommonOpt_DebugResourceUsage },
+        { "print-fault-counters", kNoArgument, kToolCommonOpt_PrintFaultCounters },
+        { "extra-cleanup-time", kArgumentRequired, kToolCommonOpt_ExtraCleanupTime },
+#endif
+        {}
+    };
+    OptionDefs = optionDefs;
+
+    HelpGroupName = "FAULT INJECTION OPTIONS";
+
+    OptionHelp =
+#if CHIP_CONFIG_TEST || CHIP_SYSTEM_CONFIG_TEST || INET_CONFIG_TEST
+        "  --faults <fault-string>\n"
+        "       Inject specified fault(s) into the operation of the tool at runtime.\n"
+        "\n"
+        "  --iterations <int>\n"
+        "       Execute the program operation the given number of times\n"
+        "\n"
+        "  --debug-resource-usage\n"
+        "       Print all stats counters before exiting.\n"
+        "\n"
+        "  --print-fault-counters\n"
+        "       Print the fault-injection counters before exiting.\n"
+        "\n"
+        "  --extra-cleanup-time\n"
+        "       Allow extra time before asserting resource leaks; this is useful when\n"
+        "       running fault-injection tests to let the system free stale ExchangeContext\n"
+        "       instances after WRMP has exhausted all retransmission; a failed WRMP transmission\n"
+        "       should fail a normal happy-sequence test, but not necessarily a fault-injection test.\n"
+        "       The value is in milliseconds; a common value is 10000.\n"
+        "\n"
+#endif
+        "";
+
+    // Defaults
+    TestIterations       = 1;
+    DebugResourceUsage   = false;
+    PrintFaultCounters   = false;
+    ExtraCleanupTimeMsec = 0;
+}
+
+bool FaultInjectionOptions::HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg)
+{
+    using namespace nl::FaultInjection;
+
+    GetManagerFn faultMgrFnTable[] = { Inet::FaultInjection::GetManager, System::FaultInjection::GetManager };
+    size_t faultMgrFnTableLen      = sizeof(faultMgrFnTable) / sizeof(faultMgrFnTable[0]);
+
+    switch (id)
+    {
+#if CHIP_CONFIG_TEST || CHIP_SYSTEM_CONFIG_TEST || INET_CONFIG_TEST
+    case kToolCommonOpt_FaultInjection: {
+        char * mutableArg = strdup(arg);
+        bool parseRes     = ParseFaultInjectionStr(mutableArg, faultMgrFnTable, faultMgrFnTableLen);
+        free(mutableArg);
+        if (!parseRes)
+        {
+            PrintArgError("%s: Invalid string specified for fault injection option: %s\n", progName, arg);
+            return false;
+        }
+        break;
+    }
+    case kToolCommonOpt_FaultTestIterations:
+        if ((!ParseInt(arg, TestIterations)) || (TestIterations == 0))
+        {
+            PrintArgError("%s: Invalid value specified for the number of iterations to execute: %s\n", progName, arg);
+            return false;
+        }
+        break;
+    case kToolCommonOpt_DebugResourceUsage:
+        DebugResourceUsage = true;
+        break;
+    case kToolCommonOpt_PrintFaultCounters:
+        PrintFaultCounters = true;
+        break;
+    case kToolCommonOpt_ExtraCleanupTime:
+        if ((!ParseInt(arg, ExtraCleanupTimeMsec)) || (ExtraCleanupTimeMsec == 0))
+        {
+            PrintArgError("%s: Invalid value specified for the extra time to wait before checking for leaks: %s\n", progName, arg);
+            return false;
+        }
+        break;
+#endif // CHIP_CONFIG_TEST || CHIP_SYSTEM_CONFIG_TEST || INET_CONFIG_TEST
+    default:
+        PrintArgError("%s: INTERNAL ERROR: Unhandled option: %s\n", progName, name);
+        return false;
+    }
+
+    return true;
+}

--- a/src/inet/tests/TestInetCommonOptions.cpp
+++ b/src/inet/tests/TestInetCommonOptions.cpp
@@ -72,7 +72,7 @@ NetworkOptions::NetworkOptions()
                  "\n"
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
                  "  --tap-device <tap-dev-name>\n"
-                 "       TAP device name for LwIP hosted OS usage. Defaults to weave-dev-<node-id>.\n"
+                 "       TAP device name for LwIP hosted OS usage. Defaults to chip-dev-<node-id>.\n"
                  "\n"
                  "  --ipv4-gateway <ip-addr>\n"
                  "       Address of default IPv4 gateway.\n"

--- a/src/inet/tests/TestInetCommonOptions.h
+++ b/src/inet/tests/TestInetCommonOptions.h
@@ -1,0 +1,97 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Common command-line option handling code for test applications.
+ *
+ */
+
+#ifndef CHIP_TEST_INET_COMMON_OPTIONS_H_
+#define CHIP_TEST_INET_COMMON_OPTIONS_H_
+
+#include <vector>
+
+#include <inet/InetLayer.h>
+#include <core/CHIPCore.h>
+#include <support/CHIPArgParser.hpp>
+#include <system/SystemLayer.h>
+
+#define TOOL_OPTIONS_ENV_VAR_NAME "CHIP_INET_TEST_OPTIONS"
+
+enum
+{
+    kToolCommonOpt_NodeAddr = 1000,
+    kToolCommonOpt_EventDelay,
+    kToolCommonOpt_FaultInjection,
+    kToolCommonOpt_FaultTestIterations,
+    kToolCommonOpt_DebugResourceUsage,
+    kToolCommonOpt_PrintFaultCounters,
+    kToolCommonOpt_ExtraCleanupTime,
+    kToolCommonOpt_DebugLwIP,
+    kToolCommonOpt_IPv4GatewayAddr,
+    kToolCommonOpt_IPv6GatewayAddr,
+    kToolCommonOpt_TapDevice,
+    kToolCommonOpt_TapInterfaceConfig,
+};
+
+/**
+ * Handler for options that control local network/network interface configuration.
+ */
+class NetworkOptions : public chip::ArgParser::OptionSetBase
+{
+public:
+    std::vector<chip::Inet::IPAddress> LocalIPv4Addr;
+    std::vector<chip::Inet::IPAddress> LocalIPv6Addr;
+
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+    std::vector<chip::Inet::IPAddress> IPv4GatewayAddr;
+    std::vector<chip::Inet::IPAddress> IPv6GatewayAddr;
+    chip::Inet::IPAddress DNSServerAddr;
+    std::vector<const char *> TapDeviceName;
+    uint8_t LwIPDebugFlags;
+    uint32_t EventDelay;
+    bool TapUseSystemConfig;
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+
+    NetworkOptions();
+
+    virtual bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg);
+};
+
+extern NetworkOptions gNetworkOptions;
+
+/**
+ * Handler for options that control fault injection testing behavior.
+ */
+class FaultInjectionOptions : public chip::ArgParser::OptionSetBase
+{
+public:
+    uint32_t TestIterations;
+    bool DebugResourceUsage;
+    bool PrintFaultCounters;
+    uint32_t ExtraCleanupTimeMsec;
+
+    FaultInjectionOptions();
+
+    virtual bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg);
+};
+
+extern FaultInjectionOptions gFaultInjectionOptions;
+#endif // CHIP_TEST_INET_COMMON_OPTIONS_H_

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -1,0 +1,611 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2018 Google LLC.
+ *    Copyright (c) 2016-2018 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *     This file implements a unit test suite for InetLayer EndPoint related features
+ *
+ */
+
+#ifndef __STDC_LIMIT_MACROS
+#define __STDC_LIMIT_MACROS
+#endif
+
+#include <errno.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <CHIPVersion.h>
+
+#include <inet/InetLayer.h>
+#include <inet/InetError.h>
+
+#include <support/CHIPArgParser.hpp>
+
+#include <system/SystemError.h>
+#include <system/SystemTimer.h>
+
+#include <nlunit-test.h>
+
+#include "TestInetCommon.h"
+
+using namespace chip;
+using namespace chip::Inet;
+using namespace chip::System;
+
+#define TOOL_NAME "TestInetEndPoint"
+
+static ArgParser::HelpOptions gHelpOptions(TOOL_NAME, "Usage: " TOOL_NAME " [<options...>]\n",
+                                           CHIP_VERSION_STRING "\n" CHIP_TOOL_COPYRIGHT);
+
+static ArgParser::OptionSet * gToolOptionSets[] = { &gNetworkOptions, &gFaultInjectionOptions, &gHelpOptions, NULL };
+
+bool callbackHandlerCalled = false;
+
+void HandleDNSResolveComplete(void * appState, INET_ERROR err, uint8_t addrCount, IPAddress * addrArray)
+{
+    callbackHandlerCalled = true;
+
+    if (addrCount > 0)
+    {
+        char destAddrStr[64];
+        addrArray->ToString(destAddrStr, sizeof(destAddrStr));
+        printf("    DNS name resolution complete: %s\n", destAddrStr);
+    }
+    else
+        printf("    DNS name resolution return no addresses\n");
+}
+
+void HandleTimer(Layer * aLayer, void * aAppState, Error aError)
+{
+    printf("    timer handler\n");
+}
+
+// Test before init network, Inet is not initialized
+static void TestInetPre(nlTestSuite * inSuite, void * inContext)
+{
+#if INET_CONFIG_ENABLE_RAW_ENDPOINT
+    RawEndPoint * testRawEP = NULL;
+#endif // INET_CONFIG_ENABLE_RAW_ENDPOINT
+#if INET_CONFIG_ENABLE_UDP_ENDPOINT
+    UDPEndPoint * testUDPEP = NULL;
+#endif // INET_CONFIG_ENABLE_UDP_ENDPOINT
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    TCPEndPoint * testTCPEP = NULL;
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
+#if INET_CONFIG_ENABLE_TUN_ENDPOINT
+    TunEndPoint * testTunEP = NULL;
+#endif // INET_CONFIG_ENABLE_TUN_ENDPOINT
+    INET_ERROR err         = INET_NO_ERROR;
+    IPAddress testDestAddr = IPAddress::Any;
+    char testHostName[20]  = "www.nest.com";
+
+#if INET_CONFIG_ENABLE_RAW_ENDPOINT
+    err = gInet.NewRawEndPoint(kIPVersion_6, kIPProtocol_ICMPv6, &testRawEP);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_INCORRECT_STATE);
+#endif // INET_CONFIG_ENABLE_RAW_ENDPOINT
+
+#if INET_CONFIG_ENABLE_UDP_ENDPOINT
+    err = gInet.NewUDPEndPoint(&testUDPEP);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_INCORRECT_STATE);
+#endif // INET_CONFIG_ENABLE_UDP_ENDPOINT
+
+#if INET_CONFIG_ENABLE_TUN_ENDPOINT
+    err = gInet.NewTunEndPoint(&testTunEP);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_INCORRECT_STATE);
+#endif // INET_CONFIG_ENABLE_TUN_ENDPOINT
+
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    err = gInet.NewTCPEndPoint(&testTCPEP);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_INCORRECT_STATE);
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
+
+    err = gSystemLayer.StartTimer(10, HandleTimer, NULL);
+    NL_TEST_ASSERT(inSuite, err == CHIP_SYSTEM_ERROR_UNEXPECTED_STATE);
+
+#if INET_CONFIG_ENABLE_DNS_RESOLVER
+    err = gInet.ResolveHostAddress(testHostName, 1, &testDestAddr, HandleDNSResolveComplete, NULL);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_INCORRECT_STATE);
+#endif // INET_CONFIG_ENABLE_DNS_RESOLVER
+
+    // then init network
+    InitSystemLayer();
+    InitNetwork();
+}
+
+#if INET_CONFIG_ENABLE_DNS_RESOLVER
+// Test Inet ResolveHostAddress functionality
+static void TestResolveHostAddress(nlTestSuite * inSuite, void * inContext)
+{
+    char testHostName1[20] = "www.nest.com";
+    char testHostName2[20] = "127.0.0.1";
+    char testHostName3[20] = "";
+    char testHostName4[260];
+    struct timeval sleepTime;
+    IPAddress testDestAddr[1] = { IPAddress::Any };
+    INET_ERROR err;
+
+    sleepTime.tv_sec  = 0;
+    sleepTime.tv_usec = 10000;
+
+    memset(testHostName4, 'w', sizeof(testHostName4));
+    testHostName4[259] = '\0';
+
+    callbackHandlerCalled = false;
+    err = gInet.ResolveHostAddress(testHostName1, 1, testDestAddr, HandleDNSResolveComplete, &callbackHandlerCalled);
+    NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
+
+    if (err == INET_NO_ERROR)
+    {
+        while (!callbackHandlerCalled)
+        {
+            ServiceNetwork(sleepTime);
+        }
+    }
+
+    callbackHandlerCalled = false;
+    err = gInet.ResolveHostAddress(testHostName2, 1, testDestAddr, HandleDNSResolveComplete, &callbackHandlerCalled);
+    NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
+
+    if (err == INET_NO_ERROR)
+    {
+        while (!callbackHandlerCalled)
+        {
+            ServiceNetwork(sleepTime);
+        }
+    }
+
+    callbackHandlerCalled = false;
+    err = gInet.ResolveHostAddress(testHostName3, 1, testDestAddr, HandleDNSResolveComplete, &callbackHandlerCalled);
+    NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
+
+    if (err == INET_NO_ERROR)
+    {
+        while (!callbackHandlerCalled)
+        {
+            ServiceNetwork(sleepTime);
+        }
+    }
+
+    err = gInet.ResolveHostAddress(testHostName2, 0, testDestAddr, HandleDNSResolveComplete, &callbackHandlerCalled);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_NO_MEMORY);
+
+    err = gInet.ResolveHostAddress(testHostName4, 1, testDestAddr, HandleDNSResolveComplete, &callbackHandlerCalled);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_HOST_NAME_TOO_LONG);
+}
+#endif // INET_CONFIG_ENABLE_DNS_RESOLVER
+
+// Test Inet ParseHostPortAndInterface
+static void TestParseHost(nlTestSuite * inSuite, void * inContext)
+{
+    char correctHostName[7][30] = {
+        "10.0.0.1", "10.0.0.1:3000", "www.nest.com", "www.nest.com:3000", "[fd00:0:1:1::1]:3000", "[fd00:0:1:1::1]:300%wpan0",
+        "%wpan0"
+    };
+    char invalidHostName[4][30] = { "[fd00::1]5", "[fd00:0:1:1::1:3000", "10.0.0.1:1234567", "10.0.0.1:er31" };
+    const char * host;
+    const char * intf;
+    uint16_t port, hostlen, intflen;
+    INET_ERROR err;
+
+    for (int i = 0; i < 7; i++)
+    {
+        err = ParseHostPortAndInterface(correctHostName[i], strlen(correctHostName[i]), host, hostlen, port, intf, intflen);
+        NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
+    }
+    for (int i = 0; i < 4; i++)
+    {
+        err = ParseHostPortAndInterface(invalidHostName[i], strlen(invalidHostName[i]), host, hostlen, port, intf, intflen);
+        NL_TEST_ASSERT(inSuite, err == INET_ERROR_INVALID_HOST_NAME);
+    }
+}
+
+static void TestInetError(nlTestSuite * inSuite, void * inContext)
+{
+    INET_ERROR err = INET_NO_ERROR;
+
+    err = MapErrorPOSIX(EPERM);
+    NL_TEST_ASSERT(inSuite, DescribeErrorPOSIX(err));
+    NL_TEST_ASSERT(inSuite, IsErrorPOSIX(err));
+}
+
+static void TestInetInterface(nlTestSuite * inSuite, void * inContext)
+{
+    InterfaceIterator intIterator;
+    InterfaceAddressIterator addrIterator;
+    char intName[20];
+    InterfaceId intId;
+    IPAddress addr;
+    IPPrefix addrWithPrefix;
+    INET_ERROR err;
+
+    err = InterfaceNameToId("0", intId);
+    NL_TEST_ASSERT(inSuite, err != INET_NO_ERROR);
+
+    err = GetInterfaceName(INET_NULL_INTERFACEID, intName, 0);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_NO_MEMORY);
+
+    err = GetInterfaceName(INET_NULL_INTERFACEID, intName, sizeof(intName));
+    NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR && intName[0] == '\0');
+
+    err = gInet.GetInterfaceFromAddr(addr, intId);
+    NL_TEST_ASSERT(inSuite, intId == INET_NULL_INTERFACEID);
+
+    err = gInet.GetLinkLocalAddr(intId, NULL);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_BAD_ARGS);
+
+    printf("    Interfaces:\n");
+    for (; intIterator.HasCurrent(); intIterator.Next())
+    {
+        intId = intIterator.GetInterface();
+        NL_TEST_ASSERT(inSuite, intId != INET_NULL_INTERFACEID);
+        memset(intName, 42, sizeof(intName));
+        err = intIterator.GetInterfaceName(intName, sizeof(intName));
+        NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
+        printf("     interface id: 0x%" PRIxPTR ", interface name: %s, interface state: %s, %s multicast, %s broadcast addr\n",
+               (uintptr_t)(intId), intName, intIterator.IsUp() ? "UP" : "DOWN", intIterator.SupportsMulticast() ? "supports" : "no",
+               intIterator.HasBroadcastAddress() ? "has" : "no");
+
+        gInet.GetLinkLocalAddr(intId, &addr);
+        gInet.MatchLocalIPv6Subnet(addr);
+    }
+    NL_TEST_ASSERT(inSuite, !intIterator.Next());
+    NL_TEST_ASSERT(inSuite, intIterator.GetInterface() == INET_NULL_INTERFACEID);
+    NL_TEST_ASSERT(inSuite, intIterator.GetInterfaceName(intName, sizeof(intName)) == INET_ERROR_INCORRECT_STATE);
+    NL_TEST_ASSERT(inSuite, !intIterator.SupportsMulticast());
+    NL_TEST_ASSERT(inSuite, !intIterator.HasBroadcastAddress());
+
+    printf("    Addresses:\n");
+    for (; addrIterator.HasCurrent(); addrIterator.Next())
+    {
+        addr = addrIterator.GetAddress();
+        addrIterator.GetAddressWithPrefix(addrWithPrefix);
+        char addrStr[80];
+        addrWithPrefix.IPAddr.ToString(addrStr, sizeof(addrStr));
+        intId = addrIterator.GetInterfaceId();
+        NL_TEST_ASSERT(inSuite, intId != INET_NULL_INTERFACEID);
+        memset(intName, 42, sizeof(intName));
+        err = addrIterator.GetInterfaceName(intName, sizeof(intName));
+        NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, intName[0] != '\0' && memchr(intName, '\0', sizeof(intName)) != NULL);
+        printf("     %s/%d, interface id: 0x%" PRIxPTR
+               ", interface name: %s, interface state: %s, %s multicast, %s broadcast addr\n",
+               addrStr, addrWithPrefix.Length, (uintptr_t)(intId), intName, addrIterator.IsUp() ? "UP" : "DOWN",
+               addrIterator.SupportsMulticast() ? "supports" : "no", addrIterator.HasBroadcastAddress() ? "has" : "no");
+    }
+    NL_TEST_ASSERT(inSuite, !addrIterator.Next());
+    addrIterator.GetAddressWithPrefix(addrWithPrefix);
+    NL_TEST_ASSERT(inSuite, addrWithPrefix.IsZero());
+    NL_TEST_ASSERT(inSuite, addrIterator.GetInterface() == INET_NULL_INTERFACEID);
+    NL_TEST_ASSERT(inSuite, addrIterator.GetInterfaceName(intName, sizeof(intName)) == INET_ERROR_INCORRECT_STATE);
+    NL_TEST_ASSERT(inSuite, !addrIterator.SupportsMulticast());
+    NL_TEST_ASSERT(inSuite, !addrIterator.HasBroadcastAddress());
+}
+
+static void TestInetEndPoint(nlTestSuite * inSuite, void * inContext)
+{
+    INET_ERROR err;
+    IPAddress addr_any = IPAddress::Any;
+    IPAddress addr;
+#if INET_CONFIG_ENABLE_IPV4
+    IPAddress addr_v4;
+#endif // INET_CONFIG_ENABLE_IPV4
+    InterfaceId intId;
+
+    // EndPoint
+    RawEndPoint * testRaw6EP = NULL;
+#if INET_CONFIG_ENABLE_IPV4
+    RawEndPoint * testRaw4EP = NULL;
+#endif // INET_CONFIG_ENABLE_IPV4
+    UDPEndPoint * testUDPEP = NULL;
+#if INET_CONFIG_ENABLE_TUN_ENDPOINT
+    TunEndPoint * testTunEP = NULL;
+#endif
+    TCPEndPoint * testTCPEP1 = NULL;
+    PacketBuffer * buf       = PacketBuffer::New();
+    bool didBind             = false;
+    bool didListen           = false;
+
+    // init all the EndPoints
+    err = gInet.NewRawEndPoint(kIPVersion_6, kIPProtocol_ICMPv6, &testRaw6EP);
+    NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
+
+#if INET_CONFIG_ENABLE_IPV4
+    err = gInet.NewRawEndPoint(kIPVersion_4, kIPProtocol_ICMPv4, &testRaw4EP);
+    NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
+#endif // INET_CONFIG_ENABLE_IPV4
+
+    err = gInet.NewUDPEndPoint(&testUDPEP);
+    NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
+
+#if INET_CONFIG_ENABLE_TUN_ENDPOINT
+    err = gInet.NewTunEndPoint(&testTunEP);
+    NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
+#endif
+
+    err = gInet.NewTCPEndPoint(&testTCPEP1);
+    NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
+
+    err = gInet.GetLinkLocalAddr(INET_NULL_INTERFACEID, &addr);
+    NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
+    err = gInet.GetInterfaceFromAddr(addr, intId);
+    NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
+
+    // RawEndPoint special cases to cover the error branch
+    uint8_t ICMP6Types[2] = { 128, 129 };
+#if INET_CONFIG_ENABLE_IPV4
+    NL_TEST_ASSERT(inSuite, IPAddress::FromString("10.0.0.1", addr_v4));
+#endif // INET_CONFIG_ENABLE_IPV4
+
+    // error bind cases
+    err = testRaw6EP->Bind(kIPAddressType_Unknown, addr_any);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_WRONG_ADDRESS_TYPE);
+#if INET_CONFIG_ENABLE_IPV4
+    err = testRaw6EP->Bind(kIPAddressType_IPv4, addr);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_WRONG_ADDRESS_TYPE);
+    err = testRaw6EP->BindIPv6LinkLocal(intId, addr_v4);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_WRONG_ADDRESS_TYPE);
+#endif // INET_CONFIG_ENABLE_IPV4
+    err = testRaw6EP->BindInterface(kIPAddressType_Unknown, INET_NULL_INTERFACEID);
+    NL_TEST_ASSERT(inSuite, err != INET_NO_ERROR);
+
+    // A bind should succeed with appropriate permissions but will
+    // otherwise fail.
+
+    err = testRaw6EP->BindIPv6LinkLocal(intId, addr);
+    NL_TEST_ASSERT(inSuite, (err == INET_NO_ERROR) || (err == System::MapErrorPOSIX(EPERM)));
+
+    didBind = (err == INET_NO_ERROR);
+
+    // Listen after bind should succeed if the prior bind succeeded.
+
+    err = testRaw6EP->Listen();
+    NL_TEST_ASSERT(inSuite, (didBind && (err == INET_NO_ERROR)) || (!didBind && (err == INET_ERROR_INCORRECT_STATE)));
+
+    didListen = (err == INET_NO_ERROR);
+
+    // If the first listen succeeded, then the second listen should be successful.
+
+    err = testRaw6EP->Listen();
+    NL_TEST_ASSERT(inSuite, (didBind && didListen && (err == INET_NO_ERROR)) || (!didBind && (err == INET_ERROR_INCORRECT_STATE)));
+
+    didListen = (err == INET_NO_ERROR);
+
+    // A bind-after-listen should result in an incorrect state error;
+    // otherwise, it will fail with a permissions error.
+
+    err = testRaw6EP->Bind(kIPAddressType_IPv6, addr);
+    NL_TEST_ASSERT(inSuite,
+                   (didListen && (err == INET_ERROR_INCORRECT_STATE)) || (!didListen && (err == System::MapErrorPOSIX(EPERM))));
+
+    // error SetICMPFilter case
+    err = testRaw6EP->SetICMPFilter(0, ICMP6Types);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_BAD_ARGS);
+
+#if INET_CONFIG_ENABLE_IPV4
+    // We should never be able to send an IPv4-addressed message on an
+    // IPv6 raw socket.
+    //
+    // Ostensibly the address obtained above from
+    // gInet.GetLinkLocalAddr(INET_NULL_INTERFACEID, &addr) is an IPv6
+    // LLA; however, make sure it actually is.
+
+    NL_TEST_ASSERT(inSuite, addr.Type() == kIPAddressType_IPv6);
+
+    err = testRaw4EP->SendTo(addr, buf);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_WRONG_ADDRESS_TYPE);
+    testRaw4EP->Free();
+#endif // INET_CONFIG_ENABLE_IPV4
+
+    // UdpEndPoint special cases to cover the error branch
+    err = testUDPEP->Listen();
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_INCORRECT_STATE);
+    err = testUDPEP->Bind(kIPAddressType_Unknown, addr_any, 3000);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_WRONG_ADDRESS_TYPE);
+    err = testUDPEP->Bind(kIPAddressType_Unknown, addr, 3000);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_WRONG_ADDRESS_TYPE);
+#if INET_CONFIG_ENABLE_IPV4
+    err = testUDPEP->Bind(kIPAddressType_IPv4, addr, 3000);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_WRONG_ADDRESS_TYPE);
+#endif // INET_CONFIG_ENABLE_IPV4
+
+    err            = testUDPEP->Bind(kIPAddressType_IPv6, addr, 3000, intId);
+    err            = testUDPEP->BindInterface(kIPAddressType_IPv6, intId);
+    InterfaceId id = testUDPEP->GetBoundInterface();
+    NL_TEST_ASSERT(inSuite, id == intId);
+
+    err = testUDPEP->Listen();
+    err = testUDPEP->Listen();
+    err = testUDPEP->Bind(kIPAddressType_IPv6, addr, 3000, intId);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_INCORRECT_STATE);
+    err = testUDPEP->BindInterface(kIPAddressType_IPv6, intId);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_INCORRECT_STATE);
+    testUDPEP->Free();
+
+    err = gInet.NewUDPEndPoint(&testUDPEP);
+    NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
+#if INET_CONFIG_ENABLE_IPV4
+    err = testUDPEP->Bind(kIPAddressType_IPv4, addr_v4, 3000, intId);
+    NL_TEST_ASSERT(inSuite, err != INET_NO_ERROR);
+    buf = PacketBuffer::New();
+    err = testUDPEP->SendTo(addr_v4, 3000, buf);
+    testUDPEP->Free();
+#endif // INET_CONFIG_ENABLE_IPV4
+
+    // TcpEndPoint special cases to cover the error branch
+    err = testTCPEP1->GetPeerInfo(NULL, NULL);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_INCORRECT_STATE);
+    buf = PacketBuffer::New();
+    err = testTCPEP1->Send(buf, false);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_INCORRECT_STATE);
+    err = testTCPEP1->EnableKeepAlive(10, 100);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_INCORRECT_STATE);
+    err = testTCPEP1->DisableKeepAlive();
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_INCORRECT_STATE);
+    err = testTCPEP1->AckReceive(10);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_INCORRECT_STATE);
+    NL_TEST_ASSERT(inSuite, !testTCPEP1->PendingReceiveLength());
+    err = testTCPEP1->Listen(4);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_INCORRECT_STATE);
+    err = testTCPEP1->GetLocalInfo(NULL, NULL);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_INCORRECT_STATE);
+
+    err = testTCPEP1->Bind(kIPAddressType_Unknown, addr_any, 3000, true);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_WRONG_ADDRESS_TYPE);
+#if INET_CONFIG_ENABLE_IPV4
+    err = testTCPEP1->Bind(kIPAddressType_IPv4, addr, 3000, true);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_WRONG_ADDRESS_TYPE);
+#endif // INET_CONFIG_ENABLE_IPV4
+    err = testTCPEP1->Bind(kIPAddressType_Unknown, addr, 3000, true);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_WRONG_ADDRESS_TYPE);
+
+    err = testTCPEP1->Bind(kIPAddressType_IPv6, addr_any, 3000, true);
+    err = testTCPEP1->Bind(kIPAddressType_IPv6, addr_any, 3000, true);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_INCORRECT_STATE);
+    err = testTCPEP1->Listen(4);
+#if INET_CONFIG_ENABLE_IPV4
+    err = testTCPEP1->Connect(addr_v4, 4000, intId);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_INCORRECT_STATE);
+#endif // INET_CONFIG_ENABLE_IPV4
+
+#if INET_CONFIG_ENABLE_TUN_ENDPOINT
+    // TunEndPoint special cases to cover the error branch
+    testTunEP->Init(&Inet);
+    InterfaceId tunId = testTunEP->GetTunnelInterfaceId();
+    NL_TEST_ASSERT(inSuite, tunId == INET_NULL_INTERFACEID);
+    NL_TEST_ASSERT(inSuite, !testTunEP->IsInterfaceUp());
+    err = testTunEP->InterfaceUp();
+    NL_TEST_ASSERT(inSuite, err != INET_NO_ERROR);
+    err = testTunEP->InterfaceDown();
+    NL_TEST_ASSERT(inSuite, err != INET_NO_ERROR);
+    err = testTunEP->Send(buf);
+    NL_TEST_ASSERT(inSuite, err != INET_NO_ERROR);
+    testTunEP->Free();
+#endif
+
+    testTCPEP1->Shutdown();
+}
+
+// Test the InetLayer resource limitation
+static void TestInetEndPointLimit(nlTestSuite * inSuite, void * inContext)
+{
+    RawEndPoint * testRawEP = NULL;
+    UDPEndPoint * testUDPEP = NULL;
+#if INET_CONFIG_ENABLE_TUN_ENDPOINT
+    TunEndPoint * testTunEP = NULL;
+#endif
+    TCPEndPoint * testTCPEP = NULL;
+    INET_ERROR err;
+    char numTimersTest[CHIP_SYSTEM_CONFIG_NUM_TIMERS + 1];
+
+    for (int i = 0; i < INET_CONFIG_NUM_RAW_ENDPOINTS + 1; i++)
+        err = gInet.NewRawEndPoint(kIPVersion_6, kIPProtocol_ICMPv6, &testRawEP);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_NO_ENDPOINTS);
+
+    for (int i = 0; i < INET_CONFIG_NUM_UDP_ENDPOINTS + 1; i++)
+        err = gInet.NewUDPEndPoint(&testUDPEP);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_NO_ENDPOINTS);
+
+#if INET_CONFIG_ENABLE_TUN_ENDPOINT
+    for (int i = 0; i < INET_CONFIG_NUM_TUN_ENDPOINTS + 1; i++)
+        err = gInet.NewTunEndPoint(&testTunEP);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_NO_ENDPOINTS);
+#endif
+
+    for (int i = 0; i < INET_CONFIG_NUM_TCP_ENDPOINTS + 1; i++)
+        err = gInet.NewTCPEndPoint(&testTCPEP);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_NO_ENDPOINTS);
+
+    // Verify same aComplete and aAppState args do not exhaust timer pool
+    for (int i = 0; i < CHIP_SYSTEM_CONFIG_NUM_TIMERS + 1; i++)
+    {
+        err = gSystemLayer.StartTimer(10, HandleTimer, NULL);
+        NL_TEST_ASSERT(inSuite, err == CHIP_SYSTEM_NO_ERROR);
+    }
+
+    for (int i = 0; i < CHIP_SYSTEM_CONFIG_NUM_TIMERS + 1; i++)
+        err = gSystemLayer.StartTimer(10, HandleTimer, &numTimersTest[i]);
+    NL_TEST_ASSERT(inSuite, err == CHIP_SYSTEM_ERROR_NO_MEMORY);
+
+    ShutdownNetwork();
+    ShutdownSystemLayer();
+}
+
+// Test Suite
+
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+static const nlTest sTests[] = { NL_TEST_DEF("InetEndPoint::PreTest", TestInetPre),
+#if INET_CONFIG_ENABLE_DNS_RESOLVER
+                                 NL_TEST_DEF("InetEndPoint::ResolveHostAddress", TestResolveHostAddress),
+#endif // INET_CONFIG_ENABLE_DNS_RESOLVER
+                                 NL_TEST_DEF("InetEndPoint::TestParseHost", TestParseHost),
+                                 NL_TEST_DEF("InetEndPoint::TestInetError", TestInetError),
+                                 NL_TEST_DEF("InetEndPoint::TestInetInterface", TestInetInterface),
+                                 NL_TEST_DEF("InetEndPoint::TestInetEndPoint", TestInetEndPoint),
+                                 NL_TEST_DEF("InetEndPoint::TestEndPointLimit", TestInetEndPointLimit),
+                                 NL_TEST_SENTINEL() };
+
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+/**
+ *  Set up the test suite.
+ *  This is a work-around to initiate PacketBuffer protected class instance's
+ *  data and set it to a known state, before an instance is created.
+ */
+static int TestSetup(void * inContext)
+{
+    return (SUCCESS);
+}
+
+/**
+ *  Tear down the test suite.
+ *  Free memory reserved at TestSetup.
+ */
+static int TestTeardown(void * inContext)
+{
+    return (SUCCESS);
+}
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
+
+int main(int argc, char * argv[])
+{
+    SetSIGUSR1Handler();
+
+    if (!ParseArgs(TOOL_NAME, argc, argv, gToolOptionSets, NULL))
+    {
+        exit(EXIT_FAILURE);
+    }
+
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+    nlTestSuite theSuite = { "inet-endpoint", &sTests[0], TestSetup, TestTeardown };
+
+    // Generate machine-readable, comma-separated value (CSV) output.
+    nl_test_set_output_style(OUTPUT_CSV);
+
+    // Run test suite against one context.
+    nlTestRunner(&theSuite, NULL);
+
+    return nlTestRunnerStats(&theSuite);
+#else  // !CHIP_SYSTEM_CONFIG_USE_SOCKETS
+    return 0;
+#endif // !CHIP_SYSTEM_CONFIG_USE_SOCKETS
+}

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -488,7 +488,7 @@ static void TestInetEndPoint(nlTestSuite * inSuite, void * inContext)
 
 #if INET_CONFIG_ENABLE_TUN_ENDPOINT
     // TunEndPoint special cases to cover the error branch
-    testTunEP->Init(&Inet);
+    testTunEP->Init(&gInet);
     InterfaceId tunId = testTunEP->GetTunnelInterfaceId();
     NL_TEST_ASSERT(inSuite, tunId == INET_NULL_INTERFACEID);
     NL_TEST_ASSERT(inSuite, !testTunEP->IsInterfaceUp());

--- a/src/inet/tests/TestInetTimer.cpp
+++ b/src/inet/tests/TestInetTimer.cpp
@@ -149,7 +149,7 @@ int main(int argc, char * argv[])
 
     InitSystemLayer();
     InitNetwork();
-    sContext.mInet      = &Inet;
+    sContext.mInet      = &gInet;
     sContext.mTestSuite = &theSuite;
     // Run test suit againt one context.
     nlTestRunner(&theSuite, &sContext);

--- a/src/inet/tests/TestInetTimer.cpp
+++ b/src/inet/tests/TestInetTimer.cpp
@@ -1,0 +1,170 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2016-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a unit test suite for
+ *      <tt>chip::Inet::InetTimer</tt>, a class that provides timers
+ *      for the Inet library.
+ *
+ */
+
+#include <inet/InetConfig.h>
+
+#if INET_CONFIG_PROVIDE_OBSOLESCENT_INTERFACES
+
+#ifndef __STDC_LIMIT_MACROS
+#define __STDC_LIMIT_MACROS
+#endif
+
+#include <stdint.h>
+#include <string.h>
+
+#include <inet/InetLayer.h>
+#include <inet/InetTimer.h>
+
+#include <nlunit-test.h>
+
+//#include "ToolCommon.h"
+
+#define MEM_ALIGN_SIZE(SZ, ALIGN) (((SZ) + (ALIGN) -1) & ~((ALIGN) -1))
+#define INET_BUF_SIZE 1536
+#define INET_BUF_HEADER_SIZE MEM_ALIGN_SIZE(sizeof(InetBuffer), 4)
+#define INET_TO_PBUF(x) (static_cast<struct pbuf *>(static_cast<void *>(x)))
+
+using namespace chip::Inet;
+
+// Test input vector format.
+
+struct TestContext
+{
+    InetLayer * mInet;
+    nlTestSuite * mTestSuite;
+};
+
+// Test input data.
+
+static struct TestContext sContext;
+
+static volatile bool sOverflowTestDone;
+
+void HandleTimer0Failed(InetLayer * inetLayer, void * appState, INET_ERROR err)
+{
+    TestContext * context = static_cast<TestContext *>(appState);
+    NL_TEST_ASSERT(context->mTestSuite, false);
+    sOverflowTestDone = true;
+}
+
+void HandleTimer1Failed(InetLayer * inetLayer, void * appState, INET_ERROR err)
+{
+    TestContext * context = static_cast<TestContext *>(appState);
+    NL_TEST_ASSERT(context->mTestSuite, false);
+    sOverflowTestDone = true;
+}
+
+void HandleTimer10Success(InetLayer * inetLayer, void * appState, INET_ERROR err)
+{
+    TestContext * context = static_cast<TestContext *>(appState);
+    NL_TEST_ASSERT(context->mTestSuite, true);
+    sOverflowTestDone = true;
+}
+
+static void CheckOverflow(nlTestSuite * inSuite, void * inContext)
+{
+    uint32_t timeout_overflow_0ms = 652835029;
+    uint32_t timeout_overflow_1ms = 1958505088;
+    uint32_t timeout_10ms         = 10;
+
+    TestContext * context = static_cast<TestContext *>(inContext);
+
+    sOverflowTestDone = false;
+    context->mInet->StartTimer(timeout_overflow_0ms, HandleTimer0Failed, inContext);
+    context->mInet->StartTimer(timeout_overflow_1ms, HandleTimer1Failed, inContext);
+    context->mInet->StartTimer(timeout_10ms, HandleTimer10Success, inContext);
+    while (!sOverflowTestDone)
+    {
+        struct timeval sleepTime;
+        sleepTime.tv_sec  = 0;
+        sleepTime.tv_usec = 1000; // 1 ms tick
+        ServiceNetwork(sleepTime);
+    }
+    context->mInet->CancelTimer(HandleTimer0Failed, inContext);
+    context->mInet->CancelTimer(HandleTimer1Failed, inContext);
+    context->mInet->CancelTimer(HandleTimer10Success, inContext);
+}
+
+// Test Suite
+
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+static const nlTest sTests[] = { NL_TEST_DEF("InetTimer::TestOverflow", CheckOverflow), NL_TEST_SENTINEL() };
+
+/**
+ *  Set up the test suite.
+ *  This is a work-around to initiate InetBuffer protected class instance's
+ *  data and set it to a known state, before an instance is created.
+ */
+static int TestSetup(void * inContext)
+{
+    return (SUCCESS);
+}
+
+/**
+ *  Tear down the test suite.
+ *  Free memory reserved at TestSetup.
+ */
+static int TestTeardown(void * inContext)
+{
+    return (SUCCESS);
+}
+
+int main(int argc, char * argv[])
+{
+#if INET_SOCKETS
+    nlTestSuite theSuite = { "inet-timer", &sTests[0], TestSetup, TestTeardown };
+
+    // Generate machine-readable, comma-separated value (CSV) output.
+    nl_test_set_output_style(OUTPUT_CSV);
+
+    SetSIGUSR1Handler();
+
+    //    ParseArgs(argc, argv);
+
+    InitSystemLayer();
+    InitNetwork();
+    sContext.mInet      = &Inet;
+    sContext.mTestSuite = &theSuite;
+    // Run test suit againt one context.
+    nlTestRunner(&theSuite, &sContext);
+
+    return nlTestRunnerStats(&theSuite);
+#else  // !INET_SOCKETS
+    return 0;
+#endif // !INET_SOCKETS
+}
+
+#else // !INET_CONFIG_PROVIDE_OBSOLESCENT_INTERFACES
+
+int main(void)
+{
+    return 0;
+}
+
+#endif // !INET_CONFIG_PROVIDE_OBSOLESCENT_INTERFACES


### PR DESCRIPTION
 #### Problem
The chip::Inet layer library is missing unit tests for the buffer, endpoint, layer, and timer objects.

#### Summary of Changes
Add or import from openweave-core such tests.

Fixes #213
