### PR TITLE
Move core/CHIPConnection to transport/UdpTransport

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2092,6 +2092,8 @@ src/lib/support/tests/Makefile
 src/platform/Makefile
 src/platform/tests/Makefile
 src/qrcodetool/Makefile
+src/transport/Makefile
+src/transport/tests/Makefile
 tests/Makefile
 ])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -38,16 +38,12 @@ MAYBE_BLE_SUBDIRS                += \
     $(NULL)
 endif # CONFIG_NETWORK_LAYER_BLE
 
-PLATFORM_SUBDIRS                  = \
-    platform                        \
-    $(NULL)
-
 MAYBE_PLATFORM_SUBDIRS            = \
     $(NULL)
 
 if CONFIG_DEVICE_LAYER
 MAYBE_PLATFORM_SUBDIRS           += \
-    $(PLATFORM_SUBDIRS)             \
+    platform                        \
     $(NULL)
 endif # CONFIG_DEVICE_LAYER
 
@@ -72,8 +68,9 @@ DIST_SUBDIRS                      = \
     lib                             \
     setup_payload                   \
     crypto                          \
-    $(PLATFORM_SUBDIRS)             \
+    platform                        \
     qrcodetool                      \
+    transport                       \
     $(NULL)
 
 # Always build (e.g. for 'make all') these subdirectories.
@@ -83,11 +80,12 @@ SUBDIRS                           = \
     include                         \
     lwip                            \
     system                          \
-    $(MAYBE_BLE_SUBDIRS)            \
     inet                            \
     lib                             \
     setup_payload                   \
     crypto                          \
+    transport                       \
+    $(MAYBE_BLE_SUBDIRS)            \
     $(MAYBE_PLATFORM_SUBDIRS)       \
     $(MAYBE_QRCODETOOL_SUBDIR)      \
     $(NULL)

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -141,7 +141,7 @@ CHIP_ERROR ChipDeviceController::ConnectDevice(uint64_t deviceId, IPAddress devi
     mDeviceCon   = new UdpTransport();
 
     mDeviceCon->Init(mInetLayer);
-    err = mDeviceCon->Connect(mDeviceId, mDeviceAddr, mDevicePort);
+    err = mDeviceCon->Connect(mDeviceAddr, mDevicePort);
     SuccessOrExit(err);
 
     mDeviceCon->OnMessageReceived = OnReceiveMessage;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -138,7 +138,7 @@ CHIP_ERROR ChipDeviceController::ConnectDevice(uint64_t deviceId, IPAddress devi
     mDeviceAddr  = deviceAddr;
     mDevicePort  = devicePort;
     mAppReqState = appReqState;
-    mDeviceCon   = new ChipConnection();
+    mDeviceCon   = new UdpTransport();
 
     mDeviceCon->Init(mInetLayer);
     err = mDeviceCon->Connect(mDeviceId, mDeviceAddr, mDevicePort);
@@ -299,7 +299,7 @@ void ChipDeviceController::ClearRequestState()
     }
 }
 
-void ChipDeviceController::OnReceiveMessage(ChipConnection * con, PacketBuffer * msgBuf, const IPPacketInfo * pktInfo)
+void ChipDeviceController::OnReceiveMessage(UdpTransport * con, PacketBuffer * msgBuf, const IPPacketInfo * pktInfo)
 {
     ChipDeviceController * mgr = (ChipDeviceController *) con->AppState;
     if (mgr->mConState == kConnectionState_Connected && mgr->mOnComplete.Response != NULL && pktInfo != NULL)
@@ -308,7 +308,7 @@ void ChipDeviceController::OnReceiveMessage(ChipConnection * con, PacketBuffer *
     }
 }
 
-void ChipDeviceController::OnReceiveError(ChipConnection * con, CHIP_ERROR err, const IPPacketInfo * pktInfo)
+void ChipDeviceController::OnReceiveError(UdpTransport * con, CHIP_ERROR err, const IPPacketInfo * pktInfo)
 {
     ChipDeviceController * mgr = (ChipDeviceController *) con->AppState;
     if (mgr->mConState == kConnectionState_Connected && mgr->mOnError != NULL && pktInfo != NULL)

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -29,10 +29,10 @@
 #ifndef __CHIPDEVICECONTROLLER_H
 #define __CHIPDEVICECONTROLLER_H
 
-#include <core/CHIPConnection.h>
 #include <core/CHIPCore.h>
 #include <core/CHIPTLV.h>
 #include <support/DLLUtil.h>
+#include <transport/UdpTransport.h>
 
 namespace chip {
 namespace DeviceController {
@@ -144,7 +144,7 @@ private:
 
     System::Layer * mSystemLayer;
     Inet::InetLayer * mInetLayer;
-    ChipConnection * mDeviceCon;
+    UdpTransport * mDeviceCon;
 
     ConnectionState mConState;
     void * mAppReqState;
@@ -165,8 +165,8 @@ private:
     void ClearRequestState();
     void ClearOpState();
 
-    static void OnReceiveMessage(ChipConnection * con, PacketBuffer * msgBuf, const IPPacketInfo * pktInfo);
-    static void OnReceiveError(ChipConnection * con, CHIP_ERROR err, const IPPacketInfo * pktInfo);
+    static void OnReceiveMessage(UdpTransport * con, PacketBuffer * msgBuf, const IPPacketInfo * pktInfo);
+    static void OnReceiveError(UdpTransport * con, CHIP_ERROR err, const IPPacketInfo * pktInfo);
 };
 
 } // namespace DeviceController

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -34,6 +34,7 @@ include ../ble/BleLayer.am
 include ../controller/DeviceController.am
 include ../inet/InetLayer.am
 include ../system/SystemLayer.am
+include ../transport/TransportLayer.am
 include core/CoreLayer.am
 include support/SupportLayer.am
 include ../app/DataModel.am
@@ -59,6 +60,7 @@ libCHIP_a_CPPFLAGS                  =                         \
     -I$(top_srcdir)/src/system                                \
     -I$(top_srcdir)/src/app/chip-zcl                          \
     -I$(top_srcdir)/src/app/gen                               \
+    -I$(top_srcdir)/src/transport                             \
     $(NLASSERT_CPPFLAGS)                                      \
     $(NLFAULTINJECTION_CPPFLAGS)                              \
     $(NLIO_CPPFLAGS)                                          \
@@ -72,6 +74,7 @@ libCHIP_a_SOURCES                  += $(CHIP_BUILD_CORE_LAYER_SOURCE_FILES)
 libCHIP_a_SOURCES                  += $(CHIP_BUILD_SUPPORT_LAYER_SOURCE_FILES)
 libCHIP_a_SOURCES                  += $(CHIP_BUILD_DEVICE_CONTROLLER_SOURCE_FILES)
 libCHIP_a_SOURCES                  += $(CHIP_BUILD_DATA_MODEL_SOURCE_FILES)
+libCHIP_a_SOURCES                  += $(CHIP_BUILD_TRANSPORT_LAYER_SOURCE_FILES)
 
 if CONFIG_NETWORK_LAYER_BLE
 libCHIP_a_SOURCES                  += $(CHIP_BUILD_BLE_LAYER_SOURCE_FILES)

--- a/src/lib/core/CoreLayer.am
+++ b/src/lib/core/CoreLayer.am
@@ -54,4 +54,5 @@ CHIP_BUILD_CORE_LAYER_HEADER_FILES                        = \
     core/CHIPKeyIds.h                                       \
     core/CHIPConnection.h                                   \
     core/CHIPSecureChannel.h                                \
+    core/Optional.h                                         \
     $(NULL)

--- a/src/lib/core/CoreLayer.am
+++ b/src/lib/core/CoreLayer.am
@@ -32,7 +32,6 @@ CHIP_BUILD_CORE_LAYER_SOURCE_FILES                        = \
     core/CHIPTLVWriter.cpp                                  \
     core/CHIPTLVUpdater.cpp                                 \
     core/CHIPKeyIds.cpp                                     \
-    core/CHIPConnection.cpp                                 \
     core/CHIPSecureChannel.cpp                              \
     $(NULL)
 
@@ -52,7 +51,6 @@ CHIP_BUILD_CORE_LAYER_HEADER_FILES                        = \
     core/CHIPTimeConfig.h                                   \
     core/CHIPTunnelConfig.h                                 \
     core/CHIPKeyIds.h                                       \
-    core/CHIPConnection.h                                   \
     core/CHIPSecureChannel.h                                \
     core/Optional.h                                         \
     $(NULL)

--- a/src/lib/core/Optional.h
+++ b/src/lib/core/Optional.h
@@ -1,8 +1,33 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines the chip::Optional class to handle values which may
+ *      or may not be present.
+ *
+ */
+
 #include <assert.h>
 
 namespace chip {
 
-/* Pairs an object with a boolean value to determine if the object value
+/**
+ * Pairs an object with a boolean value to determine if the object value
  * is actually valid or not.
  */
 template <class T>
@@ -22,9 +47,9 @@ public:
         mHasValue = true;
     }
 
-    void ClearValue() { mHasValue = false; }
+    void ClearValue(void) { mHasValue = false; }
 
-    const T & Value() const
+    const T & Value(void) const
     {
         assert(HasValue());
         return mValue;
@@ -36,7 +61,7 @@ public:
         return (mHasValue == other.mHasValue) && (!mHasValue || (mValue == other.mValue));
     }
 
-    static Optional<T> Missing() { return Optional<T>(); }
+    static Optional<T> Missing(void) { return Optional<T>(); }
     static Optional<T> Value(const T & value) { return Optional(value); }
 
 private:

--- a/src/lib/core/Optional.h
+++ b/src/lib/core/Optional.h
@@ -41,32 +41,41 @@ public:
     constexpr Optional(Optional && other)      = default;
     Optional & operator=(const Optional & other) = default;
 
+    /** Make the optional contain a specific value */
     void SetValue(const T & value)
     {
         mValue    = value;
         mHasValue = true;
     }
 
+    /** Invalidate the value inside the optional. Optional now has no value */
     void ClearValue(void) { mHasValue = false; }
 
+    /** Gets the current value of the optional. Valid IFF `HasValue`. */
     const T & Value(void) const
     {
         assert(HasValue());
         return mValue;
     }
+
+    /** Checks if the optional contains a value or not */
     bool HasValue() const { return mHasValue; }
 
+    /** Comparison operator, hadling missing values. */
     bool operator==(const Optional & other) const
     {
         return (mHasValue == other.mHasValue) && (!mHasValue || (mValue == other.mValue));
     }
 
+    /** Convenience method to create an optional without a valid value. */
     static Optional<T> Missing(void) { return Optional<T>(); }
+
+    /** Convenience method to create an optional containing the specified value. */
     static Optional<T> Value(const T & value) { return Optional(value); }
 
 private:
-    T mValue;
-    bool mHasValue;
+    T mValue;       ///< Value IFF optional contains a value
+    bool mHasValue; ///< True IFF optional contains a value
 };
 
 } // namespace chip

