### PR TITLE
remove duplicate Log() implementations, export CHIPs Log()

### DIFF
--- a/src/ble/BleLayer.am
+++ b/src/ble/BleLayer.am
@@ -29,18 +29,18 @@ CHIP_BUILD_BLE_LAYER_SOURCE_FILES                         = \
     @top_builddir@/src/ble/BleLayer.cpp                     \
     @top_builddir@/src/ble/BleUUID.cpp                      \
     @top_builddir@/src/ble/BLEEndPoint.cpp                  \
-    @top_builddir@/src/ble/BtpEngine.cpp                     \
+    @top_builddir@/src/ble/BtpEngine.cpp                    \
     $(NULL)
 
 CHIP_BUILD_BLE_LAYER_HEADER_FILES                         = \
-    CHIPBleServiceData.h                                    \
-    BLEEndPoint.h                                           \
-    Ble.h                                                   \
-    BleApplicationDelegate.h                                \
-    BleConfig.h                                             \
-    BleError.h                                              \
-    BleLayer.h                                              \
-    BlePlatformDelegate.h                                   \
-    BleUUID.h                                               \
-    BtpEngine.h                                              \
+    @top_builddir@/src/ble/CHIPBleServiceData.h             \
+    @top_builddir@/src/ble/BLEEndPoint.h                    \
+    @top_builddir@/src/ble/Ble.h                            \
+    @top_builddir@/src/ble/BleApplicationDelegate.h         \
+    @top_builddir@/src/ble/BleConfig.h                      \
+    @top_builddir@/src/ble/BleError.h                       \
+    @top_builddir@/src/ble/BleLayer.h                       \
+    @top_builddir@/src/ble/BlePlatformDelegate.h            \
+    @top_builddir@/src/ble/BleUUID.h                        \
+    @top_builddir@/src/ble/BtpEngine.h                      \
     $(NULL)

--- a/src/crypto/Crypto.am
+++ b/src/crypto/Crypto.am
@@ -1,0 +1,44 @@
+#
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+#
+#    Description:
+#      This file lists the files that go into the CHIP crypto
+#      library.
+#
+
+# for all configs
+CHIP_BUILD_CRYPTO_SOURCE_FILES                          = \
+    $(NULL)
+
+CHIP_BUILD_CRYPTO_HEADER_FILES                          = \
+    @top_builddir@/src/crypto/CHIPCryptoPAL.h             \
+    $(NULL)
+
+# source by config
+if CHIP_CRYPTO_OPENSSL
+CHIP_BUILD_CRYPTO_SOURCE_FILES                         += \
+    @top_builddir@/src/crypto/CHIPCryptoPALOpenSSL.cpp    \
+    $(NULL)
+endif
+
+if CHIP_CRYPTO_MBEDTLS
+CHIP_BUILD_CRYPTO_SOURCE_FILES                         += \
+    @top_builddir@/src/crypto/CHIPCryptoPALmbedTLS.cpp    \
+    $(NULL)
+endif
+

--- a/src/crypto/Makefile.am
+++ b/src/crypto/Makefile.am
@@ -23,14 +23,14 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
+
 SUBDIRS                    = tests
 
 lib_LIBRARIES              = libChipCrypto.a
 
-libChipCrypto_adir             = $(includedir)/crypto
+libChipCrypto_adir         = $(includedir)/crypto
 
 libChipCrypto_a_CPPFLAGS            = \
-    $(LWIP_CPPFLAGS)                  \
     $(NLASSERT_CPPFLAGS)              \
     -I$(top_srcdir)/src               \
     -I$(top_srcdir)/src/lib           \
@@ -38,23 +38,14 @@ libChipCrypto_a_CPPFLAGS            = \
     -I$(top_srcdir)/src/include/      \
     $(NULL)
 
-libChipCrypto_a_SOURCES                                       = \
+include Crypto.am
+
+libChipCrypto_a_SOURCES                                      = \
+    $(CHIP_BUILD_CRYPTO_SOURCE_FILES)                          \
     $(NULL)
 
 dist_libChipCrypto_a_HEADERS                                 = \
-    CHIPCryptoPAL.h                                            \
+    $(CHIP_BUILD_CRYPTO_HEADER_FILES)                          \
     $(NULL)
