### PR TITLE
Allow serial number to be both an unsigned int and a string

### DIFF
--- a/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
+++ b/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
@@ -94,20 +94,11 @@ string createSetupPayload()
     payload.version   = 1;
     payload.vendorID  = EXAMPLE_VENDOR_ID;
     payload.productID = 1;
-
-    OptionalQRCodeInfo ssidInfo;
-    ssidInfo.tag  = EXAMPLE_VENDOR_TAG_SSID;
-    ssidInfo.type = optionalQRCodeInfoTypeString;
-    ssidInfo.data = ap_ssid;
-    payload.addVendorOptionalData(ssidInfo);
+    payload.addVendorOptionalData(EXAMPLE_VENDOR_TAG_SSID, ap_ssid);
 
     char gw_ip[INET6_ADDRSTRLEN];
     GetGatewayIP(gw_ip, sizeof(gw_ip));
-    OptionalQRCodeInfo ipInfo;
-    ipInfo.tag  = EXAMPLE_VENDOR_TAG_IP;
-    ipInfo.type = optionalQRCodeInfoTypeString;
-    ipInfo.data = gw_ip;
-    payload.addVendorOptionalData(ipInfo);
+    payload.addVendorOptionalData(EXAMPLE_VENDOR_TAG_IP, gw_ip);
 
     QRCodeSetupPayloadGenerator generator(payload);
     string result;

