### PR TITLE
Enable make check for embedded targets

### DIFF
--- a/scripts/tools/qemu_run_test.sh
+++ b/scripts/tools/qemu_run_test.sh
@@ -27,14 +27,14 @@ die() {
     exit 1
 }
 
-source $abs_top_builddir/env.sh
-bash $abs_top_builddir/esp32_elf_builder.sh "$QEMU_TEST_TARGET"
+source "$abs_top_builddir"/env.sh
+bash "$abs_top_builddir"/esp32_elf_builder.sh "$QEMU_TEST_TARGET"
 
 flash_image_file=$(mktemp)
 log_file=$(mktemp)
 trap "{ rm -f $flash_image_file $log_file; }" EXIT
 
-"$abs_top_srcdir"/scripts/tools/build_esp32_flash_image.sh $abs_top_builddir/chip-tests.bin "$flash_image_file"
+"$abs_top_srcdir"/scripts/tools/build_esp32_flash_image.sh "$abs_top_builddir"/chip-tests.bin "$flash_image_file"
 "$abs_top_srcdir"/scripts/tools/esp32_qemu_run.sh "$flash_image_file" | tee "$log_file"
 
 # If the logs contain failure message

--- a/scripts/tools/qemu_run_test.sh
+++ b/scripts/tools/qemu_run_test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+#
+#    Description:
+#      This is a utility script that runs CHIP tests using ESP32 QEMU.
+#
+
+set -e
+
+die() {
+    echo "$me: *** ERROR: " "${*}"
+    exit 1
+}
+
+source $abs_top_builddir/env.sh
+bash $abs_top_builddir/esp32_elf_builder.sh "$QEMU_TEST_TARGET"
+
+flash_image_file=$(mktemp)
+log_file=$(mktemp)
+trap "{ rm -f $flash_image_file $log_file; }" EXIT
+
+"$abs_top_srcdir"/scripts/tools/build_esp32_flash_image.sh $abs_top_builddir/chip-tests.bin "$flash_image_file"
+"$abs_top_srcdir"/scripts/tools/esp32_qemu_run.sh "$flash_image_file" | tee "$log_file"
+
+# If the logs contain failure message
+if grep -F "] : FAILED" "$log_file"; then
+    die 'Some tests failed.'
+fi
+
+# If the logs do not contain final success status
+if grep -F "CHIP-tests: CHIP test status: 0" "$log_file"; then
+    echo "$me: All tests passed"
+else
+    die 'Tests did not run to completion.'
+fi

--- a/src/crypto/tests/Makefile.am
+++ b/src/crypto/tests/Makefile.am
@@ -94,12 +94,8 @@ TESTS_ENVIRONMENT                              = \
 
 if CHIP_TARGET_STYLE_EMBEDDED
 
-# bin_SCRIPTS                                    = \
-#     $(top_srcdir)/scripts/tools/qemu_run_test.sh \
-#     $(NULL)
-
 check_SCRIPTS                                 += \
-    ../../../qemu_run_test.sh                    \
+    qemu_crypto_tests.sh                         \
     $(NULL)
 
 TESTS_ENVIRONMENT                             += \

--- a/src/crypto/tests/Makefile.am
+++ b/src/crypto/tests/Makefile.am
@@ -82,20 +82,46 @@ COMMON_LDADD                                   = \
 # Test applications that should be run when the 'check' target is run.
 
 check_PROGRAMS                                 = \
+    $(NULL)
+
+check_SCRIPTS                                  = \
+    $(NULL)
+
+# The additional environment variables and their values that will be
+# made available to all programs and scripts in TESTS.
+TESTS_ENVIRONMENT                              = \
+    $(NULL)
+
+if CHIP_TARGET_STYLE_EMBEDDED
+
+# bin_SCRIPTS                                    = \
+#     $(top_srcdir)/scripts/tools/qemu_run_test.sh \
+#     $(NULL)
+
+check_SCRIPTS                                 += \
+    ../../../qemu_run_test.sh                    \
+    $(NULL)
+
+TESTS_ENVIRONMENT                             += \
+    abs_top_srcdir='$(abs_top_srcdir)'           \
+    abs_top_builddir='$(abs_top_builddir)'       \
+    QEMU_TEST_TARGET=libCryptoLayerTests.a       \
+    $(NULL)
+
+else # CHIP_TARGET_STYLE_EMBEDDED
+
+check_PROGRAMS                                += \
     TestCryptoPAL                                \
     $(NULL)