-
-if CHIP_CRYPTO_OPENSSL
-libChipCrypto_a_SOURCES                                      += \
-    CHIPCryptoPALOpenSSL.cpp                                    \
-    $(NULL)
-endif
-
-if CHIP_CRYPTO_MBEDTLS
-libChipCrypto_a_SOURCES                                      += \
-    CHIPCryptoPALmbedTLS.cpp                                    \
-    $(NULL)
-endif
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -789,13 +789,6 @@ void LogV(uint8_t module, uint8_t category, const char * format, va_list argptr)
     (void) module, (void) category;
     vfprintf(stderr, format, argptr);
 }
-void Log(uint8_t module, uint8_t category, const char * format, ...)
-{
-    va_list argptr;
-    va_start(argptr, format);
-    LogV(module, category, format, argptr);
-    va_end(argptr);
-}
 } // namespace Logging
 } // namespace chip
 

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -37,6 +37,7 @@ include ../system/SystemLayer.am
 include ../transport/TransportLayer.am
 include core/CoreLayer.am
 include support/SupportLayer.am
+include ../crypto/Crypto.am
 include ../app/DataModel.am
 
 # install headers for core layer
@@ -75,6 +76,7 @@ libCHIP_a_SOURCES                  += $(CHIP_BUILD_SUPPORT_LAYER_SOURCE_FILES)
 libCHIP_a_SOURCES                  += $(CHIP_BUILD_DEVICE_CONTROLLER_SOURCE_FILES)
 libCHIP_a_SOURCES                  += $(CHIP_BUILD_DATA_MODEL_SOURCE_FILES)
 libCHIP_a_SOURCES                  += $(CHIP_BUILD_TRANSPORT_LAYER_SOURCE_FILES)
+libCHIP_a_SOURCES                  += $(CHIP_BUILD_CRYPTO_SOURCE_FILES)
 
 if CONFIG_NETWORK_LAYER_BLE
 libCHIP_a_SOURCES                  += $(CHIP_BUILD_BLE_LAYER_SOURCE_FILES)

--- a/src/lib/core/CoreLayer.am
+++ b/src/lib/core/CoreLayer.am
@@ -24,31 +24,31 @@
 #
 
 CHIP_BUILD_CORE_LAYER_SOURCE_FILES                        = \
-    core/CHIPCircularTLVBuffer.cpp                          \
-    core/CHIPError.cpp                                      \
-    core/CHIPTLVDebug.cpp                                   \
-    core/CHIPTLVReader.cpp                                  \
-    core/CHIPTLVUtilities.cpp                               \
-    core/CHIPTLVWriter.cpp                                  \
-    core/CHIPTLVUpdater.cpp                                 \
-    core/CHIPKeyIds.cpp                                     \
+    @top_builddir@/src/lib/core/CHIPCircularTLVBuffer.cpp   \
+    @top_builddir@/src/lib/core/CHIPError.cpp               \
+    @top_builddir@/src/lib/core/CHIPTLVDebug.cpp            \
+    @top_builddir@/src/lib/core/CHIPTLVReader.cpp           \
+    @top_builddir@/src/lib/core/CHIPTLVUtilities.cpp        \
+    @top_builddir@/src/lib/core/CHIPTLVWriter.cpp           \
+    @top_builddir@/src/lib/core/CHIPTLVUpdater.cpp          \
+    @top_builddir@/src/lib/core/CHIPKeyIds.cpp              \
     $(NULL)
 
 CHIP_BUILD_CORE_LAYER_HEADER_FILES                        = \
