### PR TITLE
Add ipp files to vscode's associations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -61,7 +61,8 @@
         "stdexcept": "cpp",
         "streambuf": "cpp",
         "cinttypes": "cpp",
-        "typeinfo": "cpp"
+        "typeinfo": "cpp",
+        "*.ipp": "cpp"
     },
     "files.eol": "\n",
     "editor.formatOnSave": true,


### PR DESCRIPTION
 #### Problem
Accessing an ipp file causes an automatic diff in vscode
 #### Summary of Changes
Commit the automatic diff.