### PR TITLE
Make Bootstrap task more robust

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -80,7 +80,17 @@
         {
             "label": "Bootstrap",
             "type": "shell",
-            "command": "if [[ ! -f build/default/config.status ]]; then mkdir -p build/default; (cd build/default && ../../bootstrap-configure --enable-debug --enable-coverage); else ./bootstrap -w make; fi",
+            "command": [
+                "if [[ ! -f build/default/config.status ]]; then",
+                "  mkdir -p build/default;",
+                "  (cd build/default && ",
+                "  ../../bootstrap-configure --enable-debug --enable-coverage); ",
+                "elif [[ configure.ac -nt configure ]]; then",
+                "  ./bootstrap",
+                "else",
+                "  ./bootstrap -w make;",
+                "fi"
+            ],
             "group": "none",
             "problemMatcher": ["$gcc"]
         },


### PR DESCRIPTION
#### Problem
 configure.ac updates aren't detected by the vscode task Bootstrap, as a result, config.status doesn't realize it needs to reconfigure


 #### Summary of Changes
 run bootstrap if configure.ac is newer than configure