### PR TITLE
Make nlunit-test and friends into explicit deps

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1514,7 +1514,6 @@ NL_WITH_OPTIONAL_INTERNAL_PACKAGE(
         NLFAULTINJECTION_CPPFLAGS="-I\${abs_top_srcdir}/third_party/nlfaultinjection/repo/include"
         NLFAULTINJECTION_LDFLAGS="-L${ac_pwd}/third_party/nlfaultinjection/repo/src"
         NLFAULTINJECTION_LIBS="-lnlfaultinjection"
-        NLFAULTINJECTION_MAKEDIR="${ac_pwd}/third_party/nlfaultinjection/repo"
     ],
     [
         # Check for required nlfaultinjection headers.

--- a/configure.ac
+++ b/configure.ac
@@ -2003,6 +2003,7 @@ AC_MSG_NOTICE([
   Nlfaultinjection link flags                      : ${NLFAULTINJECTION_LDFLAGS:--}
   Nlfaultinjection link libraries                  : ${NLFAULTINJECTION_LIBS:--}
   Nlfaultinjection makedir                         : ${NLFAULTINJECTION_MAKEDIR:--}
+  Sockets compile flags                            : ${SOCKETS_CPPFLAGS:--}
   Sockets link flags                               : ${SOCKETS_LDFLAGS:--}
   Sockets link libraries                           : ${SOCKETS_LIBS:--}
   PThreads compile flags                           : ${PTHREAD_CFLAGS:--}

--- a/configure.ac
+++ b/configure.ac
@@ -1514,7 +1514,7 @@ NL_WITH_OPTIONAL_INTERNAL_PACKAGE(
         NLFAULTINJECTION_CPPFLAGS="-I\${abs_top_srcdir}/third_party/nlfaultinjection/repo/include"
         NLFAULTINJECTION_LDFLAGS="-L${ac_pwd}/third_party/nlfaultinjection/repo/src"
         NLFAULTINJECTION_LIBS="-lnlfaultinjection"
-        NLFAULTINJECTION_MAKEDIR=${ac_pwd}/third_party/nlfaultinjection/repo
+        NLFAULTINJECTION_MAKEDIR="${ac_pwd}/third_party/nlfaultinjection/repo"
     ],
     [
         # Check for required nlfaultinjection headers.
@@ -1585,7 +1585,6 @@ if test "${nl_cv_build_tests}" = "yes"; then
             NLUNIT_TEST_CPPFLAGS="-I\${abs_top_srcdir}/third_party/nlunit-test/repo/src"
             NLUNIT_TEST_LDFLAGS="-L${ac_pwd}/third_party/nlunit-test/repo/src"
             NLUNIT_TEST_LIBS="-lnlunit-test"
-            NLUNIT_TEST_MAKEDIR=${ac_pwd}/third_party/nlunit-test/repo
         ],
         [
             # Check for required nlunit-test headers.
@@ -1829,32 +1828,6 @@ CPPFLAGS="${CPPFLAGS} ${MBEDTLS_CPPFLAGS}"
 LDFLAGS="${LDFLAGS} ${MBEDTLS_LDFLAGS}"
 LIBS="${LIBS} ${MBEDTLS_LIBS}"
 
-# Add any nlunit-test CPPFLAGS, LDFLAGS, and LIBS
-
-CPPFLAGS="${CPPFLAGS} ${NLUNIT_TEST_CPPFLAGS}"
-LDFLAGS="${LDFLAGS} ${NLUNIT_TEST_LDFLAGS}"
-LIBS="${LIBS} ${NLUNIT_TEST_LIBS}"
-MAKEDIRS="${MAKEDIRS} ${NLUNIT_TEST_MAKEDIR}"
-
-# Add any nlio CPPFLAGS, LDFLAGS, and LIBS
-
-CPPFLAGS="${CPPFLAGS} ${NLIO_CPPFLAGS}"
-LDFLAGS="${LDFLAGS} ${NLIO_LDFLAGS}"
-LIBS="${LIBS} ${NLIO_LIBS}"
-
-# Add any nlassert CPPFLAGS, LDFLAGS, and LIBS
-
-CPPFLAGS="${CPPFLAGS} ${NLASSERT_CPPFLAGS}"
-LDFLAGS="${LDFLAGS} ${NLASSERT_LDFLAGS}"
-LIBS="${LIBS} ${NLASSERT_LIBS}"
-
-# Add any nlfaultinjection CPPFLAGS, LDFLAGS, and LIBS
-
-CPPFLAGS="${CPPFLAGS} ${NLFAULTINJECTION_CPPFLAGS}"
-LDFLAGS="${LDFLAGS} ${NLFAULTINJECTION_LDFLAGS}"
-LIBS="${LIBS} ${NLFAULTINJECTION_LIBS}"
-MAKEDIRS="${MAKEDIRS} ${NLFAULTINJECTION_MAKEDIR}"
-
 # Add any code coverage CPPFLAGS, LDFLAGS, and LIBS
 
 CPPFLAGS="${CPPFLAGS} ${NL_COVERAGE_CPPFLAGS}"
@@ -1867,9 +1840,6 @@ if test "${nl_had_CPPFLAGS_werror}" = "no"; then
     CPPFLAGS="${CPPFLAGS} ${NL_WERROR_CPPFLAGS}"
 fi
 
-# Export MAKEDIRS
-
-AC_SUBST(MAKEDIRS, [${MAKEDIRS}])
 
 # At this point, we can restore the compiler flags to whatever the
 # user passed in, now that we're clear of an -Werror issues by
@@ -1889,18 +1859,22 @@ AC_SUBST(PRETTY_CHECK_ARGS, [""])
 # Configure any autotools-based subdirectories
 if test "${nl_with_nlunit_test}" = "internal"; then
 AC_CONFIG_SUBDIRS([third_party/nlunit-test/repo])
+AC_SUBST(NLUNIT_TEST_MAKEDIR,["${ac_pwd}/third_party/nlunit-test/repo"])
 fi
 
 if test "${nl_with_nlio}" = "internal"; then
 AC_CONFIG_SUBDIRS([third_party/nlio/repo])
+AC_SUBST(NLIO_MAKEDIR,["${ac_pwd}/third_party/nlunio/repo"])
 fi
 
 if test "${nl_with_nlassert}" = "internal"; then
 AC_CONFIG_SUBDIRS([third_party/nlassert/repo])
+AC_SUBST(NLASSERT_MAKEDIR,["${ac_pwd}/third_party/nlassert/repo"])
 fi
 
 if test "${nl_with_nlfaultinjection}" = "internal"; then
 AC_CONFIG_SUBDIRS([third_party/nlfaultinjection/repo])
+AC_SUBST(NLFAULTINJECTION_MAKEDIR,["${ac_pwd}/third_party/nlfaultinjection/repo"])
 fi
 
 #
@@ -2014,19 +1988,22 @@ AC_MSG_NOTICE([
   Nlunit-test compile flags                        : ${NLUNIT_TEST_CPPFLAGS:--}
   Nlunit-test link flags                           : ${NLUNIT_TEST_LDFLAGS:--}
   Nlunit-test link libraries                       : ${NLUNIT_TEST_LIBS:--}
+  Nlunit-test makedir                              : ${NLUNIT_TEST_MAKEDIR:--}
   Nlio source                                      : ${nl_with_nlio:--}
   Nlio compile flags                               : ${NLIO_CPPFLAGS:--}
   Nlio link flags                                  : ${NLIO_LDFLAGS:--}
   Nlio link libraries                              : ${NLIO_LIBS:--}
+  Nlio makedir                                     : ${NLIO_MAKDIR:--}
   Nlassert source                                  : ${nl_with_nlassert:--}
   Nlassert compile flags                           : ${NLASSERT_CPPFLAGS:--}
   Nlassert link flags                              : ${NLASSERT_LDFLAGS:--}
   Nlassert link libraries                          : ${NLASSERT_LIBS:--}
+  Nlassert makedir                                 : ${NLASSERT_MAKEDIR:--}
   Nlfaultinjection source                          : ${nl_with_nlfaultinjection:--}
   Nlfaultinjection compile flags                   : ${NLFAULTINJECTION_CPPFLAGS:--}
   Nlfaultinjection link flags                      : ${NLFAULTINJECTION_LDFLAGS:--}
   Nlfaultinjection link libraries                  : ${NLFAULTINJECTION_LIBS:--}
-  Sockets compile flags                            : ${SOCKETS_CPPFLAGS:--}
+  Nlfaultinjection makedir                         : ${NLFAULTINJECTION_MAKEDIR:--}
   Sockets link flags                               : ${SOCKETS_LDFLAGS:--}
   Sockets link libraries                           : ${SOCKETS_LIBS:--}
   PThreads compile flags                           : ${PTHREAD_CFLAGS:--}
@@ -2053,5 +2030,4 @@ AC_MSG_NOTICE([
   Link flags                                       : ${LDFLAGS:--}
   Link libraries                                   : ${LIBS}
   Fuzzing Enabled                                  : ${enable_fuzzing}
-  Make Dirs                                        : ${MAKEDIRS:--}
 ])

--- a/integrations/ci-tools/build.sh
+++ b/integrations/ci-tools/build.sh
@@ -6,8 +6,9 @@ die() {
 }
 
 write_bash_template() {
-  echo '#!/bin/bash
-    ' >./build/scripts/build_command.sh
+  echo '#!/usr/bin/env bash
+set -x
+' >./build/scripts/build_command.sh
   chmod +x ./build/scripts/build_command.sh
 }
 
@@ -30,48 +31,48 @@ case "$TASK" in
   build-ubuntu-linux)
     write_bash_template
     write_bash_bootstrap
-    write_bash_command 'make -C build/default'
+    write_bash_command 'make V=1 -C build/default'
     docker_run_bash_command
     ;;
 
   build-nrf-example-lock-app)
     write_bash_template
-    write_bash_command 'make -C examples/lock-app/nrf5'
+    write_bash_command 'make VERBOSE=1 -C examples/lock-app/nrf5'
     docker_run_bash_command
     ;;
 
   build-distribution-check)
     write_bash_template
     write_bash_bootstrap
-    write_bash_command 'make -C build/default distcheck'
+    write_bash_command 'make V=1 -C build/default distcheck'
     docker_run_bash_command
     ;;
 
   run-unit-and-functional-tests)
     write_bash_template
     write_bash_bootstrap
-    write_bash_command 'make -C build/default check'
+    write_bash_command 'make V=1 -C build/default check'
     docker_run_bash_command
     ;;
 
   run-code-coverage)
     write_bash_template
     write_bash_bootstrap
-    write_bash_command 'make -C build/default coverage'
+    write_bash_command 'make V=1 -C build/default coverage'
     docker_run_bash_command
     ;;
 
   run-crypto-tests)
     write_bash_template
     write_bash_bootstrap
