### PR TITLE
Add support to pass back IP address M5Stack to commissioning demo iOS app

### DIFF
--- a/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
+++ b/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
@@ -47,8 +47,10 @@
 #define EXAMPLE_VENDOR_ID 3447
 // Used to indicate that an SSID has been added to the QRCode
 #define EXAMPLE_VENDOR_TAG_SSID 1
-
+// Used to indicate that an IP address has been added to the QRCode
 #define EXAMPLE_VENDOR_TAG_IP 2
+// Used to indicate that a Port has been added to the QRCode
+#define EXAMPLE_VENDOR_TAG_PORT 3
 
 #if CONFIG_HAVE_DISPLAY
 
@@ -108,6 +110,12 @@ string createSetupPayload()
     ipInfo.type = optionalQRCodeInfoTypeString;
     ipInfo.data = gw_ip;
     payload.addVendorOptionalData(ipInfo);
+
+    OptionalQRCodeInfo portInfo;
+    portInfo.tag     = EXAMPLE_VENDOR_TAG_PORT;
+    portInfo.type    = optionalQRCodeInfoTypeInt;
+    portInfo.integer = CONFIG_ECHO_PORT;
+    payload.addVendorOptionalData(portInfo);
 
     QRCodeSetupPayloadGenerator generator(payload);
     string result;

--- a/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
+++ b/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
@@ -78,9 +78,13 @@ void GetAPName(char * ssid, size_t ssid_len)
     snprintf(ssid, ssid_len, "%s%02X%02X", "CHIP_DEMO-", mac[4], mac[5]);
 }
 
-void GetGatewayIP(char *ip, size_t ip_len)
+void GetGatewayIP(char *ip_buf, size_t ip_len)
 {
-    snprintf(ip, ip_len, "192.168.1.1");
+    
+    tcpip_adapter_ip_info_t ip;
+    tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_AP, &ip);
+    IPAddress::FromIPv4(ip.ip).ToString(ip_buf, ip_len);
+    ESP_LOGE(TAG, "Got gateway ip %s", ip_buf);
 }
 
 string createSetupPayload()

--- a/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
+++ b/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
@@ -49,7 +49,6 @@
 #define EXAMPLE_VENDOR_TAG_SSID 1
 
 #define EXAMPLE_VENDOR_TAG_IP 2
-#define MAX_IP_LEN 15
 
 #if CONFIG_HAVE_DISPLAY
 
@@ -102,7 +101,7 @@ string createSetupPayload()
     ssidInfo.data = ap_ssid;
     payload.addVendorOptionalData(ssidInfo);
 
-    char gw_ip[MAX_IP_LEN];
+    char gw_ip[INET6_ADDRSTRLEN];
     GetGatewayIP(gw_ip, sizeof(gw_ip));
     OptionalQRCodeInfo ipInfo;
     ipInfo.tag  = EXAMPLE_VENDOR_TAG_IP;

--- a/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
+++ b/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
@@ -48,7 +48,7 @@
 // Used to indicate that an SSID has been added to the QRCode
 #define EXAMPLE_VENDOR_TAG_SSID 1
 
-#define EXAMPLE_VENDOR_TAG_IP 2 
+#define EXAMPLE_VENDOR_TAG_IP 2
 #define MAX_IP_LEN 15
 
 #if CONFIG_HAVE_DISPLAY
@@ -80,7 +80,7 @@ void GetAPName(char * ssid, size_t ssid_len)
 
 void GetGatewayIP(char *ip_buf, size_t ip_len)
 {
-    
+
     tcpip_adapter_ip_info_t ip;
     tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_AP, &ip);
     IPAddress::FromIPv4(ip.ip).ToString(ip_buf, ip_len);
@@ -95,8 +95,8 @@ string createSetupPayload()
     payload.version   = 1;
     payload.vendorID  = EXAMPLE_VENDOR_ID;
     payload.productID = 1;
-    
-    
+
+
     OptionalQRCodeInfo ssidInfo;
     ssidInfo.tag  = EXAMPLE_VENDOR_TAG_SSID;
     ssidInfo.type = optionalQRCodeInfoTypeString;

--- a/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
+++ b/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
@@ -78,7 +78,7 @@ void GetAPName(char * ssid, size_t ssid_len)
     snprintf(ssid, ssid_len, "%s%02X%02X", "CHIP_DEMO-", mac[4], mac[5]);
 }
 
