### PR TITLE
groom chip_xcode_connector.sh

### DIFF
--- a/src/CHIP_Framework_iOS/CHIP/chip_xcode_build_connector.sh
+++ b/src/CHIP_Framework_iOS/CHIP/chip_xcode_build_connector.sh
@@ -25,17 +25,22 @@ CHIP_PREFIX=${CHIP_PREFIX:-"$BUILT_PRODUCTS_DIR"}
 
 [[ -d ${CHIP_ROOT} ]] || die Please set CHIP_ROOT to the location of the CHIP directory
 
+DEFINES=()
 # lots of environment variables passed by xcode to this script
-if [[ ${CONFIGURATION} == Debug ]]; then
+if [[ ${CONFIGURATION} == Debug* ]]; then
     configure_OPTIONS+=(--enable-debug)
-    DEFINES+="-DDEBUG=1 -UNDEBUG"
+    DEFINES+=(-UNDEBUG)
 else
-    DEFINES+="-DNDEBUG=1 -UDEBUG"
+    DEFINES+=(-UDEBUG)
 fi
+
+read -r -a GCC_PREPROCESSOR_DEFINITIONS <<<"$GCC_PREPROCESSOR_DEFINITIONS"
+
+DEFINES+=("${GCC_PREPROCESSOR_DEFINITIONS[@]/#/-D}")
 
 ARCH_FLAGS="-arch $ARCHS"
 SYSROOT_FLAGS="-isysroot $SDK_DIR"
-COMPILER_FLAGS="$ARCH_FLAGS $SYSROOT_FLAGS $DEFINES"
+COMPILER_FLAGS="$ARCH_FLAGS $SYSROOT_FLAGS ${DEFINES[*]}"
 
 configure_OPTIONS+=(
     CPP="cc -E"
@@ -47,11 +52,11 @@ configure_OPTIONS+=(
     LDFLAGS="$ARCH_FLAGS"
 )
 
-[[ ${PLATFORM_NAME} == iphoneos ]] && {
+[[ ${PLATFORM_FAMILY_NAME} == iOS ]] && {
     configure_OPTIONS+=(--with-chip-project-includes="$CHIP_ROOT"/config/ios --with-logging-style=external)
 }
 
-[[ ${PLATFORM_NAME} == macosx ]] && configure_OPTIONS+=(--with-chip-project-includes=no)
+[[ ${PLATFORM_FAMILY_NAME} == macOS ]] && configure_OPTIONS+=(--with-chip-project-includes=no)
 
 configure_OPTIONS+=(
     --prefix="$CHIP_PREFIX"

--- a/src/CHIP_Framework_iOS/CHIPQRCodeReader/CHIPQRCodeReader.xcodeproj/project.pbxproj
+++ b/src/CHIP_Framework_iOS/CHIPQRCodeReader/CHIPQRCodeReader.xcodeproj/project.pbxproj
@@ -277,7 +277,7 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		B204A649244E1D0700C7C0E1 /* Debug */ = {
+		B204A649244E1D0700C7C0E1 /* Debug iOS */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -333,9 +333,9 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 			};
-			name = Debug;
+			name = "Debug iOS";
 		};
-		B204A64A244E1D0700C7C0E1 /* Release */ = {
+		B204A64A244E1D0700C7C0E1 /* Release iOS */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -385,9 +385,9 @@
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 			};
-			name = Release;
+			name = "Release iOS";
 		};
-		B204A64C244E1D0700C7C0E1 /* Debug */ = {
+		B204A64C244E1D0700C7C0E1 /* Debug iOS */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -405,9 +405,9 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
-			name = Debug;
+			name = "Debug iOS";
 		};
-		B204A64D244E1D0700C7C0E1 /* Release */ = {
+		B204A64D244E1D0700C7C0E1 /* Release iOS */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -425,9 +425,9 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
-			name = Release;
+			name = "Release iOS";
 		};
-		B204A64F244E1D0700C7C0E1 /* Debug */ = {
+		B204A64F244E1D0700C7C0E1 /* Debug iOS */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -444,9 +444,9 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CHIPQRCodeReader.app/CHIPQRCodeReader";
 			};
-			name = Debug;
+			name = "Debug iOS";
 		};
-		B204A650244E1D0700C7C0E1 /* Release */ = {
+		B204A650244E1D0700C7C0E1 /* Release iOS */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -463,7 +463,7 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CHIPQRCodeReader.app/CHIPQRCodeReader";
 			};
-			name = Release;
+			name = "Release iOS";
 		};
 /* End XCBuildConfiguration section */
 
@@ -471,29 +471,29 @@
 		B204A617244E1D0600C7C0E1 /* Build configuration list for PBXProject "CHIPQRCodeReader" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				B204A649244E1D0700C7C0E1 /* Debug */,
-				B204A64A244E1D0700C7C0E1 /* Release */,
+				B204A649244E1D0700C7C0E1 /* Debug iOS */,
+				B204A64A244E1D0700C7C0E1 /* Release iOS */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = "Release iOS";
 		};
 		B204A64B244E1D0700C7C0E1 /* Build configuration list for PBXNativeTarget "CHIPQRCodeReader" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				B204A64C244E1D0700C7C0E1 /* Debug */,
-				B204A64D244E1D0700C7C0E1 /* Release */,
+				B204A64C244E1D0700C7C0E1 /* Debug iOS */,
+				B204A64D244E1D0700C7C0E1 /* Release iOS */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = "Release iOS";
 		};
 		B204A64E244E1D0700C7C0E1 /* Build configuration list for PBXNativeTarget "CHIPQRCodeReaderTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				B204A64F244E1D0700C7C0E1 /* Debug */,
-				B204A650244E1D0700C7C0E1 /* Release */,
+				B204A64F244E1D0700C7C0E1 /* Debug iOS */,
+				B204A650244E1D0700C7C0E1 /* Release iOS */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = "Release iOS";
 		};
 /* End XCConfigurationList section */
 	};

--- a/src/CHIP_Framework_iOS/CHIPQRCodeReader/CHIPQRCodeReader.xcodeproj/xcshareddata/xcschemes/CHIPQRCodeReader.xcscheme
+++ b/src/CHIP_Framework_iOS/CHIPQRCodeReader/CHIPQRCodeReader.xcodeproj/xcshareddata/xcschemes/CHIPQRCodeReader.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1140"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B204A61B244E1D0600C7C0E1"
+               BuildableName = "CHIPQRCodeReader.app"
+               BlueprintName = "CHIPQRCodeReader"
+               ReferencedContainer = "container:CHIPQRCodeReader.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug iOS"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug iOS"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B204A61B244E1D0600C7C0E1"
+            BuildableName = "CHIPQRCodeReader.app"
+            BlueprintName = "CHIPQRCodeReader"
+            ReferencedContainer = "container:CHIPQRCodeReader.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release iOS"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B204A61B244E1D0600C7C0E1"
+            BuildableName = "CHIPQRCodeReader.app"
+            BlueprintName = "CHIPQRCodeReader"
+            ReferencedContainer = "container:CHIPQRCodeReader.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug iOS">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release iOS"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
#### Problems
 * iphoneossimulator isn't recognized as iOS, prefer PLATFORM_FAMILY_NAME to PLATFORM_NAME
 * "Debug iOS" isn't recognized as a debug flavor
 * no support for GCC_PREPROC...
 * QRSetupCode application was borken by the move to schemes

 #### Summary of Changes
 fix for each of the above