-    write_bash_command 'make -C build/default/src/crypto check'
+    write_bash_command 'make V=1 -C build/default/src/crypto check'
     docker_run_bash_command
     ;;
 
   run-setup-payload-tests)
     write_bash_template
     write_bash_bootstrap
-    write_bash_command 'make -C build/default/src/setup_payload check'
+    write_bash_command 'make V=1 -C build/default/src/setup_payload check'
     docker_run_bash_command
     ;;
 

--- a/integrations/ci-tools/build.sh
+++ b/integrations/ci-tools/build.sh
@@ -6,9 +6,8 @@ die() {
 }
 
 write_bash_template() {
-  echo '#!/usr/bin/env bash
-set -x
-' >./build/scripts/build_command.sh
+  echo '#!/bin/bash
+    ' >./build/scripts/build_command.sh
   chmod +x ./build/scripts/build_command.sh
 }
 
@@ -31,48 +30,48 @@ case "$TASK" in
   build-ubuntu-linux)
     write_bash_template
     write_bash_bootstrap
-    write_bash_command 'make V=1 -C build/default'
+    write_bash_command 'make -C build/default'
     docker_run_bash_command
     ;;
 
   build-nrf-example-lock-app)
     write_bash_template
-    write_bash_command 'make VERBOSE=1 -C examples/lock-app/nrf5'
+    write_bash_command 'make -C examples/lock-app/nrf5'
     docker_run_bash_command
     ;;
 
   build-distribution-check)
     write_bash_template
     write_bash_bootstrap
