### PR TITLE
Move a generated file to gen directory, where it belongs.

### DIFF
--- a/src/app/gen/Makefile.am
+++ b/src/app/gen/Makefile.am
@@ -22,20 +22,22 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
-EXTRA_DIST                    = \
-    gen-attribute-storage.h     \
-    gen-attribute-type.h        \
-    gen-callback-stubs.c        \
-    gen-callbacks.h             \
-    gen-cluster-id.h            \
-    gen-command-handler.c       \
-    gen-command-handler.h       \
-    gen-command-id.h            \
-    gen-endpoint-config.h       \
-    gen-specs.c                 \
-    gen-types.h                 \
-    gen.h                       \
-    README.md                   \
+EXTRA_DIST                    =  \
+    gen-attribute-storage.h      \
+    gen-attribute-type.h         \
+    gen-callback-stubs.c         \
+    gen-callbacks.h              \
+    gen-cluster-id.h             \
+    gen-command-handler.c        \
+    gen-command-handler.h        \
+    gen-command-id.h             \
+    gen-endpoint-config.h        \
+    gen-global-command-handler.c \
+    gen-global-command-handler.h \
+    gen-specs.c                  \
+    gen-types.h                  \
+    gen.h                        \
+    README.md                    \
     $(NULL)
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/app/gen/gen-global-command-handler.c
+++ b/src/app/gen/gen-global-command-handler.c
@@ -20,8 +20,7 @@
  *      This file provides ZCL General message processing dispatch.
  *
  */
-
-#include "general-command-handler.h"
+#include "gen-global-command-handler.h"
 
 // Forward declarations
 static ChipZclStatus_t chipZclReadAttributesCommandParse(ChipZclCommandContext_t * context);

--- a/src/app/gen/gen-global-command-handler.h
+++ b/src/app/gen/gen-global-command-handler.h
@@ -26,6 +26,8 @@
 #define ZCL_GENERAL_COMMAND_HANDLER_H
 
 #include "chip-zcl.h"
+#include "gen-command-id.h"
+#include "gen-types.h"
 #include "gen.h"
 
 ChipZclStatus_t chipZclGeneralCommandParse(ChipZclCommandContext_t * context);

--- a/src/app/gen/gen.h
+++ b/src/app/gen/gen.h
@@ -32,6 +32,7 @@
 #include "gen-command-handler.h"
 #include "gen-command-id.h"
 #include "gen-endpoint-config.h"
+#include "gen-global-command-handler.h"
 #include "gen-types.h"
 
 #endif // CHIP_ZCL_GEN_HEADER

--- a/src/app/plugin/core-message-dispatch/dispatch.h
+++ b/src/app/plugin/core-message-dispatch/dispatch.h
@@ -27,7 +27,6 @@
 
 #include "chip-zcl.h"
 #include "gen.h"
-#include "general-command-handler.h"
 
 // Main command parsing controller.
 ChipZclStatus_t chipZclCommandParse(ChipZclCommandContext_t * context);

--- a/src/app/plugin/core-message-dispatch/extra_dist.am
+++ b/src/app/plugin/core-message-dispatch/extra_dist.am
@@ -1,1 +1,1 @@
-EXTRA_DIST+=core-message-dispatch/dispatch.c core-message-dispatch/dispatch.h core-message-dispatch/general-command-handler.c core-message-dispatch/general-command-handler.h
+EXTRA_DIST+=core-message-dispatch/dispatch.c core-message-dispatch/dispatch.h

--- a/src/app/plugin/test-unit/Makefile.am
+++ b/src/app/plugin/test-unit/Makefile.am
@@ -44,6 +44,7 @@ EXTRA_DIST = ChipZclUnitTests.h
 libChipZclUnitTests_a_SOURCES                            = \
     ../../gen/gen-callback-stubs.c                         \
     ../../gen/gen-command-handler.c                        \
+    ../../gen/gen-global-command-handler.c                 \
     ../binding-mock/mock.c                                 \
     ../core-api/core-api.c                                 \
     ../cluster-server-basic/basic-server.c                 \
@@ -52,7 +53,6 @@ libChipZclUnitTests_a_SOURCES                            = \
     ../cluster-server-on-off/on-off-server.c               \
     ../codec-simple/codec-simple.c                         \
     ../core-message-dispatch/dispatch.c                    \
-    ../core-message-dispatch/general-command-handler.c     \
     ../core-data-model/zcl-data-model.c                    \
     $(NULL)
 


### PR DESCRIPTION
Global commands were manually handled in ZigbeePro implementation, but were generated in dotdot
so the global command handler ended under plugin code, instead of a gen code through some confusion.

This change moves it back to the gen/ directory where it belongs.

There is no other functional change, except moving the 2 generated files and updating the various makefiles that go with that.