### PR TITLE
Simplify addOptionalTag API to not call VendorTag

### DIFF
--- a/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
+++ b/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
@@ -83,13 +83,11 @@ string createSetupPayload()
     payload.version   = 1;
     payload.vendorID  = EXAMPLE_VENDOR_ID;
     payload.productID = 1;
-    uint64_t tag;
-    VendorTag(EXAMPLE_VENDOR_TAG, tag);
     OptionalQRCodeInfo stringInfo;
-    stringInfo.tag  = tag;
+    stringInfo.tag  = EXAMPLE_VENDOR_TAG;
     stringInfo.type = optionalQRCodeInfoTypeString;
     stringInfo.data = ap_ssid;
-    payload.addOptionalData(stringInfo);
+    payload.addVendorOptionalData(stringInfo);
     QRCodeSetupPayloadGenerator generator(payload);
     string result;
     uint8_t tlvDataStart[sizeof(ap_ssid)];

--- a/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
@@ -169,8 +169,8 @@
     if ([payload.vendorID isEqualToNumber:[NSNumber numberWithInt:EXAMPLE_VENDOR_ID]]) {
         NSArray * optionalInfo = [payload getAllOptionalData:nil];
         for (CHIPOptionalQRCodeInfo * info in optionalInfo) {
-            NSNumber * tag = [CHIPSetupPayload vendorTag:info.tag error:nil];
-            if (tag && tag.intValue == EXAMPLE_VENDOR_TAG) {
+            NSNumber * tag = info.tag;
+            if (tag && tag.unsignedCharValue == EXAMPLE_VENDOR_TAG) {
                 // If the vendor id and tag match the example values, there should be an ssid encoded
                 if ([info.infoType isEqualToNumber:[NSNumber numberWithInt:kOptionalQRCodeInfoTypeString]]) {
                     if ([info.stringValue length] > MAX_SSID_LEN) {

--- a/src/darwin/Framework/CHIP/CHIPSetupPayload.h
+++ b/src/darwin/Framework/CHIP/CHIPSetupPayload.h
@@ -45,7 +45,6 @@ typedef NS_ENUM(NSUInteger, OptionalQRCodeInfoType) { kOptionalQRCodeInfoTypeStr
 
 @property (nonatomic, strong) NSString * serialNumber;
 - (NSArray<CHIPOptionalQRCodeInfo *> *)getAllOptionalData:(NSError * __autoreleasing *)error;
-+ (NSNumber *)vendorTag:(NSNumber *)tagNumber error:(NSError * __autoreleasing *)error;
 
 #ifdef __cplusplus
 - (id)initWithSetupPayload:(chip::SetupPayload)setupPayload;

--- a/src/darwin/Framework/CHIP/CHIPSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/CHIPSetupPayload.mm
@@ -47,7 +47,7 @@
     vector<chip::OptionalQRCodeInfo> chipOptionalData = _chipSetupPayload.getAllOptionalData();
     for (chip::OptionalQRCodeInfo chipInfo : chipOptionalData) {
         CHIPOptionalQRCodeInfo * info = [CHIPOptionalQRCodeInfo new];
-        info.tag = [NSNumber numberWithUnsignedLongLong:chipInfo.tag];
+        info.tag = [NSNumber numberWithUnsignedChar:chipInfo.tag];
         switch (chipInfo.type) {
         case chip::optionalQRCodeInfoTypeString:
             info.infoType = [NSNumber numberWithInt:kOptionalQRCodeInfoTypeString];
@@ -66,18 +66,5 @@
         [allOptionalData addObject:info];
     }
     return allOptionalData;
-}
-
-+ (NSNumber *)vendorTag:(NSNumber *)tagNumber error:(NSError * __autoreleasing *)error
-{
-    uint64_t outTag;
-    NSNumber * vendorTag;
-    CHIP_ERROR chipError = chip::VendorTag(tagNumber.unsignedShortValue, outTag);
-    if (chipError == CHIP_NO_ERROR) {
-        vendorTag = [NSNumber numberWithUnsignedLongLong:outTag];
-    } else if (error) {
-        *error = [CHIPError errorForCHIPErrorCode:chipError];
-    }
-    return vendorTag;
 }
 @end

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -87,9 +87,9 @@ static void addCHIPInfoToOptionalData(SetupPayload & outPayload)
     {
         OptionalQRCodeInfo info;
         info.type = optionalQRCodeInfoTypeString;
-        info.tag  = ContextTag(kSerialNumberTag);
+        info.tag  = kSerialNumberTag;
         info.data = outPayload.serialNumber;
-        outPayload.addOptionalData(info);
+        outPayload.addCHIPOptionalData(info);
     }
 }
 
@@ -100,12 +100,12 @@ CHIP_ERROR writeOptionaData(TLVWriter & writer, vector<OptionalQRCodeInfo> optio
     {
         if (info.type == optionalQRCodeInfoTypeString)
         {
-            err = writer.PutString(info.tag, info.data.c_str());
+            err = writer.PutString(ContextTag(info.tag), info.data.c_str());
             SuccessOrExit(err);
         }
         else if (info.type == optionalQRCodeInfoTypeInt)
         {
-            err = writer.Put(info.tag, static_cast<int64_t>(info.integer));
+            err = writer.Put(ContextTag(info.tag), static_cast<int64_t>(info.integer));
             SuccessOrExit(err);
         }
     }

--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -84,12 +84,14 @@ exit:
 static CHIP_ERROR retrieveStringOptionalInfo(TLVReader & reader, OptionalQRCodeInfo & info)
 {
     CHIP_ERROR err     = CHIP_NO_ERROR;
+    uint64_t tag       = reader.GetTag();
     uint32_t valLength = reader.GetLength();
     char * val         = new char[valLength + 1];
     err                = reader.GetString(val, valLength + 1);
     SuccessOrExit(err);
+    VerifyOrExit(IsContextTag(tag) == true, err = CHIP_ERROR_INVALID_TLV_TAG);
     info.type = optionalQRCodeInfoTypeString;
-    info.tag  = reader.GetTag();
+    info.tag  = (uint8_t) TagNumFromTag(tag);
     info.data = string(val);
 exit:
     delete[] val;
@@ -99,27 +101,27 @@ exit:
 static CHIP_ERROR retrieveIntegerOptionalInfo(TLVReader & reader, OptionalQRCodeInfo & info)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
+    uint64_t tag   = reader.GetTag();
     int64_t storedInteger;
     err = reader.Get(storedInteger);
-    if (err != CHIP_NO_ERROR)
-    {
-        return err;
-    }
+    SuccessOrExit(err);
+    VerifyOrExit(IsContextTag(tag) == true, err = CHIP_ERROR_INVALID_TLV_TAG);
     info.type    = optionalQRCodeInfoTypeInt;
-    info.tag     = reader.GetTag();
+    info.tag     = (uint8_t) TagNumFromTag(tag);
     info.integer = storedInteger;
+exit:
     return err;
 }
 
 static void populatePayloadTLVField(SetupPayload & outPayload, OptionalQRCodeInfo info)
 {
-    if (info.tag == ContextTag(kSerialNumberTag))
+    if (info.tag == kSerialNumberTag)
     {
         outPayload.serialNumber = info.data;
     }
     else
     {
-        outPayload.addOptionalData(info);
+        outPayload.addVendorOptionalData(info);
     }
 }
 

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -27,6 +27,7 @@
 #include <core/CHIPTLV.h>
 #include <core/CHIPTLVData.hpp>
 #include <core/CHIPTLVUtilities.hpp>
+#include <support/CodeUtils.h>
 #include <support/RandUtils.h>
 
 using namespace chip;
@@ -85,10 +86,22 @@ bool SetupPayload::isValidManualCode()
     return true;
 }
 
-CHIP_ERROR SetupPayload::addOptionalData(OptionalQRCodeInfo info)
+CHIP_ERROR SetupPayload::addVendorOptionalData(OptionalQRCodeInfo info)
 {
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    VerifyOrExit(info.tag < 1 << kRawVendorTagLengthInBits, err = CHIP_ERROR_INVALID_ARGUMENT);
     optionalData[info.tag] = info;
-    return CHIP_NO_ERROR;
+exit:
+    return err;
+}
+
+CHIP_ERROR SetupPayload::addCHIPOptionalData(OptionalQRCodeInfo info)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    VerifyOrExit(info.tag >= 1 << kRawVendorTagLengthInBits, err = CHIP_ERROR_INVALID_ARGUMENT);
+    optionalData[info.tag] = info;
+exit:
+    return err;
 }
 
 vector<OptionalQRCodeInfo> SetupPayload::getAllOptionalData()
@@ -101,23 +114,13 @@ vector<OptionalQRCodeInfo> SetupPayload::getAllOptionalData()
     return returnedOptionalInfo;
 }
 
-CHIP_ERROR SetupPayload::removeOptionalData(uint64_t tag)
+CHIP_ERROR SetupPayload::removeOptionalData(uint8_t tag)
 {
     if (optionalData.find(tag) == optionalData.end())
     {
         return CHIP_ERROR_KEY_NOT_FOUND;
     }
     optionalData.erase(tag);
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR VendorTag(uint16_t tagNumber, uint64_t & outVendorTag)
-{
-    if (tagNumber >= 1 << kRawVendorTagLengthInBits)
-    {
-        return CHIP_ERROR_INVALID_ARGUMENT;
-    }
-    outVendorTag = ContextTag(tagNumber);
     return CHIP_NO_ERROR;
 }
 

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -81,20 +81,11 @@ enum optionalQRCodeInfoType
  **/
 struct OptionalQRCodeInfo
 {
-    uint64_t tag;
+    uint8_t tag;
     enum optionalQRCodeInfoType type;
     int integer;
     string data;
 };
-
-/**
- * @brief A function to retrieve a vendor tag
- * @param tagNumber Tag number is 7 bits long
- * @param outVendorTag A 64-bit integer representing the tag
- *                     to use in OptionalQRCodeInfo
- * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
- **/
-CHIP_ERROR VendorTag(uint16_t tagNumber, uint64_t & outVendorTag);
 
 class SetupPayload
 {
@@ -114,18 +105,24 @@ public:
      **/
     vector<OptionalQRCodeInfo> getAllOptionalData();
 
-    /** @brief A function to add an optional QR Code info object
+    /** @brief A function to add an optional QR Code info vendor object
      * @param info Optional QR code info object to add
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR addOptionalData(OptionalQRCodeInfo info);
+    CHIP_ERROR addVendorOptionalData(OptionalQRCodeInfo info);
+
+    /** @brief A function to add an optional QR Code info CHIP object
+     * @param info Optional QR code info object to add
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR addCHIPOptionalData(OptionalQRCodeInfo info);
 
     /** @brief A function to remove an optional QR Code info object
      * @param tag Optional QR code info tag number to remove
      * @return Returns CHIP_ERROR_KEY_NOT_FOUND if info could not be found in existing optional data structs,
      *                 CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR removeOptionalData(uint64_t tag);
+    CHIP_ERROR removeOptionalData(uint8_t tag);
 
     // Test that the Setup Payload is within expected value ranges
     SetupPayload() :

--- a/src/setup_payload/tests/TestQRCodeTLV.cpp
+++ b/src/setup_payload/tests/TestQRCodeTLV.cpp
@@ -122,6 +122,10 @@ void TestOptionalTagValues(nlTestSuite * inSuite, void * inContext)
     err = payload.addVendorOptionalData(stringInfo);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
+    stringInfo.tag = 0;
+    err            = payload.addVendorOptionalData(stringInfo);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
     stringInfo.tag = 128;
     err            = payload.addVendorOptionalData(stringInfo);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);


### PR DESCRIPTION
 #### Problem
Right now, when creating a QR code, we get the current flow:
1) Vendor has an 7bit tag
2) Calls VendorTag(tag, outTag) and gets back a 64 bit outTag
3) outTag is encoded

The commissioning app then pulls out this 64 bit tag and has to call VendorTag with their original value to compare it.

 #### Summary of Changes
Vendor encodes a 7 bit tag number, SetupPayload implementation calls VendorTag behind the scene and when the qr code is parsed, it turns the 64 bit tag back into the 7 bit tag number provided by vendor.

fixes #958 
