### PR TITLE
Export the silabs generated headers that other code needs to include.

### DIFF
--- a/src/app/gen/Makefile.am
+++ b/src/app/gen/Makefile.am
@@ -22,20 +22,25 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
+gendir = $(includedir)/gen
+
+gen_HEADERS = \
+    gen-cluster-id.h             \
+    gen-command-id.h             \
+    gen-types.h                  \
+    $(NULL)
+
 EXTRA_DIST                    =  \
     gen-attribute-storage.h      \
     gen-attribute-type.h         \
     gen-callback-stubs.c         \
     gen-callbacks.h              \
-    gen-cluster-id.h             \
     gen-command-handler.c        \
     gen-command-handler.h        \
-    gen-command-id.h             \
     gen-endpoint-config.h        \
     gen-global-command-handler.c \
     gen-global-command-handler.h \
     gen-specs.c                  \
-    gen-types.h                  \
     gen.h                        \
     README.md                    \
     $(NULL)


### PR DESCRIPTION
In particular, we will need to include these from the Darwin CHIP
framework.

 #### Problem
CHIP framework can't include headers from `src/app/gen`

 #### Summary of Changes
Export the headers to a place where they can then be included.

@rwalker-apple, I was torn about whether to put these in a directory called `gen` or something less generic-sounding, or the existing `chip-zcl` dir, or something else.  If you have any preferences here, please let me know.

fixes https://github.com/project-chip/connectedhomeip/issues/956
