### PR TITLE
Address 'make distcheck' Failure for Missing Project Files

### DIFF
--- a/src/app/DataModel.am
+++ b/src/app/DataModel.am
@@ -26,7 +26,6 @@
 
 CHIP_BUILD_DATA_MODEL_SOURCE_FILES                                                  = \
     @top_builddir@/src/app/gen/gen-callback-stubs.c                                   \
-    @top_builddir@/src/app/gen/gen-command-handler.c                                  \
     @top_builddir@/src/app/gen/gen-specs.c                                            \
     @top_builddir@/src/app/plugin/binding-mock/mock.c                                 \
     @top_builddir@/src/app/plugin/cluster-server-basic/basic-server.c                 \
@@ -37,7 +36,6 @@ CHIP_BUILD_DATA_MODEL_SOURCE_FILES                                              
     @top_builddir@/src/app/plugin/core-api/core-api.c                                 \
     @top_builddir@/src/app/plugin/core-data-model/zcl-data-model.c                    \
     @top_builddir@/src/app/plugin/core-message-dispatch/dispatch.c                    \
-    @top_builddir@/src/app/plugin/core-message-dispatch/general-command-handler.c     \
     $(NULL)
 
 # Excluding this one for now because it has #include syntax that does


### PR DESCRIPTION
 #### Problem
When running make distcheck against TOT (9be6f66), the target goal fails with the following files missing:

@top_builddir@/src/app/gen/gen-command-handler.c
@top_builddir@/src/app/plugin/core-message-dispatch/general-command-handler.c

 #### Summary of Changes
Remove the two cited files from `CHIP_BUILD_DATA_MODEL_SOURCE_FILES` in `src/app/DataModel.am`.

Fixes #882
