### PR TITLE
Allow the ESP32 example to use a pre-configured WiFi Network

### DIFF
--- a/examples/wifi-echo/esp32/README.md
+++ b/examples/wifi-echo/esp32/README.md
@@ -63,7 +63,7 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
     press and hold the `boot` button on the device while it's trying to connect
     before flashing.
 
-          $  make flash monitor ESPPORT=/dev/tty.SLAB_USBtoUART
+          $ idf make flash monitor ESPPORT=/dev/tty.SLAB_USBtoUART
 
     Note: Some users might have to install the
     [VCP driver](https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers)
@@ -71,15 +71,54 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
 
 ## Using the Echo Server
 
-After the application has been flashed, connect the ESP32's Soft-AP. It's
-usually something like `CHIP_DEMO-XXXX` where the last 4 digits are from the
-device's MAC address.
+There are two ways to use the Echo Server running on the deivce.
 
-Once you're connected, the server's IP can be found at the gateway address and
-at the listed port number(Default: `8000`).
+### Connect the ESP32 to a 2.4GHz Network of your choice
 
-Then running the following command will ping the ESP32 and cause it to echo. If
-necessary replace the `192.168.4.1` with the address printed by the device in
-the monitor.
+1.  To connect the device to your network all you need to do is give it the
+    credentials to your network via the `menuconfig` target.
 
-          $ echo "Hello over IP" | nc -w1 -u 192.168.4.1 8000
+                $ idf make menuconfig
+
+2.  While in the configurator, navigate to
+    `Component Config`->`CHIP Device Layer`->`WiFi Station Options` and fill out
+    the WiFi SSID and Password.
+
+3.  Now flash the device with the same command as before. (Use the right `/dev`
+    device)
+
+                $ idf make flash monitor ESPPORT=/dev/tty.SLAB_USBtoUART
+
+4.  The device should boot up and connect to your network. When that happens you
+    will see a long like this in the monitor.
+
+                I (5524) chip[DL]: SYSTEM_EVENT_STA_GOT_IP
+                I (5524) chip[DL]: IPv4 address changed on WiFi station interface: <IP_ADDRESS>...
+
+5.  Then running the following command will ping the ESP32 and cause it to echo.
+    If necessary replace the `<IP_ADDRESS>` with the address printed by the
+    device in the monitor.
+
+                $ echo "Hello over IP" | nc -w1 -u 192.168.4.1 8000
+
+Note: The ESP32 does not support 5GHz networks. Also, the Device will presist
+your network configuration. To erase it, simply run.
+
+                $ idf make erase_flash ESPPORT=/dev/tty.SLAB_USBtoUART
+
+### Use the ESP32's Network
+
+Alternatively, you can connect to the ESP32's Soft-AP directly.
+
+1.  After the application has been flashed, connect the ESP32's Soft-AP. It's
+    usually something like `CHIP_DEMO-XXXX` where the last 4 digits are from the
+    device's MAC address.
+
+2.  Once you're connected, the server's IP can be found at the gateway address
+    and at the listed port number(Default: `8000`).
+
+3.  Then running the following command will ping the ESP32 and cause it to echo.
+    If necessary replace the `192.168.4.1` with the address printed by the
+    device in the monitor.
+
+              $ echo "Hello over IP" | nc -w1 -u 192.168.4.1 8000

--- a/examples/wifi-echo/esp32/README.md
+++ b/examples/wifi-echo/esp32/README.md
@@ -101,7 +101,7 @@ There are two ways to use the Echo Server running on the device.
 
                 $ echo "Hello over IP" | nc -w1 -u 192.168.4.1 8000
 
-Note: The ESP32 does not support 5GHz networks. Also, the Device will presist
+Note: The ESP32 does not support 5GHz networks. Also, the Device will persist
 your network configuration. To erase it, simply run.
 
                 $ idf make erase_flash ESPPORT=/dev/tty.SLAB_USBtoUART

--- a/examples/wifi-echo/esp32/README.md
+++ b/examples/wifi-echo/esp32/README.md
@@ -71,7 +71,7 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
 
 ## Using the Echo Server
 
-There are two ways to use the Echo Server running on the deivce.
+There are two ways to use the Echo Server running on the device.
 
 ### Connect the ESP32 to a 2.4GHz Network of your choice
 

--- a/examples/wifi-echo/esp32/README.md
+++ b/examples/wifi-echo/esp32/README.md
@@ -90,7 +90,7 @@ There are two ways to use the Echo Server running on the deivce.
                 $ idf make flash monitor ESPPORT=/dev/tty.SLAB_USBtoUART
 
 4.  The device should boot up and connect to your network. When that happens you
-    will see a long like this in the monitor.
+    will see a log like this in the monitor.
 
                 I (5524) chip[DL]: SYSTEM_EVENT_STA_GOT_IP
                 I (5524) chip[DL]: IPv4 address changed on WiFi station interface: <IP_ADDRESS>...

--- a/examples/wifi-echo/esp32/README.md
+++ b/examples/wifi-echo/esp32/README.md
@@ -75,8 +75,8 @@ There are two ways to use the Echo Server running on the device.
 
 ### Connect the ESP32 to a 2.4GHz Network of your choice
 
-1.  To connect the device to your network all you need to do is give it the
-    credentials to your network via the `menuconfig` target.
+1.  To connect the device to your network, give it the network details via the
+    `menuconfig` target.
 
                 $ idf make menuconfig
 

