### PR TITLE
Use configure cache

### DIFF
--- a/Makefile-Android
+++ b/Makefile-Android
@@ -242,7 +242,7 @@ AMFILES =                               \
 #
 define configure-action
 $(ECHO) "  CONFIG   $(ABI_CONFIG_TUPLE_$(1))..."
-(cd $(BuildPath)/$(ABI_CONFIG_TUPLE_$(1)) && $(AbsTopSourceDir)/configure \
+(cd $(BuildPath)/$(ABI_CONFIG_TUPLE_$(1)) && $(AbsTopSourceDir)/configure -C \
 CPP="$(CPP)" CC="$(CC)" CXX="$(CXX)" OBJC="$(OBJC)" OBJCXX="$(OBJCXX)" AR="$(AR)" RANLIB="$(RANLIB)" NM="$(NM)" STRIP="$(STRIP)" \
 INSTALL="$(INSTALL) $(INSTALLFLAGS)" \
 CPPFLAGS="$(CPPFLAGS)" \

--- a/Makefile-Standalone
+++ b/Makefile-Standalone
@@ -245,7 +245,7 @@ AMFILES =                               \
 #
 define configure-target
 $(ECHO) "  CONFIG   $(1)..."
-(cd $(BuildPath)/$(1) && $(AbsTopSourceDir)/configure \
+(cd $(BuildPath)/$(1) && $(AbsTopSourceDir)/configure -C \
 INSTALL="$(INSTALL) $(INSTALLFLAGS)" \
 --prefix=/ \
 --exec-prefix=/$(1) \

--- a/Makefile-iOS
+++ b/Makefile-iOS
@@ -257,7 +257,7 @@ AMFILES =                                                \
 #
 define configure-arch
 $(ECHO) "  CONFIG   $(1)-$(TargetTuple)..."
-(cd $(BuildPath)/$(1)-$(TargetTuple) && $(AbsTopSourceDir)/configure \
+(cd $(BuildPath)/$(1)-$(TargetTuple) && $(AbsTopSourceDir)/configure -C \
 CPP="$(CPP)" CC="$(CC)" CXX="$(CXX)" OBJC="$(OBJC)" OBJCXX="$(OBJCXX)" AR="$(AR)" RANLIB="$(RANLIB)" NM="$(NM)" STRIP="$(STRIP)" \
 INSTALL="$(INSTALL) $(INSTALLFLAGS)" \
 CPPFLAGS="$(CPPFLAGS)" \

--- a/config/efr32/efr32-chip.mk
+++ b/config/efr32/efr32-chip.mk
@@ -86,7 +86,7 @@ CHIP_CXXFLAGS = $(STD_CXXFLAGS) $(CXXFLAGS)
 # ==================================================
 
 CHIP_CONFIGURE_OPTIONS = \
-    AR="$(AR)" AS="$(AS)" CC="$(CCACHE) $(CC)" CXX="$(CCACHE) $(CXX)" \
+    -C AR="$(AR)" AS="$(AS)" CC="$(CCACHE) $(CC)" CXX="$(CCACHE) $(CXX)" \
     LD="$(LD)" OBJCOPY="$(OBJCOPY)" RANLIB="$(RANLIB)" INSTALL="$(INSTALL) $(INSTALLFLAGS)" \
     CPPFLAGS="$(CHIP_CPPFLAGS)" \
     CXXFLAGS="$(CHIP_CXXFLAGS)" \

--- a/config/esp32/components/chip/component.mk
+++ b/config/esp32/components/chip/component.mk
@@ -83,7 +83,7 @@ DoubleQuoteStr = $(QuoteChar)$(subst $(QuoteChar),\$(QuoteChar),$(subst \,\\,$(1
 # ESP-IDF's project.mk fails to define RANLIB appropriately, so we define it here.
 RANLIB                      := $(call dequote,$(CONFIG_TOOLPREFIX))ranlib
 
-CONFIGURE_OPTIONS       	:= AR="$(AR)" CC="$(CC)" CXX="$(CXX)" LD="$(LD)" OBJCOPY="$(OBJCOPY)" RANLIB="$(RANLIB)" \
+CONFIGURE_OPTIONS       	:= -C AR="$(AR)" CC="$(CC)" CXX="$(CXX)" LD="$(LD)" OBJCOPY="$(OBJCOPY)" RANLIB="$(RANLIB)" \
                                INSTALL="$(INSTALL) $(INSTALLFLAGS)" \
                                CFLAGS=$(call DoubleQuoteStr, $(CFLAGS)) \
                                CPPFLAGS=$(call DoubleQuoteStr, $(CPPFLAGS)) \

--- a/config/nrf5/nrf5-chip.mk
+++ b/config/nrf5/nrf5-chip.mk
@@ -86,6 +86,7 @@ DoubleQuoteStr = $(QuoteChar)$(subst $(QuoteChar),\$(QuoteChar),$(subst \,\\,$(1
 # ==================================================
 
 CHIP_CONFIGURE_OPTIONS = \
+    -C \
     AR="$(AR)" AS="$(AS)" CC="$(CCACHE) $(CC)" CXX="$(CCACHE) $(CXX)" \
     LD="$(LD)" OBJCOPY="$(OBJCOPY)" RANLIB="$(RANLIB)" INSTALL="$(INSTALL) $(INSTALLFLAGS)" \
     CPPFLAGS=$(call DoubleQuoteStr, $(CHIP_CPPFLAGS)) \

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -94,7 +94,7 @@ be run again for the changes to be picked up.
 
 mkdir build/<CONFIG>
 cd build/<CONFIG>
-../../configure <CONFIG ARGUMENTS>
+../../configure -C <CONFIG ARGUMENTS>
 ```
 
 Where `<CONFIG>` is something that describes what configuration (as described by


### PR DESCRIPTION
#### Problem
 CHIP's configure options are cache-able but we're not generally caching them

 #### Summary of Changes
 Use config.cache