### PR TITLE
Make UdpTransport APPState be typesafe.

### DIFF
--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -130,6 +130,8 @@ public:
     CHIP_ERROR GetLayers(Layer ** systemLayer, InetLayer ** inetLayer);
 
 private:
+    using StatefulTransport = StatefulUdpTransport<ChipDeviceController *>;
+
     enum
     {
         kState_NotInitialized = 0,
@@ -144,7 +146,7 @@ private:
 
     System::Layer * mSystemLayer;
     Inet::InetLayer * mInetLayer;
-    UdpTransport * mDeviceCon;
+    StatefulTransport * mDeviceCon;
 
     ConnectionState mConState;
     void * mAppReqState;
@@ -165,8 +167,8 @@ private:
     void ClearRequestState();
     void ClearOpState();
 
-    static void OnReceiveMessage(UdpTransport * con, PacketBuffer * msgBuf, const IPPacketInfo * pktInfo);
-    static void OnReceiveError(UdpTransport * con, CHIP_ERROR err, const IPPacketInfo * pktInfo);
+    static void OnReceiveMessage(StatefulTransport * con, PacketBuffer * msgBuf, const IPPacketInfo * pktInfo);
+    static void OnReceiveError(StatefulTransport * con, CHIP_ERROR err, const IPPacketInfo * pktInfo);
 };
 
 } // namespace DeviceController

--- a/src/transport/UdpTransport.h
+++ b/src/transport/UdpTransport.h
@@ -27,6 +27,8 @@
 #ifndef __UDPTRANSPORT_H__
 #define __UDPTRANSPORT_H__
 
+#include <utility>
+
 #include <core/CHIPCore.h>
 #include <inet/IPAddress.h>
 #include <inet/IPEndPointBasis.h>
@@ -53,8 +55,6 @@ public:
         kState_Connected      = 2, /**< State when the connection has been established. */
         kState_Closed         = 3  /**< State when the connection is closed. */
     };
-
-    void * AppState; /**< A pointer to the application-specific state object. */
 
     /**
      * @brief
@@ -127,6 +127,7 @@ public:
     ReceiveErrorHandler OnReceiveError;
 
     UdpTransport();
+    virtual ~UdpTransport() {}
 
 private:
     Inet::InetLayer * mInetLayer;
@@ -143,6 +144,37 @@ private:
 
     static void HandleDataReceived(IPEndPointBasis * endPoint, chip::System::PacketBuffer * msg, const IPPacketInfo * pktInfo);
     static void HandleReceiveError(IPEndPointBasis * endPoint, INET_ERROR err, const IPPacketInfo * pktInfo);
+};
+
+/// Associates a UDP transport with a state at creation time
+template <typename StateType>
+class StatefulUdpTransport : public UdpTransport
+{
+public:
+    StatefulUdpTransport(const StateType & state) : mState(state) {}
+    StatefulUdpTransport(StateType && state) : mState(std::move(state)) {}
+
+    StateType & State(void) { return mState; }
+    const StateType & State(void) const { return mState; }
+
+    /// Typesafe equivalent of UdpTransport::MessageReceivehandler
+    typedef void (*StatefulMessageReceiveHandler)(StatefulUdpTransport * con, PacketBuffer * msgBuf, const IPPacketInfo * pktInfo);
+
+    /// Typesafe equivalent of UdpTransport::ReceiveErrorHandler
+    typedef void (*StatefulReceiveErrorHandler)(StatefulUdpTransport * con, CHIP_ERROR err, const IPPacketInfo * pktInfo);
+
+    void SetMessageReceiveHandler(StatefulMessageReceiveHandler handler)
+    {
+        OnMessageReceived = reinterpret_cast<MessageReceiveHandler>(handler);
+    }
+
+    void SetReceiveErrorHandler(StatefulReceiveErrorHandler handler)
+    {
+        OnReceiveError = reinterpret_cast<ReceiveErrorHandler>(handler);
+    }
+
+private:
+    StateType mState;
 };
 
 } // namespace chip

--- a/src/transport/UdpTransport.h
+++ b/src/transport/UdpTransport.h
@@ -163,18 +163,20 @@ public:
     /// Typesafe equivalent of UdpTransport::ReceiveErrorHandler
     typedef void (*StatefulReceiveErrorHandler)(StatefulUdpTransport * con, CHIP_ERROR err, const IPPacketInfo * pktInfo);
 
+    /// Sets the OnMessageReceived callback using a stateful callback
     void SetMessageReceiveHandler(StatefulMessageReceiveHandler handler)
     {
         OnMessageReceived = reinterpret_cast<MessageReceiveHandler>(handler);
     }
 
+    /// Sets the OnMessageReceived callback using a stateful callback
     void SetReceiveErrorHandler(StatefulReceiveErrorHandler handler)
     {
         OnReceiveError = reinterpret_cast<ReceiveErrorHandler>(handler);
     }
 
 private:
-    StateType mState;
+    StateType mState; ///< State for this transport. Often a pointer.
 };
 
 } // namespace chip


### PR DESCRIPTION
Trying to avoid passing void* and rather have a specific type for
UDP transport with state.

 #### Problem
Void* loses type information and it is hard to review code and make sure that data pointers make sense.

 #### Summary of Changes
Removed AppState from UdpTransport and subclassed it to a StatefulUdpTransport which is a template and allows ttype safety checks at compile time.

This is part of #930, however that one may take more time since it seems like the void* state pattern is used in many places.

