### PR TITLE
CI support for unit tests requiring IPv6 (switched main build to vm execution instead of docker)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@
 version: 2
 jobs:
   Build CHIP [main-build]:
-    docker:
-    - image: connectedhomeip/chip-build:0.2.11
+    machine:
+      image: ubuntu-1604:201903-01
     environment:
     - BUILD_TYPE: main-build
     steps:
@@ -14,8 +14,8 @@ jobs:
     - restore_cache:
         key: build-environment-{{ arch }}-main-build-persistent-cache
     - run:
-        command: scripts/tools/run_if.sh "ubuntu-16-lts" "$BUILD_TYPE" sudo scripts/setup/linux/install_packages.sh
-        name: Setup Environment
+        command: scripts/tools/run_if.sh "ubuntu-16-lts main-build" "$BUILD_TYPE" sudo scripts/setup/linux/install_packages.sh
+        name: Setup Environment for VM builds
     - save_cache:
         key: build-environment-{{ arch }}-main-build-persistent-cache
         paths:
@@ -49,8 +49,8 @@ jobs:
     - restore_cache:
         key: build-environment-{{ arch }}-mbedtls-build-persistent-cache
     - run:
-        command: scripts/tools/run_if.sh "ubuntu-16-lts" "$BUILD_TYPE" sudo scripts/setup/linux/install_packages.sh
-        name: Setup Environment
+        command: scripts/tools/run_if.sh "ubuntu-16-lts main-build" "$BUILD_TYPE" sudo scripts/setup/linux/install_packages.sh
+        name: Setup Environment for VM builds
     - save_cache:
         key: build-environment-{{ arch }}-mbedtls-build-persistent-cache
         paths:
@@ -74,8 +74,8 @@ jobs:
         paths:
         - build/downloads
   Run Tests [main-build]:
-    docker:
-    - image: connectedhomeip/chip-build:0.2.11
+    machine:
+      image: ubuntu-1604:201903-01
     environment:
     - BUILD_TYPE: main-build
     steps:
@@ -86,8 +86,8 @@ jobs:
     - restore_cache:
         key: build-environment-{{ arch }}-main-build-persistent-cache
     - run:
-        command: scripts/tools/run_if.sh "ubuntu-16-lts" "$BUILD_TYPE" sudo scripts/setup/linux/install_packages.sh
-        name: Setup Environment
+        command: scripts/tools/run_if.sh "ubuntu-16-lts main-build" "$BUILD_TYPE" sudo scripts/setup/linux/install_packages.sh
+        name: Setup Environment for VM builds
     - run:
         command: scripts/tools/run_if.sh "mbedtls-build" "$BUILD_TYPE" scripts/tests/mbedtls_tests.sh
         name: Run mbedTLS Tests
@@ -103,6 +103,12 @@ jobs:
     - run:
         command: scripts/tools/run_if.sh "main-build" "$BUILD_TYPE" scripts/tests/all_tests.sh
         name: Run All Unit & Functional Tests
+    - run:
+        command: scripts/tests/save_logs.sh /tmp/test_logs
+        name: Save test log files
+        when: on_fail
+    - store_artifacts:
+        path: /tmp/test_logs
   Run Tests [mbedtls-build]:
     docker:
     - image: connectedhomeip/chip-build:0.2.11
@@ -117,8 +123,8 @@ jobs:
     - restore_cache:
         key: build-environment-{{ arch }}-mbedtls-build-persistent-cache
     - run:
-        command: scripts/tools/run_if.sh "ubuntu-16-lts" "$BUILD_TYPE" sudo scripts/setup/linux/install_packages.sh
-        name: Setup Environment
+        command: scripts/tools/run_if.sh "ubuntu-16-lts main-build" "$BUILD_TYPE" sudo scripts/setup/linux/install_packages.sh
+        name: Setup Environment for VM builds
     - run:
         command: scripts/tools/run_if.sh "mbedtls-build" "$BUILD_TYPE" scripts/tests/mbedtls_tests.sh
         name: Run mbedTLS Tests
@@ -134,19 +140,15 @@ jobs:
     - run:
         command: scripts/tools/run_if.sh "main-build" "$BUILD_TYPE" scripts/tests/all_tests.sh
         name: Run All Unit & Functional Tests
-  Run Tests [ESP32-QEMU]:
-    docker:
-    - image: connectedhomeip/chip-build-esp32-qemu:0.2.11
-    environment:
-    - BUILD_TYPE: esp32-qemu-build
-    steps:
-    - checkout
     - run:
