### PR TITLE
make chipZclBuffer opaque, implement in direct terms of PacketBuffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ third_party/nlio/
 third_party/nlunit-test/
 third_party/mbedtls/
 examples/common/m5stack-tft/
-examples/common/QRCode/repo
+examples/common/QRCode/repo/
 
 # Example specific rules
 examples/**/sdkconfig
@@ -40,7 +40,7 @@ src/test_driver/esp32/build
 # Temporary Directories
 .tmp/
 
-# Xcode
+# Xcode, other development environment stuff
 *.pbxuser
 *.mode1v3
 *.mode2v3
@@ -50,3 +50,4 @@ project.xcworkspace/
 xcuserdata/
 *.xcodeproj/*
 *.xcworkspace/*
+TAGS

--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -205,8 +205,8 @@ void DoOnOff(DeviceController::ChipDeviceController * controller, Command comman
     static const size_t bufferSize = 1024;
     auto * buffer                  = System::PacketBuffer::NewWithAvailableSize(bufferSize);
 
-    ChipZclBuffer_t zcl_buffer  = { buffer->Start(), bufferSize, 0 };
-    ChipZclCommandContext_t ctx = {
+    ChipZclBuffer_t * zcl_buffer = (ChipZclBuffer_t *) buffer;
+    ChipZclCommandContext_t ctx  = {
         1,                              // endpointId
         CHIP_ZCL_CLUSTER_ON_OFF,        // clusterId
         true,                           // clusterSpecific
@@ -218,20 +218,18 @@ void DoOnOff(DeviceController::ChipDeviceController * controller, Command comman
         nullptr,                        // request
         nullptr                         // response
     };
-    chipZclEncodeZclHeader(&zcl_buffer, &ctx);
+    chipZclEncodeZclHeader(zcl_buffer, &ctx);
 
-    const size_t data_len = chipZclBufferDataLength(&zcl_buffer);
+    const size_t data_len = chipZclBufferDataLength(zcl_buffer);
 
 #ifdef DEBUG
     fprintf(stderr, "SENDING: %zu ", data_len);
     for (size_t i = 0; i < data_len; ++i)
     {
-        fprintf(stderr, "%d ", chipZclBufferPointer(&zcl_buffer)[i]);
+        fprintf(stderr, "%d ", chipZclBufferPointer(zcl_buffer)[i]);
     }
     fprintf(stderr, "\n");
 #endif
-
-    buffer->SetDataLength(data_len);
 
     controller->SendMessage(NULL, buffer);
     controller->ServiceEvents();

--- a/examples/wifi-echo/server/esp32/main/DataModelHandler.cpp
+++ b/examples/wifi-echo/server/esp32/main/DataModelHandler.cpp
@@ -45,7 +45,7 @@ void InitDataModelHandler()
 
 void HandleDataModelMessage(System::PacketBuffer * buffer)
 {
-    ChipZclStatus_t zclStatus = chipZclProcessIncoming(buffer->Start(), buffer->DataLength());
+    ChipZclStatus_t zclStatus = chipZclProcessIncoming((ChipZclBuffer_t *) buffer);
     if (zclStatus == CHIP_ZCL_STATUS_SUCCESS)
     {
         ESP_LOGI(TAG, "Data model processing success!");

--- a/scripts/examples/esp_echo_app.sh
+++ b/scripts/examples/esp_echo_app.sh
@@ -2,5 +2,5 @@
 
 make -f Makefile-bootstrap repos
 source examples/wifi-echo/server/esp32/idf.sh
-idf make -C examples/wifi-echo/server/esp32 defconfig
-idf make -C examples/wifi-echo/server/esp32
+idf make V=1 -C examples/wifi-echo/server/esp32 defconfig
+idf make V=1 -C examples/wifi-echo/server/esp32

--- a/src/app/DataModel.am
+++ b/src/app/DataModel.am
@@ -29,7 +29,7 @@ CHIP_BUILD_DATA_MODEL_SOURCE_FILES                                              
     @top_builddir@/src/app/gen/gen-command-handler.c                                  \
     @top_builddir@/src/app/gen/gen-global-command-handler.c                           \
     @top_builddir@/src/app/gen/gen-specs.c                                            \
-    @top_builddir@/src/app/plugin/binding-mock/mock.c                                 \
+    @top_builddir@/src/app/plugin/binding-chip/chip.cpp                               \
     @top_builddir@/src/app/plugin/cluster-server-basic/basic-server.c                 \
     @top_builddir@/src/app/plugin/cluster-server-identify/identify-server.c           \
     @top_builddir@/src/app/plugin/cluster-server-level-control/level-control-server.c \

--- a/src/app/Makefile.am
+++ b/src/app/Makefile.am
@@ -36,6 +36,8 @@ lib_LIBRARIES                         = libCHIPDataModel.a
 libCHIPDataModel_a_CPPFLAGS           = \
     -I$(top_srcdir)/src/app/chip-zcl    \
     -I$(top_srcdir)/src/app/gen         \
+    -I$(top_srcdir)/src                 \
+    -I$(top_srcdir)/src/lib             \
     $(NULL)
 
 libCHIPDataModel_a_SOURCES            = $(CHIP_BUILD_DATA_MODEL_SOURCE_FILES)

--- a/src/app/chip-zcl/chip-zcl-buffer.h
+++ b/src/app/chip-zcl/chip-zcl-buffer.h
@@ -26,6 +26,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* #ifdef __cplusplus */
+
 /**
  * Structure that describes the buffers passed between the CHIP layers and
  * the Zap layer.
@@ -37,24 +41,7 @@
  * from, currentPosition represents the current read position and dataLength is
  * the total length of the data that can be read.
  */
