### PR TITLE
Use implicit profile for TLV optional data

### DIFF
--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -37,6 +37,7 @@ include ../system/SystemLayer.am
 include ../transport/TransportLayer.am
 include core/CoreLayer.am
 include support/SupportLayer.am
+include profiles/ProfilesLayer.am
 include ../crypto/Crypto.am
 include ../app/DataModel.am
 
@@ -48,6 +49,9 @@ dist_CoreLayer__HEADERS=$(CHIP_BUILD_CORE_LAYER_HEADER_FILES)
 Controller_dir=$(includedir)/controller
 dist_Controller__HEADERS=$(CHIP_BUILD_DEVICE_CONTROLLER_HEADER_FILES)
 
+# install headers for profiles layer
+ProfilesLayer_dir=$(includedir)/lib/profiles
+dist_ProfilesLayer__HEADERS=$(CHIP_BUILD_PROFILES_LAYER_HEADER_FILES)
 
 lib_LIBRARIES                       = libCHIP.a
 

--- a/src/lib/core/CoreLayer.am
+++ b/src/lib/core/CoreLayer.am
@@ -51,4 +51,5 @@ CHIP_BUILD_CORE_LAYER_HEADER_FILES                        = \
     @top_builddir@/src/lib/core/CHIPTunnelConfig.h          \
     @top_builddir@/src/lib/core/CHIPKeyIds.h                \
     @top_builddir@/src/lib/core/Optional.h                  \
+    @top_builddir@/src/lib/core/CHIPVendorIdentifiers.hpp   \
     $(NULL)

--- a/src/lib/profiles/CHIPProfiles.h
+++ b/src/lib/profiles/CHIPProfiles.h
@@ -1,0 +1,62 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines constant enumerations for all public (or
+ *      common) profiles.
+ *
+ */
+
+#ifndef CHIP_PROFILES_H_
+#define CHIP_PROFILES_H_
+
+#include <core/CHIPVendorIdentifiers.hpp>
+
+/**
+ *   @namespace chip::Profiles
+ *
+ *   @brief
+ *     This namespace includes all interfaces within CHIP for CHIP profiles.
+ */
+
+namespace chip {
+namespace Profiles {
+
+//
+// CHIP Profile Ids (32-bits max)
+//
+
+enum CHIPProfileId
+{
+    // Common Profiles
+    //
+    // NOTE: Do not attempt to allocate these values yourself.
+
+    kChipProfile_Common              = (kChipVendor_Common << 16) | 0x0000, // Common Profile
+    kChipProfile_ServiceProvisioning = (kChipVendor_Common << 16) | 0x000F, // Service Provisioning Profile
+
+    // Profiles reserved for internal protocol use
+
+    kChipProfile_NotSpecified = (kChipVendor_NotSpecified << 16) | 0xFFFF, // The profile ID is either not specified or a wildcard
+};
+
+} // namespace Profiles
+} // namespace chip
+
+#endif /* CHIP_PROFILES_H_ */