-    write_bash_command 'make V=1 -C build/default distcheck'
+    write_bash_command 'make -C build/default distcheck'
     docker_run_bash_command
     ;;
 
   run-unit-and-functional-tests)
     write_bash_template
     write_bash_bootstrap
-    write_bash_command 'make V=1 -C build/default check'
+    write_bash_command 'make -C build/default check'
     docker_run_bash_command
     ;;
 
   run-code-coverage)
     write_bash_template
     write_bash_bootstrap
-    write_bash_command 'make V=1 -C build/default coverage'
+    write_bash_command 'make -C build/default coverage'
     docker_run_bash_command
     ;;
 
   run-crypto-tests)
     write_bash_template
     write_bash_bootstrap
-    write_bash_command 'make V=1 -C build/default/src/crypto check'
+    write_bash_command 'make -C build/default/src/crypto check'
     docker_run_bash_command
     ;;
 
   run-setup-payload-tests)
     write_bash_template
     write_bash_bootstrap
-    write_bash_command 'make V=1 -C build/default/src/setup_payload check'
+    write_bash_command 'make -C build/default/src/setup_payload check'
     docker_run_bash_command
     ;;
 

--- a/src/ble/Makefile.am
+++ b/src/ble/Makefile.am
@@ -38,6 +38,9 @@ libBleLayer_a_CPPFLAGS              = \
     -I$(top_srcdir)/src/lib           \
     -I$(top_srcdir)/src/lib/core      \
     -I$(top_srcdir)/src/system        \
