### PR TITLE
Specify ARM GCC path by ARM_GCC_INSTALL_ROOT

### DIFF
--- a/examples/lock-app/nrf5/README.md
+++ b/examples/lock-app/nrf5/README.md
@@ -139,7 +139,7 @@ Alternatively, you can run `Build nRF5 Lock App` VSCode task.
 
           export NRF5_SDK_ROOT=${HOME}/tools/nRF5_SDK_for_Thread_and_Zigbee_v3.1.0
           export NRF5_TOOLS_ROOT=${HOME}/tools/nRF-Command-Line-Tools
-          export GNU_INSTALL_ROOT=${HOME}/tools/gcc-arm-none-eabi-7-2018-q2-update/bin/
+          export ARM_GCC_INSTALL_ROOT=${HOME}/tools/gcc-arm-none-eabi-9-2019-q4-major/bin
           export PATH=${PATH}:${NRF5_TOOLS_ROOT}/nrfjprog
 
 <p style="margin-left: 40px">For convenience, place these settings in local script file (e.g. setup-env.sh) so that they can be loaded into the environment as needed (e.g. by running 'source ./setup-env.sh').</p>


### PR DESCRIPTION
 #### Problem
In `examples/lock-app/nrf5/README.md`, `GNU_INSTALL_ROOT` is required, however, when building following this document, make reports `ENVIRONMENT ERROR: ARM_GCC_INSTALL_ROOT not set`

According to https://github.com/project-chip/connectedhomeip/blob/bfedcf6df2849a4f739f4e69a4a8bf8900afd8e4/config/nrf5/nrf5-app.mk#L76-L78

`ARM_GCC_INSTALL_ROOT` instead of `GNU_INSTALL_ROOT` should be set in README.

 #### Summary of Changes

Updated README to set `ARM_GCC_INSTALL_ROOT` instead of `GNU_INSTALL_ROOT`

fixes #874 
