### PR TITLE
Store a pointer to the endpoint in the ESP32 Echo Server

### DIFF
--- a/examples/wifi-echo/server/esp32/main/EchoServer.cpp
+++ b/examples/wifi-echo/server/esp32/main/EchoServer.cpp
@@ -111,7 +111,7 @@ static void error(IPEndPointBasis * ep, INET_ERROR error, const IPPacketInfo * p
 }
 
 // The echo server assumes the platform's networking has been setup already
-void startServer(UDPEndPoint * endpoint)
+void startServer(UDPEndPoint *& endpoint)
 {
     ESP_LOGI(TAG, "Trying to get Inet");
     INET_ERROR err = DeviceLayer::InetLayer.NewUDPEndPoint(&endpoint);

--- a/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
@@ -39,7 +39,7 @@
 using namespace ::chip;
 using namespace ::chip::DeviceLayer;
 
-extern void startServer(UDPEndPoint * endpoint);
+extern void startServer(UDPEndPoint *& endpoint);
 extern void startClient(void);
 
 #if CONFIG_DEVICE_TYPE_M5STACK


### PR DESCRIPTION
 #### Problem
The UDPEndpoint pointer passed into the server is not being passed by reference

 #### Summary of Changes

Pass it by reference and fix leak
