### PR TITLE
Enable unit tests for mbedTLS and integrate to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ jobs:
     - stage: Tests
       name: "Setup Payload Tests"
       env: TASK="run-setup-payload-tests"
+    - stage: Tests
+      name: "mbedTLS Crypto Tests"
+      env: TASK="run-mbedtls-crypto-tests"
     - stage: Deployment Checks
       name: "Run Code Coverage"
       env: TASK="run-code-coverage"

--- a/configure.ac
+++ b/configure.ac
@@ -1446,6 +1446,7 @@ if test "${with_crypto}" = "mbedtls"; then
 	    # variables and trust all will be well.
 
 	    MBEDTLS_CPPFLAGS="-I\${abs_top_srcdir}/third_party/mbedtls/repo/include"
+	    MBEDTLS_CPPFLAGS+=" -DMBEDTLS_NO_PLATFORM_ENTROPY -DMBEDTLS_TEST_NULL_ENTROPY -DMBEDTLS_NO_DEFAULT_ENTROPY_SOURCES"
 	    MBEDTLS_LDFLAGS="-L${ac_pwd}/third_party/mbedtls"
 	    MBEDTLS_LIBS="-lmbedtls"
 	],

--- a/integrations/ci-tools/build.sh
+++ b/integrations/ci-tools/build.sh
@@ -32,6 +32,12 @@ else
    ./bootstrap -w make;
 fi'
 
+bootstrap_mbedtls='
+   git clean -xdf
+   mkdir -p build/default;
+   (cd build/default && ../../bootstrap-configure --enable-debug --enable-coverage --with-crypto=mbedtls);
+'
+
 docker_run_command() {
   integrations/docker/images/"${IMAGE:-chip-build}"/run.sh "${ENV[@]}" -- "$@"
 }
@@ -90,6 +96,13 @@ case "$TASK" in
   run-setup-payload-tests)
     docker_run_bash_command "$bootstrap"
     docker_run_bash_command 'make V=1 -C build/default/src/setup_payload check'
+    ;;
+
+  run-mbedtls-crypto-tests)
+    docker_run_bash_command "$bootstrap_mbedtls"
+    docker_run_bash_command 'make V=1 -C build/default/third_party/mbedtls'
+    docker_run_bash_command 'make V=1 -C build/default/src/crypto check'
+    docker_run_bash_command 'git clean -xdf'
     ;;
 
   *)

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -464,6 +464,7 @@ static void TestECDSA_ValidationInvalidParam(nlTestSuite * inSuite, void * inCon
  */
 
 static const nlTest sTests[] = {
+#if CHIP_CRYPTO_OPENSSL // Following tests are currently supported only for OpenSSL
     NL_TEST_DEF("Test encrypting test vectors", TestAES_CCM_256EncryptTestVectors),
     NL_TEST_DEF("Test decrypting test vectors", TestAES_CCM_256DecryptTestVectors),
     NL_TEST_DEF("Test encrypting invalid plain text", TestAES_CCM_256EncryptInvalidPlainText),
@@ -474,14 +475,15 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("Test decrypting invalid key", TestAES_CCM_256DecryptInvalidKey),
     NL_TEST_DEF("Test decrypting invalid IV", TestAES_CCM_256DecryptInvalidIVLen),
     NL_TEST_DEF("Test decrypting invalid vectors", TestAES_CCM_256DecryptInvalidTestVectors),
-    NL_TEST_DEF("Test HKDF SHA 256", TestHKDF_SHA256),
-    NL_TEST_DEF("Test DRBG invalid inputs", TestDRBG_InvalidInputs),
-    NL_TEST_DEF("Test DRBG output", TestDRBG_Output),
     NL_TEST_DEF("Test ECDSA signing and validation using SHA256", TestECDSA_Signing_SHA256),
     NL_TEST_DEF("Test ECDSA signature validation fail - Different msg", TestECDSA_ValidationFailsDifferentMessage),
     NL_TEST_DEF("Test ECDSA signature validation fail - Different signature", TestECDSA_ValidationFailIncorrectSignature),
     NL_TEST_DEF("Test ECDSA sign msg invalid parameters", TestECDSA_SigningInvalidParams),
     NL_TEST_DEF("Test ECDSA signature validation invalid parameters", TestECDSA_ValidationInvalidParam),
+    NL_TEST_DEF("Test HKDF SHA 256", TestHKDF_SHA256),
+#endif
+    NL_TEST_DEF("Test DRBG invalid inputs", TestDRBG_InvalidInputs),
+    NL_TEST_DEF("Test DRBG output", TestDRBG_Output),
 
     NL_TEST_SENTINEL()
 };

--- a/third_party/mbedtls/Makefile.am
+++ b/third_party/mbedtls/Makefile.am
@@ -103,7 +103,14 @@ libmbedtls_a_SOURCES                                                           =
     repo/library/md_wrap.c                  \
     $(NULL)
 
-libmbedtls_a_CPPFLAGS                                                             = \
+if !CONFIG_DEVICE_LAYER
+libmbedtls_a_SOURCES                                                          += \
+    repo/library/entropy_poll.c             \
+    repo/library/timing.c                   \
+    $(NULL)
+endif
+
+libmbedtls_a_CPPFLAGS                                                          = \
     -I$(top_srcdir)/third_party/mbedtls/repo/include                             \
     $(MBEDTLS_CPPFLAGS)                                                          \
     $(NULL)


### PR DESCRIPTION
 #### Problem
Crypto unit tests are not enabled for `mbedTLS` library.

 #### Summary of Changes
Enable the tests that cover the currently supported features.

#262 
