### PR TITLE
Make the inet tests depend on CHIP_TARGET_STYLE_UNIX rater than LWIP.

### DIFF
--- a/src/inet/tests/Makefile.am
+++ b/src/inet/tests/Makefile.am
@@ -124,7 +124,7 @@ COMMON_LDADD                                          = \
 #       etc. on IPv4 and IPv6 IP end points. When that issue has been
 #       resolved, move these tests to check_PROGRAMS.
 
-if CHIP_LWIP_TARGET_STANDALONE
+if CHIP_TARGET_STYLE_UNIX
 # Build and run these test targets only on standalone device targets
 noinst_PROGRAMS                                       = \
     TestLwIPDNS                                         \
@@ -149,7 +149,8 @@ check_PROGRAMS                                        = \
 TESTS                                                 = \
     $(check_PROGRAMS)                                   \
     $(NULL)
-endif # CHIP_LWIP_TARGET_STANDALONE
+
+endif # CHIP_TARGET_STYLE_UNIX
 
 # The additional environment variables and their values that will be
 # made available to all programs and scripts in TESTS.


### PR DESCRIPTION
CI and even stand-alone make check was skipping inet tests.
Re-enabling them.

 #### Problem
Inet tests not being run on "make check"

 #### Summary of Changes
Switched condition on inet tests enabling to depend on unix rather than LWIP_STANDALONE
