### PR TITLE
Fix lock-app for EFR32

### DIFF
--- a/examples/lock-app/efr32/include/ButtonHandler.h
+++ b/examples/lock-app/efr32/include/ButtonHandler.h
@@ -19,6 +19,11 @@
 #ifndef BUTTON_HANDLER_H
 #define BUTTON_HANDLER_H
 
+#include <stdint.h>
+
+#include "FreeRTOS.h"
+#include "timers.h" // provides FreeRTOS timer support
+
 class ButtonHandler
 {
 public:

--- a/examples/lock-app/efr32/include/LEDWidget.h
+++ b/examples/lock-app/efr32/include/LEDWidget.h
@@ -1,5 +1,6 @@
 /*
  *
+ *    Copyright (c) 2020 Project CHIP Authors
  *    Copyright (c) 2019 Google LLC.
  *    All rights reserved.
  *
@@ -18,6 +19,8 @@
 
 #ifndef LED_WIDGET_H
 #define LED_WIDGET_H
+
+#include <stdint.h>
 
 class LEDWidget
 {


### PR DESCRIPTION
 #### Problem
The lock-app for EFR32 doesn't compile anymore

 #### Summary of Changes

Fixed the implicit include dependencies 

fixes #495
