### PR TITLE
Add facility to auto generate .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+### THIS FILE IS GENERATED, PLEASE DO NOT EDIT DIRECTLY
+###  The generator lives at integrations/ci-tools/travis_yml.sh
 language: minimal
 
 branches:
@@ -10,7 +12,9 @@ services:
 script:
     - ./integrations/ci-tools/build.sh
 
-# Note: To add new job types, add it to the matrix below, with a unique TASK varable, then update the build.sh to do what you want during that task
+# Note: To add new non-test job types, add it to the matrix below,
+#  with a unique TASK varable, then update the accompanying build.sh
+#  to do what you want during that task
 
 jobs:
     include:
@@ -21,20 +25,33 @@ jobs:
           name: "Build NRF Example Lock App"
           env: TASK="build-nrf-example-lock-app"
         - stage: Tests
-          name: "Unit & Functional Tests"
-          env: TASK="run-unit-and-functional-tests"
+          name: "check-TESTS in src/ble/tests"
+          env: TASK=run RUN=bWFrZQotQwpidWlsZC9kZWZhdWx0L3NyYy9ibGUvdGVzdHMKY2hlY2stVEVTVFMK
         - stage: Tests
-          name: "Crypto Tests"
-          env: TASK="run-crypto-tests"
+          name: "check-TESTS in src/crypto/tests"
+          env: TASK=run RUN=bWFrZQotQwpidWlsZC9kZWZhdWx0L3NyYy9jcnlwdG8vdGVzdHMKY2hlY2stVEVTVFMK
         - stage: Tests
-          name: "Setup Payload Tests"
-          env: TASK="run-setup-payload-tests"
-        # - stage: Tests
-        #   name: "mbedTLS Crypto Tests"
-        #   env: TASK="run-mbedtls-crypto-tests"
+          name: "check-TESTS in src/inet/tests"
+          env: TASK=run RUN=bWFrZQotQwpidWlsZC9kZWZhdWx0L3NyYy9pbmV0L3Rlc3RzCmNoZWNrLVRFU1RTCg==
+        - stage: Tests
+          name: "check-TESTS in src/lib/core/tests"
+          env: TASK=run RUN=bWFrZQotQwpidWlsZC9kZWZhdWx0L3NyYy9saWIvY29yZS90ZXN0cwpjaGVjay1URVNUUwo=
+        - stage: Tests
+          name: "check-TESTS in src/lib/support/tests"
+          env: TASK=run RUN=bWFrZQotQwpidWlsZC9kZWZhdWx0L3NyYy9saWIvc3VwcG9ydC90ZXN0cwpjaGVjay1URVNUUwo=
+        - stage: Tests
+          name: "check-TESTS in src/lwip/tests"
+          env: TASK=run RUN=bWFrZQotQwpidWlsZC9kZWZhdWx0L3NyYy9sd2lwL3Rlc3RzCmNoZWNrLVRFU1RTCg==
+        - stage: Tests
+          name: "check-TESTS in src/setup_payload/tests"
+          env: TASK=run RUN=bWFrZQotQwpidWlsZC9kZWZhdWx0L3NyYy9zZXR1cF9wYXlsb2FkL3Rlc3RzCmNoZWNrLVRFU1RTCg==
+        - stage: Tests
+          name: "check-TESTS in src/system/tests"
+          env: TASK=run RUN=bWFrZQotQwpidWlsZC9kZWZhdWx0L3NyYy9zeXN0ZW0vdGVzdHMKY2hlY2stVEVTVFMK
         - stage: Deployment Checks
           name: "Run Code Coverage"
           env: TASK="run-code-coverage"
         - stage: Deployment Checks
           name: "Distribution Check"
           env: TASK="build-distribution-check"
+

--- a/integrations/ci-tools/build.sh
+++ b/integrations/ci-tools/build.sh
@@ -62,7 +62,7 @@ case "$TASK" in
     ;;
 
   run)
