### PR TITLE
Fix issue CHIP crypto names are too verbose #312

### DIFF
--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -27,7 +27,7 @@
 #include <stddef.h>
 
 namespace chip {
-namespace crypto {
+namespace Crypto {
 
 /**
  * @brief A function that implements 256-bit AES-CCM encryption

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -66,6 +66,6 @@ CHIP_ERROR AES_CCM_256_decrypt(const unsigned char * ciphertext, size_t cipherte
                                size_t aad_length, const unsigned char * tag, size_t tag_length, const unsigned char * key,
                                const unsigned char * iv, size_t iv_length, unsigned char * plaintext);
 
-} // namespace crypto
+} // namespace Crypto
 } // namespace chip
 #endif

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -26,6 +26,9 @@
 #include <core/CHIPError.h>
 #include <stddef.h>
 
+namespace chip {
+namespace crypto {
+
 /**
  * @brief A function that implements 256-bit AES-CCM encryption
  * @param plaintext Plaintext to encrypt
@@ -40,9 +43,9 @@
  * @param tag_length Expected length of tag
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  * */
-CHIP_ERROR CHIP_aes_ccm_256_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
-                                    size_t aad_length, const unsigned char * key, const unsigned char * iv, size_t iv_length,
-                                    unsigned char * ciphertext, unsigned char * tag, size_t tag_length);
+CHIP_ERROR AES_CCM_256_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
+                               size_t aad_length, const unsigned char * key, const unsigned char * iv, size_t iv_length,
+                               unsigned char * ciphertext, unsigned char * tag, size_t tag_length);
 
 /**
  * @brief A function that implements 256-bit AES-CCM decryption
@@ -59,8 +62,10 @@ CHIP_ERROR CHIP_aes_ccm_256_encrypt(const unsigned char * plaintext, size_t plai
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  **/
 
-CHIP_ERROR CHIP_aes_ccm_256_decrypt(const unsigned char * ciphertext, size_t ciphertext_length, const unsigned char * aad,
-                                    size_t aad_length, const unsigned char * tag, size_t tag_length, const unsigned char * key,
-                                    const unsigned char * iv, size_t iv_length, unsigned char * plaintext);
+CHIP_ERROR AES_CCM_256_decrypt(const unsigned char * ciphertext, size_t ciphertext_length, const unsigned char * aad,
+                               size_t aad_length, const unsigned char * tag, size_t tag_length, const unsigned char * key,
+                               const unsigned char * iv, size_t iv_length, unsigned char * plaintext);
 
+} // namespace crypto
+} // namespace chip
 #endif

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -28,8 +28,6 @@
 #include <support/CodeUtils.h>
 #include <string.h>
 
-using namespace chip::crypto;
-
 #define kKeyLengthInBits 256
 
 static bool _isValidTagLength(size_t tag_length)
@@ -41,7 +39,7 @@ static bool _isValidTagLength(size_t tag_length)
     return false;
 }
 
-CHIP_ERROR chip::crypto::AES_CCM_256_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
+CHIP_ERROR chip::Crypto::AES_CCM_256_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
                                              size_t aad_length, const unsigned char * key, const unsigned char * iv,
                                              size_t iv_length, unsigned char * ciphertext, unsigned char * tag, size_t tag_length)
 {
@@ -112,7 +110,7 @@ exit:
     return error;
 }
 
-CHIP_ERROR chip::crypto::AES_CCM_256_decrypt(const unsigned char * ciphertext, size_t ciphertext_length, const unsigned char * aad,
+CHIP_ERROR chip::Crypto::AES_CCM_256_decrypt(const unsigned char * ciphertext, size_t ciphertext_length, const unsigned char * aad,
                                              size_t aad_length, const unsigned char * tag, size_t tag_length,
                                              const unsigned char * key, const unsigned char * iv, size_t iv_length,
                                              unsigned char * plaintext)

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -28,6 +28,8 @@
 #include <support/CodeUtils.h>
 #include <string.h>
 
+using namespace chip::crypto;
+
 #define kKeyLengthInBits 256
 
 static bool _isValidTagLength(size_t tag_length)
@@ -39,9 +41,9 @@ static bool _isValidTagLength(size_t tag_length)
     return false;
 }
 
