### PR TITLE
Add CHIPCounter and PersistedCounter from openweave.

### DIFF
--- a/src/include/platform/PersistedStorage.h
+++ b/src/include/platform/PersistedStorage.h
@@ -36,6 +36,8 @@ namespace PersistedStorage {
 
 typedef CHIP_CONFIG_PERSISTED_STORAGE_KEY_TYPE Key;
 
+constexpr Key kEmptyKey = nullptr;
+
 /**
  *  @brief
  *    Read integer value of a key from persistent storage.

--- a/src/include/platform/PersistedStorage.h
+++ b/src/include/platform/PersistedStorage.h
@@ -34,9 +34,26 @@ namespace chip {
 namespace Platform {
 namespace PersistedStorage {
 
+// Persistent storage key type is const char * in core config, however
+// it is uint8_t/uint16_t on other platofmrs (EFR32 and nRF5 respectively)
 typedef CHIP_CONFIG_PERSISTED_STORAGE_KEY_TYPE Key;
 
-constexpr Key kEmptyKey = nullptr;
+namespace internal {
+template <typename T>
+struct EmptyKey
+{
+    static constexpr T value = 0; // handles numeric values
+};
+
+template <>
+struct EmptyKey<const char *>
+{
+    static constexpr const char * value = nullptr;
+};
+
+} // namespace internal
+
+constexpr Key kEmptyKey = internal::EmptyKey<Key>::value;
 
 /**
  *  @brief

--- a/src/inet/InetArgParser.cpp
+++ b/src/inet/InetArgParser.cpp
@@ -1,6 +1,7 @@
 /*
  *
  *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2017 Nest Labs, Inc.
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/inet/InetArgParser.cpp
+++ b/src/inet/InetArgParser.cpp
@@ -1,0 +1,47 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Support functions for parsing command-line arguments for Inet types
+ *
+ */
+
+#include <inet/InetArgParser.h>
+#include <inet/IPAddress.h>
+
+namespace chip {
+namespace ArgParser {
+
+/**
+ * Parse an IP address in text form.
+ *
+ * @param[in]  str    A pointer to a NULL-terminated C string containing
+ *                    the address to parse.
+ * @param[out] output A reference to an IPAddress object in which the parsed
+ *                    value will be stored on success.
+ *
+ * @return true if the value was successfully parsed; false if not.
+ */
+bool ParseIPAddress(const char * str, chip::Inet::IPAddress & output)
+{
+    return chip::Inet::IPAddress::FromString(str, output);
+}
+
+} // namespace ArgParser
+} // namespace chip

--- a/src/inet/InetArgParser.h
+++ b/src/inet/InetArgParser.h
@@ -1,6 +1,7 @@
 /*
  *
  *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2017 Nest Labs, Inc.
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/inet/InetArgParser.h
+++ b/src/inet/InetArgParser.h
@@ -34,7 +34,7 @@
 namespace chip {
 namespace ArgParser {
 
-extern bool ParseIPAddress(const char * str, chip::Inet::IPAddress & output);
+bool ParseIPAddress(const char * str, chip::Inet::IPAddress & output);
 
 } // namespace ArgParser
 } // namespace chip

--- a/src/inet/InetArgParser.h
+++ b/src/inet/InetArgParser.h
@@ -1,0 +1,43 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Support functions for parsing command-line arguments for Inet types
+ *
+ */
+
+#ifndef INETARGPARSER_H_
+#define INETARGPARSER_H_
+
+#if CHIP_CONFIG_ENABLE_ARG_PARSER
+
+#include <support/CHIPArgParser.hpp>
+#include <inet/IPAddress.h>
+
+namespace chip {
+namespace ArgParser {
+
+extern bool ParseIPAddress(const char * str, chip::Inet::IPAddress & output);
+
+} // namespace ArgParser
+} // namespace chip
+
+#endif // CHIP_CONFIG_ENABLE_ARG_PARSER
+
+#endif // INETARGPARSER_H_

--- a/src/inet/InetLayer.am
+++ b/src/inet/InetLayer.am
@@ -30,6 +30,7 @@ CHIP_BUILD_INET_LAYER_SOURCE_FILES                         = \
     @top_builddir@/src/inet/IPAddress.cpp                    \
     @top_builddir@/src/inet/IPEndPointBasis.cpp              \
     @top_builddir@/src/inet/IPPrefix.cpp                     \
+    @top_builddir@/src/inet/InetArgParser.cpp                \
     @top_builddir@/src/inet/InetError.cpp                    \
     @top_builddir@/src/inet/InetInterface.cpp                \
     @top_builddir@/src/inet/InetLayer.cpp                    \
@@ -48,6 +49,7 @@ CHIP_BUILD_INET_LAYER_HEADER_FILES                         = \
     @top_builddir@/src/inet/IPEndPointBasis.h                \
     @top_builddir@/src/inet/IPPrefix.h                       \
     @top_builddir@/src/inet/Inet.h                           \
+    @top_builddir@/src/inet/InetArgParser.h                  \
     @top_builddir@/src/inet/InetBuffer.h                     \
     @top_builddir@/src/inet/InetConfig.h                     \
     @top_builddir@/src/inet/InetError.h                      \
@@ -92,4 +94,3 @@ endif # CHIP_SYSTEM_CONFIG_USE_SOCKETS
 if CHIP_WITH_NLFAULTINJECTION
 CHIP_BUILD_INET_LAYER_SOURCE_FILES += @top_builddir@/src/inet/InetFaultInjection.cpp
 endif # CHIP_WITH_NLFAULTINJECTION
-

--- a/src/inet/tests/TestInetCommon.cpp
+++ b/src/inet/tests/TestInetCommon.cpp
@@ -637,7 +637,7 @@ static void RebootCallbackFn(void)
 
     // Need to close any open file descriptor above stdin/out/err.
     // There is no portable way to get the max fd number.
-    // Given that Weave's test apps don't open a large number of files,
+    // Given that CHIP's test apps don't open a large number of files,
     // FD_SETSIZE should be a reasonable upper bound (see the documentation
     // of select).
     for (i = 3; i < FD_SETSIZE; i++)

--- a/src/inet/tests/TestInetCommonOptions.h
+++ b/src/inet/tests/TestInetCommonOptions.h
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include <inet/InetLayer.h>
+#include <inet/InetArgParser.h>
 #include <core/CHIPCore.h>
 #include <support/CHIPArgParser.hpp>
 #include <system/SystemLayer.h>

--- a/src/lib/support/CHIPArgParser.cpp
+++ b/src/lib/support/CHIPArgParser.cpp
@@ -59,7 +59,6 @@ namespace chip {
 namespace ArgParser {
 
 using namespace chip;
-using namespace chip::Inet;
 
 static char * MakeShortOptions(OptionSet ** optSets);
 static struct option * MakeLongOptions(OptionSet ** optSets);
@@ -882,24 +881,9 @@ bool ParseInt(const char * str, uint8_t & output)
     return false;
 }
 
-/**
- * Parse an IP address in text form.
- *
- * @param[in]  str    A pointer to a NULL-terminated C string containing
- *                    the address to parse.
- * @param[out] output A reference to an IPAddress object in which the parsed
- *                    value will be stored on success.
- *
- * @return true if the value was successfully parsed; false if not.
- */
-bool ParseIPAddress(const char * str, IPAddress & output)
-{
-    return IPAddress::FromString(str, output);
-}
-
 #if CHIP_ARG_PARSER_PARSE_NODE_ID
 /**
- * Parse a Weave node id in text form.
+ * Parse a CHIP node id in text form.
  *
  * @param[in]  str    A pointer to a NULL-terminated C string containing
  *                    the node id to parse.
@@ -931,7 +915,7 @@ bool ParseNodeId(const char * str, uint64_t & nodeId)
 
 #if CHIP_ARG_PARSER_PARSE_FABRIC_ID
 /**
- * Parse a Weave fabric id in text form.
+ * Parse a CHIP fabric id in text form.
  *
  * @param[in]  str              A pointer to a NULL-terminated C string containing
  *                              the fabric id to parse.

--- a/src/lib/support/CHIPArgParser.hpp
+++ b/src/lib/support/CHIPArgParser.hpp
@@ -113,7 +113,7 @@ bool ParseArgsFromEnvVar(const char * progName, const char * varName, OptionSet 
 
 void PrintOptionHelp(OptionSet * optionSets[], FILE * s);
 
-void (*PrintArgError)(const char * msg, ...);
+extern void (*PrintArgError)(const char * msg, ...);
 void DefaultPrintArgError(const char * msg, ...);
 
 // Utility functions for parsing common argument value types.
@@ -160,4 +160,4 @@ public:
 
 #endif // CHIP_CONFIG_ENABLE_ARG_PARSER
 
-#endif // NLARGPARSER_H_
+#endif // CHIPARGPARSER_H_

--- a/src/lib/support/CHIPArgParser.hpp
+++ b/src/lib/support/CHIPArgParser.hpp
@@ -94,43 +94,42 @@ private:
     static bool CallHandleFunct(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg);
 };
 
-extern bool ParseArgs(const char * progName, int argc, char * argv[], OptionSet * optSets[]);
-extern bool ParseArgs(const char * progName, int argc, char * argv[], OptionSet * optSets[],
-                      NonOptionArgHandlerFunct nonOptArgHandler);
-extern bool ParseArgs(const char * progName, int argc, char * argv[], OptionSet * optSets[],
-                      NonOptionArgHandlerFunct nonOptArgHandler, bool ignoreUnknown);
+bool ParseArgs(const char * progName, int argc, char * argv[], OptionSet * optSets[]);
+bool ParseArgs(const char * progName, int argc, char * argv[], OptionSet * optSets[], NonOptionArgHandlerFunct nonOptArgHandler);
+bool ParseArgs(const char * progName, int argc, char * argv[], OptionSet * optSets[], NonOptionArgHandlerFunct nonOptArgHandler,
+               bool ignoreUnknown);
 
-extern bool ParseArgsFromString(const char * progName, const char * argStr, OptionSet * optSets[]);
-extern bool ParseArgsFromString(const char * progName, const char * argStr, OptionSet * optSets[],
-                                NonOptionArgHandlerFunct nonOptArgHandler);
-extern bool ParseArgsFromString(const char * progName, const char * argStr, OptionSet * optSets[],
-                                NonOptionArgHandlerFunct nonOptArgHandler, bool ignoreUnknown);
+bool ParseArgsFromString(const char * progName, const char * argStr, OptionSet * optSets[]);
+bool ParseArgsFromString(const char * progName, const char * argStr, OptionSet * optSets[],
+                         NonOptionArgHandlerFunct nonOptArgHandler);
+bool ParseArgsFromString(const char * progName, const char * argStr, OptionSet * optSets[],
+                         NonOptionArgHandlerFunct nonOptArgHandler, bool ignoreUnknown);
 
-extern bool ParseArgsFromEnvVar(const char * progName, const char * varName, OptionSet * optSets[]);
-extern bool ParseArgsFromEnvVar(const char * progName, const char * varName, OptionSet * optSets[],
-                                NonOptionArgHandlerFunct nonOptArgHandler);
-extern bool ParseArgsFromEnvVar(const char * progName, const char * varName, OptionSet * optSets[],
-                                NonOptionArgHandlerFunct nonOptArgHandler, bool ignoreUnknown);
+bool ParseArgsFromEnvVar(const char * progName, const char * varName, OptionSet * optSets[]);
+bool ParseArgsFromEnvVar(const char * progName, const char * varName, OptionSet * optSets[],
+                         NonOptionArgHandlerFunct nonOptArgHandler);
+bool ParseArgsFromEnvVar(const char * progName, const char * varName, OptionSet * optSets[],
+                         NonOptionArgHandlerFunct nonOptArgHandler, bool ignoreUnknown);
 
-extern void PrintOptionHelp(OptionSet * optionSets[], FILE * s);
+void PrintOptionHelp(OptionSet * optionSets[], FILE * s);
 
-extern void (*PrintArgError)(const char * msg, ...);
-extern void DefaultPrintArgError(const char * msg, ...);
+void (*PrintArgError)(const char * msg, ...);
+void DefaultPrintArgError(const char * msg, ...);
 
 // Utility functions for parsing common argument value types.
-extern bool ParseBoolean(const char * str, bool & output);
-extern bool ParseInt(const char * str, uint8_t & output);
-extern bool ParseInt(const char * str, uint16_t & output);
-extern bool ParseInt(const char * str, int32_t & output);
-extern bool ParseInt(const char * str, uint32_t & output);
-extern bool ParseInt(const char * str, uint64_t & output);
-extern bool ParseInt(const char * str, int32_t & output, int base);
-extern bool ParseInt(const char * str, uint32_t & output, int base);
-extern bool ParseInt(const char * str, uint64_t & output, int base);
-extern bool ParseNodeId(const char * str, uint64_t & nodeId);
-extern bool ParseFabricId(const char * str, uint64_t & fabricId, bool allowReserved = false);
-extern bool ParseSubnetId(const char * str, uint16_t & subnetId);
-extern bool ParseHexString(const char * hexStr, uint32_t strLen, uint8_t * outBuf, uint32_t outBufSize, uint32_t & outDataLen);
+bool ParseBoolean(const char * str, bool & output);
+bool ParseInt(const char * str, uint8_t & output);
+bool ParseInt(const char * str, uint16_t & output);
+bool ParseInt(const char * str, int32_t & output);
+bool ParseInt(const char * str, uint32_t & output);
+bool ParseInt(const char * str, uint64_t & output);
+bool ParseInt(const char * str, int32_t & output, int base);
+bool ParseInt(const char * str, uint32_t & output, int base);
+bool ParseInt(const char * str, uint64_t & output, int base);
+bool ParseNodeId(const char * str, uint64_t & nodeId);
+bool ParseFabricId(const char * str, uint64_t & fabricId, bool allowReserved = false);
+bool ParseSubnetId(const char * str, uint16_t & subnetId);
+bool ParseHexString(const char * hexStr, uint32_t strLen, uint8_t * outBuf, uint32_t outBufSize, uint32_t & outDataLen);
 
 extern OptionSet ** gActiveOptionSets;
 

--- a/src/lib/support/CHIPArgParser.hpp
+++ b/src/lib/support/CHIPArgParser.hpp
@@ -127,7 +127,6 @@ extern bool ParseInt(const char * str, uint64_t & output);
 extern bool ParseInt(const char * str, int32_t & output, int base);
 extern bool ParseInt(const char * str, uint32_t & output, int base);
 extern bool ParseInt(const char * str, uint64_t & output, int base);
-extern bool ParseIPAddress(const char * str, chip::Inet::IPAddress & output);
 extern bool ParseNodeId(const char * str, uint64_t & nodeId);
 extern bool ParseFabricId(const char * str, uint64_t & fabricId, bool allowReserved = false);
 extern bool ParseSubnetId(const char * str, uint16_t & subnetId);

--- a/src/lib/support/CHIPCounter.cpp
+++ b/src/lib/support/CHIPCounter.cpp
@@ -16,6 +16,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
 #include <support/CHIPCounter.h>
 
 namespace chip {

--- a/src/lib/support/CHIPCounter.cpp
+++ b/src/lib/support/CHIPCounter.cpp
@@ -1,0 +1,52 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2016-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include <support/CHIPCounter.h>
+
+namespace chip {
+
+MonotonicallyIncreasingCounter::MonotonicallyIncreasingCounter(void) : mCounterValue(0) {}
+
+MonotonicallyIncreasingCounter::~MonotonicallyIncreasingCounter(void) {}
+
+CHIP_ERROR
+MonotonicallyIncreasingCounter::Init(uint32_t aStartValue)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    mCounterValue = aStartValue;
+
+    return err;
+}
+
+CHIP_ERROR
+MonotonicallyIncreasingCounter::Advance(void)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    mCounterValue++;
+
+    return err;
+}
+
+uint32_t MonotonicallyIncreasingCounter::GetValue(void)
+{
+    return mCounterValue;
+}
+
+} // namespace chip

--- a/src/lib/support/CHIPCounter.h
+++ b/src/lib/support/CHIPCounter.h
@@ -48,7 +48,7 @@ public:
      *  @brief
      *  Advance the value of the counter.
      *
-     *  @return A Chip error code if anything failed, CHIP_NO_ERROR otherwise.
+     *  @return A CHIP error code if anything failed, CHIP_NO_ERROR otherwise.
      */
     virtual CHIP_ERROR Advance(void) = 0;
 

--- a/src/lib/support/CHIPCounter.h
+++ b/src/lib/support/CHIPCounter.h
@@ -1,0 +1,109 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2016-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @file
+ *
+ * @brief
+ *   Class declarations for a Counter base class, and a monotonically-increasing counter.
+ */
+
+#ifndef CHIP_COUNTER_H
+#define CHIP_COUNTER_H
+
+#include <core/CHIPError.h>
+
+namespace chip {
+
+/**
+ * @class Counter
+ *
+ * @brief
+ *   An interface for managing a counter as an integer value.
+ */
+
+class Counter
+{
+public:
+    Counter(void){};
+    ~Counter(void){};
+
+    /**
+     *  @brief
+     *  Advance the value of the counter.
+     *
+     *  @return A Chip error code if anything failed, CHIP_NO_ERROR otherwise.
+     */
+    virtual CHIP_ERROR Advance(void) = 0;
+
+    /**
+     *  @brief
+     *  Get the current value of the counter.
+     *
+     *  @return The current value of the counter.
+     */
+    virtual uint32_t GetValue(void) = 0;
+};
+
+/**
+ * @class MonotonicallyIncreasingCounter
+ *
+ * @brief
+ *   A class for managing a monotonically-increasing counter as an integer value.
+ */
+
+class MonotonicallyIncreasingCounter : public Counter
+{
+public:
+    MonotonicallyIncreasingCounter(void);
+    virtual ~MonotonicallyIncreasingCounter(void);
+
+    /**
+     *  @brief
+     *    Initialize a MonotonicallyIncreasingCounter object.
+     *
+     *  @param[in] aStartValue  The starting value of the counter.
+     *
+     *  @return A CHIP error code if something fails, CHIP_NO_ERROR otherwise
+     */
+    CHIP_ERROR Init(uint32_t aStartValue);
+
+    /**
+     *  @brief
+     *  Advance the value of the counter.
+     *
+     *  @return A CHIP error code if something fails, CHIP_NO_ERROR otherwise
+     */
+    virtual CHIP_ERROR Advance(void);
+
+    /**
+     *  @brief
+     *  Get the current value of the counter.
+     *
+     *  @return The current value of the counter.
+     */
+    virtual uint32_t GetValue(void);
+
+protected:
+    uint32_t mCounterValue;
+};
+
+} // namespace chip
+
+#endif // CHIP_COUNTER_H

--- a/src/lib/support/CHIPCounter.h
+++ b/src/lib/support/CHIPCounter.h
@@ -42,7 +42,7 @@ class Counter
 {
 public:
     Counter(void){};
-    ~Counter(void){};
+    virtual ~Counter(void){};
 
     /**
      *  @brief
@@ -90,7 +90,7 @@ public:
      *
      *  @return A CHIP error code if something fails, CHIP_NO_ERROR otherwise
      */
-    virtual CHIP_ERROR Advance(void);
+    CHIP_ERROR Advance(void) override;
 
     /**
      *  @brief
@@ -98,7 +98,7 @@ public:
      *
      *  @return The current value of the counter.
      */
-    virtual uint32_t GetValue(void);
+    uint32_t GetValue(void) override;
 
 protected:
     uint32_t mCounterValue;

--- a/src/lib/support/PersistedCounter.cpp
+++ b/src/lib/support/PersistedCounter.cpp
@@ -1,0 +1,164 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2016-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include <support/CodeUtils.h>
+#include <support/logging/CHIPLogging.h>
+#include <support/PersistedCounter.h>
+#include <platform/PersistedStorage.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+namespace chip {
+
+PersistedCounter::PersistedCounter(void) : MonotonicallyIncreasingCounter(), mStartingCounterValue(0), mEpoch(0)
+{
+    memset(&mId, 0, sizeof(mId));
+}
+
+PersistedCounter::~PersistedCounter(void) {}
+
+CHIP_ERROR
+PersistedCounter::Init(const chip::Platform::PersistedStorage::Key aId, uint32_t aEpoch)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    // Store the ID.
+    mId = aId;
+
+    // Check and store the epoch.
+    VerifyOrExit(aEpoch > 0, err = CHIP_ERROR_INVALID_INTEGER_VALUE);
+    mEpoch = aEpoch;
+
+    // Read our previously-stored starting value.
+    err = ReadStartValue(mStartingCounterValue);
+    SuccessOrExit(err);
+
+#if CHIP_CONFIG_PERSISTED_COUNTER_DEBUG_LOGGING
+    ChipLogDetail(EventLogging, "PersistedCounter::Init() aEpoch 0x%x mStartingCounterValue 0x%x", aEpoch, mStartingCounterValue);
+#endif
+
+    // Write out the counter value with which we'll start next time we
+    // boot up.
+    err = WriteStartValue(mStartingCounterValue + mEpoch);
+    SuccessOrExit(err);
+
+    // This will set the starting value, after which we're ready.
+    err = MonotonicallyIncreasingCounter::Init(mStartingCounterValue);
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR
+PersistedCounter::Advance(void)
+{
+    return IncrementCount();
+}
+
+CHIP_ERROR
+PersistedCounter::AdvanceEpochRelative(uint32_t aValue)
+{
+    CHIP_ERROR ret;
+
+    mStartingCounterValue = (aValue / mEpoch) * mEpoch;         // Start of enclosing epoch
+    mCounterValue         = mStartingCounterValue + mEpoch - 1; // Move to end of enclosing epoch
+    ret                   = IncrementCount();                   // Force to next epoch
+#if CHIP_CONFIG_PERSISTED_COUNTER_DEBUG_LOGGING
+    ChipLogError(EventLogging, "Advanced counter to 0x%x (relative to 0x%x)", mCounterValue, aValue);
+#endif
+
+    return ret;
+}
+
+bool PersistedCounter::GetNextValue(uint32_t & aValue)
+{
+    bool startNewEpoch = false;
+
+    // Increment aValue.
+    aValue++;
+
+    // If we've exceeded the value with which we started by aEpoch or
+    // more, we need to start a new epoch.
+    if ((aValue - mStartingCounterValue) >= mEpoch)
+    {
+        aValue        = mStartingCounterValue + mEpoch;
+        startNewEpoch = true;
+    }
+
+    return startNewEpoch;
+}
+
+CHIP_ERROR
+PersistedCounter::IncrementCount(void)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    // Get the incremented value.
+    if (GetNextValue(mCounterValue))
+    {
+        // Started a new epoch, so write out the next one.
+        err = WriteStartValue(mCounterValue + mEpoch);
+        SuccessOrExit(err);
+
+        mStartingCounterValue = mCounterValue;
+    }
+
+exit:
+    return err;
+}
+
+CHIP_ERROR
+PersistedCounter::WriteStartValue(uint32_t aStartValue)
+{
+#if CHIP_CONFIG_PERSISTED_COUNTER_DEBUG_LOGGING
+    ChipLogDetail(EventLogging, "PersistedCounter::WriteStartValue() aStartValue 0x%x", aStartValue);
+#endif
+
+    return chip::Platform::PersistedStorage::Write(mId, aStartValue);
+}
+
+CHIP_ERROR
+PersistedCounter::ReadStartValue(uint32_t & aStartValue)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    aStartValue = 0;
+
+    err = chip::Platform::PersistedStorage::Read(mId, aStartValue);
+    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+    {
+        // No previously-stored value, no worries, the counter is initialized to zero.
+        // Suppress the error.
+        err = CHIP_NO_ERROR;
+    }
+    else
+    {
+        SuccessOrExit(err);
+    }
+
+#if CHIP_CONFIG_PERSISTED_COUNTER_DEBUG_LOGGING
+    ChipLogDetail(EventLogging, "PersistedCounter::ReadStartValue() aStartValue 0x%x", aStartValue);
+#endif
+
+exit:
+    return err;
+}
+
+} // namespace chip

