### PR TITLE
make base41 more flexible in corner cases

### DIFF
--- a/scripts/build/bootstrap.sh
+++ b/scripts/build/bootstrap.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+env
 
 if [[ ! -f build/default/config.status ]]; then
     mkdir -p build/default

--- a/scripts/build/bootstrap.sh
+++ b/scripts/build/bootstrap.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -x
 env
 
 if [[ ! -f build/default/config.status ]]; then

--- a/scripts/build/default.sh
+++ b/scripts/build/default.sh
@@ -1,3 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+env
 
 make V=1 -C build/default

--- a/scripts/build/default.sh
+++ b/scripts/build/default.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -x
 env
 
 make V=1 -C build/default

--- a/scripts/build/distribution_check.sh
+++ b/scripts/build/distribution_check.sh
@@ -1,3 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-make -C build/default distcheck
+env
+
+make V=1 -C build/default distcheck

--- a/scripts/build/distribution_check.sh
+++ b/scripts/build/distribution_check.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -x
 env
 
 make V=1 -C build/default distcheck

--- a/scripts/examples/esp_echo_app.sh
+++ b/scripts/examples/esp_echo_app.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -x
 env
 
 make -f Makefile-bootstrap repos

--- a/scripts/examples/esp_echo_app.sh
+++ b/scripts/examples/esp_echo_app.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+env
 
 make -f Makefile-bootstrap repos
 source examples/wifi-echo/server/esp32/idf.sh

--- a/scripts/examples/nrf_lock_app.sh
+++ b/scripts/examples/nrf_lock_app.sh
@@ -1,3 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+env
 
 make VERBOSE=1 -C examples/lock-app/nrf5

--- a/scripts/examples/nrf_lock_app.sh
+++ b/scripts/examples/nrf_lock_app.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -x
 env
 
 make VERBOSE=1 -C examples/lock-app/nrf5

--- a/scripts/examples/standalone_echo_client.sh
+++ b/scripts/examples/standalone_echo_client.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -x
 env
 
 make -C examples/chip-tool

--- a/scripts/examples/standalone_echo_client.sh
+++ b/scripts/examples/standalone_echo_client.sh
@@ -1,3 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+env
 
 make -C examples/chip-tool

--- a/scripts/helpers/auto_enforce_code_style.sh
+++ b/scripts/helpers/auto_enforce_code_style.sh
@@ -1,3 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+env
 
 make -C build/default pretty

--- a/scripts/helpers/auto_enforce_code_style.sh
+++ b/scripts/helpers/auto_enforce_code_style.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -x
 env
 
 make -C build/default pretty

--- a/scripts/helpers/clean.sh
+++ b/scripts/helpers/clean.sh
@@ -1,3 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+env
 
 make -C build/default distclean

--- a/scripts/helpers/clean.sh
+++ b/scripts/helpers/clean.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -x
 env
 
 make -C build/default distclean

--- a/scripts/helpers/clean_tree.sh
+++ b/scripts/helpers/clean_tree.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -x
 env
 
 make -f Makefile-bootstrap clean-repos && git clean -Xdf

--- a/scripts/helpers/clean_tree.sh
+++ b/scripts/helpers/clean_tree.sh
@@ -1,3 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+env
 
 make -f Makefile-bootstrap clean-repos && git clean -Xdf

--- a/scripts/helpers/code_style_check.sh
+++ b/scripts/helpers/code_style_check.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -x
 env
 
 make -C build/default pretty-check

--- a/scripts/helpers/code_style_check.sh
+++ b/scripts/helpers/code_style_check.sh
@@ -1,3 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+env
 
 make -C build/default pretty-check

--- a/scripts/helpers/restyle_merge.sh
+++ b/scripts/helpers/restyle_merge.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -x
 env
 
 git remote add upstream https://github.com/project-chip/connectedhomeip.git

