### PR TITLE
Top level coverage

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -80,4 +80,32 @@ SUBDIRS                           = \
     $(MAYBE_PLATFORM_SUBDIRS)       \
     $(NULL)
 
+if CHIP_BUILD_TESTS
+if CHIP_BUILD_COVERAGE
+if CHIP_BUILD_COVERAGE_REPORTS
+# The bundle should positively be qualified with the absolute build
+# path. Otherwise, VPATH will get auto-prefixed to it if there is
+# already such a directory in the non-colocated source tree.
+
+CHIP_COVERAGE_BUNDLE              = ${abs_builddir}/${PACKAGE}${NL_COVERAGE_BUNDLE_SUFFIX}
+CHIP_COVERAGE_INFO                = ${CHIP_COVERAGE_BUNDLE}/${PACKAGE}${NL_COVERAGE_INFO_SUFFIX}
+
+$(CHIP_COVERAGE_BUNDLE):
+	$(call create-directory)
+
+$(CHIP_COVERAGE_INFO): check | $(CHIP_COVERAGE_BUNDLE)
+	$(call generate-coverage-report,${top_builddir},*/usr/include/* */third_party/*)
+
+coverage-local: $(CHIP_COVERAGE_INFO)
+
+clean-local: clean-local-coverage
+
+.PHONY: clean-local-coverage
+clean-local-coverage:
+	-$(AM_V_at)rm -rf $(CHIP_COVERAGE_BUNDLE)
+
+endif # CHIP_BUILD_COVERAGE_REPORTS
+endif # CHIP_BUILD_COVERAGE
+endif # CHIP_BUILD_TESTS
+
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/ble/tests/Makefile.am
+++ b/src/ble/tests/Makefile.am
@@ -99,7 +99,7 @@ $(CHIP_COVERAGE_BUNDLE):
 	$(call create-directory)
 
 $(CHIP_COVERAGE_INFO): check-local | $(CHIP_COVERAGE_BUNDLE)
-	$(call generate-coverage-report,${top_builddir})
+	$(call generate-coverage-report,${top_builddir},*/usr/include/* */third_party/*)
 
 coverage-local: $(CHIP_COVERAGE_INFO)
 

--- a/src/crypto/tests/Makefile.am
+++ b/src/crypto/tests/Makefile.am
@@ -92,7 +92,7 @@ $(CHIP_COVERAGE_BUNDLE):
 	$(call create-directory)
 
 $(CHIP_COVERAGE_INFO): check-local | $(CHIP_COVERAGE_BUNDLE)
-	$(call generate-coverage-report,${top_builddir})
+	$(call generate-coverage-report,${top_builddir},*/usr/include/* */third_party/*)
 
 coverage-local: $(CHIP_COVERAGE_INFO)
 

--- a/src/inet/tests/Makefile.am
+++ b/src/inet/tests/Makefile.am
@@ -103,7 +103,7 @@ $(CHIP_COVERAGE_BUNDLE):
 	$(call create-directory)
 
 $(CHIP_COVERAGE_INFO): check-local | $(CHIP_COVERAGE_BUNDLE)
-	$(call generate-coverage-report,${top_builddir})
+	$(call generate-coverage-report,${top_builddir},*/usr/include/* */third_party/*)
 
 coverage-local: $(CHIP_COVERAGE_INFO)
 

--- a/src/lib/core/tests/Makefile.am
+++ b/src/lib/core/tests/Makefile.am
@@ -99,7 +99,7 @@ $(CHIP_COVERAGE_BUNDLE):
 	$(call create-directory)
 
 $(CHIP_COVERAGE_INFO): check-local | $(CHIP_COVERAGE_BUNDLE)
-	$(call generate-coverage-report,${top_builddir})
+	$(call generate-coverage-report,${top_builddir},*/usr/include/* */third_party/*)
 
 coverage-local: $(CHIP_COVERAGE_INFO)
 

--- a/src/lib/support/tests/Makefile.am
+++ b/src/lib/support/tests/Makefile.am
@@ -105,7 +105,7 @@ $(CHIP_COVERAGE_BUNDLE):
 	$(call create-directory)
 
 $(CHIP_COVERAGE_INFO): check-local | $(CHIP_COVERAGE_BUNDLE)
-	$(call generate-coverage-report,${top_builddir})
+	$(call generate-coverage-report,${top_builddir},*/usr/include/* */third_party/*)
 
 coverage-local: $(CHIP_COVERAGE_INFO)
 

--- a/src/lwip/tests/Makefile.am
+++ b/src/lwip/tests/Makefile.am
@@ -86,7 +86,7 @@ $(CHIP_COVERAGE_BUNDLE):
 	$(call create-directory)
 
 $(CHIP_COVERAGE_INFO): check-local | $(CHIP_COVERAGE_BUNDLE)
-	$(call generate-coverage-report,${top_builddir})
+	$(call generate-coverage-report,${top_builddir},*/usr/include/* */third_party/*)
 
 coverage-local: $(CHIP_COVERAGE_INFO)
 

--- a/src/setup_payload/tests/Makefile.am
+++ b/src/setup_payload/tests/Makefile.am
@@ -88,7 +88,7 @@ $(CHIP_COVERAGE_BUNDLE):
 	$(call create-directory)
 
 $(CHIP_COVERAGE_INFO): check-local | $(CHIP_COVERAGE_BUNDLE)
-	$(call generate-coverage-report,${top_builddir})
+	$(call generate-coverage-report,${top_builddir},*/usr/include/* */third_party/*)
 
 coverage-local: $(CHIP_COVERAGE_INFO)
 

--- a/src/system/tests/Makefile.am
+++ b/src/system/tests/Makefile.am
@@ -119,7 +119,7 @@ $(CHIP_COVERAGE_BUNDLE):
 	$(call create-directory)
 
 $(CHIP_COVERAGE_INFO): check-local | $(CHIP_COVERAGE_BUNDLE)
-	$(call generate-coverage-report,${top_builddir})
+	$(call generate-coverage-report,${top_builddir},*/usr/include/* */third_party/*)
 
 coverage-local: $(CHIP_COVERAGE_INFO)
 


### PR DESCRIPTION
#### Problem
 Noise in coverage reports, no central report

 #### Summary of Changes
 * Added a central report (in src/)
 * Added filters to reports (needs [nlbuild-autotools 49](https://github.com/nestlabs/nlbuild-autotools/pull/49) to take effect)


