### PR TITLE
Move QEMU sdkconfig to build folder and gitignore it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ examples/common/QRCode/repo
 examples/**/sdkconfig
 examples/**/sdkconfig.old
 
+# ESP32 QEMU build
+src/test_driver/esp32/build
+
 # Temporary Directories
 .tmp/
 

--- a/src/test_driver/esp32/qemu_setup.sh
+++ b/src/test_driver/esp32/qemu_setup.sh
@@ -34,5 +34,5 @@ die() {
 cd "$here" || die 'ack!, where am I?!?'
 
 source idf.sh
-SDKCONFIG_DEFAULTS=sdkconfig_qemu.defaults idf make defconfig
-idf make esp32_elf_builder
+SDKCONFIG=./build/sdkconfig SDKCONFIG_DEFAULTS=sdkconfig_qemu.defaults idf make defconfig
+SDKCONFIG=./build/sdkconfig idf make esp32_elf_builder


### PR DESCRIPTION
 #### Problem
ESP32 QEMU build artifacts are not git ignored

 #### Summary of Changes
Consolidate the build artifacts in `build` folder, and git ignore it.
