### PR TITLE
Missing openSSL based implementation of a DRBG from NIST SP800-90A

### DIFF
--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -84,7 +84,7 @@ CHIP_ERROR HKDF_SHA256(const unsigned char * secret, const size_t secret_length,
                        size_t out_length);
 
 /**
- * @brief A cryptogaphically secure random number generator based on NIST SP800-90A
+ * @brief A cryptographically secure random number generator based on NIST SP800-90A
  * @param out_buffer Buffer to write random bytes into
  * @param out_length Number of random bytes to generate
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -82,6 +82,15 @@ CHIP_ERROR AES_CCM_256_decrypt(const unsigned char * ciphertext, size_t cipherte
 CHIP_ERROR HKDF_SHA256(const unsigned char * secret, const size_t secret_length, const unsigned char * salt,
                        const size_t salt_length, const unsigned char * info, const size_t info_length, unsigned char * out_buffer,
                        size_t out_length);
+
+/**
+ * @brief A cryptogaphically secure random number generator based on NIST SP800-90A
+ * @param out_buffer Buffer to write random bytes into
+ * @param out_length Number of random bytes to generate
+ * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+ **/
+CHIP_ERROR DRBG_get_bytes(unsigned char * out_buffer, const size_t out_length);
+
 } // namespace Crypto
 } // namespace chip
 #endif

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -23,7 +23,7 @@
 #include "CHIPCryptoPAL.h"
 
 #include <openssl/conf.h>
-#include <openssl/rand_drbg.h>
+#include <openssl/rand.h>
 #include <openssl/evp.h>
 #include <openssl/err.h>
 #include <openssl/kdf.h>
