### PR TITLE
put Crypto in libCHIP.a, harmonize sub-library .am files

### DIFF
--- a/src/ble/BleLayer.am
+++ b/src/ble/BleLayer.am
@@ -29,18 +29,18 @@ CHIP_BUILD_BLE_LAYER_SOURCE_FILES                         = \
     @top_builddir@/src/ble/BleLayer.cpp                     \
     @top_builddir@/src/ble/BleUUID.cpp                      \
     @top_builddir@/src/ble/BLEEndPoint.cpp                  \
-    @top_builddir@/src/ble/BtpEngine.cpp                     \
+    @top_builddir@/src/ble/BtpEngine.cpp                    \
     $(NULL)
 
 CHIP_BUILD_BLE_LAYER_HEADER_FILES                         = \
-    CHIPBleServiceData.h                                    \
-    BLEEndPoint.h                                           \
-    Ble.h                                                   \
-    BleApplicationDelegate.h                                \
-    BleConfig.h                                             \
-    BleError.h                                              \
-    BleLayer.h                                              \
-    BlePlatformDelegate.h                                   \
-    BleUUID.h                                               \
-    BtpEngine.h                                              \
+    @top_builddir@/src/ble/CHIPBleServiceData.h             \
+    @top_builddir@/src/ble/BLEEndPoint.h                    \
+    @top_builddir@/src/ble/Ble.h                            \
+    @top_builddir@/src/ble/BleApplicationDelegate.h         \
+    @top_builddir@/src/ble/BleConfig.h                      \
+    @top_builddir@/src/ble/BleError.h                       \
+    @top_builddir@/src/ble/BleLayer.h                       \
+    @top_builddir@/src/ble/BlePlatformDelegate.h            \
+    @top_builddir@/src/ble/BleUUID.h                        \
+    @top_builddir@/src/ble/BtpEngine.h                      \
     $(NULL)

--- a/src/crypto/Crypto.am
+++ b/src/crypto/Crypto.am
@@ -1,0 +1,44 @@
+#
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+#
+#    Description:
+#      This file lists the files that go into the CHIP crypto
+#      library.
+#
+
+# for all configs
+CHIP_BUILD_CRYPTO_SOURCE_FILES                          = \
+    $(NULL)
+
+CHIP_BUILD_CRYPTO_HEADER_FILES                          = \
+    @top_builddir@/src/crypto/CHIPCryptoPAL.h             \
+    $(NULL)
+
+# source by config
+if CHIP_CRYPTO_OPENSSL
+CHIP_BUILD_CRYPTO_SOURCE_FILES                         += \
+    @top_builddir@/src/crypto/CHIPCryptoPALOpenSSL.cpp    \
+    $(NULL)
+endif
+
+if CHIP_CRYPTO_MBEDTLS
+CHIP_BUILD_CRYPTO_SOURCE_FILES                         += \
+    @top_builddir@/src/crypto/CHIPCryptoPALmbedTLS.cpp    \
+    $(NULL)
+endif
+

--- a/src/crypto/Makefile.am
+++ b/src/crypto/Makefile.am
@@ -23,14 +23,14 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
+
 SUBDIRS                    = tests
 
 lib_LIBRARIES              = libChipCrypto.a
 
-libChipCrypto_adir             = $(includedir)/crypto
+libChipCrypto_adir         = $(includedir)/crypto
 
 libChipCrypto_a_CPPFLAGS            = \
-    $(LWIP_CPPFLAGS)                  \
     $(NLASSERT_CPPFLAGS)              \
     -I$(top_srcdir)/src               \
     -I$(top_srcdir)/src/lib           \
@@ -38,23 +38,14 @@ libChipCrypto_a_CPPFLAGS            = \
     -I$(top_srcdir)/src/include/      \
     $(NULL)
 
-libChipCrypto_a_SOURCES                                       = \
+include Crypto.am
+
+libChipCrypto_a_SOURCES                                      = \
+    $(CHIP_BUILD_CRYPTO_SOURCE_FILES)                          \
     $(NULL)
 
 dist_libChipCrypto_a_HEADERS                                 = \
-    CHIPCryptoPAL.h                                            \
+    $(CHIP_BUILD_CRYPTO_HEADER_FILES)                          \
     $(NULL)
-
-if CHIP_CRYPTO_OPENSSL
-libChipCrypto_a_SOURCES                                      += \
-    CHIPCryptoPALOpenSSL.cpp                                    \
-    $(NULL)
-endif
-
-if CHIP_CRYPTO_MBEDTLS
-libChipCrypto_a_SOURCES                                      += \
-    CHIPCryptoPALmbedTLS.cpp                                    \
-    $(NULL)
-endif
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -37,6 +37,7 @@ include ../system/SystemLayer.am
 include ../transport/TransportLayer.am
 include core/CoreLayer.am
 include support/SupportLayer.am
