### PR TITLE
Keep the last 4 bits of rendezvousInformation reserved

### DIFF
--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -45,14 +45,18 @@ bool SetupPayload::isValidQRCodePayload()
     {
         return false;
     }
-    if (rendezvousInformation >= 1 << kRendezvousInfoFieldLengthInBits)
+
+    size_t rendezvousInfoAllowedFieldLengthInBits = kRendezvousInfoFieldLengthInBits - kRendezvousInfoReservedFieldLengthInBits;
+    if (rendezvousInformation >= 1 << rendezvousInfoAllowedFieldLengthInBits)
     {
         return false;
     }
+
     if (discriminator >= 1 << kPayloadDiscriminatorFieldLengthInBits)
     {
         return false;
     }
+
     if (setUpPINCode >= 1 << kSetupPINCodeFieldLengthInBits)
     {
         return false;

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -46,8 +46,9 @@ const int kManualSetupDiscriminatorFieldLengthInBits = 4;
 const int kSetupPINCodeFieldLengthInBits             = 27;
 const int kReservedFieldLengthInBits                 = 1;
 
-const int kRawVendorTagLengthInBits = 7;
-const uint16_t kSerialNumberTag     = 128;
+const int kRendezvousInfoReservedFieldLengthInBits = 4;
+const int kRawVendorTagLengthInBits                = 7;
+const uint16_t kSerialNumberTag                    = 128;
 
 const int kManualSetupShortCodeCharLength = 10;
 const int kManualSetupLongCodeCharLength  = 20;

--- a/src/setup_payload/tests/TestQRCode.cpp
+++ b/src/setup_payload/tests/TestQRCode.cpp
@@ -161,22 +161,27 @@ void TestSetupPayloadVerify(nlTestSuite * inSuite, void * inContext)
 
     // test invalid version
     SetupPayload test_payload = payload;
-    test_payload.version      = 2 << kVersionFieldLengthInBits;
+    test_payload.version      = 1 << kVersionFieldLengthInBits;
     NL_TEST_ASSERT(inSuite, test_payload.isValidQRCodePayload() == false);
 
     // test invalid rendezvousInformation
     test_payload                       = payload;
-    test_payload.rendezvousInformation = 512;
+    test_payload.rendezvousInformation = 1 << kRendezvousInfoFieldLengthInBits;
+    NL_TEST_ASSERT(inSuite, test_payload.isValidQRCodePayload() == false);
+
+    // test invalid rendezvousInformation
+    test_payload                       = payload;
+    test_payload.rendezvousInformation = 1 << (kRendezvousInfoFieldLengthInBits - kRendezvousInfoReservedFieldLengthInBits);
     NL_TEST_ASSERT(inSuite, test_payload.isValidQRCodePayload() == false);
 
     // test invalid discriminator
     test_payload               = payload;
-    test_payload.discriminator = 2 << kPayloadDiscriminatorFieldLengthInBits;
+    test_payload.discriminator = 1 << kPayloadDiscriminatorFieldLengthInBits;
     NL_TEST_ASSERT(inSuite, test_payload.isValidQRCodePayload() == false);
 
     // test invalid stetup PIN
     test_payload              = payload;
-    test_payload.setUpPINCode = 2 << kSetupPINCodeFieldLengthInBits;
+    test_payload.setUpPINCode = 1 << kSetupPINCodeFieldLengthInBits;
     NL_TEST_ASSERT(inSuite, test_payload.isValidQRCodePayload() == false);
 }
 


### PR DESCRIPTION
 #### Problem

The section [6.1.2.3 Rendezvous Capabilities Bitmask] specify that the last 4 bits are reserved and must be 0. The SetupPayload::IsValidQRCodePayload method does not enforce that

 #### Summary of Changes

The code change the SetupPayload::IsValidQRCodePayload method to only allows the least 4 significant bits to be set to 1.
It also fix the tests and add a new test to check for that.

fixes #934 
