### PR TITLE
Remove redundant declaration of ivars

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -39,23 +39,15 @@ static const char * const CHIP_SELECT_QUEUE = "com.zigbee.chip.select";
 }
 @end
 
-@interface CHIPDeviceController () {
-    chip::DeviceController::ChipDeviceController * _cppController;
-    // queue used for all interactions with the cpp chip controller and for all chip internal events
-    // try to run small jobs in this queue
-    dispatch_queue_t _chipWorkQueue;
-    // queue used to call select on the system and inet layer fds., remove this with NW Framework.
-    // primarily used to not block the work queue
-    dispatch_queue_t _chipSelectQueue;
-    // queue used to signal callbacks to the application
-    dispatch_queue_t _appCallbackQueue;
+@interface CHIPDeviceController ()
 
-    ControllerOnMessageBlock _onMessageHandler;
-    ControllerOnErrorBlock _onErrorHandler;
-}
-
+// queue used for all interactions with the cpp chip controller and for all chip internal events
+// try to run small jobs in this queue
 @property (atomic, readonly) dispatch_queue_t chipWorkQueue;
+// queue used to call select on the system and inet layer fds., remove this with NW Framework.
+// primarily used to not block the work queue
 @property (atomic, readonly) dispatch_queue_t chipSelectQueue;
+// queue used to signal callbacks to the application
 @property (readonly) dispatch_queue_t appCallbackQueue;
 @property (readonly) ControllerOnMessageBlock onMessageHandler;
 @property (readonly) ControllerOnErrorBlock onErrorHandler;

--- a/src/darwin/Framework/CHIP/CHIPEchoClient.mm
+++ b/src/darwin/Framework/CHIP/CHIPEchoClient.mm
@@ -24,11 +24,7 @@
 static UInt32 const kDefaultFrequencySeconds = 10;
 static NSString * const kEchoString = @"Hello from darwin!";
 
-@interface CHIPEchoClient () {
-    dispatch_queue_t _echoCallbackQueue;
-    dispatch_source_t _sendTimer;
-    CHIPDeviceController * _chipController;
-}
+@interface CHIPEchoClient ()
 
 @property (readonly) dispatch_queue_t echoCallbackQueue;
 @property (readonly) dispatch_source_t sendTimer;


### PR DESCRIPTION
 #### Problem
declaring both ivars and properties is redundant 
 #### Summary of Changes
removed ivar declaration in the CHIP Framework apis.

fixes #831 