-    core/CHIPCircularTLVBuffer.h                            \
-    core/CHIPConfig.h                                       \
-    core/CHIPCore.h                                         \
-    core/CHIPEncoding.h                                     \
-    core/CHIPError.h                                        \
-    core/CHIPEventLoggingConfig.h                           \
-    core/CHIPTLV.h                                          \
-    core/CHIPTLVData.hpp                                    \
-    core/CHIPTLVDebug.hpp                                   \
-    core/CHIPTLVTags.h                                      \
-    core/CHIPTLVTypes.h                                     \
-    core/CHIPTLVUtilities.hpp                               \
-    core/CHIPTimeConfig.h                                   \
-    core/CHIPTunnelConfig.h                                 \
-    core/CHIPKeyIds.h                                       \
-    core/Optional.h                                         \
+    @top_builddir@/src/lib/core/CHIPCircularTLVBuffer.h     \
+    @top_builddir@/src/lib/core/CHIPConfig.h                \
+    @top_builddir@/src/lib/core/CHIPCore.h                  \
+    @top_builddir@/src/lib/core/CHIPEncoding.h              \
+    @top_builddir@/src/lib/core/CHIPError.h                 \
+    @top_builddir@/src/lib/core/CHIPEventLoggingConfig.h    \
+    @top_builddir@/src/lib/core/CHIPTLV.h                   \
+    @top_builddir@/src/lib/core/CHIPTLVData.hpp             \
+    @top_builddir@/src/lib/core/CHIPTLVDebug.hpp            \
+    @top_builddir@/src/lib/core/CHIPTLVTags.h               \
+    @top_builddir@/src/lib/core/CHIPTLVTypes.h              \
+    @top_builddir@/src/lib/core/CHIPTLVUtilities.hpp        \
+    @top_builddir@/src/lib/core/CHIPTimeConfig.h            \
+    @top_builddir@/src/lib/core/CHIPTunnelConfig.h          \
+    @top_builddir@/src/lib/core/CHIPKeyIds.h                \
+    @top_builddir@/src/lib/core/Optional.h                  \
     $(NULL)

--- a/src/lib/support/Makefile.am
+++ b/src/lib/support/Makefile.am
@@ -28,7 +28,6 @@ SUBDIRS                             = \
 
 include SupportLayer.am
 
-
 lib_LIBRARIES                       = libSupportLayer.a
 
 libSupportLayer_a_CPPFLAGS                    = \

--- a/src/lib/support/SupportLayer.am
+++ b/src/lib/support/SupportLayer.am
@@ -23,44 +23,45 @@
 #
 
 
-CHIP_BUILD_SUPPORT_LAYER_SOURCE_FILES                     = \
-    @top_builddir@/src/lib/support/Base64.cpp               \
-    @top_builddir@/src/lib/support/CHIPArgParser.cpp        \
-    @top_builddir@/src/lib/support/CHIPCounter.cpp          \
-    @top_builddir@/src/lib/support/CHIPFaultInjection.cpp   \
-    @top_builddir@/src/lib/support/ErrorStr.cpp             \
-    @top_builddir@/src/lib/support/FibonacciUtils.cpp       \
-    @top_builddir@/src/lib/support/logging/CHIPLogging.cpp  \
-    @top_builddir@/src/lib/support/PersistedCounter.cpp     \
-    @top_builddir@/src/lib/support/RandUtils.cpp            \
-    @top_builddir@/src/lib/support/TestUtils.cpp            \
-    @top_builddir@/src/lib/support/TimeUtils.cpp            \
-    @top_builddir@/src/lib/support/verhoeff/Verhoeff.cpp    \
-    @top_builddir@/src/lib/support/verhoeff/Verhoeff10.cpp  \
-    @top_builddir@/src/lib/support/verhoeff/Verhoeff16.cpp  \
-    @top_builddir@/src/lib/support/verhoeff/Verhoeff32.cpp  \
-    @top_builddir@/src/lib/support/verhoeff/Verhoeff36.cpp  \
+CHIP_BUILD_SUPPORT_LAYER_SOURCE_FILES                        = \
+    @top_builddir@/src/lib/support/Base64.cpp                  \
+    @top_builddir@/src/lib/support/CHIPArgParser.cpp           \
+    @top_builddir@/src/lib/support/CHIPCounter.cpp             \
+    @top_builddir@/src/lib/support/CHIPFaultInjection.cpp      \
+    @top_builddir@/src/lib/support/ErrorStr.cpp                \
+    @top_builddir@/src/lib/support/FibonacciUtils.cpp          \
+    @top_builddir@/src/lib/support/logging/CHIPLogging.cpp     \
+    @top_builddir@/src/lib/support/logging/CHIPLoggingLogV.cpp \
+    @top_builddir@/src/lib/support/PersistedCounter.cpp        \
+    @top_builddir@/src/lib/support/RandUtils.cpp               \
+    @top_builddir@/src/lib/support/TestUtils.cpp               \
+    @top_builddir@/src/lib/support/TimeUtils.cpp               \
+    @top_builddir@/src/lib/support/verhoeff/Verhoeff.cpp       \
+    @top_builddir@/src/lib/support/verhoeff/Verhoeff10.cpp     \
+    @top_builddir@/src/lib/support/verhoeff/Verhoeff16.cpp     \
+    @top_builddir@/src/lib/support/verhoeff/Verhoeff32.cpp     \
+    @top_builddir@/src/lib/support/verhoeff/Verhoeff36.cpp     \
     $(NULL)
 