+    $(NLASSERT_CPPFLAGS)              \
+    $(NLFAULTINJECTION_CPPFLAGS)      \
+    $(NLIO_CPPFLAGS)                  \
     $(LWIP_CPPFLAGS)                  \
     $(NULL)
 

--- a/src/ble/tests/Makefile.am
+++ b/src/ble/tests/Makefile.am
@@ -42,6 +42,8 @@ if CHIP_BUILD_TESTS
 AM_CPPFLAGS                                           = \
     -I$(top_srcdir)/src                                 \
     -I$(top_srcdir)/src/lib                             \
+    $(NLIO_CPPFLAGS)                                    \
+    $(NLUNIT_TEST_CPPFLAGS)                             \
     $(LWIP_CPPFLAGS)                                    \
     $(SOCKETS_CPPFLAGS)                                 \
     $(PTHREAD_CFLAGS)                                   \
@@ -56,9 +58,14 @@ MAKEDIR_TARGETS                                       = \
     $(CHIP_LDADD)                                       \
     $(NULL)
 
+MAKEDIRS                                              = \
+   $(NLUNIT_TEST_MAKEDIR)                               \
+   $(NULL)   
+
 COMMON_LDADD                                          = \
     $(COMMON_LDFLAGS)                                   \
     $(CHIP_LDADD)                                       \
+    $(NLUNIT_TEST_LDFLAGS) $(NLUNIT_TEST_LIBS)          \
     $(LWIP_LDFLAGS) $(LWIP_LIBS)                        \
     $(SOCKETS_LDFLAGS) $(SOCKETS_LIBS)                  \
     $(PTHREAD_CFLAGS) $(PTHREAD_LIBS)                   \

--- a/src/crypto/Makefile.am
+++ b/src/crypto/Makefile.am
@@ -32,6 +32,7 @@ lib_LIBRARIES              = libChipCrypto.a
 libChipCrypto_adir             = $(includedir)/crypto
 
 libChipCrypto_a_CPPFLAGS            = \
+    $(NLASSERT_CPPFLAGS)              \
     -I$(top_srcdir)/src               \
     -I$(top_srcdir)/src/lib           \
     -I$(top_srcdir)/src/system        \

--- a/src/crypto/tests/Makefile.am
+++ b/src/crypto/tests/Makefile.am
@@ -47,6 +47,8 @@ AM_CPPFLAGS                                    = \
     -I$(top_srcdir)/src/system                   \
     -I$(top_srcdir)/src/include/                 \
     -I$(top_srcdir)/src/crypto                   \
+    $(NLASSERT_CPPFLAGS)                         \
+    $(NLUNIT_TEST_CPPFLAGS)                      \
     $(NULL)
 
 CHIP_LDADD                                      = \
