### PR TITLE
Fix CHIP Darwin Framework build failure

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -182,12 +182,11 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
         }
         return NO;
     }
-
-    dispatch_sync(self.chipWorkQueue, ^() {
+    [self.lock lock];
         const unsigned char * local_key_bytes = (const unsigned char *) [local_key bytes];
         const unsigned char * peer_key_bytes = (const unsigned char *) [peer_key bytes];
         err = self.cppController->ManualKeyExchange(peer_key_bytes, peer_key.length, local_key_bytes, local_key.length);
-    });
+    [self.lock unlock];
 
     if (err != CHIP_NO_ERROR) {
         CHIP_LOG_ERROR("Error(%d): %@, key exchange failed", err, [CHIPError errorForCHIPErrorCode:err]);

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -183,9 +183,9 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
         return NO;
     }
     [self.lock lock];
-        const unsigned char * local_key_bytes = (const unsigned char *) [local_key bytes];
-        const unsigned char * peer_key_bytes = (const unsigned char *) [peer_key bytes];
-        err = self.cppController->ManualKeyExchange(peer_key_bytes, peer_key.length, local_key_bytes, local_key.length);
+    const unsigned char * local_key_bytes = (const unsigned char *) [local_key bytes];
+    const unsigned char * peer_key_bytes = (const unsigned char *) [peer_key bytes];
+    err = self.cppController->ManualKeyExchange(peer_key_bytes, peer_key.length, local_key_bytes, local_key.length);
     [self.lock unlock];
 
     if (err != CHIP_NO_ERROR) {


### PR DESCRIPTION
 #### Problem
Crossed wires during merge broke the Darwin Framework build.
 #### Summary of Changes
Fix the build by switching to using the lock instead of the dispatch queue

fixes https://github.com/project-chip/connectedhomeip/issues/1075
