### PR TITLE
Update decimalStringWithPadding to ensure 0 string terminator.

### DIFF
--- a/src/setup_payload/ManualSetupPayloadGenerator.cpp
+++ b/src/setup_payload/ManualSetupPayloadGenerator.cpp
@@ -38,8 +38,9 @@ static uint32_t shortPayloadRepresentation(SetupPayload payload)
 
 static string decimalStringWithPadding(uint32_t number, int minLength)
 {
-    char buf[minLength];
-    sprintf(buf, "%0*u", minLength, number);
+    char buf[minLength + 1];
+    snprintf(buf, minLength, "%0*u", minLength, number);
+    buf[minLength] = '\0';
     return string(buf);
 }
 

--- a/src/setup_payload/ManualSetupPayloadGenerator.cpp
+++ b/src/setup_payload/ManualSetupPayloadGenerator.cpp
@@ -38,8 +38,9 @@ static uint32_t shortPayloadRepresentation(SetupPayload payload)
 
 static string decimalStringWithPadding(uint32_t number, int minLength)
 {
-    char buf[minLength];
-    sprintf(buf, "%0*u", minLength, number);
+    char buf[minLength + 1];
+    snprintf(buf, sizeof(buf), "%0*u", minLength, number);
+    buf[minLength] = '\0';
     return string(buf);
 }
 


### PR DESCRIPTION
Got a GCC compile warning on previous code regarding string terminators.
Updated the code to use snprintf and ensured 0 terminator to the string.

 #### Problem
GCC8 warns about potentially sprintf overflow.
Potential missing 0 terminator after sprintf

 #### Summary of Changes
Updated code to use snprintf for number formatting and ensured 0-terminator in the character buffer.

fixes #516 