-void GetGatewayIP(char *ip_buf, size_t ip_len)
+void GetGatewayIP(char * ip_buf, size_t ip_len)
 {
 
     tcpip_adapter_ip_info_t ip;
@@ -95,7 +95,6 @@ string createSetupPayload()
     payload.version   = 1;
     payload.vendorID  = EXAMPLE_VENDOR_ID;
     payload.productID = 1;
-
 
     OptionalQRCodeInfo ssidInfo;
     ssidInfo.tag  = EXAMPLE_VENDOR_TAG_SSID;

--- a/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
+++ b/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
@@ -440,7 +440,7 @@
 			buildSettings = {
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
@@ -453,7 +453,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.chip.CHIPTool;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SDKROOT = iphoneos.internal;
+				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = "arm64 armv4t armv5 armv6 armv6m armv7 armv7em armv7f armv7k armv7m armv7s xscale";
 			};
@@ -464,7 +464,7 @@
 			buildSettings = {
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
@@ -477,7 +477,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.chip.CHIPTool;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SDKROOT = iphoneos.internal;
+				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = "arm64 armv4t armv5 armv6 armv6m armv7 armv7em armv7f armv7k armv7m armv7s xscale";
 			};

--- a/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
+++ b/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
@@ -351,8 +351,10 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_HARDENED_RUNTIME = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -410,8 +412,10 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_HARDENED_RUNTIME = NO;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -436,7 +440,7 @@
 			buildSettings = {
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
@@ -449,7 +453,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.chip.CHIPTool;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SDKROOT = iphoneos;
+				SDKROOT = iphoneos.internal;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = "arm64 armv4t armv5 armv6 armv6m armv7 armv7em armv7f armv7k armv7m armv7s xscale";
 			};
@@ -460,7 +464,7 @@
 			buildSettings = {
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
@@ -473,7 +477,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.chip.CHIPTool;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SDKROOT = iphoneos;
+				SDKROOT = iphoneos.internal;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = "arm64 armv4t armv5 armv6 armv6m armv7 armv7em armv7f armv7k armv7m armv7s xscale";
 			};

--- a/src/darwin/CHIPTool/CHIPTool/CHIPViewControllerBase.m
+++ b/src/darwin/CHIPTool/CHIPTool/CHIPViewControllerBase.m
@@ -22,8 +22,8 @@
 
 #define RESULT_DISPLAY_DURATION 5.0 * NSEC_PER_SEC
 
-static const NSString * ipKey = @"ipk";
-static const NSString * portKey = @"pk";
+static NSString * const ipKey = @"ipk";
+static NSString * const portKey = @"pk";
 
 @interface CHIPViewControllerBase ()
 
@@ -112,7 +112,7 @@ static const NSString * portKey = @"pk";
         error:&error
         onMessage:^(NSData * _Nonnull message, NSString * _Nonnull ipAddress, UInt16 port) {
             NSString * strMessage = [[NSString alloc] initWithData:message encoding:NSUTF8StringEncoding];
-            [self postResult:[@"Echo Response: " stringByAppendingFormat:@"%@\nFrom: %@:%d", strMessage, ipAddress, port]];
+            [self postResult:[@"Echo Response: " stringByAppendingFormat:@"%@", strMessage]];
         }
         onError:^(NSError * _Nonnull error) {
             [self postResult:[@"Error: " stringByAppendingString:error.localizedDescription]];

--- a/src/darwin/CHIPTool/CHIPTool/CHIPViewControllerBase.m
+++ b/src/darwin/CHIPTool/CHIPTool/CHIPViewControllerBase.m
@@ -76,7 +76,7 @@ static const NSString *portKey = @"pk";
                                              selector:@selector(_appEnteringForeground:)
                                                  name:UISceneWillEnterForegroundNotification
                                                object:nil];
-    
+
     BOOL shouldHide = NO;
     if ([[self _getScannedIP] length] > 0 && [self _getScannedPort] > 0)
     {
@@ -106,11 +106,11 @@ static const NSString *portKey = @"pk";
 - (void)_connect
 {
     NSError * error;
-    
-    
+
+
     NSString * inputIPAddress = [[self _getScannedIP] length] > 0 ? [self _getScannedIP] : self.serverIPTextField.text;
     UInt16 inputPort =  [self _getScannedPort] > 0 ? [self _getScannedPort] : [self.serverPortTextField.text intValue];
-    
+
     BOOL didConnect = [self.chipController connect:inputIPAddress
         port:inputPort
         error:&error

--- a/src/darwin/CHIPTool/CHIPTool/CHIPViewControllerBase.m
+++ b/src/darwin/CHIPTool/CHIPTool/CHIPViewControllerBase.m
@@ -22,8 +22,8 @@
 
 #define RESULT_DISPLAY_DURATION 5.0 * NSEC_PER_SEC
 
-static const NSString *ipKey = @"ipk";
-static const NSString *portKey = @"pk";
+static const NSString * ipKey = @"ipk";
+static const NSString * portKey = @"pk";
 
 @interface CHIPViewControllerBase ()
 
@@ -32,8 +32,8 @@ static const NSString *portKey = @"pk";
 
 @property (weak, nonatomic) IBOutlet UITextField * serverIPTextField;
 @property (weak, nonatomic) IBOutlet UITextField * serverPortTextField;
-@property (weak, nonatomic) IBOutlet UILabel *IPLabel;
-@property (weak, nonatomic) IBOutlet UILabel *portLabel;
+@property (weak, nonatomic) IBOutlet UILabel * IPLabel;
+@property (weak, nonatomic) IBOutlet UILabel * portLabel;
 
 @end
 
@@ -48,8 +48,6 @@ static const NSString *portKey = @"pk";
 {
     return [[NSUserDefaults standardUserDefaults] integerForKey:portKey];
 }
-
-
 
 - (void)viewDidLoad
 {
@@ -78,8 +76,7 @@ static const NSString *portKey = @"pk";
                                                object:nil];
 
     BOOL shouldHide = NO;
-    if ([[self _getScannedIP] length] > 0 && [self _getScannedPort] > 0)
-    {
+    if ([[self _getScannedIP] length] > 0 && [self _getScannedPort] > 0) {
         shouldHide = YES;
     }
     [self.serverIPTextField setHidden:shouldHide];
@@ -107,9 +104,8 @@ static const NSString *portKey = @"pk";
 {
     NSError * error;
 
-
     NSString * inputIPAddress = [[self _getScannedIP] length] > 0 ? [self _getScannedIP] : self.serverIPTextField.text;
-    UInt16 inputPort =  [self _getScannedPort] > 0 ? [self _getScannedPort] : [self.serverPortTextField.text intValue];
+    UInt16 inputPort = [self _getScannedPort] > 0 ? [self _getScannedPort] : [self.serverPortTextField.text intValue];
 
     BOOL didConnect = [self.chipController connect:inputIPAddress
         port:inputPort

--- a/src/darwin/CHIPTool/CHIPTool/CHIPViewControllerBase.m
+++ b/src/darwin/CHIPTool/CHIPTool/CHIPViewControllerBase.m
@@ -22,6 +22,9 @@
 
 #define RESULT_DISPLAY_DURATION 5.0 * NSEC_PER_SEC
 
+static const NSString *ipKey = @"ipk";
+static const NSString *portKey = @"pk";
+
 @interface CHIPViewControllerBase ()
 
 @property (readwrite) dispatch_queue_t chipCallbackQueue;
@@ -29,10 +32,24 @@
 
 @property (weak, nonatomic) IBOutlet UITextField * serverIPTextField;
 @property (weak, nonatomic) IBOutlet UITextField * serverPortTextField;
+@property (weak, nonatomic) IBOutlet UILabel *IPLabel;
+@property (weak, nonatomic) IBOutlet UILabel *portLabel;
 
 @end
 
 @implementation CHIPViewControllerBase
+
+- (NSString *)_getScannedIP
+{
+    return [[NSUserDefaults standardUserDefaults] stringForKey:ipKey];
+}
+
+- (NSInteger)_getScannedPort
+{
+    return [[NSUserDefaults standardUserDefaults] integerForKey:portKey];
+}
+
+
 
 - (void)viewDidLoad
 {
@@ -59,6 +76,16 @@
                                              selector:@selector(_appEnteringForeground:)
                                                  name:UISceneWillEnterForegroundNotification
                                                object:nil];
+    
+    BOOL shouldHide = NO;
+    if ([[self _getScannedIP] length] > 0 && [self _getScannedPort] > 0)
+    {
+        shouldHide = YES;
+    }
+    [self.serverIPTextField setHidden:shouldHide];
+    [self.serverPortTextField setHidden:shouldHide];
+    [self.portLabel setHidden:shouldHide];
+    [self.IPLabel setHidden:shouldHide];
 }
 
 - (void)_appEnteredBackground:(NSNotification *)notification
@@ -79,8 +106,11 @@
 - (void)_connect
 {
     NSError * error;
-    NSString * inputIPAddress = self.serverIPTextField.text;
-    UInt16 inputPort = [self.serverPortTextField.text intValue];
+    
+    
+    NSString * inputIPAddress = [[self _getScannedIP] length] > 0 ? [self _getScannedIP] : self.serverIPTextField.text;
+    UInt16 inputPort =  [self _getScannedPort] > 0 ? [self _getScannedPort] : [self.serverPortTextField.text intValue];
+    
     BOOL didConnect = [self.chipController connect:inputIPAddress
         port:inputPort
         error:&error

--- a/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
@@ -34,7 +34,7 @@
 #define MAX_SSID_LEN 32
 
 #define EXAMPLE_VENDOR_TAG_IP 2
-#define MAX_IP_LEN 15
+#define MAX_IP_LEN 46
 
 #define NOT_APPLICABLE_STRING @"N/A"
 
@@ -202,7 +202,6 @@ static NSString * const portKey = @"pk";
                     }
                     break;
                 }
-                // If the vendor id and tag match the example values, there should be an ssid encoded
             }
         }
     }

--- a/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
@@ -197,7 +197,6 @@ static const NSString *portKey = @"pk";
                             if ([info.stringValue length] > MAX_IP_LEN) {
                                 NSLog(@"Unexpected IP String... %@", info.stringValue);
                             } else {
-                                // show SoftAP detection
                                 NSLog(@"Got IP String... %@", info.stringValue);
                                 [[NSUserDefaults standardUserDefaults] setObject:info.stringValue forKey:ipKey];
                                 [[NSUserDefaults standardUserDefaults] setInteger:8000 forKey:portKey];

--- a/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
@@ -36,12 +36,10 @@
 #define EXAMPLE_VENDOR_TAG_IP 2
 #define MAX_IP_LEN 15
 
-
 #define NOT_APPLICABLE_STRING @"N/A"
 
-static const NSString *ipKey = @"ipk";
-static const NSString *portKey = @"pk";
-
+static const NSString * ipKey = @"ipk";
+static const NSString * portKey = @"pk";
 
 @interface QRCodeViewController ()
 
@@ -182,26 +180,26 @@ static const NSString *portKey = @"pk";
             NSNumber * tag = info.tag;
             if (tag) {
                 switch (tag.unsignedCharValue) {
-                    case EXAMPLE_VENDOR_TAG_SSID:
-                        if ([info.infoType isEqualToNumber:[NSNumber numberWithInt:kOptionalQRCodeInfoTypeString]]) {
-                            if ([info.stringValue length] > MAX_SSID_LEN) {
-                                NSLog(@"Unexpected SSID String...");
-                            } else {
-                                // show SoftAP detection
-                                [self RequestConnectSoftAPWithSSID:info.stringValue];
-                            }
+                case EXAMPLE_VENDOR_TAG_SSID:
+                    if ([info.infoType isEqualToNumber:[NSNumber numberWithInt:kOptionalQRCodeInfoTypeString]]) {
+                        if ([info.stringValue length] > MAX_SSID_LEN) {
+                            NSLog(@"Unexpected SSID String...");
+                        } else {
+                            // show SoftAP detection
+                            [self RequestConnectSoftAPWithSSID:info.stringValue];
                         }
+                    }
                     break;
-                    case EXAMPLE_VENDOR_TAG_IP:
-                        if ([info.infoType isEqualToNumber:[NSNumber numberWithInt:kOptionalQRCodeInfoTypeString]]) {
-                            if ([info.stringValue length] > MAX_IP_LEN) {
-                                NSLog(@"Unexpected IP String... %@", info.stringValue);
-                            } else {
-                                NSLog(@"Got IP String... %@", info.stringValue);
-                                [[NSUserDefaults standardUserDefaults] setObject:info.stringValue forKey:ipKey];
-                                [[NSUserDefaults standardUserDefaults] setInteger:8000 forKey:portKey];
-                            }
+                case EXAMPLE_VENDOR_TAG_IP:
+                    if ([info.infoType isEqualToNumber:[NSNumber numberWithInt:kOptionalQRCodeInfoTypeString]]) {
+                        if ([info.stringValue length] > MAX_IP_LEN) {
+                            NSLog(@"Unexpected IP String... %@", info.stringValue);
+                        } else {
+                            NSLog(@"Got IP String... %@", info.stringValue);
+                            [[NSUserDefaults standardUserDefaults] setObject:info.stringValue forKey:ipKey];
+                            [[NSUserDefaults standardUserDefaults] setInteger:8000 forKey:portKey];
                         }
+                    }
                     break;
                 }
                 // If the vendor id and tag match the example values, there should be an ssid encoded

--- a/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
@@ -35,6 +35,7 @@
 
 #define EXAMPLE_VENDOR_TAG_IP 2
 #define MAX_IP_LEN 46
+#define EXAMPLE_VENDOR_TAG_PORT 3
 
 #define NOT_APPLICABLE_STRING @"N/A"
 
@@ -197,10 +198,15 @@ static NSString * const portKey = @"pk";
                         } else {
                             NSLog(@"Got IP String... %@", info.stringValue);
                             [[NSUserDefaults standardUserDefaults] setObject:info.stringValue forKey:ipKey];
-                            [[NSUserDefaults standardUserDefaults] setInteger:8000 forKey:portKey];
                         }
                     }
                     break;
+                    case EXAMPLE_VENDOR_TAG_PORT:
+                        if ([info.infoType isEqualToNumber:[NSNumber numberWithInt:kOptionalQRCodeInfoTypeInt]]) {
+                            NSLog(@"Got Port number... %@", info.integerValue);
+                            [[NSUserDefaults standardUserDefaults] setInteger:info.integerValue.integerValue forKey:portKey];
+                        }
+                        break;
                 }
             }
         }

--- a/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
@@ -33,7 +33,7 @@
 #define EXAMPLE_VENDOR_TAG_SSID 1
 #define MAX_SSID_LEN 32
 
-#define EXAMPLE_VENDOR_TAG_IP 2 
+#define EXAMPLE_VENDOR_TAG_IP 2
 #define MAX_IP_LEN 15
 
 
@@ -173,7 +173,7 @@ static const NSString *portKey = @"pk";
         self->_productID.text = [NSString stringWithFormat:@"%@", payload.productID];
     }
     self->_setupPayloadView.hidden = NO;
-    
+
     NSLog(@"Payload vendorID %@", payload.vendorID);
     if ([payload.vendorID isEqualToNumber:[NSNumber numberWithInt:EXAMPLE_VENDOR_ID]]) {
         NSArray * optionalInfo = [payload getAllOptionalData:nil];

--- a/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
@@ -38,8 +38,8 @@
 
 #define NOT_APPLICABLE_STRING @"N/A"
 
-static const NSString * ipKey = @"ipk";
-static const NSString * portKey = @"pk";
+static NSString * const ipKey = @"ipk";
+static NSString * const portKey = @"pk";
 
 @interface QRCodeViewController ()
 

--- a/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
@@ -30,10 +30,18 @@
 // The expected Vendor ID for CHIP demos
 // Spells CHIP on a dialer
 #define EXAMPLE_VENDOR_ID 3447
-#define EXAMPLE_VENDOR_TAG 1
+#define EXAMPLE_VENDOR_TAG_SSID 1
 #define MAX_SSID_LEN 32
 
+#define EXAMPLE_VENDOR_TAG_IP 2 
+#define MAX_IP_LEN 15
+
+
 #define NOT_APPLICABLE_STRING @"N/A"
+
+static const NSString *ipKey = @"ipk";
+static const NSString *portKey = @"pk";
+
 
 @interface QRCodeViewController ()
 
@@ -165,21 +173,39 @@
         self->_productID.text = [NSString stringWithFormat:@"%@", payload.productID];
     }
     self->_setupPayloadView.hidden = NO;
-
+    
+    NSLog(@"Payload vendorID %@", payload.vendorID);
     if ([payload.vendorID isEqualToNumber:[NSNumber numberWithInt:EXAMPLE_VENDOR_ID]]) {
         NSArray * optionalInfo = [payload getAllOptionalData:nil];
+        NSLog(@"Count of payload info %@", @(optionalInfo.count));
         for (CHIPOptionalQRCodeInfo * info in optionalInfo) {
             NSNumber * tag = info.tag;
-            if (tag && tag.unsignedCharValue == EXAMPLE_VENDOR_TAG) {
-                // If the vendor id and tag match the example values, there should be an ssid encoded
-                if ([info.infoType isEqualToNumber:[NSNumber numberWithInt:kOptionalQRCodeInfoTypeString]]) {
-                    if ([info.stringValue length] > MAX_SSID_LEN) {
-                        NSLog(@"Unexpected SSID String...");
-                    } else {
-                        // show SoftAP detection
-                        [self RequestConnectSoftAPWithSSID:info.stringValue];
-                    }
+            if (tag) {
+                switch (tag.unsignedCharValue) {
+                    case EXAMPLE_VENDOR_TAG_SSID:
+                        if ([info.infoType isEqualToNumber:[NSNumber numberWithInt:kOptionalQRCodeInfoTypeString]]) {
+                            if ([info.stringValue length] > MAX_SSID_LEN) {
+                                NSLog(@"Unexpected SSID String...");
+                            } else {
+                                // show SoftAP detection
+                                [self RequestConnectSoftAPWithSSID:info.stringValue];
+                            }
+                        }
+                    break;
+                    case EXAMPLE_VENDOR_TAG_IP:
+                        if ([info.infoType isEqualToNumber:[NSNumber numberWithInt:kOptionalQRCodeInfoTypeString]]) {
+                            if ([info.stringValue length] > MAX_IP_LEN) {
+                                NSLog(@"Unexpected IP String... %@", info.stringValue);
+                            } else {
+                                // show SoftAP detection
+                                NSLog(@"Got IP String... %@", info.stringValue);
+                                [[NSUserDefaults standardUserDefaults] setObject:info.stringValue forKey:ipKey];
+                                [[NSUserDefaults standardUserDefaults] setInteger:8000 forKey:portKey];
+                            }
+                        }
+                    break;
                 }
+                // If the vendor id and tag match the example values, there should be an ssid encoded
             }
         }
     }

--- a/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
@@ -201,12 +201,12 @@ static NSString * const portKey = @"pk";
                         }
                     }
                     break;
-                    case EXAMPLE_VENDOR_TAG_PORT:
-                        if ([info.infoType isEqualToNumber:[NSNumber numberWithInt:kOptionalQRCodeInfoTypeInt]]) {
-                            NSLog(@"Got Port number... %@", info.integerValue);
-                            [[NSUserDefaults standardUserDefaults] setInteger:info.integerValue.integerValue forKey:portKey];
-                        }
-                        break;
+                case EXAMPLE_VENDOR_TAG_PORT:
+                    if ([info.infoType isEqualToNumber:[NSNumber numberWithInt:kOptionalQRCodeInfoTypeInt]]) {
+                        NSLog(@"Got Port number... %@", info.integerValue);
+                        [[NSUserDefaults standardUserDefaults] setInteger:info.integerValue.integerValue forKey:portKey];
+                    }
+                    break;
                 }
             }
         }

