### PR TITLE
Add / Import Missing Tests for Inet Layer Unicast and Multicast Operations

### DIFF
--- a/src/inet/tests/Makefile.am
+++ b/src/inet/tests/Makefile.am
@@ -95,6 +95,7 @@ noinst_PROGRAMS                                       = \
 check_PROGRAMS                                        = \
     TestInetAddress                                     \
     TestInetBuffer                                      \
+    TestInetEndPoint                                    \
     TestInetErrorStr                                    \
     TestInetTimer                                       \
     $(NULL)

--- a/src/inet/tests/Makefile.am
+++ b/src/inet/tests/Makefile.am
@@ -98,7 +98,6 @@ noinst_PROGRAMS                                       = \
 check_PROGRAMS                                        = \
     TestInetAddress                                     \
     TestInetBuffer                                      \
-    TestInetEndPoint                                    \
     TestInetErrorStr                                    \
     TestInetTimer                                       \
     $(NULL)

--- a/src/inet/tests/Makefile.am
+++ b/src/inet/tests/Makefile.am
@@ -29,6 +29,7 @@ include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 noinst_HEADERS                                        = \
     TestInetCommon.h                                    \
     TestInetCommonOptions.h                             \
+    TestInetLayerCommon.hpp                             \
     $(NULL)
 
 #
@@ -57,6 +58,7 @@ AM_CPPFLAGS                                           = \
 libTestInetCommon_a_SOURCES                           = \
     TestInetCommon.cpp                                  \
     TestInetCommonOptions.cpp                           \
+    TestInetLayerCommon.cpp                             \
     $(NULL)
 
 CHIP_LDADD                                            = \
@@ -87,8 +89,9 @@ COMMON_LDADD                                          = \
 
 noinst_PROGRAMS                                       = \
     TestInetEndPoint                                    \
+    TestInetLayer                                       \
+    TestInetLayerMulticast                              \
     $(NULL)
-
 
 # Test applications that should be run when the 'check' target is run.
 
@@ -129,6 +132,14 @@ TestInetEndPoint_LDADD                                = libTestInetCommon.a $(CO
 TestInetErrorStr_SOURCES                              = TestInetErrorStr.cpp    \
                                                         $(NULL)
 TestInetErrorStr_LDADD                                = $(COMMON_LDADD)
+
+TestInetLayer_SOURCES                                 = TestInetLayer.cpp    \
+                                                        $(NULL)
+TestInetLayer_LDADD                                   = libTestInetCommon.a $(COMMON_LDADD)
+
+TestInetLayerMulticast_SOURCES                        = TestInetLayerMulticast.cpp    \
+                                                        $(NULL)
+TestInetLayerMulticast_LDADD                          = libTestInetCommon.a $(COMMON_LDADD)
 
 TestInetTimer_SOURCES                                 = TestInetTimer.cpp       \
                                                         $(NULL)

--- a/src/inet/tests/TestInetCommon.h
+++ b/src/inet/tests/TestInetCommon.h
@@ -58,10 +58,24 @@
 
 #define CHIP_TOOL_COPYRIGHT "Copyright (c) 2020 Project CHIP Authors\nAll rights reserved.\n"
 
+#define INET_FAIL_ERROR(ERR, MSG)                                                                                                  \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        if ((ERR) != INET_NO_ERROR)                                                                                                \
+        {                                                                                                                          \
+            fprintf(stderr, "%s: %s\n", (MSG), ErrorStr(ERR));                                                                     \
+            exit(-1);                                                                                                              \
+        }                                                                                                                          \
+    } while (0)
+
 extern chip::System::Layer gSystemLayer;
 
 extern chip::Inet::InetLayer gInet;
 
+extern bool gDone;
+extern bool gSigusr1Received;
+
+extern void InitTestInetCommon(void);
 extern void SetSIGUSR1Handler(void);
 extern void InitSystemLayer(void);
 extern void ShutdownSystemLayer(void);
@@ -73,10 +87,15 @@ extern void SetSignalHandler(SignalHandler handler);
 extern void InitNetwork(void);
 extern void ServiceEvents(struct ::timeval & aSleepTime);
 extern void ShutdownNetwork(void);
+extern void DumpMemory(const uint8_t * mem, uint32_t len, const char * prefix, uint32_t rowWidth);
+extern void DumpMemory(const uint8_t * mem, uint32_t len, const char * prefix);
 
 inline static void ServiceNetwork(struct ::timeval & aSleepTime)
 {
     ServiceEvents(aSleepTime);
 }
 
+extern void SetupFaultInjectionContext(int argc, char * argv[]);
+extern void SetupFaultInjectionContext(int argc, char * argv[], int32_t (*aNumEventsAvailable)(void),
+                                       void (*aInjectAsyncEvents)(int32_t index));
 #endif /* CHIP_TEST_INET_COMMON_H_ */