--- a/src/lib/support/PersistedCounter.cpp
+++ b/src/lib/support/PersistedCounter.cpp
@@ -28,7 +28,7 @@
 namespace chip {
 
 PersistedCounter::PersistedCounter(void) :
-    MonotonicallyIncreasingCounter(), mStartingCounterValue(0), mEpoch(0), mId(chip::Platform::PersistedStorage::kEmptyKey)
+    MonotonicallyIncreasingCounter(), mId(chip::Platform::PersistedStorage::kEmptyKey), mStartingCounterValue(0), mEpoch(0)
 {}
 
 PersistedCounter::~PersistedCounter(void)

--- a/src/lib/support/PersistedCounter.cpp
+++ b/src/lib/support/PersistedCounter.cpp
@@ -16,6 +16,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
 #include <support/PersistedCounter.h>
@@ -31,7 +32,10 @@ PersistedCounter::PersistedCounter(void) : MonotonicallyIncreasingCounter(), mSt
     memset(&mId, 0, sizeof(mId));
 }
 
-PersistedCounter::~PersistedCounter(void) {}
+PersistedCounter::~PersistedCounter(void)
+{
+    return;
+}
 
 CHIP_ERROR
 PersistedCounter::Init(const chip::Platform::PersistedStorage::Key aId, uint32_t aEpoch)