-CHIP_BUILD_SUPPORT_LAYER_HEADER_FILES                     = \
-    @top_builddir@/src/lib/support/CHIPArgParser.hpp        \
-    @top_builddir@/src/lib/support/CHIPCounter.h            \
-    @top_builddir@/src/lib/support/CHIPFaultInjection.h     \
-    @top_builddir@/src/lib/support/CodeUtils.h              \
-    @top_builddir@/src/lib/support/DLLUtil.h                \
-    @top_builddir@/src/lib/support/ErrorStr.h               \
-    @top_builddir@/src/lib/support/FibonacciUtils.h         \
-    @top_builddir@/src/lib/support/FlagUtils.hpp            \
-    @top_builddir@/src/lib/support/logging/CHIPLogging.h    \
-    @top_builddir@/src/lib/support/Base64.h                 \
-    @top_builddir@/src/lib/support/PersistedCounter.h       \
-    @top_builddir@/src/lib/support/RandUtils.h              \
-    @top_builddir@/src/lib/support/TestUtils.h              \
-    @top_builddir@/src/lib/support/TimeUtils.h              \
+CHIP_BUILD_SUPPORT_LAYER_HEADER_FILES                        = \
+    @top_builddir@/src/lib/support/CHIPArgParser.hpp           \
+    @top_builddir@/src/lib/support/CHIPCounter.h               \
+    @top_builddir@/src/lib/support/CHIPFaultInjection.h        \
+    @top_builddir@/src/lib/support/CodeUtils.h                 \
+    @top_builddir@/src/lib/support/DLLUtil.h                   \
+    @top_builddir@/src/lib/support/ErrorStr.h                  \
+    @top_builddir@/src/lib/support/FibonacciUtils.h            \
+    @top_builddir@/src/lib/support/FlagUtils.hpp               \
+    @top_builddir@/src/lib/support/logging/CHIPLogging.h       \
+    @top_builddir@/src/lib/support/Base64.h                    \
+    @top_builddir@/src/lib/support/PersistedCounter.h          \
+    @top_builddir@/src/lib/support/RandUtils.h                 \
+    @top_builddir@/src/lib/support/TestUtils.h                 \
+    @top_builddir@/src/lib/support/TimeUtils.h                 \
     $(NULL)
 
-CHIP_BUILD_SUPPORT_LAYER_VERHOEFF_HEADER_FILES            = \
-    @top_builddir@/src/lib/support/verhoeff/Verhoeff.h      \
+CHIP_BUILD_SUPPORT_LAYER_VERHOEFF_HEADER_FILES               = \
+    @top_builddir@/src/lib/support/verhoeff/Verhoeff.h         \
     $(NULL)
 
 if CHIP_WITH_NLFAULTINJECTION

--- a/src/lib/support/SupportLayer.am
+++ b/src/lib/support/SupportLayer.am
@@ -22,9 +22,6 @@
 #      must be anchored relative to the top build directory.
 #
 
-AM_CXXFLAGS = \
-    $(NLUNIT_TEST_CPPFLAGS)                                 \
-    $(NULL)
 
 CHIP_BUILD_SUPPORT_LAYER_SOURCE_FILES                     = \
     @top_builddir@/src/lib/support/Base64.cpp               \

--- a/src/lib/support/logging/CHIPLogging.cpp
+++ b/src/lib/support/logging/CHIPLogging.cpp
@@ -150,17 +150,6 @@ uint8_t gLogFilter = kLogCategory_Max;
 
 #endif // CHIP_LOG_FILTERING
 
-#if !CHIP_LOGGING_STYLE_EXTERNAL
-/*
- * Only enable an in-package implementation of the logging interface
- * if external logging was not requested. Within that, the package
- * supports either Android-style or C Standard I/O-style logging.
- *
- * In the event a "weak" variant is specified, i.e
- * CHIP_LOGGING_STYLE_STDIO_WEAK, the in-package implementation will
- * be provided but with "weak" linkage
- */
-
 /**
  * Log, to the platform-specified mechanism, the specified log
  * message, @a msg, for the specified module, @a module, in the
@@ -183,42 +172,7 @@ uint8_t gLogFilter = kLogCategory_Max;
  *                      correspond to the format specifiers in @a msg.
  *
  */
