### PR TITLE
Update inet/tests to use MAKEDIR_TARGETS over MAKEDIRS for CHIPVersion.h

### DIFF
--- a/src/inet/tests/Makefile.am
+++ b/src/inet/tests/Makefile.am
@@ -77,7 +77,6 @@ MAKEDIR_TARGETS                                       = \
     $(NULL)
 
 MAKEDIRS                                              = \
-    $(top_builddir)/src/include                         \
     $(NLFAULTINJECTION_MAKEDIR)                         \
     $(NLUNIT_TEST_MAKEDIR)                              \
     $(NULL)


### PR DESCRIPTION
#### Problem
 In the course of developing MAKEDIRS and MAKEDIR_TARGETS an experiment escaped

 #### Summary of Changes
 Cull the experiment