### PR TITLE
Move CHIPSecureChannel to crypto folder

### DIFF
--- a/src/crypto/CHIPSecureChannel.cpp
+++ b/src/crypto/CHIPSecureChannel.cpp
@@ -72,7 +72,7 @@ exit:
 void ChipSecureChannel::Close(void)
 {
     mKeyAvailable = false;
-    mNextIV = 0;
+    mNextIV       = 0;
 }
 
 CHIP_ERROR ChipSecureChannel::Encrypt(const unsigned char * input, size_t input_length, unsigned char * output,

--- a/src/crypto/CHIPSecureChannel.cpp
+++ b/src/crypto/CHIPSecureChannel.cpp
@@ -22,8 +22,8 @@
  *
  */
 
-#include <core/CHIPSecureChannel.h>
 #include <crypto/CHIPCryptoPAL.h>
+#include <crypto/CHIPSecureChannel.h>
 #include <support/CodeUtils.h>
 
 #include <string.h>
@@ -34,39 +34,45 @@ using namespace Crypto;
 
 ChipSecureChannel::ChipSecureChannel() : mKeyAvailable(false), mNextIV(0) {}
 
-CHIP_ERROR ChipSecureChannel::Init(const unsigned char * remote_public_key, const size_t public_key_length,
-                                   const unsigned char * local_private_key, const size_t private_key_length,
-                                   const unsigned char * salt, const size_t salt_length, const unsigned char * info,
-                                   const size_t info_length)
+CHIP_ERROR ChipSecureChannel::Init(const secure_channel_params_t * params)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     uint8_t secret[kMax_ECDH_Secret_Length];
     size_t secret_size = sizeof(secret);
 
     VerifyOrExit(mKeyAvailable == false, error = CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrExit(remote_public_key != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(public_key_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(local_private_key != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(private_key_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-    if (salt_length > 0)
+    VerifyOrExit(params != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(params->remote_public_key != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(params->public_key_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(params->local_private_key != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(params->private_key_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+    if (params->salt_length > 0)
     {
-        VerifyOrExit(salt != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrExit(params->salt != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
     }
 
-    VerifyOrExit(info_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(info != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(params->info_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(params->info != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     mNextIV = 0;
 
-    error = ECDH_derive_secret(remote_public_key, public_key_length, local_private_key, private_key_length, secret, secret_size);
+    error = ECDH_derive_secret(params->remote_public_key, params->public_key_length, params->local_private_key,
+                               params->private_key_length, secret, secret_size);
     if (error == CHIP_NO_ERROR)
     {
-        error         = HKDF_SHA256(secret, sizeof(secret), salt, salt_length, info, info_length, mKey, sizeof(mKey));
+        error = HKDF_SHA256(secret, sizeof(secret), params->salt, params->salt_length, params->info, params->info_length, mKey,
+                            sizeof(mKey));
         mKeyAvailable = (error == CHIP_NO_ERROR);
     }
 
 exit:
     return error;
+}
+
+void ChipSecureChannel::Close(void)
+{
+    mKeyAvailable = false;
+    mNextIV = 0;
 }
 
 CHIP_ERROR ChipSecureChannel::Encrypt(const unsigned char * input, size_t input_length, unsigned char * output,

--- a/src/crypto/CHIPSecureChannel.h
+++ b/src/crypto/CHIPSecureChannel.h
@@ -26,7 +26,9 @@
 #ifndef __CHIPSECURECHANNEL_H__
 #define __CHIPSECURECHANNEL_H__
 
-#include <core/CHIPCore.h>
+#include <core/CHIPConfig.h>
+#include <core/CHIPError.h>
+#include <system/SystemLayer.h>
 
 namespace chip {
 
@@ -35,18 +37,45 @@ class DLL_EXPORT ChipSecureChannel
 public:
     /**
      * @brief
-     *   Derive a shared key. The derived key will be used for encryting/decrypting
-     *   data exchanged on the secure channel.
+     *   Initialization parameters of secure channel
      *
      * @param remote_public_key  A pointer to peer's public key
      * @param public_key_length  Length of remote_public_key
      * @param local_private_key  A pointer to local private key
      * @param private_key_length Length of local_private_key
+     * @param salt               Salt used for key derivation
+     * @param salt_length        Length of salt
+     * @param info               Info used for key derivation
+     * @param info_length        Length of info
+     */
+    typedef struct
+    {
+        const unsigned char * remote_public_key;
+        size_t public_key_length;
+        const unsigned char * local_private_key;
+        size_t private_key_length;
+        const unsigned char * salt;
+        size_t salt_length;
+        const unsigned char * info;
+        size_t info_length;
+    } secure_channel_params_t;
+
+    /**
+     * @brief
+     *   Derive a shared key. The derived key will be used for encryting/decrypting
+     *   data exchanged on the secure channel.
+     *
+     * @param parameters  A pointer to channel parameters
      * @return CHIP_ERROR        The result of key derivation
      */
-    CHIP_ERROR Init(const unsigned char * remote_public_key, const size_t public_key_length,
-                    const unsigned char * local_private_key, const size_t private_key_length, const unsigned char * salt,
-                    const size_t salt_length, const unsigned char * info, const size_t info_length);
+    CHIP_ERROR Init(const secure_channel_params_t * parameters);
+
+    /**
+     * @brief
+     *   Close the channel, and release its resources. The released channel can be
+     *   reused for a new security context by calling Init().
+     */
+    void Close(void);
 
     /**
      * @brief

--- a/src/crypto/Makefile.am
+++ b/src/crypto/Makefile.am
@@ -39,10 +39,12 @@ libChipCrypto_a_CPPFLAGS            = \
     $(NULL)
 
 libChipCrypto_a_SOURCES                                       = \
+    CHIPSecureChannel.cpp                                       \
     $(NULL)
 
 dist_libChipCrypto_a_HEADERS                                 = \
     CHIPCryptoPAL.h                                            \
+    CHIPSecureChannel.h                                        \
     $(NULL)
 
 if CHIP_CRYPTO_OPENSSL

--- a/src/crypto/tests/Makefile.am
+++ b/src/crypto/tests/Makefile.am
@@ -46,6 +46,7 @@ lib_LIBRARIES                                  = \
 
 libCryptoLayerTests_a_SOURCES                  = \
     CHIPCryptoPALTest.cpp                        \
+    TestCHIPSecureChannel.cpp                    \
     $(NULL)
 
 libCryptoLayerTests_adir                       = $(includedir)/crypto
@@ -108,6 +109,7 @@ else # CHIP_TARGET_STYLE_EMBEDDED
 
 check_PROGRAMS                                += \
     TestCryptoPAL                                \
+    TestCHIPSecureChannel                        \
     $(NULL)
 
 endif # CHIP_TARGET_STYLE_EMBEDDED
@@ -121,11 +123,11 @@ TESTS                                          = \
     $(NULL)
 
 # Source, compiler, and linker options for test programs.
-TestCryptoPAL_LDADD                            =        \
-    $(COMMON_LDADD)                                     \
-    $(NULL)
-
+TestCryptoPAL_LDADD                            = $(COMMON_LDADD)
 TestCryptoPAL_SOURCES                          = CHIPCryptoPALTestDriver.cpp
+
+TestCHIPSecureChannel_LDADD                    = $(COMMON_LDADD)
+TestCHIPSecureChannel_SOURCES                  = TestCHIPSecureChannelDriver.cpp
 
 #
 # Foreign make dependencies

--- a/src/crypto/tests/TestCHIPSecureChannel.cpp
+++ b/src/crypto/tests/TestCHIPSecureChannel.cpp
@@ -27,8 +27,8 @@
 
 #include <crypto/CHIPSecureChannel.h>
 
-#include <string.h>
 #include <stdarg.h>
+#include <string.h>
 #include <support/CodeUtils.h>
 #include <support/TestUtils.h>
 

--- a/src/crypto/tests/TestCHIPSecureChannelDriver.cpp
+++ b/src/crypto/tests/TestCHIPSecureChannelDriver.cpp
@@ -22,7 +22,7 @@
  *
  */
 
-#include "TestCore.h"
+#include "TestCryptoLayer.h"
 
 #include <nlunit-test.h>
 

--- a/src/crypto/tests/TestCryptoLayer.h
+++ b/src/crypto/tests/TestCryptoLayer.h
@@ -30,6 +30,7 @@ extern "C" {
 #endif
 
 int TestCHIPCryptoPAL(void);
+int TestCHIPSecureChannel(void);
 
 #ifdef __cplusplus
 }

--- a/src/lib/core/CoreLayer.am
+++ b/src/lib/core/CoreLayer.am
@@ -33,7 +33,6 @@ CHIP_BUILD_CORE_LAYER_SOURCE_FILES                        = \
     core/CHIPTLVUpdater.cpp                                 \
     core/CHIPKeyIds.cpp                                     \
     core/CHIPConnection.cpp                                 \
-    core/CHIPSecureChannel.cpp                              \
     $(NULL)
 
 CHIP_BUILD_CORE_LAYER_HEADER_FILES                        = \
@@ -53,5 +52,4 @@ CHIP_BUILD_CORE_LAYER_HEADER_FILES                        = \
     core/CHIPTunnelConfig.h                                 \
     core/CHIPKeyIds.h                                       \
     core/CHIPConnection.h                                   \
-    core/CHIPSecureChannel.h                                \
     $(NULL)

--- a/src/lib/core/tests/Makefile.am
+++ b/src/lib/core/tests/Makefile.am
@@ -44,7 +44,6 @@ libCoreTests_a_SOURCES                                = \
     TestCHIPErrorStr.cpp                                \
     TestCHIPTLV.cpp                                     \
     TestCHIPConnection.cpp                              \
-    TestCHIPSecureChannel.cpp                           \
     $(NULL)
 
 libCoreTests_adir                                     = $(includedir)/core
@@ -90,7 +89,6 @@ check_PROGRAMS                                        = \
     TestCHIPErrorStr                                    \
     TestCHIPTLV                                         \
     TestCHIPConnection                                  \
-    TestCHIPSecureChannel                               \
     $(NULL)
 
 # Test applications and scripts that should be built and run when the
@@ -116,9 +114,6 @@ TestCHIPTLV_LDADD                                     = $(COMMON_LDADD)
 
 TestCHIPConnection_SOURCES                            = TestCHIPConnectionDriver.cpp
 TestCHIPConnection_LDADD                              = $(COMMON_LDADD)
-
-TestCHIPSecureChannel_SOURCES                         = TestCHIPSecureChannelDriver.cpp
-TestCHIPSecureChannel_LDADD                           = $(COMMON_LDADD)
 
 #
 # Foreign make dependencies

--- a/src/lib/core/tests/TestCore.h
+++ b/src/lib/core/tests/TestCore.h
@@ -32,7 +32,6 @@ extern "C" {
 int TestCHIPErrorStr(void);
 int TestCHIPTLV(void);
 int TestCHIPConnection(void);
-int TestCHIPSecureChannel(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
 #### Problem
`CHIPSecureChannel` being in `src/lib/core` is causing circular dependency with `src/inet` (as `SecureUDPEndPoint` will be located in `src/inet`).

 #### Summary of Changes
Move it to `src/crypto`. Also some cleanup to the API.

fixes #848 