--- a/src/inet/tests/TestInetLayer.cpp
+++ b/src/inet/tests/TestInetLayer.cpp
@@ -1,0 +1,1079 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2019 Google LLC.
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a process to effect a functional test for
+ *      the InetLayer Internet Protocol stack abstraction interfaces.
+ *
+ */
+
+#ifndef __STDC_LIMIT_MACROS
+#define __STDC_LIMIT_MACROS
+#endif
+
+#include <signal.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <CHIPVersion.h>
+
+#include <support/CodeUtils.h>
+
+#include <system/SystemTimer.h>
+
+#include "TestInetCommon.h"
+#include "TestInetLayerCommon.hpp"
+
+using namespace chip;
+using namespace chip::Inet;
+using namespace chip::ArgParser;
+
+/* Preprocessor Macros */
+
+#define kToolName                       "TestInetLayer"
+
+#define kToolOptTCPIP                   't'
+
+#define kToolOptExpectedRxSize          (kToolOptBase + 0)
+#define kToolOptExpectedTxSize          (kToolOptBase + 1)
+
+
+/* Type Definitions */
+
+enum OptFlags
+{
+    kOptFlagExpectedRxSize = 0x00010000,
+    kOptFlagExpectedTxSize = 0x00020000,
+
+    kOptFlagUseTCPIP       = 0x00040000
+};
+
+struct TestState
+{
+    TransferStats                mStats;
+    TestStatus                   mStatus;
+};
+
+
+/* Function Declarations */
+
+static void HandleSignal(int aSignal);
+static bool HandleOption(const char *aProgram, OptionSet *aOptions, int aIdentifier, const char *aName, const char *aValue);
+static bool HandleNonOptionArgs(const char *aProgram, int argc, char *argv[]);
+
+static void StartTest(void);
+static void CleanupTest(void);
+
+
+/* Global Variables */
+
+static const uint32_t    kExpectedRxSizeDefault = 1523;
+static const uint32_t    kExpectedTxSizeDefault = kExpectedRxSizeDefault;
+
+static const uint32_t    kOptFlagsDefault       = (kOptFlagUseIPv6 | kOptFlagUseUDPIP);
+
+static RawEndPoint *     sRawIPEndPoint         = NULL;
+static TCPEndPoint *     sTCPIPEndPoint         = NULL;  // Used for connect/send/receive
+static TCPEndPoint *     sTCPIPListenEndPoint   = NULL;  // Used for accept/listen
+static UDPEndPoint *     sUDPIPEndPoint         = NULL;
+
+static const uint16_t    kTCPPort               = kUDPPort;
+
+static TestState         sTestState             =
+{
+    { { 0, 0 }, { 0, 0 } },
+    { false, false }
+};
+
+static IPAddress         sDestinationAddress   = IPAddress::Any;
+static const char *      sDestinationString    = NULL;
+
+static OptionDef         sToolOptionDefs[] =
+{
+    { "interface",                 kArgumentRequired,  kToolOptInterface              },
+    { "expected-rx-size",          kArgumentRequired,  kToolOptExpectedRxSize         },
+    { "expected-tx-size",          kArgumentRequired,  kToolOptExpectedTxSize         },
+    { "interval",                  kArgumentRequired,  kToolOptInterval               },
+#if INET_CONFIG_ENABLE_IPV4
+    { "ipv4",                      kNoArgument,        kToolOptIPv4Only               },
+#endif // INET_CONFIG_ENABLE_IPV4
+    { "ipv6",                      kNoArgument,        kToolOptIPv6Only               },
+    { "listen",                    kNoArgument,        kToolOptListen                 },
+    { "raw",                       kNoArgument,        kToolOptRawIP                  },
+    { "send-size",                 kArgumentRequired,  kToolOptSendSize               },
+    { "tcp",                       kNoArgument,        kToolOptTCPIP                  },
+    { "udp",                       kNoArgument,        kToolOptUDPIP                  },
+    { }
+};
+
+static const char *      sToolOptionHelp =
+    "  -I, --interface <interface>\n"
+    "       The network interface to bind to and from which to send and receive all packets.\n"
+    "\n"
+    "  --expected-rx-size <size>\n"
+    "       Expect to receive size bytes of user data (default 1523).\n"
+    "\n"
+    "  --expected-tx-size <size>\n"
+    "       Expect to send size bytes of user data (default 1523).\n"
+    "\n"
+    "  -i, --interval <interval>\n"
+    "       Wait interval milliseconds between sending each packet (default: 1000 ms).\n"
+    "\n"
+    "  -l, --listen\n"
+    "       Act as a server (i.e., listen) for packets rather than send them.\n"
+    "\n"
+#if INET_CONFIG_ENABLE_IPV4
+    "  -4, --ipv4\n"
+    "       Use IPv4 only.\n"
+    "\n"
+#endif // INET_CONFIG_ENABLE_IPV4
+    "  -6, --ipv6\n"
+    "       Use IPv6 only (default).\n"
+    "\n"
+    "  -s, --send-size <size>\n"
+    "       Send size bytes of user data (default: 59 bytes)\n"
+    "\n"
+    "  -r, --raw\n"
+    "       Use raw IP (default).\n"
+    "\n"
+    "  -t, --tcp\n"
+    "       Use TCP over IP.\n"
+    "\n"
+    "  -u, --udp\n"
+    "       Use UDP over IP (default).\n"
+    "\n";
+
+static OptionSet         sToolOptions =
+{
+    HandleOption,
+    sToolOptionDefs,
+    "GENERAL OPTIONS",
+    sToolOptionHelp
+};
+
+static HelpOptions       sHelpOptions(
+    kToolName,
+    "Usage: " kToolName " [ <options> ] <dest-node-addr>\n"
+    "       " kToolName " [ <options> ] --listen\n",
+    CHIP_VERSION_STRING "\n" CHIP_TOOL_COPYRIGHT
+);
+
+static OptionSet *       sToolOptionSets[] =
+{
+    &sToolOptions,
+    &gNetworkOptions,
+    &gFaultInjectionOptions,
+    &sHelpOptions,
+    NULL
+};
+
+static void CheckSucceededOrFailed(TestState &aTestState, bool &aOutSucceeded, bool &aOutFailed)
+{
+    const TransferStats &lStats = aTestState.mStats;
+
+#if DEBUG
+    printf("%u/%u sent, %u/%u received\n",
+           lStats.mTransmit.mActual, lStats.mTransmit.mExpected,
+           lStats.mReceive.mActual, lStats.mReceive.mExpected);
+#endif
+
+    if (((lStats.mTransmit.mExpected > 0) && (lStats.mTransmit.mActual > lStats.mTransmit.mExpected)) ||
+        ((lStats.mReceive.mExpected > 0) && (lStats.mReceive.mActual > lStats.mReceive.mExpected)))
+    {
+        aOutFailed = true;
+    }
+    else if (((lStats.mTransmit.mExpected > 0) && (lStats.mTransmit.mActual < lStats.mTransmit.mExpected)) ||
+             ((lStats.mReceive.mExpected > 0) && (lStats.mReceive.mActual < lStats.mReceive.mExpected)))
+    {
+        aOutSucceeded = false;
+    }
+
+    if (aOutSucceeded || aOutFailed)
+    {
+        if (aOutSucceeded)
+            aTestState.mStatus.mSucceeded = true;
+
+        if (aOutFailed)
+            SetStatusFailed(aTestState.mStatus);
+    }
+}
+
+static void HandleSignal(int aSignal)
+{
+    switch (aSignal)
+    {
+
+    case SIGUSR1:
+        SetStatusFailed(sTestState.mStatus);
+        break;
+
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    bool          lSuccessful = true;
+    INET_ERROR    lStatus;
+
+    InitTestInetCommon();
+
+    SetupFaultInjectionContext(argc, argv);
+
+    SetSignalHandler(HandleSignal);
+
+    if (argc == 1)
+    {
+        sHelpOptions.PrintBriefUsage(stderr);
+        lSuccessful = false;
+        goto exit;
+    }
+
+    if (!ParseArgsFromEnvVar(kToolName, TOOL_OPTIONS_ENV_VAR_NAME, sToolOptionSets, NULL, true) ||
+        !ParseArgs(kToolName, argc, argv, sToolOptionSets, HandleNonOptionArgs))
+    {
+        lSuccessful = false;
+        goto exit;
+    }
+
+    InitSystemLayer();
+
+    InitNetwork();
+
+    // At this point, we should have valid network interfaces,
+    // including LwIP TUN/TAP shim interfaces. Validate the
+    // -I/--interface argument, if present.
+
+    if (gInterfaceName != NULL)
+    {
+        lStatus = InterfaceNameToId(gInterfaceName, gInterfaceId);
+        if (lStatus != INET_NO_ERROR)
+        {
+            PrintArgError("%s: unknown network interface %s\n", kToolName, gInterfaceName);
+            lSuccessful = false;
+            goto shutdown;
+        }
+    }
+
+    StartTest();
+
+    while (Common::IsTesting(sTestState.mStatus))
+    {
+        struct timeval sleepTime;
+        bool lSucceeded = true;
+        bool lFailed = false;
+
+        sleepTime.tv_sec = 0;
+        sleepTime.tv_usec = 10000;
+
+        ServiceNetwork(sleepTime);
+
+        CheckSucceededOrFailed(sTestState, lSucceeded, lFailed);
+
+#if DEBUG
+        printf("%s %s number of expected bytes\n",
+               ((lSucceeded) ? "successfully" :
+                ((lFailed) ? "failed to" :
+                 "has not yet")),
+               ((lSucceeded) ? (Common::IsReceiver() ? "received" : "sent") :
+                ((lFailed) ? (Common::IsReceiver() ? "receive" : "send") :
+                 Common::IsReceiver() ? "received" : "sent"))
+               );
+#endif
+    }
+
+    CleanupTest();
+
+shutdown:
+    ShutdownNetwork();
+    ShutdownSystemLayer();
+
+    lSuccessful = Common::WasSuccessful(sTestState.mStatus);
+
+exit:
+    return (lSuccessful ? EXIT_SUCCESS : EXIT_FAILURE);
+}
+
+static bool HandleOption(const char *aProgram, OptionSet *aOptions, int aIdentifier, const char *aName, const char *aValue)
+{
+    bool       retval = true;
+
+    switch (aIdentifier)
+    {
+
+    case kToolOptInterval:
+        if (!ParseInt(aValue, gSendIntervalMs) || gSendIntervalMs > UINT32_MAX)
+        {
+            PrintArgError("%s: invalid value specified for send interval: %s\n", aProgram, aValue);
+            retval = false;
+        }
+        break;
+
+    case kToolOptListen:
+        gOptFlags |= kOptFlagListen;
+        break;
+
+    case kToolOptExpectedRxSize:
+        if (!ParseInt(aValue, sTestState.mStats.mReceive.mExpected) || sTestState.mStats.mReceive.mExpected > UINT32_MAX)
+        {
+            PrintArgError("%s: Invalid value specified for max receive: %s\n", aProgram, aValue);
+            retval = false;
+        }
+        gOptFlags |= kOptFlagExpectedRxSize;
+        break;
+
+    case kToolOptExpectedTxSize:
+        if (!ParseInt(aValue, sTestState.mStats.mTransmit.mExpected) || sTestState.mStats.mTransmit.mExpected > UINT32_MAX)
+        {
+            PrintArgError("%s: Invalid value specified for max send: %s\n", aProgram, aValue);
+            retval = false;
+        }
+        gOptFlags |= kOptFlagExpectedTxSize;
+        break;
+
+#if INET_CONFIG_ENABLE_IPV4
+    case kToolOptIPv4Only:
+        if (gOptFlags & kOptFlagUseIPv6)
+        {
+            PrintArgError("%s: the use of --ipv4 is exclusive with --ipv6. Please select only one of the two options.\n", aProgram);
+            retval = false;
+        }
+        gOptFlags |= kOptFlagUseIPv4;
+        break;
+#endif // INET_CONFIG_ENABLE_IPV4
+
+    case kToolOptIPv6Only:
+        if (gOptFlags & kOptFlagUseIPv4)
+        {
+            PrintArgError("%s: the use of --ipv6 is exclusive with --ipv4. Please select only one of the two options.\n", aProgram);
+            retval = false;
+        }
+        gOptFlags |= kOptFlagUseIPv6;
+        break;
+
+    case kToolOptInterface:
+
+        // NOTE: When using LwIP on a hosted OS, the interface will
+        // not actually be available until AFTER InitNetwork,
+        // consequently, we cannot do any meaningful validation
+        // here. Simply save the value off and we will validate it
+        // later.
+
+        gInterfaceName = aValue;
+        break;
+
+    case kToolOptRawIP:
+        if (gOptFlags & kOptFlagUseUDPIP)
+        {
+            PrintArgError("%s: the use of --raw is exclusive with --udp. Please select only one of the two options.\n", aProgram);
+            retval = false;
+        }
+		else if (gOptFlags & kOptFlagUseTCPIP)
+		{
+            PrintArgError("%s: the use of --raw is exclusive with --tcp. Please select only one of the two options.\n", aProgram);
+            retval = false;
+		}
+        gOptFlags |= kOptFlagUseRawIP;
+        break;
+
+    case kToolOptTCPIP:
+        if (gOptFlags & kOptFlagUseRawIP)
+        {
+            PrintArgError("%s: the use of --tcp is exclusive with --raw. Please select only one of the two options.\n", aProgram);
+            retval = false;
+        }
+		else if (gOptFlags & kOptFlagUseUDPIP)
+		{
+            PrintArgError("%s: the use of --tcp is exclusive with --udp. Please select only one of the two options.\n", aProgram);
+            retval = false;
+        }
+        gOptFlags |= kOptFlagUseTCPIP;
+        break;
+
+    case kToolOptSendSize:
+        if (!ParseInt(aValue, gSendSize))
+        {
+            PrintArgError("%s: invalid value specified for send size: %s\n", aProgram, aValue);
+            return false;
+        }
+        break;
+
+    case kToolOptUDPIP:
+        if (gOptFlags & kOptFlagUseRawIP)
+        {
+            PrintArgError("%s: the use of --udp is exclusive with --raw. Please select only one of the two options.\n", aProgram);
+            retval = false;
+        }
+		else if (gOptFlags & kOptFlagUseTCPIP)
+		{
+            PrintArgError("%s: the use of --udp is exclusive with --tcp. Please select only one of the two options.\n", aProgram);
+            retval = false;
+        }
+        gOptFlags |= kOptFlagUseUDPIP;
+        break;
+
+    default:
+        PrintArgError("%s: INTERNAL ERROR: Unhandled option: %s\n", aProgram, aName);
+        retval = false;
+        break;
+
+    }
+
+    return (retval);
+}
+
+bool HandleNonOptionArgs(const char *aProgram, int argc, char *argv[])
+{
+    bool retval = true;
+
+    if (Common::IsSender())
+    {
+        if (argc == 0)
+        {
+            PrintArgError("%s: Please specify a destination address.\n", aProgram);
+            retval = false;
+            goto exit;
+        }
+
+        retval = IPAddress::FromString(argv[0], sDestinationAddress);
+        VerifyOrExit(retval == true,
+                     PrintArgError("%s: Please specify a valid destination address: %s\n", aProgram, argv[0]));
+
+        sDestinationString = argv[0];
+
+        argc--; argv++;
+    }
+
+    if (argc > 0)
+    {
+        PrintArgError("%s: unexpected argument: %s\n", aProgram, argv[0]);
+        retval = false;
+        goto exit;
+    }
+
+    // If no IP version or transport flags were specified, use the defaults.
+
+    if (!(gOptFlags & (kOptFlagUseIPv4 | kOptFlagUseIPv6 | kOptFlagUseRawIP | kOptFlagUseTCPIP | kOptFlagUseUDPIP)))
+    {
+        gOptFlags |= kOptFlagsDefault;
+    }
+
+    // If no expected send or receive lengths were specified, use the defaults.
+
+    if (!(gOptFlags & kOptFlagExpectedRxSize))
+    {
+        sTestState.mStats.mReceive.mExpected = kExpectedRxSizeDefault;
+    }
+
+    if (!(gOptFlags & kOptFlagExpectedTxSize))
+    {
+        sTestState.mStats.mTransmit.mExpected = kExpectedTxSizeDefault;
+    }
+
+exit:
+    return (retval);
+}
+
+static void PrintReceivedStats(const TransferStats &aStats)
+{
+    printf("%u/%u received\n",
+           aStats.mReceive.mActual,
+           aStats.mReceive.mExpected);
+}
+
+static bool HandleDataReceived(const PacketBuffer *aBuffer, bool aCheckBuffer, uint8_t aFirstValue)
+{
+    const bool  lStatsByPacket = true;
+    bool        lStatus = true;
+
+    lStatus = Common::HandleDataReceived(aBuffer,
+                                         sTestState.mStats,
+                                         !lStatsByPacket,
+                                         aCheckBuffer,
+                                         aFirstValue);
+    VerifyOrExit(lStatus == true, );
+
+    PrintReceivedStats(sTestState.mStats);
+
+exit:
+    return (lStatus);
+}
+
+static bool HandleDataReceived(const PacketBuffer *aBuffer, bool aCheckBuffer)
+{
+    const uint8_t  lFirstValue = 0;
+    bool           lStatus = true;
+
+    lStatus = HandleDataReceived(aBuffer, aCheckBuffer, lFirstValue);
+    VerifyOrExit(lStatus == true, );
+
+exit:
+    return (lStatus);
+}
+
+// TCP Endpoint Callbacks
+
+void HandleTCPConnectionComplete(TCPEndPoint *aEndPoint, INET_ERROR aError)
+{
+    INET_ERROR lStatus;
+
+    if (aError == INET_NO_ERROR)
+    {
+        IPAddress  lPeerAddress;
+        uint16_t   lPeerPort;
+        char       lPeerAddressBuffer[INET6_ADDRSTRLEN];
+
+        lStatus = aEndPoint->GetPeerInfo(&lPeerAddress, &lPeerPort);
+        INET_FAIL_ERROR(lStatus, "TCPEndPoint::GetPeerInfo failed");
+
+        lPeerAddress.ToString(lPeerAddressBuffer, sizeof (lPeerAddressBuffer));
+
+        printf("TCP connection established to %s:%u\n", lPeerAddressBuffer, lPeerPort);
+
+        if (sTCPIPEndPoint->PendingReceiveLength() == 0)
+            sTCPIPEndPoint->PutBackReceivedData(NULL);
+
+        sTCPIPEndPoint->DisableReceive();
+        sTCPIPEndPoint->EnableKeepAlive(10, 100);
+        sTCPIPEndPoint->DisableKeepAlive();
+        sTCPIPEndPoint->EnableReceive();
+
+        DriveSend();
+    }
+    else
+    {
+        printf("TCP connection FAILED: %s\n", ErrorStr(aError));
+
+        aEndPoint->Free();
+        aEndPoint = NULL;
+
+        gSendIntervalExpired = false;
+        gSystemLayer.CancelTimer(Common::HandleSendTimerComplete, NULL);
+        gSystemLayer.StartTimer(gSendIntervalMs, Common::HandleSendTimerComplete, NULL);
+
+        SetStatusFailed(sTestState.mStatus);
+    }
+}
+
+static void HandleTCPConnectionClosed(TCPEndPoint *aEndPoint, INET_ERROR aError)
+{
+    if (aError == INET_NO_ERROR)
+    {
+        printf("TCP connection closed\n");
+    }
+    else
+    {
+        printf("TCP connection closed with error: %s\n", ErrorStr(aError));
+
+        SetStatusFailed(sTestState.mStatus);
+    }
+
+    aEndPoint->Free();
+
+    if (aEndPoint == sTCPIPEndPoint)
+    {
+        sTCPIPEndPoint = NULL;
+    }
+}
+
+static void HandleTCPDataSent(TCPEndPoint *aEndPoint, uint16_t len)
+{
+    return;
+}
+
+static void HandleTCPDataReceived(TCPEndPoint *aEndPoint, PacketBuffer *aBuffer)
+{
+    const uint8_t  lFirstValue = sTestState.mStats.mReceive.mActual;
+    const bool     lCheckBuffer = true;
+    IPAddress      lPeerAddress;
+    uint16_t       lPeerPort;
+    char           lPeerAddressBuffer[INET6_ADDRSTRLEN];
+    bool           lCheckPassed;
+    INET_ERROR     lStatus = INET_NO_ERROR;
+
+    VerifyOrExit(aEndPoint != NULL,   lStatus = INET_ERROR_BAD_ARGS);
+    VerifyOrExit(aBuffer != NULL,     lStatus = INET_ERROR_BAD_ARGS);
+
+    if (aEndPoint->State != TCPEndPoint::kState_Connected)
+    {
+        lStatus = aEndPoint->PutBackReceivedData(aBuffer);
+        aBuffer = NULL;
+        INET_FAIL_ERROR(lStatus, "TCPEndPoint::PutBackReceivedData failed");
+        goto exit;
+    }
+
+    lStatus = aEndPoint->GetPeerInfo(&lPeerAddress, &lPeerPort);
+    INET_FAIL_ERROR(lStatus, "TCPEndPoint::GetPeerInfo failed");
+
+    lPeerAddress.ToString(lPeerAddressBuffer, sizeof (lPeerAddressBuffer));
+
+    printf("TCP message received from %s:%u (%zu bytes)\n",
+           lPeerAddressBuffer,
+           lPeerPort,
+           static_cast<size_t>(aBuffer->DataLength()));
+
+    lCheckPassed = HandleDataReceived(aBuffer, lCheckBuffer, lFirstValue);
+    VerifyOrExit(lCheckPassed == true, lStatus = INET_ERROR_UNEXPECTED_EVENT);
+
+    lStatus = aEndPoint->AckReceive(aBuffer->TotalLength());
+    INET_FAIL_ERROR(lStatus, "TCPEndPoint::AckReceive failed");
+
+exit:
+    if (aBuffer != NULL)
+    {
+        PacketBuffer::Free(aBuffer);
+    }
+
+    if (lStatus != INET_NO_ERROR)
+    {
+        SetStatusFailed(sTestState.mStatus);
+    }
+}
+
+static void HandleTCPAcceptError(TCPEndPoint *aEndPoint, INET_ERROR aError)
+{
+    printf("TCP accept error: %s\n", ErrorStr(aError));
+
+    SetStatusFailed(sTestState.mStatus);
+}
+
+static void HandleTCPConnectionReceived(TCPEndPoint *aListenEndPoint, TCPEndPoint *aConnectEndPoint, const IPAddress &aPeerAddress, uint16_t aPeerPort)
+{
+    char lPeerAddressBuffer[INET6_ADDRSTRLEN];
+
+    aPeerAddress.ToString(lPeerAddressBuffer, sizeof (lPeerAddressBuffer));
+
+    printf("TCP connection accepted from %s:%u\n", lPeerAddressBuffer, aPeerPort);
+
+    aConnectEndPoint->OnConnectComplete  = HandleTCPConnectionComplete;
+    aConnectEndPoint->OnConnectionClosed = HandleTCPConnectionClosed;
+    aConnectEndPoint->OnDataSent         = HandleTCPDataSent;
+    aConnectEndPoint->OnDataReceived     = HandleTCPDataReceived;
+
+    sTCPIPEndPoint = aConnectEndPoint;
+}
+
+// Raw Endpoint Callbacks
+
+static void HandleRawMessageReceived(IPEndPointBasis *aEndPoint, PacketBuffer *aBuffer, const IPPacketInfo *aPacketInfo)
+{
+    const bool     lCheckBuffer = true;
+    const bool     lStatsByPacket = true;
+    IPAddressType  lAddressType;
+    bool           lStatus;
+
+    VerifyOrExit(aEndPoint != NULL,   lStatus = false);
+    VerifyOrExit(aBuffer != NULL,     lStatus = false);
+    VerifyOrExit(aPacketInfo != NULL, lStatus = false);
+
+    Common::HandleRawMessageReceived(aEndPoint, aBuffer, aPacketInfo);
+
+    lAddressType = aPacketInfo->DestAddress.Type();
+
+    if (lAddressType == kIPAddressType_IPv4)
+    {
+        const uint16_t kIPv4HeaderSize = 20;
+
+        aBuffer->ConsumeHead(kIPv4HeaderSize);
+
+        lStatus = Common::HandleICMPv4DataReceived(aBuffer, sTestState.mStats, !lStatsByPacket, lCheckBuffer);
+    }
+    else if (lAddressType == kIPAddressType_IPv6)
+    {
+        lStatus = Common::HandleICMPv6DataReceived(aBuffer, sTestState.mStats, !lStatsByPacket, lCheckBuffer);
+    }
+    else
+    {
+        lStatus = false;
+    }
+
+    if (lStatus)
+    {
+        PrintReceivedStats(sTestState.mStats);
+    }
+
+exit:
+    if (aBuffer != NULL)
+    {
+        PacketBuffer::Free(aBuffer);
+    }
+
+    if (!lStatus)
+    {
+        SetStatusFailed(sTestState.mStatus);
+    }
+}
+
+static void HandleRawReceiveError(IPEndPointBasis *aEndPoint, INET_ERROR aError, const IPPacketInfo *aPacketInfo)
+{
+    Common::HandleRawReceiveError(aEndPoint, aError, aPacketInfo);
+
+    SetStatusFailed(sTestState.mStatus);
+}
+
+// UDP Endpoint Callbacks
+
+static void HandleUDPMessageReceived(IPEndPointBasis *aEndPoint, PacketBuffer *aBuffer, const IPPacketInfo *aPacketInfo)
+{
+    const bool  lCheckBuffer = true;
+    bool        lStatus;
+
+    VerifyOrExit(aEndPoint != NULL,   lStatus = false);
+    VerifyOrExit(aBuffer != NULL,     lStatus = false);
+    VerifyOrExit(aPacketInfo != NULL, lStatus = false);
+
+    Common::HandleUDPMessageReceived(aEndPoint, aBuffer, aPacketInfo);
+
+    lStatus = HandleDataReceived(aBuffer, lCheckBuffer);
+
+exit:
+    if (aBuffer != NULL)
+    {
+        PacketBuffer::Free(aBuffer);
+    }
+
+    if (!lStatus)
+    {
+        SetStatusFailed(sTestState.mStatus);
+    }
+}
+
+static void HandleUDPReceiveError(IPEndPointBasis *aEndPoint, INET_ERROR aError, const IPPacketInfo *aPacketInfo)
+{
+    Common::HandleUDPReceiveError(aEndPoint, aError, aPacketInfo);
+
+    SetStatusFailed(sTestState.mStatus);
+}
+
+static bool IsTransportReadyForSend(void)
+{
+    bool lStatus = false;
+
+    if ((gOptFlags & (kOptFlagUseRawIP)) == (kOptFlagUseRawIP))
+    {
+        lStatus = (sRawIPEndPoint != NULL);
+    }
+    else if ((gOptFlags & kOptFlagUseUDPIP) == kOptFlagUseUDPIP)
+    {
+        lStatus = (sUDPIPEndPoint != NULL);
+    }
+    else if ((gOptFlags & kOptFlagUseTCPIP) == kOptFlagUseTCPIP)
+    {
+        if (sTCPIPEndPoint != NULL)
+        {
+            if (sTCPIPEndPoint->PendingSendLength() == 0)
+            {
+                switch (sTCPIPEndPoint->State)
+                {
+                case TCPEndPoint::kState_Connected:
+                case TCPEndPoint::kState_ReceiveShutdown:
+                    lStatus = true;
+                    break;
+
+                default:
+                    break;
+                }
+            }
+        }
+    }
+
+    return (lStatus);
+}
+
+static INET_ERROR PrepareTransportForSend(void)
+{
+    INET_ERROR lStatus = INET_NO_ERROR;
+
+    if (gOptFlags & kOptFlagUseTCPIP)
+    {
+        if (sTCPIPEndPoint == NULL)
+        {
+            lStatus = gInet.NewTCPEndPoint(&sTCPIPEndPoint);
+            INET_FAIL_ERROR(lStatus, "InetLayer::NewTCPEndPoint failed");
+
+            sTCPIPEndPoint->OnConnectComplete  = HandleTCPConnectionComplete;
+            sTCPIPEndPoint->OnConnectionClosed = HandleTCPConnectionClosed;
+            sTCPIPEndPoint->OnDataSent         = HandleTCPDataSent;
+            sTCPIPEndPoint->OnDataReceived     = HandleTCPDataReceived;
+
+            lStatus = sTCPIPEndPoint->Connect(sDestinationAddress, kTCPPort, gInterfaceId);
+            INET_FAIL_ERROR(lStatus, "TCPEndPoint::Connect failed");
+        }
+    }
+
+    return (lStatus);
+}
+
+static INET_ERROR DriveSendForDestination(const IPAddress &aAddress, uint16_t aSize)
+{
+    PacketBuffer *lBuffer = NULL;
+    INET_ERROR    lStatus = INET_NO_ERROR;
+
+    if ((gOptFlags & (kOptFlagUseRawIP)) == (kOptFlagUseRawIP))
+    {
+        // For ICMP (v4 or v6), we'll send n aSize or smaller
+        // datagrams (with overhead for the ICMP header), each
+        // patterned from zero to aSize - 1, following the ICMP
+        // header.
+
+        if ((gOptFlags & kOptFlagUseIPv6) == (kOptFlagUseIPv6))
+        {
+            lBuffer = Common::MakeICMPv6DataBuffer(aSize);
+            VerifyOrExit(lBuffer != NULL, lStatus = INET_ERROR_NO_MEMORY);
+        }
+#if INET_CONFIG_ENABLE_IPV4
+        else if ((gOptFlags & kOptFlagUseIPv4) == (kOptFlagUseIPv4))
+        {
+            lBuffer = Common::MakeICMPv4DataBuffer(aSize);
+            VerifyOrExit(lBuffer != NULL, lStatus = INET_ERROR_NO_MEMORY);
+        }
+#endif // INET_CONFIG_ENABLE_IPV4
+
+        lStatus = sRawIPEndPoint->SendTo(aAddress, lBuffer);
+        SuccessOrExit(lStatus);
+    }
+    else
+    {
+        if ((gOptFlags & kOptFlagUseUDPIP) == kOptFlagUseUDPIP)
+        {
+            const uint8_t lFirstValue = 0;
+
+            // For UDP, we'll send n aSize or smaller datagrams, each
+            // patterned from zero to aSize - 1.
+
+            lBuffer = Common::MakeDataBuffer(aSize, lFirstValue);
+            VerifyOrExit(lBuffer != NULL, lStatus = INET_ERROR_NO_MEMORY);
+
+            lStatus = sUDPIPEndPoint->SendTo(aAddress, kUDPPort, lBuffer);
+            SuccessOrExit(lStatus);
+        }
+        else if ((gOptFlags & kOptFlagUseTCPIP) == kOptFlagUseTCPIP)
+        {
+            const uint8_t lFirstValue = sTestState.mStats.mTransmit.mActual;
+
+            // For TCP, we'll send one byte stream of
+            // sTestState.mStats.mTransmit.mExpected in n aSize or
+            // smaller transactions, patterned from zero to
+            // sTestState.mStats.mTransmit.mExpected - 1.
+
+            lBuffer = Common::MakeDataBuffer(aSize, lFirstValue);
+            VerifyOrExit(lBuffer != NULL, lStatus = INET_ERROR_NO_MEMORY);
+
+            lStatus = sTCPIPEndPoint->Send(lBuffer);
+            SuccessOrExit(lStatus);
+        }
+    }
+
+exit:
+    return (lStatus);
+}
+
+void DriveSend(void)
+{
+    INET_ERROR lStatus = INET_NO_ERROR;
+
+    if (!Common::IsSender())
+        goto exit;
+
+    if (!gSendIntervalExpired)
+        goto exit;
+
+    if (!IsTransportReadyForSend())
+    {
+        lStatus = PrepareTransportForSend();
+        SuccessOrExit(lStatus);
+    }
+    else
+    {
+        gSendIntervalExpired = false;
+        gSystemLayer.StartTimer(gSendIntervalMs, Common::HandleSendTimerComplete, NULL);
+
+        if (sTestState.mStats.mTransmit.mActual < sTestState.mStats.mTransmit.mExpected)
+        {
+            const uint32_t lRemaining = (sTestState.mStats.mTransmit.mExpected -
+                                         sTestState.mStats.mTransmit.mActual);
+            const uint32_t lSendSize  = chip::min(lRemaining,
+                                                  static_cast<uint32_t>(gSendSize));
+
+            lStatus = DriveSendForDestination(sDestinationAddress, lSendSize);
+            SuccessOrExit(lStatus);
+
+            sTestState.mStats.mTransmit.mActual += lSendSize;
+
+            printf("%u/%u transmitted to %s\n",
+                   sTestState.mStats.mTransmit.mActual,
+                   sTestState.mStats.mTransmit.mExpected,
+                   sDestinationString);
+        }
+    }
+
+exit:
+    if (lStatus != INET_NO_ERROR)
+    {
+        SetStatusFailed(sTestState.mStatus);
+    }
+
+    return;
+}
+
+static void StartTest(void)
+{
+    IPAddressType      lIPAddressType = kIPAddressType_IPv6;
+    IPProtocol         lIPProtocol    = kIPProtocol_ICMPv6;
+    IPVersion          lIPVersion     = kIPVersion_6;
+    IPAddress          lAddress       = chip::Inet::IPAddress::Any;
+    INET_ERROR         lStatus;
+
+    if (!gNetworkOptions.LocalIPv6Addr.empty())
+        lAddress = gNetworkOptions.LocalIPv6Addr[0];
+
+#if INET_CONFIG_ENABLE_IPV4
+    if (gOptFlags & kOptFlagUseIPv4)
+    {
+        lIPAddressType = kIPAddressType_IPv4;
+        lIPProtocol    = kIPProtocol_ICMPv4;
+        lIPVersion     = kIPVersion_4;
+        if (!gNetworkOptions.LocalIPv6Addr.empty())
+            lAddress = gNetworkOptions.LocalIPv4Addr[0];
+        else
+            lAddress = chip::Inet::IPAddress::Any;
+    }
+#endif // INET_CONFIG_ENABLE_IPV4
+
+    printf("Using %sIP%s, device interface: %s (w/%c LwIP)\n",
+           ((gOptFlags & kOptFlagUseRawIP) ? "" : ((gOptFlags & kOptFlagUseTCPIP) ? "TCP/" : "UDP/")),
+           ((gOptFlags & kOptFlagUseIPv4) ? "v4" : "v6"),
+           ((gInterfaceName) ? gInterfaceName : "<none>"),
+           (CHIP_SYSTEM_CONFIG_USE_LWIP ? '\0' : 'o'));
+
+    // Allocate the endpoints for sending or receiving.
+
+    if (gOptFlags & kOptFlagUseRawIP)
+    {
+        lStatus = gInet.NewRawEndPoint(lIPVersion, lIPProtocol, &sRawIPEndPoint);
+        INET_FAIL_ERROR(lStatus, "InetLayer::NewRawEndPoint failed");
+
+        sRawIPEndPoint->OnMessageReceived = HandleRawMessageReceived;
+        sRawIPEndPoint->OnReceiveError    = HandleRawReceiveError;
+
+        if (IsInterfaceIdPresent(gInterfaceId))
+        {
+            lStatus = sRawIPEndPoint->BindInterface(lIPAddressType, gInterfaceId);
+            INET_FAIL_ERROR(lStatus, "RawEndPoint::BindInterface failed");
+        }
+    }
+    else if (gOptFlags & kOptFlagUseUDPIP)
+    {
+        lStatus = gInet.NewUDPEndPoint(&sUDPIPEndPoint);
+        INET_FAIL_ERROR(lStatus, "InetLayer::NewUDPEndPoint failed");
+
+        sUDPIPEndPoint->OnMessageReceived = HandleUDPMessageReceived;
+        sUDPIPEndPoint->OnReceiveError    = HandleUDPReceiveError;
+
+        if (IsInterfaceIdPresent(gInterfaceId))
+        {
+            lStatus = sUDPIPEndPoint->BindInterface(lIPAddressType, gInterfaceId);
+            INET_FAIL_ERROR(lStatus, "UDPEndPoint::BindInterface failed");
+        }
+    }
+
+    if (Common::IsReceiver())
+    {
+        if (gOptFlags & kOptFlagUseRawIP)
+        {
+            lStatus = sRawIPEndPoint->Bind(lIPAddressType, lAddress);
+            INET_FAIL_ERROR(lStatus, "RawEndPoint::Bind failed");
+
+            if (gOptFlags & kOptFlagUseIPv6)
+            {
+                lStatus = sRawIPEndPoint->SetICMPFilter(kICMPv6_FilterTypes, gICMPv6Types);
+                INET_FAIL_ERROR(lStatus, "RawEndPoint::SetICMPFilter failed");
+            }
+
+            lStatus = sRawIPEndPoint->Listen();
+            INET_FAIL_ERROR(lStatus, "RawEndPoint::Listen failed");
+        }
+        else if (gOptFlags & kOptFlagUseUDPIP)
+        {
+            lStatus = sUDPIPEndPoint->Bind(lIPAddressType, IPAddress::Any, kUDPPort);
+            INET_FAIL_ERROR(lStatus, "UDPEndPoint::Bind failed");
+
+            lStatus = sUDPIPEndPoint->Listen();
+            INET_FAIL_ERROR(lStatus, "UDPEndPoint::Listen failed");
+        }
+        else if (gOptFlags & kOptFlagUseTCPIP)
+        {
+            const uint16_t  lConnectionBacklogMax = 1;
+            const bool      lReuseAddress = true;
+
+            lStatus = gInet.NewTCPEndPoint(&sTCPIPListenEndPoint);
+            INET_FAIL_ERROR(lStatus, "InetLayer::NewTCPEndPoint failed");
+
+            sTCPIPListenEndPoint->OnConnectionReceived = HandleTCPConnectionReceived;
+            sTCPIPListenEndPoint->OnAcceptError        = HandleTCPAcceptError;
+
+            lStatus = sTCPIPListenEndPoint->Bind(lIPAddressType, IPAddress::Any, kTCPPort, lReuseAddress);
+            INET_FAIL_ERROR(lStatus, "TCPEndPoint::Bind failed");
+
+            lStatus = sTCPIPListenEndPoint->Listen(lConnectionBacklogMax);
+            INET_FAIL_ERROR(lStatus, "TCPEndPoint::Listen failed");
+        }
+    }
+
+    if (Common::IsReceiver())
+        printf("Listening...\n");
+    else
+        DriveSend();
+}
+
+static void CleanupTest(void)
+{
+    INET_ERROR         lStatus;
+
+    gSendIntervalExpired = false;
+    gSystemLayer.CancelTimer(Common::HandleSendTimerComplete, NULL);
+
+    // Release the resources associated with the allocated end points.
+
+    if (sRawIPEndPoint != NULL)
+    {
+        sRawIPEndPoint->Free();
+    }
+
+    if (sTCPIPEndPoint != NULL)
+    {
+        lStatus = sTCPIPEndPoint->Close();
+        INET_FAIL_ERROR(lStatus, "TCPEndPoint::Close failed");
+
+        sTCPIPEndPoint->Free();
+    }
+
+    if (sTCPIPListenEndPoint != NULL)
+    {
+        sTCPIPListenEndPoint->Shutdown();
+		sTCPIPListenEndPoint->Free();
+    }
+
+    if (sUDPIPEndPoint != NULL)
+    {
+        sUDPIPEndPoint->Free();
+    }
+}

--- a/src/inet/tests/TestInetLayer.cpp
+++ b/src/inet/tests/TestInetLayer.cpp
@@ -49,13 +49,12 @@ using namespace chip::ArgParser;
 
 /* Preprocessor Macros */
 
-#define kToolName                       "TestInetLayer"
+#define kToolName "TestInetLayer"
 
-#define kToolOptTCPIP                   't'
+#define kToolOptTCPIP 't'
 
-#define kToolOptExpectedRxSize          (kToolOptBase + 0)
-#define kToolOptExpectedTxSize          (kToolOptBase + 1)
-
+#define kToolOptExpectedRxSize (kToolOptBase + 0)
+#define kToolOptExpectedTxSize (kToolOptBase + 1)
 
 /* Type Definitions */
 
@@ -64,49 +63,49 @@ enum OptFlags
     kOptFlagExpectedRxSize = 0x00010000,
     kOptFlagExpectedTxSize = 0x00020000,
 
-    kOptFlagUseTCPIP       = 0x00040000
+    kOptFlagUseTCPIP = 0x00040000
 };
 
 struct TestState
 {
-    TransferStats                mStats;
-    TestStatus                   mStatus;
+    TransferStats mStats;
+    TestStatus mStatus;
 };
