### PR TITLE
Include the data model code in libCHIP.

### DIFF
--- a/src/app/DataModel.am
+++ b/src/app/DataModel.am
@@ -1,0 +1,48 @@
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#    Copyright (c) 2014-2017 Nest Labs, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+#
+#    Description:
+#      This file is the GNU automake header for the CHIP Data Model layer
+#      library sources.
+#
+#      These sources are shared by other SDK makefiles and consequently
+#      must be anchored relative to the top build directory.
+#
+
+CHIP_BUILD_DATA_MODEL_SOURCE_FILES                                                  = \
+    @top_builddir@/src/app/gen/gen-callback-stubs.c                                   \
+    @top_builddir@/src/app/gen/gen-command-handler.c                                  \
+    @top_builddir@/src/app/gen/gen-specs.c                                            \
+    @top_builddir@/src/app/plugin/binding-mock/mock.c                                 \
+    @top_builddir@/src/app/plugin/cluster-server-basic/basic-server.c                 \
+    @top_builddir@/src/app/plugin/cluster-server-identify/identify-server.c           \
+    @top_builddir@/src/app/plugin/cluster-server-level-control/level-control-server.c \
+    @top_builddir@/src/app/plugin/cluster-server-on-off/on-off-server.c               \
+    @top_builddir@/src/app/plugin/codec-simple/codec-simple.c                         \
+    @top_builddir@/src/app/plugin/core-api/core-api.c                                 \
+    @top_builddir@/src/app/plugin/core-data-model/zcl-data-model.c                    \
+    @top_builddir@/src/app/plugin/core-message-dispatch/dispatch.c                    \
+    @top_builddir@/src/app/plugin/core-message-dispatch/general-command-handler.c     \
+    $(NULL)
+
+# Excluding this one for now because it has #include syntax that does
+# not actually compile
+#     plugin/core-data-model/zcl-struct.c
+
+# Excluding this one because it seems to rely on stuff that's not in our tree
+#     plugin/binding-silabs/silabs.c

--- a/src/app/Makefile.am
+++ b/src/app/Makefile.am
@@ -29,4 +29,15 @@ SUBDIRS                               = \
     plugin                              \
     $(NULL)
 
+include DataModel.am
+
+lib_LIBRARIES                         = libCHIPDataModel.a
+
+libCHIPDataModel_a_CPPFLAGS           = \
+    -I$(top_srcdir)/src/app/chip-zcl    \
+    -I$(top_srcdir)/src/app/gen         \
+    $(NULL)
+
+libCHIPDataModel_a_SOURCES            = $(CHIP_BUILD_DATA_MODEL_SOURCE_FILES)
+
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -36,6 +36,7 @@ include ../inet/InetLayer.am
 include ../system/SystemLayer.am
 include core/CoreLayer.am
 include support/SupportLayer.am
+include ../app/DataModel.am
 
 # install headers for core layer
 CoreLayer_dir=$(includedir)/core
@@ -56,6 +57,8 @@ libCHIP_a_CPPFLAGS                  =                         \
     -I$(top_srcdir)/src/lib/core                              \
     -I$(top_srcdir)/src/lib/support                           \
     -I$(top_srcdir)/src/system                                \
+    -I$(top_srcdir)/src/app/chip-zcl                          \
+    -I$(top_srcdir)/src/app/gen                               \
     $(NLASSERT_CPPFLAGS)                                      \
     $(NLFAULTINJECTION_CPPFLAGS)                              \
     $(NLIO_CPPFLAGS)                                          \
@@ -68,6 +71,7 @@ libCHIP_a_SOURCES                  += $(CHIP_BUILD_INET_LAYER_SOURCE_FILES)
 libCHIP_a_SOURCES                  += $(CHIP_BUILD_CORE_LAYER_SOURCE_FILES)
 libCHIP_a_SOURCES                  += $(CHIP_BUILD_SUPPORT_LAYER_SOURCE_FILES)
 libCHIP_a_SOURCES                  += $(CHIP_BUILD_DEVICE_CONTROLLER_SOURCE_FILES)
+libCHIP_a_SOURCES                  += $(CHIP_BUILD_DATA_MODEL_SOURCE_FILES)
 
 if CONFIG_NETWORK_LAYER_BLE
 libCHIP_a_SOURCES                  += $(CHIP_BUILD_BLE_LAYER_SOURCE_FILES)


### PR DESCRIPTION
 #### Problem
Linking to libCHIP is not enough to pick up the data model code.

 #### Summary of Changes
Include the data model code in libCHIP

fixes https://github.com/project-chip/connectedhomeip/issues/876