--- a/src/darwin/CHIPTool/CHIPTool/UI/AppDelegate.m
+++ b/src/darwin/CHIPTool/CHIPTool/UI/AppDelegate.m
@@ -17,8 +17,8 @@
 
 #import "AppDelegate.h"
 
-static const NSString * ipKey = @"ipk";
-static const NSString * portKey = @"pk";
+static NSString * const ipKey = @"ipk";
+static NSString * const portKey = @"pk";
 
 @interface AppDelegate ()
 

--- a/src/darwin/CHIPTool/CHIPTool/UI/AppDelegate.m
+++ b/src/darwin/CHIPTool/CHIPTool/UI/AppDelegate.m
@@ -17,6 +17,9 @@
 
 #import "AppDelegate.h"
 
+static const NSString *ipKey = @"ipk";
+static const NSString *portKey = @"pk";
+
 @interface AppDelegate ()
 
 @end
@@ -26,6 +29,9 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     // Override point for customization after application launch.
+
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:ipKey];
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:portKey];
     return YES;
 }
 

--- a/src/darwin/CHIPTool/CHIPTool/UI/AppDelegate.m
+++ b/src/darwin/CHIPTool/CHIPTool/UI/AppDelegate.m
@@ -17,8 +17,8 @@
 
 #import "AppDelegate.h"
 