-
 
 /* Function Declarations */
 
 static void HandleSignal(int aSignal);
-static bool HandleOption(const char *aProgram, OptionSet *aOptions, int aIdentifier, const char *aName, const char *aValue);
-static bool HandleNonOptionArgs(const char *aProgram, int argc, char *argv[]);
+static bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, const char * aName, const char * aValue);
+static bool HandleNonOptionArgs(const char * aProgram, int argc, char * argv[]);
 
 static void StartTest(void);
 static void CleanupTest(void);
 
-
 /* Global Variables */
 
-static const uint32_t    kExpectedRxSizeDefault = 1523;
-static const uint32_t    kExpectedTxSizeDefault = kExpectedRxSizeDefault;
+static const uint32_t kExpectedRxSizeDefault = 1523;
+static const uint32_t kExpectedTxSizeDefault = kExpectedRxSizeDefault;
 
-static const uint32_t    kOptFlagsDefault       = (kOptFlagUseIPv6 | kOptFlagUseUDPIP);
+static const uint32_t kOptFlagsDefault = (kOptFlagUseIPv6 | kOptFlagUseUDPIP);
 
-static RawEndPoint *     sRawIPEndPoint         = NULL;
-static TCPEndPoint *     sTCPIPEndPoint         = NULL;  // Used for connect/send/receive
-static TCPEndPoint *     sTCPIPListenEndPoint   = NULL;  // Used for accept/listen
-static UDPEndPoint *     sUDPIPEndPoint         = NULL;
+static RawEndPoint * sRawIPEndPoint       = NULL;
+static TCPEndPoint * sTCPIPEndPoint       = NULL; // Used for connect/send/receive
+static TCPEndPoint * sTCPIPListenEndPoint = NULL; // Used for accept/listen
+static UDPEndPoint * sUDPIPEndPoint       = NULL;
 
-static const uint16_t    kTCPPort               = kUDPPort;
-
+static const uint16_t kTCPPort = kUDPPort;
+// clang-format off
 static TestState         sTestState             =
 {
     { { 0, 0 }, { 0, 0 } },
     { false, false }
 };
+// clang-format on
 
-static IPAddress         sDestinationAddress   = IPAddress::Any;
-static const char *      sDestinationString    = NULL;
+static IPAddress sDestinationAddress   = IPAddress::Any;
+static const char * sDestinationString = NULL;
 
+// clang-format off
 static OptionDef         sToolOptionDefs[] =
 {
     { "interface",                 kArgumentRequired,  kToolOptInterface              },
@@ -185,15 +184,15 @@ static OptionSet *       sToolOptionSets[] =
     &sHelpOptions,
     NULL
 };
+// clang-format on
 
-static void CheckSucceededOrFailed(TestState &aTestState, bool &aOutSucceeded, bool &aOutFailed)
+static void CheckSucceededOrFailed(TestState & aTestState, bool & aOutSucceeded, bool & aOutFailed)
 {
-    const TransferStats &lStats = aTestState.mStats;
+    const TransferStats & lStats = aTestState.mStats;
 
 #if DEBUG
-    printf("%u/%u sent, %u/%u received\n",
-           lStats.mTransmit.mActual, lStats.mTransmit.mExpected,
-           lStats.mReceive.mActual, lStats.mReceive.mExpected);
+    printf("%u/%u sent, %u/%u received\n", lStats.mTransmit.mActual, lStats.mTransmit.mExpected, lStats.mReceive.mActual,
+           lStats.mReceive.mExpected);
 #endif
 
     if (((lStats.mTransmit.mExpected > 0) && (lStats.mTransmit.mActual > lStats.mTransmit.mExpected)) ||
@@ -225,14 +224,13 @@ static void HandleSignal(int aSignal)
     case SIGUSR1:
         SetStatusFailed(sTestState.mStatus);
         break;
-
     }
 }
 