-typedef struct
-{
-    /**
-     * The data storage for our buffer.
-     */
-    uint8_t * buffer;
-
-    /**
-     * The size of our buffer above.
-     */
-    uint16_t bufferLength;
-
-    /**
-     * The length of the data that can be read from this buffer; nonzero only
-     * when it's ready to be read from.
-     */
-    uint16_t dataLength;
-} ChipZclBuffer_t;
+typedef struct ChipZclBuffer_t ChipZclBuffer_t;
 
 /**
  * Function that allocates a buffer.
@@ -83,14 +70,6 @@ uint8_t * chipZclBufferPointer(ChipZclBuffer_t * buffer);
 void chipZclBufferFree(ChipZclBuffer_t * buffer);
 
 /**
- * Function that resets a buffer to have its entire allocated length
- *  available for writing.
- *
- * @param[in] buffer the buffer to reset.
- */
-void chipZclBufferReset(ChipZclBuffer_t * buffer);
-
-/**
  * Function that returns the size of the used portion of the buffer, in octets,
  * when the buffer is ready for reading.  Always returns 0 for buffers that are
  * being written to.
@@ -117,4 +96,7 @@ void chipZclBufferSetDataLength(ChipZclBuffer_t * buffer, uint16_t newLength);
  */
 uint16_t chipZclBufferAvailableLength(ChipZclBuffer_t * buffer);
 
+#ifdef __cplusplus
+}
+#endif /* #ifdef __cplusplus */
 #endif // CHIP_ZCL_BUFFER

--- a/src/app/chip-zcl/chip-zcl-codec.h
+++ b/src/app/chip-zcl/chip-zcl-codec.h
@@ -31,6 +31,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* #ifdef __cplusplus */
+
 /**
  * Codec keeps track of an ongoing encode/decode session of a Buffer
  */
@@ -83,5 +87,9 @@ ChipZclStatus_t chipZclCodecDecode(ChipZclCodec_t * codec, ChipZclType_t type, v
  * @brief Call after decoding to verify that everything has been decoded
  */
 ChipZclStatus_t chipZclCodecDecodeEnd(ChipZclCodec_t * me);
+
+#ifdef __cplusplus
+}
+#endif /* #ifdef __cplusplus */
 
 #endif // CHIP_ZCL_CODEC

--- a/src/app/chip-zcl/chip-zcl-struct.h
+++ b/src/app/chip-zcl/chip-zcl-struct.h
@@ -28,6 +28,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* #ifdef __cplusplus */
+
 /**
  * Base types for the codec. This is a smaller subset than the actual ZCL types, and the
  * generated layer for a specific code is responsible for mapping ZCL types onto these
@@ -250,4 +254,7 @@ void chipZclStoreInt32uValue(uint8_t * valueLoc, uint32_t value, uint8_t valueSi
 
 /** @} end addtogroup */
 
+#ifdef __cplusplus
+}
+#endif /* #ifdef __cplusplus */
 #endif // CHIP_ZCL_STRUCT

--- a/src/app/chip-zcl/chip-zcl.h
+++ b/src/app/chip-zcl/chip-zcl.h
@@ -24,12 +24,16 @@
 #ifndef CHIP_ZCL_MASTER_HEADER
 #define CHIP_ZCL_MASTER_HEADER
 
+#include "chip-zcl-buffer.h"
+
 #include <memory.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 
