### PR TITLE
Create a transport layer directory and include it to the build system.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2092,6 +2092,8 @@ src/lib/support/tests/Makefile
 src/platform/Makefile
 src/platform/tests/Makefile
 src/qrcodetool/Makefile
+src/transport/Makefile
+src/transport/tests/Makefile
 tests/Makefile
 ])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -38,16 +38,12 @@ MAYBE_BLE_SUBDIRS                += \
     $(NULL)
 endif # CONFIG_NETWORK_LAYER_BLE
 
-PLATFORM_SUBDIRS                  = \
-    platform                        \
-    $(NULL)
-
 MAYBE_PLATFORM_SUBDIRS            = \
     $(NULL)
 
 if CONFIG_DEVICE_LAYER
 MAYBE_PLATFORM_SUBDIRS           += \
-    $(PLATFORM_SUBDIRS)             \
+    platform                        \
     $(NULL)
 endif # CONFIG_DEVICE_LAYER
 
@@ -72,8 +68,9 @@ DIST_SUBDIRS                      = \
     lib                             \
     setup_payload                   \
     crypto                          \
-    $(PLATFORM_SUBDIRS)             \
+    platform                        \
     qrcodetool                      \
+    transport                       \
     $(NULL)
 
 # Always build (e.g. for 'make all') these subdirectories.
@@ -83,11 +80,12 @@ SUBDIRS                           = \
     include                         \
     lwip                            \
     system                          \
-    $(MAYBE_BLE_SUBDIRS)            \
     inet                            \
     lib                             \
     setup_payload                   \
     crypto                          \
+    transport                       \
+    $(MAYBE_BLE_SUBDIRS)            \
     $(MAYBE_PLATFORM_SUBDIRS)       \
     $(MAYBE_QRCODETOOL_SUBDIR)      \
     $(NULL)

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -34,6 +34,7 @@ include ../ble/BleLayer.am
 include ../controller/DeviceController.am
 include ../inet/InetLayer.am
 include ../system/SystemLayer.am
+include ../transport/TransportLayer.am
 include core/CoreLayer.am
 include support/SupportLayer.am
 include ../app/DataModel.am
@@ -59,6 +60,7 @@ libCHIP_a_CPPFLAGS                  =                         \
     -I$(top_srcdir)/src/system                                \
     -I$(top_srcdir)/src/app/chip-zcl                          \
     -I$(top_srcdir)/src/app/gen                               \
+    -I$(top_srcdir)/src/transport                             \
     $(NLASSERT_CPPFLAGS)                                      \
     $(NLFAULTINJECTION_CPPFLAGS)                              \
     $(NLIO_CPPFLAGS)                                          \
@@ -72,6 +74,7 @@ libCHIP_a_SOURCES                  += $(CHIP_BUILD_CORE_LAYER_SOURCE_FILES)
 libCHIP_a_SOURCES                  += $(CHIP_BUILD_SUPPORT_LAYER_SOURCE_FILES)
 libCHIP_a_SOURCES                  += $(CHIP_BUILD_DEVICE_CONTROLLER_SOURCE_FILES)
 libCHIP_a_SOURCES                  += $(CHIP_BUILD_DATA_MODEL_SOURCE_FILES)
+libCHIP_a_SOURCES                  += $(CHIP_BUILD_TRANSPORT_LAYER_SOURCE_FILES)
 
 if CONFIG_NETWORK_LAYER_BLE
 libCHIP_a_SOURCES                  += $(CHIP_BUILD_BLE_LAYER_SOURCE_FILES)

--- a/src/lib/core/CoreLayer.am
+++ b/src/lib/core/CoreLayer.am
@@ -54,4 +54,5 @@ CHIP_BUILD_CORE_LAYER_HEADER_FILES                        = \
     core/CHIPKeyIds.h                                       \
     core/CHIPConnection.h                                   \
     core/CHIPSecureChannel.h                                \
+    core/Optional.h                                         \
     $(NULL)

--- a/src/lib/core/Optional.h
+++ b/src/lib/core/Optional.h
@@ -1,8 +1,33 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines the chip::Optional class to handle values which may
+ *      or may not be present.
+ *
+ */
+
 #include <assert.h>
 
 namespace chip {
 
-/* Pairs an object with a boolean value to determine if the object value
+/**
+ * Pairs an object with a boolean value to determine if the object value
  * is actually valid or not.
  */
 template <class T>
@@ -22,9 +47,9 @@ public:
         mHasValue = true;
     }
 
