### PR TITLE
use verbose in CI/vscode

### DIFF
--- a/scripts/tests/all_tests.sh
+++ b/scripts/tests/all_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-make -C build/default check
+make V=1 -C build/default check

--- a/scripts/tests/crypto_tests.sh
+++ b/scripts/tests/crypto_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-make -C build/default/src/crypto check
+make V=1 -C build/default/src/crypto check

--- a/scripts/tests/esp32_qemu_tests.sh
+++ b/scripts/tests/esp32_qemu_tests.sh
@@ -29,4 +29,4 @@ source "$chip_dir"/src/test_driver/esp32/idf.sh
 # Currently only crypto tests are configured to run on QEMU.
 # The "src/crypto" qualifier will be removed, once all CHIP unit tests are
 # updated to run on QEMU.
-idf make -C "$chip_dir"/src/test_driver/esp32/build/chip/src/crypto check
+idf make V=1 -C "$chip_dir"/src/test_driver/esp32/build/chip/src/crypto check

--- a/scripts/tests/openssl_tests.sh
+++ b/scripts/tests/openssl_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-make -C build/default/src/crypto/ && make -C build/default/src/crypto/tests/ TestCryptoPAL
+make V=1 -C build/default/src/crypto/ && make V=1 -C build/default/src/crypto/tests/ TestCryptoPAL

--- a/scripts/tests/qrcode_payload_tests.sh
+++ b/scripts/tests/qrcode_payload_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-make -C build/default/src/setup_payload/tests/ TestQRCode
+make V=1 -C build/default/src/setup_payload/tests/ TestQrCode

--- a/scripts/tests/setup_payload_tests.sh
+++ b/scripts/tests/setup_payload_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-make -C build/default/src/setup_payload check
+make V=1 -C build/default/src/setup_payload check


### PR DESCRIPTION
#### Problem
 builds shorten compile cmdlines to "CC x.c", which hides information that's useful in tracking down issues

 #### Summary of Changes
 add V=1 to our scripts