### PR TITLE
reorder headers and break into blocks in src/app

### DIFF
--- a/src/app/api/chip-zcl.h
+++ b/src/app/api/chip-zcl.h
@@ -24,9 +24,9 @@
 #ifndef CHIP_ZCL_MASTER_HEADER
 #define CHIP_ZCL_MASTER_HEADER
 
+#include <memory.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <memory.h>
 
 typedef uint64_t bitmap64_t;
 typedef uint8_t enum8_t;

--- a/src/app/plugin/basic-server/utest.h
+++ b/src/app/plugin/basic-server/utest.h
@@ -31,6 +31,8 @@
 #define CHIP_AF_API_ZCL_CORE "utest.h"
 
 #include "chip-zcl.h"
+
 #include "gen-types.h"
+
 #include <stdio.h>
 #endif /*  UTEST_H */

--- a/src/app/plugin/identify-server/Makefile
+++ b/src/app/plugin/identify-server/Makefile
@@ -3,7 +3,7 @@ REQUIRED_PLUGINS=../zcl-data-model/zcl-data-model.o ../../utest-gen/gen-callback
 
 # ---------- GENERIC -------------
 CC=gcc
-CFLAGS="-I../../api/" "-I../../utest-gen/" -DCHIP_TEST
+CFLAGS="-I../../api/" "-I../../utest-gen/" "-I../zcl-data-model" -DCHIP_TEST
 
 $(NAME).out: $(NAME).o utest.o ../../api/mock/mock.o $(REQUIRED_PLUGINS)
 	$(CC) -o $(NAME).out $(NAME).o ../../api/mock/mock.o utest.o  $(REQUIRED_PLUGINS)

--- a/src/app/plugin/identify-server/utest.h
+++ b/src/app/plugin/identify-server/utest.h
@@ -32,9 +32,11 @@
 #define CHIP_AF_API_HAL "utest.h"
 
 #include "chip-zcl.h"
-#include "gen-types.h"
-#include "../zcl-data-model/zcl-data-model.h"
+#include "zcl-data-model.h"
+
 #include "gen-callbacks.h"
 #include "gen-cluster-id.h"
+#include "gen-types.h"
+
 #include <stdio.h>
 #endif /*  UTEST_H */

--- a/src/app/plugin/level-control-server/utest.h
+++ b/src/app/plugin/level-control-server/utest.h
@@ -38,7 +38,9 @@
 #define CHIP_AF_PLUGIN_LEVEL_CONTROL_SERVER_MINIMUM_LEVEL 0
 
 #include "chip-zcl.h"
-#include "gen-types.h"
+
 #include "gen-cluster-id.h"
+#include "gen-types.h"
+
 #include <stdio.h>
 #endif /*  UTEST_H */

--- a/src/app/plugin/message-dispatch/dispatch.h
+++ b/src/app/plugin/message-dispatch/dispatch.h
@@ -26,8 +26,8 @@
 #define ZCL_COMMAND_DISPATCH_H
 
 #include "chip-zcl.h"
-#include "general-command-handler.h"
 #include "cluster-command-handler.h"
+#include "general-command-handler.h"
 
 // Main command parsing controller.
 ChipZclStatus_t chipZclCommandParse(ChipZclCommandContext_t * context);

--- a/src/app/plugin/message-dispatch/utest.h
+++ b/src/app/plugin/message-dispatch/utest.h
@@ -26,8 +26,10 @@
 #define UTEST_H
 
 #include "chip-zcl.h"
-#include "gen-types.h"
 #include "dispatch.h"
 #include "general-command-handler.h"
+
+#include "gen-types.h"
+
 #include <stdio.h>
 #endif /*  UTEST_H */

--- a/src/app/plugin/on-off-server/utest.h
+++ b/src/app/plugin/on-off-server/utest.h
@@ -31,7 +31,9 @@
 #define CHIP_AF_API_ZCL_CORE "utest.h"
 
 #include "chip-zcl.h"
-#include "gen-types.h"
+
 #include "gen-cluster-id.h"
+#include "gen-types.h"
+
 #include <stdio.h>
 #endif /*  UTEST_H */

--- a/src/app/plugin/zcl-data-model/utest.h
+++ b/src/app/plugin/zcl-data-model/utest.h
@@ -31,6 +31,8 @@
 #define CHIP_AF_API_ZCL_CORE "utest.h"
 
 #include "chip-zcl.h"
+
 #include "gen-types.h"
+
 #include <stdio.h>
 #endif /*  UTEST_H */

--- a/src/app/plugin/zcl-data-model/zcl-data-model.c
+++ b/src/app/plugin/zcl-data-model/zcl-data-model.c
@@ -23,6 +23,8 @@
  *
  */
 
+#include "zcl-data-model.h"
+
 #ifdef CHIP_TEST
 #include "utest.h"
 #endif
@@ -36,9 +38,9 @@
 #include CHIP_AF_API_ZCL_CORE
 
 #include "chip-zcl.h"
-#include "zcl-data-model.h"
-#include "gen-callbacks.h"
+
 #include "gen-attribute-type.h"
+#include "gen-callbacks.h"
 #include "gen-endpoint-config.h"
 
 //------------------------------------------------------------------------------

--- a/src/app/plugin/zcl-data-model/zcl-data-model.h
+++ b/src/app/plugin/zcl-data-model/zcl-data-model.h
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 #include "chip-zcl.h"
+
 #include "gen-attribute-storage.h"
 
 /**

--- a/src/app/plugin/zcl-data-model/zcl-data-model.h
+++ b/src/app/plugin/zcl-data-model/zcl-data-model.h
@@ -26,6 +26,9 @@
 #ifndef CHIP_ZCL_ATTRIBUTE_DB
 #define CHIP_ZCL_ATTRIBUTE_DB
 
+#include <stdint.h>
+
+#include "chip-zcl.h"
 #include "gen-attribute-storage.h"
 
 /**

--- a/src/app/utest-gen/cluster-command-handler.h
+++ b/src/app/utest-gen/cluster-command-handler.h
@@ -29,9 +29,10 @@
 #define CHIP_ZCL_COMMAND_PARSE_HEADER
 
 #include "chip-zcl.h"
-#include "gen-types.h"
+
 #include "gen-cluster-id.h"
 #include "gen-command-id.h"
+#include "gen-types.h"
 
 // This is a set of generated prototype for functions that parse the
 // the incomming message, and call appropriate command handler.

--- a/src/app/utest-gen/gen-specs.c
+++ b/src/app/utest-gen/gen-specs.c
@@ -25,8 +25,10 @@
  */
 
 #include "chip-zcl.h"
-#include "gen-types.h"
+
 #include "gen-cluster-id.h"
+#include "gen-types.h"
+
 #include <stdio.h>
 
 // -----------------------------------------------------------------------------

--- a/src/app/utest/utest-on-off.c
+++ b/src/app/utest/utest-on-off.c
@@ -24,10 +24,12 @@
  *
  */
 
-#include <stdio.h>
 #include "chip-zcl.h"
 #include "cluster-command-handler.h"
+
 #include "gen-cluster-id.h"
+
+#include <stdio.h>
 
 int main()
 {


### PR DESCRIPTION
#### Problem
 includes aren't sorted

 #### Summary of Changes
 * sort includes
 * break into blocks for things that shouldn't be sorted (e.g. gen-* headers aren't stand-alone, need to have zcl stuff before them)
 * make more headers stand alone

working on #116, part of #683 