--- a/scripts/helpers/restyle_merge.sh
+++ b/scripts/helpers/restyle_merge.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+env
 
 git remote add upstream https://github.com/project-chip/connectedhomeip.git
 git fetch upstream pull/"$1"/head

--- a/scripts/setup/install_packages.sh
+++ b/scripts/setup/install_packages.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
+set -x
 env

--- a/scripts/setup/install_packages.sh
+++ b/scripts/setup/install_packages.sh
@@ -1,1 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+env

--- a/scripts/setup/linux/install_packages.sh
+++ b/scripts/setup/linux/install_packages.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
+set -x
 env
 
-set -x
 apt-get update
 apt-get install -fy \
     git \

--- a/scripts/setup/linux/install_packages.sh
+++ b/scripts/setup/linux/install_packages.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+env
 
 set -x
 apt-get update

--- a/scripts/tests/all_tests.sh
+++ b/scripts/tests/all_tests.sh
@@ -1,3 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+env
 
 make V=1 -C build/default check

--- a/scripts/tests/all_tests.sh
+++ b/scripts/tests/all_tests.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -x
 env
 
 make V=1 -C build/default check

--- a/scripts/tests/crypto_tests.sh
+++ b/scripts/tests/crypto_tests.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -x
 env
 
 make V=1 -C build/default/src/crypto check

--- a/scripts/tests/crypto_tests.sh
+++ b/scripts/tests/crypto_tests.sh
@@ -1,3 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+env
 
 make V=1 -C build/default/src/crypto check

--- a/scripts/tests/mbedtls_tests.sh
+++ b/scripts/tests/mbedtls_tests.sh
@@ -1,3 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+env
+
 
 make V=1 -C build/default/third_party/mbedtls

--- a/scripts/tests/mbedtls_tests.sh
+++ b/scripts/tests/mbedtls_tests.sh
@@ -2,5 +2,4 @@
 
 env
 
-
 make V=1 -C build/default/third_party/mbedtls

--- a/scripts/tests/mbedtls_tests.sh
+++ b/scripts/tests/mbedtls_tests.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -x
 env
 
 make V=1 -C build/default/third_party/mbedtls

--- a/scripts/tests/openssl_tests.sh
+++ b/scripts/tests/openssl_tests.sh
@@ -1,3 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+env
 
 make V=1 -C build/default/src/crypto/ && make V=1 -C build/default/src/crypto/tests/ TestCryptoPAL

--- a/scripts/tests/openssl_tests.sh
+++ b/scripts/tests/openssl_tests.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -x
 env
 
 make V=1 -C build/default/src/crypto/ && make V=1 -C build/default/src/crypto/tests/ TestCryptoPAL

--- a/scripts/tests/qrcode_payload_tests.sh
+++ b/scripts/tests/qrcode_payload_tests.sh
@@ -1,3 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+env
 
 make V=1 -C build/default/src/setup_payload/tests/ TestQRCode

--- a/scripts/tests/qrcode_payload_tests.sh
+++ b/scripts/tests/qrcode_payload_tests.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -x
 env
 
 make V=1 -C build/default/src/setup_payload/tests/ TestQRCode

--- a/scripts/tests/save_logs.sh
+++ b/scripts/tests/save_logs.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -x
 env
 
 TARGET_DIR=$1

--- a/scripts/tests/save_logs.sh
+++ b/scripts/tests/save_logs.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+env
 
 TARGET_DIR=$1
 

--- a/scripts/tests/setup_payload_tests.sh
+++ b/scripts/tests/setup_payload_tests.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -x
 env
 
 make V=1 -C build/default/src/setup_payload/tests TestQRCode && build/default/src/setup_payload/tests/TestQRCode

--- a/scripts/tests/setup_payload_tests.sh
+++ b/scripts/tests/setup_payload_tests.sh
@@ -2,4 +2,5 @@
 
 env
 
