### PR TITLE
Remove src/include from MAKEDIRS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1774,10 +1774,6 @@ AC_CHECK_HEADERS([new])
 
 AC_LANG_POP([C++])
 
-#
-# Make CHIPVersion.h
-#
-MAKEDIRS="${MAKEDIRS} ${ac_pwd}/src/include"
 
 # Add test enabled macro
 if test "${nl_cv_build_tests}" = "yes"; then

--- a/src/ble/tests/Makefile.am
+++ b/src/ble/tests/Makefile.am
@@ -52,7 +52,9 @@ CHIP_LDADD                                            = \
     $(top_builddir)/src/lib/support/libSupportLayer.a   \
     $(NULL)
 
-MAKEDIR_TARGETS=$(CHIP_LDADD)
+MAKEDIR_TARGETS                                       = \
+    $(CHIP_LDADD)                                       \
+    $(NULL)
 
 COMMON_LDADD                                          = \
     $(COMMON_LDFLAGS)                                   \

--- a/src/crypto/Makefile.am
+++ b/src/crypto/Makefile.am
@@ -25,6 +25,8 @@ include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
 SUBDIRS                    = tests
 
+MAKEDIR_TARGETS            = $(top_builddir)/src/include/CHIPVersion.h
+
 lib_LIBRARIES              = libChipCrypto.a
 
 libChipCrypto_adir             = $(includedir)/crypto

--- a/src/crypto/tests/Makefile.am
+++ b/src/crypto/tests/Makefile.am
@@ -128,5 +128,3 @@ endif # CHIP_BUILD_COVERAGE
 endif # CHIP_BUILD_TESTS
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am
-
-

--- a/src/crypto/tests/Makefile.am
+++ b/src/crypto/tests/Makefile.am
@@ -45,14 +45,17 @@ AM_CPPFLAGS                                    = \
     -I$(top_srcdir)/src/                         \
     -I$(top_srcdir)/src/lib                      \
     -I$(top_srcdir)/src/system                   \
-    -I$(top_srcdir)/src/include/                 \    
+    -I$(top_srcdir)/src/include/                 \
     -I$(top_srcdir)/src/crypto                   \
     $(NULL)
 
 CHIP_LDADD                                      = \
+    $(top_builddir)/src/crypto/libChipCrypto.a    \
     $(NULL)
 
-MAKEDIR_TARGETS=$(CHIP_LDADD)
+MAKEDIR_TARGETS                                 = \
+    $(CHIP_LDADD)                                 \
+    $(NULL)
 
 COMMON_LDADD                                   = \
     $(CHIP_LDADD)                                \
@@ -82,20 +85,18 @@ TESTS_ENVIRONMENT                              = \
 
 TestCrypto_LDADD                               = \
     $(COMMON_LDADD)                              \
-    $(top_builddir)/src/crypto/libChipCrypto.a   \
     $(NULL)
 
 
 TestCrypto_SOURCES                             = CHIPCryptoTest.c
 
-#OpenSSL based tests
+# OpenSSL based tests
 TestOpenSSLCrypto_LDADD                        =        \
     $(COMMON_LDADD)                                     \
-    $(top_builddir)/src/crypto/libChipCrypto.a          \
     $(NULL)
 
 
-TestOpenSSLCrypto_SOURCES                       = CHIPCryptoPALOpenSSLTest.cpp
+TestOpenSSLCrypto_SOURCES                      = CHIPCryptoPALOpenSSLTest.cpp
 
 
 if CHIP_BUILD_COVERAGE

--- a/src/inet/Makefile.am
+++ b/src/inet/Makefile.am
@@ -27,6 +27,10 @@ SUBDIRS                             = \
     tests                             \
     $(NULL)
 
+MAKEDIR_TARGETS                             = \
+    $(top_builddir)/src/include/CHIPVersion.h \
+    $(NULL)
+
 include InetLayer.am
 
 EXTRA_DIST                          = \

--- a/src/inet/tests/Makefile.am
+++ b/src/inet/tests/Makefile.am
@@ -67,7 +67,10 @@ CHIP_LDADD                                            = \
     $(top_builddir)/src/lib/support/libSupportLayer.a   \
     $(NULL)
 
-MAKEDIR_TARGETS=$(CHIP_LDADD)
+MAKEDIR_TARGETS                                       = \
+    $(CHIP_LDADD)                                       \
+    $(top_builddir)/src/include/CHIPVersion.h           \
+    $(NULL)
 
 COMMON_LDADD                                          = \
     $(COMMON_LDFLAGS)                                   \

--- a/src/lib/core/tests/Makefile.am
+++ b/src/lib/core/tests/Makefile.am
@@ -52,7 +52,9 @@ CHIP_LDADD                                            = \
     $(top_builddir)/src/lib/support/libSupportLayer.a   \
     $(NULL)
 
-MAKEDIR_TARGETS=$(CHIP_LDADD)
+MAKEDIR_TARGETS                                       = \
+    $(CHIP_LDADD)                                       \
+    $(NULL)
 
 COMMON_LDADD                                          = \
     $(COMMON_LDFLAGS)                                   \

--- a/src/lib/support/tests/Makefile.am
+++ b/src/lib/support/tests/Makefile.am
@@ -51,7 +51,9 @@ CHIP_LDADD                                            = \
     $(top_builddir)/src/lib/support/libSupportLayer.a   \
     $(NULL)
 
-MAKEDIR_TARGETS=$(CHIP_LDADD)
+MAKEDIR_TARGETS                                       = \
+    $(CHIP_LDADD)                                       \
+    $(NULL)
 
 COMMON_LDADD                                          = \
     $(COMMON_LDFLAGS)                                   \

--- a/src/system/tests/Makefile.am
+++ b/src/system/tests/Makefile.am
@@ -56,7 +56,9 @@ CHIP_LDADD                                            = \
     $(top_builddir)/src/lib/support/libSupportLayer.a   \
     $(NULL)
 
-MAKEDIR_TARGETS=$(CHIP_LDADD)
+MAKEDIR_TARGETS                                       = \
+    $(CHIP_LDADD)                                       \
+    $(NULL)
 
 COMMON_LDADD                                          = \
     $(COMMON_LDFLAGS)                                   \


### PR DESCRIPTION
#### Problem
 MAKEDIRS is a blunt tool for dependencies, only covers implicit dependencies, and src/include/CHIPVersion.h is an explicit dependency, so treat it as such

 #### Summary of Changes

 use `MAKEDIR_TARGETS = ` to get CHIPVersion.h built by those who need it

fixes: #385