### PR TITLE
Get rid of QRCodeSetupGenerator::payloadBinaryRepresentation

### DIFF
--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -162,52 +162,6 @@ static CHIP_ERROR generateBitSet(SetupPayload & payload, uint8_t * bits, uint8_t
     return err;
 }
 
-static CHIP_ERROR payloadBinaryRepresentationWithTLV(SetupPayload & setupPayload, string & binaryRepresentation, size_t bitsetSize,
-                                                     uint8_t * tlvDataStart, size_t tlvDataLengthInBytes)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    string binary;
-    uint8_t bits[bitsetSize];
-    memset(bits, 0, bitsetSize);
-    err = generateBitSet(setupPayload, bits, tlvDataStart, tlvDataLengthInBytes);
-    SuccessOrExit(err);
-
-    for (int i = ArraySize(bits) - 1; i >= 0; i--)
-    {
-        for (unsigned j = 1 << 7; j != 0;)
-        {
-            binary += bits[i] & j ? "1" : "0";
-            j >>= 1;
-        }
-    }
-    binaryRepresentation = binary;
-exit:
-    return err;
-}
-
-CHIP_ERROR QRCodeSetupPayloadGenerator::payloadBinaryRepresentation(string & binaryRepresentation)
-{
-    return payloadBinaryRepresentation(binaryRepresentation, NULL, 0);
-}
-
-CHIP_ERROR QRCodeSetupPayloadGenerator::payloadBinaryRepresentation(string & binaryRepresentation, uint8_t * tlvDataStart,
-                                                                    size_t tlvDataStartSize)
-{
-    CHIP_ERROR err                = CHIP_NO_ERROR;
-    uint32_t tlvDataLengthInBytes = 0;
-
-    VerifyOrExit(mPayload.isValidQRCodePayload(), err = CHIP_ERROR_INVALID_ARGUMENT);
-
-    err = generateTLVFromOptionalData(mPayload, tlvDataStart, tlvDataStartSize, tlvDataLengthInBytes);
-    SuccessOrExit(err);
-
-    err = payloadBinaryRepresentationWithTLV(mPayload, binaryRepresentation, kTotalPayloadDataSizeInBytes + tlvDataLengthInBytes,
-                                             tlvDataStart, tlvDataLengthInBytes);
-    SuccessOrExit(err);
-exit:
-    return err;
-}
-
 static CHIP_ERROR payloadBase41RepresentationWithTLV(SetupPayload & setupPayload, string & base41Representation, size_t bitsetSize,
                                                      uint8_t * tlvDataStart, size_t tlvDataLengthInBytes)
 {

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.h
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.h
@@ -22,9 +22,9 @@
  *
  *      The encoding of the binary data to a base41 string is as follows:
  *      - Every 2 bytes (16 bits) of binary source data are encoded to 3
- *        characters of the Base-45 alphabet.
+ *        characters of the Base-41 alphabet.
  *      - If an odd number of bytes are to be encoded, the remaining
- *        single byte is encoded to 2 characters of the Base-45 alphabet.
+ *        single byte is encoded to 2 characters of the Base-41 alphabet.
  */
 
 #include "SetupPayload.h"
@@ -83,10 +83,6 @@ public:
      *               producing the requested string.
      */
     CHIP_ERROR payloadBase41Representation(string & base41Representation, uint8_t * tlvDataStart, size_t tlvDataStartSize);
-
-    // These methods are only used for testing purposes.
-    CHIP_ERROR payloadBinaryRepresentation(string & binaryRepresentation);
-    CHIP_ERROR payloadBinaryRepresentation(string & binaryRepresentation, uint8_t * tlvDataStart, size_t tlvDataStartSize);
 };
 
 }; // namespace chip


### PR DESCRIPTION
 #### Problem

The method QRCodeGenerator::payloadBinaryRepresentation is currently exposed as a public method of the QRCodeGenerator. While this method is useful for debugging the inner implementation it is not targeting callers of this API, is only used in tests and add more complexity than needed to the code of the class itself.

 #### Summary of Changes

This PR remove QRCodeGenerator::payloadBinaryRepresentation and add an equivalent method in tests/TestQRCode.cpp.

It also add some formatting to the output of the method to makes it easier to read the result.

fixes #948 
