### PR TITLE
Add a WiFi Echo example for the ESP32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ third_party/nlfaultinjection/
 third_party/nlio/
 third_party/nlunit-test/
 third_party/mbedtls/
+
+# Example specific rules
+examples/**/sdkconfig

--- a/examples/wifi-echo/esp32/Makefile
+++ b/examples/wifi-echo/esp32/Makefile
@@ -1,0 +1,10 @@
+#
+# This is a project Makefile. It is assumed the directory this Makefile resides in is a
+# project subdirectory.
+#
+
+PROJECT_NAME := chip-wifi-echo
+
+EXTRA_COMPONENT_DIRS += $(PROJECT_PATH)/third_party/connectedhomeip/config/esp32/components
+
+include $(IDF_PATH)/make/project.mk

--- a/examples/wifi-echo/esp32/README.md
+++ b/examples/wifi-echo/esp32/README.md
@@ -1,4 +1,4 @@
-# CHIP WiFI Echo Server Example
+# CHIP WiFi Echo Server Example
 
 A prototype appplication that uses CHIP to setup WiFi on the ESP32 and runs an
 Echo Server on a configured port. This example will evolve as more complex

--- a/examples/wifi-echo/esp32/README.md
+++ b/examples/wifi-echo/esp32/README.md
@@ -1,0 +1,84 @@
+# CHIP WiFI Echo Server Example
+
+A prototype appplication that uses CHIP to setup WiFi on the ESP32 and runs an
+Echo Server on a configured port. This example will evolve as more complex
+messaging is supported in CHIP.
+
+---
+
+-   [CHIP WiFI Echo Server Example](#chip-wifi-echo-server-example)
+-   [Supported Devices](#supported-devices)
+-   [Building the Example Application](#building-the-example-application)
+-   [Using the Echo Server](#using-the-echo-server)
+
+---
+
+## Supported Devices
+
+The CHIP demo application is intended to work on two categories of ESP32
+devices: the
+[ESP32-DevKitC](https://www.espressif.com/en/products/hardware/esp32-devkitc/overview),
+and the [M5Stack](http://m5stack.com). Support for the
+[M5Stack](http://m5stack.com) is still a Work in Progress.
+
+## Building the Example Application
+
+Building the example application requires the use of the Espressif ESP32 IoT
+Development Framework and the xtensa-esp32-elf toolchain.
+
+The VSCode devcontainer has these components pre-installed, so you can skip this
+step. To install these components manually, follow these steps:
+
+-   Clone the Expressif ESP-IDF and checkout version 4.0
+
+          $ mkdir ${HOME}/tools
+          $ cd ${HOME}/tools
+          $ git clone https://github.com/espressif/esp-idf.git
+          $ cd esp-idf
+          $ git checkout release/v4.0
+          $ git submodule update --init
+          $ export IDF_PATH=${HOME}/tools/esp-idf
+          $ ./install.sh
+
+To build the application, follow these steps:
+
+Currently building in VSCode _and_ deploying from native is not supported, so
+make sure the IDF_PATH has been exported(See the manual setup steps above).
+
+-   In the root of the example directory, use the `defconfig` make target to
+    configure the application with defaults.
+
+          $ idf make defconfig
+
+-   Run make to build the demo application
+
+          $ idf make
+
+-   After building the application, to flash it outside of VSCode, connect your
+    device via USB. Then run the following command to flash the demo application
+    onto the device and then monitor its output. If necessary, replace
+    `/dev/tty.SLAB_USBtoUART`(MacOS) with the correct USB device name for your
+    system(like `/dev/ttyUSB0` on Linux). Note that sometimes you might have to
+    press and hold the `boot` button on the device while it's trying to connect
+    before flashing.
+
+          $  make flash monitor ESPPORT=/dev/tty.SLAB_USBtoUART
+
+    Note: Some users might have to install the
+    [VCP driver](https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers)
+    before the device shows up on `/dev/tty`.
+
+## Using the Echo Server
+
+After the application has been flashed, connect the ESP32's Soft-AP. It's
+usually something like `CHIP_DEMO-XXXX` where the last 4 digits are from the
+device's MAC address.
+
+Once you're connected, the server's IP can be found at the gateway address and
+at the listed port number(Default: `8000`).
+
+Then running the following command will ping the ESP32 and cause it to echo. If
+necessary replace the `192.168.4.1` with the address printed by the device in
+the monitor.
+
+          $ echo "Hello over IP" | nc -w1 -u 192.168.4.1 8000

--- a/examples/wifi-echo/esp32/README.md
+++ b/examples/wifi-echo/esp32/README.md
@@ -6,7 +6,7 @@ messaging is supported in CHIP.
 
 ---
 
--   [CHIP WiFI Echo Server Example](#chip-wifi-echo-server-example)
+-   [CHIP WiFi Echo Server Example](#chip-wifi-echo-server-example)
 -   [Supported Devices](#supported-devices)
 -   [Building the Example Application](#building-the-example-application)
 -   [Using the Echo Server](#using-the-echo-server)

--- a/examples/wifi-echo/esp32/idf.sh
+++ b/examples/wifi-echo/esp32/idf.sh
@@ -26,11 +26,10 @@ die() {
   exit 1
 }
 idf() {
-  [[ -d $IDF_PATH && -r $IDF_PATH/export.sh ]] || die "can't find IDF's export.sh";
+  [[ -d $IDF_PATH && -r $IDF_PATH/export.sh ]] || die "can't find IDF's export.sh"
   . "$IDF_PATH/export.sh"
   "$@"
 }
-if [[ ${0} == ${BASH_SOURCE[0]} ]]
-then
+if [[ ${0} == ${BASH_SOURCE[0]} ]]; then
   idf "${@}"
 fi

--- a/examples/wifi-echo/esp32/idf.sh
+++ b/examples/wifi-echo/esp32/idf.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+#   Copyright (c) 2020 Project CHIP Authors
+#   All rights reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# If this file is sourced, it exports a function called "idf" that initializes
+# the espressif environment via the espressive export.sh script and runs
+# a command presented as arguments
+#
+# This file can also be used as an executable
+me=${0##*/}
+die() {
+  echo "$me: *** ERROR: " "${*}"
+  exit 1
+}
+idf() {
+  [[ -d $IDF_PATH && -r $IDF_PATH/export.sh ]] || die "can't find IDF's export.sh";
+  . "$IDF_PATH/export.sh"
+  "$@"
+}
+if [[ ${0} == ${BASH_SOURCE[0]} ]]
+then
+  idf "${@}"
+fi

--- a/examples/wifi-echo/esp32/main/EchoServer.cpp
+++ b/examples/wifi-echo/esp32/main/EchoServer.cpp
@@ -87,6 +87,9 @@ static void udp_server_task(void * pvParameters)
         if (err < 0)
         {
             ESP_LOGE(TAG, "Socket unable to bind: errno %d", errno);
+            // Avoid looping hard if binding fails continuously
+            vTaskDelay(50 / portTICK_PERIOD_MS);
+            continue;
         }
         ESP_LOGI(TAG, "Socket bound, port %d", PORT);
 

--- a/examples/wifi-echo/esp32/main/EchoServer.cpp
+++ b/examples/wifi-echo/esp32/main/EchoServer.cpp
@@ -1,0 +1,152 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <string.h>
+#include <sys/param.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_system.h"
+#include "esp_wifi.h"
+#include "esp_event.h"
+#include "esp_log.h"
+#include "nvs_flash.h"
+#include "tcpip_adapter.h"
+
+#include "lwip/err.h"
+#include "lwip/sockets.h"
+#include "lwip/sys.h"
+#include <lwip/netdb.h>
+
+#define PORT CONFIG_ECHO_PORT
+#define RX_LEN 128
+#define ADDR_LEN 128
+
+static const char * TAG = "echo server";
+
+static void udp_server_task(void * pvParameters)
+{
+    char rx_buffer[RX_LEN];
+    char addr_str[ADDR_LEN];
+    int addr_family = (int) pvParameters;
+    int ip_protocol = 0;
+    struct sockaddr_in6 dest_addr;
+
+    while (1)
+    {
+
+        if (addr_family == AF_INET)
+        {
+            struct sockaddr_in * dest_addr_ip4 = (struct sockaddr_in *) &dest_addr;
+            dest_addr_ip4->sin_addr.s_addr     = htonl(INADDR_ANY);
+            dest_addr_ip4->sin_family          = AF_INET;
+            dest_addr_ip4->sin_port            = htons(PORT);
+            ip_protocol                        = IPPROTO_IP;
+        }
+        else if (addr_family == AF_INET6)
+        {
+            bzero(&dest_addr.sin6_addr.un, sizeof(dest_addr.sin6_addr.un));
+            dest_addr.sin6_family = AF_INET6;
+            dest_addr.sin6_port   = htons(PORT);
+            ip_protocol           = IPPROTO_IPV6;
+        }
+
+        int sock = socket(addr_family, SOCK_DGRAM, ip_protocol);
+        if (sock < 0)
+        {
+            ESP_LOGE(TAG, "Unable to create socket: errno %d", errno);
+            break;
+        }
+        ESP_LOGI(TAG, "Socket created");
+
+#if defined(CONFIG_ECHO_IPV4) && defined(CONFIG_ECHO_IPV6)
+        if (addr_family == AF_INET6)
+        {
+            // Note that by default IPV6 binds to both protocols, it is must be disabled
+            // if both protocols used at the same time (used in CI)
+            int opt = 1;
+            setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+            setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, &opt, sizeof(opt));
+        }
+#endif
+
+        int err = bind(sock, (struct sockaddr *) &dest_addr, sizeof(dest_addr));
+        if (err < 0)
+        {
+            ESP_LOGE(TAG, "Socket unable to bind: errno %d", errno);
+        }
+        ESP_LOGI(TAG, "Socket bound, port %d", PORT);
+
+        while (1)
+        {
+
+            ESP_LOGI(TAG, "Waiting for data");
+            struct sockaddr_in6 source_addr; // Large enough for both IPv4 or IPv6
+            socklen_t socklen = sizeof(source_addr);
+            int len           = recvfrom(sock, rx_buffer, sizeof(rx_buffer) - 1, 0, (struct sockaddr *) &source_addr, &socklen);
+
+            // Error occurred during receiving
+            if (len < 0)
+            {
+                ESP_LOGE(TAG, "recvfrom failed: errno %d", errno);
+                break;
+            }
+            // Data received
+            else
+            {
+                // Get the sender's ip address as string
+                if (source_addr.sin6_family == PF_INET)
+                {
+                    inet_ntoa_r(((struct sockaddr_in *) &source_addr)->sin_addr.s_addr, addr_str, sizeof(addr_str) - 1);
+                }
+                else if (source_addr.sin6_family == PF_INET6)
+                {
+                    inet6_ntoa_r(source_addr.sin6_addr, addr_str, sizeof(addr_str) - 1);
+                }
+
+                rx_buffer[len] = 0; // Null-terminate whatever we received and treat like a string...
+                ESP_LOGI(TAG, "Received %d bytes from %s:", len, addr_str);
+                ESP_LOGI(TAG, "%s", rx_buffer);
+
+                int err = sendto(sock, rx_buffer, len, 0, (struct sockaddr *) &source_addr, sizeof(source_addr));
+                if (err < 0)
+                {
+                    ESP_LOGE(TAG, "Error occurred during sending: errno %d", errno);
+                    break;
+                }
+            }
+        }
+
+        if (sock != -1)
+        {
+            ESP_LOGE(TAG, "Shutting down socket and restarting...");
+            shutdown(sock, 0);
+            close(sock);
+        }
+    }
+    vTaskDelete(NULL);
+}
+
+// The echo server assumes the platform's networking has been setup already
+void startServer(void)
+{
+#ifdef CONFIG_ECHO_IPV4
+    xTaskCreate(udp_server_task, "udp_server", 4096, (void *) AF_INET, 5, NULL);
+#endif
+#ifdef CONFIG_ECHO_IPV6
+    xTaskCreate(udp_server_task, "udp_server", 4096, (void *) AF_INET6, 5, NULL);
+#endif
+}

--- a/examples/wifi-echo/esp32/main/Kconfig.projbuild
+++ b/examples/wifi-echo/esp32/main/Kconfig.projbuild
@@ -1,0 +1,54 @@
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+#    Description:
+#      Configuration options CHIP ESP32 demo application.
+#
+
+menu "WiFi Echo Demo"
+
+    choice
+        prompt "Device Type"
+        default DEVICE_TYPE_ESP32_DEVKITC
+        help
+            Specifies the type of ESP32 device.
+
+            Note that the "ESP32-DevKitC" choice is compatible with a number of clone devices
+            available from third-party manufacturers.
+
+        config DEVICE_TYPE_ESP32_DEVKITC
+            bool "ESP32-DevKitC"
+        config DEVICE_TYPE_M5STACK
+            bool "M5Stack"
+    endchoice
+
+    config ECHO_IPV4
+        bool "IPV4"
+        default y
+
+    config ECHO_IPV6
+        bool "IPV6"
+        default n
+        select EXAMPLE_CONNECT_IPV6
+
+    config ECHO_PORT
+        int "Port"
+        range 0 65535
+        default 8000
+        help
+            Local port the example server will listen on.
+
+endmenu

--- a/examples/wifi-echo/esp32/main/LEDWidget.cpp
+++ b/examples/wifi-echo/esp32/main/LEDWidget.cpp
@@ -16,12 +16,12 @@
  *    limitations under the License.
  */
 
+#include "LEDWidget.h"
+
 #include "esp_system.h"
 #include "esp_log.h"
 #include "driver/gpio.h"
 #include "esp_timer.h"
-
-#include "LEDWidget.h"
 
 extern const char * TAG;
 

--- a/examples/wifi-echo/esp32/main/LEDWidget.cpp
+++ b/examples/wifi-echo/esp32/main/LEDWidget.cpp
@@ -28,10 +28,10 @@ extern const char * TAG;
 void LEDWidget::Init(gpio_num_t gpioNum)
 {
     mLastChangeTimeUS = 0;
-    mBlinkOnTimeMS = 0;
-    mBlinkOffTimeMS = 0;
-    mGPIONum = gpioNum;
-    mState = false;
+    mBlinkOnTimeMS    = 0;
+    mBlinkOffTimeMS   = 0;
+    mGPIONum          = gpioNum;
+    mState            = false;
 
     if (gpioNum < GPIO_NUM_MAX)
     {
@@ -52,7 +52,7 @@ void LEDWidget::Blink(uint32_t changeRateMS)
 
 void LEDWidget::Blink(uint32_t onTimeMS, uint32_t offTimeMS)
 {
-    mBlinkOnTimeMS = onTimeMS;
+    mBlinkOnTimeMS  = onTimeMS;
     mBlinkOffTimeMS = offTimeMS;
     Animate();
 }
@@ -61,8 +61,8 @@ void LEDWidget::Animate()
 {
     if (mBlinkOnTimeMS != 0 && mBlinkOffTimeMS != 0)
     {
-        int64_t nowUS = ::esp_timer_get_time();
-        int64_t stateDurUS = ((mState) ? mBlinkOnTimeMS : mBlinkOffTimeMS) * 1000LL;
+        int64_t nowUS            = ::esp_timer_get_time();
+        int64_t stateDurUS       = ((mState) ? mBlinkOnTimeMS : mBlinkOffTimeMS) * 1000LL;
         int64_t nextChangeTimeUS = mLastChangeTimeUS + stateDurUS;
 
         if (nowUS > nextChangeTimeUS)
@@ -81,4 +81,3 @@ void LEDWidget::DoSet(bool state)
         gpio_set_level(mGPIONum, (state) ? 1 : 0);
     }
 }
-

--- a/examples/wifi-echo/esp32/main/LEDWidget.cpp
+++ b/examples/wifi-echo/esp32/main/LEDWidget.cpp
@@ -1,0 +1,84 @@
+/*
+ *
+ *    Copyright (c) 2018 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "esp_system.h"
+#include "esp_log.h"
+#include "driver/gpio.h"
+#include "esp_timer.h"
+
+#include "LEDWidget.h"
+
+extern const char * TAG;
+
+void LEDWidget::Init(gpio_num_t gpioNum)
+{
+    mLastChangeTimeUS = 0;
+    mBlinkOnTimeMS = 0;
+    mBlinkOffTimeMS = 0;
+    mGPIONum = gpioNum;
+    mState = false;
+
+    if (gpioNum < GPIO_NUM_MAX)
+    {
+        gpio_set_direction(gpioNum, GPIO_MODE_OUTPUT);
+    }
+}
+
+void LEDWidget::Set(bool state)
+{
+    mBlinkOnTimeMS = mBlinkOffTimeMS = 0;
+    DoSet(state);
+}
+
+void LEDWidget::Blink(uint32_t changeRateMS)
+{
+    Blink(changeRateMS, changeRateMS);
+}
+
+void LEDWidget::Blink(uint32_t onTimeMS, uint32_t offTimeMS)
+{
+    mBlinkOnTimeMS = onTimeMS;
+    mBlinkOffTimeMS = offTimeMS;
+    Animate();
+}
+
+void LEDWidget::Animate()
+{
+    if (mBlinkOnTimeMS != 0 && mBlinkOffTimeMS != 0)
+    {
+        int64_t nowUS = ::esp_timer_get_time();
+        int64_t stateDurUS = ((mState) ? mBlinkOnTimeMS : mBlinkOffTimeMS) * 1000LL;
+        int64_t nextChangeTimeUS = mLastChangeTimeUS + stateDurUS;
+
+        if (nowUS > nextChangeTimeUS)
+        {
+            DoSet(!mState);
+            mLastChangeTimeUS = nowUS;
+        }
+    }
+}
+
+void LEDWidget::DoSet(bool state)
+{
+    mState = state;
+    if (mGPIONum < GPIO_NUM_MAX)
+    {
+        gpio_set_level(mGPIONum, (state) ? 1 : 0);
+    }
+}
+

--- a/examples/wifi-echo/esp32/main/component.mk
+++ b/examples/wifi-echo/esp32/main/component.mk
@@ -1,0 +1,22 @@
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+#    Description:
+#      Component makefile for the ESP32 demo application.
+#
+# (Uses default behaviour of compiling all source files in directory, adding 'include' to include path.)
+
+COMPONENT_DEPENDS := chip

--- a/examples/wifi-echo/esp32/main/include/LEDWidget.h
+++ b/examples/wifi-echo/esp32/main/include/LEDWidget.h
@@ -1,0 +1,43 @@
+/*
+ *
+ *    Copyright (c) 2018 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef LED_WIDGET_H
+#define LED_WIDGET_H
+
+#include "driver/gpio.h"
+
+class LEDWidget
+{
+public:
+    void Init(gpio_num_t gpioNum);
+    void Set(bool state);
+    void Blink(uint32_t changeRateMS);
+    void Blink(uint32_t onTimeMS, uint32_t offTimeMS);
+    void Animate();
+
+private:
+    int64_t mLastChangeTimeUS;
+    uint32_t mBlinkOnTimeMS;
+    uint32_t mBlinkOffTimeMS;
+    gpio_num_t mGPIONum;
+    bool mState;
+
+    void DoSet(bool state);
+};
+
+#endif // TITLE_WIDGET_H

--- a/examples/wifi-echo/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/esp32/main/wifi-echo.cpp
@@ -1,0 +1,175 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <stdio.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_system.h"
+#include "esp_spi_flash.h"
+#include "esp_log.h"
+#include "esp_wifi.h"
+#include "esp_event_loop.h"
+#include "nvs_flash.h"
+#include "esp_heap_caps_init.h"
+#include "LEDWidget.h"
+
+#include <platform/CHIPDeviceLayer.h>
+#include <support/ErrorStr.h>
+
+using namespace ::chip;
+using namespace ::chip::DeviceLayer;
+
+extern void startServer(void);
+
+#if CONFIG_DEVICE_TYPE_M5STACK
+
+#define ATTENTION_BUTTON_GPIO_NUM GPIO_NUM_37        // Use the right button (button "C") as the attention button on M5Stack
+#define STATUS_LED_GPIO_NUM GPIO_NUM_MAX             // No status LED on M5Stack
+#define LIGHT_SWITCH_ON_BUTTON_GPIO_NUM GPIO_NUM_39  // Use the left button (button "A") as the light switch ON button on M5Stack
+#define LIGHT_SWITCH_OFF_BUTTON_GPIO_NUM GPIO_NUM_38 // Use the middle button (button "B") as the light switch OFF button on M5Stack
+#define LIGHT_CONTROLLER_OUTPUT_GPIO_NUM GPIO_NUM_2  // Use GPIO2 as the light controller output on M5Stack
+
+#elif CONFIG_DEVICE_TYPE_ESP32_DEVKITC
+
+#define ATTENTION_BUTTON_GPIO_NUM GPIO_NUM_0         // Use the IO0 button as the attention button on ESP32-DevKitC and compatibles
+#define STATUS_LED_GPIO_NUM GPIO_NUM_2               // Use LED1 (blue LED) as status LED on DevKitC
+#define LIGHT_SWITCH_ON_BUTTON_GPIO_NUM GPIO_NUM_34  // Use GPIO34 as the light switch ON button input on DevKitC
+#define LIGHT_SWITCH_OFF_BUTTON_GPIO_NUM GPIO_NUM_35 // Use GPIO35 as the light switch OFF button input on DevKitC
+#define LIGHT_CONTROLLER_OUTPUT_GPIO_NUM GPIO_NUM_33 // Use GPIO33 as the light controller output on DevKitC
+
+#else // !CONFIG_DEVICE_TYPE_ESP32_DEVKITC
+
+#error "Unsupported device type selected"
+
+#endif // !CONFIG_DEVICE_TYPE_ESP32_DEVKITC
+
+static LEDWidget statusLED;
+
+const char * TAG = "wifi-echo-demo";
+
+static void DeviceEventHandler(const ChipDeviceEvent * event, intptr_t arg);
+
+extern "C" void app_main()
+{
+    ESP_LOGI(TAG, "Wifi Echo Demo!");
+
+    /* Print chip information */
+    esp_chip_info_t chip_info;
+    esp_chip_info(&chip_info);
+
+    ESP_LOGI(TAG, "This is ESP32 chip with %d CPU cores, WiFi%s%s, ", chip_info.cores,
+             (chip_info.features & CHIP_FEATURE_BT) ? "/BT" : "", (chip_info.features & CHIP_FEATURE_BLE) ? "/BLE" : "");
+
+    ESP_LOGI(TAG, "silicon revision %d, ", chip_info.revision);
+
+    ESP_LOGI(TAG, "%dMB %s flash\n", spi_flash_get_chip_size() / (1024 * 1024),
+             (chip_info.features & CHIP_FEATURE_EMB_FLASH) ? "embedded" : "external");
+
+    CHIP_ERROR err; // A quick note about errors: CHIP adopts the error type and numbering
+                    // convention of the environment into which it is ported.  Thus esp_err_t
+                    // and CHIP_ERROR are in fact the same type, and both ESP-IDF errors
+                    // and CHIO-specific errors can be stored in the same value without
+                    // ambiguity.  For convenience, ESP_OK and CHIP_NO_ERROR are mapped
+                    // to the same value.
+
+    // Initialize the ESP NVS layer.
+    err = nvs_flash_init();
+    if (err != CHIP_NO_ERROR)
+    {
+        ESP_LOGE(TAG, "nvs_flash_init() failed: %s", ErrorStr(err));
+        return;
+    }
+
+    // Initialize the LwIP core lock.  This must be done before the ESP
+    // tcpip_adapter layer is initialized.
+    err = PlatformMgrImpl().InitLwIPCoreLock();
+    if (err != CHIP_NO_ERROR)
+    {
+        ESP_LOGE(TAG, "PlatformMgr().InitLocks() failed: %s", ErrorStr(err));
+        return;
+    }
+
+    // Initialize the ESP tcpip adapter.
+    tcpip_adapter_init();
+
+    // Arrange for the ESP event loop to deliver events into the CHIP Device layer.
+    err = esp_event_loop_init(PlatformManagerImpl::HandleESPSystemEvent, NULL);
+    if (err != CHIP_NO_ERROR)
+    {
+        ESP_LOGE(TAG, "esp_event_loop_init() failed: %s", ErrorStr(err));
+        return;
+    }
+
+    // Initialize the ESP WiFi layer.
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    err                    = esp_wifi_init(&cfg);
+    if (err != CHIP_NO_ERROR)
+    {
+        ESP_LOGE(TAG, "esp_event_loop_init() failed: %s", ErrorStr(err));
+        return;
+    }
+
+    // Initialize the CHIP stack.
+    err = PlatformMgr().InitChipStack();
+    if (err != CHIP_NO_ERROR)
+    {
+        ESP_LOGE(TAG, "PlatformMgr().InitChipStack() failed: %s", ErrorStr(err));
+        return;
+    }
+
+    // Configure the CHIP Connectivity Manager to automatically enable the WiFi AP interface
+    // whenever the WiFi station interface has not be configured.
+    ConnectivityMgr().SetWiFiAPMode(ConnectivityManager::kWiFiAPMode_OnDemand_NoStationProvision);
+
+    // Register a function to receive events from the CHIP device layer.  Note that calls to
+    // this function will happen on the CHIP event loop thread, not the app_main thread.
+    PlatformMgr().AddEventHandler(DeviceEventHandler, 0);
+
+    // Start a task to run the CHIP Device event loop.
+    err = PlatformMgr().StartEventLoopTask();
+    if (err != CHIP_NO_ERROR)
+    {
+        ESP_LOGE(TAG, "PlatformMgr().StartEventLoopTask() failed: %s", ErrorStr(err));
+        return;
+    }
+
+    statusLED.Init(STATUS_LED_GPIO_NUM);
+
+    // Start the Echo Server
+    startServer();
+
+    // Run the UI Loop
+    while (true)
+    {
+        statusLED.Blink(500);
+        statusLED.Animate();
+
+        vTaskDelay(50 / portTICK_PERIOD_MS);
+    }
+}
+
+/* Handle events from the CHIP Device layer.
+ *
+ * NOTE: This function runs on the CHIP event loop task.
+ */
+void DeviceEventHandler(const ChipDeviceEvent * event, intptr_t arg)
+{
+    if (event->Type == DeviceEventType::kSessionEstablished && event->SessionEstablished.IsCommissioner)
+    {
+        ESP_LOGI(TAG, "Commissioner detected!");
+    }
+}

--- a/examples/wifi-echo/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/esp32/main/wifi-echo.cpp
@@ -65,7 +65,7 @@ static void DeviceEventHandler(const ChipDeviceEvent * event, intptr_t arg);
 
 extern "C" void app_main()
 {
-    ESP_LOGI(TAG, "Wifi Echo Demo!");
+    ESP_LOGI(TAG, "WiFi Echo Demo!");
 
     /* Print chip information */
     esp_chip_info_t chip_info;

--- a/examples/wifi-echo/esp32/sdkconfig.defaults
+++ b/examples/wifi-echo/esp32/sdkconfig.defaults
@@ -1,0 +1,28 @@
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#    Copyright (c) 2018 Nest Labs, Inc.
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+#    Description:
+#      Some useful defaults for the demo app configuration.
+#
+
+
+# Default to 921600 baud when flashing and monitoring device
+CONFIG_ESPTOOLPY_BAUD_921600B=y
+CONFIG_ESPTOOLPY_BAUD=921600
+CONFIG_ESPTOOLPY_COMPRESSED=y
+CONFIG_MONITOR_BAUD_115200B=y
+CONFIG_MONITOR_BAUD=115200

--- a/examples/wifi-echo/esp32/third_party/connectedhomeip
+++ b/examples/wifi-echo/esp32/third_party/connectedhomeip
@@ -1,0 +1,1 @@
+../../../../../connectedhomeip/

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -542,7 +542,10 @@ inline CHIP_ERROR ConnectivityManager::Init(void)
     return static_cast<ImplClass *>(this)->_Init();
 }
 
-inline void ConnectivityManager::OnPlatformEvent(const ChipDeviceEvent * event) {}
+inline void ConnectivityManager::OnPlatformEvent(const ChipDeviceEvent * event)
+{
+    static_cast<ImplClass *>(this)->_OnPlatformEvent(event);
+}
 
 inline bool ConnectivityManager::CanStartWiFiScan(void)
 {

--- a/src/platform/ESP32/ESP32Utils.cpp
+++ b/src/platform/ESP32/ESP32Utils.cpp
@@ -25,6 +25,9 @@
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
 #include <platform/ESP32/ESP32Utils.h>
+#include <support/logging/CHIPLogging.h>
+#include <support/CodeUtils.h>
+#include <support/ErrorStr.h>
 
 #include "esp_event.h"
 #include "esp_wifi.h"
@@ -162,27 +165,6 @@ CHIP_ERROR ESP32Utils::SetAPMode(bool enabled)
 
 exit:
     return err;
-}
-
-WiFiSecurityType ESP32Utils::WiFiAuthModeToChipWiFiSecurityType(wifi_auth_mode_t authMode)
-{
-    switch (authMode)
-    {
-    case WIFI_AUTH_OPEN:
-        return kWiFiSecurityType_None;
-    case WIFI_AUTH_WEP:
-        return kWiFiSecurityType_WEP;
-    case WIFI_AUTH_WPA_PSK:
-        return kWiFiSecurityType_WPAPersonal;
-    case WIFI_AUTH_WPA2_PSK:
-        return kWiFiSecurityType_WPA2Personal;
-    case WIFI_AUTH_WPA_WPA2_PSK:
-        return kWiFiSecurityType_WPA2MixedPersonal;
-    case WIFI_AUTH_WPA2_ENTERPRISE:
-        return kWiFiSecurityType_WPA2Enterprise;
-    default:
-        return kWiFiSecurityType_NotSpecified;
-    }
 }
 
 int ESP32Utils::OrderScanResultsByRSSI(const void * _res1, const void * _res2)

--- a/src/platform/ESP32/LwIPCoreLock.cpp
+++ b/src/platform/ESP32/LwIPCoreLock.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <platform/internal/CHIPDeviceLayerInternal.h>
+#include <support/logging/CHIPLogging.h>
 
 namespace {
 

--- a/src/platform/Makefile.am
+++ b/src/platform/Makefile.am
@@ -138,8 +138,10 @@ libDeviceLayer_a_SOURCES               +=       \
     ESP32/PlatformManagerImpl.cpp               \
     ESP32/ConnectivityManagerImpl.cpp           \
     ESP32/ESP32Config.cpp                       \
+    ESP32/ESP32Utils.cpp                        \
     ESP32/Logging.cpp                           \
     ESP32/SystemTimeSupport.cpp                 \
+    ESP32/LwIPCoreLock.cpp                      \
     FreeRTOS/SystemTimeSupport.cpp              \
     $(NULL)
 


### PR DESCRIPTION
 #### Problem
The device layer for the ESP32 is never used because there's no demo application for that platform

 #### Summary of Changes
Added a very basic example for the ESP32. 

The application uses CHIP to setup the device's WiFi and in parallel hosts an Echo Server. Users can join the ESP32's network and poke at the Echo Server. 

This should provide a skeleton for us to start adding more networking and messaging structure into CHIP. I expect this example app to evolve dramatically over time. 

fixes #403
