### PR TITLE
Enable INET tests to run on ESP32 QEMU

### DIFF
--- a/src/inet/tests/Makefile.am
+++ b/src/inet/tests/Makefile.am
@@ -112,6 +112,33 @@ COMMON_LDADD                                          = \
     $(PTHREAD_CFLAGS) $(PTHREAD_LIBS)                   \
     $(NULL)
 
+# Test applications that should be run when the 'check' target is run.
+
+check_PROGRAMS                                        = \
+    $(NULL)
+
+check_SCRIPTS                                         = \
+    $(NULL)
+
+# The additional environment variables and their values that will be
+# made available to all programs and scripts in TESTS.
+TESTS_ENVIRONMENT                                     = \
+    $(NULL)
+
+if CHIP_TARGET_STYLE_EMBEDDED
+
+check_SCRIPTS                                        += \
+    qemu_inet_tests.sh                                  \
+    $(NULL)
+
+TESTS_ENVIRONMENT                                    += \
+    abs_top_srcdir='$(abs_top_srcdir)'                  \
+    abs_top_builddir='$(abs_top_builddir)'              \
+    QEMU_TEST_TARGET=libInetLayerTests.a                \
+    $(NULL)
+
+else # CHIP_TARGET_STYLE_EMBEDDED
+
 # Test executables that should be built but not installed and should
 # always be built to ensure overall "build sanity".
 #
@@ -124,7 +151,6 @@ COMMON_LDADD                                          = \
 #       etc. on IPv4 and IPv6 IP end points. When that issue has been
 #       resolved, move these tests to check_PROGRAMS.
 
-if CHIP_TARGET_STYLE_UNIX
 # Build and run these test targets only on standalone device targets
 noinst_PROGRAMS                                       = \
     TestLwIPDNS                                         \
@@ -134,28 +160,21 @@ noinst_PROGRAMS                                       = \
     TestInetLayerMulticast                              \
     $(NULL)
 
-# Test applications that should be run when the 'check' target is run.
-
-check_PROGRAMS                                        = \
+check_PROGRAMS                                       += \
     TestInetAddress                                     \
     TestInetBuffer                                      \
     TestInetErrorStr                                    \
     TestInetTimer                                       \
     $(NULL)
 
+endif # CHIP_TARGET_STYLE_EMBEDDED
+
 # Test applications and scripts that should be built and run when the
 # 'check' target is run.
 
 TESTS                                                 = \
     $(check_PROGRAMS)                                   \
-    $(NULL)
-
-endif # CHIP_TARGET_STYLE_UNIX
-
-# The additional environment variables and their values that will be
-# made available to all programs and scripts in TESTS.
-
-TESTS_ENVIRONMENT                                     = \
+    $(check_SCRIPTS)                                    \
     $(NULL)
 
 # Source, compiler, and linker options for test programs.

--- a/src/inet/tests/TestInetAddress.cpp
+++ b/src/inet/tests/TestInetAddress.cpp
@@ -47,6 +47,9 @@
 
 #include <inet/IPPrefix.h>
 
+#include <support/CodeUtils.h>
+#include <support/TestUtils.h>
+
 using namespace chip;
 using namespace chip::Inet;
 
@@ -1782,4 +1785,9 @@ int TestInetAddress(void)
     nlTestRunner(&theSuite, const_cast<TestContext *>(&sTestContext));
 
     return (nlTestRunnerStats(&theSuite));
+}
+
+static void __attribute__((constructor)) TestCHIPInetAddressCtor(void)
+{
+    VerifyOrDie(RegisterUnitTests(&TestInetAddress) == CHIP_NO_ERROR);
 }

--- a/src/inet/tests/TestInetBuffer.cpp
+++ b/src/inet/tests/TestInetBuffer.cpp
@@ -38,6 +38,8 @@
 #include <stdint.h>
 
 #include <inet/InetConfig.h>
+#include <support/CodeUtils.h>
+#include <support/TestUtils.h>
 
 #if INET_CONFIG_PROVIDE_OBSOLESCENT_INTERFACES
 
@@ -1160,6 +1162,11 @@ int TestInetBuffer(void)
     nlTestRunner(&theSuite, &sContext);
 
     return (nlTestRunnerStats(&theSuite));
