### PR TITLE
Remove redundant nlforeign deps

### DIFF
--- a/src/ble/tests/Makefile.am
+++ b/src/ble/tests/Makefile.am
@@ -94,12 +94,10 @@ TestBleErrorStr_LDADD                                 = $(COMMON_LDADD)
 NLFOREIGN_FILE_DEPENDENCIES                           = \
    $(CHIP_LDADD)                                        \
    $(NULL)
-   
+
 NLFOREIGN_SUBDIR_DEPENDENCIES                         = \
    $(NLUNIT_TEST_FOREIGN_SUBDIR_DEPENDENCY)             \
    $(NULL)
-
-$(check_PROGRAMS): $(NLFOREIGN_FILE_DEPENDENCIES)
 
 if CHIP_BUILD_COVERAGE
 CLEANFILES                                            = $(wildcard *.gcda *.gcno)

--- a/src/crypto/tests/Makefile.am
+++ b/src/crypto/tests/Makefile.am
@@ -116,8 +116,6 @@ NLFOREIGN_SUBDIR_DEPENDENCIES                         = \
    $(NLUNIT_TEST_FOREIGN_SUBDIR_DEPENDENCY)             \
    $(NULL)
 
-$(check_PROGRAMS): $(NLFOREIGN_FILE_DEPENDENCIES)
-
 if CHIP_BUILD_COVERAGE
 CLEANFILES                                     = $(wildcard *.gcda *.gcno)
 

--- a/src/inet/tests/Makefile.am
+++ b/src/inet/tests/Makefile.am
@@ -172,10 +172,6 @@ NLFOREIGN_SUBDIR_DEPENDENCIES                         = \
    $(NLUNIT_TEST_FOREIGN_SUBDIR_DEPENDENCY)             \
    $(NULL)
 
-$(check_PROGRAMS): $(NLFOREIGN_FILE_DEPENDENCIES)
-
-$(noinst_PROGRAMS): $(NLFOREIGN_FILE_DEPENDENCIES)
-
 if CHIP_BUILD_COVERAGE
 CLEANFILES                                            = $(wildcard *.gcda *.gcno)
 

--- a/src/lib/core/tests/Makefile.am
+++ b/src/lib/core/tests/Makefile.am
@@ -106,8 +106,6 @@ NLFOREIGN_SUBDIR_DEPENDENCIES                         = \
    $(NLUNIT_TEST_FOREIGN_SUBDIR_DEPENDENCY)             \
    $(NULL)
 
-$(check_PROGRAMS): $(NLFOREIGN_FILE_DEPENDENCIES)
-
 if CHIP_BUILD_COVERAGE
 CLEANFILES                                            = $(wildcard *.gcda *.gcno)
 

--- a/src/lib/support/tests/Makefile.am
+++ b/src/lib/support/tests/Makefile.am
@@ -96,8 +96,6 @@ NLFOREIGN_FILE_DEPENDENCIES                           = \
    $(CHIP_LDADD)                                        \
    $(NULL)
 
-$(check_PROGRAMS): $(NLFOREIGN_FILE_DEPENDENCIES)
-
 if CHIP_BUILD_COVERAGE
 CLEANFILES                                            = $(wildcard *.gcda *.gcno)
 

--- a/src/system/tests/Makefile.am
+++ b/src/system/tests/Makefile.am
@@ -121,8 +121,6 @@ NLFOREIGN_SUBDIR_DEPENDENCIES                         = \
    $(NLUNIT_TEST_FOREIGN_SUBDIR_DEPENDENCY)             \
    $(NULL)
 
-$(check_PROGRAMS): $(NLFOREIGN_FILE_DEPENDENCIES)
-
 if CHIP_BUILD_COVERAGE
 CLEANFILES                                            = $(wildcard *.gcda *.gcno)
 


### PR DESCRIPTION
#### Problems
 TL;DR: we don't need these lines, may confuse folks, may slow the build

 More:
 1. not all check_PROGRAMS depend upon all foreign file libs
 2. each check program *already* lists their specific foreign file as a dependency

 NLFOREIGN_FILE_DEPENDENCIES is intended to describe to the make system
  what make command to run to arrive at that dependency.  The assumption
  is that the dependency is already listed by one of the non-foreign
  targets (as is the case in these makefiles)

 #### Summary of Changes
 whack the redundant deps

 test I used to verify this PR:
 ```
 <bootstrap>
 for dir in src/ble/tests src/crypto/tests src/inet/tests src/lib/core/tests src/lib/support/tests src/system/tests
 do
    make clean
    echo ============= $dir ===========
    make -C $dir check-TESTS
 done
 ```