--- a/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
@@ -182,7 +182,7 @@ static NSString * const ipKey = @"ipk";
 
     NSLog(@"Payload vendorID %@", payload.vendorID);
     if ([payload.vendorID isEqualToNumber:[NSNumber numberWithInt:EXAMPLE_VENDOR_ID]]) {
-        NSArray * optionalInfo = [payload getAllOptionalData:nil];
+        NSArray * optionalInfo = [payload getAllOptionalVendorData:nil];
         NSLog(@"Count of payload info %@", @(optionalInfo.count));
         for (CHIPOptionalQRCodeInfo * info in optionalInfo) {
             NSNumber * tag = info.tag;
@@ -282,7 +282,7 @@ static NSString * const ipKey = @"ipk";
     dispatch_async(dispatch_get_main_queue(), ^{
         [self->_captureSession stopRunning];
     });
-    CHIPQRCodeSetupPayloadParser * parser = [[CHIPQRCodeSetupPayloadParser alloc] initWithBase45Representation:qrCode];
+    CHIPQRCodeSetupPayloadParser * parser = [[CHIPQRCodeSetupPayloadParser alloc] initWithBase41Representation:qrCode];
     NSError * error;
     CHIPSetupPayload * payload = [parser populatePayload:&error];
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1.0 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{

--- a/src/darwin/Framework/CHIP.xcodeproj/xcshareddata/xcschemes/Framework Tests iOS.xcscheme
+++ b/src/darwin/Framework/CHIP.xcodeproj/xcshareddata/xcschemes/Framework Tests iOS.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B20252952459E34F00F97062"
+               BuildableName = "CHIPTests.xctest"
+               BlueprintName = "CHIPTests"
+               ReferencedContainer = "container:CHIP.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/src/darwin/Framework/CHIP.xcodeproj/xcshareddata/xcschemes/Tests macOS.xcscheme
+++ b/src/darwin/Framework/CHIP.xcodeproj/xcshareddata/xcschemes/Tests macOS.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B20252952459E34F00F97062"
+               BuildableName = "CHIPTests.xctest"
+               BlueprintName = "CHIPTests"
+               ReferencedContainer = "container:CHIP.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/src/darwin/Framework/CHIP/CHIPQRCodeSetupPayloadParser.h
+++ b/src/darwin/Framework/CHIP/CHIPQRCodeSetupPayloadParser.h
@@ -23,7 +23,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface CHIPQRCodeSetupPayloadParser : NSObject
-- (id)initWithBase45Representation:(NSString *)base45Representation;
+- (id)initWithBase41Representation:(NSString *)base41Representation;
 - (CHIPSetupPayload *)populatePayload:(NSError * __autoreleasing *)error;
 @end
 ;

--- a/src/darwin/Framework/CHIP/CHIPQRCodeSetupPayloadParser.mm
+++ b/src/darwin/Framework/CHIP/CHIPQRCodeSetupPayloadParser.mm
@@ -22,15 +22,15 @@
 #import <setup_payload/SetupPayload.h>
 
 @implementation CHIPQRCodeSetupPayloadParser {
-    NSString * _base45Representation;
+    NSString * _base41Representation;
     chip::QRCodeSetupPayloadParser * _chipQRCodeSetupPayloadParser;
 }
 
-- (id)initWithBase45Representation:(NSString *)base45Representation
+- (id)initWithBase41Representation:(NSString *)base41Representation
 {
     if (self = [super init]) {
-        _base45Representation = base45Representation;
-        _chipQRCodeSetupPayloadParser = new chip::QRCodeSetupPayloadParser(std::string([base45Representation UTF8String]));
+        _base41Representation = base41Representation;
+        _chipQRCodeSetupPayloadParser = new chip::QRCodeSetupPayloadParser(std::string([base41Representation UTF8String]));
     }
     return self;
 }

--- a/src/darwin/Framework/CHIP/CHIPSetupPayload.h
+++ b/src/darwin/Framework/CHIP/CHIPSetupPayload.h
@@ -25,9 +25,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSUInteger, OptionalQRCodeInfoType) {
-  kOptionalQRCodeInfoTypeUnknown,
-  kOptionalQRCodeInfoTypeString,
-  kOptionalQRCodeInfoTypeInt32
+    kOptionalQRCodeInfoTypeUnknown,
+    kOptionalQRCodeInfoTypeString,
+    kOptionalQRCodeInfoTypeInt32
 };
 
 @interface CHIPOptionalQRCodeInfo : NSObject

--- a/src/darwin/Framework/CHIP/CHIPSetupPayload.h
+++ b/src/darwin/Framework/CHIP/CHIPSetupPayload.h
@@ -24,7 +24,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NS_ENUM(NSUInteger, OptionalQRCodeInfoType) { kOptionalQRCodeInfoTypeString, kOptionalQRCodeInfoTypeInt };
+typedef NS_ENUM(NSUInteger, OptionalQRCodeInfoType) {
+  kOptionalQRCodeInfoTypeUnknown,
+  kOptionalQRCodeInfoTypeString,
+  kOptionalQRCodeInfoTypeInt32
+};
 
 @interface CHIPOptionalQRCodeInfo : NSObject
 @property (nonatomic, strong) NSNumber * infoType;
@@ -44,7 +48,7 @@ typedef NS_ENUM(NSUInteger, OptionalQRCodeInfoType) { kOptionalQRCodeInfoTypeStr
 @property (nonatomic, strong) NSNumber * setUpPINCode;
 
 @property (nonatomic, strong) NSString * serialNumber;
-- (NSArray<CHIPOptionalQRCodeInfo *> *)getAllOptionalData:(NSError * __autoreleasing *)error;
+- (NSArray<CHIPOptionalQRCodeInfo *> *)getAllOptionalVendorData:(NSError * __autoreleasing *)error;
 
 #ifdef __cplusplus
 - (id)initWithSetupPayload:(chip::SetupPayload)setupPayload;

--- a/src/darwin/Framework/CHIP/CHIPSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/CHIPSetupPayload.mm
@@ -36,15 +36,25 @@
         _rendezvousInformation = [NSNumber numberWithUnsignedShort:setupPayload.rendezvousInformation];
         _discriminator = [NSNumber numberWithUnsignedShort:setupPayload.discriminator];
         _setUpPINCode = [NSNumber numberWithUnsignedLong:setupPayload.setUpPINCode];
-        _serialNumber = [NSString stringWithUTF8String:setupPayload.serialNumber.c_str()];
+
+        [self getSerialNumber:setupPayload];
     }
     return self;
 }
 
-- (NSArray<CHIPOptionalQRCodeInfo *> *)getAllOptionalData:(NSError * __autoreleasing *)error
+- (void)getSerialNumber:(chip::SetupPayload)setupPayload
+{
+    std::string serialNumberC;
+    CHIP_ERROR err = setupPayload.getSerialNumber(serialNumberC);
+    if (err == CHIP_NO_ERROR) {
+        _serialNumber = [NSString stringWithUTF8String:serialNumberC.c_str()];
+    }
+}
+
+- (NSArray<CHIPOptionalQRCodeInfo *> *)getAllOptionalVendorData:(NSError * __autoreleasing *)error
 {
     NSMutableArray<CHIPOptionalQRCodeInfo *> * allOptionalData = [NSMutableArray new];
-    vector<chip::OptionalQRCodeInfo> chipOptionalData = _chipSetupPayload.getAllOptionalData();
+    vector<chip::OptionalQRCodeInfo> chipOptionalData = _chipSetupPayload.getAllOptionalVendorData();
     for (chip::OptionalQRCodeInfo chipInfo : chipOptionalData) {
         CHIPOptionalQRCodeInfo * info = [CHIPOptionalQRCodeInfo new];
         info.tag = [NSNumber numberWithUnsignedChar:chipInfo.tag];
@@ -53,9 +63,9 @@
             info.infoType = [NSNumber numberWithInt:kOptionalQRCodeInfoTypeString];
             info.stringValue = [NSString stringWithUTF8String:chipInfo.data.c_str()];
             break;
-        case chip::optionalQRCodeInfoTypeInt:
-            info.infoType = [NSNumber numberWithInt:kOptionalQRCodeInfoTypeInt];
-            info.integerValue = [NSNumber numberWithInt:chipInfo.integer];
+        case chip::optionalQRCodeInfoTypeInt32:
+            info.infoType = [NSNumber numberWithInt:kOptionalQRCodeInfoTypeInt32];
+            info.integerValue = [NSNumber numberWithInt:chipInfo.int32];
             break;
         default:
             if (error) {

--- a/src/darwin/Framework/CHIPTests/CHIPSetupPayloadParserTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPSetupPayloadParserTests.m
@@ -95,8 +95,8 @@
 - (void)testQRCodeParserWithOptionalData
 {
     NSError * error;
-    CHIPQRCodeSetupPayloadParser * parser = [[CHIPQRCodeSetupPayloadParser alloc]
-        initWithBase41Representation:@"CH:J20800G008008006DL200UOGMHARTHOMJ300IDL530.I7"];
+    CHIPQRCodeSetupPayloadParser * parser =
+        [[CHIPQRCodeSetupPayloadParser alloc] initWithBase41Representation:@"CH:J20800G008008006DL200UOGMHARTHOMJ300IDL530.I7"];
     CHIPSetupPayload * payload = [parser populatePayload:&error];
 
     XCTAssertNotNil(payload);

--- a/src/darwin/Framework/CHIPTests/CHIPSetupPayloadParserTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPSetupPayloadParserTests.m
@@ -37,14 +37,14 @@
 {
     NSError * error;
     CHIPManualSetupPayloadParser * parser =
-        [[CHIPManualSetupPayloadParser alloc] initWithDecimalStringRepresentation:@"34896656190000100001"];
+        [[CHIPManualSetupPayloadParser alloc] initWithDecimalStringRepresentation:@"000003949100001000011"];
     CHIPSetupPayload * payload = [parser populatePayload:&error];
 
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
 
-    XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 13);
-    XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 2345);
+    XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 1);
+    XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 1234);
     XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
     XCTAssertFalse(payload.requiresCustomFlow);
@@ -65,18 +65,19 @@
 - (void)testQRCodeParser_Error
 {
     NSError * error;
-    CHIPManualSetupPayloadParser * parser =
-        [[CHIPManualSetupPayloadParser alloc] initWithDecimalStringRepresentation:@"B20800G.0G8G000"];
+    CHIPQRCodeSetupPayloadParser * parser =
+        [[CHIPQRCodeSetupPayloadParser alloc] initWithBase41Representation:@"CH:B20800G.0G8G000"];
     CHIPSetupPayload * payload = [parser populatePayload:&error];
 
     XCTAssertNil(payload);
-    XCTAssertEqual(error.code, CHIPErrorCodeInvalidIntegerValue);
+    XCTAssertEqual(error.code, CHIPErrorCodeInvalidArgument);
 }
 
 - (void)testQRCodeParser
 {
     NSError * error;
-    CHIPQRCodeSetupPayloadParser * parser = [[CHIPQRCodeSetupPayloadParser alloc] initWithBase45Representation:@"B20800G00G8G000"];
+    CHIPQRCodeSetupPayloadParser * parser =
+        [[CHIPQRCodeSetupPayloadParser alloc] initWithBase41Representation:@"CH:J20800G008008000"];
     CHIPSetupPayload * payload = [parser populatePayload:&error];
 
     XCTAssertNotNil(payload);
@@ -89,6 +90,39 @@
     XCTAssertFalse(payload.requiresCustomFlow);
     XCTAssertEqual(payload.version.unsignedIntegerValue, 5);
     XCTAssertEqual(payload.rendezvousInformation.unsignedIntegerValue, 1);
+}
+
+- (void)testQRCodeParserWithOptionalData
+{
+    NSError * error;
+    CHIPQRCodeSetupPayloadParser * parser = [[CHIPQRCodeSetupPayloadParser alloc]
+        initWithBase41Representation:@"CH:J20800G008008006DL200UOGMHARTHOMJ300IDL530.I7"];
+    CHIPSetupPayload * payload = [parser populatePayload:&error];
+
+    XCTAssertNotNil(payload);
+    XCTAssertNil(error);
+
+    XCTAssertEqual(payload.version.unsignedIntegerValue, 5);
+    XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 128);
+    XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 2048);
+    XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 12);
+    XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
+    XCTAssertFalse(payload.requiresCustomFlow);
+    XCTAssertEqual(payload.rendezvousInformation.unsignedIntegerValue, 1);
+    XCTAssertTrue([payload.serialNumber isEqualToString:@"1"]);
+
+    NSArray<CHIPOptionalQRCodeInfo *> * vendorOptionalInfo = [payload getAllOptionalVendorData:&error];
+    XCTAssertNil(error);
+    XCTAssertEqual([vendorOptionalInfo count], 2);
+    for (CHIPOptionalQRCodeInfo * info in vendorOptionalInfo) {
+        if (info.tag.intValue == 2) {
+            XCTAssertEqual(info.infoType.intValue, kOptionalQRCodeInfoTypeString);
+            XCTAssertTrue([info.stringValue isEqualToString:@"myData"]);
+        } else if (info.tag.intValue == 3) {
+            XCTAssertEqual(info.infoType.intValue, kOptionalQRCodeInfoTypeInt32);
+            XCTAssertEqual(info.integerValue.intValue, 12);
+        }
+    }
 }
 
 @end

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -82,18 +82,6 @@ static CHIP_ERROR populateTLVBits(uint8_t * bits, int & offset, uint8_t * tlvBuf
     return err;
 }
 