-int main(int argc, char *argv[])
+int main(int argc, char * argv[])
 {
-    bool          lSuccessful = true;
-    INET_ERROR    lStatus;
+    bool lSuccessful = true;
+    INET_ERROR lStatus;
 
     InitTestInetCommon();
 
@@ -279,9 +277,9 @@ int main(int argc, char *argv[])
     {
         struct timeval sleepTime;
         bool lSucceeded = true;
-        bool lFailed = false;
+        bool lFailed    = false;
 
-        sleepTime.tv_sec = 0;
+        sleepTime.tv_sec  = 0;
         sleepTime.tv_usec = 10000;
 
         ServiceNetwork(sleepTime);
@@ -289,6 +287,7 @@ int main(int argc, char *argv[])
         CheckSucceededOrFailed(sTestState, lSucceeded, lFailed);
 
 #if DEBUG
+        // clang-format off
         printf("%s %s number of expected bytes\n",
                ((lSucceeded) ? "successfully" :
                 ((lFailed) ? "failed to" :
@@ -297,6 +296,7 @@ int main(int argc, char *argv[])
                 ((lFailed) ? (Common::IsReceiver() ? "receive" : "send") :
                  Common::IsReceiver() ? "received" : "sent"))
                );
+        // clang-format on
 #endif
     }
 
@@ -312,9 +312,9 @@ exit:
     return (lSuccessful ? EXIT_SUCCESS : EXIT_FAILURE);
 }
 
-static bool HandleOption(const char *aProgram, OptionSet *aOptions, int aIdentifier, const char *aName, const char *aValue)
+static bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, const char * aName, const char * aValue)
 {
-    bool       retval = true;
+    bool retval = true;
 
     switch (aIdentifier)
     {
@@ -386,11 +386,11 @@ static bool HandleOption(const char *aProgram, OptionSet *aOptions, int aIdentif
             PrintArgError("%s: the use of --raw is exclusive with --udp. Please select only one of the two options.\n", aProgram);
             retval = false;
         }
-		else if (gOptFlags & kOptFlagUseTCPIP)
-		{
+        else if (gOptFlags & kOptFlagUseTCPIP)
+        {
             PrintArgError("%s: the use of --raw is exclusive with --tcp. Please select only one of the two options.\n", aProgram);
             retval = false;
-		}
+        }
         gOptFlags |= kOptFlagUseRawIP;
         break;
 
@@ -400,8 +400,8 @@ static bool HandleOption(const char *aProgram, OptionSet *aOptions, int aIdentif
             PrintArgError("%s: the use of --tcp is exclusive with --raw. Please select only one of the two options.\n", aProgram);
             retval = false;
         }
-		else if (gOptFlags & kOptFlagUseUDPIP)
-		{
+        else if (gOptFlags & kOptFlagUseUDPIP)
+        {
             PrintArgError("%s: the use of --tcp is exclusive with --udp. Please select only one of the two options.\n", aProgram);
             retval = false;
         }
@@ -422,8 +422,8 @@ static bool HandleOption(const char *aProgram, OptionSet *aOptions, int aIdentif
             PrintArgError("%s: the use of --udp is exclusive with --raw. Please select only one of the two options.\n", aProgram);
             retval = false;
         }
-		else if (gOptFlags & kOptFlagUseTCPIP)
-		{
+        else if (gOptFlags & kOptFlagUseTCPIP)
+        {
             PrintArgError("%s: the use of --udp is exclusive with --tcp. Please select only one of the two options.\n", aProgram);
             retval = false;
         }
@@ -434,13 +434,12 @@ static bool HandleOption(const char *aProgram, OptionSet *aOptions, int aIdentif
         PrintArgError("%s: INTERNAL ERROR: Unhandled option: %s\n", aProgram, aName);
         retval = false;
         break;
-
     }
 
     return (retval);
 }
 
-bool HandleNonOptionArgs(const char *aProgram, int argc, char *argv[])
+bool HandleNonOptionArgs(const char * aProgram, int argc, char * argv[])
 {
     bool retval = true;
 
@@ -454,12 +453,12 @@ bool HandleNonOptionArgs(const char *aProgram, int argc, char *argv[])
         }
 
         retval = IPAddress::FromString(argv[0], sDestinationAddress);
-        VerifyOrExit(retval == true,
-                     PrintArgError("%s: Please specify a valid destination address: %s\n", aProgram, argv[0]));
+        VerifyOrExit(retval == true, PrintArgError("%s: Please specify a valid destination address: %s\n", aProgram, argv[0]));
 
         sDestinationString = argv[0];
 
-        argc--; argv++;
+        argc--;
+        argv++;
     }
 
     if (argc > 0)
@@ -492,23 +491,17 @@ exit:
     return (retval);
 }
 
-static void PrintReceivedStats(const TransferStats &aStats)
+static void PrintReceivedStats(const TransferStats & aStats)
 {
-    printf("%u/%u received\n",
-           aStats.mReceive.mActual,
-           aStats.mReceive.mExpected);
+    printf("%u/%u received\n", aStats.mReceive.mActual, aStats.mReceive.mExpected);
 }
 
-static bool HandleDataReceived(const PacketBuffer *aBuffer, bool aCheckBuffer, uint8_t aFirstValue)
+static bool HandleDataReceived(const PacketBuffer * aBuffer, bool aCheckBuffer, uint8_t aFirstValue)
 {
-    const bool  lStatsByPacket = true;
-    bool        lStatus = true;
+    const bool lStatsByPacket = true;
+    bool lStatus              = true;
 
-    lStatus = Common::HandleDataReceived(aBuffer,
-                                         sTestState.mStats,
-                                         !lStatsByPacket,
-                                         aCheckBuffer,
-                                         aFirstValue);
+    lStatus = Common::HandleDataReceived(aBuffer, sTestState.mStats, !lStatsByPacket, aCheckBuffer, aFirstValue);
     VerifyOrExit(lStatus == true, );
 
     PrintReceivedStats(sTestState.mStats);
@@ -517,10 +510,10 @@ exit:
     return (lStatus);
 }
 
-static bool HandleDataReceived(const PacketBuffer *aBuffer, bool aCheckBuffer)
+static bool HandleDataReceived(const PacketBuffer * aBuffer, bool aCheckBuffer)
 {
-    const uint8_t  lFirstValue = 0;
-    bool           lStatus = true;
+    const uint8_t lFirstValue = 0;
+    bool lStatus              = true;
 
     lStatus = HandleDataReceived(aBuffer, aCheckBuffer, lFirstValue);
     VerifyOrExit(lStatus == true, );
@@ -531,20 +524,20 @@ exit:
 
 // TCP Endpoint Callbacks
 
-void HandleTCPConnectionComplete(TCPEndPoint *aEndPoint, INET_ERROR aError)
+void HandleTCPConnectionComplete(TCPEndPoint * aEndPoint, INET_ERROR aError)
 {
     INET_ERROR lStatus;
 
     if (aError == INET_NO_ERROR)
     {
-        IPAddress  lPeerAddress;
-        uint16_t   lPeerPort;
-        char       lPeerAddressBuffer[INET6_ADDRSTRLEN];
+        IPAddress lPeerAddress;
+        uint16_t lPeerPort;
+        char lPeerAddressBuffer[INET6_ADDRSTRLEN];
 
         lStatus = aEndPoint->GetPeerInfo(&lPeerAddress, &lPeerPort);
         INET_FAIL_ERROR(lStatus, "TCPEndPoint::GetPeerInfo failed");
 
-        lPeerAddress.ToString(lPeerAddressBuffer, sizeof (lPeerAddressBuffer));
+        lPeerAddress.ToString(lPeerAddressBuffer, sizeof(lPeerAddressBuffer));
 
         printf("TCP connection established to %s:%u\n", lPeerAddressBuffer, lPeerPort);
 
@@ -573,7 +566,7 @@ void HandleTCPConnectionComplete(TCPEndPoint *aEndPoint, INET_ERROR aError)
     }
 }
 
-static void HandleTCPConnectionClosed(TCPEndPoint *aEndPoint, INET_ERROR aError)
+static void HandleTCPConnectionClosed(TCPEndPoint * aEndPoint, INET_ERROR aError)
 {
     if (aError == INET_NO_ERROR)
     {
@@ -594,23 +587,23 @@ static void HandleTCPConnectionClosed(TCPEndPoint *aEndPoint, INET_ERROR aError)
     }
 }
 
-static void HandleTCPDataSent(TCPEndPoint *aEndPoint, uint16_t len)
+static void HandleTCPDataSent(TCPEndPoint * aEndPoint, uint16_t len)
 {
     return;
 }
 
-static void HandleTCPDataReceived(TCPEndPoint *aEndPoint, PacketBuffer *aBuffer)
+static void HandleTCPDataReceived(TCPEndPoint * aEndPoint, PacketBuffer * aBuffer)
 {
-    const uint8_t  lFirstValue = sTestState.mStats.mReceive.mActual;
-    const bool     lCheckBuffer = true;
-    IPAddress      lPeerAddress;
-    uint16_t       lPeerPort;
-    char           lPeerAddressBuffer[INET6_ADDRSTRLEN];
-    bool           lCheckPassed;
-    INET_ERROR     lStatus = INET_NO_ERROR;
+    const uint8_t lFirstValue = sTestState.mStats.mReceive.mActual;
+    const bool lCheckBuffer   = true;
+    IPAddress lPeerAddress;
+    uint16_t lPeerPort;
+    char lPeerAddressBuffer[INET6_ADDRSTRLEN];
+    bool lCheckPassed;
+    INET_ERROR lStatus = INET_NO_ERROR;
 
-    VerifyOrExit(aEndPoint != NULL,   lStatus = INET_ERROR_BAD_ARGS);
-    VerifyOrExit(aBuffer != NULL,     lStatus = INET_ERROR_BAD_ARGS);
+    VerifyOrExit(aEndPoint != NULL, lStatus = INET_ERROR_BAD_ARGS);
+    VerifyOrExit(aBuffer != NULL, lStatus = INET_ERROR_BAD_ARGS);
 
     if (aEndPoint->State != TCPEndPoint::kState_Connected)
     {
@@ -623,11 +616,9 @@ static void HandleTCPDataReceived(TCPEndPoint *aEndPoint, PacketBuffer *aBuffer)
     lStatus = aEndPoint->GetPeerInfo(&lPeerAddress, &lPeerPort);
     INET_FAIL_ERROR(lStatus, "TCPEndPoint::GetPeerInfo failed");
 
-    lPeerAddress.ToString(lPeerAddressBuffer, sizeof (lPeerAddressBuffer));
+    lPeerAddress.ToString(lPeerAddressBuffer, sizeof(lPeerAddressBuffer));
 
-    printf("TCP message received from %s:%u (%zu bytes)\n",
-           lPeerAddressBuffer,
-           lPeerPort,
+    printf("TCP message received from %s:%u (%zu bytes)\n", lPeerAddressBuffer, lPeerPort,
            static_cast<size_t>(aBuffer->DataLength()));
 
     lCheckPassed = HandleDataReceived(aBuffer, lCheckBuffer, lFirstValue);
@@ -648,18 +639,19 @@ exit:
     }
 }
 
-static void HandleTCPAcceptError(TCPEndPoint *aEndPoint, INET_ERROR aError)
+static void HandleTCPAcceptError(TCPEndPoint * aEndPoint, INET_ERROR aError)
 {
     printf("TCP accept error: %s\n", ErrorStr(aError));
 
     SetStatusFailed(sTestState.mStatus);
 }
 
-static void HandleTCPConnectionReceived(TCPEndPoint *aListenEndPoint, TCPEndPoint *aConnectEndPoint, const IPAddress &aPeerAddress, uint16_t aPeerPort)
+static void HandleTCPConnectionReceived(TCPEndPoint * aListenEndPoint, TCPEndPoint * aConnectEndPoint,
+                                        const IPAddress & aPeerAddress, uint16_t aPeerPort)
 {
     char lPeerAddressBuffer[INET6_ADDRSTRLEN];
 
-    aPeerAddress.ToString(lPeerAddressBuffer, sizeof (lPeerAddressBuffer));
+    aPeerAddress.ToString(lPeerAddressBuffer, sizeof(lPeerAddressBuffer));
 
     printf("TCP connection accepted from %s:%u\n", lPeerAddressBuffer, aPeerPort);
 
@@ -673,15 +665,15 @@ static void HandleTCPConnectionReceived(TCPEndPoint *aListenEndPoint, TCPEndPoin
 
 // Raw Endpoint Callbacks
 
-static void HandleRawMessageReceived(IPEndPointBasis *aEndPoint, PacketBuffer *aBuffer, const IPPacketInfo *aPacketInfo)
+static void HandleRawMessageReceived(IPEndPointBasis * aEndPoint, PacketBuffer * aBuffer, const IPPacketInfo * aPacketInfo)
 {
-    const bool     lCheckBuffer = true;
-    const bool     lStatsByPacket = true;
-    IPAddressType  lAddressType;
-    bool           lStatus;
+    const bool lCheckBuffer   = true;
+    const bool lStatsByPacket = true;
+    IPAddressType lAddressType;
+    bool lStatus;
 
-    VerifyOrExit(aEndPoint != NULL,   lStatus = false);
-    VerifyOrExit(aBuffer != NULL,     lStatus = false);
+    VerifyOrExit(aEndPoint != NULL, lStatus = false);
+    VerifyOrExit(aBuffer != NULL, lStatus = false);
     VerifyOrExit(aPacketInfo != NULL, lStatus = false);
 
     Common::HandleRawMessageReceived(aEndPoint, aBuffer, aPacketInfo);
@@ -722,7 +714,7 @@ exit:
     }
 }
 
-static void HandleRawReceiveError(IPEndPointBasis *aEndPoint, INET_ERROR aError, const IPPacketInfo *aPacketInfo)
+static void HandleRawReceiveError(IPEndPointBasis * aEndPoint, INET_ERROR aError, const IPPacketInfo * aPacketInfo)
 {
     Common::HandleRawReceiveError(aEndPoint, aError, aPacketInfo);
 
@@ -731,13 +723,13 @@ static void HandleRawReceiveError(IPEndPointBasis *aEndPoint, INET_ERROR aError,
 
 // UDP Endpoint Callbacks
 
-static void HandleUDPMessageReceived(IPEndPointBasis *aEndPoint, PacketBuffer *aBuffer, const IPPacketInfo *aPacketInfo)
+static void HandleUDPMessageReceived(IPEndPointBasis * aEndPoint, PacketBuffer * aBuffer, const IPPacketInfo * aPacketInfo)
 {
-    const bool  lCheckBuffer = true;
-    bool        lStatus;
+    const bool lCheckBuffer = true;
+    bool lStatus;
 
-    VerifyOrExit(aEndPoint != NULL,   lStatus = false);
-    VerifyOrExit(aBuffer != NULL,     lStatus = false);
+    VerifyOrExit(aEndPoint != NULL, lStatus = false);
+    VerifyOrExit(aBuffer != NULL, lStatus = false);
     VerifyOrExit(aPacketInfo != NULL, lStatus = false);
 
     Common::HandleUDPMessageReceived(aEndPoint, aBuffer, aPacketInfo);
@@ -756,7 +748,7 @@ exit:
     }
 }
 
-static void HandleUDPReceiveError(IPEndPointBasis *aEndPoint, INET_ERROR aError, const IPPacketInfo *aPacketInfo)
+static void HandleUDPReceiveError(IPEndPointBasis * aEndPoint, INET_ERROR aError, const IPPacketInfo * aPacketInfo)
 {
     Common::HandleUDPReceiveError(aEndPoint, aError, aPacketInfo);
 
@@ -822,10 +814,10 @@ static INET_ERROR PrepareTransportForSend(void)
     return (lStatus);
 }
 
-static INET_ERROR DriveSendForDestination(const IPAddress &aAddress, uint16_t aSize)
+static INET_ERROR DriveSendForDestination(const IPAddress & aAddress, uint16_t aSize)
 {
-    PacketBuffer *lBuffer = NULL;
-    INET_ERROR    lStatus = INET_NO_ERROR;
+    PacketBuffer * lBuffer = NULL;
+    INET_ERROR lStatus     = INET_NO_ERROR;
 
     if ((gOptFlags & (kOptFlagUseRawIP)) == (kOptFlagUseRawIP))
     {
@@ -908,19 +900,15 @@ void DriveSend(void)
 
         if (sTestState.mStats.mTransmit.mActual < sTestState.mStats.mTransmit.mExpected)
         {
-            const uint32_t lRemaining = (sTestState.mStats.mTransmit.mExpected -
-                                         sTestState.mStats.mTransmit.mActual);
-            const uint32_t lSendSize  = chip::min(lRemaining,
-                                                  static_cast<uint32_t>(gSendSize));
+            const uint32_t lRemaining = (sTestState.mStats.mTransmit.mExpected - sTestState.mStats.mTransmit.mActual);
+            const uint32_t lSendSize  = chip::min(lRemaining, static_cast<uint32_t>(gSendSize));
 
             lStatus = DriveSendForDestination(sDestinationAddress, lSendSize);
             SuccessOrExit(lStatus);
 
             sTestState.mStats.mTransmit.mActual += lSendSize;
 
-            printf("%u/%u transmitted to %s\n",
-                   sTestState.mStats.mTransmit.mActual,
-                   sTestState.mStats.mTransmit.mExpected,
+            printf("%u/%u transmitted to %s\n", sTestState.mStats.mTransmit.mActual, sTestState.mStats.mTransmit.mExpected,
                    sDestinationString);
         }
     }
@@ -936,11 +924,11 @@ exit:
 
 static void StartTest(void)
 {
-    IPAddressType      lIPAddressType = kIPAddressType_IPv6;
-    IPProtocol         lIPProtocol    = kIPProtocol_ICMPv6;
-    IPVersion          lIPVersion     = kIPVersion_6;
-    IPAddress          lAddress       = chip::Inet::IPAddress::Any;
-    INET_ERROR         lStatus;
+    IPAddressType lIPAddressType = kIPAddressType_IPv6;
+    IPProtocol lIPProtocol       = kIPProtocol_ICMPv6;
+    IPVersion lIPVersion         = kIPVersion_6;
+    IPAddress lAddress           = chip::Inet::IPAddress::Any;
+    INET_ERROR lStatus;
 
     if (!gNetworkOptions.LocalIPv6Addr.empty())
         lAddress = gNetworkOptions.LocalIPv6Addr[0];
@@ -958,11 +946,13 @@ static void StartTest(void)
     }
 #endif // INET_CONFIG_ENABLE_IPV4
 
+    // clang-format off
     printf("Using %sIP%s, device interface: %s (w/%c LwIP)\n",
            ((gOptFlags & kOptFlagUseRawIP) ? "" : ((gOptFlags & kOptFlagUseTCPIP) ? "TCP/" : "UDP/")),
            ((gOptFlags & kOptFlagUseIPv4) ? "v4" : "v6"),
            ((gInterfaceName) ? gInterfaceName : "<none>"),
            (CHIP_SYSTEM_CONFIG_USE_LWIP ? '\0' : 'o'));
+    // clang-format on
 
     // Allocate the endpoints for sending or receiving.
 
@@ -1021,8 +1011,8 @@ static void StartTest(void)
         }
         else if (gOptFlags & kOptFlagUseTCPIP)
         {
-            const uint16_t  lConnectionBacklogMax = 1;
-            const bool      lReuseAddress = true;
+            const uint16_t lConnectionBacklogMax = 1;
+            const bool lReuseAddress             = true;
 
             lStatus = gInet.NewTCPEndPoint(&sTCPIPListenEndPoint);
             INET_FAIL_ERROR(lStatus, "InetLayer::NewTCPEndPoint failed");
@@ -1046,7 +1036,7 @@ static void StartTest(void)
 
 static void CleanupTest(void)
 {
-    INET_ERROR         lStatus;
+    INET_ERROR lStatus;
 
     gSendIntervalExpired = false;
     gSystemLayer.CancelTimer(Common::HandleSendTimerComplete, NULL);
@@ -1069,7 +1059,7 @@ static void CleanupTest(void)
     if (sTCPIPListenEndPoint != NULL)
     {
         sTCPIPListenEndPoint->Shutdown();
-		sTCPIPListenEndPoint->Free();
+        sTCPIPListenEndPoint->Free();
     }
 
     if (sUDPIPEndPoint != NULL)

--- a/src/inet/tests/TestInetLayerCommon.cpp
+++ b/src/inet/tests/TestInetLayerCommon.cpp
@@ -1,0 +1,448 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2019 Google LLC
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines common preprocessor defintions, constants,
+ *      functions, and globals for unit and functional tests for the
+ *      Inet layer.
+ *
+ */
+
+#include "TestInetLayerCommon.hpp"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <nlbyteorder.hpp>
+
+#include <inet/InetLayer.h>
+
+#include <support/CodeUtils.h>
+
+#include "TestInetCommon.h"
+
+using namespace ::chip;
+using namespace ::chip::Inet;
+using namespace ::chip::System;
+
+
+// Type Definitions
+
+struct ICMPEchoHeader {
+    uint8_t  mType;
+    uint8_t  mCode;
+    uint16_t mChecksum;
+    uint16_t mID;
+    uint16_t mSequenceNumber;
+} __attribute__((packed));
+
+typedef struct ICMPEchoHeader ICMPv4EchoHeader;
+typedef struct ICMPEchoHeader ICMPv6EchoHeader;
+
+
+// Global Variables
+
+static const uint8_t     kICMPv4_EchoRequest   = 8;
+static const uint8_t     kICMPv4_EchoReply     = 0;
+
+static const uint8_t     kICMPv6_EchoRequest   = 128;
+static const uint8_t     kICMPv6_EchoReply     = 129;
+
+const uint8_t            gICMPv4Types[kICMPv4_FilterTypes] =
+{
+    kICMPv4_EchoRequest,
+    kICMPv4_EchoReply
+};
+
+const uint8_t            gICMPv6Types[kICMPv6_FilterTypes] =
+{
+    kICMPv6_EchoRequest,
+    kICMPv6_EchoReply
+};
+
+bool                     gSendIntervalExpired  = true;
+
+uint32_t                 gSendIntervalMs       = 1000;
+
+const char *             gInterfaceName        = NULL;
+
+InterfaceId              gInterfaceId          = INET_NULL_INTERFACEID;
+
+uint16_t                 gSendSize             = 59;
+
+uint32_t                 gOptFlags             = 0;
+
+
+namespace Common
+{
+
+bool IsReceiver(void)
+{
+    return ((gOptFlags & kOptFlagListen) == kOptFlagListen);
+}
+
+bool IsSender(void)
+{
+    return (!IsReceiver());
+}
+
+bool IsTesting(const TestStatus &aTestStatus)
+{
+    bool lStatus;
+
+    lStatus = (!aTestStatus.mFailed && !aTestStatus.mSucceeded);
+
+    return (lStatus);
+}
+
+bool WasSuccessful(const TestStatus &aTestStatus)
+{
+    bool lStatus = false;
+
+    if (aTestStatus.mFailed)
+        lStatus = false;
+    else if (aTestStatus.mSucceeded)
+        lStatus = true;
+
+    return (lStatus);
+}
+
+static void FillDataBufferPattern(uint8_t *aBuffer, uint16_t aLength, uint16_t aPatternStartOffset, uint8_t aFirstValue)
+{
+    for (uint16_t i = aPatternStartOffset; i < aLength; i++)
+    {
+        const uint8_t lValue = static_cast<uint8_t>(aFirstValue & 0xFF);
+
+        aBuffer[i] = lValue;
+
+        aFirstValue++;
+    }
+}
+
+static bool CheckDataBufferPattern(const uint8_t *aBuffer, uint16_t aLength, uint16_t aPatternStartOffset, uint8_t aFirstValue)
+{
+    bool lStatus = true;
+
+    for (uint16_t i = aPatternStartOffset; i < aLength; i++)
+    {
+        const uint8_t lValue = aBuffer[i];
+
+        VerifyOrExit(lValue == static_cast<uint8_t>(aFirstValue),
+                     printf("Bad data value at offset %u (0x%04x): "
+                            "expected 0x%02x, found 0x%02x\n",
+                            i, i, aFirstValue, lValue);
+                     lStatus = false;
+                     DumpMemory(aBuffer + aPatternStartOffset,
+                                aLength - aPatternStartOffset,
+                                "0x",
+                                16));
+
+        aFirstValue++;
+    }
+
+exit:
+    return (lStatus);
+}
+
+static PacketBuffer *MakeDataBuffer(uint16_t aDesiredLength, uint16_t aPatternStartOffset, uint8_t aFirstValue)
+{
+    PacketBuffer *  lBuffer = NULL;
+
+    VerifyOrExit(aPatternStartOffset <= aDesiredLength, );
+
+    lBuffer = PacketBuffer::New();
+    VerifyOrExit(lBuffer != NULL, );
+
+    aDesiredLength = min(lBuffer->MaxDataLength(), aDesiredLength);
+
+    FillDataBufferPattern(lBuffer->Start(), aDesiredLength, aPatternStartOffset, aFirstValue);
+
+    lBuffer->SetDataLength(aDesiredLength);
+
+exit:
+    return (lBuffer);
+}
+
+static PacketBuffer *MakeDataBuffer(uint16_t aDesiredLength, uint16_t aPatternStartOffset)
+{
+    const uint8_t   lFirstValue = 0;
+    PacketBuffer *  lBuffer = NULL;
+
+    lBuffer = MakeDataBuffer(aDesiredLength, aPatternStartOffset, lFirstValue);
+    VerifyOrExit(lBuffer != NULL, );
+
+exit:
+    return (lBuffer);
+}
+
+template <typename tType>
+static PacketBuffer *MakeICMPDataBuffer(uint16_t aDesiredUserLength, uint16_t aHeaderLength, uint16_t aPatternStartOffset, uint8_t aType)
+{
+    static uint16_t  lSequenceNumber = 0;
+    PacketBuffer *   lBuffer = NULL;
+
+    // To ensure there is enough room for the user data and the ICMP
+    // header, include both the user data size and the ICMP header length.
+
+    lBuffer = MakeDataBuffer(aDesiredUserLength + aHeaderLength, aPatternStartOffset);
+
+    if (lBuffer != NULL)
+    {
+        tType *lHeader = reinterpret_cast<tType *>(lBuffer->Start());
+
+        lHeader->mType           = aType;
+        lHeader->mCode           = 0;
+        lHeader->mChecksum       = 0;
+        lHeader->mID             = rand() & UINT16_MAX;
+        lHeader->mSequenceNumber = nlByteOrderSwap16HostToBig(lSequenceNumber++);
+    }
+
+    return (lBuffer);
+}
+
+PacketBuffer *MakeICMPv4DataBuffer(uint16_t aDesiredUserLength)
+{
+    const uint16_t  lICMPHeaderLength = sizeof (ICMPv4EchoHeader);
+    const uint16_t  lPatternStartOffset = lICMPHeaderLength;
+    const uint8_t   lType = gICMPv4Types[kICMP_EchoRequestIndex];
+    PacketBuffer *  lBuffer = NULL;
+
+    lBuffer = MakeICMPDataBuffer<ICMPv4EchoHeader>(aDesiredUserLength, lICMPHeaderLength, lPatternStartOffset, lType);
+
+    return (lBuffer);
+}
+
+PacketBuffer *MakeICMPv6DataBuffer(uint16_t aDesiredUserLength)
+{
+    const uint16_t  lICMPHeaderLength = sizeof (ICMPv6EchoHeader);
+    const uint16_t  lPatternStartOffset = lICMPHeaderLength;
+    const uint8_t   lType = gICMPv6Types[kICMP_EchoRequestIndex];
+    PacketBuffer *  lBuffer = NULL;
+
+    lBuffer = MakeICMPDataBuffer<ICMPv6EchoHeader>(aDesiredUserLength, lICMPHeaderLength, lPatternStartOffset, lType);
+
+    return (lBuffer);
+}
+
+PacketBuffer *MakeDataBuffer(uint16_t aDesiredLength, uint8_t aFirstValue)
+{
+    const uint16_t  lPatternStartOffset = 0;
+    PacketBuffer *  lBuffer = NULL;
+
+    lBuffer = MakeDataBuffer(aDesiredLength, lPatternStartOffset, aFirstValue);
+
+    return (lBuffer);
+}
+
+PacketBuffer *MakeDataBuffer(uint16_t aDesiredLength)
+{
+    const uint16_t  lPatternStartOffset = 0;
+    PacketBuffer *  lBuffer = NULL;
+
+    lBuffer = MakeDataBuffer(aDesiredLength, lPatternStartOffset);
+
+    return (lBuffer);
+}
+
+static bool HandleDataReceived(const PacketBuffer *aBuffer, TransferStats &aStats, bool aStatsByPacket, bool aCheckBuffer, uint16_t aPatternStartOffset, uint8_t aFirstValue)
+{
+    bool      lStatus = true;
+    uint16_t  lTotalDataLength = 0;
+
+    // Walk through each buffer in the packet chain, checking the
+    // buffer for the expected pattern, if requested.
+
+    for (const PacketBuffer *lBuffer = aBuffer; lBuffer != NULL; lBuffer = lBuffer->Next())
+    {
+        const uint16_t lDataLength = lBuffer->DataLength();
+
+        if (aCheckBuffer)
+        {
+            const uint8_t *p = lBuffer->Start();
+
+            lStatus = CheckDataBufferPattern(p, lDataLength, aPatternStartOffset, aFirstValue);
+            VerifyOrExit(lStatus == true, );
+        }
+
+        lTotalDataLength += lBuffer->DataLength();
+        aFirstValue += lBuffer->DataLength();
+    }
+
+    // If we are accumulating stats by packet rather than by size,
+    // then increment by one (1) rather than the total buffer length.
+
+    aStats.mReceive.mActual += ((aStatsByPacket) ? 1 : lTotalDataLength);
+
+exit:
+    return (lStatus);
+
+}
+
+static bool HandleICMPDataReceived(PacketBuffer *aBuffer, uint16_t aHeaderLength, TransferStats &aStats, bool aStatsByPacket, bool aCheckBuffer)
+{
+    const uint16_t  lPatternStartOffset = 0;
+    bool            lStatus;
+
+    aBuffer->ConsumeHead(aHeaderLength);
+
+    lStatus = HandleDataReceived(aBuffer, aStats, aStatsByPacket, aCheckBuffer, lPatternStartOffset);
+
+    return (lStatus);
+}
+
+bool HandleICMPv4DataReceived(PacketBuffer *aBuffer, TransferStats &aStats, bool aStatsByPacket, bool aCheckBuffer)
+{
+    const uint16_t  lICMPHeaderLength = sizeof (ICMPv4EchoHeader);
+    bool            lStatus;
+
+    lStatus = HandleICMPDataReceived(aBuffer, lICMPHeaderLength, aStats, aStatsByPacket, aCheckBuffer);
+
+    return (lStatus);
+}
+
+bool HandleICMPv6DataReceived(PacketBuffer *aBuffer, TransferStats &aStats, bool aStatsByPacket, bool aCheckBuffer)
+{
+    const uint16_t  lICMPHeaderLength = sizeof (ICMPv6EchoHeader);
+    bool            lStatus;
+
+    lStatus = HandleICMPDataReceived(aBuffer, lICMPHeaderLength, aStats, aStatsByPacket, aCheckBuffer);
+
+    return (lStatus);
+}
+
+bool HandleDataReceived(const PacketBuffer *aBuffer, TransferStats &aStats, bool aStatsByPacket, bool aCheckBuffer, uint8_t aFirstValue)
+{
+    const uint16_t  lPatternStartOffset = 0;
+    bool            lStatus;
+
+    lStatus = HandleDataReceived(aBuffer, aStats, aStatsByPacket, aCheckBuffer, lPatternStartOffset, aFirstValue);
+
+    return (lStatus);
+}
+
+
+bool HandleDataReceived(const PacketBuffer *aBuffer, TransferStats &aStats, bool aStatsByPacket, bool aCheckBuffer)
+{
+    const uint8_t   lFirstValue = 0;
+    const uint16_t  lPatternStartOffset = 0;
+    bool            lStatus;
+
+    lStatus = HandleDataReceived(aBuffer, aStats, aStatsByPacket, aCheckBuffer, lPatternStartOffset, lFirstValue);
+
+    return (lStatus);
+}
+
+bool HandleUDPDataReceived(const PacketBuffer *aBuffer, TransferStats &aStats, bool aStatsByPacket, bool aCheckBuffer)
+{
+    bool            lStatus;
+
+    lStatus = HandleDataReceived(aBuffer, aStats, aStatsByPacket, aCheckBuffer);
+
+    return (lStatus);
+}
+
+bool HandleTCPDataReceived(const PacketBuffer *aBuffer, TransferStats &aStats, bool aStatsByPacket, bool aCheckBuffer)
+{
+    bool            lStatus;
+
+    lStatus = HandleDataReceived(aBuffer, aStats, aStatsByPacket, aCheckBuffer);
+
+    return (lStatus);
+}
+
+// Timer Callback Handler
+
+void HandleSendTimerComplete(System::Layer *aSystemLayer, void *aAppState, System::Error aError)
+{
+    INET_FAIL_ERROR(aError, "Send timer completed with error");
+
+    gSendIntervalExpired = true;
+
+    DriveSend();
+}
+
+// Raw Endpoint Callback Handlers
+
+void HandleRawMessageReceived(const IPEndPointBasis *aEndPoint, const PacketBuffer *aBuffer, const IPPacketInfo *aPacketInfo)
+{
+    char  lSourceAddressBuffer[INET6_ADDRSTRLEN];
+    char  lDestinationAddressBuffer[INET6_ADDRSTRLEN];
+
+    aPacketInfo->SrcAddress.ToString(lSourceAddressBuffer, sizeof (lSourceAddressBuffer));
+    aPacketInfo->DestAddress.ToString(lDestinationAddressBuffer, sizeof (lDestinationAddressBuffer));
+
+    printf("Raw message received from %s to %s (%zu bytes)\n",
+           lSourceAddressBuffer,
+           lDestinationAddressBuffer,
+           static_cast<size_t>(aBuffer->DataLength()));
+}
+
+void HandleRawReceiveError(const IPEndPointBasis *aEndPoint, const INET_ERROR &aError, const IPPacketInfo *aPacketInfo)
+{
+    char     lAddressBuffer[INET6_ADDRSTRLEN];
+
+    if (aPacketInfo != NULL)
+    {
+        aPacketInfo->SrcAddress.ToString(lAddressBuffer, sizeof (lAddressBuffer));
+    }
+    else
+    {
+        strcpy(lAddressBuffer, "(unknown)");
+    }
+
+    printf("IP receive error from %s %s\n", lAddressBuffer, ErrorStr(aError));
+}
+
+// UDP Endpoint Callback Handlers
+
+void HandleUDPMessageReceived(const IPEndPointBasis *aEndPoint, const PacketBuffer *aBuffer, const IPPacketInfo *aPacketInfo)
+{
+    char  lSourceAddressBuffer[INET6_ADDRSTRLEN];
+    char  lDestinationAddressBuffer[INET6_ADDRSTRLEN];
+
+    aPacketInfo->SrcAddress.ToString(lSourceAddressBuffer, sizeof (lSourceAddressBuffer));
+    aPacketInfo->DestAddress.ToString(lDestinationAddressBuffer, sizeof (lDestinationAddressBuffer));
+
+    printf("UDP packet received from %s:%u to %s:%u (%zu bytes)\n",
+           lSourceAddressBuffer, aPacketInfo->SrcPort,
+           lDestinationAddressBuffer, aPacketInfo->DestPort,
+           static_cast<size_t>(aBuffer->DataLength()));
+}
+
+void HandleUDPReceiveError(const IPEndPointBasis *aEndPoint, const INET_ERROR &aError, const IPPacketInfo *aPacketInfo)
+{
+    char     lAddressBuffer[INET6_ADDRSTRLEN];
+    uint16_t lSourcePort;
+
+    if (aPacketInfo != NULL)
+    {
+        aPacketInfo->SrcAddress.ToString(lAddressBuffer, sizeof (lAddressBuffer));
+        lSourcePort = aPacketInfo->SrcPort;
+    }
+    else
+    {
+        strcpy(lAddressBuffer, "(unknown)");
+        lSourcePort = 0;
+    }
+
+    printf("UDP receive error from %s:%u: %s\n", lAddressBuffer, lSourcePort, ErrorStr(aError));
+}
+
+}; // namespace Common

--- a/src/inet/tests/TestInetLayerCommon.hpp
+++ b/src/inet/tests/TestInetLayerCommon.hpp
@@ -1,0 +1,165 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2019 Google LLC
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines common preprocessor defintions, constants,
+ *      functions, and globals for unit and functional tests for the
+ *      Inet layer.
+ *
+ */
+
+#ifndef CHIP_TEST_INETLAYER_COMMON_HPP
+#define CHIP_TEST_INETLAYER_COMMON_HPP
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <inet/InetError.h>
+#include <inet/InetInterface.h>
+#include <inet/RawEndPoint.h>
+#include <inet/UDPEndPoint.h>
+
+#include <system/SystemPacketBuffer.h>
+
+using namespace ::chip;
+
+// Preprocessor Macros
+
+#define SetStatusFailed(aTestStatus)    do { (aTestStatus).mFailed = true; fprintf(stderr, "Test failed at %s:%u!\n", __func__, __LINE__); } while (0)
+
+#define kToolOptBase                    1000
+
+#define kToolOptInterface               'I'
+#define kToolOptIPv4Only                '4'
+#define kToolOptIPv6Only                '6'
+#define kToolOptInterval                'i'
+#define kToolOptListen                  'l'
+#define kToolOptRawIP                   'r'
+#define kToolOptSendSize                's'
+#define kToolOptUDPIP                   'u'
+
+
+// Type Definitions
+
+enum OptFlagsCommon
+{
+    kOptFlagUseIPv4    = 0x00000001,
+    kOptFlagUseIPv6    = 0x00000002,
+
+    kOptFlagUseRawIP   = 0x00000004,
+    kOptFlagUseUDPIP   = 0x00000008,
+
+    kOptFlagListen     = 0x00000010,
+};
+
+enum kICMPTypeIndex
+{
+    kICMP_EchoRequestIndex = 0,
+    kICMP_EchoReplyIndex   = 1
+};
+
+struct Stats
+{
+    uint32_t      mExpected;
+    uint32_t      mActual;
+};
+
+struct TransferStats
+{
+    struct Stats  mReceive;
+    struct Stats  mTransmit;
+};
+
+struct TestStatus
+{
+    bool mFailed;
+    bool mSucceeded;
+};
+
+// Global Variables
+
+static const uint16_t     kUDPPort              = 4242;
+
+static const size_t       kICMPv4_FilterTypes   = 2;
+
+static const size_t       kICMPv6_FilterTypes   = 2;
+
+extern const uint8_t      gICMPv4Types[kICMPv4_FilterTypes];
+
+extern const uint8_t      gICMPv6Types[kICMPv6_FilterTypes];
+
+extern bool               gSendIntervalExpired;
+
+extern uint32_t           gSendIntervalMs;
+
+extern const char *       gInterfaceName;
+
+extern Inet::InterfaceId  gInterfaceId;
+
+extern uint16_t           gSendSize;
+
+extern uint32_t           gOptFlags;
+
+
+// Function Prototypes
+
+namespace Common
+{
+
+extern bool IsReceiver(void);
+extern bool IsSender(void);
+
+extern bool IsTesting(const TestStatus &aTestStatus);
+extern bool WasSuccessful(const TestStatus &aTestStatus);
+
+extern System::PacketBuffer *MakeDataBuffer(uint16_t aDesiredLength, uint8_t aFirstValue);
+extern System::PacketBuffer *MakeDataBuffer(uint16_t aDesiredLength);
+extern System::PacketBuffer *MakeICMPv4DataBuffer(uint16_t aDesiredUserLength);
+extern System::PacketBuffer *MakeICMPv6DataBuffer(uint16_t aDesiredUserLength);
+
+extern bool HandleDataReceived(const System::PacketBuffer *aBuffer, TransferStats &aStats, bool aStatsByPacket, bool aCheckBuffer, uint8_t aFirstValue);
+extern bool HandleDataReceived(const System::PacketBuffer *aBuffer, TransferStats &aStats, bool aStatsByPacket, bool aCheckBuffer);
+extern bool HandleICMPv4DataReceived(System::PacketBuffer *aBuffer, TransferStats &aStats, bool aStatsByPacket, bool aCheckBuffer);
+extern bool HandleICMPv6DataReceived(System::PacketBuffer *aBuffer, TransferStats &aStats, bool aStatsByPacket, bool aCheckBuffer);
+
+
+// Timer Callback Handler
+
+extern void HandleSendTimerComplete(System::Layer *aSystemLayer, void *aAppState, System::Error aError);
+
+// Raw Endpoint Callback Handlers
+
+extern void HandleRawMessageReceived(const Inet::IPEndPointBasis *aEndPoint, const System::PacketBuffer *aBuffer, const Inet::IPPacketInfo *aPacketInfo);
+extern void HandleRawReceiveError(const Inet::IPEndPointBasis *aEndPoint, const INET_ERROR &aError, const Inet::IPPacketInfo *aPacketInfo);
+
+// UDP Endpoint Callback Handlers
+
+extern void HandleUDPMessageReceived(const Inet::IPEndPointBasis *aEndPoint, const System::PacketBuffer *aBuffer, const Inet::IPPacketInfo *aPacketInfo);
+extern void HandleUDPReceiveError(const Inet::IPEndPointBasis *aEndPoint, const INET_ERROR &aError, const Inet::IPPacketInfo *aPacketInfo);
+
+}; // namespace Common
+
+// Period send function to be implemented by individual tests but
+// referenced by common code.
+
+extern void DriveSend(void);
+
+
+#endif // CHIP_TEST_INETLAYER_COMMON_HPP

--- a/src/inet/tests/TestInetLayerCommon.hpp
+++ b/src/inet/tests/TestInetLayerCommon.hpp
@@ -42,31 +42,35 @@ using namespace ::chip;
 
 // Preprocessor Macros
 
-#define SetStatusFailed(aTestStatus)    do { (aTestStatus).mFailed = true; fprintf(stderr, "Test failed at %s:%u!\n", __func__, __LINE__); } while (0)
+#define SetStatusFailed(aTestStatus)                                                                                               \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        (aTestStatus).mFailed = true;                                                                                              \
+        fprintf(stderr, "Test failed at %s:%u!\n", __func__, __LINE__);                                                            \
+    } while (0)
 
-#define kToolOptBase                    1000
+#define kToolOptBase 1000
 
-#define kToolOptInterface               'I'
-#define kToolOptIPv4Only                '4'
-#define kToolOptIPv6Only                '6'
-#define kToolOptInterval                'i'
-#define kToolOptListen                  'l'
-#define kToolOptRawIP                   'r'
-#define kToolOptSendSize                's'
-#define kToolOptUDPIP                   'u'
-
+#define kToolOptInterface 'I'
+#define kToolOptIPv4Only '4'
+#define kToolOptIPv6Only '6'
+#define kToolOptInterval 'i'
+#define kToolOptListen 'l'
+#define kToolOptRawIP 'r'
+#define kToolOptSendSize 's'
+#define kToolOptUDPIP 'u'
 
 // Type Definitions
 
 enum OptFlagsCommon
 {
-    kOptFlagUseIPv4    = 0x00000001,
-    kOptFlagUseIPv6    = 0x00000002,
+    kOptFlagUseIPv4 = 0x00000001,
+    kOptFlagUseIPv6 = 0x00000002,
 
-    kOptFlagUseRawIP   = 0x00000004,
-    kOptFlagUseUDPIP   = 0x00000008,
+    kOptFlagUseRawIP = 0x00000004,
+    kOptFlagUseUDPIP = 0x00000008,
 
-    kOptFlagListen     = 0x00000010,
+    kOptFlagListen = 0x00000010,
 };
 
 enum kICMPTypeIndex
@@ -77,14 +81,14 @@ enum kICMPTypeIndex
 
 struct Stats
 {
-    uint32_t      mExpected;
-    uint32_t      mActual;
+    uint32_t mExpected;
+    uint32_t mActual;
 };
 
 struct TransferStats
 {
-    struct Stats  mReceive;
-    struct Stats  mTransmit;
+    struct Stats mReceive;
+    struct Stats mTransmit;
 };
 
 struct TestStatus
@@ -95,64 +99,69 @@ struct TestStatus
 
 // Global Variables
 
-static const uint16_t     kUDPPort              = 4242;
+static const uint16_t kUDPPort = 4242;
 
-static const size_t       kICMPv4_FilterTypes   = 2;
+static const size_t kICMPv4_FilterTypes = 2;
 
-static const size_t       kICMPv6_FilterTypes   = 2;
+static const size_t kICMPv6_FilterTypes = 2;
 
-extern const uint8_t      gICMPv4Types[kICMPv4_FilterTypes];
+extern const uint8_t gICMPv4Types[kICMPv4_FilterTypes];
 
-extern const uint8_t      gICMPv6Types[kICMPv6_FilterTypes];
+extern const uint8_t gICMPv6Types[kICMPv6_FilterTypes];
 
-extern bool               gSendIntervalExpired;
+extern bool gSendIntervalExpired;
 
-extern uint32_t           gSendIntervalMs;
+extern uint32_t gSendIntervalMs;
 
-extern const char *       gInterfaceName;
+extern const char * gInterfaceName;
 
-extern Inet::InterfaceId  gInterfaceId;
+extern Inet::InterfaceId gInterfaceId;
 
-extern uint16_t           gSendSize;
+extern uint16_t gSendSize;
 
-extern uint32_t           gOptFlags;
-
+extern uint32_t gOptFlags;
 
 // Function Prototypes
 
-namespace Common
-{
+namespace Common {
 
 extern bool IsReceiver(void);
 extern bool IsSender(void);
 
-extern bool IsTesting(const TestStatus &aTestStatus);
-extern bool WasSuccessful(const TestStatus &aTestStatus);
+extern bool IsTesting(const TestStatus & aTestStatus);
+extern bool WasSuccessful(const TestStatus & aTestStatus);
 
-extern System::PacketBuffer *MakeDataBuffer(uint16_t aDesiredLength, uint8_t aFirstValue);
-extern System::PacketBuffer *MakeDataBuffer(uint16_t aDesiredLength);
-extern System::PacketBuffer *MakeICMPv4DataBuffer(uint16_t aDesiredUserLength);
-extern System::PacketBuffer *MakeICMPv6DataBuffer(uint16_t aDesiredUserLength);
+extern System::PacketBuffer * MakeDataBuffer(uint16_t aDesiredLength, uint8_t aFirstValue);
+extern System::PacketBuffer * MakeDataBuffer(uint16_t aDesiredLength);
+extern System::PacketBuffer * MakeICMPv4DataBuffer(uint16_t aDesiredUserLength);
+extern System::PacketBuffer * MakeICMPv6DataBuffer(uint16_t aDesiredUserLength);
 
-extern bool HandleDataReceived(const System::PacketBuffer *aBuffer, TransferStats &aStats, bool aStatsByPacket, bool aCheckBuffer, uint8_t aFirstValue);
-extern bool HandleDataReceived(const System::PacketBuffer *aBuffer, TransferStats &aStats, bool aStatsByPacket, bool aCheckBuffer);
-extern bool HandleICMPv4DataReceived(System::PacketBuffer *aBuffer, TransferStats &aStats, bool aStatsByPacket, bool aCheckBuffer);
-extern bool HandleICMPv6DataReceived(System::PacketBuffer *aBuffer, TransferStats &aStats, bool aStatsByPacket, bool aCheckBuffer);
-
+extern bool HandleDataReceived(const System::PacketBuffer * aBuffer, TransferStats & aStats, bool aStatsByPacket, bool aCheckBuffer,
+                               uint8_t aFirstValue);
+extern bool HandleDataReceived(const System::PacketBuffer * aBuffer, TransferStats & aStats, bool aStatsByPacket,
+                               bool aCheckBuffer);
+extern bool HandleICMPv4DataReceived(System::PacketBuffer * aBuffer, TransferStats & aStats, bool aStatsByPacket,
+                                     bool aCheckBuffer);
+extern bool HandleICMPv6DataReceived(System::PacketBuffer * aBuffer, TransferStats & aStats, bool aStatsByPacket,
+                                     bool aCheckBuffer);
 
 // Timer Callback Handler
 
-extern void HandleSendTimerComplete(System::Layer *aSystemLayer, void *aAppState, System::Error aError);
+extern void HandleSendTimerComplete(System::Layer * aSystemLayer, void * aAppState, System::Error aError);
 
 // Raw Endpoint Callback Handlers
 
-extern void HandleRawMessageReceived(const Inet::IPEndPointBasis *aEndPoint, const System::PacketBuffer *aBuffer, const Inet::IPPacketInfo *aPacketInfo);
-extern void HandleRawReceiveError(const Inet::IPEndPointBasis *aEndPoint, const INET_ERROR &aError, const Inet::IPPacketInfo *aPacketInfo);
+extern void HandleRawMessageReceived(const Inet::IPEndPointBasis * aEndPoint, const System::PacketBuffer * aBuffer,
+                                     const Inet::IPPacketInfo * aPacketInfo);
+extern void HandleRawReceiveError(const Inet::IPEndPointBasis * aEndPoint, const INET_ERROR & aError,
+                                  const Inet::IPPacketInfo * aPacketInfo);
 
 // UDP Endpoint Callback Handlers
 
-extern void HandleUDPMessageReceived(const Inet::IPEndPointBasis *aEndPoint, const System::PacketBuffer *aBuffer, const Inet::IPPacketInfo *aPacketInfo);
-extern void HandleUDPReceiveError(const Inet::IPEndPointBasis *aEndPoint, const INET_ERROR &aError, const Inet::IPPacketInfo *aPacketInfo);
+extern void HandleUDPMessageReceived(const Inet::IPEndPointBasis * aEndPoint, const System::PacketBuffer * aBuffer,
+                                     const Inet::IPPacketInfo * aPacketInfo);
+extern void HandleUDPReceiveError(const Inet::IPEndPointBasis * aEndPoint, const INET_ERROR & aError,
+                                  const Inet::IPPacketInfo * aPacketInfo);
 
 }; // namespace Common
 
@@ -160,6 +169,5 @@ extern void HandleUDPReceiveError(const Inet::IPEndPointBasis *aEndPoint, const 
 // referenced by common code.
 
 extern void DriveSend(void);
-
 
 #endif // CHIP_TEST_INETLAYER_COMMON_HPP

--- a/src/inet/tests/TestInetLayerMulticast.cpp
+++ b/src/inet/tests/TestInetLayerMulticast.cpp
@@ -49,17 +49,15 @@ using namespace chip;
 using namespace chip::ArgParser;
 using namespace chip::Inet;
 
-
 /* Preprocessor Macros */
 
-#define kToolName                       "TestInetLayerMulticast"
+#define kToolName "TestInetLayerMulticast"
 
-#define kToolOptNoLoopback              'L'
-#define kToolOptGroup                   'g'
+#define kToolOptNoLoopback 'L'
+#define kToolOptGroup 'g'
 
-#define kToolOptExpectedGroupRxPackets  (kToolOptBase + 0)
-#define kToolOptExpectedGroupTxPackets  (kToolOptBase + 1)
-
+#define kToolOptExpectedGroupRxPackets (kToolOptBase + 0)
+#define kToolOptExpectedGroupTxPackets (kToolOptBase + 1)
 
 /* Type Definitions */
 
@@ -70,38 +68,37 @@ enum OptFlags
 
 struct GroupAddress
 {
-    uint32_t       mGroup;
-    TransferStats  mStats;
-    IPAddress      mMulticastAddress;
+    uint32_t mGroup;
+    TransferStats mStats;
+    IPAddress mMulticastAddress;
 };
 
 template <size_t tCapacity>
 struct GroupAddresses
 {
-    size_t         mSize;
-    const size_t   mCapacity = tCapacity;
-    GroupAddress   mAddresses[tCapacity];
+    size_t mSize;
+    const size_t mCapacity = tCapacity;
+    GroupAddress mAddresses[tCapacity];
 };
 
 template <size_t tCapacity>
 struct TestState
 {
-    GroupAddresses<tCapacity> &  mGroupAddresses;
-    TestStatus                   mStatus;
+    GroupAddresses<tCapacity> & mGroupAddresses;
+    TestStatus mStatus;
 };
-
 
 /* Function Declarations */
 
 static void HandleSignal(int aSignal);
-static bool HandleOption(const char *aProgram, OptionSet *aOptions, int aIdentifier, const char *aName, const char *aValue);
-static bool HandleNonOptionArgs(const char *aProgram, int argc, char *argv[]);
-static bool ParseGroupOpt(const char *aProgram, const char *aValue, bool aIPv6, uint32_t &aOutLastGroupIndex);
-static bool ParseAndUpdateExpectedGroupPackets(const char *aProgram, const char *aValue, uint32_t aGroup, const char *aDescription, uint32_t &aOutExpected);
+static bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, const char * aName, const char * aValue);
+static bool HandleNonOptionArgs(const char * aProgram, int argc, char * argv[]);
+static bool ParseGroupOpt(const char * aProgram, const char * aValue, bool aIPv6, uint32_t & aOutLastGroupIndex);
+static bool ParseAndUpdateExpectedGroupPackets(const char * aProgram, const char * aValue, uint32_t aGroup,
+                                               const char * aDescription, uint32_t & aOutExpected);
 
 static void StartTest(void);
 static void CleanupTest(void);
-
 
 /* Global Variables */
 
@@ -204,14 +201,12 @@ static OptionSet *       sToolOptionSets[] =
 };
 // clang-format on
 
-static void CheckSucceededOrFailed(const GroupAddress &aAddress, bool &aOutSucceeded, bool &aOutFailed)
+static void CheckSucceededOrFailed(const GroupAddress & aAddress, bool & aOutSucceeded, bool & aOutFailed)
 {
-    const TransferStats &lStats = aAddress.mStats;
+    const TransferStats & lStats = aAddress.mStats;
 
 #if DEBUG
-    printf("Group %u: %u/%u sent, %u/%u received\n",
-           aAddress.mGroup,
-           lStats.mTransmit.mActual, lStats.mTransmit.mExpected,
+    printf("Group %u: %u/%u sent, %u/%u received\n", aAddress.mGroup, lStats.mTransmit.mActual, lStats.mTransmit.mExpected,
            lStats.mReceive.mActual, lStats.mReceive.mExpected);
 #endif
 
@@ -228,11 +223,11 @@ static void CheckSucceededOrFailed(const GroupAddress &aAddress, bool &aOutSucce
 }
 
 template <size_t tCapacity>
-static void CheckSucceededOrFailed(TestState<tCapacity> &aTestState, bool &aOutSucceeded, bool &aOutFailed)
+static void CheckSucceededOrFailed(TestState<tCapacity> & aTestState, bool & aOutSucceeded, bool & aOutFailed)
 {
     for (size_t i = 0; i < aTestState.mGroupAddresses.mSize; i++)
     {
-        const GroupAddress &lGroup = aTestState.mGroupAddresses.mAddresses[i];
+        const GroupAddress & lGroup = aTestState.mGroupAddresses.mAddresses[i];
 
         CheckSucceededOrFailed(lGroup, aOutSucceeded, aOutFailed);
     }
@@ -255,14 +250,13 @@ static void HandleSignal(int aSignal)
     case SIGUSR1:
         SetStatusFailed(sTestState.mStatus);
         break;
-
     }
 }
 
-int main(int argc, char *argv[])
+int main(int argc, char * argv[])
 {
-    bool          lSuccessful = true;
-    INET_ERROR    lStatus;
+    bool lSuccessful = true;
+    INET_ERROR lStatus;
 
     InitTestInetCommon();
 
@@ -319,9 +313,9 @@ int main(int argc, char *argv[])
     {
         struct timeval sleepTime;
         bool lSucceeded = true;
-        bool lFailed = false;
+        bool lFailed    = false;
 
-        sleepTime.tv_sec = 0;
+        sleepTime.tv_sec  = 0;
         sleepTime.tv_usec = 10000;
 
         ServiceNetwork(sleepTime);
@@ -329,14 +323,10 @@ int main(int argc, char *argv[])
         CheckSucceededOrFailed(sTestState, lSucceeded, lFailed);
 
 #if DEBUG
-        printf("%s %s number of expected packets\n",
-               ((lSucceeded) ? "successfully" :
-                ((lFailed) ? "failed to" :
-                 "has not yet")),
-               ((lSucceeded) ? (Common::IsReceiver() ? "received" : "sent") :
-                ((lFailed) ? (Common::IsReceiver() ? "receive" : "send") :
-                 Common::IsReceiver() ? "received" : "sent"))
-               );
+        printf("%s %s number of expected packets\n", ((lSucceeded) ? "successfully" : ((lFailed) ? "failed to" : "has not yet")),
+               ((lSucceeded)
+                    ? (Common::IsReceiver() ? "received" : "sent")
+                    : ((lFailed) ? (Common::IsReceiver() ? "receive" : "send") : Common::IsReceiver() ? "received" : "sent")));
 #endif
     }
 
@@ -352,9 +342,9 @@ exit:
     return (lSuccessful ? EXIT_SUCCESS : EXIT_FAILURE);
 }
 
-static bool HandleOption(const char *aProgram, OptionSet *aOptions, int aIdentifier, const char *aName, const char *aValue)
+static bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, const char * aName, const char * aValue)
 {
-    bool       retval = true;
+    bool retval = true;
 
     switch (aIdentifier)
     {
@@ -382,27 +372,27 @@ static bool HandleOption(const char *aProgram, OptionSet *aOptions, int aIdentif
         }
         break;
 
-    case kToolOptExpectedGroupRxPackets:
+    case kToolOptExpectedGroupRxPackets: {
+        GroupAddress & lGroupAddress = sGroupAddresses.mAddresses[sLastGroupIndex];
+
+        if (!ParseAndUpdateExpectedGroupPackets(aProgram, aValue, lGroupAddress.mGroup, "received",
+                                                lGroupAddress.mStats.mReceive.mExpected))
         {
-            GroupAddress &lGroupAddress = sGroupAddresses.mAddresses[sLastGroupIndex];
-
-            if (!ParseAndUpdateExpectedGroupPackets(aProgram, aValue, lGroupAddress.mGroup, "received", lGroupAddress.mStats.mReceive.mExpected))
-            {
-                retval = false;
-            }
+            retval = false;
         }
-        break;
+    }
+    break;
 
-    case kToolOptExpectedGroupTxPackets:
+    case kToolOptExpectedGroupTxPackets: {
+        GroupAddress & lGroupAddress = sGroupAddresses.mAddresses[sLastGroupIndex];
+
+        if (!ParseAndUpdateExpectedGroupPackets(aProgram, aValue, lGroupAddress.mGroup, "sent",
+                                                lGroupAddress.mStats.mTransmit.mExpected))
         {
-            GroupAddress &lGroupAddress = sGroupAddresses.mAddresses[sLastGroupIndex];
-
-            if (!ParseAndUpdateExpectedGroupPackets(aProgram, aValue, lGroupAddress.mGroup, "sent", lGroupAddress.mStats.mTransmit.mExpected))
-            {
-                retval = false;
-            }
+            retval = false;
         }
-        break;
+    }
+    break;
 
 #if INET_CONFIG_ENABLE_IPV4
     case kToolOptIPv4Only:
@@ -465,19 +455,19 @@ static bool HandleOption(const char *aProgram, OptionSet *aOptions, int aIdentif
         PrintArgError("%s: INTERNAL ERROR: Unhandled option: %s\n", aProgram, aName);
         retval = false;
         break;
-
     }
 
     return (retval);
 }
 
-bool HandleNonOptionArgs(const char *aProgram, int argc, char *argv[])
+bool HandleNonOptionArgs(const char * aProgram, int argc, char * argv[])
 {
     bool retval = true;
 
     if ((gOptFlags & (kOptFlagListen | kOptFlagNoLoopback)) == (kOptFlagListen | kOptFlagNoLoopback))
     {
-        PrintArgError("%s: the listen option is exclusive with the loopback suppression option. Please select one or the other.\n", aProgram);
+        PrintArgError("%s: the listen option is exclusive with the loopback suppression option. Please select one or the other.\n",
+                      aProgram);
         retval = false;
         goto exit;
     }
@@ -525,7 +515,7 @@ static IPAddress MakeIPv6Multicast(uint32_t aGroupIdentifier)
     return (IPAddress::MakeIPv6Multicast(lFlags, kIPv6MulticastScope_Site, aGroupIdentifier));
 }
 
-static void SetGroup(GroupAddress &aGroupAddress, uint32_t aGroupIdentifier, uint32_t aExpectedRx, uint32_t aExpectedTx)
+static void SetGroup(GroupAddress & aGroupAddress, uint32_t aGroupIdentifier, uint32_t aExpectedRx, uint32_t aExpectedTx)
 {
     aGroupAddress.mGroup                     = aGroupIdentifier;
     aGroupAddress.mStats.mReceive.mExpected  = aExpectedRx;
@@ -534,10 +524,10 @@ static void SetGroup(GroupAddress &aGroupAddress, uint32_t aGroupIdentifier, uin
     aGroupAddress.mStats.mTransmit.mActual   = 0;
 }
 
-static bool ParseGroupOpt(const char *aProgram, const char *aValue, bool aIPv6, uint32_t &aOutLastGroupIndex)
+static bool ParseGroupOpt(const char * aProgram, const char * aValue, bool aIPv6, uint32_t & aOutLastGroupIndex)
 {
     uint32_t lGroupIdentifier;
-    bool     lRetval = true;
+    bool lRetval = true;
 
     if (sGroupAddresses.mSize == sGroupAddresses.mCapacity)
     {
@@ -555,19 +545,17 @@ static bool ParseGroupOpt(const char *aProgram, const char *aValue, bool aIPv6, 
 
     aOutLastGroupIndex = sGroupAddresses.mSize++;
 
-    SetGroup(sGroupAddresses.mAddresses[aOutLastGroupIndex],
-             lGroupIdentifier,
-             lGroupIdentifier,
-             lGroupIdentifier);
+    SetGroup(sGroupAddresses.mAddresses[aOutLastGroupIndex], lGroupIdentifier, lGroupIdentifier, lGroupIdentifier);
 
 exit:
     return (lRetval);
 }
 
-static bool ParseAndUpdateExpectedGroupPackets(const char *aProgram, const char *aValue, uint32_t aGroup, const char *aDescription, uint32_t &aOutExpected)
+static bool ParseAndUpdateExpectedGroupPackets(const char * aProgram, const char * aValue, uint32_t aGroup,
+                                               const char * aDescription, uint32_t & aOutExpected)
 {
-    uint32_t  lExpectedGroupPackets;
-    bool      lRetval = true;
+    uint32_t lExpectedGroupPackets;
+    bool lRetval = true;
 
     if (!ParseInt(aValue, lExpectedGroupPackets))
     {
@@ -582,13 +570,13 @@ exit:
     return (lRetval);
 }
 
-static GroupAddress *FindGroupAddress(const IPAddress &aSourceAddress)
+static GroupAddress * FindGroupAddress(const IPAddress & aSourceAddress)
 {
-    GroupAddress *lResult = NULL;
+    GroupAddress * lResult = NULL;
 
     for (size_t i = 0; i < sGroupAddresses.mSize; i++)
     {
-        GroupAddress &lGroupAddress = sGroupAddresses.mAddresses[i];
+        GroupAddress & lGroupAddress = sGroupAddresses.mAddresses[i];
 
         if (lGroupAddress.mMulticastAddress == aSourceAddress)
         {
@@ -600,23 +588,18 @@ static GroupAddress *FindGroupAddress(const IPAddress &aSourceAddress)
     return (lResult);
 }
 
-static void PrintReceivedStats(const GroupAddress &aGroupAddress)
+static void PrintReceivedStats(const GroupAddress & aGroupAddress)
 {
-    printf("%u/%u received for multicast group %u\n",
-           aGroupAddress.mStats.mReceive.mActual,
-           aGroupAddress.mStats.mReceive.mExpected,
-           aGroupAddress.mGroup);
+    printf("%u/%u received for multicast group %u\n", aGroupAddress.mStats.mReceive.mActual,
+           aGroupAddress.mStats.mReceive.mExpected, aGroupAddress.mGroup);
 }
 
-static bool HandleDataReceived(const PacketBuffer *aBuffer, GroupAddress &aGroupAddress, bool aCheckBuffer)
+static bool HandleDataReceived(const PacketBuffer * aBuffer, GroupAddress & aGroupAddress, bool aCheckBuffer)
 {
-    const bool  lStatsByPacket = true;
-    bool        lStatus = true;
+    const bool lStatsByPacket = true;
+    bool lStatus              = true;
 
-    lStatus = Common::HandleDataReceived(aBuffer,
-                                         aGroupAddress.mStats,
-                                         lStatsByPacket,
-                                         aCheckBuffer);
+    lStatus = Common::HandleDataReceived(aBuffer, aGroupAddress.mStats, lStatsByPacket, aCheckBuffer);
     VerifyOrExit(lStatus == true, );
 
     PrintReceivedStats(aGroupAddress);
@@ -625,10 +608,10 @@ exit:
     return (lStatus);
 }
 
-static bool HandleDataReceived(const PacketBuffer *aBuffer, const IPPacketInfo &aPacketInfo, bool aCheckBuffer)
+static bool HandleDataReceived(const PacketBuffer * aBuffer, const IPPacketInfo & aPacketInfo, bool aCheckBuffer)
 {
-    bool            lStatus = true;
-    GroupAddress *  lGroupAddress;
+    bool lStatus = true;
+    GroupAddress * lGroupAddress;
 
     lGroupAddress = FindGroupAddress(aPacketInfo.DestAddress);
 
@@ -644,16 +627,16 @@ exit:
 
 // Raw Endpoint Callbacks
 
-static void HandleRawMessageReceived(IPEndPointBasis *aEndPoint, PacketBuffer *aBuffer, const IPPacketInfo *aPacketInfo)
+static void HandleRawMessageReceived(IPEndPointBasis * aEndPoint, PacketBuffer * aBuffer, const IPPacketInfo * aPacketInfo)
 {
-    const bool      lCheckBuffer = true;
-    const bool      lStatsByPacket = true;
-    IPAddressType   lAddressType;
-    bool            lStatus = true;
-    GroupAddress *  lGroupAddress;
+    const bool lCheckBuffer   = true;
+    const bool lStatsByPacket = true;
+    IPAddressType lAddressType;
+    bool lStatus = true;
+    GroupAddress * lGroupAddress;
 
-    VerifyOrExit(aEndPoint != NULL,   lStatus = false);
-    VerifyOrExit(aBuffer != NULL,     lStatus = false);
+    VerifyOrExit(aEndPoint != NULL, lStatus = false);
+    VerifyOrExit(aBuffer != NULL, lStatus = false);
     VerifyOrExit(aPacketInfo != NULL, lStatus = false);
 
     Common::HandleRawMessageReceived(aEndPoint, aBuffer, aPacketInfo);
@@ -699,7 +682,7 @@ exit:
     }
 }
 
-static void HandleRawReceiveError(IPEndPointBasis *aEndPoint, INET_ERROR aError, const IPPacketInfo *aPacketInfo)
+static void HandleRawReceiveError(IPEndPointBasis * aEndPoint, INET_ERROR aError, const IPPacketInfo * aPacketInfo)
 {
     Common::HandleRawReceiveError(aEndPoint, aError, aPacketInfo);
 
@@ -708,13 +691,13 @@ static void HandleRawReceiveError(IPEndPointBasis *aEndPoint, INET_ERROR aError,
 
 // UDP Endpoint Callbacks
 
-static void HandleUDPMessageReceived(IPEndPointBasis *aEndPoint, PacketBuffer *aBuffer, const IPPacketInfo *aPacketInfo)
+static void HandleUDPMessageReceived(IPEndPointBasis * aEndPoint, PacketBuffer * aBuffer, const IPPacketInfo * aPacketInfo)
 {
-    const bool  lCheckBuffer = true;
-    bool        lStatus;
+    const bool lCheckBuffer = true;
+    bool lStatus;
 
-    VerifyOrExit(aEndPoint != NULL,   lStatus = false);
-    VerifyOrExit(aBuffer != NULL,     lStatus = false);
+    VerifyOrExit(aEndPoint != NULL, lStatus = false);
+    VerifyOrExit(aBuffer != NULL, lStatus = false);
     VerifyOrExit(aPacketInfo != NULL, lStatus = false);
 
     Common::HandleUDPMessageReceived(aEndPoint, aBuffer, aPacketInfo);
@@ -733,7 +716,7 @@ exit:
     }
 }
 
-static void HandleUDPReceiveError(IPEndPointBasis *aEndPoint, INET_ERROR aError, const IPPacketInfo *aPacketInfo)
+static void HandleUDPReceiveError(IPEndPointBasis * aEndPoint, INET_ERROR aError, const IPPacketInfo * aPacketInfo)
 {
     Common::HandleUDPReceiveError(aEndPoint, aError, aPacketInfo);
 
@@ -763,10 +746,10 @@ static INET_ERROR PrepareTransportForSend(void)
     return (lStatus);
 }
 
-static INET_ERROR DriveSendForDestination(const IPAddress &aAddress, uint16_t aSize)
+static INET_ERROR DriveSendForDestination(const IPAddress & aAddress, uint16_t aSize)
 {
-    PacketBuffer *lBuffer = NULL;
-    INET_ERROR    lStatus = INET_NO_ERROR;
+    PacketBuffer * lBuffer = NULL;
+    INET_ERROR lStatus     = INET_NO_ERROR;
 
     if ((gOptFlags & (kOptFlagUseRawIP)) == (kOptFlagUseRawIP))
     {
@@ -812,7 +795,7 @@ exit:
     return (lStatus);
 }
 
-static INET_ERROR DriveSendForGroup(GroupAddress &aGroupAddress)
+static INET_ERROR DriveSendForGroup(GroupAddress & aGroupAddress)
 {
     INET_ERROR lStatus = INET_NO_ERROR;
 
@@ -823,10 +806,8 @@ static INET_ERROR DriveSendForGroup(GroupAddress &aGroupAddress)
 
         aGroupAddress.mStats.mTransmit.mActual++;
 
-        printf("%u/%u transmitted for multicast group %u\n",
-               aGroupAddress.mStats.mTransmit.mActual,
-               aGroupAddress.mStats.mTransmit.mExpected,
-               aGroupAddress.mGroup);
+        printf("%u/%u transmitted for multicast group %u\n", aGroupAddress.mStats.mTransmit.mActual,
+               aGroupAddress.mStats.mTransmit.mExpected, aGroupAddress.mGroup);
     }
 
 exit:
@@ -834,7 +815,7 @@ exit:
 }
 
 template <size_t tCapacity>
-static INET_ERROR DriveSendForGroups(GroupAddresses<tCapacity> &aGroupAddresses)
+static INET_ERROR DriveSendForGroups(GroupAddresses<tCapacity> & aGroupAddresses)
 {
     INET_ERROR lStatus = INET_NO_ERROR;
 
@@ -843,7 +824,7 @@ static INET_ERROR DriveSendForGroups(GroupAddresses<tCapacity> &aGroupAddresses)
 
     for (size_t i = 0; i < aGroupAddresses.mSize; i++)
     {
-        GroupAddress &lGroupAddress = aGroupAddresses.mAddresses[i];
+        GroupAddress & lGroupAddress = aGroupAddresses.mAddresses[i];
 
         lStatus = DriveSendForGroup(lGroupAddress);
         SuccessOrExit(lStatus);
@@ -888,13 +869,13 @@ exit:
 
 static void StartTest(void)
 {
-    IPAddressType      lIPAddressType = kIPAddressType_IPv6;
-    IPProtocol         lIPProtocol    = kIPProtocol_ICMPv6;
-    IPVersion          lIPVersion     = kIPVersion_6;
-    IPAddress          lAddress       = IPAddress::Any;
-    IPEndPointBasis *  lEndPoint      = NULL;
-    const bool         lUseLoopback   = ((gOptFlags & kOptFlagNoLoopback) == 0);
-    INET_ERROR         lStatus;
+    IPAddressType lIPAddressType = kIPAddressType_IPv6;
+    IPProtocol lIPProtocol       = kIPProtocol_ICMPv6;
+    IPVersion lIPVersion         = kIPVersion_6;
+    IPAddress lAddress           = IPAddress::Any;
+    IPEndPointBasis * lEndPoint  = NULL;
+    const bool lUseLoopback      = ((gOptFlags & kOptFlagNoLoopback) == 0);
+    INET_ERROR lStatus;
 
 #if INET_CONFIG_ENABLE_IPV4
     if (gOptFlags & kOptFlagUseIPv4)
@@ -905,11 +886,13 @@ static void StartTest(void)
     }
 #endif // INET_CONFIG_ENABLE_IPV4
 
+    // clang-format off
     printf("Using %sIP%s, device interface: %s (w/%c LwIP)\n",
            ((gOptFlags & kOptFlagUseRawIP) ? "" : "UDP/"),
            ((gOptFlags & kOptFlagUseIPv4) ? "v4" : "v6"),
            ((gInterfaceName) ? gInterfaceName : "<none>"),
            (CHIP_SYSTEM_CONFIG_USE_LWIP ? '\0' : 'o'));
+	// clang-format ob
 
     // Allocate the endpoints for sending or receiving.
 
@@ -974,9 +957,9 @@ static void StartTest(void)
 
     for (size_t i = 0; i < sGroupAddresses.mSize; i++)
     {
-        char            lAddressBuffer[INET6_ADDRSTRLEN];
-        GroupAddress &  lGroupAddress     = sGroupAddresses.mAddresses[i];
-        IPAddress &     lMulticastAddress = lGroupAddress.mMulticastAddress;
+        char lAddressBuffer[INET6_ADDRSTRLEN];
+        GroupAddress & lGroupAddress  = sGroupAddresses.mAddresses[i];
+        IPAddress & lMulticastAddress = lGroupAddress.mMulticastAddress;
 
         if ((lEndPoint != NULL) && IsInterfaceIdPresent(gInterfaceId))
         {
@@ -989,7 +972,7 @@ static void StartTest(void)
                 lMulticastAddress = MakeIPv6Multicast(lGroupAddress.mGroup);
             }
 
-            lMulticastAddress.ToString(lAddressBuffer, sizeof (lAddressBuffer));
+            lMulticastAddress.ToString(lAddressBuffer, sizeof(lAddressBuffer));
 
             printf("Will join multicast group %s\n", lAddressBuffer);
 
@@ -1006,13 +989,13 @@ static void StartTest(void)
 
 static void CleanupTest(void)
 {
-    IPEndPointBasis *  lEndPoint      = NULL;
-    INET_ERROR         lStatus;
+    IPEndPointBasis * lEndPoint = NULL;
+    INET_ERROR lStatus;
 
     gSendIntervalExpired = false;
     gSystemLayer.CancelTimer(Common::HandleSendTimerComplete, NULL);
 
-     //  Leave the multicast groups
+    //  Leave the multicast groups
 
     if (gOptFlags & kOptFlagUseRawIP)
     {
@@ -1025,13 +1008,13 @@ static void CleanupTest(void)
 
     for (size_t i = 0; i < sGroupAddresses.mSize; i++)
     {
-        char            lAddressBuffer[INET6_ADDRSTRLEN];
-        GroupAddress &  lGroupAddress     = sGroupAddresses.mAddresses[i];
-        IPAddress &     lMulticastAddress = lGroupAddress.mMulticastAddress;
+        char lAddressBuffer[INET6_ADDRSTRLEN];
+        GroupAddress & lGroupAddress  = sGroupAddresses.mAddresses[i];
+        IPAddress & lMulticastAddress = lGroupAddress.mMulticastAddress;
 
         if ((lEndPoint != NULL) && IsInterfaceIdPresent(gInterfaceId))
         {
-            lMulticastAddress.ToString(lAddressBuffer, sizeof (lAddressBuffer));
+            lMulticastAddress.ToString(lAddressBuffer, sizeof(lAddressBuffer));
 
             printf("Will leave multicast group %s\n", lAddressBuffer);
 

--- a/src/inet/tests/TestInetLayerMulticast.cpp
+++ b/src/inet/tests/TestInetLayerMulticast.cpp
@@ -1,0 +1,1054 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2018-2019 Google LLC
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a process to effect a functional test for
+ *      the InetLayer Internet Protocol stack abstraction interfaces
+ *      for handling IP (v4 or v6) multicast on either bare IP (i.e.,
+ *      "raw") or UDP endpoints.
+ *
+ */
+
+#ifndef __STDC_LIMIT_MACROS
+#define __STDC_LIMIT_MACROS
+#endif
+
+#include <signal.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <nlbyteorder.hpp>
+
+#include <CHIPVersion.h>
+
+#include <inet/IPAddress.h>
+#include <system/SystemTimer.h>
+
+#include "TestInetCommon.h"
+#include "TestInetLayerCommon.hpp"
+
+using namespace chip;
+using namespace chip::ArgParser;
+using namespace chip::Inet;
+
+
+/* Preprocessor Macros */
+
+#define kToolName                       "TestInetLayerMulticast"
+
+#define kToolOptNoLoopback              'L'
+#define kToolOptGroup                   'g'
+
+#define kToolOptExpectedGroupRxPackets  (kToolOptBase + 0)
+#define kToolOptExpectedGroupTxPackets  (kToolOptBase + 1)
+
+
+/* Type Definitions */
+
+enum OptFlags
+{
+    kOptFlagNoLoopback = 0x00010000
+};
+
+struct GroupAddress
+{
+    uint32_t       mGroup;
+    TransferStats  mStats;
+    IPAddress      mMulticastAddress;
+};
+
+template <size_t tCapacity>
+struct GroupAddresses
+{
+    size_t         mSize;
+    const size_t   mCapacity = tCapacity;
+    GroupAddress   mAddresses[tCapacity];
+};
+
+template <size_t tCapacity>
+struct TestState
+{
+    GroupAddresses<tCapacity> &  mGroupAddresses;
+    TestStatus                   mStatus;
+};
+
+
+/* Function Declarations */
+
+static void HandleSignal(int aSignal);
+static bool HandleOption(const char *aProgram, OptionSet *aOptions, int aIdentifier, const char *aName, const char *aValue);
+static bool HandleNonOptionArgs(const char *aProgram, int argc, char *argv[]);
+static bool ParseGroupOpt(const char *aProgram, const char *aValue, bool aIPv6, uint32_t &aOutLastGroupIndex);
+static bool ParseAndUpdateExpectedGroupPackets(const char *aProgram, const char *aValue, uint32_t aGroup, const char *aDescription, uint32_t &aOutExpected);
+
+static void StartTest(void);
+static void CleanupTest(void);
+
+
+/* Global Variables */
+
+// clang-format off
+static const uint32_t    kOptFlagsDefault       = (kOptFlagUseIPv6 | kOptFlagUseRawIP);
+
+static RawEndPoint *     sRawIPEndPoint         = NULL;
+static UDPEndPoint *     sUDPIPEndPoint         = NULL;
+
+static GroupAddresses<4> sGroupAddresses;
+
+static TestState<4>      sTestState             =
+{
+    sGroupAddresses,
+    { false, false }
+};
+
+static uint32_t          sLastGroupIndex        = 0;
+
+static OptionDef         sToolOptionDefs[] =
+{
+    { "interface",                 kArgumentRequired,  kToolOptInterface              },
+    { "group",                     kArgumentRequired,  kToolOptGroup                  },
+    { "group-expected-rx-packets", kArgumentRequired,  kToolOptExpectedGroupRxPackets },
+    { "group-expected-tx-packets", kArgumentRequired,  kToolOptExpectedGroupTxPackets },
+    { "interval",                  kArgumentRequired,  kToolOptInterval               },
+#if INET_CONFIG_ENABLE_IPV4
+    { "ipv4",                      kNoArgument,        kToolOptIPv4Only               },
+#endif // INET_CONFIG_ENABLE_IPV4
+    { "ipv6",                      kNoArgument,        kToolOptIPv6Only               },
+    { "listen",                    kNoArgument,        kToolOptListen                 },
+    { "no-loopback",               kNoArgument,        kToolOptNoLoopback             },
+    { "raw",                       kNoArgument,        kToolOptRawIP                  },
+    { "send-size",                 kArgumentRequired,  kToolOptSendSize               },
+    { "udp",                       kNoArgument,        kToolOptUDPIP                  },
+    { }
+};
+
+static const char *      sToolOptionHelp =
+    "  -I, --interface <interface>\n"
+    "       The network interface to bind to and from which to send and receive all packets.\n"
+    "\n"
+    "  -L, --no-loopback\n"
+    "       Suppress the loopback of multicast packets.\n"
+    "\n"
+    "  -g, --group <group>\n"
+    "       Multicast group number to join.\n"
+    "\n"
+    "  --group-expected-rx-packets <packets>\n"
+    "       Expect to receive this number of packets for the previously-specified multicast group.\n"
+    "\n"
+    "  --group-expected-tx-packets <packets>\n"
+    "       Expect to send this number of packets for the previously-specified multicast group.\n"
+    "\n"
+    "  -i, --interval <interval>\n"
+    "       Wait interval milliseconds between sending each packet (default: 1000 ms).\n"
+    "\n"
+    "  -l, --listen\n"
+    "       Act as a server (i.e., listen) for packets rather than send them.\n"
+    "\n"
+#if INET_CONFIG_ENABLE_IPV4
+    "  -4, --ipv4\n"
+    "       Use IPv4 only.\n"
+    "\n"
+#endif // INET_CONFIG_ENABLE_IPV4
+    "  -6, --ipv6\n"
+    "       Use IPv6 only (default).\n"
+    "\n"
+    "  -s, --send-size <size>\n"
+    "       Send size bytes of user data (default: 59 bytes)\n"
+    "\n"
+    "  -r, --raw\n"
+    "       Use raw IP (default).\n"
+    "\n"
+    "  -u, --udp\n"
+    "       Use UDP over IP.\n"
+    "\n";
+
+static OptionSet         sToolOptions =
+{
+    HandleOption,
+    sToolOptionDefs,
+    "GENERAL OPTIONS",
+    sToolOptionHelp
+};
+
+static HelpOptions       sHelpOptions(
+    kToolName,
+    "Usage: " kToolName " [ <options> ] [ -g <group> [ ... ] -I <interface> ]\n",
+    CHIP_VERSION_STRING "\n" CHIP_TOOL_COPYRIGHT
+);
+
+static OptionSet *       sToolOptionSets[] =
+{
+    &sToolOptions,
+    &gNetworkOptions,
+    &gFaultInjectionOptions,
+    &sHelpOptions,
+    NULL
+};
+// clang-format on
+
+static void CheckSucceededOrFailed(const GroupAddress &aAddress, bool &aOutSucceeded, bool &aOutFailed)
+{
+    const TransferStats &lStats = aAddress.mStats;
+
+#if DEBUG
+    printf("Group %u: %u/%u sent, %u/%u received\n",
+           aAddress.mGroup,
+           lStats.mTransmit.mActual, lStats.mTransmit.mExpected,
+           lStats.mReceive.mActual, lStats.mReceive.mExpected);
+#endif
+
+    if (((lStats.mTransmit.mExpected > 0) && (lStats.mTransmit.mActual > lStats.mTransmit.mExpected)) ||
+        ((lStats.mReceive.mExpected > 0) && (lStats.mReceive.mActual > lStats.mReceive.mExpected)))
+    {
+        aOutFailed = true;
+    }
+    else if (((lStats.mTransmit.mExpected > 0) && (lStats.mTransmit.mActual < lStats.mTransmit.mExpected)) ||
+             ((lStats.mReceive.mExpected > 0) && (lStats.mReceive.mActual < lStats.mReceive.mExpected)))
+    {
+        aOutSucceeded = false;
+    }
+}
+
+template <size_t tCapacity>
+static void CheckSucceededOrFailed(TestState<tCapacity> &aTestState, bool &aOutSucceeded, bool &aOutFailed)
+{
+    for (size_t i = 0; i < aTestState.mGroupAddresses.mSize; i++)
+    {
+        const GroupAddress &lGroup = aTestState.mGroupAddresses.mAddresses[i];
+
+        CheckSucceededOrFailed(lGroup, aOutSucceeded, aOutFailed);
+    }
+
+    if (aOutSucceeded || aOutFailed)
+    {
+        if (aOutSucceeded)
+            aTestState.mStatus.mSucceeded = true;
+
+        if (aOutFailed)
+            SetStatusFailed(aTestState.mStatus);
+    }
+}
+
+static void HandleSignal(int aSignal)
+{
+    switch (aSignal)
+    {
+
+    case SIGUSR1:
+        SetStatusFailed(sTestState.mStatus);
+        break;
+
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    bool          lSuccessful = true;
+    INET_ERROR    lStatus;
+
+    InitTestInetCommon();
+
+    SetupFaultInjectionContext(argc, argv);
+
+    SetSignalHandler(HandleSignal);
+
+    if (argc == 1)
+    {
+        sHelpOptions.PrintBriefUsage(stderr);
+        lSuccessful = false;
+        goto exit;
+    }
+
+    if (!ParseArgsFromEnvVar(kToolName, TOOL_OPTIONS_ENV_VAR_NAME, sToolOptionSets, NULL, true) ||
+        !ParseArgs(kToolName, argc, argv, sToolOptionSets, HandleNonOptionArgs))
+    {
+        lSuccessful = false;
+        goto exit;
+    }
+
+    InitSystemLayer();
+
+    InitNetwork();
+
+    // At this point, we should have valid network interfaces,
+    // including LwIP TUN/TAP shim interfaces. Validate the
+    // -I/--interface argument, if present.
+
+    if (gInterfaceName != NULL)
+    {
+        lStatus = InterfaceNameToId(gInterfaceName, gInterfaceId);
+        if (lStatus != INET_NO_ERROR)
+        {
+            PrintArgError("%s: unknown network interface %s\n", kToolName, gInterfaceName);
+            lSuccessful = false;
+            goto shutdown;
+        }
+    }
+
+    // If any multicast groups have been specified, ensure that a
+    // network interface identifier has been specified and is valid.
+
+    if ((sGroupAddresses.mSize > 0) && !IsInterfaceIdPresent(gInterfaceId))
+    {
+        PrintArgError("%s: a network interface is required when specifying one or more multicast groups\n", kToolName);
+        lSuccessful = false;
+        goto shutdown;
+    }
+
+    StartTest();
+
+    while (Common::IsTesting(sTestState.mStatus))
+    {
+        struct timeval sleepTime;
+        bool lSucceeded = true;
+        bool lFailed = false;
+
+        sleepTime.tv_sec = 0;
+        sleepTime.tv_usec = 10000;
+
+        ServiceNetwork(sleepTime);
+
+        CheckSucceededOrFailed(sTestState, lSucceeded, lFailed);
+
+#if DEBUG
+        printf("%s %s number of expected packets\n",
+               ((lSucceeded) ? "successfully" :
+                ((lFailed) ? "failed to" :
+                 "has not yet")),
+               ((lSucceeded) ? (Common::IsReceiver() ? "received" : "sent") :
+                ((lFailed) ? (Common::IsReceiver() ? "receive" : "send") :
+                 Common::IsReceiver() ? "received" : "sent"))
+               );
+#endif
+    }
+
+    CleanupTest();
+
+shutdown:
+    ShutdownNetwork();
+    ShutdownSystemLayer();
+
+    lSuccessful = Common::WasSuccessful(sTestState.mStatus);
+
+exit:
+    return (lSuccessful ? EXIT_SUCCESS : EXIT_FAILURE);
+}
+
+static bool HandleOption(const char *aProgram, OptionSet *aOptions, int aIdentifier, const char *aName, const char *aValue)
+{
+    bool       retval = true;
+
+    switch (aIdentifier)
+    {
+
+    case kToolOptInterval:
+        if (!ParseInt(aValue, gSendIntervalMs) || gSendIntervalMs > UINT32_MAX)
+        {
+            PrintArgError("%s: invalid value specified for send interval: %s\n", aProgram, aValue);
+            retval = false;
+        }
+        break;
+
+    case kToolOptListen:
+        gOptFlags |= kOptFlagListen;
+        break;
+
+    case kToolOptNoLoopback:
+        gOptFlags |= kOptFlagNoLoopback;
+        break;
+
+    case kToolOptGroup:
+        if (!ParseGroupOpt(aProgram, aValue, gOptFlags & kOptFlagUseIPv6, sLastGroupIndex))
+        {
+            retval = false;
+        }
+        break;
+
+    case kToolOptExpectedGroupRxPackets:
+        {
+            GroupAddress &lGroupAddress = sGroupAddresses.mAddresses[sLastGroupIndex];
+
+            if (!ParseAndUpdateExpectedGroupPackets(aProgram, aValue, lGroupAddress.mGroup, "received", lGroupAddress.mStats.mReceive.mExpected))
+            {
+                retval = false;
+            }
+        }
+        break;
+
+    case kToolOptExpectedGroupTxPackets:
+        {
+            GroupAddress &lGroupAddress = sGroupAddresses.mAddresses[sLastGroupIndex];
+
+            if (!ParseAndUpdateExpectedGroupPackets(aProgram, aValue, lGroupAddress.mGroup, "sent", lGroupAddress.mStats.mTransmit.mExpected))
+            {
+                retval = false;
+            }
+        }
+        break;
+
+#if INET_CONFIG_ENABLE_IPV4
+    case kToolOptIPv4Only:
+        if (gOptFlags & kOptFlagUseIPv6)
+        {
+            PrintArgError("%s: the use of --ipv4 is exclusive with --ipv6. Please select only one of the two options.\n", aProgram);
+            retval = false;
+        }
+        gOptFlags |= kOptFlagUseIPv4;
+        break;
+#endif // INET_CONFIG_ENABLE_IPV4
+
+    case kToolOptIPv6Only:
+        if (gOptFlags & kOptFlagUseIPv4)
+        {
+            PrintArgError("%s: the use of --ipv6 is exclusive with --ipv4. Please select only one of the two options.\n", aProgram);
+            retval = false;
+        }
+        gOptFlags |= kOptFlagUseIPv6;
+        break;
+
+    case kToolOptInterface:
+
+        // NOTE: When using LwIP on a hosted OS, the interface will
+        // not actually be available until AFTER InitNetwork,
+        // consequently, we cannot do any meaningful validation
+        // here. Simply save the value off and we will validate it
+        // later.
+
+        gInterfaceName = aValue;
+        break;
+
+    case kToolOptRawIP:
+        if (gOptFlags & kOptFlagUseUDPIP)
+        {
+            PrintArgError("%s: the use of --raw is exclusive with --udp. Please select only one of the two options.\n", aProgram);
+            retval = false;
+        }
+        gOptFlags |= kOptFlagUseRawIP;
+        break;
+
+    case kToolOptSendSize:
+        if (!ParseInt(aValue, gSendSize))
+        {
+            PrintArgError("%s: invalid value specified for send size: %s\n", aProgram, aValue);
+            return false;
+        }
+        break;
+
+    case kToolOptUDPIP:
+        if (gOptFlags & kOptFlagUseRawIP)
+        {
+            PrintArgError("%s: the use of --udp is exclusive with --raw. Please select only one of the two options.\n", aProgram);
+            retval = false;
+        }
+        gOptFlags |= kOptFlagUseUDPIP;
+        break;
+
+    default:
+        PrintArgError("%s: INTERNAL ERROR: Unhandled option: %s\n", aProgram, aName);
+        retval = false;
+        break;
+
+    }
+
+    return (retval);
+}
+
+bool HandleNonOptionArgs(const char *aProgram, int argc, char *argv[])
+{
+    bool retval = true;
+
+    if ((gOptFlags & (kOptFlagListen | kOptFlagNoLoopback)) == (kOptFlagListen | kOptFlagNoLoopback))
+    {
+        PrintArgError("%s: the listen option is exclusive with the loopback suppression option. Please select one or the other.\n", aProgram);
+        retval = false;
+        goto exit;
+    }
+
+    // If there were any additional, non-parsed arguments, it's an error.
+
+    if (argc > 0)
+    {
+        PrintArgError("%s: unexpected argument: %s\n", aProgram, argv[0]);
+        retval = false;
+        goto exit;
+    }
+
+    // If no IP version or transport flags were specified, use the defaults.
+
+    if (!(gOptFlags & (kOptFlagUseIPv4 | kOptFlagUseIPv6 | kOptFlagUseRawIP | kOptFlagUseUDPIP)))
+    {
+        gOptFlags |= kOptFlagsDefault;
+    }
+
+exit:
+    return (retval);
+}
+
+// Create an IPv4 administratively-scoped multicast address
+
+static IPAddress MakeIPv4Multicast(uint32_t aGroupIdentifier)
+{
+    IPAddress lAddress;
+
+    lAddress.Addr[0] = 0;
+    lAddress.Addr[1] = 0;
+    lAddress.Addr[2] = nlByteOrderSwap32HostToBig(0xFFFF);
+    lAddress.Addr[3] = nlByteOrderSwap32HostToBig((239 << 24) | (aGroupIdentifier & 0xFFFFFF));
+
+    return (lAddress);
+}
+
+// Create an IPv6 site-scoped multicast address
+
+static IPAddress MakeIPv6Multicast(uint32_t aGroupIdentifier)
+{
+    const uint8_t lFlags = kIPv6MulticastFlag_Transient;
+
+    return (IPAddress::MakeIPv6Multicast(lFlags, kIPv6MulticastScope_Site, aGroupIdentifier));
+}
+
+static void SetGroup(GroupAddress &aGroupAddress, uint32_t aGroupIdentifier, uint32_t aExpectedRx, uint32_t aExpectedTx)
+{
+    aGroupAddress.mGroup                     = aGroupIdentifier;
+    aGroupAddress.mStats.mReceive.mExpected  = aExpectedRx;
+    aGroupAddress.mStats.mReceive.mActual    = 0;
+    aGroupAddress.mStats.mTransmit.mExpected = aExpectedTx;
+    aGroupAddress.mStats.mTransmit.mActual   = 0;
+}
+
+static bool ParseGroupOpt(const char *aProgram, const char *aValue, bool aIPv6, uint32_t &aOutLastGroupIndex)
+{
+    uint32_t lGroupIdentifier;
+    bool     lRetval = true;
+
+    if (sGroupAddresses.mSize == sGroupAddresses.mCapacity)
+    {
+        PrintArgError("%s: the maximum number of allowed groups (%zu) have been specified\n", aProgram, sGroupAddresses.mCapacity);
+        lRetval = false;
+        goto exit;
+    }
+
+    if (!ParseInt(aValue, lGroupIdentifier))
+    {
+        PrintArgError("%s: unrecognized group %s\n", aProgram, aValue);
+        lRetval = false;
+        goto exit;
+    }
+
+    aOutLastGroupIndex = sGroupAddresses.mSize++;
+
+    SetGroup(sGroupAddresses.mAddresses[aOutLastGroupIndex],
+             lGroupIdentifier,
+             lGroupIdentifier,
+             lGroupIdentifier);
+
+exit:
+    return (lRetval);
+}
+
+static bool ParseAndUpdateExpectedGroupPackets(const char *aProgram, const char *aValue, uint32_t aGroup, const char *aDescription, uint32_t &aOutExpected)
+{
+    uint32_t  lExpectedGroupPackets;
+    bool      lRetval = true;
+
+    if (!ParseInt(aValue, lExpectedGroupPackets))
+    {
+        PrintArgError("%s: invalid value specified for expected group %u %s packets: %s\n", aProgram, aGroup, aDescription, aValue);
+        lRetval = false;
+        goto exit;
+    }
+
+    aOutExpected = lExpectedGroupPackets;
+
+exit:
+    return (lRetval);
+}
+
+static GroupAddress *FindGroupAddress(const IPAddress &aSourceAddress)
+{
+    GroupAddress *lResult = NULL;
+
+    for (size_t i = 0; i < sGroupAddresses.mSize; i++)
+    {
+        GroupAddress &lGroupAddress = sGroupAddresses.mAddresses[i];
+
+        if (lGroupAddress.mMulticastAddress == aSourceAddress)
+        {
+            lResult = &lGroupAddress;
+            break;
+        }
+    }
+
+    return (lResult);
+}
+
+static void PrintReceivedStats(const GroupAddress &aGroupAddress)
+{
+    printf("%u/%u received for multicast group %u\n",
+           aGroupAddress.mStats.mReceive.mActual,
+           aGroupAddress.mStats.mReceive.mExpected,
+           aGroupAddress.mGroup);
+}
+
+static bool HandleDataReceived(const PacketBuffer *aBuffer, GroupAddress &aGroupAddress, bool aCheckBuffer)
+{
+    const bool  lStatsByPacket = true;
+    bool        lStatus = true;
+
+    lStatus = Common::HandleDataReceived(aBuffer,
+                                         aGroupAddress.mStats,
+                                         lStatsByPacket,
+                                         aCheckBuffer);
+    VerifyOrExit(lStatus == true, );
+
+    PrintReceivedStats(aGroupAddress);
+
+exit:
+    return (lStatus);
+}
+
+static bool HandleDataReceived(const PacketBuffer *aBuffer, const IPPacketInfo &aPacketInfo, bool aCheckBuffer)
+{
+    bool            lStatus = true;
+    GroupAddress *  lGroupAddress;
+
+    lGroupAddress = FindGroupAddress(aPacketInfo.DestAddress);
+
+    if (lGroupAddress != NULL)
+    {
+        lStatus = HandleDataReceived(aBuffer, *lGroupAddress, aCheckBuffer);
+        VerifyOrExit(lStatus == true, );
+    }
+
+exit:
+    return (lStatus);
+}
+
+// Raw Endpoint Callbacks
+
+static void HandleRawMessageReceived(IPEndPointBasis *aEndPoint, PacketBuffer *aBuffer, const IPPacketInfo *aPacketInfo)
+{
+    const bool      lCheckBuffer = true;
+    const bool      lStatsByPacket = true;
+    IPAddressType   lAddressType;
+    bool            lStatus = true;
+    GroupAddress *  lGroupAddress;
+
+    VerifyOrExit(aEndPoint != NULL,   lStatus = false);
+    VerifyOrExit(aBuffer != NULL,     lStatus = false);
+    VerifyOrExit(aPacketInfo != NULL, lStatus = false);
+
+    Common::HandleRawMessageReceived(aEndPoint, aBuffer, aPacketInfo);
+
+    lGroupAddress = FindGroupAddress(aPacketInfo->DestAddress);
+
+    if (lGroupAddress != NULL)
+    {
+        lAddressType = aPacketInfo->DestAddress.Type();
+
+        if (lAddressType == kIPAddressType_IPv4)
+        {
+            const uint16_t kIPv4HeaderSize = 20;
+
+            aBuffer->ConsumeHead(kIPv4HeaderSize);
+
+            lStatus = Common::HandleICMPv4DataReceived(aBuffer, lGroupAddress->mStats, lStatsByPacket, lCheckBuffer);
+        }
+        else if (lAddressType == kIPAddressType_IPv6)
+        {
+            lStatus = Common::HandleICMPv6DataReceived(aBuffer, lGroupAddress->mStats, lStatsByPacket, lCheckBuffer);
+        }
+        else
+        {
+            lStatus = false;
+        }
+
+        if (lStatus)
+        {
+            PrintReceivedStats(*lGroupAddress);
+        }
+    }
+
+exit:
+    if (aBuffer != NULL)
+    {
+        PacketBuffer::Free(aBuffer);
+    }
+
+    if (!lStatus)
+    {
+        SetStatusFailed(sTestState.mStatus);
+    }
+}
+
+static void HandleRawReceiveError(IPEndPointBasis *aEndPoint, INET_ERROR aError, const IPPacketInfo *aPacketInfo)
+{
+    Common::HandleRawReceiveError(aEndPoint, aError, aPacketInfo);
+
+    SetStatusFailed(sTestState.mStatus);
+}
+
+// UDP Endpoint Callbacks
+
+static void HandleUDPMessageReceived(IPEndPointBasis *aEndPoint, PacketBuffer *aBuffer, const IPPacketInfo *aPacketInfo)
+{
+    const bool  lCheckBuffer = true;
+    bool        lStatus;
+
+    VerifyOrExit(aEndPoint != NULL,   lStatus = false);
+    VerifyOrExit(aBuffer != NULL,     lStatus = false);
+    VerifyOrExit(aPacketInfo != NULL, lStatus = false);
+
+    Common::HandleUDPMessageReceived(aEndPoint, aBuffer, aPacketInfo);
+
+    lStatus = HandleDataReceived(aBuffer, *aPacketInfo, lCheckBuffer);
+
+exit:
+    if (aBuffer != NULL)
+    {
+        PacketBuffer::Free(aBuffer);
+    }
+
+    if (!lStatus)
+    {
+        SetStatusFailed(sTestState.mStatus);
+    }
+}
+
+static void HandleUDPReceiveError(IPEndPointBasis *aEndPoint, INET_ERROR aError, const IPPacketInfo *aPacketInfo)
+{
+    Common::HandleUDPReceiveError(aEndPoint, aError, aPacketInfo);
+
+    SetStatusFailed(sTestState.mStatus);
+}
+
+static bool IsTransportReadyForSend(void)
+{
+    bool lStatus = false;
+
+    if ((gOptFlags & (kOptFlagUseRawIP)) == (kOptFlagUseRawIP))
+    {
+        lStatus = (sRawIPEndPoint != NULL);
+    }
+    else if ((gOptFlags & kOptFlagUseUDPIP) == kOptFlagUseUDPIP)
+    {
+        lStatus = (sUDPIPEndPoint != NULL);
+    }
+
+    return (lStatus);
+}
+
+static INET_ERROR PrepareTransportForSend(void)
+{
+    INET_ERROR lStatus = INET_NO_ERROR;
+
+    return (lStatus);
+}
+
+static INET_ERROR DriveSendForDestination(const IPAddress &aAddress, uint16_t aSize)
+{
+    PacketBuffer *lBuffer = NULL;
+    INET_ERROR    lStatus = INET_NO_ERROR;
+
+    if ((gOptFlags & (kOptFlagUseRawIP)) == (kOptFlagUseRawIP))
+    {
+        // For ICMP (v4 or v6), we'll send n aSize or smaller
+        // datagrams (with overhead for the ICMP header), each
+        // patterned from zero to aSize - 1, following the ICMP
+        // header.
+
+        if ((gOptFlags & kOptFlagUseIPv6) == (kOptFlagUseIPv6))
+        {
+            lBuffer = Common::MakeICMPv6DataBuffer(aSize);
+            VerifyOrExit(lBuffer != NULL, lStatus = INET_ERROR_NO_MEMORY);
+        }
+#if INET_CONFIG_ENABLE_IPV4
+        else if ((gOptFlags & kOptFlagUseIPv4) == (kOptFlagUseIPv4))
+        {
+            lBuffer = Common::MakeICMPv4DataBuffer(aSize);
+            VerifyOrExit(lBuffer != NULL, lStatus = INET_ERROR_NO_MEMORY);
+        }
+#endif // INET_CONFIG_ENABLE_IPV4
+
+        lStatus = sRawIPEndPoint->SendTo(aAddress, lBuffer);
+        SuccessOrExit(lStatus);
+    }
+    else
+    {
+        if ((gOptFlags & kOptFlagUseUDPIP) == kOptFlagUseUDPIP)
+        {
+            const uint8_t lFirstValue = 0;
+
+            // For UDP, we'll send n aSize or smaller datagrams, each
+            // patterned from zero to aSize - 1.
+
+            lBuffer = Common::MakeDataBuffer(aSize, lFirstValue);
+            VerifyOrExit(lBuffer != NULL, lStatus = INET_ERROR_NO_MEMORY);
+
+            lStatus = sUDPIPEndPoint->SendTo(aAddress, kUDPPort, lBuffer);
+            SuccessOrExit(lStatus);
+        }
+    }
+
+exit:
+    return (lStatus);
+}
+
+static INET_ERROR DriveSendForGroup(GroupAddress &aGroupAddress)
+{
+    INET_ERROR lStatus = INET_NO_ERROR;
+
+    if (aGroupAddress.mStats.mTransmit.mActual < aGroupAddress.mStats.mTransmit.mExpected)
+    {
+        lStatus = DriveSendForDestination(aGroupAddress.mMulticastAddress, gSendSize);
+        SuccessOrExit(lStatus);
+
+        aGroupAddress.mStats.mTransmit.mActual++;
+
+        printf("%u/%u transmitted for multicast group %u\n",
+               aGroupAddress.mStats.mTransmit.mActual,
+               aGroupAddress.mStats.mTransmit.mExpected,
+               aGroupAddress.mGroup);
+    }
+
+exit:
+    return (lStatus);
+}
+
+template <size_t tCapacity>
+static INET_ERROR DriveSendForGroups(GroupAddresses<tCapacity> &aGroupAddresses)
+{
+    INET_ERROR lStatus = INET_NO_ERROR;
+
+    // Iterate over each multicast group for which this node is a
+    // member and send a packet.
+
+    for (size_t i = 0; i < aGroupAddresses.mSize; i++)
+    {
+        GroupAddress &lGroupAddress = aGroupAddresses.mAddresses[i];
+
+        lStatus = DriveSendForGroup(lGroupAddress);
+        SuccessOrExit(lStatus);
+    }
+
+exit:
+    return (lStatus);
+}
+
+void DriveSend(void)
+{
+    INET_ERROR lStatus = INET_NO_ERROR;
+
+    if (!Common::IsSender())
+        goto exit;
+
+    if (!gSendIntervalExpired)
+        goto exit;
+
+    if (!IsTransportReadyForSend())
+    {
+        lStatus = PrepareTransportForSend();
+        SuccessOrExit(lStatus);
+    }
+    else
+    {
+        gSendIntervalExpired = false;
+        gSystemLayer.StartTimer(gSendIntervalMs, Common::HandleSendTimerComplete, NULL);
+
+        lStatus = DriveSendForGroups(sGroupAddresses);
+        SuccessOrExit(lStatus);
+    }
+
+exit:
+    if (lStatus != INET_NO_ERROR)
+    {
+        SetStatusFailed(sTestState.mStatus);
+    }
+
+    return;
+}
+
+static void StartTest(void)
+{
+    IPAddressType      lIPAddressType = kIPAddressType_IPv6;
+    IPProtocol         lIPProtocol    = kIPProtocol_ICMPv6;
+    IPVersion          lIPVersion     = kIPVersion_6;
+    IPAddress          lAddress       = IPAddress::Any;
+    IPEndPointBasis *  lEndPoint      = NULL;
+    const bool         lUseLoopback   = ((gOptFlags & kOptFlagNoLoopback) == 0);
+    INET_ERROR         lStatus;
+
+#if INET_CONFIG_ENABLE_IPV4
+    if (gOptFlags & kOptFlagUseIPv4)
+    {
+        lIPAddressType = kIPAddressType_IPv4;
+        lIPProtocol    = kIPProtocol_ICMPv4;
+        lIPVersion     = kIPVersion_4;
+    }
+#endif // INET_CONFIG_ENABLE_IPV4
+
+    printf("Using %sIP%s, device interface: %s (w/%c LwIP)\n",
+           ((gOptFlags & kOptFlagUseRawIP) ? "" : "UDP/"),
+           ((gOptFlags & kOptFlagUseIPv4) ? "v4" : "v6"),
+           ((gInterfaceName) ? gInterfaceName : "<none>"),
+           (CHIP_SYSTEM_CONFIG_USE_LWIP ? '\0' : 'o'));
+
+    // Allocate the endpoints for sending or receiving.
+
+    if (gOptFlags & kOptFlagUseRawIP)
+    {
+        lStatus = gInet.NewRawEndPoint(lIPVersion, lIPProtocol, &sRawIPEndPoint);
+        INET_FAIL_ERROR(lStatus, "InetLayer::NewRawEndPoint failed");
+
+        sRawIPEndPoint->OnMessageReceived = HandleRawMessageReceived;
+        sRawIPEndPoint->OnReceiveError    = HandleRawReceiveError;
+
+        lStatus = sRawIPEndPoint->Bind(lIPAddressType, lAddress);
+        INET_FAIL_ERROR(lStatus, "RawEndPoint::Bind failed");
+
+        if (gOptFlags & kOptFlagUseIPv6)
+        {
+            lStatus = sRawIPEndPoint->SetICMPFilter(kICMPv6_FilterTypes, gICMPv6Types);
+            INET_FAIL_ERROR(lStatus, "RawEndPoint::SetICMPFilter (IPv6) failed");
+        }
+
+        if (IsInterfaceIdPresent(gInterfaceId))
+        {
+            lStatus = sRawIPEndPoint->BindInterface(lIPAddressType, gInterfaceId);
+            INET_FAIL_ERROR(lStatus, "RawEndPoint::BindInterface failed");
+        }
+
+        lStatus = sRawIPEndPoint->Listen();
+        INET_FAIL_ERROR(lStatus, "RawEndPoint::Listen failed");
+
+        lEndPoint = sRawIPEndPoint;
+    }
+    else if (gOptFlags & kOptFlagUseUDPIP)
+    {
+        lStatus = gInet.NewUDPEndPoint(&sUDPIPEndPoint);
+        INET_FAIL_ERROR(lStatus, "InetLayer::NewUDPEndPoint failed");
+
+        sUDPIPEndPoint->OnMessageReceived = HandleUDPMessageReceived;
+        sUDPIPEndPoint->OnReceiveError    = HandleUDPReceiveError;
+
+        lStatus = sUDPIPEndPoint->Bind(lIPAddressType, lAddress, kUDPPort);
+        INET_FAIL_ERROR(lStatus, "UDPEndPoint::Bind failed");
+
+        if (IsInterfaceIdPresent(gInterfaceId))
+        {
+            lStatus = sUDPIPEndPoint->BindInterface(lIPAddressType, gInterfaceId);
+            INET_FAIL_ERROR(lStatus, "UDPEndPoint::BindInterface failed");
+        }
+
+        lStatus = sUDPIPEndPoint->Listen();
+        INET_FAIL_ERROR(lStatus, "UDPEndPoint::Listen failed");
+
+        lEndPoint = sUDPIPEndPoint;
+    }
+
+    // If loopback suppression has been requested, attempt to disable
+    // it; otherwise, attempt to enable it.
+
+    lStatus = lEndPoint->SetMulticastLoopback(lIPVersion, lUseLoopback);
+    INET_FAIL_ERROR(lStatus, "SetMulticastLoopback failed");
+
+    // Configure and join the multicast groups
+
+    for (size_t i = 0; i < sGroupAddresses.mSize; i++)
+    {
+        char            lAddressBuffer[INET6_ADDRSTRLEN];
+        GroupAddress &  lGroupAddress     = sGroupAddresses.mAddresses[i];
+        IPAddress &     lMulticastAddress = lGroupAddress.mMulticastAddress;
+
+        if ((lEndPoint != NULL) && IsInterfaceIdPresent(gInterfaceId))
+        {
+            if (gOptFlags & kOptFlagUseIPv4)
+            {
+                lMulticastAddress = MakeIPv4Multicast(lGroupAddress.mGroup);
+            }
+            else
+            {
+                lMulticastAddress = MakeIPv6Multicast(lGroupAddress.mGroup);
+            }
+
+            lMulticastAddress.ToString(lAddressBuffer, sizeof (lAddressBuffer));
+
+            printf("Will join multicast group %s\n", lAddressBuffer);
+
+            lStatus = lEndPoint->JoinMulticastGroup(gInterfaceId, lMulticastAddress);
+            INET_FAIL_ERROR(lStatus, "Could not join multicast group");
+        }
+    }
+
+    if (Common::IsReceiver())
+        printf("Listening...\n");
+    else
+        DriveSend();
+}
+
+static void CleanupTest(void)
+{
+    IPEndPointBasis *  lEndPoint      = NULL;
+    INET_ERROR         lStatus;
+
+    gSendIntervalExpired = false;
+    gSystemLayer.CancelTimer(Common::HandleSendTimerComplete, NULL);
+
+     //  Leave the multicast groups
+
+    if (gOptFlags & kOptFlagUseRawIP)
+    {
+        lEndPoint = sRawIPEndPoint;
+    }
+    else if (gOptFlags & kOptFlagUseUDPIP)
+    {
+        lEndPoint = sUDPIPEndPoint;
+    }
+
+    for (size_t i = 0; i < sGroupAddresses.mSize; i++)
+    {
+        char            lAddressBuffer[INET6_ADDRSTRLEN];
+        GroupAddress &  lGroupAddress     = sGroupAddresses.mAddresses[i];
+        IPAddress &     lMulticastAddress = lGroupAddress.mMulticastAddress;
+
+        if ((lEndPoint != NULL) && IsInterfaceIdPresent(gInterfaceId))
+        {
+            lMulticastAddress.ToString(lAddressBuffer, sizeof (lAddressBuffer));
+
+            printf("Will leave multicast group %s\n", lAddressBuffer);
+
+            lStatus = lEndPoint->LeaveMulticastGroup(gInterfaceId, lMulticastAddress);
+            INET_FAIL_ERROR(lStatus, "Could not leave multicast group");
+        }
+    }
+
+    // Release the resources associated with the allocated end points.
+
+    if (sRawIPEndPoint != NULL)
+    {
+        sRawIPEndPoint->Free();
+    }
+
+    if (sUDPIPEndPoint != NULL)
+    {
+        sUDPIPEndPoint->Free();
+    }
+}


### PR DESCRIPTION
#### Problem
The chip::Inet layer library is missing unit and functional tests for Inet layer unicast and multicast APIs and operations.

#### Summary of Changes
Added / imported tests from openweave-core.

Fixes #289
