### PR TITLE
Disable maintainer mode by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -133,13 +133,14 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AM_SILENT_RULES([yes])
 
 #
-# Enable maintainer mode to prevent the package from constantly trying
-# to rebuild configure, Makefile.in, etc. Rebuilding such files rarely,
-# if ever, needs to be done "in the field".
+# Disable maintainer mode to enable the package to automatically rebuild
+# configure, Makefile.in, etc. when the files on which they depend change (for
+# example, configure.ac, Makefile.am, etc).
 #
-# Use the included 'bootstrap' script instead when necessary.
+# For those that do not desire this behavior, run configure with
+# `--enable-maintainer-mode` and run the top-level `bootstrap` script manually.
 #
-#AM_MAINTAINER_MODE
+AM_MAINTAINER_MODE([disable])
 
 #
 # Check for the target style

--- a/configure.ac
+++ b/configure.ac
@@ -139,7 +139,7 @@ AM_SILENT_RULES([yes])
 #
 # Use the included 'bootstrap' script instead when necessary.
 #
-AM_MAINTAINER_MODE
+#AM_MAINTAINER_MODE
 
 #
 # Check for the target style


### PR DESCRIPTION
When maintainer mode is enabled, `make` will not try to run
`aclocal`/`autoconf`/`automake` when corresponding `configure.ac` or
`Makefile.am` is changed. It is very inconvenient for daily development
that these files are changing everyday. Developers are force to re-run
bootstrap and configure when these files are changed.

With maintainer mode disabled, changes of these files will be handled by
`Makefile` automatically, `make` will re-run corresponding commands when
changes of these files are detected.

The purpose of maintainer mode is to prevent updating `Makefile.in` and
`configure` after release. Because CHIP doesn't release these files,
there is no reason to enable maintainer mode.