-        command: scripts/tests/esp32_qemu_tests.sh
-        name: Build QEMU and run unit tests
+        command: scripts/tests/save_logs.sh /tmp/test_logs
+        name: Save test log files
+        when: on_fail
+    - store_artifacts:
+        path: /tmp/test_logs
   Deploy [main-build]:
-    docker:
-    - image: connectedhomeip/chip-build:0.2.11
+    machine:
+      image: ubuntu-1604:201903-01
     environment:
     - BUILD_TYPE: main-build
     steps:
@@ -157,8 +159,8 @@ jobs:
     - restore_cache:
         key: build-environment-{{ arch }}-main-build-persistent-cache
     - run:
-        command: scripts/tools/run_if.sh "ubuntu-16-lts" "$BUILD_TYPE" sudo scripts/setup/linux/install_packages.sh
-        name: Setup Environment
+        command: scripts/tools/run_if.sh "ubuntu-16-lts main-build" "$BUILD_TYPE" sudo scripts/setup/linux/install_packages.sh
+        name: Setup Environment for VM builds
     - run:
         command: scripts/build/distribution_check.sh
         name: Deployment Check
@@ -183,8 +185,8 @@ jobs:
         command: scripts/examples/esp_echo_app.sh
         name: Build example Echo App
   Build Examples [main-build]:
-    docker:
-    - image: connectedhomeip/chip-build:0.2.11
+    machine:
+      image: ubuntu-1604:201903-01
     environment:
     - BUILD_TYPE: main-build
     steps:
@@ -195,8 +197,8 @@ jobs:
     - restore_cache:
         key: build-environment-{{ arch }}-main-build-persistent-cache
     - run:
-        command: scripts/tools/run_if.sh "ubuntu-16-lts" "$BUILD_TYPE" sudo scripts/setup/linux/install_packages.sh
-        name: Setup Environment
+        command: scripts/tools/run_if.sh "ubuntu-16-lts main-build" "$BUILD_TYPE" sudo scripts/setup/linux/install_packages.sh
+        name: Setup Environment for VM builds
     - run:
         command: scripts/examples/standalone_echo_client.sh
         name: Build example Standalone Echo Client
@@ -220,11 +222,6 @@ workflows:
             - /restyled.*/
         requires:
         - Build CHIP [main-build]
-    - Run Tests [ESP32-QEMU]:
-        filters:
-          branches:
-            ignore:
-            - /restyled.*/
     - Run Tests [mbedtls-build]:
         filters:
           branches:
@@ -352,15 +349,16 @@ workflows:
 #         type: string
 #     steps:
 #     - run:
-#         command: scripts/tools/run_if.sh \"ubuntu-16-lts\" \"$BUILD_TYPE\" sudo scripts/setup/linux/install_packages.sh
-#         name: Setup Environment
+#         command: scripts/tools/run_if.sh \"ubuntu-16-lts main-build\" \"$BUILD_TYPE\"
+#           sudo scripts/setup/linux/install_packages.sh
+#         name: Setup Environment for VM builds
 # executors:
 #   esp32-build:
 #     docker:
 #     - image: connectedhomeip/chip-build-esp32:0.2.11
 #   main-build:
-#     docker:
-#     - image: connectedhomeip/chip-build:0.2.11
+#     machine:
+#       image: ubuntu-1604:201903-01
 #   mbedtls-build:
 #     docker:
 #     - image: connectedhomeip/chip-build:0.2.11
@@ -510,6 +508,12 @@ workflows:
 #     - run:
 #         command: scripts/tools/run_if.sh \"main-build\" \"$BUILD_TYPE\" scripts/tests/all_tests.sh
 #         name: Run All Unit & Functional Tests
+#     - run:
+#         command: scripts/tests/save_logs.sh /tmp/test_logs
+#         name: Save test log files
+#         when: on_fail
+#     - store_artifacts:
+#         path: /tmp/test_logs
 # version: 2.1
 # workflows:
 #   Main:

--- a/.circleci/config/commands/@commands.yml
+++ b/.circleci/config/commands/@commands.yml
@@ -19,6 +19,7 @@ save-persistent-ci-cache:
                   }}-<<parameters.builder>>-persistent-cache
               paths:
                   - ./ci-cache-persistent
+
 load-persistent-ci-cache:
     description: Load persistent CI Cache
     parameters:
@@ -108,7 +109,7 @@ setup-environment:
             type: string
     steps:
         - run:
-              name: Setup Environment
+              name: Setup Environment for VM builds
               command:
