### PR TITLE
Include information for contributors to get started

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,60 @@ Currently these are the requirements to becoming a member of the
     Writer, Developer (or exception granted), Code Approvers, or Support Staff
 -   Have approval from your company's official approver
 
+## Getting Started
+
+This repository contains the source code that implements the CHIP specification.
+It scalably implements the specification that may be used on a wide range of
+platforms including Android/iOS and Darwin/Linux down to embedded MCU-based
+platforms running FreeRTOS and LwIP.
+
+The source code can be built to generate:
+
+-   **Libraries** that can be built for iOS, Android or desktop (Linux/Mac)
+    targets. These libraries could further be integrated into applications that
+    talk _CHIP_.
+-   **Firmwares/Embedded Applications** that can be built for the supported
+    embedded platforms.
+-   **Desktop Application** that can be used in conjunction with the embedded
+    applications above to validate the end-to-end CHIP workflow.
+
+### Building your first application
+
+-   Building the firmware: This repository implements the CHIP specification on
+    3 transports: 802.15.4 Thread, BLE and Wi-Fi. The examples/ directory
+    contains example applications for all these 3 transports using 3 embedded
+    platforms. Please visit their respective directories for instructions on how
+    to build and deploy on these platforms.
+    -   NRF5 (for 802.15.4 Thread): in
+        [examples/lock-app/nrf5](examples/lock-app/nrf5)
+    -   EFR32 (for BLE): in [examples/lock-app/efr32](examples/lock-app/efr32)
+    -   ESP32 (for Wi-Fi or BLE): in
+        [examples/wifi-echo/server/esp32](examples/wifi-echo/server/esp32)
+-   Building the host utility: The host utility can be used in conjunction with
+    the embedded platform for end-to-end validation. Please visit the
+    [examples/chip-tool](examples/chip-tool) directory for further instructions.
+
+### Where should I begin?
+
+-   Good First Issue: Certain issues are marked with a label
+    [Good First Issue](https://github.com/project-chip/connectedhomeip/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+    These issues are what we believe may be good starting points for getting
+    your hands dirty.
+-   TODOs: Most items that will require work are captured in the GitHub issues
+    of this project. This serves as a good TODO list for the next steps.
+-   Milestones: A list of
+    [milestones](https://github.com/project-chip/connectedhomeip/milestones) are
+    maintained in this project. This should provide some idea of where things
+    are headed. Note that given the early days of this project, most of these
+    are not hard deadlines.
+
+### Where is the spec?
+
+-   The specification is evolving in various tiger teams. Members belonging to
+    various tiger teams may contribute experimental code for the general
+    direction where the spec is headed. Once a specification is fairly
+    finalised, it will be available/committed in the [docs/specs](docs/specs).
+
 ## Bugs
 
 If you find a bug in the source code, you can help us by


### PR DESCRIPTION
 #### Problem
Capture information that helps contributors get started. Specifically, what this repository does, what to build and run where, what are the low-hanging fruits, etc.

 #### Summary of Changes
Added this information in the CONTRIBUTING.md file. It can be moved to some other place where folks think its more relevant.

Questions:
* I have listed my understanding, please correct where applicable.
* I have used the 'controller' and 'accessory' as terminologies, but I am not sure what are the perfect ways to refer to these.
* I wanted to also include a pointer to Coding-Style guide, but I see that this is not available in the 'master' but part of some other commit-tree in the repository. 