-
-#if CHIP_LOGGING_STYLE_STDIO_WEAK
-#define __CHIP_LOGGING_LINK_ATTRIBUTE __attribute__((weak))
-#else
-#define __CHIP_LOGGING_LINK_ATTRIBUTE
-#endif
-
-DLL_EXPORT __CHIP_LOGGING_LINK_ATTRIBUTE void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
-{
-    if (IsCategoryEnabled(category))
-    {
-
-#if CHIP_LOGGING_STYLE_ANDROID
-
-        char moduleName[ChipLoggingModuleNameLen + 1];
-        GetModuleName(moduleName, module);
-
-        int priority = (category == kLogCategory_Error) ? ANDROID_LOG_ERROR : ANDROID_LOG_DEBUG;
-
-        __android_log_vprint(priority, moduleName, msg, v);
-
-#elif CHIP_LOGGING_STYLE_STDIO || CHIP_LOGGING_STYLE_STDIO_WEAK
-
-        PrintMessagePrefix(module);
-        vprintf(msg, v);
-        printf("\n");
-
-#else
-
-#error "Undefined platform-specific implementation for non-externnal chip logging style!"
-
-#endif /* CHIP_LOGGING_STYLE_ANDROID */
-    }
-}
-
-DLL_EXPORT __CHIP_LOGGING_LINK_ATTRIBUTE void Log(uint8_t module, uint8_t category, const char * msg, ...)
+DLL_EXPORT void Log(uint8_t module, uint8_t category, const char * msg, ...)
 {
     va_list v;
 
@@ -228,7 +182,6 @@ DLL_EXPORT __CHIP_LOGGING_LINK_ATTRIBUTE void Log(uint8_t module, uint8_t catego
 
     va_end(v);
 }
-#endif /* !CHIP_LOGGING_STYLE_EXTERNAL */
 
 DLL_EXPORT uint8_t GetLogFilter()
 {

--- a/src/lib/support/logging/CHIPLoggingLogV.cpp
+++ b/src/lib/support/logging/CHIPLoggingLogV.cpp
@@ -1,0 +1,122 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements macros, constants, and interfaces for a
+ *      platform-independent logging interface for the chip SDK.
+ *
+ */
+
+#include "CHIPLogging.h"
+
+#include <core/CHIPCore.h>
+#include <support/CodeUtils.h>
+#include <support/DLLUtil.h>
+
+#if CHIP_LOGGING_STYLE_ANDROID && defined(__ANDROID__)
+#include <android/log.h>
+#endif
+
+#if HAVE_SYS_TIME_H && CHIP_LOGGING_STYLE_STDIO_WITH_TIMESTAMPS
+#include <sys/time.h>
+#endif // HAVE_SYS_TIME_H && CHIP_LOGGING_STYLE_STDIO_WITH_TIMESTAMPS
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+namespace chip {
+namespace Logging {
+
+#if _CHIP_USE_LOGGING
+
+#if !CHIP_LOGGING_STYLE_EXTERNAL
+/*
+ * Only enable an in-package implementation of the logging interface
+ * if external logging was not requested. Within that, the package
+ * supports either Android-style or C Standard I/O-style logging.
+ *
+ * In the event a "weak" variant is specified, i.e
+ * CHIP_LOGGING_STYLE_STDIO_WEAK, the in-package implementation will
+ * be provided but with "weak" linkage
+ */
+
+/**
+ * Log, to the platform-specified mechanism, the specified log
+ * message, @a msg, for the specified module, @a module, in the
+ * provided category, @a category.
+ *
+ * @param[in] module    A LogModule enumeration indicating the
+ *                      source of the chip package module that
+ *                      generated the log message. This must be
+ *                      translated within the function to a module
+ *                      name for inclusion in the log message.
+ * @param[in] category  A LogCategory enumeration indicating the
+ *                      category of the log message. The category
+ *                      may be filtered in or out if
+ *                      CHIP_LOG_FILTERING was asserted.
+ * @param[in] msg       A pointer to a NULL-terminated C string with
+ *                      C Standard Library-style format specifiers
+ *                      containing the log message to be formatted and
+ *                      logged.
+ * @param[in] v         A variadic argument list whose elements should
+ *                      correspond to the format specifiers in @a msg.
+ *
+ */
+
+#if CHIP_LOGGING_STYLE_STDIO_WEAK
+#define __CHIP_LOGGING_LINK_ATTRIBUTE __attribute__((weak))
+#else
+#define __CHIP_LOGGING_LINK_ATTRIBUTE
+#endif
+
+DLL_EXPORT __CHIP_LOGGING_LINK_ATTRIBUTE void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
+{
+    if (IsCategoryEnabled(category))
+    {
+
+#if CHIP_LOGGING_STYLE_ANDROID
+
+        char moduleName[ChipLoggingModuleNameLen + 1];
+        GetModuleName(moduleName, module);
+
+        int priority = (category == kLogCategory_Error) ? ANDROID_LOG_ERROR : ANDROID_LOG_DEBUG;
+
+        __android_log_vprint(priority, moduleName, msg, v);
+
+#elif CHIP_LOGGING_STYLE_STDIO || CHIP_LOGGING_STYLE_STDIO_WEAK
+
+        PrintMessagePrefix(module);
+        vprintf(msg, v);
+        printf("\n");
+
+#else
+
+#error "Undefined platform-specific implementation for non-externnal chip logging style!"
+
+#endif /* CHIP_LOGGING_STYLE_ANDROID */
+    }
+}
+
+#endif /* !CHIP_LOGGING_STYLE_EXTERNAL */
+
+#endif /* _CHIP_USE_LOGGING */
+
+} // namespace Logging
+} // namespace chip

--- a/src/platform/EFR32/Logging.cpp
+++ b/src/platform/EFR32/Logging.cpp
@@ -213,15 +213,6 @@ void LogV(uint8_t module, uint8_t category, const char * aFormat, va_list v)
 #endif // EFR32_LOG_ENABLED && _CHIP_USE_LOGGING
 }
 
-void Log(uint8_t module, uint8_t category, const char * aFormat, ...)
-{
-    va_list v;
-
-    va_start(v, aFormat);
-    LogV(module, category, aFormat, v);
-    va_end(v);
-}
-
 } // namespace Logging
 } // namespace chip
 

