### PR TITLE
Fix invalid @param[inout] annotations

### DIFF
--- a/src/include/platform/PersistedStorage.h
+++ b/src/include/platform/PersistedStorage.h
@@ -60,8 +60,8 @@ constexpr Key kEmptyKey = internal::EmptyKey<Key>::value;
  *    Read integer value of a key from persistent storage.
  *    Platform is responsible for validating aKey.
  *
- *  @param[in]    aKey      A key to a persistently-stored value.
- *  @param[inout] aValue    A reference to an integer value.
+ *  @param[in]     aKey      A key to a persistently-stored value.
+ *  @param[in,out] aValue    A reference to an integer value.
  *
  *  @return CHIP_ERROR_INVALID_ARGUMENT if aKey is NULL
  *          CHIP_ERROR_INVALID_STRING_LENGTH if aKey exceeds

--- a/src/inet/IPAddress.h
+++ b/src/inet/IPAddress.h
@@ -352,7 +352,7 @@ public:
     /**
      * @brief   Emit the IP address in standard network representation.
      *
-     * @param[inout]    p   Reference to the cursor to use for writing.
+     * @param[in,out]   p   Reference to the cursor to use for writing.
      *
      * @details
      *  Use <tt>WriteAddress(uint8_t *&p)</tt> to encode the IP address in
@@ -365,7 +365,7 @@ public:
     /**
      * @brief   Emit the IP address in standard network representation.
      *
-     * @param[inout]    p       Reference to the cursor to use for reading.
+     * @param[in,out]   p       Reference to the cursor to use for reading.
      * @param[out]      output  Object to receive decoded IP address.
      *
      * @details

--- a/src/inet/InetLayer.cpp
+++ b/src/inet/InetLayer.cpp
@@ -564,7 +564,7 @@ out:
  *
  *  @param[in]      ipProto        A protocol within the IP family (e.g., ICMPv4 or ICMPv6).
  *
- *  @param[inout]   retEndPoint    A pointer to a pointer of the RawEndPoint object that is
+ *  @param[in,out]  retEndPoint    A pointer to a pointer of the RawEndPoint object that is
  *                                 a return parameter upon completion of the object creation.
  *                                 *retEndPoint is NULL if creation fails.
  *
@@ -606,7 +606,7 @@ exit:
  *    This function gets a free TCPEndPoint object from a pre-allocated pool
  *    and also calls the explicit initializer on the new object.
  *
- *  @param[inout]   retEndPoint    A pointer to a pointer of the TCPEndPoint object that is
+ *  @param[in,out]  retEndPoint    A pointer to a pointer of the TCPEndPoint object that is
  *                                 a return parameter upon completion of the object creation.
  *                                 *retEndPoint is NULL if creation fails.
  *
@@ -648,7 +648,7 @@ exit:
  *    This function gets a free UDPEndPoint object from a pre-allocated pool
  *    and also calls the explicit initializer on the new object.
  *
- *  @param[inout]   retEndPoint    A pointer to a pointer of the UDPEndPoint object that is
+ *  @param[in,out]  retEndPoint    A pointer to a pointer of the UDPEndPoint object that is
  *                                 a return parameter upon completion of the object creation.
  *                                 *retEndPoint is NULL if creation fails.
  *
@@ -690,7 +690,7 @@ exit:
  *    This function gets a free TunEndPoint object from a pre-allocated pool
  *    and also calls the explicit initializer on the new object.
  *
- *  @param[inout]   retEndPoint    A pointer to a pointer of the TunEndPoint object that is
+ *  @param[in,out]  retEndPoint    A pointer to a pointer of the TunEndPoint object that is
  *                                 a return parameter upon completion of the object creation.
  *                                 *retEndPoint is NULL if creation fails.
  *
@@ -1280,12 +1280,12 @@ exit:
  *  provided argument to this instance's platform-specific event /
  *  message queue.
  *
- *  @param[inout]  target  A pointer to the InetLayer object making the
+ *  @param[in,out] target  A pointer to the InetLayer object making the
  *                         post request.
  *
  *  @param[in]     type    The type of event to post.
  *
- *  @param[inout]  arg     The argument associated with the event to post.
+ *  @param[in,out] arg     The argument associated with the event to post.
  *
  *  @retval    #INET_ERROR_INCORRECT_STATE      If the state of the InetLayer
  *                                              object is incorrect.
@@ -1643,10 +1643,10 @@ namespace InetLayer {
  * may be overridden by assserting the preprocessor definition,
  * #INET_CONFIG_WILL_OVERRIDE_PLATFORM_XTOR_FUNCS.
  *
- * @param[inout]  aLayer    A pointer to the InetLayer instance being
+ * @param[in,out] aLayer    A pointer to the InetLayer instance being
  *                          initialized.
  *
- * @param[inout]  aContext  Platform-specific context data passed to
+ * @param[in,out] aContext  Platform-specific context data passed to
  *                          the layer initialization method, ::Init.
  *
  * @return #INET_NO_ERROR on success; otherwise, a specific error indicating
@@ -1667,10 +1667,10 @@ DLL_EXPORT INET_ERROR WillInit(Inet::InetLayer * aLayer, void * aContext)
  * may be overridden by assserting the preprocessor definition,
  * #INET_CONFIG_WILL_OVERRIDE_PLATFORM_XTOR_FUNCS.
  *
- * @param[inout]  aLayer    A pointer to the InetLayer instance being
+ * @param[in,out] aLayer    A pointer to the InetLayer instance being
  *                          initialized.
  *
- * @param[inout]  aContext  Platform-specific context data passed to
+ * @param[in,out] aContext  Platform-specific context data passed to
  *                          the layer initialization method, ::Init.
  *
  * @param[in]     anError   The overall status being returned via the
@@ -1691,10 +1691,10 @@ DLL_EXPORT void DidInit(Inet::InetLayer * aLayer, void * aContext, INET_ERROR an
  * may be overridden by assserting the preprocessor definition,
  * #INET_CONFIG_WILL_OVERRIDE_PLATFORM_XTOR_FUNCS.
  *
- * @param[inout]  aLayer    A pointer to the InetLayer instance being
+ * @param[in,out] aLayer    A pointer to the InetLayer instance being
  *                          shutdown.
  *
- * @param[inout]  aContext  Platform-specific context data passed to
+ * @param[in,out] aContext  Platform-specific context data passed to
  *                          the layer initialization method, ::Init.
  *
  * @return #INET_NO_ERROR on success; otherwise, a specific error indicating
@@ -1715,10 +1715,10 @@ DLL_EXPORT INET_ERROR WillShutdown(Inet::InetLayer * aLayer, void * aContext)
  * may be overridden by assserting the preprocessor definition,
  * #INET_CONFIG_WILL_OVERRIDE_PLATFORM_XTOR_FUNCS.
  *
- * @param[inout]  aLayer    A pointer to the InetLayer instance being
+ * @param[in,out] aLayer    A pointer to the InetLayer instance being
  *                          shutdown.
  *
- * @param[inout]  aContext  Platform-specific context data passed to
+ * @param[in,out] aContext  Platform-specific context data passed to
  *                          the layer initialization method, ::Init.
  *
  * @param[in]     anError   The overall status being returned via the
@@ -1748,18 +1748,18 @@ DLL_EXPORT void DidShutdown(Inet::InetLayer * aLayer, void * aContext, INET_ERRO
  *  @note
  *    This is an implementation for LwIP.
  *
- *  @param[inout]  aLayer    A pointer to the layer instance to which the
+ *  @param[in,out] aLayer    A pointer to the layer instance to which the
  *                           event / message is being posted.
  *
- *  @param[inout]  aContext  Platform-specific context data passed to
+ *  @param[in,out] aContext  Platform-specific context data passed to
  *                           the layer initialization method, ::Init.
  *
- *  @param[inout]  aTarget   A pointer to the InetLayer object making the
+ *  @param[in,out] aTarget   A pointer to the InetLayer object making the
  *                           post request.
  *
  *  @param[in]     aType     The type of event to post.
  *
- *  @param[inout]  anArg     The argument associated with the event to post.
+ *  @param[in,out] anArg     The argument associated with the event to post.
  *
  *  @return #INET_NO_ERROR on success; otherwise, a specific error indicating
  *          the reason for initialization failure.
@@ -1787,10 +1787,10 @@ INET_ERROR PostEvent(Inet::InetLayer * aInetLayer, void * aContext, InetLayerBas
  *  @note
  *    This is an implementation for LwIP.
  *
- *  @param[inout]  aInetLayer   A pointer to the layer instance for which
+ *  @param[in,out] aInetLayer   A pointer to the layer instance for which
  *                              events / messages are being dispatched.
  *
- *  @param[inout]  aContext  Platform-specific context data passed to
+ *  @param[in,out] aContext  Platform-specific context data passed to
  *                           the layer initialization method, ::Init.
  *
  *  @retval   #INET_ERROR_BAD_ARGS          If #aLayer or #aContext is NULL.
@@ -1820,10 +1820,10 @@ INET_ERROR DispatchEvents(Inet::InetLayer * aInetLayer, void * aContext)
  *  @note
  *    This is an implementation for LwIP.
  *
- *  @param[inout]  aInetLayer   A pointer to the layer instance for which
+ *  @param[in,out] aInetLayer   A pointer to the layer instance for which
  *                              events / messages are being dispatched.
  *
- *  @param[inout]  aContext  Platform-specific context data passed to
+ *  @param[in,out] aContext  Platform-specific context data passed to
  *                           the layer initialization method, ::Init.
  *
  *  @param[in]     aEvent    The platform-specific event object to
@@ -1852,8 +1852,8 @@ INET_ERROR DispatchEvent(Inet::InetLayer * aInetLayer, void * aContext, InetEven
  *  @note
  *    This is an implementation for LwIP.
  *
- *  @param[inout]  aInetLayer           A reference to the layer instance for which events / messages are being dispatched.
- *  @param[inout]  aContext             Platform-specific context data passed to the layer initialization method, ::Init.
+ *  @param[in,out] aInetLayer           A reference to the layer instance for which events / messages are being dispatched.
+ *  @param[in,out] aContext             Platform-specific context data passed to the layer initialization method, ::Init.
  *  @param[in]     aMilliseconds        The number of milliseconds to set for the timer.
  *
  *  @retval   #INET_NO_ERROR    Always succeeds unless overridden.

--- a/src/lib/core/CHIPCircularTLVBuffer.cpp
+++ b/src/lib/core/CHIPCircularTLVBuffer.cpp
@@ -163,7 +163,7 @@ exit:
  *   function evicts an element from the circular buffer, and adjusts
  *   the head of this buffer queue
  *
- * @param[inout] ioWriter  TLVWriter calling this function
+ * @param[in,out] ioWriter  TLVWriter calling this function
  *
  * @param[out] outBufStart The pointer to the new buffer
  *
@@ -209,7 +209,7 @@ exit:
  *   completion of output from the TLVWriter.  This function affects
  *   the position of the queue tail.
  *
- * @param[inout] ioWriter TLVWriter calling this function
+ * @param[in,out] ioWriter TLVWriter calling this function
  *
  * @param[in] inBufStart pointer to the start of data (from `TLVWriter`
  *                       perspective)
@@ -248,16 +248,16 @@ CHIP_ERROR CHIPCircularTLVBuffer::FinalizeBuffer(TLVWriter & ioWriter, uint8_t *
  *  TLVReader constraints.  The reader will read at most `mQueueSize`
  *  bytes from the buffer.
  *
- * @param[in] ioReader        TLVReader calling this function.
+ * @param[in] ioReader         TLVReader calling this function.
  *
- * @param[inout] outBufStart  The reference to the data buffer.  On
- *                            return, it is set to a value within this
- *                            buffer.
+ * @param[in,out] outBufStart  The reference to the data buffer.  On
+ *                             return, it is set to a value within this
+ *                             buffer.
  *
- * @param[out] outBufLen      On return, set to the number of continuous
- *                            bytes that could be read out of the buffer.
+ * @param[out] outBufLen       On return, set to the number of continuous
+ *                             bytes that could be read out of the buffer.
  *
- * @retval #CHIP_NO_ERROR    Succeeds unconditionally.
+ * @retval #CHIP_NO_ERROR      Succeeds unconditionally.
  */
 CHIP_ERROR CHIPCircularTLVBuffer::GetNextBuffer(TLVReader & ioReader, const uint8_t *& outBufStart, uint32_t & outBufLen)
 {
@@ -308,9 +308,9 @@ CHIP_ERROR CHIPCircularTLVBuffer::GetNextBuffer(TLVReader & ioReader, const uint
  * @brief
  *   A trampoline to fetch more space for the TLVWriter.
  *
- * @param[inout] ioWriter TLVWriter calling this function
+ * @param[in,out] ioWriter TLVWriter calling this function
  *
- * @param[inout] inBufHandle A handle to the `CircularTLVWriter` object
+ * @param[in,out] inBufHandle A handle to the `CircularTLVWriter` object
  *
  * @param[out] outBufStart The pointer to the new buffer
  *
@@ -341,9 +341,9 @@ exit:
  * @brief
  *   A trampoline to CHIPCircularTLVBuffer::FinalizeBuffer
  *
- * @param[inout] ioWriter TLVWriter calling this function
+ * @param[in,out] ioWriter TLVWriter calling this function
  *
- * @param[inout] inBufHandle A handle to the `CircularTLVWriter` object
+ * @param[in,out] inBufHandle A handle to the `CircularTLVWriter` object
  *
  * @param[in] inBufStart pointer to the start of data (from `TLVWriter`
  *                       perspective)
@@ -373,18 +373,18 @@ exit:
  * @brief
  *   A trampoline to CHIPCircularTLVBuffer::GetNextBuffer
  *
- * @param[inout] ioReader TLVReader calling this function
+ * @param[in,out] ioReader TLVReader calling this function
  *
- * @param[inout] inBufHandle A handle to the `CircularTLVWriter` object
+ * @param[in,out] inBufHandle A handle to the `CircularTLVWriter` object
  *
- * @param[inout] outBufStart  The reference to the data buffer.  On
- *                            return, it is set to a value within this
- *                            buffer.
+ * @param[in,out] outBufStart  The reference to the data buffer.  On
+ *                             return, it is set to a value within this
+ *                             buffer.
  *
- * @param[out] outBufLen      On return, set to the number of continuous
- *                            bytes that could be read out of the buffer.
+ * @param[out] outBufLen       On return, set to the number of continuous
+ *                             bytes that could be read out of the buffer.
  *
- * @retval #CHIP_NO_ERROR    Succeeds unconditionally.
+ * @retval #CHIP_NO_ERROR      Succeeds unconditionally.
  */
 CHIP_ERROR CHIPCircularTLVBuffer::GetNextBufferFunct(TLVReader & ioReader, uintptr_t & inBufHandle, const uint8_t *& outBufStart,
                                                      uint32_t & outBufLen)

--- a/src/lib/core/CHIPEncoding.h
+++ b/src/lib/core/CHIPEncoding.h
@@ -132,7 +132,7 @@ inline void Put8(uint8_t * p, uint8_t v)
  * from the specified pointer address and increment the pointer by
  * 8-bits (1 byte).
  *
- * @param[inout]  p   A reference to a pointer address, potentially
+ * @param[in,out] p   A reference to a pointer address, potentially
  *                    unaligned, to read the 8-bit value from and to
  *                    then increment by 8-bits (1 byte).
  *
@@ -148,7 +148,7 @@ inline uint8_t Read8(uint8_t *& p)
  * from the specified pointer address and increment the pointer by
  * 8-bits (1 byte).
  *
- * @param[inout]  p   A reference to a constant pointer address,
+ * @param[in,out] p   A reference to a constant pointer address,
  *                    potentially unaligned, to read the 8-bit value
  *                    from and to then increment by 8-bits (1 byte).
  *
@@ -164,7 +164,7 @@ inline uint8_t Read8(const uint8_t *& p)
  * to the specified pointer address and increment the pointer by
  * 8-bits (1 byte).
  *
- * @param[inout]  p   A reference to a pointer address, potentially
+ * @param[in,out] p   A reference to a pointer address, potentially
  *                    unaligned, to read the 8-bit value from and to
  *                    then increment by 8-bits (1 byte).
  *
@@ -365,7 +365,7 @@ inline void Put64(uint8_t * p, uint64_t v)
  * the value in target system byte ordering, and increment the pointer
  * by 16-bits (2 bytes).
  *
- * @param[inout]  p   A reference to a pointer address, potentially
+ * @param[in,out] p   A reference to a pointer address, potentially
  *                    unaligned, to read the 16-bit little endian byte
  *                    ordered value from and to then increment by 16-
  *                    bits (2 bytes).
@@ -385,7 +385,7 @@ inline uint16_t Read16(uint8_t *& p)
  * the value in target system byte ordering, and increment the pointer
  * by 32-bits (4 bytes).
  *
- * @param[inout]  p   A reference to a pointer address, potentially
+ * @param[in,out] p   A reference to a pointer address, potentially
  *                    unaligned, to read the 32-bit little endian byte
  *                    ordered value from and to then increment by 32-
  *                    bits (4 bytes).
@@ -405,7 +405,7 @@ inline uint32_t Read32(uint8_t *& p)
  * the value in target system byte ordering, and increment the pointer
  * by 64-bits (8 bytes).
  *
- * @param[inout]  p   A reference to a pointer address, potentially
+ * @param[in,out] p   A reference to a pointer address, potentially
  *                    unaligned, to read the 64-bit little endian byte
  *                    ordered value from and to then increment by 64-
  *                    bits (8 bytes).
@@ -425,7 +425,7 @@ inline uint64_t Read64(uint8_t *& p)
  * the value in target system byte ordering, and increment the pointer
  * by 16-bits (2 bytes).
  *
- * @param[inout]  p   A reference to a constant pointer address, potentially
+ * @param[in,out] p   A reference to a constant pointer address, potentially
  *                    unaligned, to read the 16-bit little endian byte
  *                    ordered value from and to then increment by 16-
  *                    bits (2 bytes).
@@ -445,7 +445,7 @@ inline uint16_t Read16(const uint8_t *& p)
  * the value in target system byte ordering, and increment the pointer
  * by 32-bits (4 bytes).
  *
- * @param[inout]  p   A reference to a constant pointer address, potentially
+ * @param[in,out] p   A reference to a constant pointer address, potentially
  *                    unaligned, to read the 32-bit little endian byte
  *                    ordered value from and to then increment by 32-
  *                    bits (4 bytes).
@@ -465,7 +465,7 @@ inline uint32_t Read32(const uint8_t *& p)
  * the value in target system byte ordering, and increment the pointer
  * by 64-bits (8 bytes).
  *
- * @param[inout]  p   A reference to a constant pointer address, potentially
+ * @param[in,out] p   A reference to a constant pointer address, potentially
  *                    unaligned, to read the 64-bit little endian byte
  *                    ordered value from and to then increment by 64-
  *                    bits (8 bytes).
@@ -738,7 +738,7 @@ inline void Put64(uint8_t * p, uint64_t v)
  * the value in target system byte ordering, and increment the pointer
  * by 16-bits (2 bytes).
  *
- * @param[inout]  p   A reference to a pointer address, potentially
+ * @param[in,out] p   A reference to a pointer address, potentially
  *                    unaligned, to read the 16-bit big endian byte
  *                    ordered value from and to then increment by 16-
  *                    bits (2 bytes).
@@ -758,7 +758,7 @@ inline uint16_t Read16(uint8_t *& p)
  * the value in target system byte ordering, and increment the pointer
  * by 32-bits (4 bytes).
  *
- * @param[inout]  p   A reference to a pointer address, potentially
+ * @param[in,out] p   A reference to a pointer address, potentially
  *                    unaligned, to read the 32-bit big endian byte
  *                    ordered value from and to then increment by 32-
  *                    bits (4 bytes).
@@ -778,7 +778,7 @@ inline uint32_t Read32(uint8_t *& p)
  * the value in target system byte ordering, and increment the pointer
  * by 64-bits (8 bytes).
  *
- * @param[inout]  p   A reference to a pointer address, potentially
+ * @param[in,out] p   A reference to a pointer address, potentially
  *                    unaligned, to read the 64-bit big endian byte
  *                    ordered value from and to then increment by 64-
  *                    bits (8 bytes).
@@ -798,7 +798,7 @@ inline uint64_t Read64(uint8_t *& p)
  * the value in target system byte ordering, and increment the pointer
  * by 16-bits (2 bytes).
  *
- * @param[inout]  p   A reference to a constant pointer address, potentially
+ * @param[in,out] p   A reference to a constant pointer address, potentially
  *                    unaligned, to read the 16-bit big endian byte
  *                    ordered value from and to then increment by 16-
  *                    bits (2 bytes).
@@ -818,7 +818,7 @@ inline uint16_t Read16(const uint8_t *& p)
  * the value in target system byte ordering, and increment the pointer
  * by 32-bits (4 bytes).
  *
- * @param[inout]  p   A reference to a constant pointer address, potentially
+ * @param[in,out] p   A reference to a constant pointer address, potentially
  *                    unaligned, to read the 32-bit big endian byte
  *                    ordered value from and to then increment by 32-
  *                    bits (4 bytes).
@@ -838,7 +838,7 @@ inline uint32_t Read32(const uint8_t *& p)
  * the value in target system byte ordering, and increment the pointer
  * by 64-bits (8 bytes).
  *
- * @param[inout]  p   A reference to a constant pointer address, potentially
+ * @param[in,out] p   A reference to a constant pointer address, potentially
  *                    unaligned, to read the 64-bit big endian byte
  *                    ordered value from and to then increment by 64-
  *                    bits (8 bytes).

--- a/src/lib/core/CHIPTLVDebug.cpp
+++ b/src/lib/core/CHIPTLVDebug.cpp
@@ -322,7 +322,7 @@ CHIP_ERROR DumpIterator(DumpWriter aWriter, const TLVReader & aReader)
  *  @param[in]     aReader   A read-only reference to the TLV reader containing
  *                           the TLV data to log.
  *  @param[in]     aDepth    The current depth into the TLV data.
- *  @param[inout]  aContext  A pointer to the handler-specific context.
+ *  @param[in,out] aContext  A pointer to the handler-specific context.
  *
  *  @retval  #CHIP_NO_ERROR                On success.
  *

--- a/src/lib/core/CHIPTLVUtilities.cpp
+++ b/src/lib/core/CHIPTLVUtilities.cpp
@@ -49,7 +49,7 @@ struct FindContext
  *  @param[in]     aDepth       The current depth into the TLV data.
  *  @param[in]     aHandler     A callback to invoke for the current TLV element
  *                              being visited.
- *  @param[inout]  aContext     An optional pointer to caller-provided context data.
+ *  @param[in,out] aContext     An optional pointer to caller-provided context data.
  *  @param[in]     aRecurse     A Boolean indicating whether (true) or not (false)
  *                              any encountered arrays or structures should be
  *                              descended into.
@@ -105,7 +105,7 @@ exit:
  *                              data to iterate.
  *  @param[in]     aHandler     A callback to invoke for the current TLV element
  *                              being visited.
- *  @param[inout]  aContext     An optional pointer to caller-provided context data.
+ *  @param[in,out] aContext     An optional pointer to caller-provided context data.
  *
  *  @retval  #CHIP_END_OF_TLV  On a successful iteration to the end of a TLV encoding,
  *                              or to the end of a TLV container.
@@ -134,7 +134,7 @@ CHIP_ERROR Iterate(const TLVReader & aReader, IterateHandler aHandler, void * aC
  *                              data to iterate.
  *  @param[in]     aHandler     A callback to invoke for the current TLV element
  *                              being visited.
- *  @param[inout]  aContext     An optional pointer to caller-provided context data.
+ *  @param[in,out] aContext     An optional pointer to caller-provided context data.
  *  @param[in]     aRecurse     A Boolean indicating whether (true) or not (false)
  *                              any encountered arrays or structures should be
  *                              descended into.
@@ -169,7 +169,7 @@ exit:
  *  @param[in]     aReader      A reference to the TLV reader containing the TLV
  *                              data to count the number of TLV elements.
  *  @param[in]     aDepth       The current depth into the TLV data.
- *  @param[inout]  aContext     A pointer to the handler-specific context which
+ *  @param[in,out] aContext     A pointer to the handler-specific context which
  *                              is a pointer to storage for the count value.
  *
  *  @retval  #CHIP_NO_ERROR                On success.
@@ -195,7 +195,7 @@ exit:
  *
  *  @param[in]     aReader      A read-only reference to the TLV reader for
  *                              which to count the number of TLV elements.
- *  @param[inout]  aCount       A reference to storage for the returned count.
+ *  @param[in,out] aCount       A reference to storage for the returned count.
  *                              This is initialized to zero (0) prior to counting
  *                              and is set to the number of elements counted on
  *                              success.
@@ -219,7 +219,7 @@ CHIP_ERROR Count(const TLVReader & aReader, size_t & aCount)
  *
  *  @param[in]     aReader      A read-only reference to the TLV reader for
  *                              which to count the number of TLV elements.
- *  @param[inout]  aCount       A reference to storage for the returned count.
+ *  @param[in,out] aCount       A reference to storage for the returned count.
  *                              This is initialized to zero (0) prior to counting
  *                              and is set to the number of elements counted on
  *                              success.
@@ -250,7 +250,7 @@ CHIP_ERROR Count(const TLVReader & aReader, size_t & aCount, const bool aRecurse
  *  @param[in]     aReader      A read-only reference to the TLV reader in
  *                              which to find the specified tag.
  *  @param[in]     aDepth       The current depth into the TLV data.
- *  @param[inout]  aContext     A pointer to the handler-specific context.
+ *  @param[in,out] aContext     A pointer to the handler-specific context.
  *
  *  @retval  #CHIP_NO_ERROR                On success.
  *

--- a/src/lib/support/CHIPArgParser.cpp
+++ b/src/lib/support/CHIPArgParser.cpp
@@ -946,12 +946,12 @@ bool ParseFabricId(const char * str, uint64_t & fabricId, bool allowReserved)
  * Parse and attempt to convert a string to a 16-bit unsigned subnet
  * ID, interpretting the string as hexadecimal.
  *
- * @param[in]    str       A pointer to a NULL-terminated C string
- *                         representing the subnet ID, formatted as a
- *                         hexadecimal, to parse.
- * @param[inout] subnetId  A reference to storage for a 16-bit unsigned
- *                         integer to which the parsed subnet ID value
- *                         will be stored on success.
+ * @param[in]     str       A pointer to a NULL-terminated C string
+ *                          representing the subnet ID, formatted as a
+ *                          hexadecimal, to parse.
+ * @param[in,out] subnetId  A reference to storage for a 16-bit unsigned
+ *                          integer to which the parsed subnet ID value
+ *                          will be stored on success.
  *
  * @return true on success; otherwise, false on failure.
  */

--- a/src/lib/support/PersistedCounter.h
+++ b/src/lib/support/PersistedCounter.h
@@ -100,7 +100,7 @@ private:
      *  @brief
      *    Read our starting counter value (if we have one) in from persistent storage.
      *
-     *  @param[inout] aStartValue  The value read out.
+     *  @param[in,out] aStartValue  The value read out.
      *
      *  @return Any error returned by a read from persistent storage.
      */

--- a/src/lwip/standalone/TapInterface.c
+++ b/src/lwip/standalone/TapInterface.c
@@ -316,7 +316,7 @@ static struct pbuf * TapInterface_low_level_input(TapInterface * tapif, struct n
  *  should have been called prior to invoking netif_add with this
  *  callback.
  *
- *  @param[inout]  netif  A pointer to the LwIP netif associated with the
+ *  @param[in,out] netif  A pointer to the LwIP netif associated with the
  *                        TUN/TAP shim interface.
  *
  *  @retval  #ERR_OK  on successfully setting up the TUN/TAP interface.

--- a/src/system/SystemLayer.cpp
+++ b/src/system/SystemLayer.cpp
@@ -696,9 +696,9 @@ LwIPEventHandlerDelegate Layer::sSystemEventHandlerDelegate;
 /**
  * This is the dispatch handler for system layer events.
  *
- *  @param[inout]   aTarget     A pointer to the CHIP System Layer object making the post request.
+ *  @param[in,out]  aTarget     A pointer to the CHIP System Layer object making the post request.
  *  @param[in]      aEventType  The type of event to post.
- *  @param[inout]   aArgument   The argument associated with the event to post.
+ *  @param[in,out]  aArgument   The argument associated with the event to post.
  */
 Error Layer::HandleSystemLayerEvent(Object & aTarget, EventType aEventType, uintptr_t aArgument)
 {
@@ -747,9 +747,9 @@ exit:
 /**
  * This posts an event / message of the specified type with the provided argument to this instance's platform-specific event queue.
  *
- *  @param[inout]   aTarget     A pointer to the CHIP System Layer object making the post request.
+ *  @param[in,out]  aTarget     A pointer to the CHIP System Layer object making the post request.
  *  @param[in]      aEventType  The type of event to post.
- *  @param[inout]   aArgument   The argument associated with the event to post.
+ *  @param[in,out]  aArgument   The argument associated with the event to post.
  *
  *  @retval    CHIP_SYSTEM_NO_ERROR                   On success.
  *  @retval    CHIP_SYSTEM_ERROR_UNEXPECTED_STATE     If the state of the Layer object is incorrect.
@@ -819,7 +819,7 @@ exit:
 /**
  * This implements the actual dispatch and handling of a CHIP System Layer event.
  *
- *  @param[inout]   aTarget     A reference to the layer object to which the event is targeted.
+ *  @param[in,out]  aTarget     A reference to the layer object to which the event is targeted.
  *  @param[in]      aEventType  The event / message type to handle.
  *  @param[in]      aArgument   The argument associated with the event / message.
  *
@@ -934,9 +934,9 @@ namespace Layer {
  * This is a platform-specific CHIP System Layer pre-initialization hook. This may be overridden by assserting the preprocessor
  * definition, #CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_XTOR_FUNCTIONS.
  *
- *  @param[inout]  aLayer    A reference to the CHIP System Layer instance being initialized.
+ *  @param[in,out] aLayer    A reference to the CHIP System Layer instance being initialized.
  *
- *  @param[inout]  aContext  Platform-specific context data passed to the layer initialization method, ::Init.
+ *  @param[in,out] aContext  Platform-specific context data passed to the layer initialization method, ::Init.
  *
  *  @return #CHIP_SYSTEM_NO_ERROR on success; otherwise, a specific error indicating the reason for initialization failure.
  *      Returning non-successful status will abort initialization.
@@ -953,9 +953,9 @@ DLL_EXPORT Error WillInit(Layer & aLayer, void * aContext)
  * This is a platform-specific CHIP System Layer pre-shutdown hook. This may be overridden by assserting the preprocessor
  * definition, #CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_XTOR_FUNCTIONS.
  *
- *  @param[inout]  aLayer    A pointer to the CHIP System Layer instance being shutdown.
+ *  @param[in,out] aLayer    A pointer to the CHIP System Layer instance being shutdown.
  *
- *  @param[inout]  aContext  Platform-specific context data passed to the layer initialization method, ::Shutdown.
+ *  @param[in,out] aContext  Platform-specific context data passed to the layer initialization method, ::Shutdown.
  *
  *  @return #CHIP_SYSTEM_NO_ERROR on success; otherwise, a specific error indicating the reason for shutdown failure. Returning
  *      non-successful status will abort shutdown.
@@ -972,9 +972,9 @@ DLL_EXPORT Error WillShutdown(Layer & aLayer, void * aContext)
  * This is a platform-specific CHIP System Layer post-initialization hook. This may be overridden by assserting the preprocessor
  * definition, #CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_XTOR_FUNCTIONS.
  *
- *  @param[inout]  aLayer    A reference to the CHIP System Layer instance being initialized.
+ *  @param[in,out] aLayer    A reference to the CHIP System Layer instance being initialized.
  *
- *  @param[inout]  aContext  Platform-specific context data passed to the layer initialization method, ::Init.
+ *  @param[in,out] aContext  Platform-specific context data passed to the layer initialization method, ::Init.
  *
  *  @param[in]     anError   The overall status being returned via the CHIP System Layer ::Init method.
  */
@@ -989,9 +989,9 @@ DLL_EXPORT void DidInit(Layer & aLayer, void * aContext, Error aStatus)
  * This is a platform-specific CHIP System Layer pre-shutdown hook. This may be overridden by assserting the preprocessor
  * definition, #CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_XTOR_FUNCTIONS.
  *
- *  @param[inout]  aLayer    A reference to the CHIP System Layer instance being shutdown.
+ *  @param[in,out] aLayer    A reference to the CHIP System Layer instance being shutdown.
  *
- *  @param[inout]  aContext  Platform-specific context data passed to the layer initialization method, ::Shutdown.
+ *  @param[in,out] aContext  Platform-specific context data passed to the layer initialization method, ::Shutdown.
  *
  *  @param[in]     anError   The overall status being returned via the CHIP System Layer ::Shutdown method.
  *
@@ -1022,15 +1022,15 @@ using chip::System::LwIPEvent;
  *  @note
  *    This is an implementation for LwIP.
  *
- *  @param[inout]  aLayer    A pointer to the layer instance to which the event / message is being posted.
+ *  @param[in,out] aLayer    A pointer to the layer instance to which the event / message is being posted.
  *
- *  @param[inout]  aContext  Platform-specific context data passed to the layer initialization method, ::Init.
+ *  @param[in,out] aContext  Platform-specific context data passed to the layer initialization method, ::Init.
  *
- *  @param[inout]  aTarget   A pointer to the CHIP System Layer object making the post request.
+ *  @param[in,out] aTarget   A pointer to the CHIP System Layer object making the post request.
  *
  *  @param[in]     aType     The type of event to post.
  *
- *  @param[inout]  anArg     The argument associated with the event to post.
+ *  @param[in,out] anArg     The argument associated with the event to post.
  *
  *  @return #CHIP_SYSTEM_NO_ERROR on success; otherwise, a specific error indicating the reason for initialization failure.
  */
@@ -1068,9 +1068,9 @@ exit:
  *  @note
  *    This is an implementation for LwIP.
  *
- *  @param[inout]  aLayer    A reference to the layer instance for which events / messages are being dispatched.
+ *  @param[in,out] aLayer    A reference to the layer instance for which events / messages are being dispatched.
  *
- *  @param[inout]  aContext  Platform-specific context data passed to the layer initialization method, ::Init.
+ *  @param[in,out] aContext  Platform-specific context data passed to the layer initialization method, ::Init.
  *
  *  @retval   #CHIP_SYSTEM_ERROR_BAD_ARGS          If #aLayer or #aContext is NULL.
  *  @retval   #CHIP_SYSTEM_ERROR_UNEXPECTED_STATE  If the state of the CHIP System Layer object is unexpected.
@@ -1117,8 +1117,8 @@ exit:
  *  @note
  *    This is an implementation for LwIP.
  *
- *  @param[inout]  aLayer    A reference to the layer instance for which events / messages are being dispatched.
- *  @param[inout]  aContext  Platform-specific context data passed to the layer initialization method, ::Init.
+ *  @param[in,out] aLayer    A reference to the layer instance for which events / messages are being dispatched.
+ *  @param[in,out] aContext  Platform-specific context data passed to the layer initialization method, ::Init.
  *  @param[in]     anEvent   The platform-specific event object to dispatch for handling.
  *
  *  @retval   #CHIP_SYSTEM_ERROR_BAD_ARGS          If #aLayer or the event target is NULL.
@@ -1151,8 +1151,8 @@ exit:
  *  @note
  *    This is an implementation for LwIP.
  *
- *  @param[inout]  aLayer               A reference to the layer instance for which events / messages are being dispatched.
- *  @param[inout]  aContext             Platform-specific context data passed to the layer initialization method, ::Init.
+ *  @param[in,out] aLayer               A reference to the layer instance for which events / messages are being dispatched.
+ *  @param[in,out] aContext             Platform-specific context data passed to the layer initialization method, ::Init.
  *  @param[in]     aMilliseconds        The number of milliseconds to set for the timer.
  *
  *  @retval   #CHIP_SYSTEM_NO_ERROR    Always succeeds unless overridden.

--- a/src/system/SystemMutex.cpp
+++ b/src/system/SystemMutex.cpp
@@ -39,7 +39,7 @@ namespace System {
 /**
  * Initialize the mutual exclusion lock instance.
  *
- *  @param[inout]   aThis   A zero-initialized object.
+ *  @param[in,out]  aThis   A zero-initialized object.
  *
  *  @retval         #CHIP_SYSTEM_NO_ERROR                  The mutual exclusion lock is ready to use.
  *  @retval         #CHIP_SYSTEM_ERROR_NO_MEMORY           Insufficient system memory to allocate the mutual exclusion lock.

--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -158,7 +158,7 @@ uint16_t PacketBuffer::DataLength() const
  *
  *  @param[in] aNewLen - new length, in bytes, of this buffer.
  *
- *  @param[inout] aChainHead - the head of the buffer chain the current buffer belongs to.  May be NULL if the current buffer is
+ *  @param[in,out] aChainHead - the head of the buffer chain the current buffer belongs to.  May be NULL if the current buffer is
  *      the head of the buffer chain.
  */
 void PacketBuffer::SetDataLength(uint16_t aNewLen, PacketBuffer * aChainHead)


### PR DESCRIPTION
 #### Problem
`@param[inout]` is not valid doxygen syntax.

 #### Summary of Changes
Use `@param[in,out]` instead.

fixes https://github.com/project-chip/connectedhomeip/issues/909