### PR TITLE
Add a LED Status Indicator to the M5Stack's display

### DIFF
--- a/examples/wifi-echo/server/esp32/main/Display.cpp
+++ b/examples/wifi-echo/server/esp32/main/Display.cpp
@@ -37,7 +37,8 @@
 
 #if CONFIG_HAVE_DISPLAY
 
-#define DEFFAULT_BRIGHTNESS_PERCENT 80
+// Brightness picked such that it's easy for cameras to focus on
+#define DEFFAULT_BRIGHTNESS_PERCENT 10
 
 // 8MHz is the recommended SPI speed to init the driver with
 // It later gets set to the preconfigured defaults within the driver
@@ -162,7 +163,24 @@ void WakeDisplay()
 
 void ClearDisplay()
 {
-    TFT_fillRect(0, 0, (int) DisplayWidth, (int) DisplayHeight, TFT_BLACK);
+    ClearRect();
+}
+
+void ClearRect(uint16_t x_percent_start, uint16_t y_percent_start, uint16_t x_percent_end, uint16_t y_percent_end)
+{
+    if (x_percent_end < x_percent_start)
+    {
+        x_percent_end = x_percent_start;
+    }
+    if (y_percent_end < y_percent_start)
+    {
+        y_percent_end = y_percent_start;
+    }
+    uint16_t start_x = (DisplayWidth * x_percent_start) / 100;
+    uint16_t start_y = (DisplayHeight * y_percent_start) / 100;
+    uint16_t end_x   = (DisplayWidth * x_percent_end) / 100;
+    uint16_t end_y   = (DisplayHeight * y_percent_end) / 100;
+    TFT_fillRect(start_x, start_y, end_x, end_y, TFT_BLACK);
 }
 
 void DisplayStatusMessage(char * msg, uint16_t vpos)

--- a/examples/wifi-echo/server/esp32/main/LEDWidget.cpp
+++ b/examples/wifi-echo/server/esp32/main/LEDWidget.cpp
@@ -16,12 +16,35 @@
  *    limitations under the License.
  */
 
+/**
+ * @file LEDWidget.cpp
+ *
+ * Implements an LED Widget controller that is usually tied to a GPIO
+ * It also updates the display widget if it's enabled
+ */
+
 #include "LEDWidget.h"
+#include "Display.h"
 
 #include "driver/gpio.h"
 #include "esp_log.h"
 #include "esp_system.h"
 #include "esp_timer.h"
+
+#if CONFIG_HAVE_DISPLAY
+// The Y position of the LED Status message on screen as a
+// percentage of the screen's height.
+#define LED_STATUS_POSITION 85
+// Position the LED Indicator at the bottom right corner
+#define LED_INDICATOR_X 92
+#define LED_INDICATOR_Y 88
+// The radius of the LED Indicator
+#define LED_INDICATOR_R_PX 16
+
+static const char * onMsg  = "LIGHT: ON";
+static const char * offMsg = "LIGHT: OFF";
+
+#endif
 
 extern const char * TAG;
 
@@ -75,9 +98,48 @@ void LEDWidget::Animate()
 
 void LEDWidget::DoSet(bool state)
 {
-    mState = state;
+    bool stateChange = mState != state;
+    mState           = state;
     if (mGPIONum < GPIO_NUM_MAX)
     {
         gpio_set_level(mGPIONum, (state) ? 1 : 0);
     }
+    if (stateChange)
+    {
+#if CONFIG_HAVE_DISPLAY
+
+        Display();
+        // If a status change occured, wake the display
+        WakeDisplay();
+#endif
+    }
 }
+
+#if CONFIG_HAVE_DISPLAY
+void LEDWidget::Display()
+{
+    uint16_t msgX    = 0;
+    uint16_t msgY    = (DisplayHeight * LED_STATUS_POSITION) / 100;
+    uint16_t circleX = (LED_INDICATOR_X * DisplayWidth) / 100;
+    uint16_t circleY = (LED_INDICATOR_Y * DisplayHeight) / 100;
+
+    // Wipe the Light Status Area
+    ClearRect(0, LED_STATUS_POSITION);
+    // Wipe the status circle
+    TFT_fillCircle(circleX, circleY, LED_INDICATOR_R_PX, TFT_BLACK);
+    // Display the Light Status on screen
+    TFT_setFont(DEJAVU24_FONT, NULL);
+    // Draw the default "Off" indicator
+    TFT_drawCircle(circleX, circleY, LED_INDICATOR_R_PX, TFT_DARKGREY);
+    if (mState)
+    {
+        TFT_print((char *) onMsg, msgX, msgY);
+        // Draw the "ON" indicator
+        TFT_fillCircle(circleX, circleY, LED_INDICATOR_R_PX, TFT_GREEN);
+    }
+    else
+    {
+        TFT_print((char *) offMsg, msgX, msgY);
+    }
+}
+#endif