+make V=1 -C build/default/src/setup_payload/tests TestQRCode && build/default/src/setup_payload/tests/TestQRCode
 make V=1 -C build/default/src/setup_payload check

--- a/scripts/tests/setup_payload_tests.sh
+++ b/scripts/tests/setup_payload_tests.sh
@@ -1,3 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+env
 
 make V=1 -C build/default/src/setup_payload check

--- a/scripts/tools/codecoverage.sh
+++ b/scripts/tools/codecoverage.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -x
 env
 
 make -C build/default coverage

--- a/scripts/tools/codecoverage.sh
+++ b/scripts/tools/codecoverage.sh
@@ -1,3 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+env
 
 make -C build/default coverage

--- a/scripts/tools/run_if.sh
+++ b/scripts/tools/run_if.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -x
 env
 
 if [[ $1 == *"$2"* ]]; then

--- a/scripts/tools/run_if.sh
+++ b/scripts/tools/run_if.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+env
 
 if [[ $1 == *"$2"* ]]; then
     shift

--- a/scripts/tools/run_if.sh
+++ b/scripts/tools/run_if.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 set -x
-env
 
 if [[ $1 == *"$2"* ]]; then
     shift

--- a/src/setup_payload/Base41.cpp
+++ b/src/setup_payload/Base41.cpp
@@ -40,7 +40,7 @@ static const char codes[]        = { '0', '1', '2', '3', '4', '5', '6', '7', '8'
                               'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', ' ', '*', '+', '-', '.' };
 static const int kBase41ChunkLen = 3;
 static const int kBytesChunkLen  = 2;
-static const int radix           = sizeof(codes) / sizeof(codes[0]);
+static const int kRadix          = sizeof(codes) / sizeof(codes[0]);
 
 string base41Encode(const uint8_t * buf, size_t buf_len)
 {
@@ -55,8 +55,8 @@ string base41Encode(const uint8_t * buf, size_t buf_len)
 
         for (int _ = 0; _ < kBase41ChunkLen; _++)
         {
-            result += codes[next % radix];
-            next /= radix;
+            result += codes[next % kRadix];
+            next /= kRadix;
         }
         buf += kBytesChunkLen;
         buf_len -= kBytesChunkLen;
@@ -67,8 +67,8 @@ string base41Encode(const uint8_t * buf, size_t buf_len)
         int next = buf[0];
         for (int _ = 0; _ < kBase41ChunkLen - 1; _++)
         {
-            result += codes[next % radix];
-            next /= radix;
+            result += codes[next % kRadix];
+            next /= kRadix;
         }
     }
     return result;
@@ -177,13 +177,14 @@ CHIP_ERROR base41Decode(string base41, vector<uint8_t> & result)
                 return err;
             }
 
-            value *= radix;
+            value *= kRadix;
             value += v;
         }
 
         result.push_back(value % 256);
         result.push_back(value / 256);
     }
+
     if (base41.length() % kBase41ChunkLen == kBase41ChunkLen - 1)
     {
         int i          = base41.length() - (kBase41ChunkLen - 1);
@@ -199,10 +200,13 @@ CHIP_ERROR base41Decode(string base41, vector<uint8_t> & result)
                 return err;
             }
 
-            value *= radix;
+            value *= kRadix;
             value += v;
         }
-
+        if (value > 255)
+        {
+            return CHIP_ERROR_INVALID_INTEGER_VALUE;
+        }
         result.push_back(value);
     }
     return CHIP_NO_ERROR;

--- a/src/setup_payload/tests/Makefile.am
+++ b/src/setup_payload/tests/Makefile.am
@@ -87,15 +87,6 @@ COMMON_LDADD                                           = \
     $(PTHREAD_CFLAGS) $(PTHREAD_LIBS)                    \
     $(NULL)
 
