### PR TITLE
[shell] Fix #1074: iOS build - use latest posix include.

### DIFF
--- a/src/lib/shell/streamer_stdio.cpp
+++ b/src/lib/shell/streamer_stdio.cpp
@@ -25,7 +25,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <termio.h>
+#include <termios.h>
 #include <unistd.h>
 
 namespace chip {


### PR DESCRIPTION
 #### Problem
Shell library breaks MacOS and iOS builds.

 #### Summary of Changes
Fix typo to use the latest posix header.

fixes #1074 

@sagar-apple verified on MacOS.  #1081 posted for openssl docs issue.