### PR TITLE
Enable AES-CCM-256 for mbedTLS

### DIFF
--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -59,8 +59,8 @@ static bool _isValidTagLength(size_t tag_length)
 
 static bool _isValidKeyLength(size_t length)
 {
-    // 16 bytes key for AES-CCM-128
-    if (length == 16)
+    // 16 bytes key for AES-CCM-128, 32 for AES-CCM-256
+    if (length == 16 || length == 32)
     {
         return true;
     }

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -701,7 +701,6 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("Test decrypting AES-CCM-128 invalid ct", TestAES_CCM_128DecryptInvalidCipherText),
     NL_TEST_DEF("Test decrypting AES-CCM-128 invalid key", TestAES_CCM_128DecryptInvalidKey),
     NL_TEST_DEF("Test decrypting AES-CCM-128 invalid IV", TestAES_CCM_128DecryptInvalidIVLen),
-#if CHIP_CRYPTO_OPENSSL // Following tests are currently supported only for OpenSSL
     NL_TEST_DEF("Test encrypting AES-CCM-256 test vectors", TestAES_CCM_256EncryptTestVectors),
     NL_TEST_DEF("Test decrypting AES-CCM-256 test vectors", TestAES_CCM_256DecryptTestVectors),
     NL_TEST_DEF("Test encrypting AES-CCM-256 invalid plain text", TestAES_CCM_256EncryptInvalidPlainText),
@@ -712,7 +711,6 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("Test decrypting AES-CCM-256 invalid key", TestAES_CCM_256DecryptInvalidKey),
     NL_TEST_DEF("Test decrypting AES-CCM-256 invalid IV", TestAES_CCM_256DecryptInvalidIVLen),
     NL_TEST_DEF("Test decrypting AES-CCM-256 invalid vectors", TestAES_CCM_256DecryptInvalidTestVectors),
-#endif
     NL_TEST_DEF("Test ECDSA signing and validation using SHA256", TestECDSA_Signing_SHA256),
     NL_TEST_DEF("Test ECDSA signature validation fail - Different msg", TestECDSA_ValidationFailsDifferentMessage),
     NL_TEST_DEF("Test ECDSA signature validation fail - Different signature", TestECDSA_ValidationFailIncorrectSignature),


### PR DESCRIPTION
 #### Problem
`AES-CCM-256` mode is not enabled for mbedTLS. It was due to the assumption that `mbedTLS` library does not support this mode. `OpenSSL` variant of API is already supporting `AES-CCM-256`. Testing revealed that the API works with `mbedTLS` library as well. So this should be enabled to have common set of functionality across the two variants of the API.

 #### Summary of Changes
Enable `AES-CCM-256` for `mbedTLS`, and also enable the tests.