### PR TITLE
Fix Inet build failures with different configurations

### DIFF
--- a/src/inet/tests/Makefile.am
+++ b/src/inet/tests/Makefile.am
@@ -38,13 +38,13 @@ noinst_HEADERS                                        = \
 EXTRA_DIST                                            = \
     $(NULL)
 
-noinst_LIBRARIES                                      = \
-    libTestInetCommon.a                                 \
-    $(NULL)
-
 if CHIP_BUILD_TESTS
 # C preprocessor option flags that will apply to all compiled objects in this
 # makefile.
+
+noinst_LIBRARIES                                      = \
+    libTestInetCommon.a                                 \
+    $(NULL)
 
 AM_CPPFLAGS                                           = \
     -I$(top_srcdir)/src                                 \

--- a/src/inet/tests/TestInetLayer.cpp
+++ b/src/inet/tests/TestInetLayer.cpp
@@ -46,6 +46,7 @@
 using namespace chip;
 using namespace chip::Inet;
 using namespace chip::ArgParser;
+using namespace chip::System;
 
 /* Preprocessor Macros */
 

--- a/src/inet/tests/TestInetLayerMulticast.cpp
+++ b/src/inet/tests/TestInetLayerMulticast.cpp
@@ -48,6 +48,7 @@
 using namespace chip;
 using namespace chip::ArgParser;
 using namespace chip::Inet;
+using namespace chip::System;
 
 /* Preprocessor Macros */
 


### PR DESCRIPTION
 #### Problem
The Inet sources don't seem to build successfully in a variety of configurations. 

It's a little confusing since the example apps definitely use Inet with the supposedly "incompatible" configuration. Yet trying to replicate that configuration outside of an example results in a build failure. 

 #### Summary of Changes
Fixed the errors that crop up when CHIP is configured with `--disable-tests` and/or `--with-network-layer=inet`. Why this doesn't fail on other platforms is a bit of a mystery still. I only tested this on MacOS builds. 

Pending and possibly a follow up issue, since this PR fixes the Inet test build, the Inet tests may not have been running. Need to verify(again) that they are definitely running. 

fixes https://github.com/project-chip/connectedhomeip/issues/544