### PR TITLE
Document how to quit the IDF monitor script once it's running.

### DIFF
--- a/examples/wifi-echo/server/esp32/README.md
+++ b/examples/wifi-echo/server/esp32/README.md
@@ -69,6 +69,15 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
     [VCP driver](https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers)
     before the device shows up on `/dev/tty`.
 
+-   Quit the monitor by hitting `Ctrl+]`.
+
+    Note: You can see a menu of various monitor commands by hitting
+    `Ctrl+t Ctrl+h` while the monitor is running.
+
+-   If desired, the monitor can be run again like so:
+
+          $ idf make monitor ESPPORT=/dev/tty.SLAB_USBtoUART
+
 ## Using the Echo Server
 
 There are two ways to use the Echo Server running on the device.


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/744

 #### Problem
The "how to quit" information from the IDF monitor script scrolls quickly out of view and is hard to notice.

 #### Summary of Changes
Include the relevant information in our documentation.
