### PR TITLE
Make the "Clean Tree" task less intrusive

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -89,7 +89,7 @@
         {
             "label": "Clean tree",
             "type": "shell",
-            "command": "make -f Makefile-bootstrap clean-repos && git clean -xdf",
+            "command": "make -f Makefile-bootstrap clean-repos && git clean -Xdf",
             "group": "none",
             "problemMatcher": [
                 "$gcc"


### PR DESCRIPTION
 #### Problem
The VSCode task, "Clean Tree" performs a `git clean -xdf` which purges any ignored and untracked files from the tree. 

This can lead to lost work. We really just want to delete the files ignored by git and so `git clean -Xdf` is perferred. 
 #### Summary of Changes
Updated the task to only delete files ignored by git (usually build products).
