### PR TITLE
Add an option to keep the M5Stack's display on all the time

### DIFF
--- a/examples/wifi-echo/server/esp32/main/Display.cpp
+++ b/examples/wifi-echo/server/esp32/main/Display.cpp
@@ -58,8 +58,10 @@ extern const char * TAG;
 uint16_t DisplayHeight = 0;
 uint16_t DisplayWidth  = 0;
 
+#if CONFIG_DISPLAY_AUTO_OFF
 // FreeRTOS timer used to turn the display off after a short while
 TimerHandle_t displayTimer = NULL;
+#endif
 
 static void TimerCallback(TimerHandle_t xTimer);
 static void SetupBrightnessControl();
@@ -130,7 +132,9 @@ esp_err_t InitDisplay()
     // prepare the display for brightness control
     SetupBrightnessControl();
 
+#if CONFIG_DISPLAY_AUTO_OFF
     displayTimer = xTimerCreate("DisplayTimer", pdMS_TO_TICKS(DISPLAY_TIMEOUT_MS), false, NULL, TimerCallback);
+#endif
     // lower the brightness of the screen
     WakeDisplay();
 
@@ -150,8 +154,10 @@ void SetBrightness(uint16_t brightness_percent)
 void WakeDisplay()
 {
     SetBrightness(DEFFAULT_BRIGHTNESS_PERCENT);
+#if CONFIG_DISPLAY_AUTO_OFF
     xTimerStart(displayTimer, 0);
     ESP_LOGI(TAG, "Display awake but will switch off automatically in %d seconds", DISPLAY_TIMEOUT_MS / 1000);
+#endif
 }
 
 void ClearDisplay()

--- a/examples/wifi-echo/server/esp32/main/Kconfig.projbuild
+++ b/examples/wifi-echo/server/esp32/main/Kconfig.projbuild
@@ -50,11 +50,11 @@ menu "WiFi Echo Demo"
             tested easily
 
     config ECHO_HOST_IP
-    string "IPV4 address"
-    default "127.0.0.1"
-    depends on USE_ECHO_CLIENT
-    help
-        The IPV4 Address of the ECHO Server.
+        string "IPV4 address"
+        default "127.0.0.1"
+        depends on USE_ECHO_CLIENT
+        help
+            The IPV4 Address of the ECHO Server.
 
     # NOTE: This config is not displayed as a input in the Kconfig menu, as its value is
     # entirely derived from the Device Type choice.  However the CONFIG_EXAMPLE_DISPLAY_TYPE
@@ -64,6 +64,13 @@ menu "WiFi Echo Demo"
         range 0 5
         default 3 if DEVICE_TYPE_M5STACK
         default 0 if DEVICE_TYPE_ESP32_DEVKITC
+
+    config DISPLAY_AUTO_OFF
+        bool "Automatically turn off the M5Stack's Display after a few seconds"
+        default "y"
+        depends on DEVICE_TYPE_M5STACK
+        help
+            To reduce wear and heat the M5Stack's Display is automatically switched off after a few seconds
 
 
 endmenu


### PR DESCRIPTION
 #### Problem
The M5Stack's display will automatically switch off after a few seconds. Sometimes it's useful for it to remain on when debugging or testing something

 #### Summary of Changes
Added an option to keep the display on all the time. The default behavior is to timeout the display for wear and heat protection.
 