### PR TITLE
[doc] Fill out src/README.md with purpose of subdirectories.

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,1 +1,23 @@
 ## Source Code
+
+### Directory Structure
+
+The CHIP src directory is structured as follows:
+
+| File / Folder | Contents                                           |
+| ------------- | -------------------------------------------------- |
+| app           | Application Layer -- Zigbee Cluster Library (ZCL)  |
+| ble           | BLE Layer -- Bluetooth Transport Protocol (BTP)    |
+| chipcli       | QR code tool CLI                                   |
+| controller    | Controller API                                     |
+| crypto        | Cryptography libraries                             |
+| darwin        | Darwin Framework (iOS and MacOS)                   |
+| include       | Public headers                                     |
+| inet          | Network Layer -- TCP and UDP endpoints             |
+| lib           | Core and Support libraries                         |
+| lwip          | Lightweight IP adaptation (to third_party library) |
+| platform      | Device Layer -- platform portability adaptations   |
+| qrcodetool    | QR code tool                                       |
+| setup_payload | QR code setup data encode / decode library         |
+| system        | System Layer -- common APIs for mem, work, etc.    |
+| test_driver   | Framework for on-device testing                    |


### PR DESCRIPTION
 #### Problem
The `src` directory has a bunch of sub-directories now, but it isn't always easy to know what each one is for.

 #### Summary of Changes
Adding brief descriptions of the current tree structure.
We may want to consider some targeted restructuring in the future.