### PR TITLE
Try to get xcode to build the underlying chip library

### DIFF
--- a/Makefile-iOS
+++ b/Makefile-iOS
@@ -27,7 +27,7 @@
 
 DEBUG                                                  ?= 0
 ENABLE_TARGETED_LISTEN                                 ?= 0
-OPENSSL_DIR                                            ?= internal
+OPENSSL_DIR                                            ?= $(shell if which brew > /dev/null && brew ls --versions openssl > /dev/null; then brew --prefix openssl; else echo "internal"; fi)
 
 xc-find-sdk                                             = $(shell xcrun --sdk $(1) --show-sdk-path)
 xc-find-tool                                            = $(shell xcrun -find $(1))
@@ -206,27 +206,22 @@ ModuleMap                                               = \
 ifndef BuildJobs
 BuildJobs := $(shell getconf _NPROCESSORS_ONLN)
 endif
-JOBSFLAG := -j$(BuildJobs)
+JOBSFLAG :=
 
 #
 # automake files
 #
-AMFILES =                                                \
-    src/system/SystemLayer.am                            \
-    src/system/Makefile.am                               \
-    src/lib/core/CoreLayer.am                            \
-    src/lib/support/SupportLayer.am                      \
-    src/lib/Makefile.am                                  \
-    src/inet/InetLayer.am                                \
-    src/inet/Makefile.am                                 \
-    src/ble/BleLayer.am                                  \
-    src/ble/Makefile.am                                  \
-    src/lwip/Makefile.am                                 \
-    src/Makefile.am                                      \
-    third_party/Makefile.am                              \
-    Makefile.am                                          \
-    configure.ac                                         \
-    $(NULL)
+AMFILES =                               \
+	src/system/Makefile.am              \
+	src/lib/Makefile.am                 \
+	src/inet/Makefile.am                \
+	src/ble/Makefile.am                 \
+	src/lwip/Makefile.am                \
+	src/Makefile.am                     \
+	third_party/Makefile.am             \
+	Makefile.am                         \
+	configure.ac                        \
+	$(NULL)
 
 #
 # configure-arch <arch>
@@ -257,7 +252,7 @@ AMFILES =                                                \
 #
 define configure-arch
 $(ECHO) "  CONFIG   $(1)-$(TargetTuple)..."
-(cd $(BuildPath)/$(1)-$(TargetTuple) && $(AbsTopSourceDir)/configure -C \
+(cd $(BuildPath)/$(1)-$(TargetTuple) && $(AbsTopSourceDir)/configure \
 CPP="$(CPP)" CC="$(CC)" CXX="$(CXX)" OBJC="$(OBJC)" OBJCXX="$(OBJCXX)" AR="$(AR)" RANLIB="$(RANLIB)" NM="$(NM)" STRIP="$(STRIP)" \
 INSTALL="$(INSTALL) $(INSTALLFLAGS)" \
 CPPFLAGS="$(CPPFLAGS)" \
@@ -501,7 +496,7 @@ $(FrameworkHeaderDir):
 	$(ECHO) "  Creating framework header dir: $(FrameworkHeaderDir)"
 	@$(MKDIR_P) $(FrameworkHeaderDir)
 	$(ECHO) "  Embedding headers in framework"
-	@cp $(addprefix $(ChipDeviceManagerIncludePath)/,*) $(FrameworkHeaderDir)
+	@cp -R $(addprefix $(ChipDeviceManagerIncludePath)/,*) $(FrameworkHeaderDir)
 
 $(FrameworkModulesDir):
 	$(ECHO) "  Creating framework modules dir: $(FrameworkModulesDir)"

--- a/bootstrap
+++ b/bootstrap
@@ -26,6 +26,8 @@
 
 # Set this to the relative location of nlbuild-autotools to this script
 
+echo "RUNNING BOOTSTRAP"
+
 nlbuild_autotools_stem="third_party/nlbuild-autotools/repo"
 
 abs_srcdir=$(cd "$(dirname "${0}")" && pwd)

--- a/src/CHIP_Framework_iOS/CHIP/CHIP.xcodeproj/project.pbxproj
+++ b/src/CHIP_Framework_iOS/CHIP/CHIP.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B20252A12459E34F00F97062 /* Build configuration list for PBXNativeTarget "CHIP" */;
 			buildPhases = (
+				0C40A67D246C9AC700885C81 /* ShellScript */,
 				B20252882459E34F00F97062 /* Headers */,
 				B20252892459E34F00F97062 /* Sources */,
 				B202528A2459E34F00F97062 /* Frameworks */,
@@ -232,6 +233,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		0C40A67D246C9AC700885C81 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nexport PKG_CONFIG_PATH=\"/usr/local/opt/openssl@1.1/lib/pkgconfig\" && $SRCROOT/../../../bootstrap && cd $SRCROOT/../../../ && make -f $SRCROOT/../../..//Makefile-iOS arm64\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		B20252892459E34F00F97062 /* Sources */ = {
@@ -385,7 +406,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = K3V3JM297H;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -412,7 +433,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = K3V3JM297H;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";


### PR DESCRIPTION
 #### Problem
Try to get xcode to build the underlying chip library

 #### Summary of Changes
Changes made 
Add a new `Run Script` phase to the `CHIP.fwk` target

How to run
Select `CHIP > Generic iOS Device` target and press `CMD + B`

Result
Build fails with error `fatal error: 'core/CHIPError.h' file not found`

What seems to be happening is the output of the Makefile-iOS does not seem to copy over the headers in `src/lib/core` into `output/include`
This is what Shana was running into as well. She worked around it by manually copying over these headers after running Makefile-iOS

Next steps
Figure out why Makefile-iOS output is corrupt