-CHIP_ERROR CHIP_aes_ccm_256_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
-                                    size_t aad_length, const unsigned char * key, const unsigned char * iv, size_t iv_length,
-                                    unsigned char * ciphertext, unsigned char * tag, size_t tag_length)
+CHIP_ERROR chip::crypto::AES_CCM_256_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
+                                             size_t aad_length, const unsigned char * key, const unsigned char * iv,
+                                             size_t iv_length, unsigned char * ciphertext, unsigned char * tag, size_t tag_length)
 {
     EVP_CIPHER_CTX * context = NULL;
     int bytesWritten         = 0;
@@ -110,9 +112,10 @@ exit:
     return error;
 }
 
-CHIP_ERROR CHIP_aes_ccm_256_decrypt(const unsigned char * ciphertext, size_t ciphertext_length, const unsigned char * aad,
-                                    size_t aad_length, const unsigned char * tag, size_t tag_length, const unsigned char * key,
-                                    const unsigned char * iv, size_t iv_length, unsigned char * plaintext)
+CHIP_ERROR chip::crypto::AES_CCM_256_decrypt(const unsigned char * ciphertext, size_t ciphertext_length, const unsigned char * aad,
+                                             size_t aad_length, const unsigned char * tag, size_t tag_length,
+                                             const unsigned char * key, const unsigned char * iv, size_t iv_length,
+                                             unsigned char * plaintext)
 {
     EVP_CIPHER_CTX * context = NULL;
     CHIP_ERROR error         = CHIP_NO_ERROR;

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -22,17 +22,19 @@
 
 #include "CHIPCryptoPAL.h"
 
-CHIP_ERROR CHIP_aes_ccm_256_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
-                                    size_t aad_length, const unsigned char * key, const unsigned char * iv, size_t iv_length,
-                                    unsigned char * ciphertext, unsigned char * tag, size_t tag_length)
+using namespace chip::crypto;
+
+CHIP_ERROR AES_CCM_256_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
+                               size_t aad_length, const unsigned char * key, const unsigned char * iv, size_t iv_length,
+                               unsigned char * ciphertext, unsigned char * tag, size_t tag_length)
 {
     // TODO: Need mbedTLS based implementation for AES-CCM #264
     return CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE;
 }
 
-CHIP_ERROR CHIP_aes_ccm_256_decrypt(const unsigned char * ciphertext, size_t ciphertext_len, const unsigned char * aad,
-                                    size_t aad_len, const unsigned char * tag, size_t tag_length, const unsigned char * key,
-                                    const unsigned char * iv, size_t iv_length, unsigned char * plaintext)
+CHIP_ERROR AES_CCM_256_decrypt(const unsigned char * ciphertext, size_t ciphertext_len, const unsigned char * aad, size_t aad_len,
+                               const unsigned char * tag, size_t tag_length, const unsigned char * key, const unsigned char * iv,
+                               size_t iv_length, unsigned char * plaintext)
 {
     // TODO: Need mbedTLS based implementation for AES-CCM #264
     return CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE;

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -22,19 +22,18 @@
 
 #include "CHIPCryptoPAL.h"
 
-using namespace chip::crypto;
-
-CHIP_ERROR AES_CCM_256_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
-                               size_t aad_length, const unsigned char * key, const unsigned char * iv, size_t iv_length,
-                               unsigned char * ciphertext, unsigned char * tag, size_t tag_length)
+CHIP_ERROR chip::Crypto::AES_CCM_256_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
+                                             size_t aad_length, const unsigned char * key, const unsigned char * iv,
+                                             size_t iv_length, unsigned char * ciphertext, unsigned char * tag, size_t tag_length)
 {
     // TODO: Need mbedTLS based implementation for AES-CCM #264
     return CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE;
 }
 
