### PR TITLE
kPayloadDiscriminatorFieldLengthInBits is 8 bits when spec expect 12

### DIFF
--- a/src/setup_payload/Base41.cpp
+++ b/src/setup_payload/Base41.cpp
@@ -203,8 +203,7 @@ CHIP_ERROR base41Decode(string base41, vector<uint8_t> & result)
             value += v;
         }
 
-        result.push_back(value % 256);
-        result.push_back(value / 256);
+        result.push_back(value);
     }
     return CHIP_NO_ERROR;
 }

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -157,7 +157,7 @@ static CHIP_ERROR generateBitSet(SetupPayload & payload, uint8_t * bits, uint8_t
     err = populateBits(bits, offset, payload.rendezvousInformation, kRendezvousInfoFieldLengthInBits, kTotalPayloadDataSizeInBits);
     err = populateBits(bits, offset, payload.discriminator, kPayloadDiscriminatorFieldLengthInBits, kTotalPayloadDataSizeInBits);
     err = populateBits(bits, offset, payload.setUpPINCode, kSetupPINCodeFieldLengthInBits, kTotalPayloadDataSizeInBits);
-    err = populateBits(bits, offset, 0, kReservedFieldLengthInBits, kTotalPayloadDataSizeInBits);
+    err = populateBits(bits, offset, 0, kPaddingFieldLengthInBits, kTotalPayloadDataSizeInBits);
     err = populateTLVBits(bits, offset, tlvDataStart, tlvDataLengthInBytes, totalPayloadSizeInBits);
     return err;
 }

--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -269,7 +269,7 @@ CHIP_ERROR QRCodeSetupPayloadParser::populatePayload(SetupPayload & outPayload)
     SuccessOrExit(err);
     outPayload.setUpPINCode = dest;
 
-    err = readBits(buf, indexToReadFrom, dest, kReservedFieldLengthInBits);
+    err = readBits(buf, indexToReadFrom, dest, kPaddingFieldLengthInBits);
     SuccessOrExit(err);
 
     err = populateTLV(outPayload, buf, indexToReadFrom);

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -41,10 +41,10 @@ const int kVendorIDFieldLengthInBits                 = 16;
 const int kProductIDFieldLengthInBits                = 16;
 const int kCustomFlowRequiredFieldLengthInBits       = 1;
 const int kRendezvousInfoFieldLengthInBits           = 8;
-const int kPayloadDiscriminatorFieldLengthInBits     = 8;
+const int kPayloadDiscriminatorFieldLengthInBits     = 12;
 const int kManualSetupDiscriminatorFieldLengthInBits = 4;
 const int kSetupPINCodeFieldLengthInBits             = 27;
-const int kReservedFieldLengthInBits                 = 1;
+const int kPaddingFieldLengthInBits                  = 5;
 
 const int kRendezvousInfoReservedFieldLengthInBits = 4;
 const int kRawVendorTagLengthInBits                = 7;
@@ -55,11 +55,19 @@ const int kManualSetupLongCodeCharLength  = 20;
 const int kManualSetupVendorIdCharLength  = 5;
 const int kManualSetupProductIdCharLength = 5;
 
+// clang-format off
 const int kTotalPayloadDataSizeInBits =
-    (kVersionFieldLengthInBits + kVendorIDFieldLengthInBits + kProductIDFieldLengthInBits + kCustomFlowRequiredFieldLengthInBits +
-     kRendezvousInfoFieldLengthInBits + kPayloadDiscriminatorFieldLengthInBits + kSetupPINCodeFieldLengthInBits +
-     kReservedFieldLengthInBits);
-const int kTotalPayloadDataSizeInBytes = (kTotalPayloadDataSizeInBits + 7) / 8;
+    kVersionFieldLengthInBits +
+    kVendorIDFieldLengthInBits +
+    kProductIDFieldLengthInBits +
+    kCustomFlowRequiredFieldLengthInBits +
+    kRendezvousInfoFieldLengthInBits +
+    kPayloadDiscriminatorFieldLengthInBits +
+    kSetupPINCodeFieldLengthInBits +
+    kPaddingFieldLengthInBits;
+// clang-format on
+
+const int kTotalPayloadDataSizeInBytes = kTotalPayloadDataSizeInBits / 8;
 
 const char * const kQRCodePrefix = "CH:";
 