@@ -245,7 +245,7 @@ CHIP_ERROR chip::Crypto::DRBG_get_bytes(unsigned char * out_buffer, const size_t
     VerifyOrExit(out_buffer != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(out_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    result = RAND_DRBG_bytes(RAND_DRBG_get0_private(), out_buffer, out_length);
+    result = RAND_priv_bytes(out_buffer, out_length);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
 exit:

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -23,6 +23,7 @@
 #include "CHIPCryptoPAL.h"
 
 #include <openssl/conf.h>
+#include <openssl/rand_drbg.h>
 #include <openssl/evp.h>
 #include <openssl/err.h>
 #include <openssl/kdf.h>
@@ -178,11 +179,12 @@ CHIP_ERROR chip::Crypto::HKDF_SHA256(const unsigned char * secret, const size_t 
                                      unsigned char * out_buffer, size_t out_length)
 {
     EVP_PKEY_CTX * context;
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    int result       = 1;
+
     context = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, NULL);
     VerifyOrExit(context != NULL, error = CHIP_ERROR_INTERNAL);
 
-    CHIP_ERROR error = CHIP_NO_ERROR;
-    int result       = 1;
     VerifyOrExit(secret != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(secret_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
 
@@ -232,5 +234,20 @@ exit:
     {
         EVP_PKEY_CTX_free(context);
     }
+    return error;
+}
+
+CHIP_ERROR chip::Crypto::DRBG_get_bytes(unsigned char * out_buffer, const size_t out_length)
+{
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    int result       = 0;
+
+    VerifyOrExit(out_buffer != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(out_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+
+    result = RAND_DRBG_bytes(RAND_DRBG_get0_private(), out_buffer, out_length);
+    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
+
+exit:
     return error;
 }

--- a/src/crypto/tests/CHIPCryptoPALOpenSSLTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALOpenSSLTest.cpp
@@ -301,23 +301,20 @@ static void TestDRBG_Output(nlTestSuite * inSuite, void * inContext)
  *   Test Suite. It lists all the test functions.
  */
 
-static const nlTest sTests[] =
-{
-    NL_TEST_DEF("Test encrypting test vectors", TestAES_CCM_256EncryptTestVectors),
-    NL_TEST_DEF("Test decrypting test vectors", TestAES_CCM_256DecryptTestVectors),
-    NL_TEST_DEF("Test encrypting invalid plain text", TestAES_CCM_256EncryptInvalidPlainText),
-    NL_TEST_DEF("Test encrypting using nil key", TestAES_CCM_256EncryptNilKey),
-    NL_TEST_DEF("Test encrypting using invalid IV", TestAES_CCM_256EncryptInvalidIVLen),
-    NL_TEST_DEF("Test encrypting using invalid tag", TestAES_CCM_256EncryptInvalidTagLen),
-    NL_TEST_DEF("Test decrypting invalid ct", TestAES_CCM_256DecryptInvalidCipherText),
-    NL_TEST_DEF("Test decrypting invalid key", TestAES_CCM_256DecryptInvalidKey), 
-    NL_TEST_DEF("Test decrypting invalid IV", TestAES_CCM_256DecryptInvalidIVLen),
-    NL_TEST_DEF("Test decrypting invalid vectors", TestAES_CCM_256DecryptInvalidTestVectors),
-    NL_TEST_DEF("Test HKDF SHA 256", TestHKDF_SHA256),
-    NL_TEST_DEF("Test DRBG invalid inputs", TestDRBG_InvalidInputs),
-    NL_TEST_DEF("Test DRBG output", TestDRBG_Output),
-    NL_TEST_SENTINEL()
-};
+static const nlTest sTests[] = { NL_TEST_DEF("Test encrypting test vectors", TestAES_CCM_256EncryptTestVectors),
+                                 NL_TEST_DEF("Test decrypting test vectors", TestAES_CCM_256DecryptTestVectors),
+                                 NL_TEST_DEF("Test encrypting invalid plain text", TestAES_CCM_256EncryptInvalidPlainText),
+                                 NL_TEST_DEF("Test encrypting using nil key", TestAES_CCM_256EncryptNilKey),
+                                 NL_TEST_DEF("Test encrypting using invalid IV", TestAES_CCM_256EncryptInvalidIVLen),
+                                 NL_TEST_DEF("Test encrypting using invalid tag", TestAES_CCM_256EncryptInvalidTagLen),
+                                 NL_TEST_DEF("Test decrypting invalid ct", TestAES_CCM_256DecryptInvalidCipherText),
+                                 NL_TEST_DEF("Test decrypting invalid key", TestAES_CCM_256DecryptInvalidKey),
+                                 NL_TEST_DEF("Test decrypting invalid IV", TestAES_CCM_256DecryptInvalidIVLen),
+                                 NL_TEST_DEF("Test decrypting invalid vectors", TestAES_CCM_256DecryptInvalidTestVectors),
+                                 NL_TEST_DEF("Test HKDF SHA 256", TestHKDF_SHA256),
+                                 NL_TEST_DEF("Test DRBG invalid inputs", TestDRBG_InvalidInputs),
+                                 NL_TEST_DEF("Test DRBG output", TestDRBG_Output),
+                                 NL_TEST_SENTINEL() };
 
 int main(void)
 {

--- a/src/crypto/tests/CHIPCryptoPALOpenSSLTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALOpenSSLTest.cpp
@@ -274,23 +274,51 @@ static void TestHKDF_SHA256(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, numOfTestsExecuted == 3);
 }
 
+static void TestDRBG_InvalidInputs(nlTestSuite * inSuite, void * inContext)
+{
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    error            = DRBG_get_bytes(NULL, 10);
+    NL_TEST_ASSERT(inSuite, error == CHIP_ERROR_INVALID_ARGUMENT);
+    error = CHIP_NO_ERROR;
+    unsigned char buffer[5];
+    error = DRBG_get_bytes(buffer, 0);
+    NL_TEST_ASSERT(inSuite, error == CHIP_ERROR_INVALID_ARGUMENT);
+}
+
+static void TestDRBG_Output(nlTestSuite * inSuite, void * inContext)
+{
+    // No good way to unit test a DRBG. Just validate that we get out something
+    CHIP_ERROR error           = CHIP_ERROR_INVALID_ARGUMENT;
+    unsigned char out_buf[10]  = { 0 };
+    unsigned char orig_buf[10] = { 0 };
+
+    error = DRBG_get_bytes(out_buf, sizeof(out_buf));
+    NL_TEST_ASSERT(inSuite, error == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, memcmp(out_buf, orig_buf, sizeof(out_buf)) != 0);
+}
+
 /**
  *   Test Suite. It lists all the test functions.
  */
 
-static const nlTest sTests[] = { NL_TEST_DEF("Test encrypting test vectors", TestAES_CCM_256EncryptTestVectors),
-                                 NL_TEST_DEF("Test decrypting test vectors", TestAES_CCM_256DecryptTestVectors),
-                                 NL_TEST_DEF("Test encrypting invalid plain text", TestAES_CCM_256EncryptInvalidPlainText),
-                                 NL_TEST_DEF("Test encrypting using nil key", TestAES_CCM_256EncryptNilKey),
-                                 NL_TEST_DEF("Test encrypting using invalid IV", TestAES_CCM_256EncryptInvalidIVLen),
-                                 NL_TEST_DEF("Test encrypting using invalid tag", TestAES_CCM_256EncryptInvalidTagLen),
-                                 NL_TEST_DEF("Test decrypting invalid ct", TestAES_CCM_256DecryptInvalidCipherText),
-                                 NL_TEST_DEF("Test decrypting invalid key", TestAES_CCM_256DecryptInvalidKey),
-                                 NL_TEST_DEF("Test decrypting invalid IV", TestAES_CCM_256DecryptInvalidIVLen),
-                                 NL_TEST_DEF("Test decrypting invalid vectors", TestAES_CCM_256DecryptInvalidTestVectors),
-                                 NL_TEST_DEF("Test HKDF SHA 256", TestHKDF_SHA256),
-
-                                 NL_TEST_SENTINEL() };
+// clang-format off
+static const nlTest sTests[] =
+{
+    NL_TEST_DEF("Test encrypting test vectors", TestAES_CCM_256EncryptTestVectors),
+    NL_TEST_DEF("Test decrypting test vectors", TestAES_CCM_256DecryptTestVectors),
+    NL_TEST_DEF("Test encrypting invalid plain text", TestAES_CCM_256EncryptInvalidPlainText),
+    NL_TEST_DEF("Test encrypting using nil key", TestAES_CCM_256EncryptNilKey),
+    NL_TEST_DEF("Test encrypting using invalid IV", TestAES_CCM_256EncryptInvalidIVLen),
+    NL_TEST_DEF("Test encrypting using invalid tag", TestAES_CCM_256EncryptInvalidTagLen),
+    NL_TEST_DEF("Test decrypting invalid ct", TestAES_CCM_256DecryptInvalidCipherText),
+    NL_TEST_DEF("Test decrypting invalid key", TestAES_CCM_256DecryptInvalidKey), 
+    NL_TEST_DEF("Test decrypting invalid IV", TestAES_CCM_256DecryptInvalidIVLen),
+    NL_TEST_DEF("Test decrypting invalid vectors", TestAES_CCM_256DecryptInvalidTestVectors),
+    NL_TEST_DEF("Test HKDF SHA 256", TestHKDF_SHA256),
+    NL_TEST_DEF("Test DRBG invalid inputs", TestDRBG_InvalidInputs),
+    NL_TEST_DEF("Test DRBG output", TestDRBG_Output),
+    NL_TEST_SENTINEL()
+};
 
 int main(void)
 {

--- a/src/crypto/tests/CHIPCryptoPALOpenSSLTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALOpenSSLTest.cpp
@@ -301,7 +301,6 @@ static void TestDRBG_Output(nlTestSuite * inSuite, void * inContext)
  *   Test Suite. It lists all the test functions.
  */
 
-// clang-format off
 static const nlTest sTests[] =
 {
     NL_TEST_DEF("Test encrypting test vectors", TestAES_CCM_256EncryptTestVectors),


### PR DESCRIPTION
 #### Problem
Missing openSSL based implementation of a DRBG from NIST SP800-90A

 #### Summary of Changes
Calls into `openSSL`'s `RAND_DRBG_bytes` using `RAND_DRBG_get0_private` to generate random bytes 

fixes #254