-static void addCHIPInfoToOptionalData(SetupPayload & outPayload)
-{
-    if (outPayload.serialNumber.length() > 0)
-    {
-        OptionalQRCodeInfo info;
-        info.type = optionalQRCodeInfoTypeString;
-        info.tag  = kSerialNumberTag;
-        info.data = outPayload.serialNumber;
-        outPayload.addCHIPOptionalData(info);
-    }
-}
-
 CHIP_ERROR writeTag(TLVWriter & writer, uint64_t tag, OptionalQRCodeInfo & info)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -102,28 +90,60 @@ CHIP_ERROR writeTag(TLVWriter & writer, uint64_t tag, OptionalQRCodeInfo & info)
     {
         err = writer.PutString(tag, info.data.c_str());
     }
-    else if (info.type == optionalQRCodeInfoTypeInt)
+    else if (info.type == optionalQRCodeInfoTypeInt32)
     {
-        err = writer.Put(tag, static_cast<int64_t>(info.integer));
+        err = writer.Put(tag, info.int32);
+    }
+    else
+    {
+        err = CHIP_ERROR_INVALID_ARGUMENT;
     }
 
     return err;
 }
 
-CHIP_ERROR generateTLVFromOptionalData(SetupPayload & outPayload, uint8_t * tlvDataStart, uint32_t maxLen,
-                                       uint32_t & tlvDataLengthInBytes)
+CHIP_ERROR writeTag(TLVWriter & writer, uint64_t tag, OptionalQRCodeInfoExtension & info)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    addCHIPInfoToOptionalData(outPayload);
-    vector<OptionalQRCodeInfo> optionalData = outPayload.getAllOptionalData();
-    VerifyOrExit(optionalData.size() != 0, err = CHIP_NO_ERROR);
+
+    if (info.type == optionalQRCodeInfoTypeString || info.type == optionalQRCodeInfoTypeInt32)
+    {
+        err = writeTag(writer, tag, static_cast<OptionalQRCodeInfo &>(info));
+    }
+    else if (info.type == optionalQRCodeInfoTypeInt64)
+    {
+        err = writer.Put(tag, info.int64);
+    }
+    else if (info.type == optionalQRCodeInfoTypeUInt32)
+    {
+        err = writer.Put(tag, info.uint32);
+    }
+    else if (info.type == optionalQRCodeInfoTypeUInt64)
+    {
+        err = writer.Put(tag, info.uint64);
+    }
+    else
+    {
+        err = CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    return err;
+}
+
+CHIP_ERROR QRCodeSetupPayloadGenerator::generateTLVFromOptionalData(SetupPayload & outPayload, uint8_t * tlvDataStart,
+                                                                    uint32_t maxLen, uint32_t & tlvDataLengthInBytes)
+{
+    CHIP_ERROR err                                            = CHIP_NO_ERROR;
+    vector<OptionalQRCodeInfo> optionalData                   = outPayload.getAllOptionalVendorData();
+    vector<OptionalQRCodeInfoExtension> optionalExtensionData = outPayload.getAllOptionalExtensionData();
+    VerifyOrExit(optionalData.size() != 0 || optionalExtensionData.size() != 0, err = CHIP_NO_ERROR);
 
     TLVWriter rootWriter;
     rootWriter.Init(tlvDataStart, maxLen);
     rootWriter.ImplicitProfileId = chip::Profiles::kChipProfile_ServiceProvisioning;
 
     // The cost (in bytes) of the top-level container is amortized as soon as there is at least 4 optionals elements.
-    if (optionalData.size() >= 4)
+    if ((optionalData.size() + optionalExtensionData.size()) >= 4)
     {
 
         TLVWriter innerStructureWriter;
@@ -138,12 +158,24 @@ CHIP_ERROR generateTLVFromOptionalData(SetupPayload & outPayload, uint8_t * tlvD
             SuccessOrExit(err);
         }
 
+        for (OptionalQRCodeInfoExtension info : optionalExtensionData)
+        {
+            err = writeTag(innerStructureWriter, ContextTag(info.tag), info);
+            SuccessOrExit(err);
+        }
+
         err = rootWriter.CloseContainer(innerStructureWriter);
         SuccessOrExit(err);
     }
     else
     {
         for (OptionalQRCodeInfo info : optionalData)
+        {
+            err = writeTag(rootWriter, ProfileTag(rootWriter.ImplicitProfileId, info.tag), info);
+            SuccessOrExit(err);
+        }
+
+        for (OptionalQRCodeInfoExtension info : optionalExtensionData)
         {
             err = writeTag(rootWriter, ProfileTag(rootWriter.ImplicitProfileId, info.tag), info);
             SuccessOrExit(err);

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.h
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.h
@@ -83,6 +83,10 @@ public:
      *               producing the requested string.
      */
     CHIP_ERROR payloadBase41Representation(string & base41Representation, uint8_t * tlvDataStart, size_t tlvDataStartSize);
+
+private:
+    CHIP_ERROR generateTLVFromOptionalData(SetupPayload & outPayload, uint8_t * tlvDataStart, uint32_t maxLen,
+                                           uint32_t & tlvDataLengthInBytes);
 };
 
 }; // namespace chip

--- a/src/setup_payload/QRCodeSetupPayloadParser.h
+++ b/src/setup_payload/QRCodeSetupPayloadParser.h
@@ -24,6 +24,8 @@
 #include "SetupPayload.h"
 
 #include <core/CHIPError.h>
+#include <core/CHIPTLV.h>
+
 #include <string>
 using namespace std;
 
@@ -41,6 +43,11 @@ private:
 public:
     QRCodeSetupPayloadParser(string base41Representation) : mBase41Representation(base41Representation){};
     CHIP_ERROR populatePayload(SetupPayload & outPayload);
+
+private:
+    CHIP_ERROR retrieveOptionalInfos(SetupPayload & outPayload, TLV::TLVReader & reader);
+    CHIP_ERROR populateTLV(SetupPayload & outPayload, const vector<uint8_t> & buf, int & index);
+    CHIP_ERROR parseTLVFields(chip::SetupPayload & outPayload, uint8_t * tlvDataStart, uint32_t tlvDataLengthInBytes);
 };
 
 }; // namespace chip

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -36,6 +36,16 @@ using namespace chip::TLV;
 
 namespace chip {
 
+bool IsCHIPTag(uint8_t tag)
+{
+    return tag >= (1 << kRawVendorTagLengthInBits);
+}
+
+bool IsVendorTag(uint8_t tag)
+{
+    return tag < (1 << kRawVendorTagLengthInBits);
+}
+
 // Check the Setup Payload for validity
 //
 // `vendor_id` and `product_id` are allowed all of uint16_t
@@ -90,49 +100,230 @@ bool SetupPayload::isValidManualCode()
     return true;
 }
 
