### PR TITLE
Add vscode task to build nRF52 app in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,9 +28,6 @@
         "GIT_PS1_SHOWDIRTYSTATE": "1",
         "GIT_PS1_SHOWSTASHSTATE": "1",
         "GIT_PS1_SHOWCOLORHINTS": "true",
-        "PROMPT_COMMAND": "${localEnv:PROMPT_COMMAND}",
-        "NRF5_SDK_ROOT": "/var/nRF5_SDK_for_Thread_and_Zigbee",
-        "NRF5_TOOLS_ROOT": "/var/nRF5_tools",
-        "ARM_GCC_INSTALL_ROOT": "/var/gcc-arm-none-eabi-9-2019-q4-major/bin/"
+        "PROMPT_COMMAND": "${localEnv:PROMPT_COMMAND}"
     }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -140,5 +140,14 @@
                 "$gcc"
             ]
         },
+        {
+            "label": "Build nRF5 Lock App",
+            "type": "shell",
+            "command": "cd examples/lock-app/nrf5 && make",
+            "group": "none",
+            "problemMatcher": [
+                "$gcc"
+            ]
+        },
     ],
 }


### PR DESCRIPTION
 #### Problem
Missing convenient shortcut to build nRF52 sample app

 #### Summary of Changes
Added a new task to vscode. Also, removed duplicated environment variables (added these to `chip-build` docker container).