-    void ClearValue() { mHasValue = false; }
+    void ClearValue(void) { mHasValue = false; }
 
-    const T & Value() const
+    const T & Value(void) const
     {
         assert(HasValue());
         return mValue;
@@ -36,7 +61,7 @@ public:
         return (mHasValue == other.mHasValue) && (!mHasValue || (mValue == other.mValue));
     }
 
-    static Optional<T> Missing() { return Optional<T>(); }
+    static Optional<T> Missing(void) { return Optional<T>(); }
     static Optional<T> Value(const T & value) { return Optional(value); }
 
 private:

--- a/src/lib/core/Optional.h
+++ b/src/lib/core/Optional.h
@@ -41,32 +41,41 @@ public:
     constexpr Optional(Optional && other)      = default;
     Optional & operator=(const Optional & other) = default;
 
+    /** Make the optional contain a specific value */
     void SetValue(const T & value)
     {
         mValue    = value;
         mHasValue = true;
     }
 
+    /** Invalidate the value inside the optional. Optional now has no value */
     void ClearValue(void) { mHasValue = false; }
 
+    /** Gets the current value of the optional. Valid IFF `HasValue`. */
     const T & Value(void) const
     {
         assert(HasValue());
         return mValue;
     }
+
+    /** Checks if the optional contains a value or not */
     bool HasValue() const { return mHasValue; }
 
+    /** Comparison operator, hadling missing values. */
     bool operator==(const Optional & other) const
     {
         return (mHasValue == other.mHasValue) && (!mHasValue || (mValue == other.mValue));
     }
 
+    /** Convenience method to create an optional without a valid value. */
     static Optional<T> Missing(void) { return Optional<T>(); }
+
+    /** Convenience method to create an optional containing the specified value. */
     static Optional<T> Value(const T & value) { return Optional(value); }
 
 private:
-    T mValue;
-    bool mHasValue;
+    T mValue;       ///< Value IFF optional contains a value
+    bool mHasValue; ///< True IFF optional contains a value
 };
 
 } // namespace chip

--- a/src/lib/core/Optional.h
+++ b/src/lib/core/Optional.h
@@ -1,0 +1,47 @@
+#include <assert.h>
+
+namespace chip {
+
+/* Pairs an object with a boolean value to determine if the object value
+ * is actually valid or not.
+ */
+template <class T>
+class Optional
+{
+public:
+    Optional() : mHasValue(false) {}
+    explicit Optional(const T & value) : mValue(value), mHasValue(true) {}
+
+    constexpr Optional(const Optional & other) = default;
+    constexpr Optional(Optional && other)      = default;
+    Optional & operator=(const Optional & other) = default;
+
+    void SetValue(const T & value)
+    {
+        mValue    = value;
+        mHasValue = true;
+    }
+
+    void ClearValue() { mHasValue = false; }
+
+    const T & Value() const
+    {
+        assert(HasValue());
+        return mValue;
+    }
+    bool HasValue() const { return mHasValue; }
+
+    bool operator==(const Optional & other) const
+    {
+        return (mHasValue == other.mHasValue) && (!mHasValue || (mValue == other.mValue));
+    }
+
+    static Optional<T> Missing() { return Optional<T>(); }
+    static Optional<T> Value(const T & value) { return Optional(value); }
+
+private:
+    T mValue;
+    bool mHasValue;
+};
+
+} // namespace chip

--- a/src/transport/Makefile.am
+++ b/src/transport/Makefile.am
@@ -1,0 +1,52 @@
+#
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#    Copyright (c) 2014-2017 Nest Labs, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+#
+#    Description:
+#      This file is the GNU automake template for the CHIP Trasport
+#      library.
+#
+
+include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
+
+SUBDIRS = tests
+
+include TransportLayer.am
+
+lib_LIBRARIES                       = libTransportLayer.a
+
+libTransportLayer_a_CPPFLAGS        = \
+    -I$(top_srcdir)/src               \
+    -I$(top_srcdir)/src/include       \
+    -I$(top_srcdir)/src/lib           \
+    -I$(top_srcdir)/src/lib/core      \
+    -I$(top_srcdir)/src/system        \
+    -I$(top_srcdir)/src/transport     \
+    $(NLASSERT_CPPFLAGS)              \
+    $(NLFAULTINJECTION_CPPFLAGS)      \
+    $(NLIO_CPPFLAGS)                  \
+    $(LWIP_CPPFLAGS)                  \
+    $(NULL)
+
+libTransportLayer_a_SOURCES      = $(CHIP_BUILD_TRANSPORT_LAYER_SOURCE_FILES)
+
+libTransportLayer_adir           = $(includedir)/transport
+
+dist_libTransportLayer_a_HEADERS = $(CHIP_BUILD_TRANSPORT_LAYER_HEADER_FILES)
+
+include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/transport/MessageHeader.cpp
+++ b/src/transport/MessageHeader.cpp
@@ -1,3 +1,24 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @file  This file contains the implementation the chip::MessageHeader class.
+ */
+
 #include "MessageHeader.h"
 
 #include <assert.h>