-CHIP_ERROR SetupPayload::addVendorOptionalData(OptionalQRCodeInfo info)
+CHIP_ERROR SetupPayload::addOptionalVendorData(uint8_t tag, string data)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    VerifyOrExit(info.tag < 1 << kRawVendorTagLengthInBits, err = CHIP_ERROR_INVALID_ARGUMENT);
-    optionalData[info.tag] = info;
+    OptionalQRCodeInfo info;
+    info.tag  = tag;
+    info.type = optionalQRCodeInfoTypeString;
+    info.data = data;
+
+    err = addOptionalVendorData(info);
+    SuccessOrExit(err);
+
 exit:
     return err;
 }
 
-CHIP_ERROR SetupPayload::addCHIPOptionalData(OptionalQRCodeInfo info)
+CHIP_ERROR SetupPayload::addOptionalVendorData(uint8_t tag, int32_t data)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    VerifyOrExit(info.tag >= 1 << kRawVendorTagLengthInBits, err = CHIP_ERROR_INVALID_ARGUMENT);
-    optionalData[info.tag] = info;
+    OptionalQRCodeInfo info;
+    info.tag   = tag;
+    info.type  = optionalQRCodeInfoTypeInt32;
+    info.int32 = data;
+
+    err = addOptionalVendorData(info);
+    SuccessOrExit(err);
+
 exit:
     return err;
 }
 
-vector<OptionalQRCodeInfo> SetupPayload::getAllOptionalData()
+vector<OptionalQRCodeInfo> SetupPayload::getAllOptionalVendorData()
 {
     vector<OptionalQRCodeInfo> returnedOptionalInfo;
-    for (map<uint64_t, OptionalQRCodeInfo>::iterator it = optionalData.begin(); it != optionalData.end(); ++it)
+    for (map<uint8_t, OptionalQRCodeInfo>::iterator it = optionalVendorData.begin(); it != optionalVendorData.end(); ++it)
     {
         returnedOptionalInfo.push_back(it->second);
     }
     return returnedOptionalInfo;
 }
 
-CHIP_ERROR SetupPayload::removeOptionalData(uint8_t tag)
+CHIP_ERROR SetupPayload::removeOptionalVendorData(uint8_t tag)
 {
-    if (optionalData.find(tag) == optionalData.end())
-    {
-        return CHIP_ERROR_KEY_NOT_FOUND;
-    }
-    optionalData.erase(tag);
-    return CHIP_NO_ERROR;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    VerifyOrExit(optionalVendorData.find(tag) != optionalVendorData.end(), err = CHIP_ERROR_KEY_NOT_FOUND);
+    optionalVendorData.erase(tag);
+
+exit:
+    return err;
 }
 
