### PR TITLE
Add RAND_bytes support in CHIPCrypto.

### DIFF
--- a/src/crypto/CHIPCrypto.h
+++ b/src/crypto/CHIPCrypto.h
@@ -19,6 +19,8 @@
 #ifndef CHIP_CRYPTO_H
 #define CHIP_CRYPTO_H
 
+#include <stdbool.h>
+
 #include "CHIPBase+CompilerAbstraction.h"
 
 #ifndef CHIP_IP
@@ -182,6 +184,8 @@ int CHIP_constant_time_equal(const void * x, const void * y, size_t length);
 int CHIP_constant_time_is_zero(const void * x, size_t length);
 void CHIP_constant_time_fill_zero(void * x, size_t length);
 void CHIP_constant_time_copy(void * x, const void * y, size_t length);
+
+bool CHIP_RAND_bytes(void *buf, size_t len);
 
 #ifdef __cplusplus
 }

--- a/src/crypto/CHIPCrypto.h
+++ b/src/crypto/CHIPCrypto.h
@@ -185,7 +185,7 @@ int CHIP_constant_time_is_zero(const void * x, size_t length);
 void CHIP_constant_time_fill_zero(void * x, size_t length);
 void CHIP_constant_time_copy(void * x, const void * y, size_t length);
 
-bool CHIP_RAND_bytes(void *buf, size_t len);
+bool CHIP_RAND_bytes(void * buf, size_t len);
 
 #ifdef __cplusplus
 }

--- a/src/crypto/CHIPOpenSSL.c
+++ b/src/crypto/CHIPOpenSSL.c
@@ -556,3 +556,8 @@ void CHIP_aes_ctr_done(CHIP_aes_ctr_ctx * ctx)
     EVP_CIPHER_CTX_free(handle->ctx);
     handle->ctx = NULL;
 }
+
+bool CHIP_RAND_bytes(void *buf, size_t len) {
+    return (RAND_bytes(buf, len) == 1);
+}
+

--- a/src/crypto/CHIPOpenSSL.c
+++ b/src/crypto/CHIPOpenSSL.c
@@ -557,7 +557,7 @@ void CHIP_aes_ctr_done(CHIP_aes_ctr_ctx * ctx)
     handle->ctx = NULL;
 }
 
-bool CHIP_RAND_bytes(void *buf, size_t len) {
+bool CHIP_RAND_bytes(void * buf, size_t len)
+{
     return (RAND_bytes(buf, len) == 1);
 }
-


### PR DESCRIPTION
Future code (e.g. fabric id number generation) will require random byte
generation. This functionality seems small enough and stand-alone enough
to be added as a separate check-in.

 #### Problem
These are pre-requisites to add the message layer from Weave. I am attempting to add small changes rather than one large commit.

 #### Summary of Changes
Adds CHIP_RND_bytes method.
