### PR TITLE
Fix CHIPDeviceController retain cycle

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
+++ b/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0C47BE4424885B97005E97F6 /* CHIPViewControllerBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C47BE4324885B97005E97F6 /* CHIPViewControllerBase.m */; };
 		0CA0E0CF248599BB009087B9 /* OnOffViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CA0E0CE248599BB009087B9 /* OnOffViewController.m */; };
-		515C401924868BF0004C4DB3 /* CHIPViewControllerBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 515C401724868BF0004C4DB3 /* CHIPViewControllerBase.m */; };
 		991DC091247747F500C13860 /* EchoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 991DC090247747F500C13860 /* EchoViewController.m */; };
 		B204A621244E1D0600C7C0E1 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = B204A620244E1D0600C7C0E1 /* AppDelegate.m */; };
 		B204A624244E1D0600C7C0E1 /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = B204A623244E1D0600C7C0E1 /* SceneDelegate.m */; };
@@ -46,9 +46,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0C47BE4324885B97005E97F6 /* CHIPViewControllerBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CHIPViewControllerBase.m; sourceTree = "<group>"; };
 		0CA0E0CD248599BB009087B9 /* OnOffViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OnOffViewController.h; sourceTree = "<group>"; };
 		0CA0E0CE248599BB009087B9 /* OnOffViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OnOffViewController.m; sourceTree = "<group>"; };
-		515C401724868BF0004C4DB3 /* CHIPViewControllerBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CHIPViewControllerBase.m; sourceTree = "<group>"; };
 		515C401824868BF0004C4DB3 /* CHIPViewControllerBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPViewControllerBase.h; sourceTree = "<group>"; };
 		991DC08F247747F500C13860 /* EchoViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EchoViewController.h; sourceTree = "<group>"; };
 		991DC090247747F500C13860 /* EchoViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EchoViewController.m; sourceTree = "<group>"; };
@@ -149,13 +149,13 @@
 				B2F53AEC245B0D190010745E /* Main.storyboard */,
 				B2F53AE9245B0D140010745E /* LaunchScreen.storyboard */,
 				B204A630244E1D0700C7C0E1 /* Info.plist */,
-				B204A631244E1D0700C7C0E1 /* main.m */,
 				515C401824868BF0004C4DB3 /* CHIPViewControllerBase.h */,
-				515C401724868BF0004C4DB3 /* CHIPViewControllerBase.m */,
-				B204A61F244E1D0600C7C0E1 /* AppDelegate.h */,
+				0C47BE4324885B97005E97F6 /* CHIPViewControllerBase.m */,
 				B204A620244E1D0600C7C0E1 /* AppDelegate.m */,
+				B204A631244E1D0700C7C0E1 /* main.m */,
 				B204A622244E1D0600C7C0E1 /* SceneDelegate.h */,
 				B204A623244E1D0600C7C0E1 /* SceneDelegate.m */,
+				B204A61F244E1D0600C7C0E1 /* AppDelegate.h */,
 				0C79937824858B3B0047A373 /* QRCode */,
 				0C79937924858B4F0047A373 /* Echo client */,
 				0CA0E0D0248599C4009087B9 /* OnOffCluster */,
@@ -277,7 +277,7 @@
 				B204A621244E1D0600C7C0E1 /* AppDelegate.m in Sources */,
 				B204A632244E1D0700C7C0E1 /* main.m in Sources */,
 				B204A624244E1D0600C7C0E1 /* SceneDelegate.m in Sources */,