--- a/examples/wifi-echo/esp32/main/EchoClient.cpp
+++ b/examples/wifi-echo/esp32/main/EchoClient.cpp
@@ -42,6 +42,7 @@ static const char * PAYLOAD = "Message from echo client!";
 
 static void udp_client_task(void * pvParameters)
 {
+#if USE_ECHO_CLIENT
     char rx_buffer[RX_LEN];
     char host_ip[]  = HOST_IP_ADDR;
     int addr_family = 0;
@@ -106,10 +107,13 @@ static void udp_client_task(void * pvParameters)
         }
     }
     vTaskDelete(NULL);
+#endif
 }
 
 // The echo client assumes the platform's networking has been setup already
 void startClient(void)
 {
+#if USE_ECHO_CLIENT
     xTaskCreate(udp_client_task, "udp_client", 4096, (void *) AF_INET, 5, NULL);
+#endif
 }

--- a/examples/wifi-echo/esp32/main/EchoServer.cpp
+++ b/examples/wifi-echo/esp32/main/EchoServer.cpp
@@ -64,7 +64,7 @@ static void echo(IPEndPointBasis * endpoint, System::PacketBuffer * buffer, cons
                  packet_info->DestPort, static_cast<size_t>(data_len));
 
         // attempt to print the incoming message
-        char msg_buffer[data_len];
+        char msg_buffer[data_len + 1];
         msg_buffer[data_len] = 0; // Null-terminate whatever we received and treat like a string...
         memcpy(msg_buffer, buffer->Start(), data_len);
         ESP_LOGI(TAG, "Client sent: \"%s\"", msg_buffer);

--- a/examples/wifi-echo/esp32/main/EchoServer.cpp
+++ b/examples/wifi-echo/esp32/main/EchoServer.cpp
@@ -64,7 +64,7 @@ static void echo(IPEndPointBasis * endpoint, System::PacketBuffer * buffer, cons
                  packet_info->DestPort, static_cast<size_t>(data_len));
 
         // attempt to print the incoming message
-        char msg_buffer[data_len + 1];
+        char msg_buffer[data_len];
         msg_buffer[data_len] = 0; // Null-terminate whatever we received and treat like a string...
         memcpy(msg_buffer, buffer->Start(), data_len);
         ESP_LOGI(TAG, "Client sent: \"%s\"", msg_buffer);

--- a/examples/wifi-echo/esp32/main/Kconfig.projbuild
+++ b/examples/wifi-echo/esp32/main/Kconfig.projbuild
@@ -35,13 +35,6 @@ menu "WiFi Echo Demo"
             bool "M5Stack"
     endchoice
 
-    config USE_ECHO_CLIENT
-        bool "Enable the built-in Echo Client"
-        default "y"
-        help
-            This enables a local FreeRTOS Echo Client so that the end-to-end echo server can be
-            tested easily
-
     config ECHO_PORT
         int "Port"
         range 0 65535
@@ -49,10 +42,17 @@ menu "WiFi Echo Demo"
         help
             Local port the example server will listen on.
 
+    config USE_ECHO_CLIENT
+        bool "Enable the built-in Echo Client"
+        default "y"
+        help
+            This enables a local FreeRTOS Echo Client so that the end-to-end echo server can be
+            tested easily
+
     config ECHO_HOST_IP
     string "IPV4 address"
     default "127.0.0.1"
+    depends on USE_ECHO_CLIENT
     help
         The IPV4 Address of the ECHO Server.
-
 endmenu

--- a/examples/wifi-echo/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/esp32/main/wifi-echo.cpp
@@ -132,8 +132,8 @@ extern "C" void app_main()
         return;
     }
 
-    // Configure the CHIP Connectivity Manager to automatically enable the WiFi AP interface
-    // whenever the WiFi station interface has not be configured.
+    // Configure the CHIP Connectivity Manager to always enable the AP. The Station interface
+    // will be enabled automatically if the required configuration is set.
     ConnectivityMgr().SetWiFiAPMode(ConnectivityManager::kWiFiAPMode_Enabled);
 
     // Register a function to receive events from the CHIP device layer.  Note that calls to

--- a/examples/wifi-echo/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/esp32/main/wifi-echo.cpp
@@ -134,7 +134,7 @@ extern "C" void app_main()
 
     // Configure the CHIP Connectivity Manager to automatically enable the WiFi AP interface
     // whenever the WiFi station interface has not be configured.
-    ConnectivityMgr().SetWiFiAPMode(ConnectivityManager::kWiFiAPMode_OnDemand_NoStationProvision);
+    ConnectivityMgr().SetWiFiAPMode(ConnectivityManager::kWiFiAPMode_Enabled);
 
     // Register a function to receive events from the CHIP device layer.  Note that calls to
     // this function will happen on the CHIP event loop thread, not the app_main thread.

--- a/src/platform/Makefile.am
+++ b/src/platform/Makefile.am
@@ -60,6 +60,8 @@ noinst_HEADERS                          = \
     @top_srcdir@/src/include/platform/ESP32/SoftwareUpdateManagerImpl.h \
     @top_srcdir@/src/include/platform/ESP32/CHIPDevicePlatformEvent.h \
     @top_srcdir@/src/include/platform/ESP32/NetworkProvisioningServerImpl.h \
+    @top_srcdir@/src/include/platform/ESP32/ESP32Utils.h \
+    @top_srcdir@/src/include/platform/ESP32/ESP32Config.h \
     @top_srcdir@/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.h \
     @top_srcdir@/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp \
     @top_srcdir@/src/include/platform/GeneralUtils.h \


### PR DESCRIPTION
 #### Problem
Testing the ESP32 echo server requires hopping onto the device's Soft-AP. 
This is a little bit inconvenient.

 #### Summary of Changes
The ESP32 Device Layer already supports connecting to a Network defined during the example's configure stage. Added documentation to show how to use that.