--- a/examples/wifi-echo/server/esp32/main/include/Display.h
+++ b/examples/wifi-echo/server/esp32/main/include/Display.h
@@ -67,6 +67,19 @@ extern esp_err_t InitDisplay();
 extern void ClearDisplay();
 /**
  * @brief
+ *  Clear a portion of the display by drawing a black rectangle based on the given arguments
+ *
+ *  Calling this with default arguments is the same as calling `ClearDisplay()`.
+ *
+ * @param x_percent_start   The starting x coordinate specified as a percentage of the screen's width.
+ * @param y_percent_start   The starting y coordinate specified as a percentage of the screen's height.
+ * @param x_percent_end     The end x coordinate specified as a percentage of the screen's width.
+ * @param y_percent_end     The end y coordinate specified as a percentage of the screen's height.
+ */
+extern void ClearRect(uint16_t x_percent_start = 0, uint16_t y_percent_start = 0, uint16_t x_percent_end = 100,
+                      uint16_t y_percent_end = 100);
+/**
+ * @brief
  *  Display a status message at a given vertical position
  *
  *  The status message will be drawn from the left edge of the screen

--- a/examples/wifi-echo/server/esp32/main/include/LEDWidget.h
+++ b/examples/wifi-echo/server/esp32/main/include/LEDWidget.h
@@ -20,6 +20,8 @@
 #ifndef LED_WIDGET_H
 #define LED_WIDGET_H
 
+#include "Display.h"
+
 #include "driver/gpio.h"
 
 class LEDWidget
@@ -30,6 +32,9 @@ public:
     void Blink(uint32_t changeRateMS);
     void Blink(uint32_t onTimeMS, uint32_t offTimeMS);
     void Animate();
+#if CONFIG_HAVE_DISPLAY
+    void Display();
+#endif
 
 private:
     int64_t mLastChangeTimeUS;

--- a/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
@@ -72,7 +72,6 @@ static QRCodeWidget sQRCodeWidget;
 
 LEDWidget statusLED;
 static Button attentionButton;
-static volatile ConnectivityChange sConnectionState = kConnectivity_NoChange;
 
 const char * TAG = "wifi-echo-demo";
 
@@ -193,6 +192,7 @@ extern "C" void app_main()
     // Display the UI widgets.
     ClearDisplay();
     sQRCodeWidget.Display();
+    statusLED.Display();
 
 #endif // CONFIG_HAVE_DISPLAY
 
@@ -209,37 +209,6 @@ extern "C" void app_main()
             WakeDisplay();
         }
 
-        switch (sConnectionState)
-        {
-        case kConnectivity_Established:
-            // Show the currently connected state
-            tcpip_adapter_ip_info_t ipInfo;
-            if (tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_STA, &ipInfo) == ESP_OK)
-            {
-                char ipAddrStr[INET_ADDRSTRLEN];
-                IPAddress::FromIPv4(ipInfo.ip).ToString(ipAddrStr, sizeof(ipAddrStr));
-                wifi_ap_record_t apInfo;
-                if (esp_wifi_sta_get_ap_info(&apInfo) == ESP_OK)
-                {
-                    char message[256];
-                    snprintf(message, sizeof(message), "WiFi Connected: %s\nEcho Server at %s:%d", (char *) apInfo.ssid, ipAddrStr,
-                             CONFIG_ECHO_PORT);
-                    // place it close to the bottom of the screen
-                    DisplayStatusMessage(message, 85);
-                }
-            }
-            sConnectionState = kConnectivity_NoChange;
-            break;
-        case kConnectivity_Lost:
-            // Hide the currently connected state
-            sConnectionState = kConnectivity_NoChange;
-            ClearDisplay();
-            sQRCodeWidget.Display();
-            break;
-        case kConnectivity_NoChange:
-        default:
-            break;
-        }
 #endif // CONFIG_HAVE_DISPLAY
 
         vTaskDelay(50 / portTICK_PERIOD_MS);
@@ -262,13 +231,11 @@ void DeviceEventHandler(const ChipDeviceEvent * event, intptr_t arg)
                 char ipAddrStr[INET_ADDRSTRLEN];
                 IPAddress::FromIPv4(ipInfo.ip).ToString(ipAddrStr, sizeof(ipAddrStr));
                 ESP_LOGI(TAG, "Server ready at: %s:%d", ipAddrStr, CONFIG_ECHO_PORT);
-                sConnectionState = kConnectivity_Established;
             }
         }
         else if (event->InternetConnectivityChange.IPv4 == kConnectivity_Lost)
         {
             ESP_LOGE(TAG, "Lost IPv4 address...");
-            sConnectionState = kConnectivity_Lost;
         }
     }
     if (event->Type == DeviceEventType::kSessionEstablished && event->SessionEstablished.IsCommissioner)


### PR DESCRIPTION
 #### Problem
There's no indication of the light controller demo on the M5Stack
 #### Summary of Changes
Add a simple indication on the display to show the status of the LED.
Removed the IP address indicator, IP address will be delivered via the QRCode

<img src=https://user-images.githubusercontent.com/61470494/83574896-4166a980-a4e3-11ea-899d-aef3f50da873.png width=250>
