### PR TITLE
Minor: Ignore backup sdk config for the ESP32 example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ third_party/mbedtls/
 
 # Example specific rules
 examples/**/sdkconfig
+examples/**/sdkconfig.old


### PR DESCRIPTION
 #### Problem
Changing the ESP32 example causes a untracked file to show up in git
 #### Summary of Changes
Add the backup file to gitignore