### PR TITLE
Add support for nested container for restyle_path

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,8 +20,8 @@ RUN apt-get -fy install git vim emacs sudo \
     build-essential cmake cppcheck valgrind \
     wget curl telnet bsdtar \
     docker.io
-RUN groupadd --gid $USER_GID $USERNAME
-RUN useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME
+RUN groupadd -g $USER_GID $USERNAME
+RUN useradd -s /bin/bash -u $USER_UID -g $USER_GID -G docker -m $USERNAME
 RUN echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME
 RUN chmod 0440 /etc/sudoers.d/$USERNAME
 
@@ -36,5 +36,4 @@ RUN mkdir -p /home/vscode/bin
 RUN curl https://raw.githubusercontent.com/restyled-io/restyler/master/bin/restyle-path -o /home/vscode/bin/restyle-path
 RUN chmod +x /home/vscode/bin/restyle-path
 RUN chown -R vscode:vscode /home/vscode
-
-
+RUN echo "PATH=/home/vscode/bin:${PATH}" >> /home/vscode/.bashrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
     "name": "CHIP Ubuntu Development Environment",
     "runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
+    "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
     "build": {
         "dockerfile": "Dockerfile",
         "args": {
@@ -28,7 +29,7 @@
     "settings": {
         "terminal.integrated.shell.linux": "/bin/bash"
     },
-    "postCreateCommand": "source /usr/share/bash-completion/bash_completion && source /etc/bash_completion.d/git-prompt",
+    "postCreateCommand": "source /usr/share/bash-completion/bash_completion && source /etc/bash_completion.d/git-prompt && sudo chgrp docker /var/run/docker.sock",
     "remoteEnv": {
         "GIT_PS1_SHOWDIRTYSTATE": "1",
         "GIT_PS1_SHOWSTASHSTATE": "1",


### PR DESCRIPTION
#### Problem
 Can't run restyle-path from inside the devcontainer on MacOS

 #### Summary of Changes
 * add a bind mount for the unix socker to docker
 * chgrp it inside the container to docker
 * put dev user in the docker group
 * put restyle-path on vscode's PATH