### PR TITLE
Implement Secure Channel class and its unit tests

### DIFF
--- a/src/lib/core/CHIPSecureChannel.cpp
+++ b/src/lib/core/CHIPSecureChannel.cpp
@@ -1,0 +1,138 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements the CHIP Secure Channel object.
+ *
+ */
+
+#include <core/CHIPSecureChannel.h>
+#include <crypto/CHIPCryptoPAL.h>
+#include <support/CodeUtils.h>
+
+namespace chip {
+
+using namespace Crypto;
+
+ChipSecureChannel::ChipSecureChannel() : mKeyAvailable(false), mNextIV(0) {}
+
+CHIP_ERROR ChipSecureChannel::Init(const unsigned char * remote_public_key, const size_t public_key_length,
+                                   const unsigned char * local_private_key, const size_t private_key_length,
+                                   const unsigned char * salt, const size_t salt_length, const unsigned char * info,
+                                   const size_t info_length)
+{
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    uint8_t secret[kMax_ECDH_Secret_Length];
+    size_t secret_size = sizeof(secret);
+
+    VerifyOrExit(mKeyAvailable == false, error = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(remote_public_key != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(public_key_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(local_private_key != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(private_key_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+    if (salt_length > 0)
+    {
+        VerifyOrExit(salt != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    }
+
+    VerifyOrExit(info_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(info != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+
+    mNextIV = 0;
+
+    error = ECDH_derive_secret(remote_public_key, public_key_length, local_private_key, private_key_length, secret, secret_size);
+    if (error == CHIP_NO_ERROR)
+    {
+        error         = HKDF_SHA256(secret, sizeof(secret), salt, salt_length, info, info_length, mKey, sizeof(mKey));
+        mKeyAvailable = (error == CHIP_NO_ERROR);
+    }
+
+exit:
+    return error;
+}
+
+CHIP_ERROR ChipSecureChannel::Encrypt(const unsigned char * input, size_t input_length, unsigned char * output,
+                                      size_t output_length)
+{
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    uint64_t tag     = 0;
+    security_header_t header;
+    size_t overhead = EncryptionOverhead();
+
+    VerifyOrExit(mKeyAvailable, error = CHIP_ERROR_INVALID_USE_OF_SESSION_KEY);
+    VerifyOrExit(input != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(input_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(output != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(output_length >= overhead + input_length, error = CHIP_ERROR_INVALID_ARGUMENT);
+
+    header.payload_length = input_length;
+    header.IV             = mNextIV;
+    header.tag            = 0;
+
+    error = AES_CCM_encrypt(input, input_length, (const unsigned char *) &header, sizeof(header), mKey, sizeof(mKey),
+                            (const unsigned char *) &header.IV, sizeof(header.IV), &output[overhead], (unsigned char *) &tag,
+                            sizeof(tag));
+    if (error == CHIP_NO_ERROR)
+    {
+        header.tag = tag;
+        memcpy(output, &header, sizeof(header));
+        mNextIV++;
+    }
+
+exit:
+    return error;
+}
+
+CHIP_ERROR ChipSecureChannel::Decrypt(const unsigned char * input, size_t input_length, unsigned char * output,
+                                      size_t & output_length)
+{
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    uint64_t tag     = 0;
+    security_header_t header;
+    size_t overhead = EncryptionOverhead();
+
+    VerifyOrExit(mKeyAvailable, error = CHIP_ERROR_INVALID_USE_OF_SESSION_KEY);
+    VerifyOrExit(input != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(input_length > overhead, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(output != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+
+    memcpy(&header, input, sizeof(header));
+    tag        = header.tag;
+    header.tag = 0;
+
+    VerifyOrExit(output_length >= header.payload_length, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(input_length >= header.payload_length + overhead, error = CHIP_ERROR_INVALID_ARGUMENT);
+
+    error = AES_CCM_decrypt(&input[overhead], header.payload_length, (const unsigned char *) &header, sizeof(header),
+                            (const unsigned char *) &tag, sizeof(tag), mKey, sizeof(mKey), (const unsigned char *) &header.IV,
+                            sizeof(header.IV), output);
+    if (error == CHIP_NO_ERROR)
+    {
+        output_length = header.payload_length;
+    }
+exit:
+    return error;
+}
+
+size_t ChipSecureChannel::EncryptionOverhead(void)
+{
+    return sizeof(security_header_t);
+}
+
+} // namespace chip

--- a/src/lib/core/CHIPSecureChannel.cpp
+++ b/src/lib/core/CHIPSecureChannel.cpp
@@ -24,8 +24,9 @@
 
 #include <core/CHIPSecureChannel.h>
 #include <crypto/CHIPCryptoPAL.h>
-#include <string.h>
 #include <support/CodeUtils.h>
+
+#include <string.h>
 
 namespace chip {
 

--- a/src/lib/core/CHIPSecureChannel.cpp
+++ b/src/lib/core/CHIPSecureChannel.cpp
@@ -24,6 +24,7 @@
 
 #include <core/CHIPSecureChannel.h>
 #include <crypto/CHIPCryptoPAL.h>
+#include <string.h>
 #include <support/CodeUtils.h>
 
 namespace chip {

--- a/src/lib/core/CHIPSecureChannel.h
+++ b/src/lib/core/CHIPSecureChannel.h
@@ -81,7 +81,7 @@ public:
      */
     size_t EncryptionOverhead(void);
 
-    ChipSecureChannel();
+    ChipSecureChannel(void);
 
 private:
     static const size_t kAES_CCM128_Key_Length = 16;

--- a/src/lib/core/CHIPSecureChannel.h
+++ b/src/lib/core/CHIPSecureChannel.h
@@ -1,0 +1,103 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines the CHIP Secure Channel object that provides
+ *      APIs for encrypting/decryting data using cryptographic keys.
+ *
+ */
+
+#ifndef __CHIPSECURECHANNEL_H__
+#define __CHIPSECURECHANNEL_H__
+
+#include <core/CHIPCore.h>
+
+namespace chip {
+
+class DLL_EXPORT ChipSecureChannel
+{
+public:
+    /**
+     * @brief
+     *   Derive a shared key. The derived key will be used for encryting/decrypting
+     *   data exchanged on the secure channel.
+     *
+     * @param remote_public_key  A pointer to peer's public key
+     * @param public_key_length  Length of remote_public_key
+     * @param local_private_key  A pointer to local private key
+     * @param private_key_length Length of local_private_key
+     * @return CHIP_ERROR        The result of key derivation
+     */
+    CHIP_ERROR Init(const unsigned char * remote_public_key, const size_t public_key_length,
+                    const unsigned char * local_private_key, const size_t private_key_length, const unsigned char * salt,
+                    const size_t salt_length, const unsigned char * info, const size_t info_length);
+
+    /**
+     * @brief
+     *   Encrypt the input data using keys established in the secure channel
+     *
+     * @param input Unencrypted input data
+     * @param input_length Length of the input data
+     * @param output Output buffer for encrypted data
+     * @param output_length Length of the output buffer
+     * @return CHIP_ERROR The result of encryption
+     */
+    CHIP_ERROR Encrypt(const unsigned char * input, size_t input_length, unsigned char * output, size_t output_length);
+
+    /**
+     * @brief
+     *   Decrypt the input data using keys established in the secure channel
+     *
+     * @param input Encrypted input data
+     * @param input_length Length of the input data
+     * @param output Output buffer for decrypted data
+     * @param output_length Length of the output buffer
+     * @return CHIP_ERROR The result of decryption
+     */
+    CHIP_ERROR Decrypt(const unsigned char * input, size_t input_length, unsigned char * output, size_t & output_length);
+
+    /**
+     * @brief
+     *   Memory overhead of encrypting data. The overhead is indepedent of size of
+     *   the data being encrypted. The extra space is used for storing the common header.
+     *
+     * @return number of bytes.
+     */
+    size_t EncryptionOverhead(void);
+
+    ChipSecureChannel();
+
+private:
+    static const size_t kAES_CCM128_Key_Length = 16;
+
+    typedef struct
+    {
+        size_t payload_length;
+        uint64_t IV;
+        uint64_t tag;
+    } security_header_t;
+
+    bool mKeyAvailable;
+    uint64_t mNextIV;
+    uint8_t mKey[kAES_CCM128_Key_Length];
+};
+
+} // namespace chip
+
+#endif // __CHIPSECURECHANNEL_H__

--- a/src/lib/core/CoreLayer.am
+++ b/src/lib/core/CoreLayer.am
@@ -33,6 +33,7 @@ CHIP_BUILD_CORE_LAYER_SOURCE_FILES                        = \
     core/CHIPTLVUpdater.cpp                                 \
     core/CHIPKeyIds.cpp                                     \
     core/CHIPConnection.cpp                                 \
+    core/CHIPSecureChannel.cpp                              \
     $(NULL)
 
 CHIP_BUILD_CORE_LAYER_HEADER_FILES                        = \
@@ -52,4 +53,5 @@ CHIP_BUILD_CORE_LAYER_HEADER_FILES                        = \
     core/CHIPTunnelConfig.h                                 \
     core/CHIPKeyIds.h                                       \
     core/CHIPConnection.h                                   \
+    core/CHIPSecureChannel.h                                \
     $(NULL)

--- a/src/lib/core/tests/Makefile.am
+++ b/src/lib/core/tests/Makefile.am
@@ -44,6 +44,7 @@ libCoreTests_a_SOURCES                                = \
     TestCHIPErrorStr.cpp                                \
     TestCHIPTLV.cpp                                     \
     TestCHIPConnection.cpp                              \
+    TestCHIPSecureChannel.cpp                           \
     $(NULL)
 
 libCoreTests_adir                                     = $(includedir)/core
@@ -69,6 +70,7 @@ AM_CPPFLAGS                                           = \
 CHIP_LDADD                                            = \
     $(top_builddir)/src/lib/libCHIP.a                   \
     $(top_builddir)/src/lib/support/libSupportLayer.a   \
+    $(top_builddir)/src/crypto/libChipCrypto.a          \
     $(NULL)
 
 COMMON_LDADD                                          =  \
@@ -88,6 +90,7 @@ check_PROGRAMS                                        = \
     TestCHIPErrorStr                                    \
     TestCHIPTLV                                         \
     TestCHIPConnection                                  \
+    TestCHIPSecureChannel                               \
     $(NULL)
 
 # Test applications and scripts that should be built and run when the
@@ -113,6 +116,9 @@ TestCHIPTLV_LDADD                                     = $(COMMON_LDADD)
 
 TestCHIPConnection_SOURCES                            = TestCHIPConnectionDriver.cpp
 TestCHIPConnection_LDADD                              = $(COMMON_LDADD)
+
+TestCHIPSecureChannel_SOURCES                         = TestCHIPSecureChannelDriver.cpp
+TestCHIPSecureChannel_LDADD                           = $(COMMON_LDADD)
 #
 # Foreign make dependencies
 #

--- a/src/lib/core/tests/Makefile.am
+++ b/src/lib/core/tests/Makefile.am
@@ -119,6 +119,7 @@ TestCHIPConnection_LDADD                              = $(COMMON_LDADD)
 
 TestCHIPSecureChannel_SOURCES                         = TestCHIPSecureChannelDriver.cpp
 TestCHIPSecureChannel_LDADD                           = $(COMMON_LDADD)
+
 #
 # Foreign make dependencies
 #

--- a/src/lib/core/tests/TestCHIPSecureChannel.cpp
+++ b/src/lib/core/tests/TestCHIPSecureChannel.cpp
@@ -1,0 +1,247 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements unit tests for the CHIPSecureChannel implementation.
+ */
+
+#include "TestCore.h"
+
+#include <errno.h>
+#include <nlbyteorder.h>
+#include <nlunit-test.h>
+
+#include <core/CHIPCore.h>
+#include <core/CHIPSecureChannel.h>
+
+#include <stdarg.h>
+#include <support/CodeUtils.h>
+
+using namespace chip;
+
+static const unsigned char secure_channel_test_private_key1[] = { 0xc6, 0x1a, 0x2f, 0x89, 0x36, 0x67, 0x2b, 0x26, 0x12, 0x47, 0x4f,
+                                                                  0x11, 0x0e, 0x34, 0x15, 0x81, 0x81, 0x12, 0xfc, 0x36, 0xeb, 0x65,
+                                                                  0x61, 0x07, 0xaa, 0x63, 0xe8, 0xc5, 0x22, 0xac, 0x52, 0xa1 };
+
+static const unsigned char secure_channel_test_public_key1[] = { 0x04, 0xe2, 0x07, 0x64, 0xff, 0x6f, 0x6a, 0x91, 0xd9, 0xc2, 0xc3,
+                                                                 0x0a, 0xc4, 0x3c, 0x56, 0x4b, 0x42, 0x8a, 0xf3, 0xb4, 0x49, 0x29,
+                                                                 0x39, 0x95, 0xa2, 0xf7, 0x02, 0x8c, 0xa5, 0xce, 0xf3, 0xc9, 0xca,
+                                                                 0x24, 0xc5, 0xd4, 0x5c, 0x60, 0x79, 0x48, 0x30, 0x3c, 0x53, 0x86,
+                                                                 0xd9, 0x23, 0xe6, 0x61, 0x1f, 0x5a, 0x3d, 0xdf, 0x9f, 0xdc, 0x35,
+                                                                 0xea, 0xd0, 0xde, 0x16, 0x7e, 0x64, 0xde, 0x7f, 0x3c, 0xa6 };
+
+static const unsigned char secure_channel_test_private_key2[] = {
+    0x00, 0xd1, 0x90, 0xd9, 0xb3, 0x95, 0x1c, 0x5f, 0xa4, 0xe7, 0x47, 0x92, 0x5b, 0x0a, 0xa9, 0xa7, 0xc1,
+    0x1c, 0xe7, 0x06, 0x10, 0xe2, 0xdd, 0x16, 0x41, 0x52, 0x55, 0xb7, 0xb8, 0x80, 0x8d, 0x87, 0xa1
+};
+
+static const unsigned char secure_channel_test_public_key2[] = { 0x04, 0x30, 0x77, 0x2c, 0xe7, 0xd4, 0x0a, 0xf2, 0xf3, 0x19, 0xbd,
+                                                                 0xfb, 0x1f, 0xcc, 0x88, 0xd9, 0x83, 0x25, 0x89, 0xf2, 0x09, 0xf3,
+                                                                 0xab, 0xe4, 0x33, 0xb6, 0x7a, 0xff, 0x73, 0x3b, 0x01, 0x35, 0x34,
+                                                                 0x92, 0x73, 0x14, 0x59, 0x0b, 0xbd, 0x44, 0x72, 0x1b, 0xcd, 0xb9,
+                                                                 0x02, 0x53, 0xd9, 0xaf, 0xcc, 0x1a, 0xcd, 0xae, 0xe8, 0x87, 0x2e,
+                                                                 0x52, 0x3b, 0x98, 0xf0, 0xa1, 0x88, 0x4a, 0xe3, 0x03, 0x75 };
+
+void SecureChannelInitTest(nlTestSuite * inSuite, void * inContext)
+{
+    ChipSecureChannel channel;
+    // Test all combinations of invalid parameters
+    NL_TEST_ASSERT(inSuite, channel.Init(NULL, 0, NULL, 0, NULL, 0, NULL, 0) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite,
+                   channel.Init(secure_channel_test_public_key1, 0, NULL, 0, NULL, 0, NULL, 0) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite,
+                   channel.Init(secure_channel_test_public_key1, sizeof(secure_channel_test_public_key1), NULL, 0, NULL, 0, NULL,
+                                0) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite,
+                   channel.Init(secure_channel_test_public_key1, sizeof(secure_channel_test_public_key1),
+                                secure_channel_test_private_key2, 0, NULL, 0, NULL, 0) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite,
+                   channel.Init(secure_channel_test_public_key1, sizeof(secure_channel_test_public_key1),
+                                secure_channel_test_private_key2, sizeof(secure_channel_test_private_key2), NULL, 0, NULL,
+                                0) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite,
+                   channel.Init(secure_channel_test_public_key1, sizeof(secure_channel_test_public_key1),
+                                secure_channel_test_private_key2, sizeof(secure_channel_test_private_key2), NULL, 10, NULL,
+                                0) == CHIP_ERROR_INVALID_ARGUMENT);
+
+    // Test the channel is successfully created with valid parameters
+    const char * info = "Test Info";
+    NL_TEST_ASSERT(inSuite,
+                   channel.Init(secure_channel_test_public_key1, sizeof(secure_channel_test_public_key1),
+                                secure_channel_test_private_key2, sizeof(secure_channel_test_private_key2), NULL, 0,
+                                (const unsigned char *) info, sizeof(info)) == CHIP_NO_ERROR);
+
+    // Test the channel cannot be reinitialized
+    NL_TEST_ASSERT(inSuite,
+                   channel.Init(secure_channel_test_public_key1, sizeof(secure_channel_test_public_key1),
+                                secure_channel_test_private_key2, sizeof(secure_channel_test_private_key2), NULL, 0,
+                                (const unsigned char *) info, sizeof(info)) == CHIP_ERROR_INCORRECT_STATE);
+
+    // Test the channel can be initialized with valid salt
+    const char * salt = "Test Salt";
+    ChipSecureChannel channel2;
+    NL_TEST_ASSERT(inSuite,
+                   channel2.Init(secure_channel_test_public_key1, sizeof(secure_channel_test_public_key1),
+                                 secure_channel_test_private_key2, sizeof(secure_channel_test_private_key2),
+                                 (const unsigned char *) salt, sizeof(salt), (const unsigned char *) info,
+                                 sizeof(info)) == CHIP_NO_ERROR);
+}
+
+void SecureChannelEncryptTest(nlTestSuite * inSuite, void * inContext)
+{
+    ChipSecureChannel channel;
+    const unsigned char plain_text[] = { 0x86, 0x74, 0x64, 0xe5, 0x0b, 0xd4, 0x0d, 0x90,
+                                         0xe1, 0x17, 0xa3, 0x2d, 0x4b, 0xd4, 0xe1, 0xe6 };
+    unsigned char output[128];
+
+    // Test uninitialized channel
+    NL_TEST_ASSERT(
+        inSuite, channel.Encrypt(plain_text, sizeof(plain_text), output, sizeof(output)) == CHIP_ERROR_INVALID_USE_OF_SESSION_KEY);
+
+    const char * info = "Test Info";
+    const char * salt = "Test Salt";
+    NL_TEST_ASSERT(inSuite,
+                   channel.Init(secure_channel_test_public_key1, sizeof(secure_channel_test_public_key1),
+                                secure_channel_test_private_key2, sizeof(secure_channel_test_private_key2),
+                                (const unsigned char *) salt, sizeof(salt), (const unsigned char *) info,
+                                sizeof(info)) == CHIP_NO_ERROR);
+
+    // Test initialized channel, but invalid arguments
+    NL_TEST_ASSERT(inSuite, channel.Encrypt(NULL, 0, NULL, 0) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, channel.Encrypt(plain_text, 0, NULL, 0) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, channel.Encrypt(plain_text, sizeof(plain_text), NULL, 0) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, channel.Encrypt(plain_text, sizeof(plain_text), output, 0) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite,
+                   channel.Encrypt(plain_text, sizeof(plain_text), output, sizeof(plain_text)) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, channel.EncryptionOverhead() <= sizeof(output) - sizeof(plain_text));
+    NL_TEST_ASSERT(inSuite,
+                   channel.Encrypt(plain_text, sizeof(plain_text), output, sizeof(plain_text) + channel.EncryptionOverhead() - 1) ==
+                       CHIP_ERROR_INVALID_ARGUMENT);
+
+    // Valid arguments
+    NL_TEST_ASSERT(inSuite,
+                   channel.Encrypt(plain_text, sizeof(plain_text), output, sizeof(plain_text) + channel.EncryptionOverhead()) ==
+                       CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite,
+                   channel.Encrypt(plain_text, sizeof(plain_text), output, sizeof(plain_text) + channel.EncryptionOverhead() + 1) ==
+                       CHIP_NO_ERROR);
+}
+
+void SecureChannelDecryptTest(nlTestSuite * inSuite, void * inContext)
+{
+    ChipSecureChannel channel;
+    const unsigned char plain_text[] = { 0x86, 0x74, 0x64, 0xe5, 0x0b, 0xd4, 0x0d, 0x90,
+                                         0xe1, 0x17, 0xa3, 0x2d, 0x4b, 0xd4, 0xe1, 0xe6 };
+    unsigned char encrypted[128];
+
+    const char * info = "Test Info";
+    const char * salt = "Test Salt";
+
+    NL_TEST_ASSERT(inSuite,
+                   channel.Init(secure_channel_test_public_key1, sizeof(secure_channel_test_public_key1),
+                                secure_channel_test_private_key2, sizeof(secure_channel_test_private_key2),
+                                (const unsigned char *) salt, sizeof(salt), (const unsigned char *) info,
+                                sizeof(info)) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite,
+                   channel.Encrypt(plain_text, sizeof(plain_text), encrypted, sizeof(plain_text) + channel.EncryptionOverhead()) ==
+                       CHIP_NO_ERROR);
+
+    ChipSecureChannel channel2;
+    unsigned char output[128];
+    size_t output_length = sizeof(output);
+    // Uninitialized channel
+    NL_TEST_ASSERT(inSuite,
+                   channel2.Decrypt(encrypted, sizeof(plain_text) + channel.EncryptionOverhead(), output, output_length) ==
+                       CHIP_ERROR_INVALID_USE_OF_SESSION_KEY);
+    NL_TEST_ASSERT(inSuite,
+                   channel2.Init(secure_channel_test_public_key2, sizeof(secure_channel_test_public_key2),
+                                 secure_channel_test_private_key1, sizeof(secure_channel_test_private_key1),
+                                 (const unsigned char *) salt, sizeof(salt), (const unsigned char *) info,
+                                 sizeof(info)) == CHIP_NO_ERROR);
+
+    // Channel initialized, but invalid arguments to decrypt
+    output_length = 0;
+    NL_TEST_ASSERT(inSuite, channel2.Decrypt(NULL, 0, NULL, output_length) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, channel2.Decrypt(encrypted, 0, NULL, output_length) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, channel2.Decrypt(encrypted, sizeof(encrypted), NULL, output_length) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, channel2.Decrypt(encrypted, sizeof(encrypted), output, output_length) == CHIP_ERROR_INVALID_ARGUMENT);
+
+    // Valid arguments
+    output_length = sizeof(output);
+    NL_TEST_ASSERT(inSuite,
+                   channel2.Decrypt(encrypted, sizeof(plain_text) + channel.EncryptionOverhead(), output, output_length) ==
+                       CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, output_length == sizeof(plain_text));
+    NL_TEST_ASSERT(inSuite, memcmp(plain_text, output, sizeof(plain_text)) == 0);
+
+    NL_TEST_ASSERT(inSuite, channel2.Decrypt(encrypted, sizeof(encrypted), output, output_length) == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, output_length == sizeof(plain_text));
+    NL_TEST_ASSERT(inSuite, memcmp(plain_text, output, sizeof(plain_text)) == 0);
+}
+
+// Test Suite
+
+/**
+ *  Test Suite that lists all the test functions.
+ */
+// clang-format off
+static const nlTest sTests[] =
+{
+    NL_TEST_DEF("Init",    SecureChannelInitTest),
+    NL_TEST_DEF("Encrypt", SecureChannelEncryptTest),
+    NL_TEST_DEF("Decrypt", SecureChannelDecryptTest),
+
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+// clang-format off
+static nlTestSuite sSuite =
+{
+    "Test-CHIP-SecureChannel",
+    &sTests[0],
+    NULL,
+    NULL
+};
+// clang-format on
+
+/**
+ *  Main
+ */
+int TestCHIPSecureChannel()
+{
+    // Run test suit against one context
+    nlTestRunner(&sSuite, NULL);
+
+    return (nlTestRunnerStats(&sSuite));
+}
+
+namespace chip {
+namespace Logging {
+void Log(uint8_t module, uint8_t category, const char * format, ...)
+{
+    va_list argptr;
+    va_start(argptr, format);
+    vfprintf(stderr, format, argptr);
+    va_end(argptr);
+}
+} // namespace Logging
+} // namespace chip

--- a/src/lib/core/tests/TestCHIPSecureChannelDriver.cpp
+++ b/src/lib/core/tests/TestCHIPSecureChannelDriver.cpp
@@ -17,25 +17,19 @@
 
 /**
  *    @file
- *      This file declares test entry points for CHIP core library
- *      unit tests.
+ *      This file implements a standalone/native program executable
+ *      test driver for the CHIP core library CHIP Secure Channel tests.
  *
  */
 
-#ifndef TESTCORE_H
-#define TESTCORE_H
+#include "TestCore.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include <nlunit-test.h>
 
-int TestCHIPErrorStr(void);
-int TestCHIPTLV(void);
-int TestCHIPConnection(void);
-int TestCHIPSecureChannel(void);
+int main(void)
+{
+    // Generate machine-readable, comma-separated value (CSV) output.
+    nlTestSetOutputStyle(OUTPUT_CSV);
 
-#ifdef __cplusplus
+    return (TestCHIPSecureChannel());
 }
-#endif
-
-#endif // TESTCORE_H


### PR DESCRIPTION
 #### Problem
Missing implementation of class that provides security/crypto bindings for IP communication.

 #### Summary of Changes
Added `CHIPSecureChannel` class and corresponding unit tests.

fixes #601 
