### PR TITLE
Add cache for others missed in 561

### DIFF
--- a/scripts/build/bootstrap.sh
+++ b/scripts/build/bootstrap.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 
-# if [[ ! -f build/default/config.status ]]; then mkdir -p build/default; (cd build/default && ../../bootstrap-configure --enable-debug --enable-coverage); else ./bootstrap -w make; fi
-
 if [[ ! -f build/default/config.status ]]; then
   mkdir -p build/default
   (cd build/default &&
-    ../../bootstrap-configure --enable-debug --enable-coverage)
+    ../../bootstrap-configure -C --enable-debug --enable-coverage)
 elif [[ configure.ac -nt configure ]]; then
   ./bootstrap
 else

--- a/scripts/build/bootstrap_mbedtls.sh
+++ b/scripts/build/bootstrap_mbedtls.sh
@@ -2,4 +2,4 @@
 
 git clean -xdf
 mkdir -p build/default
-(cd build/default && ../../bootstrap-configure --enable-debug --enable-coverage --with-crypto=mbedtls)
+(cd build/default && ../../bootstrap-configure -C --enable-debug --enable-coverage --with-crypto=mbedtls)


### PR DESCRIPTION
#### Problem
 Configure is slower than it needs to be, can use config.cache.  Some runners of configure are not doing so.

 #### Summary of Changes
 Fix the stragglers from #561

fixes #634