### PR TITLE
Make the ESP32 Echo Server use Inet

### DIFF
--- a/examples/wifi-echo/esp32/main/EchoClient.cpp
+++ b/examples/wifi-echo/esp32/main/EchoClient.cpp
@@ -1,0 +1,115 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, softwarEchoe
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <string.h>
+#include <sys/param.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_system.h"
+#include "esp_wifi.h"
+#include "esp_event.h"
+#include "esp_log.h"
+#include "nvs_flash.h"
+#include "tcpip_adapter.h"
+
+#include "lwip/err.h"
+#include "lwip/sockets.h"
+#include "lwip/sys.h"
+#include <lwip/netdb.h>
+
+#define PORT CONFIG_ECHO_PORT
+#define RX_LEN 128
+#define ADDR_LEN 128
+
+#define HOST_IP_ADDR CONFIG_ECHO_HOST_IP
+
+static const char * TAG     = "echo_client";
+static const char * PAYLOAD = "Message from echo client!";
+
+static void udp_client_task(void * pvParameters)
+{
+    char rx_buffer[RX_LEN];
+    char host_ip[]  = HOST_IP_ADDR;
+    int addr_family = 0;
+    int ip_protocol = 0;
+
+    while (1)
+    {
+        struct sockaddr_in dest_addr;
+        dest_addr.sin_addr.s_addr = inet_addr(HOST_IP_ADDR);
+        dest_addr.sin_family      = AF_INET;
+        dest_addr.sin_port        = htons(PORT);
+        addr_family               = AF_INET;
+        ip_protocol               = IPPROTO_IP;
+
+        int sock = socket(addr_family, SOCK_DGRAM, ip_protocol);
+        if (sock < 0)
+        {
+            ESP_LOGE(TAG, "Unable to create socket: errno %d", errno);
+            break;
+        }
+        ESP_LOGI(TAG, "Socket created, sending to %s:%d", HOST_IP_ADDR, PORT);
+
+        while (1)
+        {
+            int err = sendto(sock, PAYLOAD, strlen(PAYLOAD), 0, (struct sockaddr *) &dest_addr, sizeof(dest_addr));
+            if (err < 0)
+            {
+                ESP_LOGE(TAG, "Error occurred during sending: errno %d", errno);
+                break;
+            }
+            ESP_LOGI(TAG, "Message sent");
+
+            struct sockaddr_in source_addr; // Large enough for both IPv4 or IPv6
+            socklen_t socklen = sizeof(source_addr);
+            int len           = recvfrom(sock, rx_buffer, sizeof(rx_buffer) - 1, 0, (struct sockaddr *) &source_addr, &socklen);
+
+            // Error occurred during receiving
+            if (len < 0)
+            {
+                ESP_LOGE(TAG, "recvfrom failed: errno %d", errno);
+                continue;
+            }
+            // Data received
+            else
+            {
+                rx_buffer[len] = 0; // Null-terminate whatever we received and treat like a string
+                ESP_LOGI(TAG, "Received %d bytes from %s:", len, host_ip);
+                if (strncmp(rx_buffer, PAYLOAD, strlen(PAYLOAD)) == 0)
+                {
+                    ESP_LOGI(TAG, "Received expected message...");
+                }
+            }
+
+            vTaskDelay(5000 / portTICK_PERIOD_MS);
+        }
+
+        if (sock != -1)
+        {
+            ESP_LOGE(TAG, "Shutting down socket and restarting...");
+            shutdown(sock, 0);
+            close(sock);
+        }
+    }
+    vTaskDelete(NULL);
+}
+
+// The echo client assumes the platform's networking has been setup already
+void startClient(void)
+{
+    xTaskCreate(udp_client_task, "udp_client", 4096, (void *) AF_INET, 5, NULL);
+}

--- a/examples/wifi-echo/esp32/main/Kconfig.projbuild
+++ b/examples/wifi-echo/esp32/main/Kconfig.projbuild
@@ -35,14 +35,12 @@ menu "WiFi Echo Demo"
             bool "M5Stack"
     endchoice
 
-    config ECHO_IPV4
-        bool "IPV4"
-        default y
-
-    config ECHO_IPV6
-        bool "IPV6"
-        default n
-        select EXAMPLE_CONNECT_IPV6
+    config USE_ECHO_CLIENT
+        bool "Enable the built-in Echo Client"
+        default "y"
+        help
+            This enables a local FreeRTOS Echo Client so that the end-to-end echo server can be
+            tested easily
 
     config ECHO_PORT
         int "Port"
@@ -50,5 +48,11 @@ menu "WiFi Echo Demo"
         default 8000
         help
             Local port the example server will listen on.
+
+    config ECHO_HOST_IP
+    string "IPV4 address"
+    default "127.0.0.1"
+    help
+        The IPV4 Address of the ECHO Server.
 
 endmenu

--- a/examples/wifi-echo/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/esp32/main/wifi-echo.cpp
@@ -33,7 +33,8 @@
 using namespace ::chip;
 using namespace ::chip::DeviceLayer;
 
-extern void startServer(void);
+extern void startServer(UDPEndPoint * endpoint);
+extern void startClient(void);
 
 #if CONFIG_DEVICE_TYPE_M5STACK
 
@@ -150,7 +151,11 @@ extern "C" void app_main()
     statusLED.Init(STATUS_LED_GPIO_NUM);
 
     // Start the Echo Server
-    startServer();
+    UDPEndPoint * sEndpoint = NULL;
+    startServer(sEndpoint);
+#if CONFIG_USE_ECHO_CLIENT
+    startClient();
+#endif
 
     // Run the UI Loop
     while (true)


### PR DESCRIPTION
 #### Problem

The ESP32 WiFi-echo example doesn't use the InetLayer and so doesn't pass signals through the CHIP stack
 #### Summary of Changes

- Switched the server to use Inet UDPEndPoints instead of BSD Sockets via the ESP32's LwIP. 
- Added an Echo send call to the Server (so it actually sends the Echo back to the client) 
- Added a local Echo Client(enabled by default) so that the end-to-end Echo Server <-> Client flow can be run without hopping onto the ESP32's SoftAP.

fixes #533
