### PR TITLE
Use a single CHIPDeviceController for all the views in the iOS app.

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -36,12 +36,7 @@ typedef void (^ControllerOnErrorBlock)(NSError * error);
 
 @interface CHIPDeviceController : NSObject
 
-- (nullable instancetype)initWithCallbackQueue:(dispatch_queue_t)appCallbackQueue;
-- (BOOL)connect:(NSString *)ipAddress
-           port:(UInt16)port
-          error:(NSError * __autoreleasing *)error
-      onMessage:(ControllerOnMessageBlock)onMessage
-        onError:(ControllerOnErrorBlock)onError;
+- (BOOL)connect:(NSString *)ipAddress port:(UInt16)port error:(NSError * __autoreleasing *)error;
 - (nullable AddressInfo *)getAddressInfo;
 - (BOOL)sendMessage:(NSData *)message error:(NSError * __autoreleasing *)error;
 // We can't include definitions of ChipZclClusterId_t and ChipZclCommandId_t
@@ -52,6 +47,26 @@ typedef void (^ControllerOnErrorBlock)(NSError * error);
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
+
+/**
+ * Return the single CHIPDeviceController we support existing.
+ */
++ (CHIPDeviceController *)sharedController;
+
+/**
+ * Register callbacks for network activity.
+ *
+ * @param[in] appCallbackQueue the queue that should be used to deliver the
+ *                             message/error callbacks for this consumer.
+ *
+ * @param[in] onMessage the block to call when the controller gets a message
+ *                      from the network.
+ *
+ * @param[in] onError the block to call when there is a network error.
+ */
+- (void)registerCallbacks:(dispatch_queue_t)appCallbackQueue
+                onMessage:(ControllerOnMessageBlock)onMessage
+                  onError:(ControllerOnErrorBlock)onError;
 
 @end
 

--- a/src/darwin/Framework/CHIP/CHIPEchoClient.mm
+++ b/src/darwin/Framework/CHIP/CHIPEchoClient.mm
@@ -39,11 +39,8 @@ static NSString * const kEchoString = @"Hello from darwin!";
     if (self = [super init]) {
         NSError * error;
         _echoCallbackQueue = dispatch_queue_create("com.zigbee.chip.echo", NULL);
-        _chipController = [[CHIPDeviceController alloc] initWithCallbackQueue:_echoCallbackQueue];
-
-        BOOL didInit = [_chipController connect:ipAddress
-            port:port
-            error:&error
+        _chipController = [CHIPDeviceController sharedController];
+        [self.chipController registerCallbacks:_echoCallbackQueue
             onMessage:^(NSData * _Nonnull message, NSString * _Nonnull ipAddress, UInt16 port) {
                 NSData * sentMessage = [kEchoString dataUsingEncoding:NSUTF8StringEncoding];
                 if ([sentMessage isEqualToData:message]) {
@@ -56,6 +53,8 @@ static NSString * const kEchoString = @"Hello from darwin!";
                 os_log(OS_LOG_DEFAULT, "Received error %@. Stopping...", error);
                 [self stop];
             }];
+
+        BOOL didInit = [_chipController connect:ipAddress port:port error:&error];
 
         if (!didInit) {
             os_log(OS_LOG_DEFAULT, "Failed to init with error %@", error);


### PR DESCRIPTION
We don't want to be reinitializing the CHIP stack as the user
navigates through the app.

This also fixes issues where we'd have multiple CHIPDeviceController
instances live at the same time, which would bind to the same
low-level socket and confuse the networking layer into delivering
response notifications to the wrong CHIPDeviceController.

The dealloc block for CHIPDeviceController was removed because now we
always keep it alive in a static, so it would never run anyway.

 #### Problem
We create a new CHIPDeviceController every time we switch views in the iOS app.

 #### Summary of Changes
Have a single, static, CHIPDeviceController that all the views share.

fixes https://github.com/project-chip/connectedhomeip/issues/984
