### PR TITLE
Remove unused nlfaultinjection from apps

### DIFF
--- a/config/efr32/efr32-chip.mk
+++ b/config/efr32/efr32-chip.mk
@@ -155,7 +155,6 @@ STD_LIBS += \
     -lDeviceLayer \
     -lCHIP \
     -lInetLayer \
-    -lnlfaultinjection \
     -lSystemLayer \
     -llwip \
     -lmbedtls
@@ -170,7 +169,6 @@ STD_LINK_PREREQUISITES += \
     $(CHIP_OUTPUT_DIR)/lib/libDeviceLayer.a \
     $(CHIP_OUTPUT_DIR)/lib/libCHIP.a \
     $(CHIP_OUTPUT_DIR)/lib/libInetLayer.a \
-    $(CHIP_OUTPUT_DIR)/lib/libnlfaultinjection.a \
     $(CHIP_OUTPUT_DIR)/lib/libSystemLayer.a \
     $(CHIP_OUTPUT_DIR)/lib/liblwip.a \
     $(CHIP_OUTPUT_DIR)/lib/libmbedtls.a

--- a/config/esp32/components/chip/component.mk
+++ b/config/esp32/components/chip/component.mk
@@ -137,7 +137,6 @@ COMPONENT_ADD_INCLUDEDIRS 	 = project-config \
 COMPONENT_ADD_LDFLAGS        = -L$(OUTPUT_DIR)/lib/ \
 					           -lCHIP \
 					           -lInetLayer \
-					           -lnlfaultinjection \
 					           -lSystemLayer \
 					           -lDeviceLayer
 

--- a/config/nrf5/nrf5-chip.mk
+++ b/config/nrf5/nrf5-chip.mk
@@ -147,7 +147,6 @@ STD_LIBS += \
     -lDeviceLayer \
     -lCHIP \
     -lInetLayer \
-    -lnlfaultinjection \
     -lSystemLayer \
     -llwip \
     -lmbedtls
@@ -162,7 +161,6 @@ STD_LINK_PREREQUISITES += \
     $(CHIP_OUTPUT_DIR)/lib/libDeviceLayer.a \
     $(CHIP_OUTPUT_DIR)/lib/libCHIP.a \
     $(CHIP_OUTPUT_DIR)/lib/libInetLayer.a \
-    $(CHIP_OUTPUT_DIR)/lib/libnlfaultinjection.a \
     $(CHIP_OUTPUT_DIR)/lib/libSystemLayer.a \
     $(CHIP_OUTPUT_DIR)/lib/liblwip.a \
     $(CHIP_OUTPUT_DIR)/lib/libmbedtls.a


### PR DESCRIPTION
#### Problem
 nlfaultinjection is listed on the link line, but is unused by these applications

 #### Summary of Changes
 removal