--- a/src/platform/ESP32/Logging.cpp
+++ b/src/platform/ESP32/Logging.cpp
@@ -89,15 +89,6 @@ void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
     }
 }
 
-void Log(uint8_t module, uint8_t category, const char * msg, ...)
-{
-    va_list v;
-
-    va_start(v, msg);
-    LogV(module, category, msg, v);
-    va_end(v);
-}
-
 } // namespace Logging
 
 } // namespace chip

--- a/src/platform/Linux/Logging.cpp
+++ b/src/platform/Linux/Logging.cpp
@@ -67,13 +67,6 @@ void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
         DeviceLayer::OnLogOutput();
     }
 }
-void Log(uint8_t module, uint8_t category, const char * msg, ...)
-{
-    va_list v;
-    va_start(v, msg);
-    LogV(module, category, msg, v);
-    va_end(v);
-}
 
 } // namespace Logging
 } // namespace chip

--- a/src/platform/nRF5/Logging.cpp
+++ b/src/platform/nRF5/Logging.cpp
@@ -78,6 +78,10 @@ NRF_LOG_MODULE_REGISTER();
 namespace chip {
 namespace Logging {
 
+/**
+ * CHIP log output function.
+ */
+
 void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
 {
     (void) module;
@@ -128,18 +132,6 @@ void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
     (void) msg;
     (void) v;
 #endif // NRF_LOG_ENABLED
-}
-
-/**
- * Openchip log output function.
- */
-void Log(uint8_t module, uint8_t category, const char * msg, ...)
-{
-    va_list v;
-
-    va_start(v, msg);
-    LogV(module, category, msg, v);
-    va_end(v);
 }
 
 } // namespace Logging

--- a/src/system/SystemLayer.am
+++ b/src/system/SystemLayer.am
@@ -38,16 +38,16 @@ CHIP_BUILD_SYSTEM_LAYER_SOURCE_FILES += @top_builddir@/src/system/SystemFaultInj
 endif # CHIP_WITH_NLFAULTINJECTION
 
 CHIP_BUILD_SYSTEM_LAYER_HEADER_FILES                  = \
-    SystemAlignSize.h                                   \
-    SystemClock.h                                       \
-    SystemConfig.h                                      \
-    SystemError.h                                       \
-    SystemEvent.h                                       \
-    SystemFaultInjection.h                              \
-    SystemStats.h                                       \
-    SystemLayer.h                                       \
-    SystemMutex.h                                       \
-    SystemObject.h                                      \
-    SystemTimer.h                                       \
-    SystemPacketBuffer.h                                \
+    @top_builddir@/src/system/SystemAlignSize.h         \
+    @top_builddir@/src/system/SystemClock.h             \
+    @top_builddir@/src/system/SystemConfig.h            \
+    @top_builddir@/src/system/SystemError.h             \
+    @top_builddir@/src/system/SystemEvent.h             \
+    @top_builddir@/src/system/SystemFaultInjection.h    \
+    @top_builddir@/src/system/SystemStats.h             \
+    @top_builddir@/src/system/SystemLayer.h             \
+    @top_builddir@/src/system/SystemMutex.h             \
+    @top_builddir@/src/system/SystemObject.h            \
+    @top_builddir@/src/system/SystemTimer.h             \
+    @top_builddir@/src/system/SystemPacketBuffer.h      \
     $(NULL)

--- a/src/transport/TransportLayer.am
+++ b/src/transport/TransportLayer.am
@@ -30,8 +30,8 @@ CHIP_BUILD_TRANSPORT_LAYER_SOURCE_FILES                  = \
     @top_builddir@/src/transport/CHIPSecureChannel.cpp     \
     $(NULL)
 
-CHIP_BUILD_TRANSPORT_LAYER_HEADER_FILES  = \
-    MessageHeader.h                        \
-    UdpTransport.h                         \
-    CHIPSecureChannel.h                    \
+CHIP_BUILD_TRANSPORT_LAYER_HEADER_FILES             = \
+    @top_builddir@/src/transport/MessageHeader.h      \
+    @top_builddir@/src/transport/UdpTransport.h       \
+    @top_builddir@/src/transport/CHIPSecureChannel.h  \
     $(NULL)

--- a/src/transport/tests/Makefile.am
+++ b/src/transport/tests/Makefile.am
@@ -67,7 +67,6 @@ AM_CPPFLAGS                                           = \
     $(NULL)
 
 CHIP_LDADD                                            = \
-    $(top_builddir)/src/crypto/libChipCrypto.a          \
     $(top_builddir)/src/lib/libCHIP.a                   \
     $(NULL)
 

--- a/src/transport/tests/Makefile.am
+++ b/src/transport/tests/Makefile.am
@@ -67,8 +67,8 @@ AM_CPPFLAGS                                           = \
     $(NULL)
 
 CHIP_LDADD                                            = \
-    $(top_builddir)/src/lib/libCHIP.a                   \
     $(top_builddir)/src/crypto/libChipCrypto.a          \
+    $(top_builddir)/src/lib/libCHIP.a                   \
     $(NULL)
 
 COMMON_LDADD                                          = \
@@ -124,6 +124,7 @@ NLFOREIGN_FILE_DEPENDENCIES                           = \
 
 NLFOREIGN_SUBDIR_DEPENDENCIES                         = \
    $(LWIP_FOREIGN_SUBDIR_DEPENDENCY)                    \
+   $(NLFAULTINJECTION_FOREIGN_SUBDIR_DEPENDENCY)        \
    $(NLUNIT_TEST_FOREIGN_SUBDIR_DEPENDENCY)             \
    $(NULL)
 

--- a/src/transport/tests/TestCHIPSecureChannel.cpp
+++ b/src/transport/tests/TestCHIPSecureChannel.cpp
@@ -240,12 +240,5 @@ void LogV(uint8_t module, uint8_t category, const char * format, va_list argptr)
     (void) module, (void) category;
     vfprintf(stderr, format, argptr);
 }
-void Log(uint8_t module, uint8_t category, const char * format, ...)
-{
-    va_list argptr;
-    va_start(argptr, format);
-    LogV(module, category, format, argptr);
-    va_end(argptr);
-}
 } // namespace Logging
 } // namespace chip


### PR DESCRIPTION
#### Problem
 everyone not using chip::Logging::LogV() had to provide their own chip::Logging::Log(), which were all identical

 #### Summary of Changes
 consolidation