### PR TITLE
Allow non-cluster-specific commands in chipZclProcessIncoming.

### DIFF
--- a/src/app/plugin/core-api/core-api.c
+++ b/src/app/plugin/core-api/core-api.c
@@ -18,6 +18,7 @@
 #include <memory.h>
 
 #include "chip-zcl.h"
+#include "gen-global-command-handler.h"
 
 ChipZclStatus_t chipZclClusterCommandParse(ChipZclCommandContext_t * context);
 
@@ -27,5 +28,6 @@ ChipZclStatus_t chipZclProcessIncoming(ChipZclBuffer_t * message)
 
     chipZclDecodeZclHeader(message, &context);
 
-    return chipZclClusterCommandParse(&context);
+    // Should this just use chipZclCommandParse?
+    return context.clusterSpecific ? chipZclClusterCommandParse(&context) : chipZclGeneralCommandParse(&context);
 }


### PR DESCRIPTION
We want to support commands like "configure reporting" and "read
attributes", which are not cluster-specific.

 #### Problem
Global commands are not supported in `chipZclProcessIncoming`

 #### Summary of Changes
At least try to parse them.

fixes https://github.com/project-chip/connectedhomeip/issues/1056
