### PR TITLE
Clone mbedTLS to third_party folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ third_party/nlassert/
 third_party/nlfaultinjection/
 third_party/nlio/
 third_party/nlunit-test/
+third_party/mbedtls/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -65,7 +65,8 @@
         "streambuf": "cpp",
         "cinttypes": "cpp",
         "typeinfo": "cpp",
-        "*.ipp": "cpp"
+        "*.ipp": "cpp",
+        "aes.h": "c"
     },
     "files.eol": "\n",
     "editor.formatOnSave": true,

--- a/configure.ac
+++ b/configure.ac
@@ -1359,7 +1359,7 @@ fi
 # mbedTLS
 #
 
-NL_WITH_PACKAGE(
+NL_WITH_OPTIONAL_INTERNAL_PACKAGE(
     [mbedTLS],
     [MBEDTLS],
     [mbedtls],

--- a/configure.ac
+++ b/configure.ac
@@ -1359,10 +1359,21 @@ fi
 # mbedTLS
 #
 
-NL_WITH_OPTIONAL_EXTERNAL_PACKAGE([mbedTLS],
+NL_WITH_PACKAGE(
+    [mbedTLS],
     [MBEDTLS],
     [mbedtls],
     [-lmbedtls],
+    [
+        # At this point, the internal mbedTLS package will be neither
+        # configured nor built, so the normal checks we undertake for an
+        # external package cannot be run here. Simply set the appropriate
+        # variables and trust all will be well.
+
+        NLASSERT_CPPFLAGS="-I\${abs_top_srcdir}/third_party/mbedtls/repo/include"
+        NLASSERT_LDFLAGS=
+        NLASSERT_LIBS=
+    ],
     [
         # Check for required mbedTLS headers.
 
@@ -1376,13 +1387,28 @@ NL_WITH_OPTIONAL_EXTERNAL_PACKAGE([mbedTLS],
     ]
 )
 
-AM_CONDITIONAL([CHIP_WITH_MBEDTLS], [test "${nl_with_mbedtls}" != "no"])
+# Depending on whether mbedTLS has been configured for an internal
+# location, its directory stem within this package needs to be set
+# accordingly. In addition, if the location is internal, then we need
+# to attempt to pull it down using the bootstrap makefile.
 
-if test "${nl_with_mbedtls}" = "no"; then
-    AC_DEFINE([CHIP_WITH_MBEDTLS], [0], [Define to 1 to build CHIP with mbedTLS features])
+if test "${nl_with_mbedtls}" = "internal"; then
+    maybe_mbedtls_dirstem="mbedtls/repo"
+    mbedtls_dirstem="third_party/${maybe_mbedtls_dirstem}"
+
+    AC_MSG_NOTICE([attempting to create internal ${mbedtls_dirstem}])
+
+    ${MAKE-make} --no-print-directory -C ${srcdir} -f Makefile-bootstrap ${mbedtls_dirstem}
+
+    if test $? -ne 0; then
+        AC_MSG_ERROR([failed to create ${mbedtls_dirstem}. Please check your network connection or the correctness of 'repos.conf'])
+    fi
 else
-    AC_DEFINE([CHIP_WITH_MBEDTLS], [1], [Define to 1 to build CHIP with mbedTLS features])
+    maybe_mbedtls_dirstem=""
 fi
+
+AC_SUBST(MBEDTLS_SUBDIRS, [${maybe_mbedtls_dirstem}])
+AM_CONDITIONAL([CHIP_WITH_MBEDTLS_INTERNAL], [test "${nl_with_mbedtls}" = "internal"])
 
 #
 # LwIP
@@ -1897,6 +1923,10 @@ fi
 
 if test "${nl_with_nlassert}" = "internal"; then
 AC_CONFIG_SUBDIRS([third_party/nlassert/repo])
+fi
+
+if test "${nl_with_mbedtls}" = "internal"; then
+AC_CONFIG_SUBDIRS([third_party/mbedtls/repo])
 fi
 
 if test "${nl_with_nlfaultinjection}" = "internal"; then

--- a/configure.ac
+++ b/configure.ac
@@ -1394,7 +1394,7 @@ NL_WITH_OPTIONAL_INTERNAL_PACKAGE(
 
 if test "${nl_with_mbedtls}" = "internal"; then
     maybe_mbedtls_dirstem="mbedtls"
-    mbedtls_dirstem="third_party/${maybe_mbedtls_dirstem}"
+    mbedtls_dirstem="third_party/${maybe_mbedtls_dirstem}/repo"
 
     AC_MSG_NOTICE([attempting to create internal ${mbedtls_dirstem}])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1371,7 +1371,7 @@ NL_WITH_OPTIONAL_INTERNAL_PACKAGE(
         # variables and trust all will be well.
 
         MBEDTLS_CPPFLAGS="-I\${abs_top_srcdir}/third_party/mbedtls/repo/include"
-        MBEDTLS_LDFLAGS="-L${ac_pwd}/third_party/mbedtls/repo/library"
+        MBEDTLS_LDFLAGS="-L${ac_pwd}/third_party/mbedtls"
         MBEDTLS_LIBS="-lmbedtls"
     ],
     [

--- a/configure.ac
+++ b/configure.ac
@@ -1370,9 +1370,9 @@ NL_WITH_PACKAGE(
         # external package cannot be run here. Simply set the appropriate
         # variables and trust all will be well.
 
-        NLASSERT_CPPFLAGS="-I\${abs_top_srcdir}/third_party/mbedtls/repo/include"
-        NLASSERT_LDFLAGS=
-        NLASSERT_LIBS=
+        MBEDTLS_CPPFLAGS="-I\${abs_top_srcdir}/third_party/mbedtls/repo/include"
+        MBEDTLS_LDFLAGS=
+        MBEDTLS_LIBS=
     ],
     [
         # Check for required mbedTLS headers.

--- a/configure.ac
+++ b/configure.ac
@@ -1358,6 +1358,9 @@ fi
 #
 # mbedTLS
 #
+if test "${with_mbedtls}" != "internal"; then
+    with_mbedtls="no"
+fi
 
 NL_WITH_OPTIONAL_INTERNAL_PACKAGE(
     [mbedTLS],

--- a/configure.ac
+++ b/configure.ac
@@ -1363,7 +1363,7 @@ NL_WITH_PACKAGE(
     [mbedTLS],
     [MBEDTLS],
     [mbedtls],
-    [-lmbedtls],
+    [],
     [
         # At this point, the internal mbedTLS package will be neither
         # configured nor built, so the normal checks we undertake for an
@@ -1371,8 +1371,8 @@ NL_WITH_PACKAGE(
         # variables and trust all will be well.
 
         MBEDTLS_CPPFLAGS="-I\${abs_top_srcdir}/third_party/mbedtls/repo/include"
-        MBEDTLS_LDFLAGS=
-        MBEDTLS_LIBS=
+        MBEDTLS_LDFLAGS="-L${ac_pwd}/third_party/mbedtls/repo/library"
+        MBEDTLS_LIBS="-lmbedtls"
     ],
     [
         # Check for required mbedTLS headers.
@@ -1393,7 +1393,7 @@ NL_WITH_PACKAGE(
 # to attempt to pull it down using the bootstrap makefile.
 
 if test "${nl_with_mbedtls}" = "internal"; then
-    maybe_mbedtls_dirstem="mbedtls/repo"
+    maybe_mbedtls_dirstem="mbedtls"
     mbedtls_dirstem="third_party/${maybe_mbedtls_dirstem}"
 
     AC_MSG_NOTICE([attempting to create internal ${mbedtls_dirstem}])
@@ -1940,6 +1940,7 @@ AC_CONFIG_FILES([
 Makefile
 third_party/Makefile
 third_party/lwip/Makefile
+third_party/mbedtls/Makefile
 src/Makefile
 src/include/Makefile
 src/ble/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -1943,7 +1943,6 @@ AC_CONFIG_FILES([
 Makefile
 third_party/Makefile
 third_party/lwip/Makefile
-third_party/mbedtls/Makefile
 src/Makefile
 src/include/Makefile
 src/ble/Makefile
@@ -1965,6 +1964,10 @@ src/lib/support/tests/Makefile
 src/platform/Makefile
 tests/Makefile
 ])
+
+if test "${nl_with_mbedtls}" = "internal"; then
+AC_CONFIG_FILES([third_party/mbedtls/Makefile])
+fi
 
 #
 # Generate the auto-generated files for the package

--- a/examples/lock-app/nrf5/Makefile
+++ b/examples/lock-app/nrf5/Makefile
@@ -148,7 +148,6 @@ INC_DIRS = \
     $(NRF5_SDK_ROOT)/external/freertos/portable/CMSIS/nrf52 \
     $(NRF5_SDK_ROOT)/external/freertos/portable/GCC/nrf52 \
     $(NRF5_SDK_ROOT)/external/freertos/source/include \
-    $(NRF5_SDK_ROOT)/external/mbedtls/include \
     $(NRF5_SDK_ROOT)/external/segger_rtt \
     $(NRF5_SDK_ROOT)/integration/nrfx \
     $(NRF5_SDK_ROOT)/integration/nrfx/legacy \

--- a/repos.conf
+++ b/repos.conf
@@ -18,3 +18,8 @@
 	url = https://github.com/nestlabs/nlunit-test.git
 	branch = master
 	update = none
+[submodule "mbedtls"]
+	path = third_party/mbedtls/repo
+	url = https://github.com/ARMmbed/mbedtls.git
+	branch = mbedtls-2.18
+	update = none

--- a/third_party/Makefile.am
+++ b/third_party/Makefile.am
@@ -41,7 +41,7 @@ DIST_SUBDIRS                                 = \
 # of the 'distclean' target. Consequently, we conditionally include
 # them in DIST_SUBDIRS on invocation of 'distclean-recursive'
 
-distclean-recursive: DIST_SUBDIRS += $(NLASSERT_SUBDIRS) $(NLFAULTINJECTION_SUBDIRS) $(NLIO_SUBDIRS) $(NLUNIT_TEST_SUBDIRS)
+distclean-recursive: DIST_SUBDIRS += $(NLASSERT_SUBDIRS) $(NLFAULTINJECTION_SUBDIRS) $(NLIO_SUBDIRS) $(NLUNIT_TEST_SUBDIRS) $(MBEDTLS_SUBDIRS)
 
 # Always build (e.g. for 'make all') these subdirectories.
 #
@@ -54,6 +54,7 @@ SUBDIRS                                      = \
     $(NLFAULTINJECTION_SUBDIRS)                \
     $(NLIO_SUBDIRS)                            \
     $(NLUNIT_TEST_SUBDIRS)                     \
+    $(MBEDTLS_SUBDIRS)                         \
     $(NULL)
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/third_party/mbedtls/Makefile.am
+++ b/third_party/mbedtls/Makefile.am
@@ -1,0 +1,111 @@
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+
+#
+#    Description:
+#      This file is the GNU automake template for the CHIP in-package,
+#      mbedTLS library.
+#
+#
+
+include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
+
+lib_LIBRARIES                                                                  = libmbedtls.a
+
+libmbedtls_a_SOURCES                                                           = \
+    repo/library/aes.c                      \
+    repo/library/pem.c                      \
+    repo/library/aesni.c                    \
+    repo/library/pk.c                       \
+    repo/library/arc4.c                     \
+    repo/library/pkcs11.c                   \
+    repo/library/aria.c                     \
+    repo/library/pkcs12.c                   \
+    repo/library/asn1parse.c                \
+    repo/library/pkcs5.c                    \
+    repo/library/asn1write.c                \
+    repo/library/pkparse.c                  \
+    repo/library/base64.c                   \
+    repo/library/pk_wrap.c                  \
+    repo/library/bignum.c                   \
+    repo/library/pkwrite.c                  \
+    repo/library/blowfish.c                 \
+    repo/library/platform.c                 \
+    repo/library/camellia.c                 \
+    repo/library/platform_util.c            \
+    repo/library/ccm.c                      \
+    repo/library/poly1305.c                 \
+    repo/library/certs.c                    \
+    repo/library/chacha20.c                 \
+    repo/library/chachapoly.c               \
+    repo/library/cipher.c                   \
+    repo/library/cipher_wrap.c              \
+    repo/library/cmac.c                     \
+    repo/library/ripemd160.c                \
+    repo/library/ctr_drbg.c                 \
+    repo/library/rsa.c                      \
+    repo/library/debug.c                    \
+    repo/library/rsa_internal.c             \
+    repo/library/des.c                      \
+    repo/library/sha1.c                     \
+    repo/library/dhm.c                      \
+    repo/library/sha256.c                   \
+    repo/library/ecdh.c                     \
+    repo/library/sha512.c                   \
+    repo/library/ecdsa.c                    \
+    repo/library/ssl_cache.c                \
+    repo/library/ecjpake.c                  \
+    repo/library/ssl_ciphersuites.c         \
+    repo/library/ecp.c                      \
+    repo/library/ssl_cli.c                  \
+    repo/library/ecp_curves.c               \
+    repo/library/ssl_cookie.c               \
+    repo/library/entropy.c                  \
+    repo/library/ssl_srv.c                  \
+    repo/library/error.c                    \
+    repo/library/ssl_ticket.c               \
+    repo/library/gcm.c                      \
+    repo/library/ssl_tls.c                  \
+    repo/library/havege.c                   \
+    repo/library/threading.c                \
+    repo/library/hkdf.c                     \
+    repo/library/hmac_drbg.c                \
+    repo/library/version.c                  \
+    repo/library/md2.c                      \
+    repo/library/version_features.c         \
+    repo/library/md4.c                      \
+    repo/library/x509.c                     \
+    repo/library/md5.c                      \
+    repo/library/x509_create.c              \
+    repo/library/md.c                       \
+    repo/library/x509_crl.c                 \
+    repo/library/memory_buffer_alloc.c      \
+    repo/library/x509_csr.c                 \
+    repo/library/nist_kw.c                  \
+    repo/library/x509write_crt.c            \
+    repo/library/oid.c                      \
+    repo/library/x509write_csr.c            \
+    repo/library/padlock.c                  \
+    repo/library/xtea.c                     \
+    repo/library/md_wrap.c                  \
+    $(NULL)
+
+liblwip_a_CPPFLAGS                                                             = \
+    -I$(top_srcdir)/third_party/mbedtls/repo/include                             \
+    $(MBEDTLS_CPPFLAGS)                                                          \
+    $(NULL)
+
+include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/third_party/mbedtls/Makefile.am
+++ b/third_party/mbedtls/Makefile.am
@@ -103,7 +103,7 @@ libmbedtls_a_SOURCES                                                           =
     repo/library/md_wrap.c                  \
     $(NULL)
 
-liblwip_a_CPPFLAGS                                                             = \
+libmbedtls_a_CPPFLAGS                                                             = \
     -I$(top_srcdir)/third_party/mbedtls/repo/include                             \
     $(MBEDTLS_CPPFLAGS)                                                          \
     $(NULL)


### PR DESCRIPTION
 #### Problem
Platform SDKs have older version of `mbedTLS` library.

 #### Summary of Changes
Clone sources to `third_party` and build from source.

fixes #408 