### PR TITLE
Fix built-in esp32 echo client

### DIFF
--- a/examples/wifi-echo/server/esp32/main/EchoClient.cpp
+++ b/examples/wifi-echo/server/esp32/main/EchoClient.cpp
@@ -42,7 +42,7 @@ static const char * PAYLOAD = "Message from echo client!";
 
 static void udp_client_task(void * pvParameters)
 {
-#if USE_ECHO_CLIENT
+#if CONFIG_USE_ECHO_CLIENT
     char rx_buffer[RX_LEN];
     char host_ip[]  = HOST_IP_ADDR;
     int addr_family = 0;
@@ -113,7 +113,7 @@ static void udp_client_task(void * pvParameters)
 // The echo client assumes the platform's networking has been setup already
 void startClient(void)
 {
-#if USE_ECHO_CLIENT
+#if CONFIG_USE_ECHO_CLIENT
     xTaskCreate(udp_client_task, "udp_client", 4096, (void *) AF_INET, 5, NULL);
 #endif
 }


### PR DESCRIPTION
 #### Problem
The built-in echo client on the esp32 example application regressed. The check to see whether the client should be enabled is incorrect.

 #### Summary of Changes

Fix the `#if CONFIG` check so that the client works again. 

