### PR TITLE
[scripts] Add cleantree script for cleaning out build artifacts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,12 @@ config.status
 configure
 src/include/BuildConfig.h.in
 
+# Build Artifacts
+.deps
+.dirstamp
+*.o
+*.a
+
 # Repos stuff
 .repos-warning-stamp
 third_party/nlassert/

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -97,7 +97,7 @@
         {
             "label": "Clean Tree",
             "type": "shell",
-            "command": "make -f Makefile-bootstrap clean-repos && git clean -Xdf",
+            "command": "scripts/cleantree.sh",
             "group": "none",
             "problemMatcher": ["$gcc"]
         },

--- a/docs/VSCODE_DEVELOPMENT.md
+++ b/docs/VSCODE_DEVELOPMENT.md
@@ -29,10 +29,11 @@ Tested on:
 1. Git clone the main CHIP repository here:
    <https://github.com/project-chip/connectedhomeip>
 1. Launch Visual Studio Code, and open the cloned folder from
+   `File -> Open Folder...`
 1. Install the
    [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
-   extension for Visual Studio Code, this extension allows you to use docker
-   containers as a development backend.
+   extension for Visual Studio Code from `View -> Extensions`. This extension
+   allows you to use docker containers as a development backend.
 1. Once this is installed, you'll be prompted to reload Visual Studio Code, do
    so
 1. At the bottom right of your Visual Studio Code window you should have a new

--- a/scripts/cleantree.sh
+++ b/scripts/cleantree.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+#
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+abs_srcdir=$(cd "$(dirname "${0}")" && pwd)/..
+
+(cd "$abs_srcdir" && make -f Makefile-bootstrap clean-repos && git clean -Xdf)


### PR DESCRIPTION
 #### Problem
It is sometimes desirable to clear out build artifacts from a tree when those build files are in a partial state.  This use case comes up when switching branches for example where one branch has changed .ac or .am files from another.

 #### Summary of Changes
Adds ./scripts/cleantree.sh script which quickly clears out build files, even when those files are in a partial state.