### PR TITLE
Use docker container with openssl for main build

### DIFF
--- a/.circleci/config/executors/@executors.yml
+++ b/.circleci/config/executors/@executors.yml
@@ -1,27 +1,27 @@
 main-build:
     docker:
-        - image: connectedhomeip/chip-build:0.2.11
+        - image: connectedhomeip/chip-build-openssl:0.2.12
 nrf-build:
     docker:
-        - image: connectedhomeip/chip-build-nrf-platform:0.2.11
+        - image: connectedhomeip/chip-build-nrf-platform:0.2.12
 esp32-build:
     docker:
-        - image: connectedhomeip/chip-build-esp32:0.2.11
+        - image: connectedhomeip/chip-build-esp32:0.2.12
 esp32-qemu-build:
     docker:
-        - image: connectedhomeip/chip-build-esp32-qemu:0.2.11
+        - image: connectedhomeip/chip-build-esp32-qemu:0.2.12
 linux-embedded:
     environment:
         BOOTSTRAP_ARGUMENTS: " --with-device-layer=linux"
     docker:
-        - image: connectedhomeip/chip-build:0.2.11
+        - image: connectedhomeip/chip-build:0.2.12
 mbedtls-build:
     environment:
         BOOTSTRAP_ARGUMENTS: " --with-crypto=mbedtls"
     docker:
-        - image: connectedhomeip/chip-build:0.2.11
+        - image: connectedhomeip/chip-build:0.2.12
 clang-build:
     environment:
         BOOTSTRAP_ARGUMENTS: " CC=clang-9 CXX=clang++-9"
     docker:
-        - image: connectedhomeip/chip-build:0.2.11
+        - image: connectedhomeip/chip-build:0.2.12


### PR DESCRIPTION
 #### Problem
The `main` build fails when trying to integrate secure channel.

 #### Summary of Changes
Main build was not using docker container with crypto libs. Also, the version of the container was older than the latest.