@@ -51,7 +72,7 @@ size_t MessageHeader::EncodeSizeBytes() const
     return size;
 }
 
-CHIP_ERROR MessageHeader::Decode(const uint8_t * data, size_t size)
+CHIP_ERROR MessageHeader::Decode(const uint8_t * data, size_t size, size_t * decode_len)
 {
     CHIP_ERROR err    = CHIP_NO_ERROR;
     const uint8_t * p = data;
@@ -90,6 +111,8 @@ CHIP_ERROR MessageHeader::Decode(const uint8_t * data, size_t size)
     {
         mDestinationNodeId.ClearValue();
     }
+
+    *decode_len = p - data;
 
 exit:
 

--- a/src/transport/MessageHeader.cpp
+++ b/src/transport/MessageHeader.cpp
@@ -42,16 +42,21 @@ namespace {
 
 using namespace chip::Encoding;
 
+/// size of the fixed portion of the header
 constexpr size_t kFixedHeaderSizeBytes = 6;
-constexpr size_t kNodeIdSizeBytes      = 8;
 
-// Available flags
+/// size of a serialized node id inside a header
+constexpr size_t kNodeIdSizeBytes = 8;
+
+/// Header flag specifying that a destination node id is included in the header.
 constexpr uint16_t kFlagDestinationNodeIdPresent = 0x0100;
-constexpr uint16_t kFlagSourceNodeIdPresent      = 0x0200;
+/// Header flag specifying that a source node id is included in the header.
+constexpr uint16_t kFlagSourceNodeIdPresent = 0x0200;
 
-// Version parsing and setting
+/// Mask to extract just the version part from a 16bit header prefix.
 constexpr uint16_t kVersionMask = 0xF000;
-constexpr int kVersionShift     = 12;
+/// Shift to convert to/from a masked version 16bit value to a 4bit version.
+constexpr int kVersionShift = 12;
 
 } // namespace
 

--- a/src/transport/MessageHeader.cpp
+++ b/src/transport/MessageHeader.cpp
@@ -1,0 +1,134 @@
+#include "MessageHeader.h"
+
+#include <assert.h>
+
+#include <core/CHIPEncoding.h>
+#include <core/CHIPError.h>
+#include <support/CodeUtils.h>
+
+/**********************************************
+ * Header format (little endian):
+ *
+ *  16 bit: | VERSION: 4 bit | FLAGS: 4 bit | RESERVED: 8 bit |
+ *  32 bit: | MESSAGE_ID                                      |
+ *  64 bit: | SOURCE_NODE_ID (iff source node flag is set)    |
+ *  64 bit: | DEST_NODE_ID (iff destination node flag is set) |
+ *
+ **********************************************/
+
+namespace chip {
+namespace {
+
+using namespace chip::Encoding;
+
+constexpr size_t kFixedHeaderSizeBytes = 6;
+constexpr size_t kNodeIdSizeBytes      = 8;
+
+// Available flags
+constexpr uint16_t kFlagDestinationNodeIdPresent = 0x0100;
+constexpr uint16_t kFlagSourceNodeIdPresent      = 0x0200;
+
+// Version parsing and setting
+constexpr uint16_t kVersionMask = 0xF000;
+constexpr int kVersionShift     = 12;
+
+} // namespace
+
+size_t MessageHeader::EncodeSizeBytes() const
+{
+    size_t size = kFixedHeaderSizeBytes;
+
+    if (mSourceNodeId.HasValue())
+    {
+        size += kNodeIdSizeBytes;
+    }
+
+    if (mDestinationNodeId.HasValue())
+    {
+        size += kNodeIdSizeBytes;
+    }
+
+    return size;
+}
+
+CHIP_ERROR MessageHeader::Decode(const uint8_t * data, size_t size)
+{
+    CHIP_ERROR err    = CHIP_NO_ERROR;
+    const uint8_t * p = data;
+    uint16_t header;
+    int version;
+
+    VerifyOrExit(size >= kFixedHeaderSizeBytes, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    header  = LittleEndian::Read16(p);
+    version = ((header & kVersionMask) >> kVersionShift);
+    VerifyOrExit(version == kHeaderVersion, err = CHIP_ERROR_VERSION_MISMATCH);
+
+    mMessageId = LittleEndian::Read32(p);
+
+    assert(p - data == kFixedHeaderSizeBytes);
+    size -= kFixedHeaderSizeBytes;
+
+    if (header & kFlagSourceNodeIdPresent)
+    {
+        VerifyOrExit(size >= kNodeIdSizeBytes, err = CHIP_ERROR_INVALID_ARGUMENT);
+        mSourceNodeId.SetValue(LittleEndian::Read64(p));
+        size -= kFixedHeaderSizeBytes;
+    }
+    else
+    {
+        mSourceNodeId.ClearValue();
+    }
+
+    if (header & kFlagDestinationNodeIdPresent)
+    {
+        VerifyOrExit(size >= kNodeIdSizeBytes, err = CHIP_ERROR_INVALID_ARGUMENT);
+        mDestinationNodeId.SetValue(LittleEndian::Read64(p));
+        size -= kFixedHeaderSizeBytes;
+    }
+    else
+    {
+        mDestinationNodeId.ClearValue();
+    }
+
+exit:
+
+    return err;
+}
+
+CHIP_ERROR MessageHeader::Encode(uint8_t * data, size_t size, size_t * encode_size)
+{
+    CHIP_ERROR err  = CHIP_NO_ERROR;
+    uint8_t * p     = data;
+    uint16_t header = kHeaderVersion << kVersionShift;
+
+    VerifyOrExit(size >= EncodeSizeBytes(), err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    if (mSourceNodeId.HasValue())
+    {
+        header |= kFlagSourceNodeIdPresent;
+    }
+    if (mDestinationNodeId.HasValue())
+    {
+        header |= kFlagDestinationNodeIdPresent;
+    }
+
+    LittleEndian::Write16(p, header);
+    LittleEndian::Write32(p, mMessageId);
+    if (mSourceNodeId.HasValue())
+    {
+        LittleEndian::Write64(p, mSourceNodeId.Value());
+    }
+    if (mDestinationNodeId.HasValue())
+    {
+        LittleEndian::Write64(p, mDestinationNodeId.Value());
+    }
+
+    // Written data size provided to caller on success
+    *encode_size = p - data;
+
+exit:
+    return err;
+}
+
+} // namespace chip

--- a/src/transport/MessageHeader.h
+++ b/src/transport/MessageHeader.h
@@ -88,6 +88,12 @@ public:
      * @param size - bytes available in the buffer
      * @param decode_size - number of bytes read from the buffer to decode the
      *                      object
+     *
+     * @return CHIP_NO_ERROR on success.
+     *
+     * Possible failures:
+     *    CHIP_ERROR_INVALID_ARGUMENT on insufficient buffer size
+     *    CHIP_ERROR_VERSION_MISMATCH if header version is not supported.
      */
     CHIP_ERROR Decode(const uint8_t * data, size_t size, size_t * decode_size);
 
@@ -97,6 +103,11 @@ public:
      * @param data - the buffer to write to
      * @param size - space available in the buffer (in bytes)
      * @param decode_size - number of bytes written to the buffer.
+     *
+     * @return CHIP_NO_ERROR on success.
+     *
+     * Possible failures:
+     *    CHIP_ERROR_INVALID_ARGUMENT on insufficient buffer size
      */
     CHIP_ERROR Encode(uint8_t * data, size_t size, size_t * encode_size);
 

--- a/src/transport/MessageHeader.h
+++ b/src/transport/MessageHeader.h
@@ -34,10 +34,29 @@ namespace chip {
 class MessageHeader
 {
 public:
+    /**
+     * Gets the source node id in the current message.
+     *
+     * NOTE: the source node id is optional and may be missing.
+     */
     const Optional<uint64_t> & GetSourceNodeId() const { return mSourceNodeId; }
+
+    /**
+     * Gets the destination node id in the current message.
+     *
+     * NOTE: the destination node id is optional and may be missing.
+     */
     const Optional<uint64_t> & GetDestinationNodeId() const { return mDestinationNodeId; }
+
+    /**
+     * Gets the message id set in the header.
+     *
+     * Message IDs are expecte to monotonically increase by one for each mesage
+     * that has been sent.
+     */
     uint32_t GetMessageId() const { return mMessageId; }
 
+    /** Set the message id for this header. */
     MessageHeader & SetMessageId(uint32_t id)
     {
         mMessageId = id;
@@ -45,6 +64,7 @@ public:
         return *this;
     }
 
+    /** Set the source node id for this header. */
     MessageHeader & SetSourceNodeId(uint64_t id)
     {
         mSourceNodeId.SetValue(id);
@@ -52,6 +72,7 @@ public:
         return *this;
     }
 
+    /** Clear the source node id for this header. */
     MessageHeader & ClearSourceNodeId()
     {
         mSourceNodeId.ClearValue();
@@ -59,6 +80,7 @@ public:
         return *this;
     }
 
+    /** Set the destination node id for this header. */
     MessageHeader & SetDestinationNodeId(uint64_t id)
     {
         mDestinationNodeId.SetValue(id);
@@ -66,6 +88,7 @@ public:
         return *this;
     }
 
+    /** Clear the destination node id for this header. */
     MessageHeader & ClearDestinationNodeId()
     {
         mDestinationNodeId.ClearValue();

--- a/src/transport/MessageHeader.h
+++ b/src/transport/MessageHeader.h
@@ -1,0 +1,65 @@
+#ifndef MESSAGEHEADER_H_
+#define MESSAGEHEADER_H_
+
+#include <cstddef>
+#include <cstdint>
+
+#include <core/CHIPError.h>
+#include <core/Optional.h>
+
+namespace chip {
+
+/** Handles encoding/decoding of CHIP message headers */
+class MessageHeader
+{
+public:
+    const Optional<uint64_t> & GetSourceNodeId() const { return mSourceNodeId; }
+    const Optional<uint64_t> & GetDestinationNodeId() const { return mDestinationNodeId; }
+    uint32_t GetMessageId() const { return mMessageId; }
+
+    MessageHeader & SetMessageId(uint32_t id)
+    {
+        mMessageId = id;
+        return *this;
+    }
+
+    MessageHeader & SetSourceNodeId(uint64_t id)
+    {
+        mSourceNodeId.SetValue(id);
+        return *this;
+    }
+
+    MessageHeader & ClearSourceNodeId()
+    {
+        mSourceNodeId.ClearValue();
+        return *this;
+    }
+
+    MessageHeader & SetDestinationNodeId(uint64_t id)
+    {
+        mDestinationNodeId.SetValue(id);
+        return *this;
+    }
+
+    MessageHeader & ClearDestinationNodeId()
+    {
+        mDestinationNodeId.ClearValue();
+        return *this;
+    }
+
+    size_t EncodeSizeBytes() const;
+    CHIP_ERROR Decode(const uint8_t * data, size_t size);
+    CHIP_ERROR Encode(uint8_t * data, size_t size, size_t * encode_size);
+
+private:
+    static constexpr int kHeaderVersion = 2;
+
+    uint32_t mMessageId = 0;
+
+    Optional<uint64_t> mSourceNodeId;
+    Optional<uint64_t> mDestinationNodeId;
+};
+
+} // namespace chip
+
+#endif // MESSAGEHEADER_H_

--- a/src/transport/MessageHeader.h
+++ b/src/transport/MessageHeader.h
@@ -101,11 +101,16 @@ public:
     CHIP_ERROR Encode(uint8_t * data, size_t size, size_t * encode_size);
 
 private:
+    /// Represents the current encode/decode header version
     static constexpr int kHeaderVersion = 2;
 
+    /// Value expected to be incremented for each message sent.
     uint32_t mMessageId = 0;
 
+    /// What node the message originated from
     Optional<uint64_t> mSourceNodeId;
+
+    /// Intended recipient of the message.
     Optional<uint64_t> mDestinationNodeId;
 };
 

--- a/src/transport/MessageHeader.h
+++ b/src/transport/MessageHeader.h
@@ -1,3 +1,24 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @file  This file defines the chip::MessageHeader class.
+ */
+
 #ifndef MESSAGEHEADER_H_
 #define MESSAGEHEADER_H_
 
@@ -20,35 +41,63 @@ public:
     MessageHeader & SetMessageId(uint32_t id)
     {
         mMessageId = id;
+
         return *this;
     }
 
     MessageHeader & SetSourceNodeId(uint64_t id)
     {
         mSourceNodeId.SetValue(id);
+
         return *this;
     }
 
     MessageHeader & ClearSourceNodeId()
     {
         mSourceNodeId.ClearValue();
+
         return *this;
     }
 
     MessageHeader & SetDestinationNodeId(uint64_t id)
     {
         mDestinationNodeId.SetValue(id);
+
         return *this;
     }
 
     MessageHeader & ClearDestinationNodeId()
     {
         mDestinationNodeId.ClearValue();
+
         return *this;
     }
 
+    /**
+     * A call to `Encode` will require at least this many bytes on the current
+     * object to be successful.
+     *
+     * @return the number of bytes needed in a buffer to be able to Encode.
+     */
     size_t EncodeSizeBytes() const;
-    CHIP_ERROR Decode(const uint8_t * data, size_t size);
+
+    /**
+     * Decodes a header from the given buffer.
+     *
+     * @param data - the buffer to read from
+     * @param size - bytes available in the buffer
+     * @param decode_size - number of bytes read from the buffer to decode the
+     *                      object
+     */
+    CHIP_ERROR Decode(const uint8_t * data, size_t size, size_t * decode_size);
+
+    /**
+     * Encodes a header into the given buffer.
+     *
+     * @param data - the buffer to write to
+     * @param size - space available in the buffer (in bytes)
+     * @param decode_size - number of bytes written to the buffer.
+     */
     CHIP_ERROR Encode(uint8_t * data, size_t size, size_t * encode_size);
 
 private:

--- a/src/transport/TransportLayer.am
+++ b/src/transport/TransportLayer.am
@@ -1,0 +1,33 @@
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#    Copyright (c) 2014-2017 Nest Labs, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+#
+#    Description:
+#      This file is the GNU automake header for the CHIP BleLayer
+#      library sources.
+#
+#      These sources are shared by other SDK makefiles and consequently
+#      must be anchored relative to the top build directory.
+#
+
+CHIP_BUILD_TRANSPORT_LAYER_SOURCE_FILES                  = \
+    @top_builddir@/src/transport/MessageHeader.cpp         \
+    $(NULL)
+
+CHIP_BUILD_TRANSPORT_LAYER_HEADER_FILES  = \
+    MessageHeader.h                        \
+    $(NULL)

--- a/src/transport/tests/Makefile.am
+++ b/src/transport/tests/Makefile.am
@@ -1,0 +1,146 @@
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+#
+#    Description:
+#      This file is the GNU automake template for the Project CHIP
+#      transport layer library unit tests.
+#
+
+include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
+
+#
+# Local headers to build against and distribute but not to install
+# since they are not part of the package.
+#
+noinst_HEADERS                                        = \
+    $(NULL)
+
+#
+# Other files we do want to distribute with the package.
+#
+EXTRA_DIST                                            = \
+    $(NULL)
+
+if CHIP_BUILD_TESTS
+lib_LIBRARIES                                         = \
+    libTransportLayerTests.a                            \
+    $(NULL)
+
+libTransportLayerTests_a_SOURCES                      = \
+    TestMessageHeader.cpp                               \
+    $(NULL)
+
+libTransportLayerTests_adir                           = $(includedir)/transport
+
+dist_libTransportLayerTests_a_HEADERS                 = \
+    TestTransportLayer.h                                \
+    $(NULL)
+
+# C/C++ preprocessor option flags that will apply to all compiled
+# objects in this makefile.
+
+AM_CPPFLAGS                                           = \
+    -I$(top_srcdir)/src                                 \
+    -I$(top_srcdir)/src/lib                             \
+    $(NLIO_CPPFLAGS)                                    \
+    $(NLUNIT_TEST_CPPFLAGS)                             \
+    $(LWIP_CPPFLAGS)                                    \
+    $(SOCKETS_CPPFLAGS)                                 \
+    $(PTHREAD_CFLAGS)                                   \
+    $(NULL)
+
+CHIP_LDADD                                            = \
+    $(top_builddir)/src/transport/libTransportLayer.a   \
+    $(top_builddir)/src/lib/support/libSupportLayer.a   \
+    $(NULL)
+
+COMMON_LDADD                                          = \
+    libTransportLayerTests.a                            \
+    $(COMMON_LDFLAGS)                                   \
+    $(CHIP_LDADD)                                       \
+    $(NLUNIT_TEST_LDFLAGS) $(NLUNIT_TEST_LIBS)          \
+    $(LWIP_LDFLAGS) $(LWIP_LIBS)                        \
+    $(SOCKETS_LDFLAGS) $(SOCKETS_LIBS)                  \
+    $(PTHREAD_CFLAGS) $(PTHREAD_LIBS)                   \
+    $(NULL)
+
+# Test applications that should be run when the 'check' target is run.
+
+check_PROGRAMS             = \
+    TestMessageHeader        \
+    $(NULL)
+
+# Test applications and scripts that should be built and run when the
+# 'check' target is run.
+
+TESTS                       = \
+    $(check_PROGRAMS)         \
+    $(NULL)
+
+# The additional environment variables and their values that will be
+# made available to all programs and scripts in TESTS.
+
+TESTS_ENVIRONMENT             = \
+    $(NULL)
+
+# Source, compiler, and linker options for test programs.
+
+TestMessageHeader_SOURCES     = TestMessageHeaderDriver.cpp
+TestMessageHeader_LDADD       = $(COMMON_LDADD)
+
+#
+# Foreign make dependencies
+#
+
+NLFOREIGN_FILE_DEPENDENCIES                           = \
+   $(CHIP_LDADD)                                        \
+   $(NULL)
+
+NLFOREIGN_SUBDIR_DEPENDENCIES                         = \
+   $(LWIP_FOREIGN_SUBDIR_DEPENDENCY)                    \
+   $(NLUNIT_TEST_FOREIGN_SUBDIR_DEPENDENCY)             \
+   $(NULL)
+
+if CHIP_BUILD_COVERAGE
+CLEANFILES                                            = $(wildcard *.gcda *.gcno)
+
+if CHIP_BUILD_COVERAGE_REPORTS
+# The bundle should positively be qualified with the absolute build
+# path. Otherwise, VPATH will get auto-prefixed to it if there is
+# already such a directory in the non-colocated source tree.
+
+CHIP_COVERAGE_BUNDLE                                  = ${abs_builddir}/${PACKAGE}${NL_COVERAGE_BUNDLE_SUFFIX}
+CHIP_COVERAGE_INFO                                    = ${CHIP_COVERAGE_BUNDLE}/${PACKAGE}${NL_COVERAGE_INFO_SUFFIX}
+
+$(CHIP_COVERAGE_BUNDLE):
+	$(call create-directory)
+
+$(CHIP_COVERAGE_INFO): check-local | $(CHIP_COVERAGE_BUNDLE)
+	$(call generate-coverage-report,${top_builddir},*/usr/include/* */third_party/*)
+
+coverage-local: $(CHIP_COVERAGE_INFO)
+
+clean-local: clean-local-coverage
+
+.PHONY: clean-local-coverage
+clean-local-coverage:
+	-$(AM_V_at)rm -rf $(CHIP_COVERAGE_BUNDLE)
+endif # CHIP_BUILD_COVERAGE_REPORTS
+endif # CHIP_BUILD_COVERAGE
+endif # CHIP_BUILD_TESTS
+
+include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/transport/tests/TestMessageHeader.cpp
+++ b/src/transport/tests/TestMessageHeader.cpp
@@ -47,6 +47,7 @@ void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     MessageHeader header;
     uint8_t buffer[64];
     size_t encodeLen;
+    size_t decodeLen;
 
     header.SetMessageId(123);
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
@@ -54,7 +55,8 @@ void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     // change it to verify decoding
     header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
 
-    NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen, &decodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, encodeLen == decodeLen);
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 123);
     NL_TEST_ASSERT(inSuite, !header.GetDestinationNodeId().HasValue());
     NL_TEST_ASSERT(inSuite, !header.GetSourceNodeId().HasValue());
@@ -65,7 +67,8 @@ void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     // change it to verify decoding
     header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
 
-    NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen, &decodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, encodeLen == decodeLen);
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 123);
     NL_TEST_ASSERT(inSuite, !header.GetDestinationNodeId().HasValue());
     NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(55));
@@ -75,7 +78,8 @@ void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
 
     // change it to verify decoding
     header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
-    NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen, &decodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, encodeLen == decodeLen);
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 123);
     NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(11));
     NL_TEST_ASSERT(inSuite, !header.GetSourceNodeId().HasValue());
@@ -85,10 +89,24 @@ void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
 
     // change it to verify decoding
     header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
-    NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen, &decodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, encodeLen == decodeLen);
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 234);
     NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(88));
     NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77));
+}
+
+void TestHeaderEncodeDecodeBounds(nlTestSuite * inSuite, void * inContext)
+{
+    MessageHeader header;
+    uint8_t buffer[64];
+    size_t unusedLen;
+
+    for (size_t shortLen = 0; shortLen < 6; shortLen++)
+    {
+        NL_TEST_ASSERT(inSuite, header.Encode(buffer, shortLen, &unusedLen) != CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, header.Decode(buffer, shortLen, &unusedLen) != CHIP_NO_ERROR);
+    }
 }
 
 } // namespace
@@ -98,6 +116,7 @@ static const nlTest sTests[] =
 {
     NL_TEST_DEF("InitialState", TestHeaderInitialState),
     NL_TEST_DEF("EncodeDecode", TestHeaderEncodeDecode),
+    NL_TEST_DEF("EncodeDecodeBounds", TestHeaderEncodeDecodeBounds),
     NL_TEST_SENTINEL()
 };
 // clang-format on

--- a/src/transport/tests/TestMessageHeader.cpp
+++ b/src/transport/tests/TestMessageHeader.cpp
@@ -1,0 +1,110 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a process to effect a functional test for
+ *      the Message Header class within the transport layer
+ *
+ */
+#include "TestTransportLayer.h"
+
+#include <support/ErrorStr.h>
+#include <transport/MessageHeader.h>
+
+#include <nlunit-test.h>
+
+namespace {
+
+using namespace chip;
+
+void TestHeaderInitialState(nlTestSuite * inSuite, void * inContext)
+{
+    MessageHeader header;
+
+    NL_TEST_ASSERT(inSuite, header.GetMessageId() == 0);
+    NL_TEST_ASSERT(inSuite, !header.GetDestinationNodeId().HasValue());
+    NL_TEST_ASSERT(inSuite, !header.GetSourceNodeId().HasValue());
+}
+
+void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
+{
+    MessageHeader header;
+    uint8_t buffer[64];
+    size_t encodeLen;
+
+    header.SetMessageId(123);
+    NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
+
+    // change it to verify decoding
+    header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
+
+    NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.GetMessageId() == 123);
+    NL_TEST_ASSERT(inSuite, !header.GetDestinationNodeId().HasValue());
+    NL_TEST_ASSERT(inSuite, !header.GetSourceNodeId().HasValue());
+
+    header.SetSourceNodeId(55);
+    NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
+
+    // change it to verify decoding
+    header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
+
+    NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.GetMessageId() == 123);
+    NL_TEST_ASSERT(inSuite, !header.GetDestinationNodeId().HasValue());
+    NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(55));
+
+    header.ClearSourceNodeId().SetDestinationNodeId(11);
+    NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
+
+    // change it to verify decoding
+    header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
+    NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.GetMessageId() == 123);
+    NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(11));
+    NL_TEST_ASSERT(inSuite, !header.GetSourceNodeId().HasValue());
+
+    header.SetMessageId(234).SetSourceNodeId(77).SetDestinationNodeId(88);
+    NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
+
+    // change it to verify decoding
+    header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
+    NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.GetMessageId() == 234);
+    NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(88));
+    NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77));
+}
+
+} // namespace
+
+// clang-format off
+static const nlTest sTests[] =
+{
+    NL_TEST_DEF("InitialState", TestHeaderInitialState),
+    NL_TEST_DEF("EncodeDecode", TestHeaderEncodeDecode),
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+int TestMessageHeader(void)
+{
+    nlTestSuite theSuite = { "Transport-MessageHeader", &sTests[0], NULL, NULL };
+    nlTestRunner(&theSuite, NULL);
+    return nlTestRunnerStats(&theSuite);
+}

--- a/src/transport/tests/TestMessageHeaderDriver.cpp
+++ b/src/transport/tests/TestMessageHeaderDriver.cpp
@@ -1,0 +1,34 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a standalone/native program executable
+ *      test driver for the CHIP Transport Layer Message header unit
+ *      tests.
+ *
+ */
+
+#include "TestTransportLayer.h"
+
+#include <nlunit-test.h>
+
+int main(void)
+{
+    nlTestSetOutputStyle(OUTPUT_CSV);
+    return TestMessageHeader();
+}

--- a/src/transport/tests/TestTransportLayer.h
+++ b/src/transport/tests/TestTransportLayer.h
@@ -1,0 +1,38 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file declares test entry points for CHIP Transport layer
+ *      layer library unit tests.
+ *
+ */
+
+#ifndef TESTTRANSPORTLAYER_H
+#define TESTTRANSPORTLAYER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int TestMessageHeader(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TESTTRANSPORTLAYER_H


### PR DESCRIPTION
The intent is to proide the transport support (UDP, TCP, BLE and others) into its own layer.
Currently started with the message header according to the WML format, with encryption and tunneling flags and options stripped out.

 #### Problem
Transport layer is not yet defined. WML wholesale port does not seem viable due to class interlinkage. Trying for small PRs with a clear goal.

 #### Summary of Changes
Created MessageHeader class that defines encoding and decoding methods for message headers.
