### PR TITLE
Issue 825 - Allow callers to pass a custom TLV encoding buffer.

### DIFF
--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -187,13 +187,19 @@ exit:
 
 CHIP_ERROR QRCodeSetupPayloadGenerator::payloadBinaryRepresentation(string & binaryRepresentation)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    uint8_t tlvDataStart[2048];
+    uint8_t tlvDataStart[kTotalPayloadDataSizeInBytes];
+    return payloadBinaryRepresentation(binaryRepresentation, tlvDataStart, sizeof(tlvDataStart));
+}
+
+CHIP_ERROR QRCodeSetupPayloadGenerator::payloadBinaryRepresentation(string & binaryRepresentation, uint8_t * tlvDataStart,
+                                                                    size_t tlvDataStartSize)
+{
+    CHIP_ERROR err                = CHIP_NO_ERROR;
     uint32_t tlvDataLengthInBytes = 0;
 
     VerifyOrExit(mPayload.isValidQRCodePayload(), err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    err = generateTLVFromOptionalData(mPayload, tlvDataStart, sizeof(tlvDataStart), tlvDataLengthInBytes);
+    err = generateTLVFromOptionalData(mPayload, tlvDataStart, tlvDataStartSize, tlvDataLengthInBytes);
     SuccessOrExit(err);
 
     err = payloadBinaryRepresentationWithTLV(mPayload, binaryRepresentation, kTotalPayloadDataSizeInBytes + tlvDataLengthInBytes,
@@ -221,12 +227,18 @@ exit:
 
 CHIP_ERROR QRCodeSetupPayloadGenerator::payloadBase41Representation(string & base41Representation)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    uint8_t tlvDataStart[512]; // TODO: Allow caller to allocate buffer #825
+    uint8_t tlvDataStart[kTotalPayloadDataSizeInBytes];
+    return payloadBase41Representation(base41Representation, tlvDataStart, sizeof(tlvDataStart));
+}
+
+CHIP_ERROR QRCodeSetupPayloadGenerator::payloadBase41Representation(string & base41Representation, uint8_t * tlvDataStart,
+                                                                    size_t tlvDataStartSize)
+{
+    CHIP_ERROR err                = CHIP_NO_ERROR;
     uint32_t tlvDataLengthInBytes = 0;
 
     VerifyOrExit(mPayload.isValidQRCodePayload(), err = CHIP_ERROR_INVALID_ARGUMENT);
-    err = generateTLVFromOptionalData(mPayload, tlvDataStart, sizeof(tlvDataStart), tlvDataLengthInBytes);
+    err = generateTLVFromOptionalData(mPayload, tlvDataStart, tlvDataStartSize, tlvDataLengthInBytes);
     SuccessOrExit(err);
 
     err = payloadBase41RepresentationWithTLV(mPayload, base41Representation, kTotalPayloadDataSizeInBytes + tlvDataLengthInBytes,

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.h
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.h
@@ -43,9 +43,50 @@ private:
     SetupPayload mPayload;
 
 public:
-    CHIP_ERROR payloadBinaryRepresentation(string & binaryRepresentation);
-    CHIP_ERROR payloadBase41Representation(string & base41Representation);
     QRCodeSetupPayloadGenerator(SetupPayload setupPayload) : mPayload(setupPayload){};
+
+    /**
+     * This function is called to encode the binary data of a payload to a
+     * base41 string using CHIP TLV encoding scheme.
+     *
+     * @param[out] base41Representation
+     *                  The string to copy the base41 to.
+     *
+     * @retval #CHIP_NO_ERROR if the method succeeded.
+     * @retval #CHIP_ERROR_INVALID_ARGUMENT if the payload is invalid.
+     * @retval other Other CHIP or platform-specific error codes indicating
+     *               that an error occurred preventing the function from
+     *               producing the requested string.
+     */
+    CHIP_ERROR payloadBase41Representation(string & base41Representation);
+
+    /**
+     * This function is called to encode the binary data of a payload to a
+     * base41 string. Callers must pass a buffer of at least
+     * chip::kTotalPayloadDataInBytes or more if there is any serialNumber or
+     * any other optional data. The buffer should be big enough to hold the
+     * TLV encoded value of the payload. If not an error will be throw.
+     *
+     * @param[out] base41Representation
+     *                  The string to copy the base41 to.
+     * @param[in]  tlvDataStart
+     *                  A pointer to an uint8_t buffer into which the TLV
+     *                  should be written.
+     * @param[in]  tlvDataStartSize
+     *                  The maximum number of bytes that should be written to
+     *                  the output buffer.
+     *
+     * @retval #CHIP_NO_ERROR if the method succeeded.
+     * @retval #CHIP_ERROR_INVALID_ARGUMENT if the payload is invalid.
+     * @retval other Other CHIP or platform-specific error codes indicating
+     *               that an error occurred preventing the function from
+     *               producing the requested string.
+     */
+    CHIP_ERROR payloadBase41Representation(string & base41Representation, uint8_t * tlvDataStart, size_t tlvDataStartSize);
+
+    // These methods are only used for testing purposes.
+    CHIP_ERROR payloadBinaryRepresentation(string & binaryRepresentation);
+    CHIP_ERROR payloadBinaryRepresentation(string & binaryRepresentation, uint8_t * tlvDataStart, size_t tlvDataStartSize);
 };
 
 }; // namespace chip


### PR DESCRIPTION
 #### Problem

Allows callers of QRCodeSetupPayloadGenerator::payloadBase41Representation to customize the tlv buffer size.

 #### Summary of Changes

* Allows callers of QRCodeSetupPayloadGenerator::payloadBase41Representation to customize the tlv buffer size.

 * If no custom buffer is used, uses chip::kTotalPayloadDataSizeInBytes as the default buffer size.
   That said I would assume that vendors would like to forward the device serial number, which actually means they will pass a custom buffer most of the time.

 * Adds a few tests to TestQRCodeTLV.cpp

fixes #825 