-bool SetupPayload::operator==(const SetupPayload & input)
+CHIP_ERROR SetupPayload::addSerialNumber(string serialNumber)
 {
-    return this->version == input.version && this->vendorID == input.vendorID && this->productID == input.productID &&
-        this->requiresCustomFlow == input.requiresCustomFlow && this->rendezvousInformation == input.rendezvousInformation &&
-        this->discriminator == input.discriminator && this->setUpPINCode == input.setUpPINCode;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    OptionalQRCodeInfoExtension info;
+    info.tag  = kSerialNumberTag;
+    info.type = optionalQRCodeInfoTypeString;
+    info.data = serialNumber;
+
+    err = addOptionalExtensionData(info);
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR SetupPayload::addSerialNumber(uint32_t serialNumber)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    OptionalQRCodeInfoExtension info;
+    info.tag    = kSerialNumberTag;
+    info.type   = optionalQRCodeInfoTypeUInt32;
+    info.uint32 = serialNumber;
+
+    err = addOptionalExtensionData(info);
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR SetupPayload::getSerialNumber(string & outSerialNumber)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    OptionalQRCodeInfoExtension info;
+    err = getOptionalExtensionData(kSerialNumberTag, info);
+    SuccessOrExit(err);
+
+    switch (info.type)
+    {
+    case (optionalQRCodeInfoTypeString):
+        outSerialNumber = info.data;
+        break;
+    case (optionalQRCodeInfoTypeUInt32):
+        outSerialNumber = to_string(info.uint32);
+        break;
+    default:
+        err = CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+exit:
+    return err;
+}
+
+CHIP_ERROR SetupPayload::removeSerialNumber(void)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    VerifyOrExit(optionalExtensionData.find(kSerialNumberTag) != optionalExtensionData.end(), err = CHIP_ERROR_KEY_NOT_FOUND);
+    optionalExtensionData.erase(kSerialNumberTag);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR SetupPayload::addOptionalVendorData(OptionalQRCodeInfo info)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    VerifyOrExit(IsVendorTag(info.tag), err = CHIP_ERROR_INVALID_ARGUMENT);
+    optionalVendorData[info.tag] = info;
+
+exit:
+    return err;
+}
+
+CHIP_ERROR SetupPayload::addOptionalExtensionData(OptionalQRCodeInfoExtension info)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    VerifyOrExit(IsCHIPTag(info.tag), err = CHIP_ERROR_INVALID_ARGUMENT);
+    optionalExtensionData[info.tag] = info;
+
+exit:
+    return err;
+}
+
+CHIP_ERROR SetupPayload::getOptionalVendorData(uint8_t tag, OptionalQRCodeInfo & info)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    VerifyOrExit(optionalVendorData.find(tag) != optionalVendorData.end(), err = CHIP_ERROR_KEY_NOT_FOUND);
+    info = optionalVendorData[tag];
+
+exit:
+    return err;
+}
+
+CHIP_ERROR SetupPayload::getOptionalExtensionData(uint8_t tag, OptionalQRCodeInfoExtension & info)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    VerifyOrExit(optionalExtensionData.find(tag) != optionalExtensionData.end(), err = CHIP_ERROR_KEY_NOT_FOUND);
+    info = optionalExtensionData[tag];
+
+exit:
+    return err;
+}
+
+optionalQRCodeInfoType SetupPayload::getNumericTypeFor(uint8_t tag)
+{
+    optionalQRCodeInfoType elemType = optionalQRCodeInfoTypeUnknown;
+
+    if (IsVendorTag(tag))
+    {
+        elemType = optionalQRCodeInfoTypeInt32;
+    }
+    else if (tag == kSerialNumberTag)
+    {
+        elemType = optionalQRCodeInfoTypeUInt32;
+    }
+
+    return elemType;
+}
+
+vector<OptionalQRCodeInfoExtension> SetupPayload::getAllOptionalExtensionData()
+{
+    vector<OptionalQRCodeInfoExtension> returnedOptionalInfo;
+    for (map<uint8_t, OptionalQRCodeInfoExtension>::iterator it = optionalExtensionData.begin(); it != optionalExtensionData.end();
+         ++it)
+    {
+        returnedOptionalInfo.push_back(it->second);
+    }
+    return returnedOptionalInfo;
+}
+
+bool SetupPayload::operator==(SetupPayload & input)
+{
+    bool isIdentical = true;
+    vector<OptionalQRCodeInfo> inputOptionalVendorData;
+    vector<OptionalQRCodeInfoExtension> inputOptionalExtensionData;
+
+    VerifyOrExit(this->version == input.version && this->vendorID == input.vendorID && this->productID == input.productID &&
+                     this->requiresCustomFlow == input.requiresCustomFlow &&
+                     this->rendezvousInformation == input.rendezvousInformation && this->discriminator == input.discriminator &&
+                     this->setUpPINCode == input.setUpPINCode,
+                 isIdentical = false);
+
+    inputOptionalVendorData = input.getAllOptionalVendorData();
+    VerifyOrExit(optionalVendorData.size() == inputOptionalVendorData.size(), isIdentical = false);
+
+    for (OptionalQRCodeInfo inputInfo : inputOptionalVendorData)
+    {
+        OptionalQRCodeInfo info;
+        CHIP_ERROR err = getOptionalVendorData(inputInfo.tag, info);
+        VerifyOrExit(err == CHIP_NO_ERROR, isIdentical = false);
+        VerifyOrExit(inputInfo.type == info.type, isIdentical = false);
+        VerifyOrExit(inputInfo.data.compare(info.data) == 0, isIdentical = false);
+        VerifyOrExit(inputInfo.int32 == info.int32, isIdentical = false);
+    }
+
+    inputOptionalExtensionData = input.getAllOptionalExtensionData();
+    VerifyOrExit(optionalExtensionData.size() == inputOptionalExtensionData.size(), isIdentical = false);
+
+    for (OptionalQRCodeInfoExtension inputInfo : inputOptionalExtensionData)
+    {
+        OptionalQRCodeInfoExtension info;
+        CHIP_ERROR err = getOptionalExtensionData(inputInfo.tag, info);
+        VerifyOrExit(err == CHIP_NO_ERROR, isIdentical = false);
+        VerifyOrExit(inputInfo.type == info.type, isIdentical = false);
+        VerifyOrExit(inputInfo.data.compare(info.data) == 0, isIdentical = false);
+        VerifyOrExit(inputInfo.int32 == info.int32, isIdentical = false);
+        VerifyOrExit(inputInfo.int64 == info.int64, isIdentical = false);
+        VerifyOrExit(inputInfo.uint32 == info.uint32, isIdentical = false);
+        VerifyOrExit(inputInfo.uint64 == info.uint64, isIdentical = false);
+    }
+
+exit:
+    return isIdentical;
 }
 
 } // namespace chip

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -48,13 +48,14 @@ const int kPaddingFieldLengthInBits                  = 5;
 
 const int kRendezvousInfoReservedFieldLengthInBits = 4;
 const int kRawVendorTagLengthInBits                = 7;
-const uint16_t kSerialNumberTag                    = 128;
-const uint32_t kTag_QRCodeExensionDescriptor       = 0x00;
 
 const int kManualSetupShortCodeCharLength = 10;
 const int kManualSetupLongCodeCharLength  = 20;
 const int kManualSetupVendorIdCharLength  = 5;
 const int kManualSetupProductIdCharLength = 5;
+
+const uint8_t kSerialNumberTag               = 128;
+const uint32_t kTag_QRCodeExensionDescriptor = 0x00;
 
 // clang-format off
 const int kTotalPayloadDataSizeInBits =
@@ -74,8 +75,12 @@ const char * const kQRCodePrefix = "CH:";
 
 enum optionalQRCodeInfoType
 {
+    optionalQRCodeInfoTypeUnknown,
     optionalQRCodeInfoTypeString,
-    optionalQRCodeInfoTypeInt
+    optionalQRCodeInfoTypeInt32,
+    optionalQRCodeInfoTypeInt64,
+    optionalQRCodeInfoTypeUInt32,
+    optionalQRCodeInfoTypeUInt64
 };
 
 /**
@@ -91,14 +96,39 @@ enum optionalQRCodeInfoType
  **/
 struct OptionalQRCodeInfo
 {
+    OptionalQRCodeInfo() { int32 = 0; };
+
     uint8_t tag;
     enum optionalQRCodeInfoType type;
-    int integer;
     string data;
+    int32_t int32;
 };
