### PR TITLE
Add MAKEDIRS and MAKEDIR_TARGETS to capture, build implicit and explicit "make -C" based dependencies

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1294,7 +1294,7 @@ CHIP_CHECK_PROJECT_CONFIG_INCLUDES(chip-project-includes, CHIP_PROJECT_CONFIG_IN
 
 # Device Layer
 
-if test "${CONFIG_DEVICE_LAYER}" = 1; then 
+if test "${CONFIG_DEVICE_LAYER}" = 1; then
     CHIP_CHECK_PROJECT_CONFIG_INCLUDES(chip-device-project-includes, CHIP_DEVICE_PROJECT_CONFIG_INCLUDE, CHIPDeviceProjectConfig.h, CHIP Device Layer,)
 fi
 
@@ -1484,6 +1484,7 @@ NL_WITH_OPTIONAL_INTERNAL_PACKAGE(
         NLFAULTINJECTION_CPPFLAGS="-I\${abs_top_srcdir}/third_party/nlfaultinjection/repo/include"
         NLFAULTINJECTION_LDFLAGS="-L${ac_pwd}/third_party/nlfaultinjection/repo/src"
         NLFAULTINJECTION_LIBS="-lnlfaultinjection"
+        NLFAULTINJECTION_MAKEDIR=${ac_pwd}/third_party/nlfaultinjection/repo
     ],
     [
         # Check for required nlfaultinjection headers.
@@ -1554,6 +1555,7 @@ if test "${nl_cv_build_tests}" = "yes"; then
             NLUNIT_TEST_CPPFLAGS="-I\${abs_top_srcdir}/third_party/nlunit-test/repo/src"
             NLUNIT_TEST_LDFLAGS="-L${ac_pwd}/third_party/nlunit-test/repo/src"
             NLUNIT_TEST_LIBS="-lnlunit-test"
+            NLUNIT_TEST_MAKEDIR=${ac_pwd}/third_party/nlunit-test/repo
         ],
         [
             # Check for required nlunit-test headers.
@@ -1772,6 +1774,10 @@ AC_CHECK_HEADERS([new])
 
 AC_LANG_POP([C++])
 
+#
+# Make CHIPVersion.h
+#
+MAKEDIRS="${MAKEDIRS} ${ac_pwd}/src/include"
 
 # Add test enabled macro
 if test "${nl_cv_build_tests}" = "yes"; then
@@ -1784,6 +1790,7 @@ if test "${nl_cv_build_tests}" = "yes"; then
     fi
 fi
 
+
 # Add any OpenSSL CPPFLAGS, LDFLAGS, and LIBS
 
 CPPFLAGS="${CPPFLAGS} ${OPENSSL_CPPFLAGS}"
@@ -1795,6 +1802,7 @@ LIBS="${LIBS} ${OPENSSL_LIBS}"
 CPPFLAGS="${CPPFLAGS} ${NLUNIT_TEST_CPPFLAGS}"
 LDFLAGS="${LDFLAGS} ${NLUNIT_TEST_LDFLAGS}"
 LIBS="${LIBS} ${NLUNIT_TEST_LIBS}"
+MAKEDIRS="${MAKEDIRS} ${NLUNIT_TEST_MAKEDIR}"
 
 # Add any nlio CPPFLAGS, LDFLAGS, and LIBS
 
@@ -1813,6 +1821,7 @@ LIBS="${LIBS} ${NLASSERT_LIBS}"
 CPPFLAGS="${CPPFLAGS} ${NLFAULTINJECTION_CPPFLAGS}"
 LDFLAGS="${LDFLAGS} ${NLFAULTINJECTION_LDFLAGS}"
 LIBS="${LIBS} ${NLFAULTINJECTION_LIBS}"
+MAKEDIRS="${MAKEDIRS} ${NLFAULTINJECTION_MAKEDIR}"
 
 # Add any code coverage CPPFLAGS, LDFLAGS, and LIBS
 
@@ -1825,6 +1834,10 @@ LIBS="${LIBS} ${NL_COVERAGE_LIBS}"
 if test "${nl_had_CPPFLAGS_werror}" = "no"; then
     CPPFLAGS="${CPPFLAGS} ${NL_WERROR_CPPFLAGS}"
 fi
+
+# Export MAKEDIRS
+
+AC_SUBST(MAKEDIRS, [${MAKEDIRS}])
 
 # At this point, we can restore the compiler flags to whatever the
 # user passed in, now that we're clear of an -Werror issues by
@@ -2004,4 +2017,5 @@ AC_MSG_NOTICE([
   Link flags                                       : ${LDFLAGS:--}
   Link libraries                                   : ${LIBS}
   Fuzzing Enabled                                  : ${enable_fuzzing}
+  Make Dirs                                        : ${MAKEDIRS:--}
 ])

--- a/src/ble/Makefile.am
+++ b/src/ble/Makefile.am
@@ -47,6 +47,4 @@ libBleLayer_adir                    = $(includedir)/ble
 
 dist_libBleLayer_a_HEADERS          = $(CHIP_BUILD_BLE_LAYER_HEADER_FILES)
 
-$(RECURSIVE_TARGETS): $(lib_LIBRARIES)
-
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/ble/tests/Makefile.am
+++ b/src/ble/tests/Makefile.am
@@ -52,6 +52,8 @@ CHIP_LDADD                                            = \
     $(top_builddir)/src/lib/support/libSupportLayer.a   \
     $(NULL)
 
+MAKEDIR_TARGETS=$(CHIP_LDADD)
+
 COMMON_LDADD                                          = \
     $(COMMON_LDFLAGS)                                   \
     $(CHIP_LDADD)                                       \

--- a/src/crypto/Makefile.am
+++ b/src/crypto/Makefile.am
@@ -48,6 +48,4 @@ dist_libChipCrypto_a_HEADERS                                 = \
     CHIPCryptoPAL.h                                            \
     $(NULL)
 
-$(RECURSIVE_TARGETS): $(lib_LIBRARIES)
-
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/crypto/tests/Makefile.am
+++ b/src/crypto/tests/Makefile.am
@@ -51,6 +51,8 @@ AM_CPPFLAGS                                    = \
 CHIP_LDADD                                      = \
     $(NULL)
 
+MAKEDIR_TARGETS=$(CHIP_LDADD)
+
 COMMON_LDADD                                   = \
     $(CHIP_LDADD)                                \
     $(NULL)

--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -50,6 +50,8 @@ define check-file-CHIPVersion.h
 $(top_srcdir)/build/scripts/gen-chip-version "`cat $(1)`" -o "$(2)"
 endef # check-file-CHIPVersion.h
 
+MAKEDIR_TARGETS=$(top_builddir)/.local-version
+
 CHIPVersion.h: $(top_builddir)/.local-version
 	$(call check-file,CHIPVersion.h)
 

--- a/src/inet/Makefile.am
+++ b/src/inet/Makefile.am
@@ -53,6 +53,4 @@ libInetLayer_adir                   = $(includedir)/inet
 
 dist_libInetLayer_a_HEADERS         = $(CHIP_BUILD_INET_LAYER_HEADER_FILES)
 
-$(RECURSIVE_TARGETS): $(lib_LIBRARIES)
-
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/inet/tests/Makefile.am
+++ b/src/inet/tests/Makefile.am
@@ -67,6 +67,8 @@ CHIP_LDADD                                            = \
     $(top_builddir)/src/lib/support/libSupportLayer.a   \
     $(NULL)
 
+MAKEDIR_TARGETS=$(CHIP_LDADD)
+
 COMMON_LDADD                                          = \
     $(COMMON_LDFLAGS)                                   \
     $(CHIP_LDADD)                                       \

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -63,6 +63,4 @@ if CONFIG_NETWORK_LAYER_BLE
 libCHIP_a_SOURCES                  += $(CHIP_BUILD_BLE_LAYER_SOURCE_FILES)
 endif # CONFIG_NETWORK_LAYER_BLE
 
-$(RECURSIVE_TARGETS): $(lib_LIBRARIES)
-
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/lib/core/tests/Makefile.am
+++ b/src/lib/core/tests/Makefile.am
@@ -52,6 +52,8 @@ CHIP_LDADD                                            = \
     $(top_builddir)/src/lib/support/libSupportLayer.a   \
     $(NULL)
 
+MAKEDIR_TARGETS=$(CHIP_LDADD)
+
 COMMON_LDADD                                          = \
     $(COMMON_LDFLAGS)                                   \
     $(CHIP_LDADD)                                       \

--- a/src/lib/support/Makefile.am
+++ b/src/lib/support/Makefile.am
@@ -43,6 +43,4 @@ libSupportLayer_adir                = $(includedir)/support
 
 dist_libSupportLayer_a_HEADERS      = $(CHIP_BUILD_SUPPORT_LAYER_HEADER_FILES)
 
-$(RECURSIVE_TARGETS): $(lib_LIBRARIES)
-
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/lib/support/tests/Makefile.am
+++ b/src/lib/support/tests/Makefile.am
@@ -51,6 +51,8 @@ CHIP_LDADD                                            = \
     $(top_builddir)/src/lib/support/libSupportLayer.a   \
     $(NULL)
 
+MAKEDIR_TARGETS=$(CHIP_LDADD)
+
 COMMON_LDADD                                          = \
     $(COMMON_LDFLAGS)                                   \
     $(CHIP_LDADD)                                       \

--- a/src/setup_payload/Makefile.am
+++ b/src/setup_payload/Makefile.am
@@ -54,6 +54,4 @@ dist_libSetupPayload_a_HEADERS                                  = \
     QRCodeSetupPayloadParser.h                              \
     $(NULL)
 
-$(RECURSIVE_TARGETS): $(lib_LIBRARIES)
-
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/system/Makefile.am
+++ b/src/system/Makefile.am
@@ -52,6 +52,4 @@ libSystemLayer_adir               = $(includedir)/system
 
 dist_libSystemLayer_a_HEADERS     = $(CHIP_BUILD_SYSTEM_LAYER_HEADER_FILES)
 
-$(RECURSIVE_TARGETS): $(lib_LIBRARIES)
-
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/system/tests/Makefile.am
+++ b/src/system/tests/Makefile.am
@@ -56,6 +56,8 @@ CHIP_LDADD                                            = \
     $(top_builddir)/src/lib/support/libSupportLayer.a   \
     $(NULL)
 
+MAKEDIR_TARGETS=$(CHIP_LDADD)
+
 COMMON_LDADD                                          = \
     $(COMMON_LDFLAGS)                                   \
     $(CHIP_LDADD)                                       \


### PR DESCRIPTION
#### Problem
 This generally fails...
```
   $ make -C src/lib/support/tests
```
 ... unless one satisfies src/lib/support/tests' dependencies by knowing that nlfaultinjection, nlunit-tests, (maybe openssl,) CHIPVersion.h, .local-version.h, and the parent directory's library have to be built first, or by blindly building the whole tree first.

 The issue is that neither implicit dependencies (like nlunit-tests, added to the link line at the top level) nor **_explicit_** dependencies (like libSupportLayer.a) have a facility for getting them built from the tests subdirectory.

 #### Summary of Changes
 Add MAKEDIRS and MAKEDIR_TARGETS to capture implicit and explicit dependencies (across the tree).

 Verifying this PR works:
```
$ rm -rf build/default
$ ./bootstrap
$ mkdir build/default
$ cd build/default
$ ../../configure
$ find src -path \*/tests/Makefile |
$ while read -r test &&
     make clean &&
     make  -C ${test%/*} check
do
  :
done
```

 #### Depends on
 https://github.com/nestlabs/nlbuild-autotools/pull/52

fixes #337
fixes #333