-static const NSString *ipKey = @"ipk";
-static const NSString *portKey = @"pk";
+static const NSString * ipKey = @"ipk";
+static const NSString * portKey = @"pk";
 
 @interface AppDelegate ()
 

--- a/src/darwin/CHIPTool/CHIPTool/UI/Base.lproj/Main.storyboard
+++ b/src/darwin/CHIPTool/CHIPTool/UI/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16085" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="lXE-RO-59g">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="vbD-2y-iuf">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16078.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>

--- a/src/darwin/CHIPTool/CHIPTool/UI/Base.lproj/Main.storyboard
+++ b/src/darwin/CHIPTool/CHIPTool/UI/Base.lproj/Main.storyboard
@@ -349,16 +349,16 @@
                                 <textInputTraits key="textInputTraits" keyboardType="decimalPad"/>
                             </textField>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Hello from iOS!" textAlignment="natural" adjustsFontSizeToFit="NO" minimumFontSize="14" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="lvN-Eg-W6F">
-                                <rect key="frame" x="16" y="323" width="283" height="34"/>
+                                <rect key="frame" x="16" y="323" width="263" height="34"/>
                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cfO-gM-sug">
-                                <rect key="frame" x="309" y="323" width="50" height="34"/>
+                                <rect key="frame" x="289" y="323" width="70" height="34"/>
                                 <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="50" id="hYC-K5-DeY"/>