-                  scripts/tools/run_if.sh "ubuntu-16-lts" "$BUILD_TYPE" sudo
-                  scripts/setup/linux/install_packages.sh
+                  scripts/tools/run_if.sh "ubuntu-16-lts main-build"
+                  "$BUILD_TYPE" sudo scripts/setup/linux/install_packages.sh

--- a/.circleci/config/executors/@executors.yml
+++ b/.circleci/config/executors/@executors.yml
@@ -1,6 +1,6 @@
 main-build:
-    docker:
-        - image: connectedhomeip/chip-build:0.2.11
+    machine:
+        image: ubuntu-1604:201903-01
 nrf-build:
     docker:
         - image: connectedhomeip/chip-build-nrf-platform:0.2.11

--- a/.circleci/config/jobs/test.yml
+++ b/.circleci/config/jobs/test.yml
@@ -41,3 +41,9 @@ steps:
           command:
               scripts/tools/run_if.sh "main-build" "$BUILD_TYPE"
               scripts/tests/all_tests.sh
+    - run:
+          name: Save test log files
+          command: scripts/tests/save_logs.sh /tmp/test_logs
+          when: on_fail
+    - store_artifacts:
+          path: /tmp/test_logs

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -37,6 +37,7 @@ exclude:
     - "examples/lock-app/efr32/third_party/**"
     - "build/**/*"
     - "autom4te.cache/**/*"
+    - "scripts/tests/save_logs.sh" # quotes $(...) in a for loop
 
 # Restylers to run, and how
 restylers:

--- a/scripts/setup/linux/install_packages.sh
+++ b/scripts/setup/linux/install_packages.sh
@@ -42,3 +42,6 @@ fi
 
 cd ~/project/ci-cache-persistent/openssl/openssl/openssl-OpenSSL_1_1_1f
 make install_sw install_ssldirs
+
+# new libraries may be installed in /usr/local/lib. Pick them up
+ldconfig

--- a/scripts/tests/save_logs.sh
+++ b/scripts/tests/save_logs.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+TARGET_DIR=$1
+
+mkdir -p "$1"
+
+for name in $(find . -name test-suite.log); do
+    destination="$1"/$(echo "$name" | sed -E s-\^.\/-- | sed s-/-_-g)
+    echo "Saving $name to $destination"
+    cp "$name" "$destination"
+done

--- a/src/inet/tests/Makefile.am
+++ b/src/inet/tests/Makefile.am
@@ -117,18 +117,19 @@ COMMON_LDADD                                          = \
 #
 # These will NOT be part of the externally-consumable binary SDK.
 #
-# XXX - At this point TestInetEndPoint and TestInetLayerDNS are stranded
-#       here until a solution for enabling IPv6 on Linux containers for
-#       Docker on macOS can be resolved as that test involves
-#       executing APIs that exercise bind, listen, connect, accept,
-#       etc. on IPv4 and IPv6 IP end points. When that issue has been
-#       resolved, move these tests to check_PROGRAMS.
+# TODO: some tests are stranded as CI servers historically did not fully
+#       support IPv6. Supporting these is a WIP.
+#
+# CI documentation on IPv6:
+#    https://circleci.com/docs/2.0/faq/#can-i-use-ipv6-in-my-tests
+
+# When support is added, move these tests to check_PROGRAMS.
+#
 
 if CHIP_TARGET_STYLE_UNIX
 # Build and run these test targets only on standalone device targets
 noinst_PROGRAMS                                       = \
     TestLwIPDNS                                         \
-    TestInetEndPoint                                    \
     TestInetLayer                                       \
     TestInetLayerDNS                                    \
     TestInetLayerMulticast                              \
@@ -139,6 +140,7 @@ noinst_PROGRAMS                                       = \
 check_PROGRAMS                                        = \
     TestInetAddress                                     \
     TestInetBuffer                                      \
+    TestInetEndPoint                                    \
     TestInetErrorStr                                    \
     TestInetTimer                                       \
     $(NULL)


### PR DESCRIPTION
This is a follow up on previous attempts to re-enable inet tests that require IPv6 support

 #### Problem
Tests that require IPv6 do not run in CI

 #### Summary of Changes
Based on https://circleci.com/docs/2.0/faq/#can-i-use-ipv6-in-my-tests, enabling running tests as a machine executor instead of docker (this has a speed penalty, I believe of 1-2 minutes, but did not exactly check)

- Executing as machine for "main build"
- Enabled a inet test that requires ipv6
- added script to save test log files in case of log failure
- ran ldconfig to pick up new folder of /usr/local/lib where we put our crypto libs

