### PR TITLE
Groom .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,12 +5,10 @@
 !.vscode/launch.json
 !.vscode/settings.json
 
+# Platforms
+.DS_Store
+
 # Build System
-.deps
-.dirstamp
-.DS_Store
-.local-version
-.DS_Store
 Makefile.in
 aclocal.m4
 autom4te.cache
@@ -31,7 +29,6 @@ examples/**/build
 config.log
 config.status
 configure
-src/include/BuildConfig.h
 src/include/BuildConfig.h.in
 
 # Repos stuff


### PR DESCRIPTION
#### Problem
 Some of the lines in .gitignore are mis-attributed, or deal with
 running build in the source tree, which is not recommended

 #### Summary of Changes
 clean up the nits

 CC #405