### PR TITLE
shellcheck_tree to exclude .git

### DIFF
--- a/.shellcheck_tree
+++ b/.shellcheck_tree
@@ -1,2 +1,2 @@
 # configuration for shellcheck_tree.sh
-excludes+=('third_party/*' 'build/*')
+excludes+=('third_party/*' 'build/*' '.git/*')


### PR DESCRIPTION
#### Problem
 when in non-git mode (default) files in .git/ should be skipped

 #### Summary of Changes
 exclude .git/*