### PR TITLE
Fix merge conflict with f46213fa83c6a19fea1654bd0bee316308d76d14

### DIFF
--- a/src/app/DataModel.am
+++ b/src/app/DataModel.am
@@ -27,6 +27,7 @@
 CHIP_BUILD_DATA_MODEL_SOURCE_FILES                                                  = \
     @top_builddir@/src/app/gen/gen-callback-stubs.c                                   \
     @top_builddir@/src/app/gen/gen-command-handler.c                                  \
+    @top_builddir@/src/app/gen/gen-global-command-handler.c                           \
     @top_builddir@/src/app/gen/gen-specs.c                                            \
     @top_builddir@/src/app/plugin/binding-mock/mock.c                                 \
     @top_builddir@/src/app/plugin/cluster-server-basic/basic-server.c                 \
@@ -37,7 +38,6 @@ CHIP_BUILD_DATA_MODEL_SOURCE_FILES                                              
     @top_builddir@/src/app/plugin/core-api/core-api.c                                 \
     @top_builddir@/src/app/plugin/core-data-model/zcl-data-model.c                    \
     @top_builddir@/src/app/plugin/core-message-dispatch/dispatch.c                    \
-    @top_builddir@/src/app/plugin/core-message-dispatch/general-command-handler.c     \
     $(NULL)
 
 # Excluding this one for now because it has #include syntax that does


### PR DESCRIPTION
 #### Problem
`make distcheck` fails, as do other things that try to compile the data model bits, because there was a file rename that raced with `Makefile.am` changes that listed filenames, so we are listing the wrong filename.

 #### Summary of Changes
List the right filename in `Makefile.am`

fixes https://github.com/project-chip/connectedhomeip/issues/882