+}
+
+static void __attribute__((constructor)) TestCHIPInetBufferCtor(void)
+{
+    VerifyOrDie(RegisterUnitTests(&TestInetBuffer) == CHIP_NO_ERROR);
 }
 
 #else // !INET_CONFIG_PROVIDE_OBSOLESCENT_INTERFACES

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -39,6 +39,8 @@
 #include <inet/InetLayer.h>
 
 #include <support/CHIPArgParser.hpp>
+#include <support/CodeUtils.h>
+#include <support/TestUtils.h>
 
 #include <system/SystemError.h>
 #include <system/SystemTimer.h>
@@ -606,6 +608,11 @@ int TestInetEndPoint(void)
 #else  // !CHIP_SYSTEM_CONFIG_USE_SOCKETS
     return (0);
 #endif // !CHIP_SYSTEM_CONFIG_USE_SOCKETS
+}
+
+static void __attribute__((constructor)) TestCHIPInetEndpointCtor(void)
+{
+    VerifyOrDie(RegisterUnitTests(&TestInetEndPoint) == CHIP_NO_ERROR);
 }
 
 int main(int argc, char * argv[])

--- a/src/inet/tests/TestInetErrorStr.cpp
+++ b/src/inet/tests/TestInetErrorStr.cpp
@@ -39,7 +39,9 @@
 #include <string.h>
 
 #include <inet/InetError.h>
+#include <support/CodeUtils.h>
 #include <support/ErrorStr.h>
+#include <support/TestUtils.h>
 
 #include <nlunit-test.h>
 
@@ -137,4 +139,9 @@ int TestInetErrorStr(void)
     nlTestRunner(&theSuite, &sContext);
 
     return (nlTestRunnerStats(&theSuite));
+}
+
+static void __attribute__((constructor)) TestCHIPInetErrorStrCtor(void)
+{
+    VerifyOrDie(RegisterUnitTests(&TestInetErrorStr) == CHIP_NO_ERROR);
 }

--- a/src/inet/tests/TestInetLayerDNS.cpp
+++ b/src/inet/tests/TestInetLayerDNS.cpp
@@ -37,6 +37,8 @@
 #include <CHIPVersion.h>
 
 #include <inet/InetLayer.h>
+#include <support/CodeUtils.h>
+#include <support/TestUtils.h>
 
 #include <system/SystemClock.h>
 #include <system/SystemTimer.h>
@@ -713,6 +715,11 @@ int TestInetLayerDNS(void)
     ShutdownSystemLayer();
 
     return nlTestRunnerStats(&DNSTestSuite);
+}
+
+static void __attribute__((constructor)) TestCHIPInetLayerDNSCtor(void)
+{
+    VerifyOrDie(RegisterUnitTests(&TestInetLayerDNS) == CHIP_NO_ERROR);
 }
 
 #else // !INET_CONFIG_ENABLE_DNS_RESOLVER

--- a/src/inet/tests/TestInetTimer.cpp
+++ b/src/inet/tests/TestInetTimer.cpp
@@ -28,6 +28,8 @@
 #include "TestInetLayer.h"
 
 #include <inet/InetConfig.h>
+#include <support/CodeUtils.h>
+#include <support/TestUtils.h>
 
 #if INET_CONFIG_PROVIDE_OBSOLESCENT_INTERFACES
 
@@ -163,6 +165,11 @@ int TestInetTimer(void)
 #else  // !INET_SOCKETS
     return (0);
 #endif // !INET_SOCKETS
+}
+
+static void __attribute__((constructor)) TestCHIPInetTimerCtor(void)
+{
+    VerifyOrDie(RegisterUnitTests(&TestInetTimer) == CHIP_NO_ERROR);
 }
 
 #else // !INET_CONFIG_PROVIDE_OBSOLESCENT_INTERFACES

--- a/src/inet/tests/qemu_inet_tests.sh
+++ b/src/inet/tests/qemu_inet_tests.sh
@@ -1,0 +1,1 @@
+../../../scripts/tools/qemu_run_test.sh


### PR DESCRIPTION
 #### Problem
`INET` unit tests do not run on ESP32 QEMU

 #### Summary of Changes
Enable INET tests to run on ESP32 QEMU