### PR TITLE
Missing implementation of inter operable QR code format #316

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
             "environment": [],
             "externalConsole": false,
             "MIMode": "gdb",
-            "preLaunchTask": "Run Setup Payload Tests",
+            "preLaunchTask": "Build QRCode Payload Tests",
             "setupCommands": [
                 {
                     "description": "Enable pretty-printing for gdb",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -85,9 +85,9 @@
             "problemMatcher": ["$gcc"]
         },
         {
-            "label": "Run Setup Payload Tests",
+            "label": "Build QRCode Payload Tests",
             "type": "shell",
-            "command": "scripts/tests/setup_payload_tests.sh",
+            "command": "scripts/tests/qrcode_payload_tests.sh",
             "group": "none",
             "dependsOn": "Bootstrap",
             "problemMatcher": ["$gcc"]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -85,6 +85,14 @@
             "problemMatcher": ["$gcc"]
         },
         {
+            "label": "Run Setup Payload Tests",
+            "type": "shell",
+            "command": "scripts/tests/setup_payload_tests.sh",
+            "group": "none",
+            "dependsOn": "Bootstrap",
+            "problemMatcher": ["$gcc"]
+        },
+        {
             "label": "Build QRCode Payload Tests",
             "type": "shell",
             "command": "scripts/tests/qrcode_payload_tests.sh",

--- a/scripts/tests/qrcode_payload_tests.sh
+++ b/scripts/tests/qrcode_payload_tests.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make -C build/default/src/setup_payload/tests/ TestQrCode

--- a/scripts/tests/setup_payload_tests.sh
+++ b/scripts/tests/setup_payload_tests.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-make -C build/default/src/setup_payload check

--- a/scripts/tests/setup_payload_tests.sh
+++ b/scripts/tests/setup_payload_tests.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make -C build/default/src/setup_payload check

--- a/src/setup_payload/Base41.cpp
+++ b/src/setup_payload/Base41.cpp
@@ -17,17 +17,17 @@
 
 /**
  *    @file
- *      This file implements converting an array of bytes into a Base45 String and
+ *      This file implements converting an array of bytes into a Base41 String and
  *       the reverse.
  *
  *      The encoding chosen is: treat every 2 bytes of input data as a little-endian
- *        uint16_t, then div and mod that into 3 base45 characters, with the least-significant
+ *        uint16_t, then div and mod that into 3 base41 characters, with the least-significant
  *        encoding bits in the first character of the resulting string.  If an odd
  *        number of bytes is encoded, 2 characters are used to encode the last byte.
  *
  */
 
-#include "Base45.h"
+#include "Base41.h"
 
 #include <iostream>
 
@@ -35,26 +35,25 @@ using namespace std;
 
 namespace chip {
 
-static const int kBase45ChunkLen = 3;
+static const char codes[]        = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D',
+                              'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
+                              'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', ' ', '*', '+', '-', '.' };
+static const int kBase41ChunkLen = 3;
 static const int kBytesChunkLen  = 2;
+static const int radix           = sizeof(codes) / sizeof(codes[0]);
 
-string base45Encode(const uint8_t * buf, size_t buf_len)
+string base41Encode(const uint8_t * buf, size_t buf_len)
 {
-    const char codes[] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E',
-                           'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
-                           'U', 'V', 'W', 'X', 'Y', 'Z', ' ', '$', '%', '*', '+', '-', '.', '/', ':' };
-
     string result;
-    int radix = sizeof(codes) / sizeof(codes[0]);
 
     // eat little-endian uint16_ts from the byte array
-    // encode as 3 base45 characters
+    // encode as 3 base41 characters
 
     while (buf_len >= kBytesChunkLen)
     {
         int next = buf[0] + buf[1] * 256;
 
-        for (int _ = 0; _ < kBase45ChunkLen; _++)
+        for (int _ = 0; _ < kBase41ChunkLen; _++)
         {
             result += codes[next % radix];
             next /= radix;
@@ -66,7 +65,7 @@ string base45Encode(const uint8_t * buf, size_t buf_len)
     if (buf_len != 0)
     {
         int next = buf[0];
-        for (int _ = 0; _ < kBase45ChunkLen - 1; _++)
+        for (int _ = 0; _ < kBase41ChunkLen - 1; _++)
         {
             result += codes[next % radix];
             next /= radix;
@@ -78,25 +77,25 @@ string base45Encode(const uint8_t * buf, size_t buf_len)
 static inline CHIP_ERROR decodeChar(char c, uint8_t & value)
 {
     static const int kBogus = 255;
-    // map of base45 charater to numeric value
+    // map of base41 charater to numeric value
     // subtract 32 from the charater, then index into this array, if possible
     const uint8_t decodes[] = {
         36,     // ' ', =32
         kBogus, // '!', =33
         kBogus, // '"', =34
         kBogus, // '#', =35
-        37,     // '$', =36
-        38,     // '%', =37
+        kBogus, // '$', =36
+        kBogus, // '%', =37
         kBogus, // '&', =38
         kBogus, // ''', =39
         kBogus, // '(', =40
         kBogus, // ')', =41
-        39,     // '*', =42
-        40,     // '+', =43
+        37,     // '*', =42
+        38,     // '+', =43
         kBogus, // ',', =44
-        41,     // '-', =45
-        42,     // '.', =46
-        43,     // '/', =47
+        39,     // '-', =45
+        40,     // '.', =46
+        kBogus, // '/', =47
         0,      // '0', =48
         1,      // '1', =49
         2,      // '2', =50
@@ -107,7 +106,7 @@ static inline CHIP_ERROR decodeChar(char c, uint8_t & value)
         7,      // '7', =55
         8,      // '8', =56
         9,      // '9', =57
-        44,     // ':', =58
+        kBogus, // ':', =58
         kBogus, // ';', =59
         kBogus, // '<', =50
         kBogus, // '=', =61
@@ -154,53 +153,53 @@ static inline CHIP_ERROR decodeChar(char c, uint8_t & value)
     return 0;
 }
 
-CHIP_ERROR base45Decode(string base45, vector<uint8_t> & result)
+CHIP_ERROR base41Decode(string base41, vector<uint8_t> & result)
 {
     // not long enough, there are always at least 2
-    //  base45 characters
-    if (base45.length() % kBase45ChunkLen == 1)
+    //  base41 characters
+    if (base41.length() % kBase41ChunkLen == 1)
     {
         return CHIP_ERROR_INVALID_MESSAGE_LENGTH;
     }
     result.clear();
 
-    for (int i = 0; base45.length() - i >= kBase45ChunkLen; i += kBase45ChunkLen)
+    for (int i = 0; base41.length() - i >= kBase41ChunkLen; i += kBase41ChunkLen)
     {
         uint16_t value = 0;
 
-        for (int iv = i + (kBase45ChunkLen - 1); iv >= i; iv--)
+        for (int iv = i + (kBase41ChunkLen - 1); iv >= i; iv--)
         {
             uint8_t v;
-            CHIP_ERROR err = decodeChar(base45[iv], v);
+            CHIP_ERROR err = decodeChar(base41[iv], v);
 
             if (err != CHIP_NO_ERROR)
             {
                 return err;
             }
 
-            value *= 45;
+            value *= radix;
             value += v;
         }
 
         result.push_back(value % 256);
         result.push_back(value / 256);
     }
-    if (base45.length() % kBase45ChunkLen == kBase45ChunkLen - 1)
+    if (base41.length() % kBase41ChunkLen == kBase41ChunkLen - 1)
     {
-        int i          = base45.length() - (kBase45ChunkLen - 1);
+        int i          = base41.length() - (kBase41ChunkLen - 1);
         uint16_t value = 0;
 
-        for (int iv = i + (kBase45ChunkLen - 2); iv >= i; iv--)
+        for (int iv = i + (kBase41ChunkLen - 2); iv >= i; iv--)
         {
             uint8_t v;
-            CHIP_ERROR err = decodeChar(base45[iv], v);
+            CHIP_ERROR err = decodeChar(base41[iv], v);
 
             if (err != CHIP_NO_ERROR)
             {
                 return err;
             }
 
-            value *= 45;
+            value *= radix;
             value += v;
         }
 

--- a/src/setup_payload/Base41.h
+++ b/src/setup_payload/Base41.h
@@ -17,7 +17,7 @@
 
 /**
  *    @file
- *      Utility header to encode an input into a Base45 String
+ *      Utility header to encode an input into a Base41 String
  */
 
 #ifndef _SETUP_CODE_UTILS_H_
@@ -33,8 +33,8 @@ using namespace std;
 
 namespace chip {
 // returns CHIP_NO_ERROR on successful decode
-CHIP_ERROR base45Decode(string base45, vector<uint8_t> & out);
-string base45Encode(const uint8_t * buf, size_t buf_len);
+CHIP_ERROR base41Decode(string base41, vector<uint8_t> & out);
+string base41Encode(const uint8_t * buf, size_t buf_len);
 
 } // namespace chip
 

--- a/src/setup_payload/Makefile.am
+++ b/src/setup_payload/Makefile.am
@@ -41,7 +41,7 @@ libSetupPayload_a_SOURCES                                       = \
     ManualSetupPayloadParser.cpp                            \
     QRCodeSetupPayloadGenerator.cpp                         \
     SetupPayload.cpp                                        \
-    Base45.cpp                                              \
+    Base41.cpp                                              \
     QRCodeSetupPayloadParser.cpp                            \
    $(NULL)
 
@@ -50,7 +50,7 @@ dist_libSetupPayload_a_HEADERS                                  = \
     ManualSetupPayloadParser.h                              \
     QRCodeSetupPayloadGenerator.h                           \
     SetupPayload.h                                          \
-    Base45.h                                                \
+    Base41.h                                                \
     QRCodeSetupPayloadParser.h                              \
     $(NULL)
 

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -23,7 +23,7 @@
  */
 
 #include "QRCodeSetupPayloadGenerator.h"
-#include "Base45.h"
+#include "Base41.h"
 
 #include <iostream>
 #include <stdlib.h>
@@ -94,7 +94,7 @@ string QRCodeSetupPayloadGenerator::payloadBinaryRepresentation()
     }
 }
 
-string QRCodeSetupPayloadGenerator::payloadBase45Representation()
+string QRCodeSetupPayloadGenerator::payloadBase41Representation()
 {
     if (mPayload.isValidQRCodePayload())
     {
@@ -102,7 +102,9 @@ string QRCodeSetupPayloadGenerator::payloadBase45Representation()
 
         generateBitSet(mPayload, bits);
 
-        return base45Encode(bits, sizeof(bits) / sizeof(bits[0]));
+        string encodedPayload = base41Encode(bits, sizeof(bits) / sizeof(bits[0]));
+        encodedPayload.insert(0, kQRCodePrefix);
+        return encodedPayload;
     }
     else
     {

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.h
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.h
@@ -20,7 +20,7 @@
  *      This file describes a QRCode Setup Payload generator based on the
  *      CHIP specification.
  *
- *      The encoding of the binary data to a base45 string is as follows:
+ *      The encoding of the binary data to a base41 string is as follows:
  *      - Every 2 bytes (16 bits) of binary source data are encoded to 3
  *        characters of the Base-45 alphabet.
  *      - If an odd number of bytes are to be encoded, the remaining
@@ -44,7 +44,7 @@ private:
 
 public:
     string payloadBinaryRepresentation();
-    string payloadBase45Representation();
+    string payloadBase41Representation();
     QRCodeSetupPayloadGenerator(SetupPayload setupPayload) : mPayload(setupPayload){};
 };
 

--- a/src/setup_payload/QRCodeSetupPayloadParser.h
+++ b/src/setup_payload/QRCodeSetupPayloadParser.h
@@ -31,15 +31,15 @@ namespace chip {
 
 /**
  * @class QRCodeSetupPayloadParser
- * A class that can be used to convert a base45 encoded payload to a SetupPayload object
+ * A class that can be used to convert a base41 encoded payload to a SetupPayload object
  * */
 class QRCodeSetupPayloadParser
 {
 private:
-    string mBase45Representation;
+    string mBase41Representation;
 
 public:
-    QRCodeSetupPayloadParser(string base45Representation) : mBase45Representation(base45Representation){};
+    QRCodeSetupPayloadParser(string base41Representation) : mBase41Representation(base41Representation){};
     CHIP_ERROR populatePayload(SetupPayload & outPayload);
 };
 

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -53,6 +53,8 @@ const int kTotalPayloadDataSizeInBits =
      kReservedFieldLengthInBits);
 const int kTotalPayloadDataSizeInBytes = (kTotalPayloadDataSizeInBits + 7) / 8;
 
+const char * kQRCodePrefix = "CH:";
+
 class SetupPayload
 {
 public:

--- a/src/setup_payload/tests/tests_qrcode.cpp
+++ b/src/setup_payload/tests/tests_qrcode.cpp
@@ -291,6 +291,12 @@ int testExtractPayload()
     surprises += EXPECT_EQ(extractPayload(string("%Z%CH:ABC%DDD")), string("ABC"));
     surprises += EXPECT_EQ(extractPayload(string("CH:ABC%DDD")), string("ABC"));
     surprises += EXPECT_EQ(extractPayload(string("CH:ABC%")), string("ABC"));
+    surprises += EXPECT_EQ(extractPayload(string("%CH:")), string(""));
+    surprises += EXPECT_EQ(extractPayload(string("%CH:%")), string(""));
+    surprises += EXPECT_EQ(extractPayload(string("A%")), string(""));
+    surprises += EXPECT_EQ(extractPayload(string("CH:%")), string(""));
+    surprises += EXPECT_EQ(extractPayload(string("%CH:ABC")), string("ABC"));
+    surprises += EXPECT_EQ(extractPayload(string("ABC")), string(""));
 
     return surprises;
 }

--- a/src/setup_payload/tests/tests_qrcode.cpp
+++ b/src/setup_payload/tests/tests_qrcode.cpp
@@ -22,7 +22,7 @@
 #include <iostream>
 
 #include "SetupPayload.cpp"
-#include "Base45.cpp"
+#include "Base41.cpp"
 #include "QRCodeSetupPayloadGenerator.cpp"
 #include "QRCodeSetupPayloadParser.cpp"
 
@@ -51,7 +51,7 @@ int testPayloadByteArrayRep()
     return EXPECT_EQ(result, expected);
 }
 
-int testPayloadBase45Rep()
+int testPayloadBase41Rep()
 {
     SetupPayload payload;
 
@@ -64,30 +64,30 @@ int testPayloadBase45Rep()
     payload.setUpPINCode          = 2048;
 
     QRCodeSetupPayloadGenerator generator(payload);
-    string result   = generator.payloadBase45Representation();
-    string expected = "B20800G00G8G000";
+    string result   = generator.payloadBase41Representation();
+    string expected = "CH:J20800G00HKJ000";
 
     return EXPECT_EQ(result, expected);
 }
 
-int testBase45()
+int testBase41()
 {
     int surprises = 0;
 
     uint8_t input[] = { 10, 10, 10 };
 
-    surprises += EXPECT_EQ(base45Encode(input, 0), "");
+    surprises += EXPECT_EQ(base41Encode(input, 0), "");
 
-    surprises += EXPECT_EQ(base45Encode(input, 1), "A0");
+    surprises += EXPECT_EQ(base41Encode(input, 1), "A0");
 
-    surprises += EXPECT_EQ(base45Encode(input, 2), "5C1");
+    surprises += EXPECT_EQ(base41Encode(input, 2), "SL1");
 
-    surprises += EXPECT_EQ(base45Encode(input, 3), "5C1A0");
+    surprises += EXPECT_EQ(base41Encode(input, 3), "SL1A0");
 
-    surprises += EXPECT_EQ(base45Encode((uint8_t *) "Hello World!", sizeof("Hello World!") - 1), "8 C VDN44I3E.VD/94");
+    surprises += EXPECT_EQ(base41Encode((uint8_t *) "Hello World!", sizeof("Hello World!") - 1), "GHF.KGL+48-G5LGK35");
 
     vector<uint8_t> decoded = vector<uint8_t>();
-    surprises += EXPECT_EQ(base45Decode("8 C VDN44I3E.VD/94", decoded), CHIP_NO_ERROR);
+    surprises += EXPECT_EQ(base41Decode("GHF.KGL+48-G5LGK35", decoded), CHIP_NO_ERROR);
 
     string hello_world;
     for (size_t _ = 0; _ < decoded.size(); _++)
@@ -97,35 +97,35 @@ int testBase45()
     surprises += EXPECT_EQ(hello_world, "Hello World!");
 
     // short input
-    surprises += EXPECT_EQ(base45Decode("A0", decoded), CHIP_NO_ERROR);
+    surprises += EXPECT_EQ(base41Decode("A0", decoded), CHIP_NO_ERROR);
     surprises += EXPECT_EQ(decoded.size(), 2);
 
     // empty == empty
-    surprises += EXPECT_EQ(base45Decode("", decoded), CHIP_NO_ERROR);
+    surprises += EXPECT_EQ(base41Decode("", decoded), CHIP_NO_ERROR);
     surprises += EXPECT_EQ(decoded.size(), 0);
     // too short
-    surprises += EXPECT_EQ(base45Decode("A", decoded), CHIP_ERROR_INVALID_MESSAGE_LENGTH);
+    surprises += EXPECT_EQ(base41Decode("A", decoded), CHIP_ERROR_INVALID_MESSAGE_LENGTH);
 
     // outside valid chars
-    surprises += EXPECT_EQ(base45Decode("0\001", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    surprises += EXPECT_EQ(base45Decode("\0010", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    surprises += EXPECT_EQ(base45Decode("[0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    surprises += EXPECT_EQ(base45Decode("0[", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    surprises += EXPECT_EQ(base41Decode("0\001", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    surprises += EXPECT_EQ(base41Decode("\0010", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    surprises += EXPECT_EQ(base41Decode("[0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    surprises += EXPECT_EQ(base41Decode("0[", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
 
     // BOGUS chars
-    surprises += EXPECT_EQ(base45Decode("!0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    surprises += EXPECT_EQ(base45Decode("\"0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    surprises += EXPECT_EQ(base45Decode("#0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    surprises += EXPECT_EQ(base45Decode("&0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    surprises += EXPECT_EQ(base45Decode("'0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    surprises += EXPECT_EQ(base45Decode("(0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    surprises += EXPECT_EQ(base45Decode(")0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    surprises += EXPECT_EQ(base45Decode(",0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    surprises += EXPECT_EQ(base45Decode(";0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    surprises += EXPECT_EQ(base45Decode("<0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    surprises += EXPECT_EQ(base45Decode("=0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    surprises += EXPECT_EQ(base45Decode(">0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    surprises += EXPECT_EQ(base45Decode("@0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    surprises += EXPECT_EQ(base41Decode("!0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    surprises += EXPECT_EQ(base41Decode("\"0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    surprises += EXPECT_EQ(base41Decode("#0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    surprises += EXPECT_EQ(base41Decode("&0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    surprises += EXPECT_EQ(base41Decode("'0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    surprises += EXPECT_EQ(base41Decode("(0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    surprises += EXPECT_EQ(base41Decode(")0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    surprises += EXPECT_EQ(base41Decode(",0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    surprises += EXPECT_EQ(base41Decode(";0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    surprises += EXPECT_EQ(base41Decode("<0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    surprises += EXPECT_EQ(base41Decode("=0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    surprises += EXPECT_EQ(base41Decode(">0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    surprises += EXPECT_EQ(base41Decode("@0", decoded), CHIP_ERROR_INVALID_INTEGER_VALUE);
 
     return surprises;
 }
@@ -262,10 +262,10 @@ int testQRCodeToPayloadGeneration()
     payload.setUpPINCode          = 5221133;
 
     QRCodeSetupPayloadGenerator generator(payload);
-    string base45Rep = generator.payloadBase45Representation();
+    string base41Rep = generator.payloadBase41Representation();
 
     SetupPayload resultingPayload;
-    QRCodeSetupPayloadParser parser(base45Rep);
+    QRCodeSetupPayloadParser parser(base41Rep);
 
     CHIP_ERROR err  = parser.populatePayload(resultingPayload);
     bool didSucceed = err == CHIP_NO_ERROR;
@@ -277,11 +277,29 @@ int testQRCodeToPayloadGeneration()
     return surprises;
 }
 
+int testExtractPayload()
+{
+    int surprises = 0;
+    surprises += EXPECT_EQ(extractPayload(string("CH:ABC")), string("ABC"));
+    surprises += EXPECT_EQ(extractPayload(string("CH:")), string(""));
+    surprises += EXPECT_EQ(extractPayload(string("H:")), string(""));
+    surprises += EXPECT_EQ(extractPayload(string("ASCH:")), string(""));
+    surprises += EXPECT_EQ(extractPayload(string("Z%CH:ABC%")), string("ABC"));
+    surprises += EXPECT_EQ(extractPayload(string("Z%CH:ABC")), string("ABC"));
+    surprises += EXPECT_EQ(extractPayload(string("%Z%CH:ABC")), string("ABC"));
+    surprises += EXPECT_EQ(extractPayload(string("%Z%CH:ABC%")), string("ABC"));
+    surprises += EXPECT_EQ(extractPayload(string("%Z%CH:ABC%DDD")), string("ABC"));
+    surprises += EXPECT_EQ(extractPayload(string("CH:ABC%DDD")), string("ABC"));
+    surprises += EXPECT_EQ(extractPayload(string("CH:ABC%")), string("ABC"));
+
+    return surprises;
+}
+
 int main(int argc, char ** argv)
 {
-    int result = testBitsetLen() + testPayloadByteArrayRep() + testPayloadBase45Rep() + testBase45() + testSetupPayloadVerify() +
+    int result = testBitsetLen() + testPayloadByteArrayRep() + testPayloadBase41Rep() + testBase41() + testSetupPayloadVerify() +
         testPayloadEquality() + testPayloadInEquality() + testQRCodeToPayloadGeneration() +
-        testInvalidQRCodePayload_WrongCharacterSet() + testInvalidQRCodePayload_WrongLength();
+        testInvalidQRCodePayload_WrongCharacterSet() + testInvalidQRCodePayload_WrongLength() + testExtractPayload();
     if (result == 0)
     {
         printf("\n** All QRCode tests pass **\n");


### PR DESCRIPTION
 #### Problem
We would like a QR code be able to include other setup payload types (e.g zigee) in addition to CHIP.
To do this we use `%` as a delimiter between the strings. 
Also the CHIP payload needs to have a `CH:` prefix to let the parser identify the CHIP portion of the payload.
Lastly we also encode this using base-41 to avoid having to encode special characters like `:` or `%`. There is no loss of data packing efficiency by doing so. 

 #### Summary of Changes
Change from base45 to base41
Add support to extract the payload from a string that may potentially contain other payloads in it.

fixes #316