--- a/src/lib/core/Optional.h
+++ b/src/lib/core/Optional.h
@@ -1,0 +1,47 @@
+#include <assert.h>
+
+namespace chip {
+
+/* Pairs an object with a boolean value to determine if the object value
+ * is actually valid or not.
+ */
+template <class T>
+class Optional
+{
+public:
+    Optional() : mHasValue(false) {}
+    explicit Optional(const T & value) : mValue(value), mHasValue(true) {}
+
+    constexpr Optional(const Optional & other) = default;
+    constexpr Optional(Optional && other)      = default;
+    Optional & operator=(const Optional & other) = default;
+
+    void SetValue(const T & value)
+    {
+        mValue    = value;
+        mHasValue = true;
+    }
+
+    void ClearValue() { mHasValue = false; }
+
+    const T & Value() const
+    {
+        assert(HasValue());
+        return mValue;
+    }
+    bool HasValue() const { return mHasValue; }
+
+    bool operator==(const Optional & other) const
+    {
+        return (mHasValue == other.mHasValue) && (!mHasValue || (mValue == other.mValue));
+    }
+
+    static Optional<T> Missing() { return Optional<T>(); }
+    static Optional<T> Value(const T & value) { return Optional(value); }
+
+private:
+    T mValue;
+    bool mHasValue;
+};
+
+} // namespace chip

--- a/src/lib/core/tests/Makefile.am
+++ b/src/lib/core/tests/Makefile.am
@@ -43,7 +43,6 @@ lib_LIBRARIES                                         = \
 libCoreTests_a_SOURCES                                = \
     TestCHIPErrorStr.cpp                                \
     TestCHIPTLV.cpp                                     \
-    TestCHIPConnection.cpp                              \
     TestCHIPSecureChannel.cpp                           \
     $(NULL)
 
@@ -89,7 +88,6 @@ COMMON_LDADD                                          =  \
 check_PROGRAMS                                        = \
     TestCHIPErrorStr                                    \
     TestCHIPTLV                                         \
-    TestCHIPConnection                                  \
     TestCHIPSecureChannel                               \
     $(NULL)
 
@@ -113,9 +111,6 @@ TestCHIPErrorStr_LDADD                                = $(COMMON_LDADD)
 
 TestCHIPTLV_SOURCES                                   = TestCHIPTLVDriver.cpp
 TestCHIPTLV_LDADD                                     = $(COMMON_LDADD)
-
-TestCHIPConnection_SOURCES                            = TestCHIPConnectionDriver.cpp
-TestCHIPConnection_LDADD                              = $(COMMON_LDADD)
 
 TestCHIPSecureChannel_SOURCES                         = TestCHIPSecureChannelDriver.cpp
 TestCHIPSecureChannel_LDADD                           = $(COMMON_LDADD)

--- a/src/lib/core/tests/TestCore.h
+++ b/src/lib/core/tests/TestCore.h
@@ -31,7 +31,6 @@ extern "C" {
 
 int TestCHIPErrorStr(void);
 int TestCHIPTLV(void);
-int TestCHIPConnection(void);
 int TestCHIPSecureChannel(void);
 
 #ifdef __cplusplus

--- a/src/transport/Makefile.am
+++ b/src/transport/Makefile.am
@@ -1,0 +1,52 @@
+#
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#    Copyright (c) 2014-2017 Nest Labs, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+#
+#    Description:
+#      This file is the GNU automake template for the CHIP Trasport
+#      library.
+#
+
+include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
+
+SUBDIRS = tests
+
+include TransportLayer.am
+
+lib_LIBRARIES                       = libTransportLayer.a
+
+libTransportLayer_a_CPPFLAGS        = \
+    -I$(top_srcdir)/src               \
+    -I$(top_srcdir)/src/include       \
+    -I$(top_srcdir)/src/lib           \
+    -I$(top_srcdir)/src/lib/core      \
+    -I$(top_srcdir)/src/system        \
+    -I$(top_srcdir)/src/transport     \
+    $(NLASSERT_CPPFLAGS)              \
+    $(NLFAULTINJECTION_CPPFLAGS)      \
+    $(NLIO_CPPFLAGS)                  \
+    $(LWIP_CPPFLAGS)                  \
+    $(NULL)
+
+libTransportLayer_a_SOURCES      = $(CHIP_BUILD_TRANSPORT_LAYER_SOURCE_FILES)
+
+libTransportLayer_adir           = $(includedir)/transport
+
+dist_libTransportLayer_a_HEADERS = $(CHIP_BUILD_TRANSPORT_LAYER_HEADER_FILES)
+
+include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/transport/MessageHeader.cpp
+++ b/src/transport/MessageHeader.cpp
@@ -1,3 +1,24 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @file  This file contains the implementation the chip::MessageHeader class.
+ */
+
 #include "MessageHeader.h"
 
 #include <assert.h>
@@ -51,7 +72,7 @@ size_t MessageHeader::EncodeSizeBytes() const
     return size;
 }
 
