### PR TITLE
Support AES-CCM-128 encryption for OpenSSL

### DIFF
--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -32,44 +32,7 @@ namespace Crypto {
 const size_t kMax_ECDSA_Signature_Length = 72;
 
 /**
- * @brief A function that implements 256-bit AES-CCM encryption
- * @param plaintext Plaintext to encrypt
- * @param plaintext_length Length of plain_text
- * @param aad Additional authentication data
- * @param aad_length Length of additional authentication data
- * @param key Encryption key
- * @param iv Initial vector
- * @param iv_length Length of initial vector
- * @param ciphertext Buffer to write ciphertext into. Caller must ensure this is large enough to hold the ciphertext
- * @param tag Buffer to write tag into. Caller must ensure this is large enough to hold the tag
- * @param tag_length Expected length of tag
- * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
- * */
-CHIP_ERROR AES_CCM_256_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
-                               size_t aad_length, const unsigned char * key, const unsigned char * iv, size_t iv_length,
-                               unsigned char * ciphertext, unsigned char * tag, size_t tag_length);
-
-/**
- * @brief A function that implements 256-bit AES-CCM decryption
- * @param ciphertext Ciphertext to decrypt
- * @param ciphertext_length Length of ciphertext
- * @param aad Additional authentical data.
- * @param aad_length Length of additional authentication data
- * @param tag Tag to use to decrypt
- * @param tag_length Length of tag
- * @param key Decryption key
- * @param iv Initial vector
- * @param iv_length Length of initial vector
- * @param plaintext Buffer to write plaintext into
- * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
- **/
-
-CHIP_ERROR AES_CCM_256_decrypt(const unsigned char * ciphertext, size_t ciphertext_length, const unsigned char * aad,
-                               size_t aad_length, const unsigned char * tag, size_t tag_length, const unsigned char * key,
-                               const unsigned char * iv, size_t iv_length, unsigned char * plaintext);
-
-/**
- * @brief A function that implements 128-bit AES-CCM encryption
+ * @brief A function that implements AES-CCM encryption
  * @param plaintext Plaintext to encrypt
  * @param plaintext_length Length of plain_text
  * @param aad Additional authentication data
@@ -83,12 +46,12 @@ CHIP_ERROR AES_CCM_256_decrypt(const unsigned char * ciphertext, size_t cipherte
  * @param tag_length Expected length of tag
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  * */
-CHIP_ERROR AES_CCM_128_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
-                               size_t aad_length, const unsigned char * key, size_t key_length, const unsigned char * iv,
-                               size_t iv_length, unsigned char * ciphertext, unsigned char * tag, size_t tag_length);
+CHIP_ERROR AES_CCM_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad, size_t aad_length,
+                           const unsigned char * key, size_t key_length, const unsigned char * iv, size_t iv_length,
+                           unsigned char * ciphertext, unsigned char * tag, size_t tag_length);
 
 /**
- * @brief A function that implements 128-bit AES-CCM decryption
+ * @brief A function that implements AES-CCM decryption
  * @param ciphertext Ciphertext to decrypt
  * @param ciphertext_length Length of ciphertext
  * @param aad Additional authentical data.
@@ -103,9 +66,9 @@ CHIP_ERROR AES_CCM_128_encrypt(const unsigned char * plaintext, size_t plaintext
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  **/
 
