### PR TITLE
Store example app binaries as CI artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,14 @@ jobs:
     - run:
         command: scripts/examples/nrf_lock_app.sh
         name: Build example nRF5 Lock App
+    - run:
+        command: |
+          mkdir -p example_binaries/nrf-build
+          cp examples/lock-app/nrf5/build/chip-nrf52840-lock-example.out \
+             example_binaries/nrf-build/chip-nrf52840-lock-example.out
+        name: Preserve artifacts
+    - store_artifacts:
+        path: example_binaries/nrf-build
   Deploy [main-build]:
     docker:
     - image: connectedhomeip/chip-build:0.2.11
@@ -90,6 +98,14 @@ jobs:
     - run:
         command: scripts/examples/standalone_echo_client.sh
         name: Build example Standalone Echo Client
+    - run:
+        command: |
+          mkdir -p example_binaries/main-build
+          cp examples/chip-tool/build/chip-standalone-demo.out \
+             example_binaries/main-build/chip-standalone-demo.out
+        name: Preserve artifacts
+    - store_artifacts:
+        path: example_binaries/main-build
   Run Tests [ESP32-QEMU]:
     docker:
     - image: connectedhomeip/chip-build-esp32-qemu:0.2.11
@@ -254,6 +270,14 @@ jobs:
     - run:
         command: scripts/examples/esp_echo_app.sh
         name: Build example Echo App
+    - run:
+        command: |
+          mkdir -p example_binaries/esp32-build
+          cp examples/wifi-echo/server/esp32/build/chip-wifi-echo.elf \
+             example_binaries/esp32-build/chip-wifi-echo.elf
+        name: Preserve artifacts
+    - store_artifacts:
+        path: example_binaries/esp32-build
   Run Tests [clang-build]:
     docker:
     - image: connectedhomeip/chip-build:0.2.11

--- a/.circleci/config/jobs/examples_esp32.yml
+++ b/.circleci/config/jobs/examples_esp32.yml
@@ -6,3 +6,11 @@ steps:
     - run:
           name: Build example Echo App
           command: scripts/examples/esp_echo_app.sh
+    - run:
+          name: Preserve artifacts
+          command: |
+              mkdir -p example_binaries/esp32-build
+              cp examples/wifi-echo/server/esp32/build/chip-wifi-echo.elf \
+                 example_binaries/esp32-build/chip-wifi-echo.elf
+    - store_artifacts:
+          path: example_binaries/esp32-build

--- a/.circleci/config/jobs/examples_nrf.yml
+++ b/.circleci/config/jobs/examples_nrf.yml
@@ -6,3 +6,11 @@ steps:
     - run:
           name: Build example nRF5 Lock App
           command: scripts/examples/nrf_lock_app.sh
+    - run:
+          name: Preserve artifacts
+          command: |
+              mkdir -p example_binaries/nrf-build
+              cp examples/lock-app/nrf5/build/chip-nrf52840-lock-example.out \
+                 example_binaries/nrf-build/chip-nrf52840-lock-example.out
+    - store_artifacts:
+          path: example_binaries/nrf-build

--- a/.circleci/config/jobs/examples_standalone.yml
+++ b/.circleci/config/jobs/examples_standalone.yml
@@ -16,3 +16,11 @@ steps:
     - run:
           name: Build example Standalone Echo Client
           command: scripts/examples/standalone_echo_client.sh
+    - run:
+          name: Preserve artifacts
+          command: |
+              mkdir -p example_binaries/<<parameters.builder>>
+              cp examples/chip-tool/build/chip-standalone-demo.out \
+                 example_binaries/<<parameters.builder>>/chip-standalone-demo.out
+    - store_artifacts:
+          path: example_binaries/<<parameters.builder>>


### PR DESCRIPTION
 #### Problem
We need a way to compare effects of code in output binaries

 #### Summary of Changes
Use save_artifacts to store example apps in our CI builds.