+
+struct OptionalQRCodeInfoExtension : OptionalQRCodeInfo
+{
+    OptionalQRCodeInfoExtension()
+    {
+        int32  = 0;
+        int64  = 0;
+        uint32 = 0;
+        uint64 = 0;
+    };
+
+    int64_t int64;
+    uint64_t uint32;
+    uint64_t uint64;
+};
+
+bool IsCHIPTag(uint8_t tag);
+bool IsVendorTag(uint8_t tag);
+;
 
 class SetupPayload
 {
+
+    friend class QRCodeSetupPayloadGenerator;
+    friend class QRCodeSetupPayloadParser;
+
 public:
     uint8_t version;
     uint16_t vendorID;
@@ -107,32 +137,54 @@ public:
     uint16_t rendezvousInformation;
     uint16_t discriminator;
     uint32_t setUpPINCode;
-    string serialNumber;
 
+    /** @brief A function to add an optional vendor data
+     * @param tag 7 bit [0-127] tag number
+     * @param data String representation of data to add
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR addOptionalVendorData(uint8_t tag, string data);
+
+    /** @brief A function to add an optional vendor data
+     * @param tag 7 bit [0-127] tag number
+     * @param data Integer representation of data to add
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR addOptionalVendorData(uint8_t tag, int32_t data);
+
+    /** @brief A function to remove an optional vendor data
+     * @param tag 7 bit [0-127] tag number
+     * @return Returns a CHIP_ERROR_KEY_NOT_FOUND on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR removeOptionalVendorData(uint8_t tag);
     /**
      * @brief A function to retrieve the vector of OptionalQRCodeInfo infos
      * @return Returns a vector of optionalQRCodeInfos
      **/
-    vector<OptionalQRCodeInfo> getAllOptionalData();
+    vector<OptionalQRCodeInfo> getAllOptionalVendorData();
 
-    /** @brief A function to add an optional QR Code info vendor object
-     * @param info Optional QR code info object to add
+    /** @brief A function to add a string serial number
+     * @param serialNumber string serial number
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR addVendorOptionalData(OptionalQRCodeInfo info);
+    CHIP_ERROR addSerialNumber(string serialNumber);
 
-    /** @brief A function to add an optional QR Code info CHIP object
-     * @param info Optional QR code info object to add
+    /** @brief A function to add a uint32_t serial number
+     * @param serialNumber uint32_t serial number
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR addCHIPOptionalData(OptionalQRCodeInfo info);
+    CHIP_ERROR addSerialNumber(uint32_t serialNumber);
 
-    /** @brief A function to remove an optional QR Code info object
-     * @param tag Optional QR code info tag number to remove
-     * @return Returns CHIP_ERROR_KEY_NOT_FOUND if info could not be found in existing optional data structs,
-     *                 CHIP_NO_ERROR otherwise
+    /** @brief A function to retrieve serial number as a string
+     * @param outSerialNumber retrieved string serial number
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR removeOptionalData(uint8_t tag);
+    CHIP_ERROR getSerialNumber(string & outSerialNumber);
+
+    /** @brief A function to remove the serial number from the payload
+     * @return Returns a CHIP_ERROR_KEY_NOT_FOUND on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR removeSerialNumber(void);
 
     // Test that the Setup Payload is within expected value ranges
     SetupPayload() :
@@ -140,10 +192,49 @@ public:
 
     bool isValidQRCodePayload();
     bool isValidManualCode();
-    bool operator==(const SetupPayload & input);
+    bool operator==(SetupPayload & input);
 
 private:
-    map<uint64_t, OptionalQRCodeInfo> optionalData;
+    map<uint8_t, OptionalQRCodeInfo> optionalVendorData;
+    map<uint8_t, OptionalQRCodeInfoExtension> optionalExtensionData;
+
+    /** @brief A function to add an optional QR Code info vendor object
+     * @param info Optional QR code info object to add
+     * @return Returns a CHIP_ERROR_INVALID_ARGUMENT on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR addOptionalVendorData(OptionalQRCodeInfo info);
+
+    /** @brief A function to add an optional QR Code info CHIP object
+     * @param info Optional QR code info object to add
+     * @return Returns a CHIP_ERROR_INVALID_ARGUMENT on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR addOptionalExtensionData(OptionalQRCodeInfoExtension info);
+
+    /**
+     * @brief A function to retrieve the vector of CHIPQRCodeInfo infos
+     * @return Returns a vector of CHIPQRCodeInfos
+     **/
+    vector<OptionalQRCodeInfoExtension> getAllOptionalExtensionData();
+
+    /** @brief A function to retrieve an optional QR Code info vendor object
+     * @param tag 7 bit [0-127] tag number
+     * @param outSerialNumber retrieved OptionalQRCodeInfo object
+     * @return Returns a CHIP_ERROR_KEY_NOT_FOUND on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR getOptionalVendorData(uint8_t tag, OptionalQRCodeInfo & info);
+
+    /** @brief A function to retrieve an optional QR Code info extended object
+     * @param tag 8 bit [128-255] tag number
+     * @param outSerialNumber retrieved OptionalQRCodeInfoExtension object
+     * @return Returns a CHIP_ERROR_KEY_NOT_FOUND on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR getOptionalExtensionData(uint8_t tag, OptionalQRCodeInfoExtension & info);
+
+    /** @brief A function to retrieve the associated expected numeric value for a tag
+     * @param tag 8 bit [0-255] tag number
+     * @return Returns an optionalQRCodeInfoType value
+     **/
+    optionalQRCodeInfoType getNumericTypeFor(uint8_t tag);
 };
 
 }; // namespace chip

--- a/src/setup_payload/tests/TestHelpers.h
+++ b/src/setup_payload/tests/TestHelpers.h
@@ -25,6 +25,15 @@
 const uint16_t kSmallBufferSizeInBytes   = 1;
 const uint16_t kDefaultBufferSizeInBytes = 512;
 