+                                    <constraint firstAttribute="width" constant="70" id="hYC-K5-DeY"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <state key="normal" title="Send">
@@ -368,7 +368,7 @@
                                     <action selector="sendAction:" destination="NR6-8N-IDd" eventType="touchUpInside" id="zLO-Yj-bAY"/>
                                 </connections>
                             </button>
-                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ERROR" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" autoshrinkMode="minimumScaleFactor" translatesAutoresizingMaskIntoConstraints="NO" id="6Z1-j3-AvT">
+                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ERROR" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6Z1-j3-AvT">
                                 <rect key="frame" x="16" y="397" width="343" height="14.333333333333314"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -550,34 +550,21 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" keyboardType="decimalPad"/>
                             </textField>
-                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" misplaced="YES" text="ERROR" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" autoshrinkMode="minimumScaleFactor" translatesAutoresizingMaskIntoConstraints="NO" id="ERS-fv-Yhs">
-                                <rect key="frame" x="35" y="433" width="343" height="14.333333333333314"/>
+                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ERROR" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ERS-fv-Yhs">
+                                <rect key="frame" x="16" y="380" width="343" height="14.333333333333314"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jhI-Pt-QaG">
-                                <rect key="frame" x="35" y="316" width="30" height="37"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jhI-Pt-QaG">
+                                <rect key="frame" x="16" y="310" width="62" height="40"/>
                                 <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="30" id="Pkn-Un-j1t"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <state key="normal" title="On">
                                     <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="default" weight="bold"/>
                                 </state>
                                 <connections>
                                     <action selector="onButtonTapped:" destination="UgW-Ob-0KX" eventType="touchUpInside" id="vWi-b0-t9k"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cwX-vi-vgG">
