### PR TITLE
[SetupPayload] Set TLV buffer to null if there is no optional data

### DIFF
--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -187,8 +187,7 @@ exit:
 
 CHIP_ERROR QRCodeSetupPayloadGenerator::payloadBinaryRepresentation(string & binaryRepresentation)
 {
-    uint8_t tlvDataStart[kTotalPayloadDataSizeInBytes];
-    return payloadBinaryRepresentation(binaryRepresentation, tlvDataStart, sizeof(tlvDataStart));
+    return payloadBinaryRepresentation(binaryRepresentation, NULL, 0);
 }
 
 CHIP_ERROR QRCodeSetupPayloadGenerator::payloadBinaryRepresentation(string & binaryRepresentation, uint8_t * tlvDataStart,
@@ -227,8 +226,9 @@ exit:
 
 CHIP_ERROR QRCodeSetupPayloadGenerator::payloadBase41Representation(string & base41Representation)
 {
-    uint8_t tlvDataStart[kTotalPayloadDataSizeInBytes];
-    return payloadBase41Representation(base41Representation, tlvDataStart, sizeof(tlvDataStart));
+    // 6.1.2.2. Table: Packed Binary Data Structure
+    // The TLV Data should be 0 length if TLV is not included.
+    return payloadBase41Representation(base41Representation, NULL, 0);
 }
 
 CHIP_ERROR QRCodeSetupPayloadGenerator::payloadBase41Representation(string & base41Representation, uint8_t * tlvDataStart,

--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -174,7 +174,7 @@ static CHIP_ERROR populateTLV(SetupPayload & outPayload, const vector<uint8_t> &
     }
     size_t bitsLeftToRead = (buf.size() * 8) - index;
     size_t tlvBytesLength = ceil(double(bitsLeftToRead) / 8);
-    uint8_t * tlvArray    = new uint8_t[tlvBytesLength]; // TODO: Allow caller to allocate buffer #825
+    uint8_t * tlvArray    = new uint8_t[tlvBytesLength];
     for (size_t i = 0; i < tlvBytesLength; i++)
     {
         uint64_t dest;

--- a/src/setup_payload/tests/TestQRCodeTLV.cpp
+++ b/src/setup_payload/tests/TestQRCodeTLV.cpp
@@ -205,7 +205,8 @@ void TestSimpleRead(nlTestSuite * inSuite, void * inContext)
 
 void TestOptionalDataWriteSerial(nlTestSuite * inSuite, void * inContext)
 {
-    SetupPayload inPayload = GetDefaultPayloadWithSerialNumber();
+    SetupPayload inPayload = GetDefaultPayload();
+    inPayload.serialNumber = "1";
 
     QRCodeSetupPayloadGenerator generator(inPayload);
     string result;


### PR DESCRIPTION
 #### Problem
While fixing #825 with PR #853 it introduced in the code a minimum size for the TLV buffer. Shana points out this is incorrect - but the code got already merged.

This PR fix that by setting not using a TLV buffer at all by default.

Also the change add a reference to the related paragraph of the specification. I have not seen any in the setup_payload code but I would like to add more since I think it would be helpful to match the current behaviour of the code to the related part of the spec.


 #### Summary of Changes
* Use NULL instead of a buffer if there is no optional data
* Change the serial number test to use a 1 character serial number (0 got ignore by the underlying Implementation)
* Remove a leftover TODO

fixes #927