-#include "chip-zcl-buffer.h"
+#ifdef __cplusplus
+extern "C" {
+#endif /* #ifdef __cplusplus */
 
 typedef uint64_t bitmap64_t;
 typedef uint8_t enum8_t;
@@ -833,6 +837,7 @@ typedef struct
 void chipZclEventSetDelayMs(Event * event, uint32_t delay);
 
 void chEventControlSetDelayMS(ChipZclEventControl * event, uint32_t delay);
+
 /** @brief Sets this ::EmberEventControl to run "delay" milliseconds in the future.
  *  NOTE: To avoid rollover errors in event calculation, the delay must be
  *  less than ::EMBER_MAX_EVENT_CONTROL_DELAY_MS.
@@ -976,15 +981,6 @@ void chipZclEventSetDelayMs(Event * event, uint32_t delay);
 // Endpoint Management
 ChipZclEndpointId_t chipZclEndpointIndexToId(ChipZclEndpointIndex_t index, const ChipZclClusterSpec_t * clusterSpec);
 
-// Some platform CHIP_ZCL_STATUS_INSUFFICIENT_SPACE
-#define MEMSET(d, v, l) memset(d, v, l)
-#define MEMCOPY(d, s, l) memcpy(d, s, l)
-#define MEMMOVE(d, s, l) memmove(d, s, l)
-#define MEMCOMPARE(s0, s1, l) memcmp(s0, s1, l)
-#define MEMPGMCOMPARE(s0, s1, l) memcmp(s0, s1, l)
-#define LOW_BYTE(n) ((uint8_t)((n) &0xFF))
-#define HIGH_BYTE(n) ((uint8_t)(LOW_BYTE((n) >> 8)))
-#define IS_BIG_ENDIAN() false
 /**
  * @brief Returns the value built from the two \c uint8_t
  * values \c high and \c low.
@@ -1113,6 +1109,9 @@ void chipZclEncodeZclHeader(ChipZclBuffer_t * buffer, ChipZclCommandContext_t * 
  */
 void chipZclDecodeZclHeader(ChipZclBuffer_t * buffer, ChipZclCommandContext_t * context);
 
-ChipZclStatus_t chipZclProcessIncoming(uint8_t * buffer, uint16_t bufferLength);
+ChipZclStatus_t chipZclProcessIncoming(ChipZclBuffer_t * buffer);
 
+#ifdef __cplusplus
+}
+#endif /* #ifdef __cplusplus */
 #endif // CHIP_ZCL_MASTER_HEADER

--- a/src/app/plugin/core-api/core-api.c
+++ b/src/app/plugin/core-api/core-api.c
@@ -21,50 +21,11 @@
 
 ChipZclStatus_t chipZclClusterCommandParse(ChipZclCommandContext_t * context);
 
-ChipZclStatus_t chipZclProcessIncoming(uint8_t * rawBuffer, uint16_t rawBufferLength)
+ChipZclStatus_t chipZclProcessIncoming(ChipZclBuffer_t * message)
 {
-    ChipZclBuffer_t buffer = { rawBuffer, rawBufferLength, rawBufferLength };
-
     ChipZclCommandContext_t context = { 0 };
 
-    chipZclDecodeZclHeader(&buffer, &context);
+    chipZclDecodeZclHeader(message, &context);
 
     return chipZclClusterCommandParse(&context);
-}
-
-/**
- * Function that returns a pointer to the raw buffer.
- */
-uint8_t * chipZclBufferPointer(ChipZclBuffer_t * buffer)
-{
-    return buffer->buffer;
-}
-
-/**
- * Function that returns the size of the used portion of the buffer.
- */
-uint16_t chipZclBufferDataLength(ChipZclBuffer_t * buffer)
-{
-    return buffer->dataLength;
-}
-
-/**
- * returns space available for writing after any data already in the buffer
- */
-uint16_t chipZclBufferAvailableLength(ChipZclBuffer_t * buffer)
-{
-    return buffer->bufferLength - buffer->dataLength;
-}
-
-/**
- *  sets data length for a buffer that's being written to
- */
-void chipZclBufferSetDataLength(ChipZclBuffer_t * buffer, uint16_t newLength)
-{
-    buffer->dataLength = newLength;
-}
-
-void chipZclBufferReset(ChipZclBuffer_t * buffer)
-{
-    buffer->dataLength = 0;
 }

--- a/src/app/plugin/tests/cluster-cmd-on-off-test.c
+++ b/src/app/plugin/tests/cluster-cmd-on-off-test.c
@@ -99,11 +99,9 @@ int testClusterCmdOnOff(void)
         return 1;
     }
 
-    uint8_t * rawBuffer   = chipZclBufferPointer(buffer);
-    uint16_t bufferLength = chipZclBufferDataLength(buffer);
     bool onOff;
 
-    printf("Buffer for processing is ready, length: %d\n", bufferLength);
+    printf("Buffer for processing is ready, length: %d\n", chipZclBufferDataLength(buffer));
 
     // Make sure initial value of the attribute is false.
     status = chipZclReadAttribute(1, &chipZclClusterOnOffServerSpec, CHIP_ZCL_CLUSTER_ON_OFF_SERVER_ATTRIBUTE_ON_OFF, &onOff,
@@ -116,7 +114,7 @@ int testClusterCmdOnOff(void)
 
     // At this point, we have a buffer encoded with the command context that contains the command.
     // So we will be testing top-level entry API.
-    status = chipZclProcessIncoming(rawBuffer, bufferLength);
+    status = chipZclProcessIncoming(buffer);
 
     if (status == CHIP_ZCL_STATUS_SUCCESS)
     {


### PR DESCRIPTION
#### Problem
 chipZclBuffer is implemented with malloc() and free(), but should be in
 terms of PacketBuffer

 #### Summary of Changes
 * make chipZclBuffer an opaque type
 * move current chipZclBuffer impl to mock.c
 * add a CHIP chipZclBuffer implementation (in chip.cpp)
 * fix issues that arose from the above
 * misc nits/bugs (e.g. HIGH_BYTE() was borken)


fixes #657