### PR TITLE
Link crypto libs to standalone app

### DIFF
--- a/config/standalone/standalone-chip.mk
+++ b/config/standalone/standalone-chip.mk
@@ -136,7 +136,6 @@ STD_LDFLAGS += $(shell pkg-config --libs openssl)
 # Add CHIP libraries to standard libraries list.
 STD_LIBS += \
     -lCHIP \
-    -lChipCrypto \
     -lInetLayer \
     -lnlfaultinjection \
     -lSystemLayer
@@ -149,7 +148,6 @@ STD_COMPILE_PREREQUISITES += install-chip
 # Add the CHIP libraries as prerequisites for linking the application.
 STD_LINK_PREREQUISITES += \
     $(CHIP_OUTPUT_DIR)/lib/libCHIP.a \
-    $(CHIP_OUTPUT_DIR)/lib/libChipCrypto.a \
     $(CHIP_OUTPUT_DIR)/lib/libInetLayer.a \
     $(CHIP_OUTPUT_DIR)/lib/libnlfaultinjection.a \
     $(CHIP_OUTPUT_DIR)/lib/libSystemLayer.a

--- a/config/standalone/standalone-chip.mk
+++ b/config/standalone/standalone-chip.mk
@@ -131,10 +131,12 @@ STD_INC_DIRS += \
 
 # Add the location of CHIP libraries to application link action.
 STD_LDFLAGS += -L$(CHIP_OUTPUT_DIR)/lib
+STD_LDFLAGS += $(shell pkg-config --libs openssl)
 
 # Add CHIP libraries to standard libraries list.
 STD_LIBS += \
     -lCHIP \
+    -lChipCrypto \
     -lInetLayer \
     -lnlfaultinjection \
     -lSystemLayer
@@ -147,6 +149,7 @@ STD_COMPILE_PREREQUISITES += install-chip
 # Add the CHIP libraries as prerequisites for linking the application.
 STD_LINK_PREREQUISITES += \
     $(CHIP_OUTPUT_DIR)/lib/libCHIP.a \
+    $(CHIP_OUTPUT_DIR)/lib/libChipCrypto.a \
     $(CHIP_OUTPUT_DIR)/lib/libInetLayer.a \
     $(CHIP_OUTPUT_DIR)/lib/libnlfaultinjection.a \
     $(CHIP_OUTPUT_DIR)/lib/libSystemLayer.a


### PR DESCRIPTION
 #### Problem
Standalone apps do not link with crypto libraries.

 #### Summary of Changes
Fixed the makefile to link with CHIP crypto and OpenSSL libs