### PR TITLE
add LogV

### DIFF
--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -784,11 +784,16 @@ static void TestECDH_SampleInputVectors(nlTestSuite * inSuite, void * inContext)
 
 namespace chip {
 namespace Logging {
+void LogV(uint8_t module, uint8_t category, const char * format, va_list argptr)
+{
+    (void) module, (void) category;
+    vfprintf(stderr, format, argptr);
+}
 void Log(uint8_t module, uint8_t category, const char * format, ...)
 {
     va_list argptr;
     va_start(argptr, format);
-    vfprintf(stderr, format, argptr);
+    LogV(module, category, format, argptr);
     va_end(argptr);
 }
 } // namespace Logging

--- a/src/lib/core/tests/TestCHIPSecureChannel.cpp
+++ b/src/lib/core/tests/TestCHIPSecureChannel.cpp
@@ -236,11 +236,16 @@ int TestCHIPSecureChannel()
 
 namespace chip {
 namespace Logging {
+void LogV(uint8_t module, uint8_t category, const char * format, va_list argptr)
+{
+    (void) module, (void) category;
+    vfprintf(stderr, format, argptr);
+}
 void Log(uint8_t module, uint8_t category, const char * format, ...)
 {
     va_list argptr;
     va_start(argptr, format);
-    vfprintf(stderr, format, argptr);
+    LogV(module, category, format, argptr);
     va_end(argptr);
 }
 } // namespace Logging

--- a/src/lib/support/logging/CHIPLogging.cpp
+++ b/src/lib/support/logging/CHIPLogging.cpp
@@ -190,12 +190,8 @@ uint8_t gLogFilter = kLogCategory_Max;
 #define __CHIP_LOGGING_LINK_ATTRIBUTE
 #endif
 
-DLL_EXPORT __CHIP_LOGGING_LINK_ATTRIBUTE void Log(uint8_t module, uint8_t category, const char * msg, ...)
+DLL_EXPORT __CHIP_LOGGING_LINK_ATTRIBUTE void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
 {
-    va_list v;
-
-    va_start(v, msg);
-
     if (IsCategoryEnabled(category))
     {
 
@@ -220,6 +216,15 @@ DLL_EXPORT __CHIP_LOGGING_LINK_ATTRIBUTE void Log(uint8_t module, uint8_t catego
 
 #endif /* CHIP_LOGGING_STYLE_ANDROID */
     }
+}
+
+DLL_EXPORT __CHIP_LOGGING_LINK_ATTRIBUTE void Log(uint8_t module, uint8_t category, const char * msg, ...)
+{
+    va_list v;
+
+    va_start(v, msg);
+
+    LogV(module, category, msg, v);
 
     va_end(v);
 }

--- a/src/lib/support/logging/CHIPLogging.h
+++ b/src/lib/support/logging/CHIPLogging.h
@@ -37,6 +37,7 @@
 
 #include <core/CHIPConfig.h>
 
+#include <stdarg.h>
 #include <stdint.h>
 
 /**
@@ -106,6 +107,7 @@ enum LogModule
     kLogModule_EventLogging,
     kLogModule_Support,
     kLogModule_chipTool,
+    kLogModule_Zcl,
 
     kLogModule_Max
 };
@@ -184,6 +186,7 @@ enum LogCategory
     kLogCategory_Max = kLogCategory_Retain
 };
 
+extern void LogV(uint8_t module, uint8_t category, const char * msg, va_list args);
 extern void Log(uint8_t module, uint8_t category, const char * msg, ...);
 extern uint8_t GetLogFilter(void);
 extern void SetLogFilter(uint8_t category);

--- a/src/platform/EFR32/Logging.cpp
+++ b/src/platform/EFR32/Logging.cpp
@@ -161,13 +161,10 @@ namespace chip {
 namespace Logging {
 
 /**
- * CHIP log output function.
+ * CHIP log output functions.
  */
-void Log(uint8_t module, uint8_t category, const char * aFormat, ...)
+void LogV(uint8_t module, uint8_t category, const char * aFormat, va_list v)
 {
-    va_list v;
-
-    va_start(v, aFormat);
 #if EFR32_LOG_ENABLED && _CHIP_USE_LOGGING
     if (IsCategoryEnabled(category))
     {
@@ -214,6 +211,14 @@ void Log(uint8_t module, uint8_t category, const char * aFormat, ...)
     // Let the application know that a log message has been emitted.
     DeviceLayer::OnLogOutput();
 #endif // EFR32_LOG_ENABLED && _CHIP_USE_LOGGING
+}
+
+void Log(uint8_t module, uint8_t category, const char * aFormat, ...)
+{
+    va_list v;
+
+    va_start(v, aFormat);
+    LogV(module, category, aFormat, v);
     va_end(v);
 }
 

--- a/src/platform/ESP32/Logging.cpp
+++ b/src/platform/ESP32/Logging.cpp
@@ -101,4 +101,3 @@ void Log(uint8_t module, uint8_t category, const char * msg, ...)
 } // namespace Logging
 
 } // namespace chip
-} // namespace chip

--- a/src/platform/ESP32/Logging.cpp
+++ b/src/platform/ESP32/Logging.cpp
@@ -51,12 +51,8 @@ void GetModuleName(char * buf, uint8_t module)
 namespace chip {
 namespace Logging {
 
-void Log(uint8_t module, uint8_t category, const char * msg, ...)
+void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
 {
-    va_list v;
-
-    va_start(v, msg);
-
     if (IsCategoryEnabled(category))
     {
         enum
@@ -91,9 +87,18 @@ void Log(uint8_t module, uint8_t category, const char * msg, ...)
             break;
         }
     }
+}
 
+void Log(uint8_t module, uint8_t category, const char * msg, ...)
+{
+    va_list v;
+
+    va_start(v, msg);
+    LogV(module, category, msg, v);
     va_end(v);
 }
 
 } // namespace Logging
+
+} // namespace chip
 } // namespace chip