--- a/src/setup_payload/tests/TestQRCode.cpp
+++ b/src/setup_payload/tests/TestQRCode.cpp
@@ -96,7 +96,7 @@ string toBinaryRepresentation(string base41Result)
     pos -= kSetupPINCodeFieldLengthInBits;
     binaryResult.insert(pos, " ");
 
-    pos -= kReservedFieldLengthInBits;
+    pos -= kPaddingFieldLengthInBits;
     binaryResult.insert(pos, " ");
 
     return binaryResult;
@@ -112,7 +112,7 @@ void TestPayloadByteArrayRep(nlTestSuite * inSuite, void * inContext)
     bool didSucceed = err == CHIP_NO_ERROR;
     NL_TEST_ASSERT(inSuite, didSucceed == true);
 
-    string expected = " 0 000000000000000100000000000 10000000 00000001 0 0000000000000001 0000000000001100 101";
+    string expected = " 00000 000000000000000100000000000 000010000000 00000001 0 0000000000000001 0000000000001100 101";
     NL_TEST_ASSERT(inSuite, toBinaryRepresentation(result) == expected);
 }
 
@@ -126,7 +126,7 @@ void TestPayloadBase41Rep(nlTestSuite * inSuite, void * inContext)
     bool didSucceed = err == CHIP_NO_ERROR;
     NL_TEST_ASSERT(inSuite, didSucceed == true);
 
-    string expected = "CH:J20800G00HKJ000";
+    string expected = "CH:J20800G0080080000";
     NL_TEST_ASSERT(inSuite, result == expected);
 }
 
@@ -157,7 +157,7 @@ void TestBase41(nlTestSuite * inSuite, void * inContext)
 
     // short input
     NL_TEST_ASSERT(inSuite, base41Decode("A0", decoded) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, decoded.size() == 2);
+    NL_TEST_ASSERT(inSuite, decoded.size() == 1);
 
     // empty == empty
     NL_TEST_ASSERT(inSuite, base41Decode("", decoded) == CHIP_NO_ERROR);

--- a/src/setup_payload/tests/TestQRCodeTLV.cpp
+++ b/src/setup_payload/tests/TestQRCodeTLV.cpp
@@ -32,6 +32,7 @@
 using namespace chip;
 using namespace std;
 
+const uint16_t kSmallBufferSizeInBytes   = 1;
 const uint16_t kDefaultBufferSizeInBytes = 512;
 
 SetupPayload GetDefaultPayload()
@@ -286,7 +287,7 @@ void TestOptionalDataWriteSmallBuffer(nlTestSuite * inSuite, void * inContext)
 
     QRCodeSetupPayloadGenerator generator(inPayload);
     string result;
-    uint8_t optionalInfo[kTotalPayloadDataSizeInBytes];
+    uint8_t optionalInfo[kSmallBufferSizeInBytes];
     CHIP_ERROR err = generator.payloadBase41Representation(result, optionalInfo, sizeof(optionalInfo));
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
 }


### PR DESCRIPTION
 #### Problem

The section [6.1.2.2 Table: Packed Binary Data Structure] specify that the size in bits of the discriminator should be 12 bits while the kPayloadDiscriminatorFieldLengthInBits in the code is 8.

 #### Summary of Changes

* Changes the field length from 8 to 12
* in order for the tests to run I have to revert some changes:
  - https://github.com/project-chip/connectedhomeip/commit/800bb908d6487614513f5ad127422ca201c01571#diff-6beaa900588dd66f6d726df7d5a6e41cL189
  - https://github.com/project-chip/connectedhomeip/commit/b3c2444bb52007761da66268617a55caf4fed798#diff-e651755545d7b969df0fd9213e093ed5L109

  The reason to revert this change is that currently base41Encode outputs 1 additional char for an odd bytes length, but with the reverted changes base41Decode outputs 2 bytes for the  extra byte. I would like to have @rwalker-apple opinion on it since he made the mentioned changes and I may have missed the reasoning behind it.

fixes #935 