--- a/src/lib/profiles/ProfilesLayer.am
+++ b/src/lib/profiles/ProfilesLayer.am
@@ -1,0 +1,28 @@
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+#
+#    Description:
+#      This file is the GNU automake template for the CHIP Support library.
+#
+#      These sources are shared by other SDK makefiles and consequently
+#      must be anchored relative to the top build directory.
+#
+
+
+CHIP_BUILD_PROFILES_LAYER_HEADER_FILES                        = \
+    @top_builddir@/src/lib/profiles/CHIPProfiles.h              \
+    $(NULL)

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -123,10 +123,11 @@ CHIP_ERROR generateTLVFromOptionalData(SetupPayload & outPayload, uint8_t * tlvD
 
     TLVWriter rootWriter;
     rootWriter.Init(tlvDataStart, maxLen);
+    rootWriter.ImplicitProfileId = outPayload.productID;
 
     TLVWriter innerStructureWritter;
 
-    err = rootWriter.OpenContainer(ProfileTag(2, 1), kTLVType_Structure,
+    err = rootWriter.OpenContainer(ProfileTag(outPayload.productID, kTag_QRCodeExensionDescriptor), kTLVType_Structure,
                                    innerStructureWritter); // TODO: Remove outer nest of QR code TLV encoding #728
     SuccessOrExit(err);
 

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -121,7 +121,8 @@ CHIP_ERROR generateTLVFromOptionalData(SetupPayload & outPayload, uint8_t * tlvD
     rootWriter.Init(tlvDataStart, maxLen);
     rootWriter.ImplicitProfileId = outPayload.productID;
 
-    if (optionalData.size() > 1)
+    // The cost (in bytes) of the top-level container is amortized as soon as there is at least 4 optionals elements.
+    if (optionalData.size() >= 4)
     {
 
         TLVWriter innerStructureWriter;
@@ -141,9 +142,11 @@ CHIP_ERROR generateTLVFromOptionalData(SetupPayload & outPayload, uint8_t * tlvD
     }
     else
     {
-        OptionalQRCodeInfo info = optionalData.front();
-        err                     = writeTag(rootWriter, ProfileTag(outPayload.productID, info.tag), info);
-        SuccessOrExit(err);
+        for (OptionalQRCodeInfo info : optionalData)
+        {
+            err = writeTag(rootWriter, ProfileTag(outPayload.productID, info.tag), info);
+            SuccessOrExit(err);
+        }
     }
     err = rootWriter.Finalize();
     SuccessOrExit(err);

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -30,6 +30,7 @@
 #include <core/CHIPTLVData.hpp>
 #include <core/CHIPTLVDebug.hpp>
 #include <core/CHIPTLVUtilities.hpp>
+#include <profiles/CHIPProfiles.h>
 #include <support/CodeUtils.h>
 #include <support/RandUtils.h>
 
@@ -119,7 +120,7 @@ CHIP_ERROR generateTLVFromOptionalData(SetupPayload & outPayload, uint8_t * tlvD
 
     TLVWriter rootWriter;
     rootWriter.Init(tlvDataStart, maxLen);
-    rootWriter.ImplicitProfileId = outPayload.productID;
+    rootWriter.ImplicitProfileId = chip::Profiles::kChipProfile_ServiceProvisioning;
 
     // The cost (in bytes) of the top-level container is amortized as soon as there is at least 4 optionals elements.
     if (optionalData.size() >= 4)
@@ -127,7 +128,7 @@ CHIP_ERROR generateTLVFromOptionalData(SetupPayload & outPayload, uint8_t * tlvD
 
         TLVWriter innerStructureWriter;
 
-        err = rootWriter.OpenContainer(ProfileTag(outPayload.productID, kTag_QRCodeExensionDescriptor), kTLVType_Structure,
+        err = rootWriter.OpenContainer(ProfileTag(rootWriter.ImplicitProfileId, kTag_QRCodeExensionDescriptor), kTLVType_Structure,
                                        innerStructureWriter);
         SuccessOrExit(err);
 
@@ -144,7 +145,7 @@ CHIP_ERROR generateTLVFromOptionalData(SetupPayload & outPayload, uint8_t * tlvD
     {
         for (OptionalQRCodeInfo info : optionalData)
         {
-            err = writeTag(rootWriter, ProfileTag(outPayload.productID, info.tag), info);
+            err = writeTag(rootWriter, ProfileTag(rootWriter.ImplicitProfileId, info.tag), info);
             SuccessOrExit(err);
         }
     }

--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -89,7 +89,7 @@ static CHIP_ERROR retrieveStringOptionalInfo(TLVReader & reader, OptionalQRCodeI
     char * val         = new char[valLength + 1];
     err                = reader.GetString(val, valLength + 1);
     SuccessOrExit(err);
-    VerifyOrExit(IsContextTag(tag) == true, err = CHIP_ERROR_INVALID_TLV_TAG);
+    VerifyOrExit(IsContextTag(tag) == true || IsProfileTag(tag) == true, err = CHIP_ERROR_INVALID_TLV_TAG);
     info.type = optionalQRCodeInfoTypeString;
     info.tag  = (uint8_t) TagNumFromTag(tag);
     info.data = string(val);
@@ -105,7 +105,7 @@ static CHIP_ERROR retrieveIntegerOptionalInfo(TLVReader & reader, OptionalQRCode
     int64_t storedInteger;
     err = reader.Get(storedInteger);
     SuccessOrExit(err);
-    VerifyOrExit(IsContextTag(tag) == true, err = CHIP_ERROR_INVALID_TLV_TAG);
+    VerifyOrExit(IsContextTag(tag) == true || IsProfileTag(tag) == true, err = CHIP_ERROR_INVALID_TLV_TAG);
     info.type    = optionalQRCodeInfoTypeInt;
     info.tag     = (uint8_t) TagNumFromTag(tag);
     info.integer = storedInteger;
@@ -125,6 +125,42 @@ static void populatePayloadTLVField(SetupPayload & outPayload, OptionalQRCodeInf
     }
 }
 
+static CHIP_ERROR retrieveOptionalInfos(SetupPayload & outPayload, TLVReader & reader)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    TLVType type;
+    while (err == CHIP_NO_ERROR)
+    {
+        OptionalQRCodeInfo info;
+
+        type = reader.GetType();
+        if (type != kTLVType_UTF8String && type != kTLVType_SignedInteger)
+        {
+            err = reader.Next();
+            continue;
+        }
+        if (type == kTLVType_UTF8String)
+        {
+            err = retrieveStringOptionalInfo(reader, info);
+        }
+        else if (type == kTLVType_SignedInteger)
+        {
+            err = retrieveIntegerOptionalInfo(reader, info);
+        }
+        SuccessOrExit(err);
+
+        populatePayloadTLVField(outPayload, info);
+        err = reader.Next();
+    }
+    if (err == CHIP_END_OF_TLV)
+    {
+        err = CHIP_NO_ERROR;
+    }
+
+exit:
+    return err;
+}
+
 static CHIP_ERROR parseTLVFields(SetupPayload & outPayload, uint8_t * tlvDataStart, uint32_t tlvDataLengthInBytes)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -133,34 +169,22 @@ static CHIP_ERROR parseTLVFields(SetupPayload & outPayload, uint8_t * tlvDataSta
     rootReader.ImplicitProfileId = outPayload.productID;
     err                          = rootReader.Next();
     SuccessOrExit(err);
+
+    if (rootReader.GetType() == kTLVType_Structure)
     {
         TLVReader innerStructureReader;
         err = openTLVContainer(rootReader, kTLVType_Structure, ProfileTag(outPayload.productID, kTag_QRCodeExensionDescriptor),
                                innerStructureReader);
         SuccessOrExit(err);
         err = innerStructureReader.Next();
-        while (err == CHIP_NO_ERROR)
-        {
-            TLVType type = innerStructureReader.GetType();
-            OptionalQRCodeInfo info;
-            if (type != kTLVType_UTF8String && type != kTLVType_SignedInteger)
-            {
-                err = innerStructureReader.Next();
-                continue;
-            }
-            if (type == kTLVType_UTF8String)
-            {
-                err = retrieveStringOptionalInfo(innerStructureReader, info);
-            }
-            else if (type == kTLVType_SignedInteger)
-            {
-                err = retrieveIntegerOptionalInfo(innerStructureReader, info);
-            }
-            SuccessOrExit(err);
-            populatePayloadTLVField(outPayload, info);
-            err = innerStructureReader.Next();
-        }
+        SuccessOrExit(err);
+        err = retrieveOptionalInfos(outPayload, innerStructureReader);
     }
+    else
+    {
+        err = retrieveOptionalInfos(outPayload, rootReader);
+    }
+
     if (err == CHIP_END_OF_TLV)
     {
         err = CHIP_NO_ERROR;

--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -135,7 +135,8 @@ static CHIP_ERROR parseTLVFields(SetupPayload & outPayload, uint8_t * tlvDataSta
     SuccessOrExit(err);
     {
         TLVReader innerStructureReader;
-        err = openTLVContainer(rootReader, kTLVType_Structure, ProfileTag(2, 1), innerStructureReader);
+        err = openTLVContainer(rootReader, kTLVType_Structure, ProfileTag(outPayload.productID, kTag_QRCodeExensionDescriptor),
+                               innerStructureReader);
         SuccessOrExit(err);
         err = innerStructureReader.Next();
         while (err == CHIP_NO_ERROR)

--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -34,6 +34,7 @@
 #include <core/CHIPTLV.h>
 #include <core/CHIPTLVData.hpp>
 #include <core/CHIPTLVUtilities.hpp>
+#include <profiles/CHIPProfiles.h>
 #include <support/CodeUtils.h>
 #include <support/RandUtils.h>
 
@@ -166,15 +167,15 @@ static CHIP_ERROR parseTLVFields(SetupPayload & outPayload, uint8_t * tlvDataSta
     CHIP_ERROR err = CHIP_NO_ERROR;
     TLVReader rootReader;
     rootReader.Init(tlvDataStart, tlvDataLengthInBytes);
-    rootReader.ImplicitProfileId = outPayload.productID;
+    rootReader.ImplicitProfileId = chip::Profiles::kChipProfile_ServiceProvisioning;
     err                          = rootReader.Next();
     SuccessOrExit(err);
 
     if (rootReader.GetType() == kTLVType_Structure)
     {
         TLVReader innerStructureReader;
-        err = openTLVContainer(rootReader, kTLVType_Structure, ProfileTag(outPayload.productID, kTag_QRCodeExensionDescriptor),
-                               innerStructureReader);
+        err = openTLVContainer(rootReader, kTLVType_Structure,
+                               ProfileTag(rootReader.ImplicitProfileId, kTag_QRCodeExensionDescriptor), innerStructureReader);
         SuccessOrExit(err);
         err = innerStructureReader.Next();
         SuccessOrExit(err);

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -49,6 +49,7 @@ const int kPaddingFieldLengthInBits                  = 5;
 const int kRendezvousInfoReservedFieldLengthInBits = 4;
 const int kRawVendorTagLengthInBits                = 7;
 const uint16_t kSerialNumberTag                    = 128;
+const uint32_t kTag_QRCodeExensionDescriptor       = 0x00;
 
 const int kManualSetupShortCodeCharLength = 10;
 const int kManualSetupLongCodeCharLength  = 20;

--- a/src/setup_payload/tests/Makefile.am
+++ b/src/setup_payload/tests/Makefile.am
@@ -49,8 +49,9 @@ libSetupPayloadTests_a_SOURCES                 = \
 libSetupPayloadTests_adir                      = $(includedir)/setup_payload
 
 dist_libSetupPayloadTests_a_HEADERS            = \
-    TestQRCode.h                                 \
+    TestHelpers.h                                \
     TestManualCode.h                             \
+    TestQRCode.h                                 \
     TestQRCodeTLV.h                              \
     $(NULL)
 

--- a/src/setup_payload/tests/TestHelpers.h
+++ b/src/setup_payload/tests/TestHelpers.h
@@ -1,0 +1,158 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <bitset>
+
+#include "Base41.cpp"
+#include "QRCodeSetupPayloadGenerator.cpp"
+#include "QRCodeSetupPayloadParser.cpp"
+#include "SetupPayload.cpp"
+
+const uint16_t kSmallBufferSizeInBytes   = 1;
+const uint16_t kDefaultBufferSizeInBytes = 512;
+
+SetupPayload GetDefaultPayload()
+{
+    SetupPayload payload;
+
+    payload.version               = 5;
+    payload.vendorID              = 12;
+    payload.productID             = 1;
+    payload.requiresCustomFlow    = 0;
+    payload.rendezvousInformation = 1;
+    payload.discriminator         = 128;
+    payload.setUpPINCode          = 2048;
+
+    return payload;
+}
+
+SetupPayload GetDefaultPayloadWithSerialNumber()
+{
+    SetupPayload payload = GetDefaultPayload();
+    payload.serialNumber = "123456789QWDHANTYUIOP";
+
+    return payload;
+}
+
+OptionalQRCodeInfo GetOptionalDefaultString()
+{
+    OptionalQRCodeInfo info;
+    info.tag  = 2;
+    info.type = optionalQRCodeInfoTypeString;
+    info.data = "myData";
+
+    return info;
+}
+
+OptionalQRCodeInfo GetOptionalDefaultInt()
+{
+    OptionalQRCodeInfo info;
+    info.tag     = 3;
+    info.type    = optionalQRCodeInfoTypeInt;
+    info.integer = 12;
+
+    return info;
+}
+
+SetupPayload GetDefaultPayloadWithOptionalDefaults()
+{
+    SetupPayload payload = GetDefaultPayloadWithSerialNumber();
+
+    OptionalQRCodeInfo stringInfo = GetOptionalDefaultString();
+    OptionalQRCodeInfo intInfo    = GetOptionalDefaultInt();
+
+    payload.addVendorOptionalData(stringInfo);
+    payload.addVendorOptionalData(intInfo);
+
+    return payload;
+}
+
+string toBinaryRepresentation(string base41Result)
+{
+    // Remove the kQRCodePrefix
+    base41Result.erase(0, strlen(kQRCodePrefix));
+
+    // Decode the base41 encoded string
+    vector<uint8_t> buffer;
+    base41Decode(base41Result, buffer);
+
+    // Convert it to binary
+    string binaryResult;
+    for (int i = buffer.size() - 1; i >= 0; i--)
+    {
+        binaryResult += bitset<8>(buffer[i]).to_string();
+    }
+
+    // Insert spaces after each block
+    size_t pos = binaryResult.size();
+
+    pos -= kVersionFieldLengthInBits;
+    binaryResult.insert(pos, " ");
+
+    pos -= kVendorIDFieldLengthInBits;
+    binaryResult.insert(pos, " ");
+
+    pos -= kProductIDFieldLengthInBits;
+    binaryResult.insert(pos, " ");
+
+    pos -= kCustomFlowRequiredFieldLengthInBits;
+    binaryResult.insert(pos, " ");
+
+    pos -= kRendezvousInfoFieldLengthInBits;
+    binaryResult.insert(pos, " ");
+
+    pos -= kPayloadDiscriminatorFieldLengthInBits;
+    binaryResult.insert(pos, " ");
+
+    pos -= kSetupPINCodeFieldLengthInBits;
+    binaryResult.insert(pos, " ");
+
+    pos -= kPaddingFieldLengthInBits;
+    binaryResult.insert(pos, " ");
+
+    return binaryResult;
+}
+
+bool CompareBinary(SetupPayload & payload, string & expectedBinary)
+{
+    QRCodeSetupPayloadGenerator generator(payload);
+
+    string result;
+    uint8_t optionalInfo[kDefaultBufferSizeInBytes];
+    generator.payloadBase41Representation(result, optionalInfo, sizeof(optionalInfo));
+
+    string resultBinary = toBinaryRepresentation(result);
+    return (expectedBinary == resultBinary);
+}
+
+bool CompareBinaryLength(SetupPayload & payload, size_t expectedTLVLengthInBytes)
+{
+    string result;
+    uint8_t optionalInfo[kDefaultBufferSizeInBytes];
+
+    SetupPayload basePayload = GetDefaultPayload();
+    QRCodeSetupPayloadGenerator baseGenerator(basePayload);
+    baseGenerator.payloadBase41Representation(result, optionalInfo, sizeof(optionalInfo));
+    string baseBinary = toBinaryRepresentation(result);
+
+    QRCodeSetupPayloadGenerator generator(payload);
+    generator.payloadBase41Representation(result, optionalInfo, sizeof(optionalInfo));
+
+    string resultBinary           = toBinaryRepresentation(result);
+    size_t resultTLVLengthInBytes = (resultBinary.size() - baseBinary.size()) / 8;
+    return (expectedTLVLengthInBytes == resultTLVLengthInBytes);
+}

--- a/src/setup_payload/tests/TestQRCode.cpp
+++ b/src/setup_payload/tests/TestQRCode.cpp
@@ -23,97 +23,21 @@
  */
 
 #include "TestQRCode.h"
-
-#include <assert.h>
-#include <bitset>
-#include <stdio.h>
-#include <unistd.h>
+#include "TestHelpers.h"
 
 #include <iostream>
 #include <nlbyteorder.h>
 #include <nlunit-test.h>
 
-#include "Base41.cpp"
-#include "QRCodeSetupPayloadGenerator.cpp"
-#include "QRCodeSetupPayloadParser.cpp"
-#include "SetupPayload.cpp"
-
 using namespace chip;
 using namespace std;
-
-SetupPayload GetDefaultPayload()
-{
-    SetupPayload payload;
-
-    payload.version               = 5;
-    payload.vendorID              = 12;
-    payload.productID             = 1;
-    payload.requiresCustomFlow    = 0;
-    payload.rendezvousInformation = 1;
-    payload.discriminator         = 128;
-    payload.setUpPINCode          = 2048;
-
-    return payload;
-}
-
-string toBinaryRepresentation(string base41Result)
-{
-    // Remove the kQRCodePrefix
-    base41Result.erase(0, strlen(kQRCodePrefix));
-
-    // Decode the base41 encoded string
-    vector<uint8_t> buffer;
-    base41Decode(base41Result, buffer);
-
-    // Convert it to binary
-    string binaryResult;
-    for (int i = buffer.size() - 1; i >= 0; i--)
-    {
-        binaryResult += bitset<8>(buffer[i]).to_string();
-    }
-
-    // Insert spaces after each block
-    size_t pos = binaryResult.size();
-
-    pos -= kVersionFieldLengthInBits;
-    binaryResult.insert(pos, " ");
-
-    pos -= kVendorIDFieldLengthInBits;
-    binaryResult.insert(pos, " ");
-
-    pos -= kProductIDFieldLengthInBits;
-    binaryResult.insert(pos, " ");
-
-    pos -= kCustomFlowRequiredFieldLengthInBits;
-    binaryResult.insert(pos, " ");
-
-    pos -= kRendezvousInfoFieldLengthInBits;
-    binaryResult.insert(pos, " ");
-
-    pos -= kPayloadDiscriminatorFieldLengthInBits;
-    binaryResult.insert(pos, " ");
-
-    pos -= kSetupPINCodeFieldLengthInBits;
-    binaryResult.insert(pos, " ");
-
-    pos -= kPaddingFieldLengthInBits;
-    binaryResult.insert(pos, " ");
-
-    return binaryResult;
-}
 
 void TestPayloadByteArrayRep(nlTestSuite * inSuite, void * inContext)
 {
     SetupPayload payload = GetDefaultPayload();
 
-    QRCodeSetupPayloadGenerator generator(payload);
-    string result;
-    CHIP_ERROR err  = generator.payloadBase41Representation(result);
-    bool didSucceed = err == CHIP_NO_ERROR;
-    NL_TEST_ASSERT(inSuite, didSucceed == true);
-
     string expected = " 00000 000000000000000100000000000 000010000000 00000001 0 0000000000000001 0000000000001100 101";
-    NL_TEST_ASSERT(inSuite, toBinaryRepresentation(result) == expected);
+    NL_TEST_ASSERT(inSuite, CompareBinary(payload, expected));
 }
 
 void TestPayloadBase41Rep(nlTestSuite * inSuite, void * inContext)


### PR DESCRIPTION
 #### Problem

This PR use the implicit profile for TLV optional data as specified in the [8. TLV Content] section of the spec.
This code may dissapears once #728 lands but in the meantime I don't think it hurts to follow the spec (and it also removes 3 bytes of outputs for the current encoded TLV) 

 #### Summary of Changes
 * Use the implicit profile branch of TLVWriter

fixes #978 