-                                <rect key="frame" x="157" y="316" width="39" height="37"/>
-                                <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <state key="normal" title="Off">
-                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="default" weight="bold"/>
-                                </state>
-                                <connections>
-                                    <action selector="offButtonTapped:" destination="UgW-Ob-0KX" eventType="touchUpInside" id="JJt-5D-6pb"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="On / Off cluster" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eg3-7c-7WS">
@@ -589,37 +576,61 @@
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1XM-cR-Y6o">
-                                <rect key="frame" x="35" y="382" width="55" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1XM-cR-Y6o">
+                                <rect key="frame" x="160" y="310" width="62" height="40"/>
                                 <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="62" id="Aps-iV-q27"/>
+                                    <constraint firstAttribute="height" constant="40" id="fC7-42-Oyl"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <state key="normal" title="Toggle"/>
                                 <connections>
                                     <action selector="toggleButtonTapped:" destination="UgW-Ob-0KX" eventType="touchUpInside" id="tnj-3E-KKW"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cwX-vi-vgG">
+                                <rect key="frame" x="88" y="310" width="62" height="40"/>
+                                <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <state key="normal" title="Off">
+                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="default" weight="bold"/>
+                                </state>
+                                <connections>
+                                    <action selector="offButtonTapped:" destination="UgW-Ob-0KX" eventType="touchUpInside" id="JJt-5D-6pb"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="cwX-vi-vgG" firstAttribute="leading" secondItem="jhI-Pt-QaG" secondAttribute="trailing" constant="90" id="2pP-hz-iTG"/>
+                            <constraint firstItem="cwX-vi-vgG" firstAttribute="width" secondItem="1XM-cR-Y6o" secondAttribute="width" id="582-Pj-QoZ"/>
+                            <constraint firstItem="XIj-Oo-qmz" firstAttribute="leading" secondItem="kG5-yT-GzM" secondAttribute="leading" constant="16" id="6o4-kh-TOw"/>
+                            <constraint firstItem="jhI-Pt-QaG" firstAttribute="top" secondItem="23l-Oa-cls" secondAttribute="bottom" constant="46" id="79r-Fr-K9c"/>
+                            <constraint firstItem="cwX-vi-vgG" firstAttribute="height" secondItem="1XM-cR-Y6o" secondAttribute="height" id="ARb-ea-aSV"/>
                             <constraint firstItem="eg3-7c-7WS" firstAttribute="top" secondItem="kG5-yT-GzM" secondAttribute="top" constant="19" id="Eu0-fd-IpC"/>
                             <constraint firstItem="XIj-Oo-qmz" firstAttribute="leading" secondItem="c45-FF-oLb" secondAttribute="leadingMargin" id="KLq-hK-kli"/>
