### PR TITLE
Preserve test logs as CI artifacts in case of CI failure.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,12 @@ jobs:
     - run:
         command: scripts/tools/run_if.sh "main-build" "$BUILD_TYPE" scripts/tests/all_tests.sh
         name: Run All Unit & Functional Tests
+    - run:
+        command: scripts/tests/save_logs.sh /tmp/test_logs
+        name: Save test log files
+        when: on_fail
+    - store_artifacts:
+        path: /tmp/test_logs
   Build Examples [nRF]:
     docker:
     - image: connectedhomeip/chip-build-nrf-platform:0.2.11
@@ -200,6 +206,12 @@ jobs:
     - run:
         command: scripts/tools/run_if.sh "main-build" "$BUILD_TYPE" scripts/tests/all_tests.sh
         name: Run All Unit & Functional Tests
+    - run:
+        command: scripts/tests/save_logs.sh /tmp/test_logs
+        name: Save test log files
+        when: on_fail
+    - store_artifacts:
+        path: /tmp/test_logs
 workflows:
   Main:
     jobs:
@@ -513,6 +525,12 @@ workflows:
 #     - run:
 #         command: scripts/tools/run_if.sh \"main-build\" \"$BUILD_TYPE\" scripts/tests/all_tests.sh
 #         name: Run All Unit & Functional Tests
+#     - run:
+#         command: scripts/tests/save_logs.sh /tmp/test_logs
+#         name: Save test log files
+#         when: on_fail
+#     - store_artifacts:
+#         path: /tmp/test_logs
 #   test_esp32_qemu:
 #     environment:
 #       BUILD_TYPE: esp32-qemu-build

--- a/.circleci/config/jobs/test.yml
+++ b/.circleci/config/jobs/test.yml
@@ -41,3 +41,9 @@ steps:
           command:
               scripts/tools/run_if.sh "main-build" "$BUILD_TYPE"
               scripts/tests/all_tests.sh
+    - run:
+          name: Save test log files
+          command: scripts/tests/save_logs.sh /tmp/test_logs
+          when: on_fail
+    - store_artifacts:
+          path: /tmp/test_logs

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -37,6 +37,7 @@ exclude:
     - "examples/lock-app/efr32/third_party/**"
     - "build/**/*"
     - "autom4te.cache/**/*"
+    - "scripts/tests/save_logs.sh" # quotes $(...) in a for loop
 
 # Restylers to run, and how
 restylers:

--- a/scripts/tests/save_logs.sh
+++ b/scripts/tests/save_logs.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+TARGET_DIR=$1
+
+mkdir -p "$1"
+
+for name in $(find . -name test-suite.log); do
+    destination="$1"/$(echo "$name" | sed -E s-\^.\/-- | sed s-/-_-g)
+    echo "Saving $name to $destination"
+    cp "$name" "$destination"
+done


### PR DESCRIPTION
This makes it easier to debug CI failures.

 #### Problem
CI failures do not include the failure logs, making it hard to investigate failures due to environment.

 #### Summary of Changes
Record failure logs as CI artifacts.

fixes #819 