-    (( ${#RUN[*]} )) || die "no RUN specified"
+    ((${#RUN[*]})) || die "no RUN specified"
     docker_run_command "${RUN[@]}"
     ;;
 

--- a/integrations/ci-tools/build.sh
+++ b/integrations/ci-tools/build.sh
@@ -11,7 +11,8 @@
 #  ENV     a comma-separated list of --env arguments to be passed to
 #            docker run, e.g. "GITHUB_TOKEN,FOO=BAR" will convey
 #            as "--env GITHUB_TOKEN --env FOO=BAR"
-#  RUN     if task is "run", RUN is the command line, URL encoded
+#  RUN     if task is "run", RUN is the command line, base64-encoded
+#            with one command argument per line
 #
 
 me=$(basename "$0")

--- a/integrations/ci-tools/travis_yml.sh
+++ b/integrations/ci-tools/travis_yml.sh
@@ -23,9 +23,8 @@ read -r -a TESTDIRS <<<"${TESTDIRS[@]%/*}"
 
 # build the yml
 TESTS_YML=""
-for dir in "${TESTDIRS[@]}"
-do
-  RUN=$(base64<<<"make
+for dir in "${TESTDIRS[@]}"; do
+  RUN=$(base64 <<<"make
 -C
 build/default/$dir
 check-TESTS")
@@ -39,7 +38,7 @@ done
 #
 # .travis.yml template
 #
-cat<<EOF
+cat <<EOF
 ### THIS FILE IS GENERATED, PLEASE DO NOT EDIT DIRECTLY
 ###  The generator lives at integrations/ci-tools/travis_yml.sh
 language: minimal

--- a/integrations/ci-tools/travis_yml.sh
+++ b/integrations/ci-tools/travis_yml.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+me=$(basename "$0")
+here=$(cd "$(dirname "$0")" && pwd)
+
+die() {
+  echo "$me: *** ERROR: " "${*}"
+  exit 1
+}
+
+# move to ToT, I don't work anywhere else
+cd "$here/../.." || die 'ack!, where am I?!?'
+
+#
+# find and compile tests directories
+#
+readarray -t TESTDIRS < <(git ls-files \*/tests/Makefile.am)
+
+#
+# pull off the Makefile.am from the list
+#
+read -r -a TESTDIRS <<<"${TESTDIRS[@]%/*}"
+
+# build the yml
+TESTS_YML=""
+for dir in "${TESTDIRS[@]}"
+do
+  RUN=$(base64<<<"make
+-C
+build/default/$dir
+check-TESTS")
+  TESTS_YML+="
+        - stage: Tests
+          name: \"check-TESTS in $dir\"
+          env: TASK=run RUN=$RUN"
+
+done
+
+#
+# .travis.yml template
+#
+cat<<EOF
+### THIS FILE IS GENERATED, PLEASE DO NOT EDIT DIRECTLY
+###  The generator lives at integrations/ci-tools/travis_yml.sh
+language: minimal
+
+branches:
+    except:
+        - /^restyled.*$/
+
+services:
+    - docker
+
+script:
+    - ./integrations/ci-tools/build.sh
+
+# Note: To add new non-test job types, add it to the matrix below,
+#  with a unique TASK varable, then update the accompanying build.sh
+#  to do what you want during that task
+
+jobs:
+    include:
+        - stage: Build
+          name: "Build Ubuntu Linux Xenial LTS"
+          env: TASK="build-ubuntu-linux"
+        - stage: Build
+          name: "Build NRF Example Lock App"
+          env: TASK="build-nrf-example-lock-app"${TESTS_YML[@]}
+        - stage: Deployment Checks
+          name: "Run Code Coverage"
+          env: TASK="run-code-coverage"
+        - stage: Deployment Checks
+          name: "Distribution Check"
+          env: TASK="build-distribution-check"
+
+EOF


### PR DESCRIPTION
#### Problem
 Unit tests could be run in parallel across ci tasks, were they enumerated
  by .travis.yml, but they're not.  Further, enumerating the test directories
  is tedious.

 #### Summary of Changes
 * Add a travis.yml generator
 * Add support for a "run" task in build.sh to avoid writing an
    individual shell script for every test

fixes #464