### PR TITLE
Better handling of default value for `--with-mbedtls`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1359,8 +1359,7 @@ fi
 # mbedTLS
 #
 AC_ARG_WITH(mbedtls,
-    [AS_HELP_STRING([--with-mbedtls=<no/internal/external>],
-        [Specify if mbedTLS should be used, and how to link with it.])],
+    [],
     [],
     [with_mbedtls="no"])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1358,9 +1358,11 @@ fi
 #
 # mbedTLS
 #
-if test "${with_mbedtls}" != "internal"; then
-    with_mbedtls="no"
-fi
+AC_ARG_WITH(mbedtls,
+    [AS_HELP_STRING([--with-mbedtls=<no/internal/external>],
+        [Specify if mbedTLS should be used, and how to link with it.])],
+    [],
+    [with_mbedtls="no"])
 
 NL_WITH_OPTIONAL_INTERNAL_PACKAGE(
     [mbedTLS],


### PR DESCRIPTION
 #### Problem
CHIP `configure.ac` is only allowing `internal` configuration for `mbedtls` library. If configuration command line option (`--with-mbedtls`) is not `internal` it forces it to `no`. That precludes `external` configuration for the library.

 #### Summary of Changes
Use `AC_ARG_WITH` primitive, and provide the default value for `--with-mbedtls` if its absent.