-PHONY: debugging
-
-debugging:
-	ls -l $(top_srcdir)/src/setup_payload/Base41.cpp TestQRCode.o
-	strings TestQRCode.o | grep 96 # this needs to be in there
-	strings TestQRCode.o | grep A6 # this needs to be in there, new test
-
-TestQRCode: debugging
-
 # Test applications that should be run when the 'check' target is run.
 
 check_PROGRAMS                                 = \

--- a/src/setup_payload/tests/Makefile.am
+++ b/src/setup_payload/tests/Makefile.am
@@ -86,7 +86,14 @@ COMMON_LDADD                                           = \
     $(SOCKETS_LDFLAGS) $(SOCKETS_LIBS)                   \
     $(PTHREAD_CFLAGS) $(PTHREAD_LIBS)                    \
     $(NULL)
-    
+
+PHONY: debugging
+
+debugging:
+	ls -l $(top_srcdir)/src/setup_payload/Base41.cpp TestQRCode.o
+
+TestQRCode: debugging
+
 # Test applications that should be run when the 'check' target is run.
 
 check_PROGRAMS                                 = \

--- a/src/setup_payload/tests/Makefile.am
+++ b/src/setup_payload/tests/Makefile.am
@@ -91,6 +91,8 @@ PHONY: debugging
 
 debugging:
 	ls -l $(top_srcdir)/src/setup_payload/Base41.cpp TestQRCode.o
+	strings TestQRCode.o | grep 96 # this needs to be in there
+	strings TestQRCode.o | grep A6 # this needs to be in there, new test
 
 TestQRCode: debugging
 

--- a/src/setup_payload/tests/TestQRCode.cpp
+++ b/src/setup_payload/tests/TestQRCode.cpp
@@ -339,10 +339,11 @@ void TestExtractPayload(nlTestSuite * inSuite, void * inContext)
 // clang-format off
 static const nlTest sTests[] =
 {
+
+    NL_TEST_DEF("Test Base 41",                                                     TestBase41),
     NL_TEST_DEF("Test Bitset Length",                                               TestBitsetLen),
     NL_TEST_DEF("Test Payload Byte Array Representation",                           TestPayloadByteArrayRep),
     NL_TEST_DEF("Test Payload Base 41 Representation",                              TestPayloadBase41Rep),
-    NL_TEST_DEF("Test Payload Base 41",                                             TestBase41),
     NL_TEST_DEF("Test Setup Payload Verify",                                        TestSetupPayloadVerify),
     NL_TEST_DEF("Test Payload Equality",                                            TestPayloadEquality),
     NL_TEST_DEF("Test Payload Inequality",                                          TestPayloadInEquality),

--- a/src/setup_payload/tests/TestQRCode.cpp
+++ b/src/setup_payload/tests/TestQRCode.cpp
@@ -191,7 +191,6 @@ void TestBase41(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, decoded.size() == 1);
     NL_TEST_ASSERT(
         inSuite, base41Decode("A6", decoded) == CHIP_ERROR_INVALID_INTEGER_VALUE); // this is 256, something we should never encode
-    NL_TEST_ASSERT(inSuite, decoded.size() == 1);
 }
 
 void TestBitsetLen(nlTestSuite * inSuite, void * inContext)

--- a/src/setup_payload/tests/TestQRCode.cpp
+++ b/src/setup_payload/tests/TestQRCode.cpp
@@ -142,6 +142,16 @@ void TestBase41(nlTestSuite * inSuite, void * inContext)
 
     NL_TEST_ASSERT(inSuite, base41Encode(input, 3).compare("SL1A") == 0);
 
+    // test single odd byte corner conditions
+    input[2] = 0;
+    NL_TEST_ASSERT(inSuite, base41Encode(input, 3).compare("SL10") == 0);
+    input[2] = 40;
+    NL_TEST_ASSERT(inSuite, base41Encode(input, 3).compare("SL1.") == 0);
+    input[2] = 41;
+    NL_TEST_ASSERT(inSuite, base41Encode(input, 3).compare("SL101") == 0);
+    input[2] = 255;
+    NL_TEST_ASSERT(inSuite, base41Encode(input, 3).compare("SL196") == 0);
+
     NL_TEST_ASSERT(inSuite,
                    base41Encode((uint8_t *) "Hello World!", sizeof("Hello World!") - 1).compare("GHF.KGL+48-G5LGK35") == 0);
 
