### PR TITLE
Otimize last bytes chunk in base41encode

### DIFF
--- a/src/setup_payload/Base41.cpp
+++ b/src/setup_payload/Base41.cpp
@@ -75,7 +75,7 @@ string base41Encode(const uint8_t * buf, size_t buf_len)
         //
         int encodeLen = kBase41ChunkLen;
         if (buf_len == 0 &&            // the very last value, i.e. not an odd byte
-            (value > 255) &&           // the value wouldn't fit in one byte
+            (value > UINT8_MAX) &&     // the value wouldn't fit in one byte
             (value < kRadix * kRadix)) // the value can be encoded with 2 base41 chars
         {
             encodeLen--;


### PR DESCRIPTION
#### Problem
 The last 16bit value always encodes as 3 base41 chars, even though sometimes 2 chararcters would be sufficient

 #### Summary of Changes
 * Add the optimization in cases where that works.
 * Add tests