-CHIP_ERROR AES_CCM_256_decrypt(const unsigned char * ciphertext, size_t ciphertext_len, const unsigned char * aad, size_t aad_len,
-                               const unsigned char * tag, size_t tag_length, const unsigned char * key, const unsigned char * iv,
-                               size_t iv_length, unsigned char * plaintext)
+CHIP_ERROR chip::Crypto::AES_CCM_256_decrypt(const unsigned char * ciphertext, size_t ciphertext_len, const unsigned char * aad,
+                                             size_t aad_len, const unsigned char * tag, size_t tag_length,
+                                             const unsigned char * key, const unsigned char * iv, size_t iv_length,
+                                             unsigned char * plaintext)
 {
     // TODO: Need mbedTLS based implementation for AES-CCM #264
     return CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE;

--- a/src/crypto/tests/CHIPCryptoPALOpenSSLTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALOpenSSLTest.cpp
@@ -23,7 +23,7 @@
 #include <string.h>
 #include <support/CodeUtils.h>
 
-using namespace chip::crypto;
+using namespace chip::Crypto;
 
 static void TestAES_CCM_256EncryptTestVectors(nlTestSuite * inSuite, void * inContext)
 {

--- a/src/crypto/tests/CHIPCryptoPALOpenSSLTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALOpenSSLTest.cpp
@@ -23,6 +23,8 @@
 #include <string.h>
 #include <support/CodeUtils.h>
 
+using namespace chip::crypto;
+
 static void TestAES_CCM_256EncryptTestVectors(nlTestSuite * inSuite, void * inContext)
 {
     int numOfTestVectors = ArraySize(ccm_test_vectors);
@@ -36,8 +38,8 @@ static void TestAES_CCM_256EncryptTestVectors(nlTestSuite * inSuite, void * inCo
             unsigned char out_ct[vector->ct_len];
             unsigned char out_tag[vector->tag_len];
 
-            CHIP_ERROR err    = CHIP_aes_ccm_256_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, vector->key,
-                                                      vector->iv, vector->iv_len, out_ct, out_tag, vector->tag_len);
+            CHIP_ERROR err = AES_CCM_256_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, vector->key, vector->iv,
+                                                 vector->iv_len, out_ct, out_tag, vector->tag_len);
             bool areCTsEqual  = memcmp(out_ct, vector->ct, vector->ct_len) == 0;
             bool areTagsEqual = memcmp(out_tag, vector->tag, vector->tag_len) == 0;
             NL_TEST_ASSERT(inSuite, areCTsEqual);
@@ -68,8 +70,8 @@ static void TestAES_CCM_256DecryptTestVectors(nlTestSuite * inSuite, void * inCo
         {
             numOfTestsRan++;
             unsigned char out_pt[vector->pt_len];
-            CHIP_ERROR err = CHIP_aes_ccm_256_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag,
-                                                      vector->tag_len, vector->key, vector->iv, vector->iv_len, out_pt);
+            CHIP_ERROR err = AES_CCM_256_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag,
+                                                 vector->tag_len, vector->key, vector->iv, vector->iv_len, out_pt);
 
             bool arePTsEqual = memcmp(vector->pt, out_pt, vector->pt_len) == 0;
             NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -96,8 +98,8 @@ static void TestAES_CCM_256EncryptInvalidPlainText(nlTestSuite * inSuite, void *
             unsigned char out_ct[vector->ct_len];
             unsigned char out_tag[vector->tag_len];
 
-            CHIP_ERROR err = CHIP_aes_ccm_256_encrypt(vector->pt, 0, vector->aad, vector->aad_len, vector->key, vector->iv,
-                                                      vector->iv_len, out_ct, out_tag, vector->tag_len);
+            CHIP_ERROR err = AES_CCM_256_encrypt(vector->pt, 0, vector->aad, vector->aad_len, vector->key, vector->iv,
+                                                 vector->iv_len, out_ct, out_tag, vector->tag_len);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -118,8 +120,8 @@ static void TestAES_CCM_256EncryptNilKey(nlTestSuite * inSuite, void * inContext
             unsigned char out_ct[vector->ct_len];
             unsigned char out_tag[vector->tag_len];
 
-            CHIP_ERROR err = CHIP_aes_ccm_256_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, NULL, vector->iv,
-                                                      vector->iv_len, out_ct, out_tag, vector->tag_len);
+            CHIP_ERROR err = AES_CCM_256_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, NULL, vector->iv,
+                                                 vector->iv_len, out_ct, out_tag, vector->tag_len);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -140,8 +142,8 @@ static void TestAES_CCM_256EncryptInvalidIVLen(nlTestSuite * inSuite, void * inC
             unsigned char out_ct[vector->ct_len];
             unsigned char out_tag[vector->tag_len];
 
-            CHIP_ERROR err = CHIP_aes_ccm_256_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, vector->key,
-                                                      vector->iv, 0, out_ct, out_tag, vector->tag_len);
+            CHIP_ERROR err = AES_CCM_256_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, vector->key, vector->iv,
+                                                 0, out_ct, out_tag, vector->tag_len);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -162,8 +164,8 @@ static void TestAES_CCM_256EncryptInvalidTagLen(nlTestSuite * inSuite, void * in
             unsigned char out_ct[vector->ct_len];
             unsigned char out_tag[vector->tag_len];
 
-            CHIP_ERROR err = CHIP_aes_ccm_256_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, vector->key,
-                                                      vector->iv, vector->iv_len, out_ct, out_tag, 13);
+            CHIP_ERROR err = AES_CCM_256_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, vector->key, vector->iv,
+                                                 vector->iv_len, out_ct, out_tag, 13);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -182,8 +184,8 @@ static void TestAES_CCM_256DecryptInvalidCipherText(nlTestSuite * inSuite, void 
         {
 
             unsigned char out_pt[vector->pt_len];
-            CHIP_ERROR err = CHIP_aes_ccm_256_decrypt(vector->ct, 0, vector->aad, vector->aad_len, vector->tag, vector->tag_len,
-                                                      vector->key, vector->iv, vector->iv_len, out_pt);
+            CHIP_ERROR err = AES_CCM_256_decrypt(vector->ct, 0, vector->aad, vector->aad_len, vector->tag, vector->tag_len,
+                                                 vector->key, vector->iv, vector->iv_len, out_pt);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -202,8 +204,8 @@ static void TestAES_CCM_256DecryptInvalidKey(nlTestSuite * inSuite, void * inCon
         {
 
             unsigned char out_pt[vector->pt_len];
-            CHIP_ERROR err = CHIP_aes_ccm_256_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag,
-                                                      vector->tag_len, NULL, vector->iv, vector->iv_len, out_pt);
+            CHIP_ERROR err = AES_CCM_256_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag,
+                                                 vector->tag_len, NULL, vector->iv, vector->iv_len, out_pt);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -222,8 +224,8 @@ static void TestAES_CCM_256DecryptInvalidIVLen(nlTestSuite * inSuite, void * inC
         {
 
             unsigned char out_pt[vector->pt_len];
-            CHIP_ERROR err = CHIP_aes_ccm_256_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag,
-                                                      vector->tag_len, vector->key, vector->iv, 0, out_pt);
+            CHIP_ERROR err = AES_CCM_256_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag,
+                                                 vector->tag_len, vector->key, vector->iv, 0, out_pt);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -242,8 +244,8 @@ static void TestAES_CCM_256DecryptInvalidTestVectors(nlTestSuite * inSuite, void
         {
             numOfTestsRan++;
             unsigned char out_pt[vector->pt_len];
-            CHIP_ERROR err = CHIP_aes_ccm_256_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag,
-                                                      vector->tag_len, vector->key, vector->iv, vector->iv_len, out_pt);
+            CHIP_ERROR err = AES_CCM_256_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag,
+                                                 vector->tag_len, vector->key, vector->iv, vector->iv_len, out_pt);
 
             bool arePTsEqual = memcmp(vector->pt, out_pt, vector->pt_len) == 0;
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INTERNAL);


### PR DESCRIPTION
 #### Problem
Fix issue CHIP crypto names are too verbose #312

 #### Summary of Changes
Use a namespace to make the crypto function names less verbose

fixes #312 