+
+endif # CHIP_TARGET_STYLE_EMBEDDED
 
 # Test applications and scripts that should be built and run when the
 # 'check' target is run.
 
 TESTS                                          = \
     $(check_PROGRAMS)                            \
-    $(NULL)
-
-# The additional environment variables and their values that will be
-# made available to all programs and scripts in TESTS.
-
-TESTS_ENVIRONMENT                              = \
+    $(check_SCRIPTS)                             \
     $(NULL)
 
 # Source, compiler, and linker options for test programs.

--- a/src/crypto/tests/qemu_crypto_tests.sh
+++ b/src/crypto/tests/qemu_crypto_tests.sh
@@ -1,0 +1,1 @@
+../../../scripts/tools/qemu_run_test.sh

--- a/src/test_driver/esp32/Makefile
+++ b/src/test_driver/esp32/Makefile
@@ -11,9 +11,14 @@ EXTRA_COMPONENT_DIRS += $(PROJECT_PATH)/third_party/connectedhomeip/config/esp32
 
 include $(IDF_PATH)/make/project.mk
 
-esp32_elf_builder:
+esp32_elf_builder: all
 	mkdir -p build/chip/
 	echo $(CC) -L$(PROJECT_PATH)/build/chip/lib -Wl,--whole-archive '$$1' -Wl,--no-whole-archive \
 		 -lnlunit-test $(LDFLAGS) -o $(PROJECT_PATH)/build/chip-tests.elf -Wl,-Map=$(APP_MAP) > build/chip/esp32_elf_builder.sh
 	echo $(ESPTOOLPY) elf2image $(ESPTOOL_FLASH_OPTIONS) $(ESPTOOL_ELF2IMAGE_OPTIONS) \
-		 -o $(PROJECT_PATH)/build/chip-tests.bin $(PROJECT_PATH)/build/chip-tests.elf >> build/chip/esp32_elf_builder.sh
+		 -o $(PROJECT_PATH)/build/chip/chip-tests.bin $(PROJECT_PATH)/build/chip-tests.elf >> build/chip/esp32_elf_builder.sh
+	ln -s $(PROJECT_PATH)/build/partitions_singleapp.bin $(PROJECT_PATH)/build/chip/partitions_singleapp.bin
+	mkdir -p build/chip/bootloader
+	ln -s $(PROJECT_PATH)/build/bootloader/bootloader.bin $(PROJECT_PATH)/build/chip/bootloader/bootloader.bin
+	ln -s $(PROJECT_PATH)/idf.sh $(PROJECT_PATH)/build/chip/env.sh
+	ln -s $(PROJECT_PATH)/third_party/connectedhomeip/scripts/tools/qemu_run_test.sh $(PROJECT_PATH)/build/chip/qemu_run_test.sh

--- a/src/test_driver/esp32/Makefile
+++ b/src/test_driver/esp32/Makefile
@@ -21,4 +21,3 @@ esp32_elf_builder: all
 	mkdir -p build/chip/bootloader
 	ln -s $(PROJECT_PATH)/build/bootloader/bootloader.bin $(PROJECT_PATH)/build/chip/bootloader/bootloader.bin
 	ln -s $(PROJECT_PATH)/idf.sh $(PROJECT_PATH)/build/chip/env.sh
-	ln -s $(PROJECT_PATH)/third_party/connectedhomeip/scripts/tools/qemu_run_test.sh $(PROJECT_PATH)/build/chip/qemu_run_test.sh


### PR DESCRIPTION
 #### Problem
Missing `make check` facility for embedded targets.

 #### Summary of Changes
Added support for `make check` using QEMU. Currently it supports Crypto tests. Once the approach is approved, similar makefile changes can be made to other test suites.

fixes #721 