+include ../crypto/Crypto.am
 include ../app/DataModel.am
 
 # install headers for core layer
@@ -75,6 +76,7 @@ libCHIP_a_SOURCES                  += $(CHIP_BUILD_SUPPORT_LAYER_SOURCE_FILES)
 libCHIP_a_SOURCES                  += $(CHIP_BUILD_DEVICE_CONTROLLER_SOURCE_FILES)
 libCHIP_a_SOURCES                  += $(CHIP_BUILD_DATA_MODEL_SOURCE_FILES)
 libCHIP_a_SOURCES                  += $(CHIP_BUILD_TRANSPORT_LAYER_SOURCE_FILES)
+libCHIP_a_SOURCES                  += $(CHIP_BUILD_CRYPTO_SOURCE_FILES)
 
 if CONFIG_NETWORK_LAYER_BLE
 libCHIP_a_SOURCES                  += $(CHIP_BUILD_BLE_LAYER_SOURCE_FILES)

--- a/src/lib/core/CoreLayer.am
+++ b/src/lib/core/CoreLayer.am
@@ -24,31 +24,31 @@
 #
 
 CHIP_BUILD_CORE_LAYER_SOURCE_FILES                        = \
-    core/CHIPCircularTLVBuffer.cpp                          \
-    core/CHIPError.cpp                                      \
-    core/CHIPTLVDebug.cpp                                   \
-    core/CHIPTLVReader.cpp                                  \
-    core/CHIPTLVUtilities.cpp                               \
-    core/CHIPTLVWriter.cpp                                  \
-    core/CHIPTLVUpdater.cpp                                 \
-    core/CHIPKeyIds.cpp                                     \
+    @top_builddir@/src/lib/core/CHIPCircularTLVBuffer.cpp   \
+    @top_builddir@/src/lib/core/CHIPError.cpp               \
+    @top_builddir@/src/lib/core/CHIPTLVDebug.cpp            \
+    @top_builddir@/src/lib/core/CHIPTLVReader.cpp           \
+    @top_builddir@/src/lib/core/CHIPTLVUtilities.cpp        \
+    @top_builddir@/src/lib/core/CHIPTLVWriter.cpp           \
+    @top_builddir@/src/lib/core/CHIPTLVUpdater.cpp          \
+    @top_builddir@/src/lib/core/CHIPKeyIds.cpp              \
     $(NULL)
 
 CHIP_BUILD_CORE_LAYER_HEADER_FILES                        = \
-    core/CHIPCircularTLVBuffer.h                            \
-    core/CHIPConfig.h                                       \
-    core/CHIPCore.h                                         \
-    core/CHIPEncoding.h                                     \
-    core/CHIPError.h                                        \
-    core/CHIPEventLoggingConfig.h                           \
-    core/CHIPTLV.h                                          \
-    core/CHIPTLVData.hpp                                    \
-    core/CHIPTLVDebug.hpp                                   \
-    core/CHIPTLVTags.h                                      \
-    core/CHIPTLVTypes.h                                     \
-    core/CHIPTLVUtilities.hpp                               \
-    core/CHIPTimeConfig.h                                   \
-    core/CHIPTunnelConfig.h                                 \
-    core/CHIPKeyIds.h                                       \
-    core/Optional.h                                         \
+    @top_builddir@/src/lib/core/CHIPCircularTLVBuffer.h     \
+    @top_builddir@/src/lib/core/CHIPConfig.h                \
+    @top_builddir@/src/lib/core/CHIPCore.h                  \
+    @top_builddir@/src/lib/core/CHIPEncoding.h              \
+    @top_builddir@/src/lib/core/CHIPError.h                 \
+    @top_builddir@/src/lib/core/CHIPEventLoggingConfig.h    \
+    @top_builddir@/src/lib/core/CHIPTLV.h                   \
+    @top_builddir@/src/lib/core/CHIPTLVData.hpp             \
+    @top_builddir@/src/lib/core/CHIPTLVDebug.hpp            \
+    @top_builddir@/src/lib/core/CHIPTLVTags.h               \
+    @top_builddir@/src/lib/core/CHIPTLVTypes.h              \
+    @top_builddir@/src/lib/core/CHIPTLVUtilities.hpp        \
+    @top_builddir@/src/lib/core/CHIPTimeConfig.h            \
+    @top_builddir@/src/lib/core/CHIPTunnelConfig.h          \
+    @top_builddir@/src/lib/core/CHIPKeyIds.h                \
+    @top_builddir@/src/lib/core/Optional.h                  \
     $(NULL)

--- a/src/lib/support/Makefile.am
+++ b/src/lib/support/Makefile.am
@@ -28,7 +28,6 @@ SUBDIRS                             = \
 
 include SupportLayer.am
 