@@ -57,7 +59,12 @@ MAKEDIR_TARGETS                                 = \
     $(CHIP_LDADD)                                 \
     $(NULL)
 
+MAKEDIRS                                       = \
+   $(NLUNIT_TEST_MAKEDIR)                        \
+   $(NULL)   
+
 COMMON_LDADD                                   = \
+    $(NLUNIT_TEST_LDFLAGS) $(NLUNIT_TEST_LIBS)   \
     $(CHIP_LDADD)                                \
     $(NULL)
 

--- a/src/inet/Makefile.am
+++ b/src/inet/Makefile.am
@@ -47,6 +47,9 @@ libInetLayer_a_CPPFLAGS             = \
     -I$(top_srcdir)/src/lib           \
     -I$(top_srcdir)/src/lib/core      \
     $(nl_InetLayer_CPPFLAGS)          \
+    $(NLASSERT_CPPFLAGS)              \
+    $(NLFAULTINJECTION_CPPFLAGS)      \
+    $(NLIO_CPPFLAGS)                  \
     $(LWIP_CPPFLAGS)                  \
     $(SOCKETS_CPPFLAGS)               \
     $(NULL)

--- a/src/inet/tests/Makefile.am
+++ b/src/inet/tests/Makefile.am
@@ -50,6 +50,10 @@ AM_CPPFLAGS                                           = \
     -I$(top_srcdir)/src                                 \
     -I$(top_srcdir)/src/include                         \
     -I$(top_srcdir)/src/lib                             \
+    $(NLASSERT_CPPFLAGS)                                \
+    $(NLFAULTINJECTION_CPPFLAGS)                        \
+    $(NLIO_CPPFLAGS)                                    \
+    $(NLUNIT_TEST_CPPFLAGS)                             \
     $(LWIP_CPPFLAGS)                                    \
     $(SOCKETS_CPPFLAGS)                                 \
     $(PTHREAD_CFLAGS)                                   \
@@ -72,9 +76,17 @@ MAKEDIR_TARGETS                                       = \
     $(top_builddir)/src/include/CHIPVersion.h           \
     $(NULL)
 
+MAKEDIRS                                              = \
+    $(top_builddir)/src/include                         \
+    $(NLFAULTINJECTION_MAKEDIR)                         \
+    $(NLUNIT_TEST_MAKEDIR)                              \
+    $(NULL)
+
 COMMON_LDADD                                          = \
     $(COMMON_LDFLAGS)                                   \
     $(CHIP_LDADD)                                       \
+    $(NLFAULTINJECTION_LDFLAGS) $(NLFAULTINJECTION_LIBS)\
+    $(NLUNIT_TEST_LDFLAGS) $(NLUNIT_TEST_LIBS)          \
     $(LWIP_LDFLAGS) $(LWIP_LIBS)                        \
     $(SOCKETS_LDFLAGS) $(SOCKETS_LIBS)                  \
     $(PTHREAD_CFLAGS) $(PTHREAD_LIBS)                   \

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -50,6 +50,9 @@ libCHIP_a_CPPFLAGS                  =                         \
     -I$(top_srcdir)/src/lib/core                              \
     -I$(top_srcdir)/src/lib/support                           \
     -I$(top_srcdir)/src/system                                \
+    $(NLASSERT_CPPFLAGS)                                      \
+    $(NLFAULTINJECTION_CPPFLAGS)                              \
+    $(NLIO_CPPFLAGS)                                          \
     $(LWIP_CPPFLAGS)                                          \
     $(SOCKETS_CPPFLAGS)                                       \
     $(NULL)

--- a/src/lib/core/tests/Makefile.am
+++ b/src/lib/core/tests/Makefile.am
@@ -42,6 +42,9 @@ if CHIP_BUILD_TESTS
 AM_CPPFLAGS                                           = \
     -I$(top_srcdir)/src                                 \
     -I$(top_srcdir)/src/lib                             \
+    $(NLASSERT_CPPFLAGS)                                \
+    $(NLIO_CPPFLAGS)                                    \
+    $(NLUNIT_TEST_CPPFLAGS)                             \
     $(LWIP_CPPFLAGS)                                    \
     $(SOCKETS_CPPFLAGS)                                 \
     $(PTHREAD_CFLAGS)                                   \