+const uint8_t kOptionalDefaultStringTag  = 2;
+const string kOptionalDefaultStringValue = "myData";
+
+const uint8_t kOptionalDefaultIntTag    = 3;
+const uint32_t kOptionalDefaultIntValue = 12;
+
+const char * kSerialNumberDefaultStringValue   = "123456789";
+const uint32_t kSerialNumberDefaultUInt32Value = 123456789;
+
 SetupPayload GetDefaultPayload()
 {
     SetupPayload payload;
@@ -43,40 +52,17 @@ SetupPayload GetDefaultPayload()
 SetupPayload GetDefaultPayloadWithSerialNumber()
 {
     SetupPayload payload = GetDefaultPayload();
-    payload.serialNumber = "123456789QWDHANTYUIOP";
+    payload.addSerialNumber(kSerialNumberDefaultStringValue);
 
     return payload;
-}
-
-OptionalQRCodeInfo GetOptionalDefaultString()
-{
-    OptionalQRCodeInfo info;
-    info.tag  = 2;
-    info.type = optionalQRCodeInfoTypeString;
-    info.data = "myData";
-
-    return info;
-}
-
-OptionalQRCodeInfo GetOptionalDefaultInt()
-{
-    OptionalQRCodeInfo info;
-    info.tag     = 3;
-    info.type    = optionalQRCodeInfoTypeInt;
-    info.integer = 12;
-
-    return info;
 }
 
 SetupPayload GetDefaultPayloadWithOptionalDefaults()
 {
     SetupPayload payload = GetDefaultPayloadWithSerialNumber();
 
-    OptionalQRCodeInfo stringInfo = GetOptionalDefaultString();
-    OptionalQRCodeInfo intInfo    = GetOptionalDefaultInt();
-
-    payload.addVendorOptionalData(stringInfo);
-    payload.addVendorOptionalData(intInfo);
+    payload.addOptionalVendorData(kOptionalDefaultStringTag, kOptionalDefaultStringValue);
+    payload.addOptionalVendorData(kOptionalDefaultIntTag, kOptionalDefaultIntValue);
 
     return payload;
 }

--- a/src/setup_payload/tests/TestQRCodeTLV.cpp
+++ b/src/setup_payload/tests/TestQRCodeTLV.cpp
@@ -24,29 +24,6 @@
 using namespace chip;
 using namespace std;
 
-void ComparePayloads(nlTestSuite * inSuite, void * inContext, SetupPayload & inPayload, SetupPayload & outPayload)
-{
-    NL_TEST_ASSERT(inSuite, inPayload.version == outPayload.version);
-    NL_TEST_ASSERT(inSuite, inPayload.vendorID == outPayload.vendorID);
-    NL_TEST_ASSERT(inSuite, inPayload.productID == outPayload.productID);
-    NL_TEST_ASSERT(inSuite, inPayload.requiresCustomFlow == outPayload.requiresCustomFlow);
-    NL_TEST_ASSERT(inSuite, inPayload.rendezvousInformation == outPayload.rendezvousInformation);
-    NL_TEST_ASSERT(inSuite, inPayload.discriminator == outPayload.discriminator);
-    NL_TEST_ASSERT(inSuite, inPayload.setUpPINCode == outPayload.setUpPINCode);
-    NL_TEST_ASSERT(inSuite, inPayload.serialNumber.compare(outPayload.serialNumber) == 0);
-
-    vector<OptionalQRCodeInfo> in  = inPayload.getAllOptionalData();
-    vector<OptionalQRCodeInfo> out = outPayload.getAllOptionalData();
-
-    NL_TEST_ASSERT(inSuite, in.size() == out.size());
-
-    for (size_t i = 0; i < in.size(); i++)
-    {
-        NL_TEST_ASSERT(inSuite, in[i].type == out[i].type);
-        NL_TEST_ASSERT(inSuite, in[i].tag == out[i].tag);
-        NL_TEST_ASSERT(inSuite, in[i].data.compare(out[i].data) == 0);
-    }
-}
 void CompareWriteRead(nlTestSuite * inSuite, void * inContext, SetupPayload & inPayload)
 {
     SetupPayload outPayload;
@@ -60,93 +37,52 @@ void CompareWriteRead(nlTestSuite * inSuite, void * inContext, SetupPayload & in
     QRCodeSetupPayloadParser parser = QRCodeSetupPayloadParser(result);
     err                             = parser.populatePayload(outPayload);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    ComparePayloads(inSuite, inContext, inPayload, outPayload);
-}
-
-void TestOptionalTagValues(nlTestSuite * inSuite, void * inContext)
-{
-    SetupPayload payload          = GetDefaultPayload();
-    OptionalQRCodeInfo stringInfo = GetOptionalDefaultString();
-    CHIP_ERROR err;
-
-    err = payload.addVendorOptionalData(stringInfo);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    stringInfo.tag = 0;
-    err            = payload.addVendorOptionalData(stringInfo);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    stringInfo.tag = 128;
-    err            = payload.addVendorOptionalData(stringInfo);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
-
-    stringInfo.tag = 255;
-    err            = payload.addVendorOptionalData(stringInfo);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
-
-    stringInfo.tag = 127;
-    err            = payload.addVendorOptionalData(stringInfo);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    stringInfo.tag = 128;
-    err            = payload.addCHIPOptionalData(stringInfo);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    stringInfo.tag = 127;
-    err            = payload.addCHIPOptionalData(stringInfo);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
-
-    stringInfo.tag = 255;
-    err            = payload.addCHIPOptionalData(stringInfo);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, inPayload == outPayload);
 }
 
 void TestOptionalDataAddRemove(nlTestSuite * inSuite, void * inContext)
 {
-    SetupPayload payload          = GetDefaultPayload();
-    OptionalQRCodeInfo stringInfo = GetOptionalDefaultString();
-    OptionalQRCodeInfo intInfo    = GetOptionalDefaultInt();
+    SetupPayload payload = GetDefaultPayload();
     vector<OptionalQRCodeInfo> optionalData;
     CHIP_ERROR err;
 
-    optionalData = payload.getAllOptionalData();
+    optionalData = payload.getAllOptionalVendorData();
     NL_TEST_ASSERT(inSuite, optionalData.size() == 0);
 
-    err = payload.addVendorOptionalData(stringInfo);
+    err = payload.addOptionalVendorData(kOptionalDefaultStringTag, kOptionalDefaultStringValue);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    optionalData = payload.getAllOptionalData();
+    optionalData = payload.getAllOptionalVendorData();
     NL_TEST_ASSERT(inSuite, optionalData.size() == 1);
 
-    err = payload.addVendorOptionalData(intInfo);
+    err = payload.addOptionalVendorData(kOptionalDefaultIntTag, kOptionalDefaultIntValue);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    optionalData = payload.getAllOptionalData();
+    optionalData = payload.getAllOptionalVendorData();
     NL_TEST_ASSERT(inSuite, optionalData.size() == 2);
 
-    err = payload.removeOptionalData(stringInfo.tag);
+    err = payload.removeOptionalVendorData(kOptionalDefaultStringTag);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    optionalData = payload.getAllOptionalData();
+    optionalData = payload.getAllOptionalVendorData();
     NL_TEST_ASSERT(inSuite, optionalData.size() == 1);
 
-    payload.removeOptionalData(intInfo.tag);
+    payload.removeOptionalVendorData(kOptionalDefaultIntTag);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    optionalData = payload.getAllOptionalData();
+    optionalData = payload.getAllOptionalVendorData();
     NL_TEST_ASSERT(inSuite, optionalData.size() == 0);
 
-    err = payload.removeOptionalData(stringInfo.tag);
+    err = payload.removeOptionalVendorData(kOptionalDefaultStringTag);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_KEY_NOT_FOUND);
 
-    optionalData = payload.getAllOptionalData();
+    optionalData = payload.getAllOptionalVendorData();
     NL_TEST_ASSERT(inSuite, optionalData.size() == 0);
 
-    err = payload.removeOptionalData(intInfo.tag);
+    err = payload.removeOptionalVendorData(kOptionalDefaultIntTag);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_KEY_NOT_FOUND);
 
-    optionalData = payload.getAllOptionalData();
+    optionalData = payload.getAllOptionalVendorData();
     NL_TEST_ASSERT(inSuite, optionalData.size() == 0);
 }
 
@@ -174,17 +110,61 @@ void TestSimpleRead(nlTestSuite * inSuite, void * inContext)
     err                             = parser.populatePayload(outPayload);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    ComparePayloads(inSuite, inContext, inPayload, outPayload);
