### PR TITLE
Change reviewers for SmartThings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @anush-apple @chrisdecenzo @hawk248 @gerickson @robszewczyk @woody-apple @BroderickCarlin @tpmanley @jelderton
+* @anush-apple @chrisdecenzo @hawk248 @gerickson @robszewczyk @woody-apple @BroderickCarlin @saurabhst @jelderton

--- a/REVIEWERS.md
+++ b/REVIEWERS.md
@@ -10,5 +10,5 @@ PR
 | [jelderton](https://github.com/jelderton)             | Comcast, Inc.       |
 | [gerickson](https://github.com/gerickson)             | Google, Inc.        |
 | [robszewczyk](https://github.com/robszewczyk)         | Google, Inc.        |
-| [tpmanley](https://github.com/tpmanley)               | Samsung SmartThings |
+| [saurabhst](https://github.com/saurabhst)             | Samsung SmartThings |
 | [woody-apple](https://github.com/woody-apple)         | Apple, Inc.         |


### PR DESCRIPTION
 #### Problem
I haven't been able to devote as much time to reviews as it deserves.

 #### Summary of Changes
Replace `tpmanley` with `saurabhst` as a reviewer for SmartThings.
 
