### PR TITLE
remove RawAlloc RawFree

### DIFF
--- a/src/app/plugin/binding-mock/mock.c
+++ b/src/app/plugin/binding-mock/mock.c
@@ -96,18 +96,22 @@ void chipZclReverseClusterSpec(const ChipZclClusterSpec_t * s1, ChipZclClusterSp
 }
 
 /**
- * Raw memory allocation. Can be mapped to an equivalent of malloc().
- * Expected to return NULL if it failed.
+ * Function that allocates a buffer.
  */
-void * chipZclRawAlloc(uint16_t allocatedLength)
+ChipZclBuffer_t * chipZclBufferAlloc(uint16_t allocatedLength)
 {
-    return malloc(allocatedLength);
+    ChipZclBuffer_t * buffer = (ChipZclBuffer_t *) malloc(sizeof(ChipZclBuffer_t) + allocatedLength);
+    buffer->buffer           = (uint8_t *) (buffer + 1);
+    buffer->dataLength       = 0;
+    buffer->currentPosition  = 0;
+    buffer->totalLength      = allocatedLength;
+    return buffer;
 }
 
 /**
- * Raw memory free. Can be mapped to an equivalent of free().
+ * Function that frees a buffer and its storage.
  */
-void chipZclRawFree(void * allocatedMemory)
+void chipZclBufferFree(ChipZclBuffer_t * buffer)
 {
-    free(allocatedMemory);
+    free(buffer);
 }

--- a/src/app/plugin/core-api/core-api.c
+++ b/src/app/plugin/core-api/core-api.c
@@ -20,32 +20,6 @@
 #include "chip-zcl.h"
 
 /**
- * Function that allocates a buffer.
- */
-ChipZclBuffer_t * chipZclBufferAlloc(uint16_t allocatedLength)
-{
-    ChipZclBuffer_t * buffer = chipZclRawAlloc(sizeof(ChipZclBuffer_t));
-    buffer->buffer           = chipZclRawAlloc(allocatedLength * sizeof(uint8_t));
-    buffer->dataLength       = 0;
-    buffer->currentPosition  = 0;
-    buffer->totalLength      = allocatedLength;
-    return buffer;
-}
-
-/**
- * Creates a zcl buffer out of a raw chunk of memory.
- */
-ChipZclBuffer_t * chipZclBufferCreate(uint8_t * rawBuffer, uint16_t rawLength)
-{
-    ChipZclBuffer_t * buffer = chipZclRawAlloc(sizeof(ChipZclBuffer_t));
-    buffer->buffer           = rawBuffer;
-    buffer->dataLength       = 0;
-    buffer->currentPosition  = 0;
-    buffer->totalLength      = rawLength;
-    return buffer;
-}
-
-/**
  * Function that returns a pointer to the raw buffer.
  */
 uint8_t * chipZclBufferPointer(ChipZclBuffer_t * buffer)
@@ -59,23 +33,6 @@ uint8_t * chipZclBufferPointer(ChipZclBuffer_t * buffer)
 uint16_t chipZclBufferUsedLength(ChipZclBuffer_t * buffer)
 {
     return buffer->dataLength;
-}
-
-/**
- * Function that frees a buffer and its storage.
- */
-void chipZclBufferFree(ChipZclBuffer_t * buffer)
-{
-    chipZclRawFree(buffer->buffer);
-    chipZclBufferFreeOnlyBuffer(buffer);
-}
-
-/**
- * Function that frees a buffer but not its storage.
- */
-void chipZclBufferFreeOnlyBuffer(ChipZclBuffer_t * buffer)
-{
-    chipZclRawFree(buffer);
 }
 
 void chipZclBufferReset(ChipZclBuffer_t * buffer)
@@ -99,14 +56,12 @@ ChipZclStatus_t chipZclClusterCommandParse(ChipZclCommandContext_t * context);
 
 ChipZclStatus_t chipZclProcessIncoming(uint8_t * rawBuffer, uint16_t rawBufferLength)
 {
-    ChipZclBuffer_t * buffer          = chipZclBufferCreate(rawBuffer, rawBufferLength);
-    ChipZclCommandContext_t * context = chipZclRawAlloc(sizeof(ChipZclCommandContext_t));
+    ChipZclBuffer_t buffer = { rawBuffer, 0, 0, rawBufferLength };
 
-    chipZclDecodeZclHeader(buffer, context);
-    chipZclClusterCommandParse(context);
+    ChipZclCommandContext_t context = { 0 };
 
-    chipZclRawFree(context);
-    chipZclBufferFreeOnlyBuffer(buffer);
+    chipZclDecodeZclHeader(&buffer, &context);
+    chipZclClusterCommandParse(&context);
 
     return CHIP_ZCL_STATUS_SUCCESS;
 }

--- a/src/app/plugin/test-on-off/cluster-cmd-on-off-test.c
+++ b/src/app/plugin/test-on-off/cluster-cmd-on-off-test.c
@@ -24,19 +24,14 @@
 #include <stdio.h>
 
 // Test function that creates a command context and populates it with some data.
-ChipZclCommandContext_t * testCreateCommandContext()
+void testInitCommandContext(ChipZclCommandContext_t * context)
 {
-    ChipZclCommandContext_t * context;
-
-    context                  = (ChipZclCommandContext_t *) chipZclRawAlloc(sizeof(ChipZclCommandContext_t));
     context->endpointId      = 1;
     context->clusterId       = CHIP_ZCL_CLUSTER_ON_OFF;
     context->clusterSpecific = true;
     context->mfgSpecific     = false;
     context->commandId       = ZCL_ON_COMMAND_ID;
     context->direction       = ZCL_DIRECTION_CLIENT_TO_SERVER;
-
-    return context;
 }
 
 // Function that tests that the command encoder/decoder works correctly.
@@ -92,13 +87,14 @@ int testClusterCmdOnOff(void)
     // First construct an incoming buffer for test, give it 1024 bytes for no good reason.
     ChipZclBuffer_t * buffer = chipZclBufferAlloc(1024);
 
-    ChipZclCommandContext_t * context = testCreateCommandContext();
+    ChipZclCommandContext_t context;
+    testInitCommandContext(&context);
 
     // Encode the header into the buffer
-    chipZclEncodeZclHeader(buffer, context);
+    chipZclEncodeZclHeader(buffer, &context);
     chipZclBufferFinishWriting(buffer);
 
-    if (testEncodingDecoding(buffer, context) != 0)
+    if (testEncodingDecoding(buffer, &context) != 0)
     {
         return 1;
     }


### PR DESCRIPTION
#### Problem
 no equivalent exists in CHIP as yet and this code doesn't yet really need it

 #### Summary of Changes
 * remove RawAlloc, RawFree, use automatic variables in place of those
 * move alloc/free-based buffer stuff to mock.c

step 2 of #657