@@ -56,12 +59,19 @@ MAKEDIR_TARGETS                                       = \
     $(CHIP_LDADD)                                       \
     $(NULL)
 
-COMMON_LDADD                                          = \
-    $(COMMON_LDFLAGS)                                   \
-    $(CHIP_LDADD)                                       \
-    $(LWIP_LDFLAGS) $(LWIP_LIBS)                        \
-    $(SOCKETS_LDFLAGS) $(SOCKETS_LIBS)                  \
-    $(PTHREAD_CFLAGS) $(PTHREAD_LIBS)                   \
+MAKEDIRS                                              = \
+    $(NLFAULTINJECTION_MAKEDIR)                         \
+    $(NLUNIT_TEST_MAKEDIR)                              \
+    $(NULL)
+
+COMMON_LDADD                                          =  \
+    $(COMMON_LDFLAGS)                                    \
+    $(CHIP_LDADD)                                        \
+    $(NLFAULTINJECTION_LDFLAGS) $(NLFAULTINJECTION_LIBS) \
+    $(NLUNIT_TEST_LDFLAGS) $(NLUNIT_TEST_LIBS)           \
+    $(LWIP_LDFLAGS) $(LWIP_LIBS)                         \
+    $(SOCKETS_LDFLAGS) $(SOCKETS_LIBS)                   \
+    $(PTHREAD_CFLAGS) $(PTHREAD_LIBS)                    \
     $(NULL)
 
 # Test applications that should be run when the 'check' target is run.

--- a/src/lib/support/Makefile.am
+++ b/src/lib/support/Makefile.am
@@ -35,6 +35,8 @@ libSupportLayer_a_CPPFLAGS          = \
     -I$(top_srcdir)/src               \
     -I$(top_srcdir)/src/lib           \
     -I$(top_srcdir)/src/include       \
+    $(NLASSERT_CPPFLAGS)              \
+    $(NLFAULTINJECTION_CPPFLAGS)      \
     $(NULL)
 
 libSupportLayer_a_SOURCES           = $(CHIP_BUILD_SUPPORT_LAYER_SOURCE_FILES)

--- a/src/platform/Makefile.am
+++ b/src/platform/Makefile.am
@@ -80,6 +80,8 @@ libDeviceLayer_a_CPPFLAGS               = \
     -I$(top_srcdir)/src/lib               \
     -I$(top_srcdir)/src/system            \
     -I$(top_srcdir)/src                   \
+    $(NLASSERT_CPPFLAGS)                  \
+    $(NLIO_CPPFLAGS)                      \
     $(LWIP_CPPFLAGS)                      \
     $(SOCKETS_CPPFLAGS)                   \
     $(NULL)

--- a/src/system/Makefile.am
+++ b/src/system/Makefile.am
@@ -29,7 +29,6 @@ SUBDIRS                             = \
     tests                             \
     $(NULL)
 
-
 EXTRA_DIST                          = \
     SystemLayerPrivate.h              \
     $(NULL)
@@ -42,6 +41,8 @@ libSystemLayer_a_CPPFLAGS           = \
     -I$(top_srcdir)/src/system        \
     -I$(top_srcdir)/src/lib           \
     -I$(top_srcdir)/src/lib/core      \
+    $(NLASSERT_CPPFLAGS)              \
+    $(NLFAULTINJECTION_CPPFLAGS)      \
     $(LWIP_CPPFLAGS)                  \
     $(SOCKETS_CPPFLAGS)               \
     $(NULL)

--- a/src/system/tests/Makefile.am
+++ b/src/system/tests/Makefile.am
@@ -46,6 +46,8 @@ AM_CPPFLAGS                                           = \
     -I$(top_srcdir)/src/lib                             \
     -I$(top_srcdir)/src/lib/core                        \
     -I$(top_srcdir)/src/system                          \
+    $(NLASSERT_CPPFLAGS)                                \
+    $(NLUNIT_TEST_CPPFLAGS)                             \
     $(LWIP_CPPFLAGS)                                    \
     $(SOCKETS_CPPFLAGS)                                 \
     $(PTHREAD_CFLAGS)                                   \
