### PR TITLE
Optimize-SUBDIRS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,9 +32,9 @@ AM_MAKEFLAGS                             = --no-print-directory
 
 SUBDIRS                                  = \
     examples                               \
-    third_party                            \
     src                                    \
     tests                                  \
+    third_party                            \
     $(NULL)
 
 PRETTY_SUBDIRS                           = \
@@ -42,7 +42,7 @@ PRETTY_SUBDIRS                           = \
     $(NULL)
 
 EXTRA_DIST                               = \
-    CODE_OF_CONDUCT.md                            \
+    CODE_OF_CONDUCT.md                     \
     CONTRIBUTING.md                        \
     Makefile-Android                       \
     Makefile-bootstrap                     \

--- a/config/efr32/efr32-chip.mk
+++ b/config/efr32/efr32-chip.mk
@@ -155,7 +155,6 @@ STD_LIBS += \
     -lDeviceLayer \
     -lCHIP \
     -lInetLayer \
-    -lnlfaultinjection \
     -lSystemLayer \
     -llwip \
     -lmbedtls
@@ -170,7 +169,6 @@ STD_LINK_PREREQUISITES += \
     $(CHIP_OUTPUT_DIR)/lib/libDeviceLayer.a \
     $(CHIP_OUTPUT_DIR)/lib/libCHIP.a \
     $(CHIP_OUTPUT_DIR)/lib/libInetLayer.a \
-    $(CHIP_OUTPUT_DIR)/lib/libnlfaultinjection.a \
     $(CHIP_OUTPUT_DIR)/lib/libSystemLayer.a \
     $(CHIP_OUTPUT_DIR)/lib/liblwip.a \
     $(CHIP_OUTPUT_DIR)/lib/libmbedtls.a

--- a/config/esp32/components/chip/component.mk
+++ b/config/esp32/components/chip/component.mk
@@ -137,7 +137,6 @@ COMPONENT_ADD_INCLUDEDIRS 	 = project-config \
 COMPONENT_ADD_LDFLAGS        = -L$(OUTPUT_DIR)/lib/ \
 					           -lCHIP \
 					           -lInetLayer \
-					           -lnlfaultinjection \
 					           -lSystemLayer \
 					           -lDeviceLayer
 

--- a/config/nrf5/nrf5-chip.mk
+++ b/config/nrf5/nrf5-chip.mk
@@ -146,7 +146,6 @@ STD_LIBS += \
     -lDeviceLayer \
     -lCHIP \
     -lInetLayer \
-    -lnlfaultinjection \
     -lSystemLayer \
     -llwip \
     -lmbedtls
@@ -161,7 +160,6 @@ STD_LINK_PREREQUISITES += \
     $(CHIP_OUTPUT_DIR)/lib/libDeviceLayer.a \
     $(CHIP_OUTPUT_DIR)/lib/libCHIP.a \
     $(CHIP_OUTPUT_DIR)/lib/libInetLayer.a \
-    $(CHIP_OUTPUT_DIR)/lib/libnlfaultinjection.a \
     $(CHIP_OUTPUT_DIR)/lib/libSystemLayer.a \
     $(CHIP_OUTPUT_DIR)/lib/liblwip.a \
     $(CHIP_OUTPUT_DIR)/lib/libmbedtls.a

--- a/third_party/Makefile.am
+++ b/third_party/Makefile.am
@@ -29,7 +29,6 @@ EXTRA_DIST                                   = \
     $(NULL)
 
 # Always package (e.g. for 'make dist') these subdirectories.
-
 DIST_SUBDIRS                                 = \
     lwip                                       \
     mbedtls                                    \
@@ -42,7 +41,7 @@ DIST_SUBDIRS                                 = \
 # of the 'distclean' target. Consequently, we conditionally include
 # them in DIST_SUBDIRS on invocation of 'distclean-recursive'
 
-distclean-recursive: DIST_SUBDIRS += $(NLASSERT_SUBDIRS) $(NLFAULTINJECTION_SUBDIRS) $(NLIO_SUBDIRS) $(NLUNIT_TEST_SUBDIRS) $(MBEDTLS_SUBDIRS)
+distclean-recursive: DIST_SUBDIRS += $(NLASSERT_SUBDIRS) $(NLFAULTINJECTION_SUBDIRS) $(NLIO_SUBDIRS) $(NLUNIT_TEST_SUBDIRS) mbedtls
 
 # Always build (e.g. for 'make all') these subdirectories.
 #
@@ -51,11 +50,6 @@ distclean-recursive: DIST_SUBDIRS += $(NLASSERT_SUBDIRS) $(NLFAULTINJECTION_SUBD
 # the third-party packages listed in repos.conf>=internal
 
 SUBDIRS                                      = \
-    $(NLASSERT_SUBDIRS)                        \
-    $(NLFAULTINJECTION_SUBDIRS)                \
-    $(NLIO_SUBDIRS)                            \
-    $(NLUNIT_TEST_SUBDIRS)                     \
-    $(MBEDTLS_SUBDIRS)                         \
     $(NULL)
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am


### PR DESCRIPTION
#### Problem
 nlassert and friends do not need to be built as SUBDIRS, they
  are built as explicit NLFOREIGN_DIR_DEPENDENCIES

 #### Summary of Changes
 Remove them from SUBDIRS