-CHIP_ERROR MessageHeader::Decode(const uint8_t * data, size_t size)
+CHIP_ERROR MessageHeader::Decode(const uint8_t * data, size_t size, size_t * decode_len)
 {
     CHIP_ERROR err    = CHIP_NO_ERROR;
     const uint8_t * p = data;
@@ -90,6 +111,8 @@ CHIP_ERROR MessageHeader::Decode(const uint8_t * data, size_t size)
     {
         mDestinationNodeId.ClearValue();
     }
+
+    *decode_len = p - data;
 
 exit:
 

--- a/src/transport/MessageHeader.cpp
+++ b/src/transport/MessageHeader.cpp
@@ -42,16 +42,21 @@ namespace {
 
 using namespace chip::Encoding;
 
+/// size of the fixed portion of the header
 constexpr size_t kFixedHeaderSizeBytes = 6;
-constexpr size_t kNodeIdSizeBytes      = 8;
 
-// Available flags
+/// size of a serialized node id inside a header
+constexpr size_t kNodeIdSizeBytes = 8;
+
+/// Header flag specifying that a destination node id is included in the header.
 constexpr uint16_t kFlagDestinationNodeIdPresent = 0x0100;
-constexpr uint16_t kFlagSourceNodeIdPresent      = 0x0200;
+/// Header flag specifying that a source node id is included in the header.
+constexpr uint16_t kFlagSourceNodeIdPresent = 0x0200;
 
-// Version parsing and setting
+/// Mask to extract just the version part from a 16bit header prefix.
 constexpr uint16_t kVersionMask = 0xF000;
-constexpr int kVersionShift     = 12;
+/// Shift to convert to/from a masked version 16bit value to a 4bit version.
+constexpr int kVersionShift = 12;
 
 } // namespace
 

--- a/src/transport/MessageHeader.cpp
+++ b/src/transport/MessageHeader.cpp
@@ -1,0 +1,134 @@
+#include "MessageHeader.h"
+
+#include <assert.h>
+
+#include <core/CHIPEncoding.h>
+#include <core/CHIPError.h>
+#include <support/CodeUtils.h>
+
+/**********************************************
+ * Header format (little endian):
+ *
+ *  16 bit: | VERSION: 4 bit | FLAGS: 4 bit | RESERVED: 8 bit |
+ *  32 bit: | MESSAGE_ID                                      |
+ *  64 bit: | SOURCE_NODE_ID (iff source node flag is set)    |
+ *  64 bit: | DEST_NODE_ID (iff destination node flag is set) |
+ *
+ **********************************************/
+
+namespace chip {
+namespace {
+
+using namespace chip::Encoding;
+
+constexpr size_t kFixedHeaderSizeBytes = 6;
+constexpr size_t kNodeIdSizeBytes      = 8;
+
+// Available flags
+constexpr uint16_t kFlagDestinationNodeIdPresent = 0x0100;
+constexpr uint16_t kFlagSourceNodeIdPresent      = 0x0200;
+
+// Version parsing and setting
+constexpr uint16_t kVersionMask = 0xF000;
+constexpr int kVersionShift     = 12;
+
+} // namespace
+
+size_t MessageHeader::EncodeSizeBytes() const
+{
+    size_t size = kFixedHeaderSizeBytes;
+
+    if (mSourceNodeId.HasValue())
+    {
+        size += kNodeIdSizeBytes;
+    }
+
+    if (mDestinationNodeId.HasValue())
+    {
+        size += kNodeIdSizeBytes;
+    }
+
+    return size;
+}
+
+CHIP_ERROR MessageHeader::Decode(const uint8_t * data, size_t size)
+{
+    CHIP_ERROR err    = CHIP_NO_ERROR;
+    const uint8_t * p = data;
+    uint16_t header;
+    int version;
+
+    VerifyOrExit(size >= kFixedHeaderSizeBytes, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    header  = LittleEndian::Read16(p);
+    version = ((header & kVersionMask) >> kVersionShift);
+    VerifyOrExit(version == kHeaderVersion, err = CHIP_ERROR_VERSION_MISMATCH);
+
+    mMessageId = LittleEndian::Read32(p);
+
+    assert(p - data == kFixedHeaderSizeBytes);
+    size -= kFixedHeaderSizeBytes;
+
+    if (header & kFlagSourceNodeIdPresent)
+    {
+        VerifyOrExit(size >= kNodeIdSizeBytes, err = CHIP_ERROR_INVALID_ARGUMENT);
+        mSourceNodeId.SetValue(LittleEndian::Read64(p));
+        size -= kFixedHeaderSizeBytes;
+    }
+    else
+    {
+        mSourceNodeId.ClearValue();
+    }
+
+    if (header & kFlagDestinationNodeIdPresent)
+    {
+        VerifyOrExit(size >= kNodeIdSizeBytes, err = CHIP_ERROR_INVALID_ARGUMENT);
+        mDestinationNodeId.SetValue(LittleEndian::Read64(p));
+        size -= kFixedHeaderSizeBytes;
+    }
+    else
+    {
+        mDestinationNodeId.ClearValue();
+    }
+
+exit:
+
+    return err;
+}
+
+CHIP_ERROR MessageHeader::Encode(uint8_t * data, size_t size, size_t * encode_size)
+{
+    CHIP_ERROR err  = CHIP_NO_ERROR;
+    uint8_t * p     = data;
+    uint16_t header = kHeaderVersion << kVersionShift;
+
+    VerifyOrExit(size >= EncodeSizeBytes(), err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    if (mSourceNodeId.HasValue())
+    {
+        header |= kFlagSourceNodeIdPresent;
+    }
+    if (mDestinationNodeId.HasValue())
+    {
+        header |= kFlagDestinationNodeIdPresent;
+    }
+
+    LittleEndian::Write16(p, header);
+    LittleEndian::Write32(p, mMessageId);
+    if (mSourceNodeId.HasValue())
+    {
+        LittleEndian::Write64(p, mSourceNodeId.Value());
+    }
+    if (mDestinationNodeId.HasValue())
+    {
+        LittleEndian::Write64(p, mDestinationNodeId.Value());
+    }
+
+    // Written data size provided to caller on success
+    *encode_size = p - data;
+
+exit:
+    return err;
+}
+
+} // namespace chip

--- a/src/transport/MessageHeader.h
+++ b/src/transport/MessageHeader.h
@@ -88,6 +88,12 @@ public:
      * @param size - bytes available in the buffer
      * @param decode_size - number of bytes read from the buffer to decode the
      *                      object
+     *
+     * @return CHIP_NO_ERROR on success.
+     *
+     * Possible failures:
+     *    CHIP_ERROR_INVALID_ARGUMENT on insufficient buffer size
+     *    CHIP_ERROR_VERSION_MISMATCH if header version is not supported.
      */
     CHIP_ERROR Decode(const uint8_t * data, size_t size, size_t * decode_size);
 
@@ -97,6 +103,11 @@ public:
      * @param data - the buffer to write to
      * @param size - space available in the buffer (in bytes)
      * @param decode_size - number of bytes written to the buffer.
+     *
+     * @return CHIP_NO_ERROR on success.
+     *
+     * Possible failures:
+     *    CHIP_ERROR_INVALID_ARGUMENT on insufficient buffer size
      */
     CHIP_ERROR Encode(uint8_t * data, size_t size, size_t * encode_size);
 

--- a/src/transport/MessageHeader.h
+++ b/src/transport/MessageHeader.h
@@ -34,10 +34,29 @@ namespace chip {
 class MessageHeader
 {
 public:
+    /**
+     * Gets the source node id in the current message.
+     *
+     * NOTE: the source node id is optional and may be missing.
+     */
     const Optional<uint64_t> & GetSourceNodeId() const { return mSourceNodeId; }
+
+    /**
+     * Gets the destination node id in the current message.
+     *
+     * NOTE: the destination node id is optional and may be missing.
+     */
     const Optional<uint64_t> & GetDestinationNodeId() const { return mDestinationNodeId; }
+
+    /**
+     * Gets the message id set in the header.
+     *
+     * Message IDs are expecte to monotonically increase by one for each mesage
+     * that has been sent.
+     */
     uint32_t GetMessageId() const { return mMessageId; }
 
+    /** Set the message id for this header. */
     MessageHeader & SetMessageId(uint32_t id)
     {
         mMessageId = id;
@@ -45,6 +64,7 @@ public:
         return *this;
     }
 
+    /** Set the source node id for this header. */
     MessageHeader & SetSourceNodeId(uint64_t id)
     {
         mSourceNodeId.SetValue(id);
@@ -52,6 +72,7 @@ public:
         return *this;
     }
 
+    /** Clear the source node id for this header. */
     MessageHeader & ClearSourceNodeId()
     {
         mSourceNodeId.ClearValue();
@@ -59,6 +80,7 @@ public:
         return *this;
     }
 
+    /** Set the destination node id for this header. */
     MessageHeader & SetDestinationNodeId(uint64_t id)
     {
         mDestinationNodeId.SetValue(id);
@@ -66,6 +88,7 @@ public:
         return *this;
     }
 
+    /** Clear the destination node id for this header. */
     MessageHeader & ClearDestinationNodeId()
     {
         mDestinationNodeId.ClearValue();

--- a/src/transport/MessageHeader.h
+++ b/src/transport/MessageHeader.h
@@ -1,0 +1,65 @@
+#ifndef MESSAGEHEADER_H_
+#define MESSAGEHEADER_H_
+
+#include <cstddef>
+#include <cstdint>
+
+#include <core/CHIPError.h>
+#include <core/Optional.h>
+
+namespace chip {
+
+/** Handles encoding/decoding of CHIP message headers */
+class MessageHeader
+{
+public:
+    const Optional<uint64_t> & GetSourceNodeId() const { return mSourceNodeId; }
+    const Optional<uint64_t> & GetDestinationNodeId() const { return mDestinationNodeId; }
+    uint32_t GetMessageId() const { return mMessageId; }
+
+    MessageHeader & SetMessageId(uint32_t id)
+    {
+        mMessageId = id;
+        return *this;
+    }
+
+    MessageHeader & SetSourceNodeId(uint64_t id)
+    {
+        mSourceNodeId.SetValue(id);
+        return *this;
+    }
+
+    MessageHeader & ClearSourceNodeId()
+    {
+        mSourceNodeId.ClearValue();
+        return *this;
+    }
+
+    MessageHeader & SetDestinationNodeId(uint64_t id)
+    {
+        mDestinationNodeId.SetValue(id);
+        return *this;
+    }
+
+    MessageHeader & ClearDestinationNodeId()
+    {
+        mDestinationNodeId.ClearValue();
+        return *this;
+    }
+
+    size_t EncodeSizeBytes() const;
+    CHIP_ERROR Decode(const uint8_t * data, size_t size);
+    CHIP_ERROR Encode(uint8_t * data, size_t size, size_t * encode_size);
+
+private:
+    static constexpr int kHeaderVersion = 2;
+
+    uint32_t mMessageId = 0;
+
+    Optional<uint64_t> mSourceNodeId;
+    Optional<uint64_t> mDestinationNodeId;
+};
+
+} // namespace chip
+
+#endif // MESSAGEHEADER_H_

--- a/src/transport/MessageHeader.h
+++ b/src/transport/MessageHeader.h
@@ -101,11 +101,16 @@ public:
     CHIP_ERROR Encode(uint8_t * data, size_t size, size_t * encode_size);
 
 private:
+    /// Represents the current encode/decode header version
     static constexpr int kHeaderVersion = 2;
 
+    /// Value expected to be incremented for each message sent.
     uint32_t mMessageId = 0;
 
+    /// What node the message originated from
     Optional<uint64_t> mSourceNodeId;
+
+    /// Intended recipient of the message.
     Optional<uint64_t> mDestinationNodeId;
 };
 

--- a/src/transport/MessageHeader.h
+++ b/src/transport/MessageHeader.h
@@ -1,3 +1,24 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @file  This file defines the chip::MessageHeader class.
+ */
+
 #ifndef MESSAGEHEADER_H_
 #define MESSAGEHEADER_H_
 
@@ -20,35 +41,63 @@ public:
     MessageHeader & SetMessageId(uint32_t id)
     {
         mMessageId = id;
+
         return *this;
     }
 
     MessageHeader & SetSourceNodeId(uint64_t id)
     {
         mSourceNodeId.SetValue(id);
+
         return *this;
     }
 
     MessageHeader & ClearSourceNodeId()
     {
         mSourceNodeId.ClearValue();
+
         return *this;
     }
 
     MessageHeader & SetDestinationNodeId(uint64_t id)
     {
         mDestinationNodeId.SetValue(id);
+
         return *this;
     }
 
     MessageHeader & ClearDestinationNodeId()
     {
         mDestinationNodeId.ClearValue();
+
         return *this;
     }
 
+    /**
+     * A call to `Encode` will require at least this many bytes on the current
+     * object to be successful.
+     *
+     * @return the number of bytes needed in a buffer to be able to Encode.
+     */
     size_t EncodeSizeBytes() const;
-    CHIP_ERROR Decode(const uint8_t * data, size_t size);
+
+    /**
+     * Decodes a header from the given buffer.
+     *
+     * @param data - the buffer to read from
+     * @param size - bytes available in the buffer
+     * @param decode_size - number of bytes read from the buffer to decode the
+     *                      object
+     */
+    CHIP_ERROR Decode(const uint8_t * data, size_t size, size_t * decode_size);
+
+    /**
+     * Encodes a header into the given buffer.
+     *
+     * @param data - the buffer to write to
+     * @param size - space available in the buffer (in bytes)
+     * @param decode_size - number of bytes written to the buffer.
+     */
     CHIP_ERROR Encode(uint8_t * data, size_t size, size_t * encode_size);
 
 private:

--- a/src/transport/TransportLayer.am
+++ b/src/transport/TransportLayer.am
@@ -1,0 +1,33 @@
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#    Copyright (c) 2014-2017 Nest Labs, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+#
+#    Description:
+#      This file is the GNU automake header for the CHIP BleLayer
+#      library sources.
+#
+#      These sources are shared by other SDK makefiles and consequently
+#      must be anchored relative to the top build directory.
+#
+
+CHIP_BUILD_TRANSPORT_LAYER_SOURCE_FILES                  = \
+    @top_builddir@/src/transport/MessageHeader.cpp         \
+    $(NULL)
+
+CHIP_BUILD_TRANSPORT_LAYER_HEADER_FILES  = \
+    MessageHeader.h                        \
+    $(NULL)

--- a/src/transport/TransportLayer.am
+++ b/src/transport/TransportLayer.am
@@ -26,8 +26,10 @@
 
 CHIP_BUILD_TRANSPORT_LAYER_SOURCE_FILES                  = \
     @top_builddir@/src/transport/MessageHeader.cpp         \
+    @top_builddir@/src/transport/UdpTransport.cpp          \
     $(NULL)
 
 CHIP_BUILD_TRANSPORT_LAYER_HEADER_FILES  = \
     MessageHeader.h                        \
+    UdpTransport.h                         \
     $(NULL)

--- a/src/transport/UdpTransport.cpp
+++ b/src/transport/UdpTransport.cpp
@@ -24,7 +24,7 @@
  *
  */
 
-#include <core/CHIPConnection.h>
+#include <transport/UdpTransport.h>
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
 
@@ -32,7 +32,7 @@
 
 namespace chip {
 
-ChipConnection::ChipConnection() : mState(kState_NotReady), mRefCount(1)
+UdpTransport::UdpTransport() : mState(kState_NotReady), mRefCount(1)
 {
     mState            = kState_NotReady;
     mRefCount         = 1;
@@ -45,7 +45,7 @@ ChipConnection::ChipConnection() : mState(kState_NotReady), mRefCount(1)
     mPeerPort         = 0;
 }
 
-void ChipConnection::Init(Inet::InetLayer * inetLayer)
+void UdpTransport::Init(Inet::InetLayer * inetLayer)
 {
     if (mState != kState_NotReady)
     {
@@ -57,7 +57,7 @@ void ChipConnection::Init(Inet::InetLayer * inetLayer)
 
 } // namespace chip
 
-CHIP_ERROR ChipConnection::Connect(uint64_t peerNodeId, const IPAddress & peerAddr, uint16_t peerPort)
+CHIP_ERROR UdpTransport::Connect(uint64_t peerNodeId, const IPAddress & peerAddr, uint16_t peerPort)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -78,7 +78,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR ChipConnection::DoConnect()
+CHIP_ERROR UdpTransport::DoConnect()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -119,7 +119,7 @@ CHIP_ERROR ChipConnection::DoConnect()
     return err;
 }
 
-CHIP_ERROR ChipConnection::SendMessage(PacketBuffer * msgBuf)
+CHIP_ERROR UdpTransport::SendMessage(PacketBuffer * msgBuf)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -143,10 +143,10 @@ exit:
     return err;
 }
 
-void ChipConnection::HandleDataReceived(IPEndPointBasis * endPoint, chip::System::PacketBuffer * msg, const IPPacketInfo * pktInfo)
+void UdpTransport::HandleDataReceived(IPEndPointBasis * endPoint, chip::System::PacketBuffer * msg, const IPPacketInfo * pktInfo)
 {
     UDPEndPoint * udpEndPoint   = static_cast<UDPEndPoint *>(endPoint);
-    ChipConnection * connection = (ChipConnection *) udpEndPoint->AppState;
+    UdpTransport * connection = (UdpTransport *) udpEndPoint->AppState;
 
     // TODO this where where messages should be decoded
     if (connection->StateAllowsReceive() && msg != NULL)
@@ -155,25 +155,25 @@ void ChipConnection::HandleDataReceived(IPEndPointBasis * endPoint, chip::System
     }
 }
 
-void ChipConnection::HandleReceiveError(IPEndPointBasis * endPoint, CHIP_ERROR err, const IPPacketInfo * pktInfo)
+void UdpTransport::HandleReceiveError(IPEndPointBasis * endPoint, CHIP_ERROR err, const IPPacketInfo * pktInfo)
 {
     UDPEndPoint * udpEndPoint   = static_cast<UDPEndPoint *>(endPoint);
-    ChipConnection * connection = (ChipConnection *) udpEndPoint->AppState;
+    UdpTransport * connection = (UdpTransport *) udpEndPoint->AppState;
     if (connection->StateAllowsReceive())
     {
         connection->OnReceiveError(connection, err, pktInfo);
     }
 }
 /**
- *  Performs a non-blocking graceful close of the UDP based ChipConnection, delivering any
+ *  Performs a non-blocking graceful close of the UDP based UdpTransport, delivering any
  *  remaining outgoing data before resetting the connection.
  *
  *  This method provides no strong guarantee that any outgoing message not acknowledged at the application
  *  protocol level has been received by the remote peer.
  *
- *  Once Close() has been called, the ChipConnection object can no longer be used for further communication.
+ *  Once Close() has been called, the UdpTransport object can no longer be used for further communication.
  *
- *  Calling Close() decrements the reference count associated with the ChipConnection object, whether or not
+ *  Calling Close() decrements the reference count associated with the UdpTransport object, whether or not
  *  the connection is open/active at the time the method is called.  If this results in the reference count
  *  reaching zero, the resources associated with the connection object are freed.  When this happens, the
  *  application must have no further interactions with the object.
@@ -183,12 +183,12 @@ void ChipConnection::HandleReceiveError(IPEndPointBasis * endPoint, CHIP_ERROR e
  *  @return #CHIP_NO_ERROR unconditionally.
  *
  */
-CHIP_ERROR ChipConnection::Close()
+CHIP_ERROR UdpTransport::Close()
 {
     // Perform a graceful close.
     DoClose(CHIP_NO_ERROR);
 
-    // Decrement the ref count that was added when the ChipConnection object
+    // Decrement the ref count that was added when the UdpTransport object
     // was allocated.
     VerifyOrDie(mRefCount != 0);
     mRefCount--;
@@ -196,7 +196,7 @@ CHIP_ERROR ChipConnection::Close()
     return CHIP_NO_ERROR;
 }
 
-void ChipConnection::DoClose(CHIP_ERROR err)
+void UdpTransport::DoClose(CHIP_ERROR err)
 {
     if (mState != kState_Closed)
     {
@@ -223,26 +223,26 @@ void ChipConnection::DoClose(CHIP_ERROR err)
 }
 
 /**
- * Reserve a reference to the ChipConnection object.
+ * Reserve a reference to the UdpTransport object.
  *
- * The Retain() method increments the reference count associated with the ChipConnection object.  For every
+ * The Retain() method increments the reference count associated with the UdpTransport object.  For every
  * call to Retain(), the application is responsible for making a corresponding call to either Release(), Close()
  * or Abort().
  */
-void ChipConnection::Retain()
+void UdpTransport::Retain()
 {
     VerifyOrDie(mRefCount < UINT8_MAX);
     ++mRefCount;
 }
 
 /**
- *  Decrement the reference count on the ChipConnection object.
+ *  Decrement the reference count on the UdpTransport object.
  *
- *  The Release() method decrements the reference count associated with the ChipConnection object.  If
+ *  The Release() method decrements the reference count associated with the UdpTransport object.  If
  *  this results in the reference count reaching zero, the connection is closed and the connection object
  *  is freed.  When this happens, the application must have no further interactions with the object.
  */
-void ChipConnection::Release()
+void UdpTransport::Release()
 {
     // If the only reference that will remain after this call is the one that was automatically added
     // when the connection started, close the connection.

--- a/src/transport/UdpTransport.cpp
+++ b/src/transport/UdpTransport.cpp
@@ -70,7 +70,7 @@ CHIP_ERROR UdpTransport::Connect(const IPAddress & peerAddr, uint16_t peerPort)
     // happening from an underlying layer.
     mRefCount++;
 
-    ChipLogProgress(Inet, "Connection start %016llX", peerNodeId);
+    ChipLogProgress(Inet, "Connection start");
     err = DoConnect();
 exit:
     return err;

--- a/src/transport/UdpTransport.cpp
+++ b/src/transport/UdpTransport.cpp
@@ -24,9 +24,9 @@
  *
  */
 
-#include <transport/UdpTransport.h>
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
+#include <transport/UdpTransport.h>
 
 #include <inttypes.h>
 
@@ -40,7 +40,6 @@ UdpTransport::UdpTransport() : mState(kState_NotReady), mRefCount(1)
     mRefCount         = 1;
     OnMessageReceived = NULL;
     OnReceiveError    = NULL;
-    mPeerNodeId       = 0;
     mPeerAddr         = IPAddress::Any;
     mPeerPort         = 0;
 }
@@ -57,15 +56,14 @@ void UdpTransport::Init(Inet::InetLayer * inetLayer)
 
 } // namespace chip
 
-CHIP_ERROR UdpTransport::Connect(uint64_t peerNodeId, const IPAddress & peerAddr, uint16_t peerPort)
+CHIP_ERROR UdpTransport::Connect(const IPAddress & peerAddr, uint16_t peerPort)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     VerifyOrExit(mState == kState_ReadyToConnect, err = CHIP_ERROR_INCORRECT_STATE);
 
-    mPeerNodeId = peerNodeId;
-    mPeerAddr   = peerAddr;
-    mPeerPort   = (peerPort != 0) ? peerPort : CHIP_PORT;
+    mPeerAddr = peerAddr;
+    mPeerPort = (peerPort != 0) ? peerPort : CHIP_PORT;
 
     // Bump the reference count when we start the connection process. The corresponding decrement happens when the
     // DoClose() method is called. This ensures the object stays live while there's the possibility of a callback
@@ -145,7 +143,7 @@ exit:
 
 void UdpTransport::HandleDataReceived(IPEndPointBasis * endPoint, chip::System::PacketBuffer * msg, const IPPacketInfo * pktInfo)
 {
-    UDPEndPoint * udpEndPoint   = static_cast<UDPEndPoint *>(endPoint);
+    UDPEndPoint * udpEndPoint = static_cast<UDPEndPoint *>(endPoint);
     UdpTransport * connection = (UdpTransport *) udpEndPoint->AppState;
 
     // TODO this where where messages should be decoded
@@ -157,7 +155,7 @@ void UdpTransport::HandleDataReceived(IPEndPointBasis * endPoint, chip::System::
 
 void UdpTransport::HandleReceiveError(IPEndPointBasis * endPoint, CHIP_ERROR err, const IPPacketInfo * pktInfo)
 {
-    UDPEndPoint * udpEndPoint   = static_cast<UDPEndPoint *>(endPoint);
+    UDPEndPoint * udpEndPoint = static_cast<UDPEndPoint *>(endPoint);
     UdpTransport * connection = (UdpTransport *) udpEndPoint->AppState;
     if (connection->StateAllowsReceive())
     {

--- a/src/transport/UdpTransport.h
+++ b/src/transport/UdpTransport.h
@@ -68,12 +68,11 @@ public:
      * @brief
      *   Attempt to establish a connection to the given peer
      *
-     * @param peerNodeId    Currently unused; a NodeId to identify this peer
      * @param peerAddr      The <tt>chip::Inet::IPAddress</tt> of the requested peer
      * @param peerPort      The port of the requested peer
      * @return CHIP_ERROR   The connection result
      */
-    CHIP_ERROR Connect(uint64_t peerNodeId, const IPAddress & peerAddr, uint16_t peerPort = 0);
+    CHIP_ERROR Connect(const IPAddress & peerAddr, uint16_t peerPort = 0);
 
     /**
      * @brief
@@ -132,7 +131,6 @@ public:
 private:
     Inet::InetLayer * mInetLayer;
     UDPEndPoint * mUDPEndPoint;
-    uint64_t mPeerNodeId;
     IPAddress mPeerAddr;
     uint16_t mPeerPort;
     State mState;

--- a/src/transport/UdpTransport.h
+++ b/src/transport/UdpTransport.h
@@ -24,8 +24,8 @@
  *
  */
 
-#ifndef __CHIPCONNECTION_H__
-#define __CHIPCONNECTION_H__
+#ifndef __UDPTRANSPORT_H__
+#define __UDPTRANSPORT_H__
 
 #include <core/CHIPCore.h>
 #include <inet/IPAddress.h>
@@ -35,7 +35,7 @@ namespace chip {
 
 using namespace System;
 
-class DLL_EXPORT ChipConnection
+class DLL_EXPORT UdpTransport
 {
 public:
     /**
@@ -90,7 +90,7 @@ public:
 
     /**
      * @brief
-     *   Close an existing connection. Once close is called, the ChipConnection object can no longer be used
+     *   Close an existing connection. Once close is called, the UdpTransport object can no longer be used
      *
      * @return CHIP_ERROR   The close result
      */
@@ -103,31 +103,31 @@ public:
      *  This function is the application callback that is invoked when a message is received over a
      *  Chip connection.
      *
-     *  @param[in]    con           A pointer to the ChipConnection object.
+     *  @param[in]    con           A pointer to the UdpTransport object.
      *
      *  @param[in]    msgBuf        A pointer to the PacketBuffer object holding the message.
      *
      *  @param[in]    pktInfo       A pointer to the IPPacketInfo object carrying sender details.
      *
      */
-    typedef void (*MessageReceiveHandler)(ChipConnection * con, PacketBuffer * msgBuf, const IPPacketInfo * pktInfo);
+    typedef void (*MessageReceiveHandler)(UdpTransport * con, PacketBuffer * msgBuf, const IPPacketInfo * pktInfo);
     MessageReceiveHandler OnMessageReceived;
 
     /**
      *  This function is the application callback invoked upon encountering an error when receiving
      *  a Chip message.
      *
-     *  @param[in]     con            A pointer to the ChipConnection object.
+     *  @param[in]     con            A pointer to the UdpTransport object.
      *
      *  @param[in]     err            The CHIP_ERROR encountered when receiving data over the connection.
      *
      *  @param[in]    pktInfo         A pointer to the IPPacketInfo object carrying sender details.
      *
      */
-    typedef void (*ReceiveErrorHandler)(ChipConnection * con, CHIP_ERROR err, const IPPacketInfo * pktInfo);
+    typedef void (*ReceiveErrorHandler)(UdpTransport * con, CHIP_ERROR err, const IPPacketInfo * pktInfo);
     ReceiveErrorHandler OnReceiveError;
 
-    ChipConnection();
+    UdpTransport();
 
 private:
     Inet::InetLayer * mInetLayer;
@@ -149,4 +149,4 @@ private:
 
 } // namespace chip
 
-#endif // __CHIPCONNECTION_H__
+#endif // __UDPTRANSPORT_H__

--- a/src/transport/tests/Makefile.am
+++ b/src/transport/tests/Makefile.am
@@ -1,0 +1,146 @@
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+#
+#    Description:
+#      This file is the GNU automake template for the Project CHIP
+#      transport layer library unit tests.
+#
+
+include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
+
+#
+# Local headers to build against and distribute but not to install
+# since they are not part of the package.
+#
+noinst_HEADERS                                        = \
+    $(NULL)
+
+#
+# Other files we do want to distribute with the package.
+#
+EXTRA_DIST                                            = \
+    $(NULL)
+
+if CHIP_BUILD_TESTS
+lib_LIBRARIES                                         = \
+    libTransportLayerTests.a                            \
+    $(NULL)
+
+libTransportLayerTests_a_SOURCES                      = \
+    TestMessageHeader.cpp                               \
+    $(NULL)
+
+libTransportLayerTests_adir                           = $(includedir)/transport
+
+dist_libTransportLayerTests_a_HEADERS                 = \
+    TestTransportLayer.h                                \
+    $(NULL)
+
+# C/C++ preprocessor option flags that will apply to all compiled
+# objects in this makefile.
+
+AM_CPPFLAGS                                           = \
+    -I$(top_srcdir)/src                                 \
+    -I$(top_srcdir)/src/lib                             \
+    $(NLIO_CPPFLAGS)                                    \
+    $(NLUNIT_TEST_CPPFLAGS)                             \
+    $(LWIP_CPPFLAGS)                                    \
+    $(SOCKETS_CPPFLAGS)                                 \
+    $(PTHREAD_CFLAGS)                                   \
+    $(NULL)
+
+CHIP_LDADD                                            = \
+    $(top_builddir)/src/transport/libTransportLayer.a   \
+    $(top_builddir)/src/lib/support/libSupportLayer.a   \
+    $(NULL)
+
+COMMON_LDADD                                          = \
+    libTransportLayerTests.a                            \
+    $(COMMON_LDFLAGS)                                   \
+    $(CHIP_LDADD)                                       \
+    $(NLUNIT_TEST_LDFLAGS) $(NLUNIT_TEST_LIBS)          \
+    $(LWIP_LDFLAGS) $(LWIP_LIBS)                        \
+    $(SOCKETS_LDFLAGS) $(SOCKETS_LIBS)                  \
+    $(PTHREAD_CFLAGS) $(PTHREAD_LIBS)                   \
+    $(NULL)
+
+# Test applications that should be run when the 'check' target is run.
+
+check_PROGRAMS             = \
+    TestMessageHeader        \
+    $(NULL)
+
+# Test applications and scripts that should be built and run when the
+# 'check' target is run.
+
+TESTS                       = \
+    $(check_PROGRAMS)         \
+    $(NULL)
+
+# The additional environment variables and their values that will be
+# made available to all programs and scripts in TESTS.
+
+TESTS_ENVIRONMENT             = \
+    $(NULL)
+
+# Source, compiler, and linker options for test programs.
+
+TestMessageHeader_SOURCES     = TestMessageHeaderDriver.cpp
+TestMessageHeader_LDADD       = $(COMMON_LDADD)
+
+#
+# Foreign make dependencies
+#
+
+NLFOREIGN_FILE_DEPENDENCIES                           = \
+   $(CHIP_LDADD)                                        \
+   $(NULL)
+
+NLFOREIGN_SUBDIR_DEPENDENCIES                         = \
+   $(LWIP_FOREIGN_SUBDIR_DEPENDENCY)                    \
+   $(NLUNIT_TEST_FOREIGN_SUBDIR_DEPENDENCY)             \
+   $(NULL)
+
+if CHIP_BUILD_COVERAGE
+CLEANFILES                                            = $(wildcard *.gcda *.gcno)
+
+if CHIP_BUILD_COVERAGE_REPORTS
+# The bundle should positively be qualified with the absolute build
+# path. Otherwise, VPATH will get auto-prefixed to it if there is
+# already such a directory in the non-colocated source tree.
+
+CHIP_COVERAGE_BUNDLE                                  = ${abs_builddir}/${PACKAGE}${NL_COVERAGE_BUNDLE_SUFFIX}
+CHIP_COVERAGE_INFO                                    = ${CHIP_COVERAGE_BUNDLE}/${PACKAGE}${NL_COVERAGE_INFO_SUFFIX}
+
+$(CHIP_COVERAGE_BUNDLE):
+	$(call create-directory)
+
+$(CHIP_COVERAGE_INFO): check-local | $(CHIP_COVERAGE_BUNDLE)
+	$(call generate-coverage-report,${top_builddir},*/usr/include/* */third_party/*)
+
+coverage-local: $(CHIP_COVERAGE_INFO)
+
+clean-local: clean-local-coverage
+
+.PHONY: clean-local-coverage
+clean-local-coverage:
+	-$(AM_V_at)rm -rf $(CHIP_COVERAGE_BUNDLE)
+endif # CHIP_BUILD_COVERAGE_REPORTS
+endif # CHIP_BUILD_COVERAGE
+endif # CHIP_BUILD_TESTS
+
+include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/transport/tests/Makefile.am
+++ b/src/transport/tests/Makefile.am
@@ -42,6 +42,7 @@ lib_LIBRARIES                                         = \
 
 libTransportLayerTests_a_SOURCES                      = \
     TestMessageHeader.cpp                               \
+    TestUdpTransport.cpp                                \
     $(NULL)
 
 libTransportLayerTests_adir                           = $(includedir)/transport
@@ -56,6 +57,7 @@ dist_libTransportLayerTests_a_HEADERS                 = \
 AM_CPPFLAGS                                           = \
     -I$(top_srcdir)/src                                 \
     -I$(top_srcdir)/src/lib                             \
+    $(NLASSERT_CPPFLAGS)                                \
     $(NLIO_CPPFLAGS)                                    \
     $(NLUNIT_TEST_CPPFLAGS)                             \
     $(LWIP_CPPFLAGS)                                    \
@@ -64,14 +66,15 @@ AM_CPPFLAGS                                           = \
     $(NULL)
 
 CHIP_LDADD                                            = \
-    $(top_builddir)/src/transport/libTransportLayer.a   \
-    $(top_builddir)/src/lib/support/libSupportLayer.a   \
+    $(top_builddir)/src/lib/libCHIP.a                   \
+    $(top_builddir)/src/crypto/libChipCrypto.a          \
     $(NULL)
 
 COMMON_LDADD                                          = \
     libTransportLayerTests.a                            \
     $(COMMON_LDFLAGS)                                   \
     $(CHIP_LDADD)                                       \
+    $(NLFAULTINJECTION_LDFLAGS) $(NLFAULTINJECTION_LIBS) \
     $(NLUNIT_TEST_LDFLAGS) $(NLUNIT_TEST_LIBS)          \
     $(LWIP_LDFLAGS) $(LWIP_LIBS)                        \
     $(SOCKETS_LDFLAGS) $(SOCKETS_LIBS)                  \
@@ -82,6 +85,7 @@ COMMON_LDADD                                          = \
 
 check_PROGRAMS             = \
     TestMessageHeader        \
+    TestUdpTransport         \
     $(NULL)
 
 # Test applications and scripts that should be built and run when the
@@ -101,6 +105,9 @@ TESTS_ENVIRONMENT             = \
 
 TestMessageHeader_SOURCES     = TestMessageHeaderDriver.cpp
 TestMessageHeader_LDADD       = $(COMMON_LDADD)
+
+TestUdpTransport_SOURCES     = TestUdpTransportDriver.cpp
+TestUdpTransport_LDADD       = $(COMMON_LDADD)
 
 #
 # Foreign make dependencies

--- a/src/transport/tests/TestMessageHeader.cpp
+++ b/src/transport/tests/TestMessageHeader.cpp
@@ -47,6 +47,7 @@ void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     MessageHeader header;
     uint8_t buffer[64];
     size_t encodeLen;
+    size_t decodeLen;
 
     header.SetMessageId(123);
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
@@ -54,7 +55,8 @@ void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     // change it to verify decoding
     header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
 
-    NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen, &decodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, encodeLen == decodeLen);
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 123);
     NL_TEST_ASSERT(inSuite, !header.GetDestinationNodeId().HasValue());
     NL_TEST_ASSERT(inSuite, !header.GetSourceNodeId().HasValue());
@@ -65,7 +67,8 @@ void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     // change it to verify decoding
     header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
 
-    NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen, &decodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, encodeLen == decodeLen);
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 123);
     NL_TEST_ASSERT(inSuite, !header.GetDestinationNodeId().HasValue());
     NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(55));
@@ -75,7 +78,8 @@ void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
 
     // change it to verify decoding
     header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
-    NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen, &decodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, encodeLen == decodeLen);
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 123);
     NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(11));
     NL_TEST_ASSERT(inSuite, !header.GetSourceNodeId().HasValue());
@@ -85,10 +89,24 @@ void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
 
     // change it to verify decoding
     header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
-    NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen, &decodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, encodeLen == decodeLen);
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 234);
     NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(88));
     NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77));
+}
+
+void TestHeaderEncodeDecodeBounds(nlTestSuite * inSuite, void * inContext)
+{
+    MessageHeader header;
+    uint8_t buffer[64];
+    size_t unusedLen;
+
+    for (size_t shortLen = 0; shortLen < 6; shortLen++)
+    {
+        NL_TEST_ASSERT(inSuite, header.Encode(buffer, shortLen, &unusedLen) != CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, header.Decode(buffer, shortLen, &unusedLen) != CHIP_NO_ERROR);
+    }
 }
 
 } // namespace
@@ -98,6 +116,7 @@ static const nlTest sTests[] =
 {
     NL_TEST_DEF("InitialState", TestHeaderInitialState),
     NL_TEST_DEF("EncodeDecode", TestHeaderEncodeDecode),
+    NL_TEST_DEF("EncodeDecodeBounds", TestHeaderEncodeDecodeBounds),
     NL_TEST_SENTINEL()
 };
 // clang-format on

--- a/src/transport/tests/TestMessageHeader.cpp
+++ b/src/transport/tests/TestMessageHeader.cpp
@@ -1,0 +1,110 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a process to effect a functional test for
+ *      the Message Header class within the transport layer
+ *
+ */
+#include "TestTransportLayer.h"
+
+#include <support/ErrorStr.h>
+#include <transport/MessageHeader.h>
+
+#include <nlunit-test.h>
+
+namespace {
+
+using namespace chip;
+
+void TestHeaderInitialState(nlTestSuite * inSuite, void * inContext)
+{
+    MessageHeader header;
+
+    NL_TEST_ASSERT(inSuite, header.GetMessageId() == 0);
+    NL_TEST_ASSERT(inSuite, !header.GetDestinationNodeId().HasValue());
+    NL_TEST_ASSERT(inSuite, !header.GetSourceNodeId().HasValue());
+}
+
+void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
+{
+    MessageHeader header;
+    uint8_t buffer[64];
+    size_t encodeLen;
+
+    header.SetMessageId(123);
+    NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
+
+    // change it to verify decoding
+    header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
+
+    NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.GetMessageId() == 123);
+    NL_TEST_ASSERT(inSuite, !header.GetDestinationNodeId().HasValue());
+    NL_TEST_ASSERT(inSuite, !header.GetSourceNodeId().HasValue());
+
+    header.SetSourceNodeId(55);
+    NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
+
+    // change it to verify decoding
+    header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
+
+    NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.GetMessageId() == 123);
+    NL_TEST_ASSERT(inSuite, !header.GetDestinationNodeId().HasValue());
+    NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(55));
+
+    header.ClearSourceNodeId().SetDestinationNodeId(11);
+    NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
+
+    // change it to verify decoding
+    header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
+    NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.GetMessageId() == 123);
+    NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(11));
+    NL_TEST_ASSERT(inSuite, !header.GetSourceNodeId().HasValue());
+
+    header.SetMessageId(234).SetSourceNodeId(77).SetDestinationNodeId(88);
+    NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
+
+    // change it to verify decoding
+    header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
+    NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.GetMessageId() == 234);
+    NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(88));
+    NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77));
+}
+
+} // namespace
+
+// clang-format off
+static const nlTest sTests[] =
+{
+    NL_TEST_DEF("InitialState", TestHeaderInitialState),
+    NL_TEST_DEF("EncodeDecode", TestHeaderEncodeDecode),
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+int TestMessageHeader(void)
+{
+    nlTestSuite theSuite = { "Transport-MessageHeader", &sTests[0], NULL, NULL };
+    nlTestRunner(&theSuite, NULL);
+    return nlTestRunnerStats(&theSuite);
+}

--- a/src/transport/tests/TestMessageHeaderDriver.cpp
+++ b/src/transport/tests/TestMessageHeaderDriver.cpp
@@ -1,0 +1,34 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a standalone/native program executable
+ *      test driver for the CHIP Transport Layer Message header unit
+ *      tests.
+ *
+ */
+
+#include "TestTransportLayer.h"
+
+#include <nlunit-test.h>
+
+int main(void)
+{
+    nlTestSetOutputStyle(OUTPUT_CSV);
+    return TestMessageHeader();
+}

--- a/src/transport/tests/TestTransportLayer.h
+++ b/src/transport/tests/TestTransportLayer.h
@@ -30,6 +30,7 @@ extern "C" {
 #endif
 
 int TestMessageHeader(void);
+int TestUdpTransport(void);
 
 #ifdef __cplusplus
 }

--- a/src/transport/tests/TestTransportLayer.h
+++ b/src/transport/tests/TestTransportLayer.h
@@ -1,0 +1,38 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file declares test entry points for CHIP Transport layer
+ *      layer library unit tests.
+ *
+ */
+
+#ifndef TESTTRANSPORTLAYER_H
+#define TESTTRANSPORTLAYER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int TestMessageHeader(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TESTTRANSPORTLAYER_H

--- a/src/transport/tests/TestUdpTransport.cpp
+++ b/src/transport/tests/TestUdpTransport.cpp
@@ -18,14 +18,14 @@
 
 /**
  *    @file
- *      This file implements unit tests for the CHIPConnection implementation.
+ *      This file implements unit tests for the UdpTransport implementation.
  */
 
-#include "TestCore.h"
+#include "TestTransportLayer.h"
 
-#include <core/CHIPConnection.h>
 #include <core/CHIPCore.h>
 #include <support/CodeUtils.h>
+#include <transport/UdpTransport.h>
 
 #include <nlbyteorder.h>
 #include <nlunit-test.h>
@@ -48,7 +48,7 @@ struct TestContext sContext;
 
 static const char PAYLOAD[] = "Hello!";
 
-static void MessageReceiveHandler(ChipConnection * con, PacketBuffer * msgBuf, const IPPacketInfo * pktInfo)
+static void MessageReceiveHandler(UdpTransport * con, PacketBuffer * msgBuf, const IPPacketInfo * pktInfo)
 {
     size_t data_len = msgBuf->DataLength();
 
@@ -56,7 +56,7 @@ static void MessageReceiveHandler(ChipConnection * con, PacketBuffer * msgBuf, c
     NL_TEST_ASSERT(reinterpret_cast<nlTestSuite *>(con->AppState), compare == 0);
 };
 
-static void ReceiveErrorHandler(ChipConnection * con, CHIP_ERROR err, const IPPacketInfo * pktInfo)
+static void ReceiveErrorHandler(UdpTransport * con, CHIP_ERROR err, const IPPacketInfo * pktInfo)
 {
     NL_TEST_ASSERT(reinterpret_cast<nlTestSuite *>(con->AppState), false);
 };
@@ -121,7 +121,7 @@ void CheckSimpleInitTest(nlTestSuite * inSuite, void * inContext)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
-    ChipConnection conn;
+    UdpTransport conn;
     conn.Init(&ctx.mInetLayer);
     CHIP_ERROR err = conn.Close();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -135,7 +135,7 @@ void CheckSimpleConnectTest(nlTestSuite * inSuite, void * inContext)
     IPAddress::FromString("127.0.0.1", addr);
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    ChipConnection conn;
+    UdpTransport conn;
     conn.Init(&ctx.mInetLayer);
     err = conn.Connect(0, addr, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -160,7 +160,7 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
     IPAddress::FromString("127.0.0.1", addr);
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    ChipConnection conn;
+    UdpTransport conn;
     conn.Init(&ctx.mInetLayer);
     conn.AppState          = inSuite;
     conn.OnMessageReceived = MessageReceiveHandler;
@@ -251,7 +251,7 @@ static int Finalize(void * aContext)
 /**
  *  Main
  */
-int TestCHIPConnection()
+int TestUdpTransport()
 {
     // Run test suit against one context
     nlTestRunner(&sSuite, &sContext);

--- a/src/transport/tests/TestUdpTransport.cpp
+++ b/src/transport/tests/TestUdpTransport.cpp
@@ -137,9 +137,9 @@ void CheckSimpleConnectTest(nlTestSuite * inSuite, void * inContext)
 
     UdpTransport conn;
     conn.Init(&ctx.mInetLayer);
-    err = conn.Connect(0, addr, 0);
+    err = conn.Connect(addr, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    err = conn.Connect(0, addr, 0);
+    err = conn.Connect(addr, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
 
     err = conn.Close();
@@ -166,7 +166,7 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
     conn.OnMessageReceived = MessageReceiveHandler;
     conn.OnReceiveError    = ReceiveErrorHandler;
 
-    err = conn.Connect(0, addr, 0);
+    err = conn.Connect(addr, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     // Should be able to send a message to itself by just calling send.

--- a/src/transport/tests/TestUdpTransportDriver.cpp
+++ b/src/transport/tests/TestUdpTransportDriver.cpp
@@ -22,7 +22,7 @@
  *
  */
 
-#include "TestCore.h"
+#include "TestTransportLayer.h"
 
 #include <nlunit-test.h>
 
@@ -31,5 +31,5 @@ int main(void)
     // Generate machine-readable, comma-separated value (CSV) output.
     nlTestSetOutputStyle(OUTPUT_CSV);
 
-    return (TestCHIPConnection());
+    return (TestUdpTransport());
 }


### PR DESCRIPTION
 #### Problem
Follow up on #884, Moving CHIPConnection to UDPTransport.
Plan is to have any data tansport classes for indivdual peers within the transport layer

 #### Summary of Changes
- Renames CHIPConnection to UdpTransport (including tests)
- Removes nodeID from the connect call since it was unused and node id to peer translation should probably be done somewhere else

#### Open questions
Current udp class seems to bind and listen for requests when establishing a connection. We may want to revisit this since this would create a new UDP listen for any connection. If we want to support multiple peer connections (it sounds like we do) udp receiving will need to be split. This probably needs to be done on a connection management/pooling class which may also be aware of peer nodes.