@@ -189,17 +199,13 @@ void TestBase41(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, base41Decode(">0", decoded) == CHIP_ERROR_INVALID_INTEGER_VALUE);
     NL_TEST_ASSERT(inSuite, base41Decode("@0", decoded) == CHIP_ERROR_INVALID_INTEGER_VALUE);
 
-    // overflow of odd byte
+    // odd byte(s) cases
     NL_TEST_ASSERT(inSuite, base41Decode("96", decoded) == CHIP_NO_ERROR); // this is 255
-    NL_TEST_ASSERT(inSuite, decoded.size() == 1);
+    NL_TEST_ASSERT(inSuite, decoded.size() == 1 && decoded[0] == 255);
     NL_TEST_ASSERT(inSuite, base41Decode("A6", decoded) == CHIP_NO_ERROR); // this is 256, needs 2 output bytes
-    NL_TEST_ASSERT(inSuite, decoded.size() == 2);
+    NL_TEST_ASSERT(inSuite, decoded.size() == 2 && decoded[0] + decoded[1] * 256 == 256);
     NL_TEST_ASSERT(inSuite, base41Decode("..", decoded) == CHIP_NO_ERROR); // this is 41^2-1, or 1680, needs 2 output bytes
-    NL_TEST_ASSERT(inSuite, decoded.size() == 2);
-    if (decoded.size() == 2)
-    {
-        NL_TEST_ASSERT(inSuite, (kRadix * kRadix) - 1 == decoded[0] + decoded[1] * 256);
-    }
+    NL_TEST_ASSERT(inSuite, decoded.size() == 2 && decoded[0] + decoded[1] * 256 == (kRadix * kRadix) - 1);
 }
 
 void TestBitsetLen(nlTestSuite * inSuite, void * inContext)

--- a/src/setup_payload/tests/TestQRCode.cpp
+++ b/src/setup_payload/tests/TestQRCode.cpp
@@ -185,6 +185,13 @@ void TestBase41(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, base41Decode("=0", decoded) == CHIP_ERROR_INVALID_INTEGER_VALUE);
     NL_TEST_ASSERT(inSuite, base41Decode(">0", decoded) == CHIP_ERROR_INVALID_INTEGER_VALUE);
     NL_TEST_ASSERT(inSuite, base41Decode("@0", decoded) == CHIP_ERROR_INVALID_INTEGER_VALUE);
+
+    // overflow of odd byte
+    NL_TEST_ASSERT(inSuite, base41Decode("96", decoded) == CHIP_NO_ERROR); // this is 255
+    NL_TEST_ASSERT(inSuite, decoded.size() == 1);
+    NL_TEST_ASSERT(
+        inSuite, base41Decode("A6", decoded) == CHIP_ERROR_INVALID_INTEGER_VALUE); // this is 256, something we should never encode
+    NL_TEST_ASSERT(inSuite, decoded.size() == 1);
 }
 
 void TestBitsetLen(nlTestSuite * inSuite, void * inContext)


### PR DESCRIPTION
#### Problem
Base41 strings that encode() produces are always a multiple of 3, or a multiple of 3 -1.   The latter form is only produced when an odd length byte string is encoded, and as such the value of those last 2 characters should always be less than 256.  base41Decode() currently doesn't enforce this.

 #### Summary of Changes
 * in Encode(): output a single encoded char, if the last byte value is < 41
 * in Decode(): tolerate a single odd base41 character, and tolerate cases where the last 2 encoded chars would overflow a single byte

fixes #982