### PR TITLE
disable qrcodetool if tools disabled

### DIFF
--- a/src/qrcodetool/Makefile.am
+++ b/src/qrcodetool/Makefile.am
@@ -1,5 +1,7 @@
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
+if CHIP_BUILD_TOOLS
+
 bin_PROGRAMS                       = qrcodetool
 qrcodetool_SOURCES                   = qrcodetool.cpp setup_payload_commands.cpp setup_payload_commands.h qrcodetool_command_manager.h
 
@@ -19,5 +21,7 @@ qrcodetool_LDADD = \
 NLFOREIGN_FILE_DEPENDENCIES = \
       $(qrcodetool_LDADD) \
       $(NULL)
+
+endif
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am


### PR DESCRIPTION
#### Problem
 qrcodetool is a console app, unsupported for iOS

 #### Summary of Changes
 disable making qrcodetool if tools are disabled