-				515C401924868BF0004C4DB3 /* CHIPViewControllerBase.m in Sources */,
+				0C47BE4424885B97005E97F6 /* CHIPViewControllerBase.m in Sources */,
 				0CA0E0CF248599BB009087B9 /* OnOffViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -440,7 +440,7 @@
 			buildSettings = {
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
@@ -453,7 +453,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.chip.CHIPTool;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SDKROOT = iphoneos;
+				SDKROOT = iphoneos.internal;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = "arm64 armv4t armv5 armv6 armv6m armv7 armv7em armv7f armv7k armv7m armv7s xscale";
 			};
@@ -464,7 +464,7 @@
 			buildSettings = {
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
@@ -477,7 +477,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.chip.CHIPTool;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SDKROOT = iphoneos;
+				SDKROOT = iphoneos.internal;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = "arm64 armv4t armv5 armv6 armv6m armv7 armv7em armv7f armv7k armv7m armv7s xscale";
 			};

--- a/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
+++ b/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
@@ -440,7 +440,7 @@
 			buildSettings = {
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
@@ -453,7 +453,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.chip.CHIPTool;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SDKROOT = iphoneos.internal;
+				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = "arm64 armv4t armv5 armv6 armv6m armv7 armv7em armv7f armv7k armv7m armv7s xscale";
 			};
@@ -464,7 +464,7 @@
 			buildSettings = {
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
@@ -477,7 +477,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.chip.CHIPTool;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SDKROOT = iphoneos.internal;
+				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = "arm64 armv4t armv5 armv6 armv6m armv7 armv7em armv7f armv7k armv7m armv7s xscale";
 			};

--- a/src/darwin/CHIPTool/CHIPTool/CHIPViewControllerBase.m
+++ b/src/darwin/CHIPTool/CHIPTool/CHIPViewControllerBase.m
@@ -107,7 +107,6 @@ static NSString * const ipKey = @"ipk";
 
     NSString * inputIPAddress = [[self _getScannedIP] length] > 0 ? [self _getScannedIP] : self.serverIPTextField.text;
 
-
     BOOL didConnect = [self.chipController connect:inputIPAddress error:&error];
     if (!didConnect) {
         [self postResult:[@"Error: " stringByAppendingString:error.localizedDescription]];
@@ -118,7 +117,6 @@ static NSString * const ipKey = @"ipk";
 {
     [self.serverIPTextField resignFirstResponder];
 }
-
 
 - (void)reconnectIfNeeded
 {
@@ -162,13 +160,13 @@ static NSString * const ipKey = @"ipk";
 - (void)viewDidDisappear:(BOOL)animated
 {
     [super viewDidDisappear:animated];
-    NSError *error = nil;
+    NSError * error = nil;
     // This disconnect is needed to make sure the connection goes away.
     // The VC deallocation doesnt sometimes happen right away.
-    // So if one goes back out of the VC and back in, and send an echo msg right away, then the first reponse at times gets dropped as the first VC was not deallocated on time.
+    // So if one goes back out of the VC and back in, and send an echo msg right away, then the first reponse at times gets dropped
+    // as the first VC was not deallocated on time.
     [self.chipController disconnect:&error];
-    if (error)
-    {
+    if (error) {
         NSLog(@"Error disconnecting on view disappearing %@", error);
     }
 }

--- a/src/darwin/CHIPTool/CHIPTool/CHIPViewControllerBase.m
+++ b/src/darwin/CHIPTool/CHIPTool/CHIPViewControllerBase.m
@@ -165,7 +165,7 @@ static NSString * const ipKey = @"ipk";
     NSError *error = nil;
     // This disconnect is needed to make sure the connection goes away.
     // The VC deallocation doesnt sometimes happen right away.
-    // So if one goes back out of the VC and back in, and send an echo msg right away, then the first reponse at times gets dropped as the first VC was not deallocated on time. 
+    // So if one goes back out of the VC and back in, and send an echo msg right away, then the first reponse at times gets dropped as the first VC was not deallocated on time.
     [self.chipController disconnect:&error];
     if (error)
     {

--- a/src/darwin/CHIPTool/CHIPTool/CHIPViewControllerBase.m
+++ b/src/darwin/CHIPTool/CHIPTool/CHIPViewControllerBase.m
@@ -107,6 +107,7 @@ static NSString * const ipKey = @"ipk";
 
     NSString * inputIPAddress = [[self _getScannedIP] length] > 0 ? [self _getScannedIP] : self.serverIPTextField.text;
 
+
     BOOL didConnect = [self.chipController connect:inputIPAddress error:&error];
     if (!didConnect) {
         [self postResult:[@"Error: " stringByAppendingString:error.localizedDescription]];
@@ -117,6 +118,7 @@ static NSString * const ipKey = @"ipk";
 {
     [self.serverIPTextField resignFirstResponder];
 }
+
 
 - (void)reconnectIfNeeded
 {
@@ -155,6 +157,20 @@ static NSString * const ipKey = @"ipk";
             self.resultLabel.hidden = YES;
         });
     });
+}
+
+- (void)viewDidDisappear:(BOOL)animated
+{
+    [super viewDidDisappear:animated];
+    NSError *error = nil;
+    // This disconnect is needed to make sure the connection goes away.
+    // The VC deallocation doesnt sometimes happen right away.
+    // So if one goes back out of the VC and back in, and send an echo msg right away, then the first reponse at times gets dropped as the first VC was not deallocated on time. 
+    [self.chipController disconnect:&error];
+    if (error)
+    {
+        NSLog(@"Error disconnecting on view disappearing %@", error);
+    }
 }
 
 @end

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -46,8 +46,7 @@ static const char * const CHIP_SELECT_QUEUE = "com.zigbee.chip.select";
 
 @interface CHIPDeviceController ()
 
-
-@property (nonatomic, readonly, strong, nonnull) NSRecursiveLock *lock;
+@property (nonatomic, readonly, strong, nonnull) NSRecursiveLock * lock;
 
 // queue used to call select on the system and inet layer fds., remove this with NW Framework.
 // primarily used to not block the work queue
@@ -101,7 +100,7 @@ static const char * const CHIP_SELECT_QUEUE = "com.zigbee.chip.select";
 }
 
 static void onMessageReceived(chip::DeviceController::ChipDeviceController * deviceController, void * appReqState,
-                              chip::System::PacketBuffer * buffer, const chip::IPPacketInfo * packet_info)
+    chip::System::PacketBuffer * buffer, const chip::IPPacketInfo * packet_info)
 {
     CHIPDeviceController * controller = (__bridge CHIPDeviceController *) appReqState;
 
@@ -129,7 +128,7 @@ static void onMessageReceived(chip::DeviceController::ChipDeviceController * dev
 }
 
 static void onInternalError(chip::DeviceController::ChipDeviceController * deviceController, void * appReqState, CHIP_ERROR error,
-                            const chip::IPPacketInfo * pi)
+    const chip::IPPacketInfo * pi)
 {
     CHIPDeviceController * controller = (__bridge CHIPDeviceController *) appReqState;
     [controller _dispatchAsyncErrorBlock:[CHIPError errorForCHIPErrorCode:error]];
@@ -166,7 +165,6 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
     // this could be done async but the error we care about is sync. However, I think this could be restructured such that
     // the request is fired async and that Block can then return an error to the caller. This function would then never error out.
     // the only drawback is that it complicates the api where the user must handle async errors on every function
-
 
     [self.lock lock];
     chip::Inet::IPAddress addr;
@@ -278,7 +276,6 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
 {
     __block CHIP_ERROR err = CHIP_NO_ERROR;
 
-
     [self.lock lock];
 
     err = self.cppController->DisconnectDevice();
@@ -339,7 +336,6 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
             inetLayer->PrepareSelect(numFDs, &readFDs, &writeFDs, &exceptFDs, aSleepTime);
         }
 
-
         [self.lock unlock];
 
         int selectRes = select(numFDs, &readFDs, &writeFDs, &exceptFDs, const_cast<struct timeval *>(&aSleepTime));
@@ -364,7 +360,6 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
         [self.lock unlock];
         [self _serviceEvents];
     });
-
 }
 
 - (void)registerCallbacks:appCallbackQueue onMessage:(ControllerOnMessageBlock)onMessage onError:(ControllerOnErrorBlock)onError
@@ -379,7 +374,7 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
 extern "C" {
 // We have to have this empty callback, because the ZCL code links against it.
 void chipZclPostAttributeChangeCallback(uint8_t endpoint, ChipZclClusterId clusterId, ChipZclAttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+    uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
 {
 }
 } // extern "C"

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -172,7 +172,6 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
     err = self.cppController->ConnectDevice(0, addr, NULL, onMessageReceived, onInternalError, CHIP_PORT);
     [self.lock unlock];
 
-
     if (err != CHIP_NO_ERROR) {
         CHIP_LOG_ERROR("Error(%d): %@, connect failed", err, [CHIPError errorForCHIPErrorCode:err]);
         if (error) {
@@ -180,7 +179,6 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
         }
         return NO;
     }
-
 
     // Start the IO pump
     [self _serviceEvents];

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -46,9 +46,9 @@ static const char * const CHIP_SELECT_QUEUE = "com.zigbee.chip.select";
 
 @interface CHIPDeviceController ()
 
-// queue used for all interactions with the cpp chip controller and for all chip internal events
-// try to run small jobs in this queue
-@property (atomic, readonly) dispatch_queue_t chipWorkQueue;
+
+@property (nonatomic, readonly, strong, nonnull) NSRecursiveLock *lock;
+
 // queue used to call select on the system and inet layer fds., remove this with NW Framework.
 // primarily used to not block the work queue
 @property (atomic, readonly) dispatch_queue_t chipSelectQueue;
@@ -76,22 +76,21 @@ static const char * const CHIP_SELECT_QUEUE = "com.zigbee.chip.select";
 - (instancetype)init
 {
     if (self = [super init]) {
-        _chipWorkQueue = dispatch_queue_create(CHIP_WORK_QUEUE, DISPATCH_QUEUE_SERIAL);
-        if (!_chipWorkQueue) {
-            return nil;
-        }
+
+        
+        _lock = [[NSRecursiveLock alloc] init];
 
         _chipSelectQueue = dispatch_queue_create(CHIP_SELECT_QUEUE, DISPATCH_QUEUE_SERIAL);
         if (!_chipSelectQueue) {
             return nil;
         }
-
+        
         _cppController = new chip::DeviceController::ChipDeviceController();
         if (!_cppController) {
             CHIP_LOG_ERROR("Error: couldn't create c++ controller");
             return nil;
         }
-
+        
         if (CHIP_NO_ERROR != _cppController->Init()) {
             CHIP_LOG_ERROR("Error: couldn't initialize c++ controller");
             delete _cppController;
@@ -99,40 +98,39 @@ static const char * const CHIP_SELECT_QUEUE = "com.zigbee.chip.select";
             return nil;
         }
     }
-
     return self;
 }
 
 static void onMessageReceived(chip::DeviceController::ChipDeviceController * deviceController, void * appReqState,
-    chip::System::PacketBuffer * buffer, const chip::IPPacketInfo * packet_info)
+                              chip::System::PacketBuffer * buffer, const chip::IPPacketInfo * packet_info)
 {
     CHIPDeviceController * controller = (__bridge CHIPDeviceController *) appReqState;
-
+    
     char src_addr[INET_ADDRSTRLEN];
     size_t data_len = buffer->DataLength();
-
+    
     packet_info->SrcAddress.ToString(src_addr, sizeof(src_addr));
     NSString * ipAddress = [[NSString alloc] initWithUTF8String:src_addr];
-
+    
     // convert to NSData and pass back to the application
     NSMutableData * dataBuffer = [[NSMutableData alloc] initWithBytes:buffer->Start() length:data_len];
     buffer = buffer->Next();
-
+    
     while (buffer != NULL) {
         data_len = buffer->DataLength();
         [dataBuffer appendBytes:buffer->Start() length:data_len];
         buffer = buffer->Next();
     }
-
+    
     [controller _dispatchAsyncMessageBlock:dataBuffer ipAddress:ipAddress port:packet_info->SrcPort];
-
+    
     // ignore unused variable
     (void) deviceController;
     chip::System::PacketBuffer::Free(buffer);
 }
 
 static void onInternalError(chip::DeviceController::ChipDeviceController * deviceController, void * appReqState, CHIP_ERROR error,
-    const chip::IPPacketInfo * pi)
+                            const chip::IPPacketInfo * pi)
 {
     CHIPDeviceController * controller = (__bridge CHIPDeviceController *) appReqState;
     [controller _dispatchAsyncErrorBlock:[CHIPError errorForCHIPErrorCode:error]];
@@ -143,7 +141,7 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
     CHIP_LOG_METHOD_ENTRY();
     // to avoid retaining "self"
     ControllerOnErrorBlock onErrorHandler = self.onErrorHandler;
-
+    
     dispatch_async(_appCallbackQueue, ^() {
         onErrorHandler(error);
     });
@@ -154,7 +152,7 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
     CHIP_LOG_METHOD_ENTRY();
     // to avoid retaining "self"
     ControllerOnMessageBlock onMessageHandler = self.onMessageHandler;
-
+    
     dispatch_async(_appCallbackQueue, ^() {
         onMessageHandler(data, ipAddress, port);
     });
@@ -163,17 +161,21 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
 - (BOOL)connect:(NSString *)ipAddress error:(NSError * __autoreleasing *)error
 {
     __block CHIP_ERROR err = CHIP_NO_ERROR;
-
+    
     // TODO maybe refactor
     // the work queue is being used for atomic access to chip's cpp controller
     // this could be done async but the error we care about is sync. However, I think this could be restructured such that
     // the request is fired async and that Block can then return an error to the caller. This function would then never error out.
     // the only drawback is that it complicates the api where the user must handle async errors on every function
-    dispatch_sync(self.chipWorkQueue, ^() {
-        chip::Inet::IPAddress addr;
-        chip::Inet::IPAddress::FromString([ipAddress UTF8String], addr);
-        err = self.cppController->ConnectDevice(0, addr, NULL, onMessageReceived, onInternalError, CHIP_PORT);
-    });
+
+    
+    
+    [self.lock lock];
+    chip::Inet::IPAddress addr;
+    chip::Inet::IPAddress::FromString([ipAddress UTF8String], addr);
+    err = self.cppController->ConnectDevice(0, addr, NULL, onMessageReceived, onInternalError, CHIP_PORT);
+    [self.lock unlock];
+    
 
     if (err != CHIP_NO_ERROR) {
         CHIP_LOG_ERROR("Error(%d): %@, connect failed", err, [CHIPError errorForCHIPErrorCode:err]);
@@ -185,7 +187,7 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
 
     // Start the IO pump
     [self _serviceEvents];
-
+    
     return YES;
 }
 
@@ -194,11 +196,11 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
     __block CHIP_ERROR err = CHIP_NO_ERROR;
     __block chip::IPAddress ipAddr;
     __block uint16_t port;
-
-    dispatch_sync(self.chipWorkQueue, ^() {
-        err = self.cppController->GetDeviceAddress(&ipAddr, &port);
-    });
-
+    
+    [self.lock lock];
+    err = self.cppController->GetDeviceAddress(&ipAddr, &port);
+    [self.lock unlock];
+    
     if (err != CHIP_NO_ERROR) {
         return nil;
     }
@@ -215,18 +217,18 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
 - (BOOL)sendMessage:(NSData *)message error:(NSError * __autoreleasing *)error
 {
     __block CHIP_ERROR err = CHIP_NO_ERROR;
-
-    dispatch_sync(self.chipWorkQueue, ^() {
-        size_t messageLen = [message length];
-        const void * messageChars = [message bytes];
-
-        chip::System::PacketBuffer * buffer = chip::System::PacketBuffer::NewWithAvailableSize(messageLen);
-        buffer->SetDataLength(messageLen);
-
-        memcpy(buffer->Start(), messageChars, messageLen);
-        err = self.cppController->SendMessage((__bridge void *) self, buffer);
-    });
-
+    
+    [self.lock lock];
+    size_t messageLen = [message length];
+    const void * messageChars = [message bytes];
+    
+    chip::System::PacketBuffer * buffer = chip::System::PacketBuffer::NewWithAvailableSize(messageLen);
+    buffer->SetDataLength(messageLen);
+    
+    memcpy(buffer->Start(), messageChars, messageLen);
+    err = self.cppController->SendMessage((__bridge void *) self, buffer);
+    [self.lock unlock];
+    
     if (err != CHIP_NO_ERROR) {
         CHIP_LOG_ERROR("Error(%d): %@, send failed", err, [CHIPError errorForCHIPErrorCode:err]);
         if (error) {
@@ -240,32 +242,32 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
 - (BOOL)sendCHIPCommand:(ChipZclClusterId_t)cluster command:(ChipZclCommandId_t)command
 {
     __block CHIP_ERROR err = CHIP_NO_ERROR;
-    dispatch_sync(self.chipWorkQueue, ^() {
-        // FIXME: This needs a better buffersizing setup!
-        static const size_t bufferSize = 1024;
-        chip::System::PacketBuffer * buffer = chip::System::PacketBuffer::NewWithAvailableSize(bufferSize);
-
-        ChipZclBuffer_t * zcl_buffer = (ChipZclBuffer_t *) buffer;
-        ChipZclCommandContext_t ctx = {
-            1, // endpointId
-            cluster, // clusterId
-            true, // clusterSpecific
-            false, // mfgSpecific
-            0, // mfgCode
-            command, // commandId
-            ZCL_DIRECTION_CLIENT_TO_SERVER, // direction
-            0, // payloadStartIndex
-            nullptr, // request
-            nullptr // response
-        };
-        chipZclEncodeZclHeader(zcl_buffer, &ctx);
-
-        const size_t data_len = chipZclBufferDataLength(zcl_buffer);
-
-        buffer->SetDataLength(data_len);
-
-        err = self.cppController->SendMessage((__bridge void *) self, buffer);
-    });
+    [self.lock lock];
+    // FIXME: This needs a better buffersizing setup!
+    static const size_t bufferSize = 1024;
+    chip::System::PacketBuffer * buffer = chip::System::PacketBuffer::NewWithAvailableSize(bufferSize);
+    
+    ChipZclBuffer_t * zcl_buffer = (ChipZclBuffer_t *) buffer;
+    ChipZclCommandContext_t ctx = {
+        1, // endpointId
+        cluster, // clusterId
+        true, // clusterSpecific
+        false, // mfgSpecific
+        0, // mfgCode
+        command, // commandId
+        ZCL_DIRECTION_CLIENT_TO_SERVER, // direction
+        0, // payloadStartIndex
+        nullptr, // request
+        nullptr // response
+    };
+    chipZclEncodeZclHeader(zcl_buffer, &ctx);
+    
+    const size_t data_len = chipZclBufferDataLength(zcl_buffer);
+    
+    buffer->SetDataLength(data_len);
+    
+    err = self.cppController->SendMessage((__bridge void *) self, buffer);
+    [self.lock unlock];
     if (err != CHIP_NO_ERROR) {
         CHIP_LOG_ERROR("Error(%d): %@, send failed", err, [CHIPError errorForCHIPErrorCode:err]);
         return NO;
@@ -276,11 +278,13 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
 - (BOOL)disconnect:(NSError * __autoreleasing *)error
 {
     __block CHIP_ERROR err = CHIP_NO_ERROR;
-
-    dispatch_sync(self.chipWorkQueue, ^() {
-        err = self.cppController->DisconnectDevice();
-    });
-
+    
+    
+    [self.lock lock];
+    
+    err = self.cppController->DisconnectDevice();
+    [self.lock unlock];
+    
     if (err != CHIP_NO_ERROR) {
         CHIP_LOG_ERROR("Error(%d): %@, disconnect failed", err, [CHIPError errorForCHIPErrorCode:err]);
         if (error) {
@@ -294,63 +298,74 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
 - (BOOL)isConnected
 {
     __block bool isConnected = false;
-
-    // the work queue is being used for atomic access to chip's cpp controller
-    dispatch_sync(self.chipWorkQueue, ^() {
-        isConnected = self.cppController->IsConnected();
-    });
-
+    
+    [self.lock lock];
+    isConnected = self.cppController->IsConnected();
+    [self.lock unlock];
+    
     return isConnected ? YES : NO;
 }
 
 // TODO kill this with fire (NW might implicitly replace this?)
 - (void)_serviceEvents
 {
-    dispatch_async(self.chipWorkQueue, ^() {
+    __weak typeof(self) weakSelf = self;
+    dispatch_async(self.chipSelectQueue, ^() {
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) {
+            return;
+        }
+        
         __block fd_set readFDs, writeFDs, exceptFDs;
         struct timeval aSleepTime;
         int numFDs = 0;
         aSleepTime.tv_sec = 5;
-
+        
         FD_ZERO(&readFDs);
         FD_ZERO(&writeFDs);
         FD_ZERO(&exceptFDs);
-
+        
         chip::System::Layer * systemLayer = NULL;
         chip::Inet::InetLayer * inetLayer = NULL;
         // ask for the system and inet layers
+        
+        [self.lock lock];
         self.cppController->GetLayers(&systemLayer, &inetLayer);
-
-        if (systemLayer != NULL && systemLayer->State() == chip::System::kLayerState_Initialized)
+        
+        if (systemLayer != NULL && systemLayer->State() == chip::System::kLayerState_Initialized) {
             systemLayer->PrepareSelect(numFDs, &readFDs, &writeFDs, &exceptFDs, aSleepTime);
-
-        if (inetLayer != NULL && inetLayer->State == chip::Inet::InetLayer::kState_Initialized)
+        }
+        
+        if (inetLayer != NULL && inetLayer->State == chip::Inet::InetLayer::kState_Initialized) {
             inetLayer->PrepareSelect(numFDs, &readFDs, &writeFDs, &exceptFDs, aSleepTime);
-
-        dispatch_async(self.chipSelectQueue, ^() {
-            int selectRes = select(numFDs, &readFDs, &writeFDs, &exceptFDs, const_cast<struct timeval *>(&aSleepTime));
-
-            dispatch_async(self.chipWorkQueue, ^() {
-                if (!self.cppController->IsConnected()) {
-                    // cancel the loop, it'll restart the next time a connection is established
-                    return;
-                }
-                chip::System::Layer * systemLayer = NULL;
-                chip::Inet::InetLayer * inetLayer = NULL;
-                self.cppController->GetLayers(&systemLayer, &inetLayer);
-
-                if (systemLayer != NULL && systemLayer->State() == chip::System::kLayerState_Initialized) {
-                    systemLayer->HandleSelectResult(selectRes, &readFDs, &writeFDs, &exceptFDs);
-                }
-
-                if (inetLayer != NULL && inetLayer->State == chip::Inet::InetLayer::kState_Initialized) {
-                    inetLayer->HandleSelectResult(selectRes, &readFDs, &writeFDs, &exceptFDs);
-                }
-
-                [self _serviceEvents];
-            });
-        });
+        }
+        
+        
+        [self.lock unlock];
+        
+        int selectRes = select(numFDs, &readFDs, &writeFDs, &exceptFDs, const_cast<struct timeval *>(&aSleepTime));
+        
+        [self.lock lock];
+        if (!self.cppController->IsConnected()) {
+            [self.lock unlock];
+            // cancel the loop, it'll restart the next time a connection is established
+            return;
+        }
+        systemLayer = NULL;
+        inetLayer = NULL;
+        self.cppController->GetLayers(&systemLayer, &inetLayer);
+        
+        if (systemLayer != NULL && systemLayer->State() == chip::System::kLayerState_Initialized) {
+            systemLayer->HandleSelectResult(selectRes, &readFDs, &writeFDs, &exceptFDs);
+        }
+        
+        if (inetLayer != NULL && inetLayer->State == chip::Inet::InetLayer::kState_Initialized) {
+            inetLayer->HandleSelectResult(selectRes, &readFDs, &writeFDs, &exceptFDs);
+        }
+        [self.lock unlock];
+        [self _serviceEvents];
     });
+    
 }
 
 - (void)registerCallbacks:appCallbackQueue onMessage:(ControllerOnMessageBlock)onMessage onError:(ControllerOnErrorBlock)onError
@@ -365,7 +380,7 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
 extern "C" {
 // We have to have this empty callback, because the ZCL code links against it.
 void chipZclPostAttributeChangeCallback(uint8_t endpoint, ChipZclClusterId clusterId, ChipZclAttributeId attributeId, uint8_t mask,
-    uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
 {
 }
 } // extern "C"


### PR DESCRIPTION
 #### Problem
CHIPDeviceController had retain cycles between blocks and self.

Solution
Replace the `_chipWorkQueue` with a lock as it was mostly being used as a lock. 
Refactor some of the `-[_serviceEvents]` methods.