-CHIP_ERROR AES_CCM_128_decrypt(const unsigned char * ciphertext, size_t ciphertext_length, const unsigned char * aad,
-                               size_t aad_length, const unsigned char * tag, size_t tag_length, const unsigned char * key,
-                               size_t key_length, const unsigned char * iv, size_t iv_length, unsigned char * plaintext);
+CHIP_ERROR AES_CCM_decrypt(const unsigned char * ciphertext, size_t ciphertext_length, const unsigned char * aad, size_t aad_length,
+                           const unsigned char * tag, size_t tag_length, const unsigned char * key, size_t key_length,
+                           const unsigned char * iv, size_t iv_length, unsigned char * plaintext);
 
 /**
  * @brief A function that implements SHA-256 based HKDF

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -101,9 +101,8 @@ static const EVP_MD * _digestForType(DigestType digestType)
 }
 
 static CHIP_ERROR AES_CCM_encrypt(const EVP_CIPHER * type, const unsigned char * plaintext, size_t plaintext_length,
-                                  const unsigned char * aad, size_t aad_length, const unsigned char * key, size_t key_length,
-                                  const unsigned char * iv, size_t iv_length, unsigned char * ciphertext, unsigned char * tag,
-                                  size_t tag_length)
+                                  const unsigned char * aad, size_t aad_length, const unsigned char * key, const unsigned char * iv,
+                                  size_t iv_length, unsigned char * ciphertext, unsigned char * tag, size_t tag_length)
 {
     EVP_CIPHER_CTX * context = NULL;
     int bytesWritten         = 0;
@@ -175,8 +174,7 @@ exit:
 
 static CHIP_ERROR AES_CCM_decrypt(const EVP_CIPHER * type, const unsigned char * ciphertext, size_t ciphertext_length,
                                   const unsigned char * aad, size_t aad_length, const unsigned char * tag, size_t tag_length,
-                                  const unsigned char * key, size_t key_length, const unsigned char * iv, size_t iv_length,
-                                  unsigned char * plaintext)
+                                  const unsigned char * key, const unsigned char * iv, size_t iv_length, unsigned char * plaintext)
 {
     EVP_CIPHER_CTX * context = NULL;
     CHIP_ERROR error         = CHIP_NO_ERROR;
@@ -240,8 +238,8 @@ CHIP_ERROR chip::Crypto::AES_CCM_128_encrypt(const unsigned char * plaintext, si
                                              const unsigned char * iv, size_t iv_length, unsigned char * ciphertext,
                                              unsigned char * tag, size_t tag_length)
 {
-    return AES_CCM_encrypt(EVP_aes_128_ccm(), plaintext, plaintext_length, aad, aad_length, key, key_length, iv, iv_length,
-                           ciphertext, tag, tag_length);
+    return AES_CCM_encrypt(EVP_aes_128_ccm(), plaintext, plaintext_length, aad, aad_length, key, iv, iv_length, ciphertext, tag,
+                           tag_length);
 }
 
 CHIP_ERROR chip::Crypto::AES_CCM_128_decrypt(const unsigned char * ciphertext, size_t ciphertext_length, const unsigned char * aad,
@@ -249,15 +247,15 @@ CHIP_ERROR chip::Crypto::AES_CCM_128_decrypt(const unsigned char * ciphertext, s
                                              const unsigned char * key, size_t key_length, const unsigned char * iv,
                                              size_t iv_length, unsigned char * plaintext)
 {
-    return AES_CCM_decrypt(EVP_aes_128_ccm(), ciphertext, ciphertext_length, aad, aad_length, tag, tag_length, key, key_length, iv,
-                           iv_length, plaintext);
+    return AES_CCM_decrypt(EVP_aes_128_ccm(), ciphertext, ciphertext_length, aad, aad_length, tag, tag_length, key, iv, iv_length,
+                           plaintext);
 }
 
 CHIP_ERROR chip::Crypto::AES_CCM_256_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
                                              size_t aad_length, const unsigned char * key, const unsigned char * iv,
                                              size_t iv_length, unsigned char * ciphertext, unsigned char * tag, size_t tag_length)
 {
-    return AES_CCM_encrypt(EVP_aes_256_ccm(), plaintext, plaintext_length, aad, aad_length, key, 0, iv, iv_length, ciphertext, tag,
+    return AES_CCM_encrypt(EVP_aes_256_ccm(), plaintext, plaintext_length, aad, aad_length, key, iv, iv_length, ciphertext, tag,
                            tag_length);
 }
 
@@ -266,8 +264,8 @@ CHIP_ERROR chip::Crypto::AES_CCM_256_decrypt(const unsigned char * ciphertext, s
                                              const unsigned char * key, const unsigned char * iv, size_t iv_length,
                                              unsigned char * plaintext)
 {
-    return AES_CCM_decrypt(EVP_aes_256_ccm(), ciphertext, ciphertext_length, aad, aad_length, tag, tag_length, key, 0, iv,
-                           iv_length, plaintext);
+    return AES_CCM_decrypt(EVP_aes_256_ccm(), ciphertext, ciphertext_length, aad, aad_length, tag, tag_length, key, iv, iv_length,
+                           plaintext);
 }
 
 CHIP_ERROR chip::Crypto::HKDF_SHA256(const unsigned char * secret, const size_t secret_length, const unsigned char * salt,

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -59,6 +59,7 @@ static bool _isValidTagLength(size_t tag_length)
 
 static bool _isValidKeyLength(size_t length)
 {
+    // 16 bytes key for AES-CCM-128
     if (length == 16)
     {
         return true;
@@ -66,25 +67,9 @@ static bool _isValidKeyLength(size_t length)
     return false;
 }
 
-CHIP_ERROR chip::Crypto::AES_CCM_256_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
-                                             size_t aad_length, const unsigned char * key, const unsigned char * iv,
-                                             size_t iv_length, unsigned char * ciphertext, unsigned char * tag, size_t tag_length)
-{
-    return CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE;
-}
-
-CHIP_ERROR chip::Crypto::AES_CCM_256_decrypt(const unsigned char * ciphertext, size_t ciphertext_len, const unsigned char * aad,
-                                             size_t aad_len, const unsigned char * tag, size_t tag_length,
-                                             const unsigned char * key, const unsigned char * iv, size_t iv_length,
-                                             unsigned char * plaintext)
-{
-    return CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE;
-}
-
-CHIP_ERROR chip::Crypto::AES_CCM_128_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
-                                             size_t aad_length, const unsigned char * key, size_t key_length,
-                                             const unsigned char * iv, size_t iv_length, unsigned char * ciphertext,
-                                             unsigned char * tag, size_t tag_length)
+CHIP_ERROR chip::Crypto::AES_CCM_encrypt(const unsigned char * plaintext, size_t plaintext_length, const unsigned char * aad,
+                                         size_t aad_length, const unsigned char * key, size_t key_length, const unsigned char * iv,
+                                         size_t iv_length, unsigned char * ciphertext, unsigned char * tag, size_t tag_length)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 1;
@@ -95,7 +80,7 @@ CHIP_ERROR chip::Crypto::AES_CCM_128_encrypt(const unsigned char * plaintext, si
     VerifyOrExit(plaintext != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(plaintext_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(key != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(_isValidKeyLength(key_length), error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(_isValidKeyLength(key_length), error = CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE);
     VerifyOrExit(iv != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(iv_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(tag != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
@@ -120,10 +105,9 @@ exit:
     return error;
 }
 
-CHIP_ERROR chip::Crypto::AES_CCM_128_decrypt(const unsigned char * ciphertext, size_t ciphertext_len, const unsigned char * aad,
-                                             size_t aad_len, const unsigned char * tag, size_t tag_length,
-                                             const unsigned char * key, size_t key_length, const unsigned char * iv,
-                                             size_t iv_length, unsigned char * plaintext)
+CHIP_ERROR chip::Crypto::AES_CCM_decrypt(const unsigned char * ciphertext, size_t ciphertext_len, const unsigned char * aad,
+                                         size_t aad_len, const unsigned char * tag, size_t tag_length, const unsigned char * key,
+                                         size_t key_length, const unsigned char * iv, size_t iv_length, unsigned char * plaintext)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 1;
@@ -136,7 +120,7 @@ CHIP_ERROR chip::Crypto::AES_CCM_128_decrypt(const unsigned char * ciphertext, s
     VerifyOrExit(tag != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(_isValidTagLength(tag_length), error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(key != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(_isValidKeyLength(key_length), error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(_isValidKeyLength(key_length), error = CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE);
     VerifyOrExit(iv != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(iv_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     if (aad_len > 0)

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -42,8 +42,8 @@ static void TestAES_CCM_256EncryptTestVectors(nlTestSuite * inSuite, void * inCo
             unsigned char out_ct[vector->ct_len];
             unsigned char out_tag[vector->tag_len];
 
-            CHIP_ERROR err = AES_CCM_256_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, vector->key, vector->iv,
-                                                 vector->iv_len, out_ct, out_tag, vector->tag_len);
+            CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, vector->key, vector->key_len,
+                                             vector->iv, vector->iv_len, out_ct, out_tag, vector->tag_len);
             bool areCTsEqual  = memcmp(out_ct, vector->ct, vector->ct_len) == 0;
             bool areTagsEqual = memcmp(out_tag, vector->tag, vector->tag_len) == 0;
             NL_TEST_ASSERT(inSuite, areCTsEqual);
@@ -74,8 +74,8 @@ static void TestAES_CCM_256DecryptTestVectors(nlTestSuite * inSuite, void * inCo
         {
             numOfTestsRan++;
             unsigned char out_pt[vector->pt_len];
-            CHIP_ERROR err = AES_CCM_256_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag,
-                                                 vector->tag_len, vector->key, vector->iv, vector->iv_len, out_pt);
+            CHIP_ERROR err = AES_CCM_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag, vector->tag_len,
+                                             vector->key, vector->key_len, vector->iv, vector->iv_len, out_pt);
 
             bool arePTsEqual = memcmp(vector->pt, out_pt, vector->pt_len) == 0;
             NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -102,8 +102,8 @@ static void TestAES_CCM_256EncryptInvalidPlainText(nlTestSuite * inSuite, void *
             unsigned char out_ct[vector->ct_len];
             unsigned char out_tag[vector->tag_len];
 
-            CHIP_ERROR err = AES_CCM_256_encrypt(vector->pt, 0, vector->aad, vector->aad_len, vector->key, vector->iv,
-                                                 vector->iv_len, out_ct, out_tag, vector->tag_len);
+            CHIP_ERROR err = AES_CCM_encrypt(vector->pt, 0, vector->aad, vector->aad_len, vector->key, vector->key_len, vector->iv,
+                                             vector->iv_len, out_ct, out_tag, vector->tag_len);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -124,8 +124,8 @@ static void TestAES_CCM_256EncryptNilKey(nlTestSuite * inSuite, void * inContext
             unsigned char out_ct[vector->ct_len];
             unsigned char out_tag[vector->tag_len];
 
-            CHIP_ERROR err = AES_CCM_256_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, NULL, vector->iv,
-                                                 vector->iv_len, out_ct, out_tag, vector->tag_len);
+            CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, NULL, 32, vector->iv,
+                                             vector->iv_len, out_ct, out_tag, vector->tag_len);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -146,8 +146,8 @@ static void TestAES_CCM_256EncryptInvalidIVLen(nlTestSuite * inSuite, void * inC
             unsigned char out_ct[vector->ct_len];
             unsigned char out_tag[vector->tag_len];
 
-            CHIP_ERROR err = AES_CCM_256_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, vector->key, vector->iv,
-                                                 0, out_ct, out_tag, vector->tag_len);
+            CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, vector->key, vector->key_len,
+                                             vector->iv, 0, out_ct, out_tag, vector->tag_len);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -168,8 +168,8 @@ static void TestAES_CCM_256EncryptInvalidTagLen(nlTestSuite * inSuite, void * in
             unsigned char out_ct[vector->ct_len];
             unsigned char out_tag[vector->tag_len];
 
-            CHIP_ERROR err = AES_CCM_256_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, vector->key, vector->iv,
-                                                 vector->iv_len, out_ct, out_tag, 13);
+            CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, vector->key, vector->key_len,
+                                             vector->iv, vector->iv_len, out_ct, out_tag, 13);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -188,8 +188,8 @@ static void TestAES_CCM_256DecryptInvalidCipherText(nlTestSuite * inSuite, void 
         {
 
             unsigned char out_pt[vector->pt_len];
-            CHIP_ERROR err = AES_CCM_256_decrypt(vector->ct, 0, vector->aad, vector->aad_len, vector->tag, vector->tag_len,
-                                                 vector->key, vector->iv, vector->iv_len, out_pt);
+            CHIP_ERROR err = AES_CCM_decrypt(vector->ct, 0, vector->aad, vector->aad_len, vector->tag, vector->tag_len, vector->key,
+                                             vector->key_len, vector->iv, vector->iv_len, out_pt);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -208,8 +208,8 @@ static void TestAES_CCM_256DecryptInvalidKey(nlTestSuite * inSuite, void * inCon
         {
 
             unsigned char out_pt[vector->pt_len];
-            CHIP_ERROR err = AES_CCM_256_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag,
-                                                 vector->tag_len, NULL, vector->iv, vector->iv_len, out_pt);
+            CHIP_ERROR err = AES_CCM_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag, vector->tag_len,
+                                             NULL, 32, vector->iv, vector->iv_len, out_pt);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -228,8 +228,8 @@ static void TestAES_CCM_256DecryptInvalidIVLen(nlTestSuite * inSuite, void * inC
         {
 
             unsigned char out_pt[vector->pt_len];
-            CHIP_ERROR err = AES_CCM_256_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag,
-                                                 vector->tag_len, vector->key, vector->iv, 0, out_pt);
+            CHIP_ERROR err = AES_CCM_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag, vector->tag_len,
+                                             vector->key, vector->key_len, vector->iv, 0, out_pt);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -248,8 +248,8 @@ static void TestAES_CCM_256DecryptInvalidTestVectors(nlTestSuite * inSuite, void
         {
             numOfTestsRan++;
             unsigned char out_pt[vector->pt_len];
-            CHIP_ERROR err = AES_CCM_256_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag,
-                                                 vector->tag_len, vector->key, vector->iv, vector->iv_len, out_pt);
+            CHIP_ERROR err = AES_CCM_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag, vector->tag_len,
+                                             vector->key, vector->key_len, vector->iv, vector->iv_len, out_pt);
 
             bool arePTsEqual = memcmp(vector->pt, out_pt, vector->pt_len) == 0;
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INTERNAL);


### PR DESCRIPTION
 #### Problem
Missing AES-CCM-128 implementation that uses OpenSSL. Current implementation is for AES-CCM-256.

 #### Summary of Changes
Refactored the code to support AES-CCM-128

fixes #484 