--- a/src/platform/Linux/Logging.cpp
+++ b/src/platform/Linux/Logging.cpp
@@ -55,13 +55,10 @@ namespace chip {
 namespace Logging {
 
 /**
- * CHIP log output function.
+ * CHIP log output functions.
  */
-void Log(uint8_t module, uint8_t category, const char * msg, ...)
+void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
 {
-    va_list v;
-    va_start(v, msg);
-
     if (IsCategoryEnabled(category))
     {
         vsyslog(LOG_INFO, msg, v);
@@ -69,7 +66,12 @@ void Log(uint8_t module, uint8_t category, const char * msg, ...)
         // Let the application know that a log message has been emitted.
         DeviceLayer::OnLogOutput();
     }
-
+}
+void Log(uint8_t module, uint8_t category, const char * msg, ...)
+{
+    va_list v;
+    va_start(v, msg);
+    LogV(module, category, msg, v);
     va_end(v);
 }
 

--- a/src/platform/nRF5/Logging.cpp
+++ b/src/platform/nRF5/Logging.cpp
@@ -78,17 +78,10 @@ NRF_LOG_MODULE_REGISTER();
 namespace chip {
 namespace Logging {
 
-/**
- * Openchip log output function.
- */
-void Log(uint8_t module, uint8_t category, const char * msg, ...)
+void LogV(uint8_t module, uint8_t category, const char * msg, ...)
 {
-    va_list v;
-
     (void) module;
     (void) category;
-
-    va_start(v, msg);
 
 #if NRF_LOG_ENABLED
 
@@ -131,9 +124,21 @@ void Log(uint8_t module, uint8_t category, const char * msg, ...)
         // Let the application know that a log message has been emitted.
         DeviceLayer::OnLogOutput();
     }
-
+#else  // NRF_LOG_ENABLED
+    (void) msg;
+    (void) v;
 #endif // NRF_LOG_ENABLED
+}
 
+/**
+ * Openchip log output function.
+ */
+void Log(uint8_t module, uint8_t category, const char * msg, ...)
+{
+    va_list v;
+
+    va_start(v, msg);
+    LogV(module, category, msg, v);
     va_end(v);
 }
 

--- a/src/platform/nRF5/Logging.cpp
+++ b/src/platform/nRF5/Logging.cpp
@@ -78,7 +78,7 @@ NRF_LOG_MODULE_REGISTER();
 namespace chip {
 namespace Logging {
 
-void LogV(uint8_t module, uint8_t category, const char * msg, ...)
+void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
 {
     (void) module;
     (void) category;


### PR DESCRIPTION
#### Problem
 layers that supply their own Log() or printf() need a vararg version of CHIP Logging APIs to consume, and there isn't one

 #### Summary of Changes
 add a vararg form