--- a/src/lib/support/PersistedCounter.cpp
+++ b/src/lib/support/PersistedCounter.cpp
@@ -27,10 +27,9 @@
 
 namespace chip {
 
-PersistedCounter::PersistedCounter(void) : MonotonicallyIncreasingCounter(), mStartingCounterValue(0), mEpoch(0)
-{
-    memset(&mId, 0, sizeof(mId));
-}
+PersistedCounter::PersistedCounter(void) :
+    MonotonicallyIncreasingCounter(), mStartingCounterValue(0), mEpoch(0), mId(chip::Platform::PersistedStorage::kEmptyKey)
+{}
 
 PersistedCounter::~PersistedCounter(void)
 {

--- a/src/lib/support/PersistedCounter.h
+++ b/src/lib/support/PersistedCounter.h
@@ -1,0 +1,132 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2016-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @file
+ *
+ * @brief
+ *   Class declarations for a monotonically-increasing counter that is periodically
+ *   saved in the platform's persistent storage.
+ */
+
+#ifndef PERSISTED_COUNTER_H
+#define PERSISTED_COUNTER_H
+
+#include <platform/PersistedStorage.h>
+#include <support/CHIPCounter.h>
+
+namespace chip {
+
+/**
+ * @class PersistedCounter
+ *
+ * @brief
+ *   A class for managing a counter as an integer value intended to persist
+ *   across reboots.
+ */
+
+class PersistedCounter : public MonotonicallyIncreasingCounter
+{
+public:
+    PersistedCounter(void);
+    virtual ~PersistedCounter(void);
+
+    /**
+     *  @brief
+     *    Initialize a PersistedCounter object.
+     *
+     *  @param[in] aId     The identifier of this PersistedCounter instance.
+     *  @param[in] aEpoch  On bootup, values we vend will start at a
+     *                     multiple of this parameter.
+     *
+     *  @return CHIP_ERROR_INVALID_ARGUMENT if aId is NULL
+     *          CHIP_ERROR_INVALID_STRING_LENGTH if aId is longer than
+     *          CHIP_CONFIG_PERSISTED_STORAGE_MAX_KEY_LENGTH.
+     *          CHIP_ERROR_INVALID_INTEGER_VALUE if aEpoch is 0.
+     *          CHIP_NO_ERROR otherwise
+     */
+    CHIP_ERROR Init(const chip::Platform::PersistedStorage::Key aId, uint32_t aEpoch);
+
+    /**
+     *  @brief
+     *  Increment the counter and write to persisted storage if we've completed
+     *  the current epoch.
+     *
+     *  @return Any error returned by a write to persisted storage.
+     */
+    CHIP_ERROR Advance(void);
+
+    /*
+     *  @brief
+     *    Advance the counter to start of the epoch following the provided
+     *    value.
+     *
+     *  @return Any error returned by a write to persistent storage.
+     */
+    CHIP_ERROR AdvanceEpochRelative(uint32_t aValue);
+
+private:
+    /**
+     *  @brief
+     *  Get the next value of the counter, based on aValue.
+     *
+     *  @param[inout] aValue.  The value to be incremented.
+     *
+     *  @return true if incrementing aValue started a new epoch, false otherwise.
+     */
+    bool GetNextValue(uint32_t & aValue);
+
+    /**
+     *  @brief
+     *    Increment the value of the counter by one.  May perform a write to
+     *    persistent storage.
+     *
+     *  @return Any error returned by a write to persistent storage,
+     *          CHIP_NO_ERROR otherwise
+     */
+    CHIP_ERROR IncrementCount(void);
+
+    /**
+     *  @brief
+     *    Write out the counter value to persistent storage.
+     *
+     *  @param[in] aStartValue  The counter value to write out.
+     *
+     *  @return Any error returned by a write to persistent storage.
+     */
+    CHIP_ERROR WriteStartValue(uint32_t aStartValue);
+
+    /**
+     *  @brief
+     *    Read our starting counter value (if we have one) in from persistent storage.
+     *
+     *  @param[inout] aStartValue  The value read out.
+     *
+     *  @return Any error returned by a read from persistent storage.
+     */
+    CHIP_ERROR ReadStartValue(uint32_t & aStartValue);
+
+    chip::Platform::PersistedStorage::Key mId;
+    uint32_t mStartingCounterValue;
+    uint32_t mEpoch;
+};
+
+} // namespace chip
+
+#endif // PERSISTED_COUNTER_H

--- a/src/lib/support/PersistedCounter.h
+++ b/src/lib/support/PersistedCounter.h
@@ -70,7 +70,7 @@ public:
      *
      *  @return Any error returned by a write to persisted storage.
      */
-    CHIP_ERROR Advance(void);
+    CHIP_ERROR Advance(void) override;
 
     /*
      *  @brief

--- a/src/lib/support/SupportLayer.am
+++ b/src/lib/support/SupportLayer.am
@@ -25,16 +25,19 @@
 CHIP_BUILD_SUPPORT_LAYER_SOURCE_FILES                     = \
     @top_builddir@/src/lib/support/Base64.cpp               \
     @top_builddir@/src/lib/support/CHIPArgParser.cpp        \
+    @top_builddir@/src/lib/support/CHIPCounter.cpp          \
     @top_builddir@/src/lib/support/CHIPFaultInjection.cpp   \
     @top_builddir@/src/lib/support/ErrorStr.cpp             \
     @top_builddir@/src/lib/support/FibonacciUtils.cpp       \
     @top_builddir@/src/lib/support/logging/CHIPLogging.cpp  \
+    @top_builddir@/src/lib/support/PersistedCounter.cpp     \
     @top_builddir@/src/lib/support/RandUtils.cpp            \
     @top_builddir@/src/lib/support/TimeUtils.cpp            \
     $(NULL)
 
 CHIP_BUILD_SUPPORT_LAYER_HEADER_FILES                     = \
     @top_builddir@/src/lib/support/CHIPArgParser.hpp        \
+    @top_builddir@/src/lib/support/CHIPCounter.h            \
     @top_builddir@/src/lib/support/CHIPFaultInjection.h     \
     @top_builddir@/src/lib/support/CodeUtils.h              \
     @top_builddir@/src/lib/support/DLLUtil.h                \
@@ -43,6 +46,7 @@ CHIP_BUILD_SUPPORT_LAYER_HEADER_FILES                     = \
     @top_builddir@/src/lib/support/FlagUtils.hpp            \
     @top_builddir@/src/lib/support/logging/CHIPLogging.h    \
     @top_builddir@/src/lib/support/Base64.h                 \
+    @top_builddir@/src/lib/support/PersistedCounter.h       \
     @top_builddir@/src/lib/support/RandUtils.h              \
     @top_builddir@/src/lib/support/TimeUtils.h              \
     $(NULL)

--- a/src/lib/support/tests/Makefile.am
+++ b/src/lib/support/tests/Makefile.am
@@ -27,6 +27,7 @@ include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 # since they are not part of the package.
 #
 noinst_HEADERS                                        = \
+    TestPersistedStorageImplementation.h                \
     $(NULL)
 
 #

--- a/src/lib/support/tests/Makefile.am
+++ b/src/lib/support/tests/Makefile.am
@@ -42,9 +42,12 @@ if CHIP_BUILD_TESTS
 AM_CPPFLAGS                                           = \
     -I$(top_srcdir)/src                                 \
     -I$(top_srcdir)/src/lib                             \
+    -I$(top_srcdir)/src/include                         \
     $(LWIP_CPPFLAGS)                                    \
     $(SOCKETS_CPPFLAGS)                                 \
     $(PTHREAD_CFLAGS)                                   \
+    $(NLASSERT_CPPFLAGS)                                \
+    $(NLUNIT_TEST_CPPFLAGS)                             \
     $(NULL)
 
 CHIP_LDADD                                            = \
@@ -57,6 +60,7 @@ COMMON_LDADD                                          = \
     $(LWIP_LDFLAGS) $(LWIP_LIBS)                        \
     $(SOCKETS_LDFLAGS) $(SOCKETS_LIBS)                  \
     $(PTHREAD_CFLAGS) $(PTHREAD_LIBS)                   \
+    $(NLUNIT_TEST_LDFLAGS) $(NLUNIT_TEST_LIBS)          \
     $(NULL)
 
 # Test applications that should be run when the 'check' target is run.
@@ -64,6 +68,8 @@ check_PROGRAMS                                        = \
     TestCHIPArgParser                                   \
     TestErrorStr                                        \
     TestTimeUtils                                       \
+    TestCHIPCounter                                     \
+    TestPersistedCounter                                \
     $(NULL)
 
 # Test applications and scripts that should be built and run when the
@@ -90,10 +96,22 @@ TestTimeUtils_LDADD                                   = $(COMMON_LDADD)
 TestErrorStr_SOURCES                                  = TestErrorStr.cpp
 TestErrorStr_LDADD                                    = $(COMMON_LDADD)
 
+TestCHIPCounter_SOURCES                               = TestCHIPCounter.cpp
+TestCHIPCounter_LDADD                                 = $(COMMON_LDADD)
+
+TestPersistedCounter_SOURCES                          = \
+    TestPersistedCounter.cpp                            \
+    TestPersistedStorageImplementation.cpp
+TestPersistedCounter_LDADD                            = $(COMMON_LDADD)
+
 # Foreign make dependencies
 
 NLFOREIGN_FILE_DEPENDENCIES                           = \
    $(CHIP_LDADD)                                        \
+   $(NULL)
+
+NLFOREIGN_SUBDIR_DEPENDENCIES                         = \
+   $(NLUNIT_TEST_FOREIGN_SUBDIR_DEPENDENCY)             \
    $(NULL)
 
 if CHIP_BUILD_COVERAGE

--- a/src/lib/support/tests/TestCHIPArgParser.cpp
+++ b/src/lib/support/tests/TestCHIPArgParser.cpp
@@ -692,26 +692,6 @@ static void HandleArgError(const char * msg, ...)
     sCallbackRecordCount++;
 }
 
-/*
- * Mock interface to avoid an unnecessary circular dependency on the
- * Inet layer library imposed by the argument parsing facility.
- *
- */
-namespace chip {
-
-namespace Inet {
-
-class IPAddress;
-
-bool IPAddress::FromString(char const * aString, IPAddress & aAddress)
-{
-    return (false);
-}
-
-}; // namespace Inet
-
-}; // namespace chip
-
 int main(int argc, char * argv[])
 {
     SimpleParseTest_SingleLongOption();

--- a/src/lib/support/tests/TestCHIPCounter.cpp
+++ b/src/lib/support/tests/TestCHIPCounter.cpp
@@ -1,0 +1,97 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <nlunit-test.h>
+
+#include <support/CHIPCounter.h>
+
+static void CheckStartWithZero(nlTestSuite * inSuite, void * inContext)
+{
+    chip::MonotonicallyIncreasingCounter counter;
+    NL_TEST_ASSERT(inSuite, counter.GetValue() == 0);
+}
+
+static void CheckInitialize(nlTestSuite * inSuite, void * inContext)
+{
+    chip::MonotonicallyIncreasingCounter counter;
+
+    NL_TEST_ASSERT(inSuite, counter.Init(4321) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, counter.GetValue() == 4321);
+}
+
+static void CheckAdvance(nlTestSuite * inSuite, void * inContext)
+{
+    chip::MonotonicallyIncreasingCounter counter;
+
+    NL_TEST_ASSERT(inSuite, counter.Init(22) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, counter.GetValue() == 22);
+    NL_TEST_ASSERT(inSuite, counter.Advance() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, counter.GetValue() == 23);
+    NL_TEST_ASSERT(inSuite, counter.Advance() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, counter.GetValue() == 24);
+}
+
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+
+// clang-format off
+static const nlTest sTests[] =
+{
+    NL_TEST_DEF("Start with zero", CheckStartWithZero),
+    NL_TEST_DEF("Can initialize",  CheckInitialize),
+    NL_TEST_DEF("Can Advance",     CheckAdvance),
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+/**
+ *  Set up the test suite.
+ */
+static int TestSetup(void * inContext)
+{
+    return (SUCCESS);
+}
+
+/**
+ *  Tear down the test suite.
+ */
+static int TestTeardown(void * inContext)
+{
+    return (SUCCESS);
+}
+
+int main(int argc, char * argv[])
+{
+    // clang-format off
+    nlTestSuite theSuite = {
+        "chip-counter",
+        &sTests[0],
+        TestSetup,
+        TestTeardown
+    };
+    // clang-format on
+
+    // Generate machine-readable, comma-separated value (CSV) output.
+    nl_test_set_output_style(OUTPUT_CSV);
+
+    // Run test suit againt one context.
+    nlTestRunner(&theSuite, NULL);
+
+    return nlTestRunnerStats(&theSuite);
+}

--- a/src/lib/support/tests/TestPersistedCounter.cpp
+++ b/src/lib/support/tests/TestPersistedCounter.cpp
@@ -1,0 +1,212 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2016-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Unit tests for the Chip Persisted Storage API.
+ *
+ */
+
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
+#ifndef __STDC_LIMIT_MACROS
+#define __STDC_LIMIT_MACROS
+#endif
+#define CHIP_CONFIG_BDX_NAMESPACE kChipManagedNamespace_Development
+
+#include <new>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <nlunit-test.h>
+
+#include <CHIPVersion.h>
+#include <support/CHIPArgParser.hpp>
+#include <support/PersistedCounter.h>
+#include <platform/PersistedStorage.h>
+
+#include "TestPersistedStorageImplementation.h"
+
+#define TOOL_NAME "TestPersistedCounter"
+#define TOOL_OPTIONS_ENV_VAR_NAME "CHIP_SUPPORT_TEST_OPTIONS"
+#define CHIP_TOOL_COPYRIGHT "Copyright (c) 2020 Project CHIP Authors\nAll rights reserved.\n"
+
+using namespace chip::ArgParser;
+
+struct TestPersistedCounterContext
+{
+    TestPersistedCounterContext();
+    bool mVerbose;
+};
+
+TestPersistedCounterContext::TestPersistedCounterContext() : mVerbose(false) {}
+
+static void InitializePersistedStorage(TestPersistedCounterContext * context)
+{
+    sPersistentStore.clear();
+}
+
+static int TestSetup(void * inContext)
+{
+    return SUCCESS;
+}
+
+static int TestTeardown(void * inContext)
+{
+    sPersistentStore.clear();
+    return SUCCESS;
+}
+
+static void CheckOOB(nlTestSuite * inSuite, void * inContext)
+{
+    TestPersistedCounterContext * context = static_cast<TestPersistedCounterContext *>(inContext);
+    CHIP_ERROR err                        = CHIP_NO_ERROR;
+    chip::PersistedCounter counter;
+    const char * testKey = "testcounter";
+    char testValue[CHIP_CONFIG_PERSISTED_STORAGE_MAX_VALUE_LENGTH];
+    uint64_t value = 0;
+
+    memset(testValue, 0, sizeof(testValue));
+
+    InitializePersistedStorage(context);
+
+    // When initializing the first time out of the box, we should have
+    // a count of 0 and a value of 0x10000 for the next starting value
+    // in persistent storage.
+
+    err = counter.Init(testKey, 0x10000);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    value = counter.GetValue();
+    NL_TEST_ASSERT(inSuite, value == 0);
+}
+
+static void CheckReboot(nlTestSuite * inSuite, void * inContext)
+{
+    TestPersistedCounterContext * context = static_cast<TestPersistedCounterContext *>(inContext);
+    CHIP_ERROR err                        = CHIP_NO_ERROR;
+    chip::PersistedCounter counter, counter2;
+    const char * testKey = "testcounter";
+    char testValue[CHIP_CONFIG_PERSISTED_STORAGE_MAX_VALUE_LENGTH];
+    uint64_t value = 0;
+
+    memset(testValue, 0, sizeof(testValue));
+
+    InitializePersistedStorage(context);
+
+    // When initializing the first time out of the box, we should have
+    // a count of 0.
+
+    err = counter.Init(testKey, 0x10000);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    value = counter.GetValue();
+    NL_TEST_ASSERT(inSuite, value == 0);
+
+    // Now we "reboot", and we should get a count of 0x10000.
+
+    err = counter2.Init(testKey, 0x10000);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    value = counter2.GetValue();
+    NL_TEST_ASSERT(inSuite, value == 0x10000);
+}
+
+static void CheckWriteNextCounterStart(nlTestSuite * inSuite, void * inContext)
+{
+    TestPersistedCounterContext * context = static_cast<TestPersistedCounterContext *>(inContext);
+    CHIP_ERROR err                        = CHIP_NO_ERROR;
+    chip::PersistedCounter counter;
+    const char * testKey = "testcounter";
+    char testValue[CHIP_CONFIG_PERSISTED_STORAGE_MAX_VALUE_LENGTH];
+    uint64_t value = 0;
+
+    memset(testValue, 0, sizeof(testValue));
+
+    InitializePersistedStorage(context);
+
+    // When initializing the first time out of the box, we should have
+    // a count of 0.
+
+    err = counter.Init(testKey, 0x10000);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    value = counter.GetValue();
+    NL_TEST_ASSERT(inSuite, value == 0);
+
+    // Verify that we write out the next starting counter value after
+    // we've exhausted the counter's range.
+
+    for (int32_t i = 0; i < 0x10000; i++)
+    {
+        err = counter.Advance();
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    }
+
+    value = counter.GetValue();
+    NL_TEST_ASSERT(inSuite, value == 0x10000);
+
+    for (int32_t i = 0; i < 0x10000; i++)
+    {
+        err = counter.Advance();
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    }
+
+    value = counter.GetValue();
+    NL_TEST_ASSERT(inSuite, value == 0x20000);
+}
+
+// Test Suite
+
+/**
+ *  Test Suite that lists all the test functions.
+ */
+static const nlTest sTests[] = { NL_TEST_DEF("Out of box Test", CheckOOB), NL_TEST_DEF("Reboot Test", CheckReboot),
+                                 NL_TEST_DEF("Write Next Counter Start Test", CheckWriteNextCounterStart),
+
+                                 NL_TEST_SENTINEL() };
+
+static HelpOptions gHelpOptions(TOOL_NAME, "Usage: " TOOL_NAME " [<options...>]\n", CHIP_VERSION_STRING "\n" CHIP_TOOL_COPYRIGHT,
+                                "Test persisted counter API.  Without any options, the program invokes a suite of local tests.\n");
+
+static OptionSet * gOptionSets[] = { &gHelpOptions, NULL };
+
+int main(int argc, char * argv[])
+{
+    TestPersistedCounterContext context;
+
+    if (!ParseArgsFromEnvVar(TOOL_NAME, TOOL_OPTIONS_ENV_VAR_NAME, gOptionSets, NULL, true) ||
+        !ParseArgs(TOOL_NAME, argc, argv, gOptionSets))
+    {
+        exit(EXIT_FAILURE);
+    }
+
+    nlTestSuite theSuite = { "chip-persisted-storage", &sTests[0], TestSetup, TestTeardown };
+
+    // Generate machine-readable, comma-separated value (CSV) output.
+    nl_test_set_output_style(OUTPUT_CSV);
+
+    // Run test suit against one context
+    nlTestRunner(&theSuite, &context);
+
+    return nlTestRunnerStats(&theSuite);
+}

--- a/src/lib/support/tests/TestPersistedCounter.cpp
+++ b/src/lib/support/tests/TestPersistedCounter.cpp
@@ -27,11 +27,6 @@
 #define __STDC_FORMAT_MACROS
 #endif
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-#define CHIP_CONFIG_BDX_NAMESPACE kChipManagedNamespace_Development
-
 #include <new>
 #include <stdint.h>
 #include <string.h>

--- a/src/lib/support/tests/TestPersistedStorageImplementation.cpp
+++ b/src/lib/support/tests/TestPersistedStorageImplementation.cpp
@@ -1,0 +1,192 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2016-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Implementation of a simple std::map based persisted store.
+ *
+ */
+
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
+#ifndef __STDC_LIMIT_MACROS
+#define __STDC_LIMIT_MACROS
+#endif
+
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <support/Base64.h>
+#include <support/CHIPArgParser.hpp>
+#include <support/CodeUtils.h>
+#include <platform/PersistedStorage.h>
+
+#include "TestPersistedStorageImplementation.h"
+
+using namespace chip::ArgParser;
+
+std::map<std::string, std::string> sPersistentStore;
+
+FILE * sPersistentStoreFile = NULL;
+
+namespace chip {
+namespace Platform {
+namespace PersistedStorage {
+
+static void RemoveEndOfLineSymbol(char * str)
+{
+    size_t len = strlen(str) - 1;
+    if (str[len] == '\n')
+        str[len] = '\0';
+}
+
+static CHIP_ERROR GetCounterValueFromFile(const char * aKey, uint32_t & aValue)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    char key[CHIP_CONFIG_PERSISTED_STORAGE_MAX_KEY_LENGTH];
+    char value[CHIP_CONFIG_PERSISTED_STORAGE_MAX_VALUE_LENGTH];
+
+    rewind(sPersistentStoreFile);
+
+    while (fgets(key, sizeof(key), sPersistentStoreFile) != NULL)
+    {
+        RemoveEndOfLineSymbol(key);
+
+        if (strcmp(key, aKey) == 0)
+        {
+            if (fgets(value, sizeof(value), sPersistentStoreFile) == NULL)
+            {
+                err = CHIP_ERROR_PERSISTED_STORAGE_FAIL;
+            }
+            else
+            {
+                RemoveEndOfLineSymbol(value);
+
+                if (!ParseInt(value, aValue, 0))
+                    err = CHIP_ERROR_PERSISTED_STORAGE_FAIL;
+            }
+
+            ExitNow();
+        }
+    }
+
+    err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+
+exit:
+    return err;
+}
+
+static CHIP_ERROR SaveCounterValueToFile(const char * aKey, uint32_t aValue)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    int res;
+    char key[CHIP_CONFIG_PERSISTED_STORAGE_MAX_KEY_LENGTH];
+    char value[CHIP_CONFIG_PERSISTED_STORAGE_MAX_VALUE_LENGTH];
+
+    snprintf(value, sizeof(value), "0x%08X\n", aValue);
+
+    rewind(sPersistentStoreFile);
+
+    // Find the stored counter value location in the file.
+    while (fgets(key, sizeof(key), sPersistentStoreFile) != NULL)
+    {
+        RemoveEndOfLineSymbol(key);
+
+        // If value is found in the file then override it.
+        if (strcmp(key, aKey) == 0)
+        {
+            res = fputs(value, sPersistentStoreFile);
+            VerifyOrExit(res != EOF, err = CHIP_ERROR_PERSISTED_STORAGE_FAIL);
+
+            ExitNow();
+        }
+    }
+
+    // If value not found in the file then write the counter key and
+    // the counter value to the end of the file.
+    res = fputs(aKey, sPersistentStoreFile);
+    VerifyOrExit(res != EOF, err = CHIP_ERROR_PERSISTED_STORAGE_FAIL);
+
+    res = fputs("\n", sPersistentStoreFile);
+    VerifyOrExit(res != EOF, err = CHIP_ERROR_PERSISTED_STORAGE_FAIL);
+
+    res = fputs(value, sPersistentStoreFile);
+    VerifyOrExit(res != EOF, err = CHIP_ERROR_PERSISTED_STORAGE_FAIL);
+
+exit:
+    fflush(sPersistentStoreFile);
+    return err;
+}
+
+CHIP_ERROR Read(const char * aKey, uint32_t & aValue)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    std::map<std::string, std::string>::iterator it;
+
+    VerifyOrExit(aKey != NULL, err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(strlen(aKey) <= CHIP_CONFIG_PERSISTED_STORAGE_MAX_KEY_LENGTH, err = CHIP_ERROR_INVALID_STRING_LENGTH);
+
+    if (sPersistentStoreFile)
+    {
+        err = GetCounterValueFromFile(aKey, aValue);
+    }
+    else
+    {
+        it = sPersistentStore.find(aKey);
+        VerifyOrExit(it != sPersistentStore.end(), err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+
+        size_t aValueLength = Base64Decode(it->second.c_str(), strlen(it->second.c_str()), (uint8_t *) &aValue);
+        VerifyOrExit(aValueLength == sizeof(uint32_t), err = CHIP_ERROR_PERSISTED_STORAGE_FAIL);
+    }
+
+exit:
+    return err;
+}
+
+CHIP_ERROR Write(const char * aKey, uint32_t aValue)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    VerifyOrExit(aKey != NULL, err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(strlen(aKey) <= CHIP_CONFIG_PERSISTED_STORAGE_MAX_KEY_LENGTH, err = CHIP_ERROR_INVALID_STRING_LENGTH);
+
+    if (sPersistentStoreFile)
+    {
+        err = SaveCounterValueToFile(aKey, aValue);
+    }
+    else
+    {
+        char encodedValue[BASE64_ENCODED_LEN(sizeof(uint32_t)) + 1];
+
+        memset(encodedValue, 0, sizeof(encodedValue));
+        Base64Encode((uint8_t *) &aValue, sizeof(aValue), encodedValue);
+
+        sPersistentStore[aKey] = encodedValue;
+    }
+
+exit:
+    return err;
+}
+
+} // namespace PersistedStorage
+} // namespace Platform
+} // namespace chip

--- a/src/lib/support/tests/TestPersistedStorageImplementation.h
+++ b/src/lib/support/tests/TestPersistedStorageImplementation.h
@@ -1,0 +1,25 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2016-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <string>
+#include <map>
+
+extern std::map<std::string, std::string> sPersistentStore;
+
+extern FILE * sPersistentStoreFile;

--- a/src/platform/Makefile.am
+++ b/src/platform/Makefile.am
@@ -77,6 +77,7 @@ noinst_HEADERS                          = \
     @top_srcdir@/src/include/platform/internal/GenericSoftwareUpdateManagerImpl.h \
     @top_srcdir@/src/include/platform/internal/GenericSoftwareUpdateManagerImpl.ipp \
     @top_srcdir@/src/include/platform/internal/CHIPDeviceLayerInternal.h \
+    @top_srcdir@/src/include/platform/PersistedStorage.h \
     $(NULL)
 
 if CONFIG_DEVICE_LAYER


### PR DESCRIPTION
CHIPCounter/PresistedCounter is used by weave message layer. Adding this as an independent
patch in the interest of keeping pull requests small.

Changes from original weave implementation:
  - Renaming weave to chip (namespaces, constants)
  - fix includes
  - update copyright
  - clean up includes (add required include in header, drop unnecessary
    includes from cpp file)
  - Update PersistedCounter unit test files to run (updated includes,
    changed defineds)
  - Added a TestCHIPCounter unit test.

Additional changes:
  - Created separate InetArgParser h/cpp to remove dependency between
    support layer and inet layer. This makes the inet layer support
    inet-specific argument parsing

Tested: compilation works and CHIPCounter is included in the support
        library
Tested: PersistedCounter and CHIPCounter unit tests pass in `make check`

 #### Problem
This is starter work in integrating Weave MessageLayer components. Looking into adding small pieces instead of large change.

Specifically I am currently working on the prerequisites for FabricState.cpp.

 #### Summary of Changes
  - Added CHIPCounter and PersistedCounter into the support library
  - Separate out IPAddress ArgParsing functions so that we remove a dependency from support into inetlayer
  - Added unit test: new one for CHIPCounter and ported existing one for PersistedCounter


