### PR TITLE
Fix bad project path

### DIFF
--- a/src/darwin/Darwin.xcworkspace/contents.xcworkspacedata
+++ b/src/darwin/Darwin.xcworkspace/contents.xcworkspacedata
@@ -2,7 +2,7 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:/Users/sagar_dhawan/Work/connectedhomeip/src/darwin/CHIPTool/CHIPTool.xcodeproj">
+      location = "group:CHIPTool/CHIPTool.xcodeproj">
    </FileRef>
    <FileRef
       location = "group:Framework/CHIP.xcodeproj">


### PR DESCRIPTION
 #### Problem
The project path for the CHIPTool iOS app is incorrect
 #### Summary of Changes
Fix the path