-
 lib_LIBRARIES                       = libSupportLayer.a
 
 libSupportLayer_a_CPPFLAGS                    = \

--- a/src/lib/support/SupportLayer.am
+++ b/src/lib/support/SupportLayer.am
@@ -22,9 +22,6 @@
 #      must be anchored relative to the top build directory.
 #
 
-AM_CXXFLAGS = \
-    $(NLUNIT_TEST_CPPFLAGS)                                 \
-    $(NULL)
 
 CHIP_BUILD_SUPPORT_LAYER_SOURCE_FILES                     = \
     @top_builddir@/src/lib/support/Base64.cpp               \

--- a/src/system/SystemLayer.am
+++ b/src/system/SystemLayer.am
@@ -38,16 +38,16 @@ CHIP_BUILD_SYSTEM_LAYER_SOURCE_FILES += @top_builddir@/src/system/SystemFaultInj
 endif # CHIP_WITH_NLFAULTINJECTION
 
 CHIP_BUILD_SYSTEM_LAYER_HEADER_FILES                  = \
-    SystemAlignSize.h                                   \
-    SystemClock.h                                       \
-    SystemConfig.h                                      \
-    SystemError.h                                       \
-    SystemEvent.h                                       \
-    SystemFaultInjection.h                              \
-    SystemStats.h                                       \
-    SystemLayer.h                                       \
-    SystemMutex.h                                       \
-    SystemObject.h                                      \
-    SystemTimer.h                                       \
-    SystemPacketBuffer.h                                \
+    @top_builddir@/src/system/SystemAlignSize.h         \
+    @top_builddir@/src/system/SystemClock.h             \
+    @top_builddir@/src/system/SystemConfig.h            \
+    @top_builddir@/src/system/SystemError.h             \
+    @top_builddir@/src/system/SystemEvent.h             \
+    @top_builddir@/src/system/SystemFaultInjection.h    \
+    @top_builddir@/src/system/SystemStats.h             \
+    @top_builddir@/src/system/SystemLayer.h             \
+    @top_builddir@/src/system/SystemMutex.h             \
+    @top_builddir@/src/system/SystemObject.h            \
+    @top_builddir@/src/system/SystemTimer.h             \
+    @top_builddir@/src/system/SystemPacketBuffer.h      \
     $(NULL)

--- a/src/transport/TransportLayer.am
+++ b/src/transport/TransportLayer.am
@@ -30,8 +30,8 @@ CHIP_BUILD_TRANSPORT_LAYER_SOURCE_FILES                  = \
     @top_builddir@/src/transport/CHIPSecureChannel.cpp     \
     $(NULL)
 
-CHIP_BUILD_TRANSPORT_LAYER_HEADER_FILES  = \
-    MessageHeader.h                        \
-    UdpTransport.h                         \
-    CHIPSecureChannel.h                    \
+CHIP_BUILD_TRANSPORT_LAYER_HEADER_FILES             = \
+    @top_builddir@/src/transport/MessageHeader.h      \
+    @top_builddir@/src/transport/UdpTransport.h       \
+    @top_builddir@/src/transport/CHIPSecureChannel.h  \
     $(NULL)

--- a/src/transport/tests/Makefile.am
+++ b/src/transport/tests/Makefile.am
@@ -67,7 +67,6 @@ AM_CPPFLAGS                                           = \
     $(NULL)
 
 CHIP_LDADD                                            = \
-    $(top_builddir)/src/crypto/libChipCrypto.a          \
     $(top_builddir)/src/lib/libCHIP.a                   \
     $(NULL)
 

--- a/src/transport/tests/Makefile.am
+++ b/src/transport/tests/Makefile.am
@@ -67,8 +67,8 @@ AM_CPPFLAGS                                           = \
     $(NULL)
 
 CHIP_LDADD                                            = \
-    $(top_builddir)/src/lib/libCHIP.a                   \
     $(top_builddir)/src/crypto/libChipCrypto.a          \
+    $(top_builddir)/src/lib/libCHIP.a                   \
     $(NULL)
 
 COMMON_LDADD                                          = \
@@ -124,6 +124,7 @@ NLFOREIGN_FILE_DEPENDENCIES                           = \
 
 NLFOREIGN_SUBDIR_DEPENDENCIES                         = \
    $(LWIP_FOREIGN_SUBDIR_DEPENDENCY)                    \
+   $(NLFAULTINJECTION_FOREIGN_SUBDIR_DEPENDENCY)        \
    $(NLUNIT_TEST_FOREIGN_SUBDIR_DEPENDENCY)             \
    $(NULL)
 


### PR DESCRIPTION
#### Problem
 Crypto isn't in libCHIP, but depends on symbols in libCHIP, which in turn depends on Crypto (since transport came into the tree)

 #### Summary of Changes
 * put Crypto in libCHIP
 * harmonize all the component *.am files