### PR TITLE
Force null string terminator after strncpy in TunEndPoint.cpp.

### DIFF
--- a/src/inet/TunEndPoint.cpp
+++ b/src/inet/TunEndPoint.cpp
@@ -681,6 +681,7 @@ INET_ERROR TunEndPoint::TunDevOpen(const char * intfName)
     if (*intfName)
     {
         strncpy(ifr.ifr_name, intfName, sizeof(ifr.ifr_name) - 1);
+        ifr.ifr_name[sizeof(ifr.ifr_name) - 1] = '\0';
     }
 
 #if HAVE_LINUX_IF_TUN_H
@@ -701,6 +702,7 @@ INET_ERROR TunEndPoint::TunDevOpen(const char * intfName)
     {
         // Keep member copy of interface name and Id
         strncpy(tunIntfName, ifr.ifr_name, sizeof(tunIntfName) - 1);
+        tunIntfName[sizeof(tunIntfName) - 1] = '\0';
     }
     else
     {


### PR DESCRIPTION
GCC8 warns about truncation. This warning was only for

strncpy(tunIntfName, ifr.ifr_name, sizeof(tunIntfName) - 1);

however I changed both that and the previous strncpy usage for
consistency.

 #### Problem
- GCC8 warning fix
- Potential missing 0 terminator in string

 #### Summary of Changes
- ensures strings are 0-terminated

fixes #514