+    NL_TEST_ASSERT(inSuite, inPayload == outPayload);
+}
+
+void TestOptionalTagValues(nlTestSuite * inSuite, void * inContext)
+{
+    SetupPayload payload = GetDefaultPayload();
+    CHIP_ERROR err;
+
+    err = payload.addOptionalVendorData(kOptionalDefaultStringTag, kOptionalDefaultStringValue);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = payload.addOptionalVendorData(0, kOptionalDefaultStringValue);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = payload.addOptionalVendorData(127, kOptionalDefaultStringValue);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = payload.addOptionalVendorData(128, kOptionalDefaultStringValue);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
+
+    err = payload.addOptionalVendorData(255, kOptionalDefaultStringValue);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
+}
+
+void TestSerialNumberAddRemove(nlTestSuite * inSuite, void * inContext)
+{
+    SetupPayload inPayload = GetDefaultPayload();
+
+    string sn;
+    NL_TEST_ASSERT(inSuite, inPayload.getSerialNumber(sn) == CHIP_ERROR_KEY_NOT_FOUND);
+    NL_TEST_ASSERT(inSuite, inPayload.removeSerialNumber() == CHIP_ERROR_KEY_NOT_FOUND);
+
+    NL_TEST_ASSERT(inSuite, inPayload.addSerialNumber(kSerialNumberDefaultStringValue) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, inPayload.getSerialNumber(sn) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, sn.compare(kSerialNumberDefaultStringValue) == 0);
+
+    NL_TEST_ASSERT(inSuite, inPayload.addSerialNumber(kSerialNumberDefaultUInt32Value) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, inPayload.getSerialNumber(sn) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, sn.compare(to_string(kSerialNumberDefaultUInt32Value)) == 0);
+
+    NL_TEST_ASSERT(inSuite, inPayload.removeSerialNumber() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, inPayload.getSerialNumber(sn) == CHIP_ERROR_KEY_NOT_FOUND);
+    NL_TEST_ASSERT(inSuite, inPayload.removeSerialNumber() == CHIP_ERROR_KEY_NOT_FOUND);
 }
 
 void TestOptionalDataWriteSerial(nlTestSuite * inSuite, void * inContext)
 {
+    CHIP_ERROR err         = CHIP_NO_ERROR;
     SetupPayload inPayload = GetDefaultPayload();
-    inPayload.serialNumber = "1";
+    err                    = inPayload.addSerialNumber("1");
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     QRCodeSetupPayloadGenerator generator(inPayload);
     string result;
-    CHIP_ERROR err = generator.payloadBase41Representation(result);
+    err = generator.payloadBase41Representation(result);
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
 
     uint8_t optionalInfo[kDefaultBufferSizeInBytes];
@@ -206,25 +186,26 @@ void TestOptionalDataWrite(nlTestSuite * inSuite, void * inContext)
 void TestOptionalDataReadSerial(nlTestSuite * inSuite, void * inContext)
 {
     SetupPayload inPayload = GetDefaultPayload();
-    inPayload.serialNumber = "1";
 
+    inPayload.addSerialNumber(kSerialNumberDefaultStringValue);
+    CompareWriteRead(inSuite, inContext, inPayload);
+
+    inPayload.addSerialNumber(kSerialNumberDefaultUInt32Value);
     CompareWriteRead(inSuite, inContext, inPayload);
 }
 
 void TestOptionalDataReadVendorInt(nlTestSuite * inSuite, void * inContext)
 {
-    SetupPayload inPayload     = GetDefaultPayload();
-    OptionalQRCodeInfo intInfo = GetOptionalDefaultInt();
-    inPayload.addVendorOptionalData(intInfo);
+    SetupPayload inPayload = GetDefaultPayload();
+    inPayload.addOptionalVendorData(kOptionalDefaultIntTag, kOptionalDefaultIntValue);
 
     CompareWriteRead(inSuite, inContext, inPayload);
 }
 
 void TestOptionalDataReadVendorString(nlTestSuite * inSuite, void * inContext)
 {
-    SetupPayload inPayload        = GetDefaultPayload();
-    OptionalQRCodeInfo stringInfo = GetOptionalDefaultString();
-    inPayload.addVendorOptionalData(stringInfo);
+    SetupPayload inPayload = GetDefaultPayload();
+    inPayload.addOptionalVendorData(kOptionalDefaultStringTag, kOptionalDefaultStringValue);
 
     CompareWriteRead(inSuite, inContext, inPayload);
 }
@@ -262,34 +243,23 @@ void TestPayloadBinary(nlTestSuite * inSuite, void * inContext)
     SetupPayload payload = GetDefaultPayload();
     NL_TEST_ASSERT(inSuite, CompareBinaryLength(payload, 0));
 
-    OptionalQRCodeInfo info = GetOptionalDefaultString();
-    info.data               = "1";
-
-    payload.addVendorOptionalData(info);
+    payload.addOptionalVendorData(kOptionalDefaultStringTag, "1");
     NL_TEST_ASSERT(inSuite, CompareBinaryLength(payload, 5));
-    payload.removeOptionalData(info.tag);
+    payload.removeOptionalVendorData(kOptionalDefaultStringTag);
 
-    info         = GetOptionalDefaultInt();
-    info.integer = 1;
-
-    info.tag = 1;
-    payload.addVendorOptionalData(info);
+    payload.addOptionalVendorData(1, kOptionalDefaultIntValue);
     NL_TEST_ASSERT(inSuite, CompareBinaryLength(payload, 4));
 
-    info.tag = 2;
-    payload.addVendorOptionalData(info);
+    payload.addOptionalVendorData(2, kOptionalDefaultIntValue);
     NL_TEST_ASSERT(inSuite, CompareBinaryLength(payload, 8));
 
-    info.tag = 3;
-    payload.addVendorOptionalData(info);
+    payload.addOptionalVendorData(3, kOptionalDefaultIntValue);
     NL_TEST_ASSERT(inSuite, CompareBinaryLength(payload, 12));
 
-    info.tag = 4;
-    payload.addVendorOptionalData(info);
+    payload.addOptionalVendorData(4, kOptionalDefaultIntValue);
     NL_TEST_ASSERT(inSuite, CompareBinaryLength(payload, 16));
 
-    info.tag = 5;
-    payload.addVendorOptionalData(info);
+    payload.addOptionalVendorData(5, kOptionalDefaultIntValue);
     NL_TEST_ASSERT(inSuite, CompareBinaryLength(payload, 19));
 }
 
@@ -304,6 +274,7 @@ static const nlTest sTests[] =
     NL_TEST_DEF("Test Simple Write",                TestSimpleWrite),
     NL_TEST_DEF("Test Simple Read",                 TestSimpleRead),
     NL_TEST_DEF("Test Optional Add Remove",         TestOptionalDataAddRemove),
+    NL_TEST_DEF("Test Serial Number Add Remove",    TestSerialNumberAddRemove),
     NL_TEST_DEF("Test Optional Write",              TestOptionalDataWrite),
     NL_TEST_DEF("Test Optional Write Serial",       TestOptionalDataWriteSerial),
     NL_TEST_DEF("Test Optional Write No Buffer",    TestOptionalDataWriteNoBuffer),


### PR DESCRIPTION
 #### Problem
- Serial number could only be provided as a string

 #### Summary of Changes
- Serial number can be provided as string or uint32
- Simplify some of the APIs for vendors so they don't have to deal with OptionaQRCodeInfo objects but instead can just add optional data by passing a tag and value
- Fix the iOS Framework tests and add new ones testing the optional data parsing

fixes #932 #1042 