+                            <constraint firstItem="ERS-fv-Yhs" firstAttribute="leading" secondItem="kG5-yT-GzM" secondAttribute="leading" constant="16" id="LVO-tn-vpG"/>
                             <constraint firstItem="eg3-7c-7WS" firstAttribute="leading" secondItem="kG5-yT-GzM" secondAttribute="leading" constant="77" id="LyU-T1-mwz"/>
-                            <constraint firstItem="jhI-Pt-QaG" firstAttribute="baseline" secondItem="cwX-vi-vgG" secondAttribute="baseline" id="M7U-kC-85C"/>
                             <constraint firstItem="23l-Oa-cls" firstAttribute="leading" secondItem="Ezc-du-JDZ" secondAttribute="trailing" constant="96" id="NtY-zP-Rlc"/>
                             <constraint firstItem="23l-Oa-cls" firstAttribute="top" secondItem="WTA-xG-Iyv" secondAttribute="bottom" constant="9" id="Oow-zL-KUd"/>
-                            <constraint firstItem="1XM-cR-Y6o" firstAttribute="top" relation="greaterThanOrEqual" secondItem="jhI-Pt-QaG" secondAttribute="bottom" constant="20" id="Pw9-4K-7au"/>
+                            <constraint firstItem="1XM-cR-Y6o" firstAttribute="centerY" secondItem="cwX-vi-vgG" secondAttribute="centerY" id="PIV-cB-jxE"/>
                             <constraint firstItem="23l-Oa-cls" firstAttribute="centerY" secondItem="Ezc-du-JDZ" secondAttribute="centerY" id="QVB-6k-YPM"/>
-                            <constraint firstItem="1XM-cR-Y6o" firstAttribute="leading" secondItem="kG5-yT-GzM" secondAttribute="leading" constant="35" id="Ux0-gv-R5P"/>
-                            <constraint firstItem="ERS-fv-Yhs" firstAttribute="top" secondItem="1XM-cR-Y6o" secondAttribute="bottom" constant="20" id="Z7f-bC-AAf"/>
+                            <constraint firstItem="Ezc-du-JDZ" firstAttribute="leading" secondItem="kG5-yT-GzM" secondAttribute="leading" constant="16.000000000000004" id="Rkq-lO-goG"/>
+                            <constraint firstItem="ERS-fv-Yhs" firstAttribute="top" secondItem="jhI-Pt-QaG" secondAttribute="bottom" constant="30" id="SfK-C8-ojg"/>
+                            <constraint firstItem="kG5-yT-GzM" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="1XM-cR-Y6o" secondAttribute="trailing" constant="200" id="Ssx-2M-iya"/>
+                            <constraint firstItem="cwX-vi-vgG" firstAttribute="leading" secondItem="jhI-Pt-QaG" secondAttribute="trailing" constant="10" id="Urx-pk-Pkt"/>
+                            <constraint firstItem="jhI-Pt-QaG" firstAttribute="height" secondItem="cwX-vi-vgG" secondAttribute="height" id="ZQb-0R-izb"/>
+                            <constraint firstItem="jhI-Pt-QaG" firstAttribute="leading" secondItem="kG5-yT-GzM" secondAttribute="leading" constant="16" id="cec-Qo-hyK"/>
                             <constraint firstItem="XIj-Oo-qmz" firstAttribute="top" secondItem="eg3-7c-7WS" secondAttribute="bottom" constant="14.666666666666657" id="eBh-cR-lX1"/>
                             <constraint firstItem="kG5-yT-GzM" firstAttribute="trailing" secondItem="23l-Oa-cls" secondAttribute="trailing" constant="16" id="fDV-I9-84c"/>
                             <constraint firstItem="XIj-Oo-qmz" firstAttribute="leading" secondItem="Ezc-du-JDZ" secondAttribute="leading" id="gBb-uO-Qg6"/>
-                            <constraint firstItem="jhI-Pt-QaG" firstAttribute="top" secondItem="Ezc-du-JDZ" secondAttribute="bottom" constant="58" id="q9S-Um-2Gx"/>
+                            <constraint firstItem="kG5-yT-GzM" firstAttribute="trailing" secondItem="ERS-fv-Yhs" secondAttribute="trailing" constant="16" id="gij-Jw-J5R"/>
+                            <constraint firstItem="1XM-cR-Y6o" firstAttribute="leading" secondItem="cwX-vi-vgG" secondAttribute="trailing" constant="10" id="kCe-dG-Nbo"/>
+                            <constraint firstItem="cwX-vi-vgG" firstAttribute="centerY" secondItem="jhI-Pt-QaG" secondAttribute="centerY" id="lGp-co-aTI"/>
+                            <constraint firstItem="jhI-Pt-QaG" firstAttribute="width" secondItem="cwX-vi-vgG" secondAttribute="width" id="ojo-ur-0qY"/>
                             <constraint firstItem="WTA-xG-Iyv" firstAttribute="top" secondItem="eg3-7c-7WS" secondAttribute="bottom" constant="8" id="qHB-PH-HAy"/>
                             <constraint firstItem="Ezc-du-JDZ" firstAttribute="top" secondItem="XIj-Oo-qmz" secondAttribute="bottom" constant="21.999999999999972" id="tfI-Y9-8mx"/>
                             <constraint firstItem="WTA-xG-Iyv" firstAttribute="leading" secondItem="XIj-Oo-qmz" secondAttribute="trailing" constant="60" id="vKc-Pj-8mO"/>
