### PR TITLE
Enable IPv6 support for the ESP32 Example

### DIFF
--- a/examples/wifi-echo/server/esp32/main/include/Display.h
+++ b/examples/wifi-echo/server/esp32/main/include/Display.h
@@ -65,6 +65,7 @@ extern esp_err_t InitDisplay();
  *  Clear the display by setting the whole screen to black
  */
 extern void ClearDisplay();
+
 /**
  * @brief
  *  Clear a portion of the display by drawing a black rectangle based on the given arguments

--- a/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
@@ -39,7 +39,7 @@
 using namespace ::chip;
 using namespace ::chip::DeviceLayer;
 
-extern void startServer(UDPEndPoint *& endpoint);
+extern void startServer(UDPEndPoint *& endpoint_ipv4, UDPEndPoint *& endpoint_ipv6);
 extern void startClient(void);
 
 #if CONFIG_DEVICE_TYPE_M5STACK
@@ -68,6 +68,10 @@ extern void startClient(void);
 
 static QRCodeWidget sQRCodeWidget;
 
+// Where to draw the connection status message
+#define CONNECTION_MESSAGE 75
+// Where to draw the IPv6 information
+#define IPV6_INFO 85
 #endif // CONFIG_HAVE_DISPLAY
 
 LEDWidget statusLED;
@@ -165,8 +169,9 @@ extern "C" void app_main()
 
     // Start the Echo Server
     InitDataModelHandler();
-    UDPEndPoint * sEndpoint = NULL;
-    startServer(sEndpoint);
+    UDPEndPoint * sEndpointIPv4 = NULL;
+    UDPEndPoint * sEndpointIPv6 = NULL;
+    startServer(sEndpointIPv4, sEndpointIPv6);
 #if CONFIG_USE_ECHO_CLIENT
     startClient();
 #endif
@@ -235,7 +240,15 @@ void DeviceEventHandler(const ChipDeviceEvent * event, intptr_t arg)
         }
         else if (event->InternetConnectivityChange.IPv4 == kConnectivity_Lost)
         {
-            ESP_LOGE(TAG, "Lost IPv4 address...");
+            ESP_LOGE(TAG, "Lost IPv4 connectivity...");
+        }
+        if (event->InternetConnectivityChange.IPv6 == kConnectivity_Established)
+        {
+            ESP_LOGI(TAG, "IPv6 Server ready...");
+        }
+        else if (event->InternetConnectivityChange.IPv6 == kConnectivity_Lost)
+        {
+            ESP_LOGE(TAG, "Lost IPv6 connectivity...");
         }
     }
     if (event->Type == DeviceEventType::kSessionEstablished && event->SessionEstablished.IsCommissioner)


### PR DESCRIPTION
 #### Problem
The ESP32 example doesn't currently run on IPv6
 #### Summary of Changes
Add IPv6 support. The ESP32 is listening on it's SoftAP's LLA as well as a GUA if it generates one via the STA interface (when it connects to configured network)

fixes #1034