### PR TITLE
Only grab the buffer length if we will use it.

### DIFF
--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -220,9 +220,9 @@ void DoOnOff(DeviceController::ChipDeviceController * controller, Command comman
     };
     chipZclEncodeZclHeader(zcl_buffer, &ctx);
 
+#ifdef DEBUG
     const size_t data_len = chipZclBufferDataLength(zcl_buffer);
 
-#ifdef DEBUG
     fprintf(stderr, "SENDING: %zu ", data_len);
     for (size_t i = 0; i < data_len; ++i)
     {


### PR DESCRIPTION
 #### Problem
Build warning in chip-tool app.

 #### Summary of Changes
Only declare `data_len` when it's used.

fixes https://github.com/project-chip/connectedhomeip/issues/971