-                            <constraint firstItem="jhI-Pt-QaG" firstAttribute="leading" secondItem="kG5-yT-GzM" secondAttribute="leading" constant="35" id="vlh-uz-5R2"/>
-                            <constraint firstItem="jhI-Pt-QaG" firstAttribute="leading" secondItem="ERS-fv-Yhs" secondAttribute="leading" id="zAN-os-P5a"/>
                             <constraint firstItem="kG5-yT-GzM" firstAttribute="trailing" secondItem="WTA-xG-Iyv" secondAttribute="trailing" constant="16" id="zn9-Cg-vpP"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="kG5-yT-GzM"/>

--- a/src/darwin/CHIPTool/CHIPTool/UI/Base.lproj/Main.storyboard
+++ b/src/darwin/CHIPTool/CHIPTool/UI/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="lXE-RO-59g">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16085" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="lXE-RO-59g">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16078.1"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -404,7 +404,9 @@
                     <tabBarItem key="tabBarItem" title="Echo" image="repeat" catalog="system" selectedImage="repeat" id="0Dy-Fp-mle"/>
                     <navigationItem key="navigationItem" id="gdO-P7-Ere"/>
                     <connections>
+                        <outlet property="IPLabel" destination="Tzm-Xh-QOZ" id="lYU-0W-rNa"/>
                         <outlet property="messageTextField" destination="lvN-Eg-W6F" id="I9L-eN-4b6"/>
+                        <outlet property="portLabel" destination="Sg4-Qo-For" id="PmK-2R-RF6"/>
                         <outlet property="resultLabel" destination="6Z1-j3-AvT" id="mMP-KW-l7u"/>
                         <outlet property="sendButton" destination="cfO-gM-sug" id="jSr-fh-7Y0"/>
                         <outlet property="serverIPTextField" destination="tC3-Jk-Opv" id="5IZ-oS-hdt"/>

--- a/src/darwin/CHIPTool/CHIPTool/UI/Base.lproj/Main.storyboard
+++ b/src/darwin/CHIPTool/CHIPTool/UI/Base.lproj/Main.storyboard
@@ -637,8 +637,10 @@
                     </view>
                     <navigationItem key="navigationItem" id="X3a-IB-ct7"/>
                     <connections>
+                        <outlet property="IPLabel" destination="XIj-Oo-qmz" id="MW7-GN-hns"/>
                         <outlet property="offButton" destination="cwX-vi-vgG" id="ctm-j9-5Vj"/>
                         <outlet property="onButton" destination="jhI-Pt-QaG" id="qUw-MV-lYT"/>
+                        <outlet property="portLabel" destination="Ezc-du-JDZ" id="olk-be-Huo"/>
                         <outlet property="resultLabel" destination="ERS-fv-Yhs" id="Jgg-GZ-RIs"/>
                         <outlet property="serverIPTextField" destination="WTA-xG-Iyv" id="704-EI-lpg"/>
                         <outlet property="serverPortTextField" destination="23l-Oa-cls" id="Vtc-FU-O8a"/>

--- a/src/darwin/CHIPTool/CHIPTool/UI/Base.lproj/Main.storyboard
+++ b/src/darwin/CHIPTool/CHIPTool/UI/Base.lproj/Main.storyboard
@@ -559,7 +559,7 @@
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jhI-Pt-QaG">
                                 <rect key="frame" x="16" y="310" width="62" height="40"/>
                                 <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <state key="normal" title="On">
                                     <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="default" weight="bold"/>
                                 </state>
@@ -583,7 +583,7 @@
                                     <constraint firstAttribute="width" constant="62" id="Aps-iV-q27"/>
                                     <constraint firstAttribute="height" constant="40" id="fC7-42-Oyl"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <state key="normal" title="Toggle"/>
                                 <connections>
                                     <action selector="toggleButtonTapped:" destination="UgW-Ob-0KX" eventType="touchUpInside" id="tnj-3E-KKW"/>
@@ -592,7 +592,7 @@
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cwX-vi-vgG">
                                 <rect key="frame" x="88" y="310" width="62" height="40"/>
                                 <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <state key="normal" title="Off">
                                     <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="default" weight="bold"/>
                                 </state>


### PR DESCRIPTION
 #### Problem
The M5Stack doesnt pass back the IP address in the QR code to the iOS App

 #### Summary of Changes
Add a new vendor tags for demo app to encode IP address and Port of M5Stack.
iOS app uses this IP address to locate the M5Stack. 
If no IP address in QR code, user can still manually enter the IP address.