### PR TITLE
[nrf5] use prebuilt mbedtls

### DIFF
--- a/config/nrf5/nrf5-chip.mk
+++ b/config/nrf5/nrf5-chip.mk
@@ -114,6 +114,7 @@ CHIP_CONFIGURE_OPTIONS = \
     --disable-docs \
     --disable-java \
     --disable-device-manager \
+    --with-mbedtls=$(NRF5_SDK_ROOT)/external/openthread/nrf_security \
     --with-crypto=mbedtls
 
 # Enable / disable optimization.
@@ -148,8 +149,7 @@ STD_LIBS += \
     -lCHIP \
     -lInetLayer \
     -lSystemLayer \
-    -llwip \
-    -lmbedtls
+    -llwip
 
 # Add the appropriate CHIP target as a prerequisite to all application
 # compilation targets to ensure that CHIP gets built and its header
@@ -162,8 +162,7 @@ STD_LINK_PREREQUISITES += \
     $(CHIP_OUTPUT_DIR)/lib/libCHIP.a \
     $(CHIP_OUTPUT_DIR)/lib/libInetLayer.a \
     $(CHIP_OUTPUT_DIR)/lib/libSystemLayer.a \
-    $(CHIP_OUTPUT_DIR)/lib/liblwip.a \
-    $(CHIP_OUTPUT_DIR)/lib/libmbedtls.a
+    $(CHIP_OUTPUT_DIR)/lib/liblwip.a
 
 
 # ==================================================

--- a/configure.ac
+++ b/configure.ac
@@ -1519,8 +1519,15 @@ if test "${with_crypto}" = "mbedtls"; then
 		[],
 		[
 		    AC_MSG_ERROR(The mbedTLS header "$ac_header" is required but cannot be found.)
-		]
-	    )
+		],
+        [
+// Undefine MBEDTLS_CONFIG_FILE and MBEDTLS_USER_CONFIG_FILE to prevent
+// including these files at configure stage.  This is necessary because
+// CPPFLAGS is shell expanded during configure stage, which is not
+// compatible with the expansion of make.
+#undef MBEDTLS_CONFIG_FILE
+#undef MBEDTLS_USER_CONFIG_FILE
+		])
 	]
     )
 fi

--- a/examples/lock-app/nrf5/Makefile
+++ b/examples/lock-app/nrf5/Makefile
@@ -142,12 +142,18 @@ INC_DIRS = \
     $(NRF5_SDK_ROOT)/components/softdevice/mbr/nrf52840/headers \
     $(NRF5_SDK_ROOT)/components/thread/freertos_mbedtls_mutex \
     $(NRF5_SDK_ROOT)/components/toolchain/cmsis/include \
+    $(NRF5_SDK_ROOT)/external/openthread/nrf_security/config \
+    $(NRF5_SDK_ROOT)/external/openthread/nrf_security/mbedtls_plat_config \
+    $(NRF5_SDK_ROOT)/external/openthread/nrf_security/nrf_cc310_plat/include \
+    $(NRF5_SDK_ROOT)/external/openthread/project/config \
+    $(NRF5_SDK_ROOT)/external/openthread/project/nrf52840 \
     $(NRF5_SDK_ROOT)/config/nrf52840/config \
     $(NRF5_SDK_ROOT)/external/fprintf \
     $(NRF5_SDK_ROOT)/external/freertos/config \
     $(NRF5_SDK_ROOT)/external/freertos/portable/CMSIS/nrf52 \
     $(NRF5_SDK_ROOT)/external/freertos/portable/GCC/nrf52 \
     $(NRF5_SDK_ROOT)/external/freertos/source/include \
+    $(NRF5_SDK_ROOT)/external/openthread/include \
     $(NRF5_SDK_ROOT)/external/segger_rtt \
     $(NRF5_SDK_ROOT)/integration/nrfx \
     $(NRF5_SDK_ROOT)/integration/nrfx/legacy \
@@ -162,12 +168,26 @@ DEFINES = \
     BSP_DEFINES_ONLY \
     CONFIG_GPIO_AS_PINRESET \
     FLOAT_ABI_HARD \
+    MBEDTLS_CONFIG_FILE=\"nrf-config.h\" \
+    MBEDTLS_USER_CONFIG_FILE=\"nrf52840-mbedtls-config.h\" \
+    OPENTHREAD_CONFIG_FILE=\"openthread-config-wrap.h\" \
     USE_APP_CONFIG \
     __HEAP_SIZE=40960 \
     __STACK_SIZE=8192 \
     SOFTDEVICE_PRESENT \
     PRINTF_DISABLE_SUPPORT_EXPONENTIAL \
     S140
+
+LIBS = \
+    $(NRF5_SDK_ROOT)/external/openthread/nrf_security/lib/libmbedcrypto_glue.a \
+    $(NRF5_SDK_ROOT)/external/openthread/nrf_security/lib/libmbedcrypto_glue_cc310.a \
+    $(NRF5_SDK_ROOT)/external/openthread/nrf_security/lib/libmbedcrypto_glue_vanilla.a \
+    $(NRF5_SDK_ROOT)/external/openthread/nrf_security/lib/libmbedcrypto_cc310_backend.a \
+    $(NRF5_SDK_ROOT)/external/openthread/nrf_security/lib/libmbedcrypto_vanilla_backend.a \
+    $(NRF5_SDK_ROOT)/external/openthread/nrf_security/lib/libmbedtls_base_vanilla.a \
+    $(NRF5_SDK_ROOT)/external/openthread/nrf_security/lib/libmbedtls_tls_vanilla.a \
+    $(NRF5_SDK_ROOT)/external/openthread/nrf_security/lib/libmbedtls_x509_vanilla.a \
+    $(NRF5_SDK_ROOT)/external/openthread/nrf_security/lib/libnrf_cc310_platform_0.9.1.a \
 
 CFLAGS = \
     --specs=nano.specs


### PR DESCRIPTION
 #### Problem
The lock app example does not enable hardware acceleration of mbedtls.

 #### Summary of Changes
This commit change the lock-app to use prebuilt mbedtls for OpenThread, which has hardware acceleration.

fixes #925