@@ -60,12 +62,19 @@ MAKEDIR_TARGETS                                       = \
     $(CHIP_LDADD)                                       \
     $(NULL)
 
-COMMON_LDADD                                          = \
-    $(COMMON_LDFLAGS)                                   \
-    $(CHIP_LDADD)                                       \
-    $(LWIP_LDFLAGS) $(LWIP_LIBS)                        \
-    $(SOCKETS_LDFLAGS) $(SOCKETS_LIBS)                  \
-    $(PTHREAD_CFLAGS) $(PTHREAD_LIBS)                   \
+MAKEDIRS                                              = \
+   $(NLUNIT_TEST_MAKEDIR)                               \
+   $(NLFAULTINJECTION_MAKEDIR)                          \
+   $(NULL)   
+
+COMMON_LDADD                                           = \
+    $(COMMON_LDFLAGS)                                    \
+    $(CHIP_LDADD)                                        \
+    $(NLUNIT_TEST_LDFLAGS) $(NLUNIT_TEST_LIBS)           \
+    $(NLFAULTINJECTION_LDFLAGS) $(NLFAULTINJECTION_LIBS) \
+    $(LWIP_LDFLAGS) $(LWIP_LIBS)                         \
+    $(SOCKETS_LDFLAGS) $(SOCKETS_LIBS)                   \
+    $(PTHREAD_CFLAGS) $(PTHREAD_LIBS)                    \
     $(NULL)
 
 # Test applications that should be run when the 'check' target is run.

--- a/third_party/nlbuild-autotools/repo/automake/post/rules/makedirs.am
+++ b/third_party/nlbuild-autotools/repo/automake/post/rules/makedirs.am
@@ -31,11 +31,19 @@
 #        (all _OBJECTS) defined by a Makefile.am to depend upon an invocation
 #        of `$(MAKE) -C <DIR>` in that directory.
 #
+
+# same as ifdef MAKEDIRS || MAKEDIR_TARGETS
+ifneq ($(strip $(MAKEDIRS)$(MAKEDIR_TARGETS)),)
+
+.PHONY: makedirs-force
+makedirs-force: # no rules, please always build ;)
+
+endif # ifneq ($(strip $(MAKEDIRS)$(MAKEDIR_TARGETS)),)
+
 ifdef MAKEDIRS
 
-.PHONY: makedirs force
+.PHONY: makedirs
 
-force: # no rules, please always build ;)
 
 # The way we make a MAKEDIR
 define makedirs-make
@@ -54,7 +62,7 @@ $(foreach objects,$(filter %_OBJECTS,$(.VARIABLES)),\
    $(foreach object,$($(objects)),\
    $(eval $(call makedirs-depends,$(object)))))
 
-makedirs: force
+makedirs: makedirs-force
 	$(foreach dir,$(MAKEDIRS),$(call makedirs-make,$(dir)))
 
 endif # ifdef MAKEDIRS
@@ -62,7 +70,7 @@ endif # ifdef MAKEDIRS
 ifdef MAKEDIR_TARGETS
 # The way me make a MAKEDIR_TARGET
 define makedirs-makedir-target-rule
-$1: force
+$1: makedirs-force
 	$(MAKE) -C $$(dir $$(@)) $$(notdir $$(@))
 endef # makedirs-makedir-target-rule
 


### PR DESCRIPTION
#### Problem
 configure.ac puts nlunit-test nlfault injection on every link line

 This leads to an implicit dependency on that library being built, handled
  nicely by SUBDIRS, but if one's not running a ToT build (e.g. iterating
  on a library test) you have know to do a ToT build first.

 The previous solution to this problem, exporting MAKEDIRS as a top-level,
   global construct for the "always on the link line" libraries, led
   to massively long build times, because every Makefile was also
   building nlunit-test and nlfaultinjection _**for every make**_,
   which blows up build times.

 #### Summary of Changes
  * drop MAKEDIRS as a global construct (remove from configure.ac)
  * remove nlunit-test and friends from global LDFLAGS and CPPFLAGS
  * move use of MAKEDIRS into subdirectories that actually have the
     dependencies
  * add nlunit-test and friends to the Makefiles for the components
     that actually have the dependencies