### PR TITLE
[linux] Refactor the platform test modules into two parts (per the pa…

### DIFF
--- a/src/platform/tests/Makefile.am
+++ b/src/platform/tests/Makefile.am
@@ -36,6 +36,22 @@ EXTRA_DIST                                     = \
     $(NULL)
 
 if CHIP_BUILD_TESTS
+lib_LIBRARIES                                  = \
+    libPlatformTests.a                           \
+    $(NULL)
+
+libPlatformTests_a_SOURCES                     = \
+    TestPlatformMgr.cpp                          \
+    TestPlatformTime.cpp                         \
+    $(NULL)
+
+libPlatformTests_adir                          = $(includedir)/platform
+
+dist_libPlatformTests_a_HEADERS                = \
+    TestPlatformMgr.h                            \
+    TestPlatformTime.h                           \
+    $(NULL)
+
 # C/C++ preprocessor option flags that will apply to all compiled
 # objects in this makefile.
 
@@ -57,8 +73,9 @@ CHIP_LDADD                                      = \
     $(top_builddir)/src/lib/support/libSupportLayer.a   \
     $(NULL)
 
-COMMON_LDADD                                   = \
-    $(CHIP_LDADD)                                \
+COMMON_LDADD                                          = \
+    libPlatformTests.a                                  \
+    $(CHIP_LDADD)                                       \
     $(NLFAULTINJECTION_LDFLAGS) $(NLFAULTINJECTION_LIBS)\
     $(NLUNIT_TEST_LDFLAGS) $(NLUNIT_TEST_LIBS)          \
     $(LWIP_LDFLAGS) $(LWIP_LIBS)                        \
@@ -89,10 +106,10 @@ TESTS_ENVIRONMENT                              = \
 # Source, compiler, and linker options for test programs.
 
 TestPlatformTime_LDADD                         = $(COMMON_LDADD)
-TestPlatformTime_SOURCES                       = TestPlatformTime.cpp
+TestPlatformTime_SOURCES                       = TestPlatformTimeDriver.cpp
 
 TestPlatformMgr_LDADD                          = $(COMMON_LDADD)
-TestPlatformMgr_SOURCES                        = TestPlatformMgr.cpp
+TestPlatformMgr_SOURCES                        = TestPlatformMgrDriver.cpp
 
 #
 # Foreign make dependencies

--- a/src/platform/tests/TestPlatformMgr.cpp
+++ b/src/platform/tests/TestPlatformMgr.cpp
@@ -15,6 +15,15 @@
  *    limitations under the License.
  */
 
+/**
+ *    @file
+ *      This file implements a unit test suite for the Platform Manager
+ *      code functionality.
+ *
+ */
+
+#include "TestPlatformMgr.h"
+
 #include <inttypes.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -95,7 +104,7 @@ static const nlTest sTests[] = {
     NL_TEST_SENTINEL()
 };
 
-int main(void)
+int TestPlatformMgr(void)
 {
     nlTestSuite theSuite = { "CHIP DeviceLayer time tests", &sTests[0], NULL, NULL };
 

--- a/src/platform/tests/TestPlatformMgr.h
+++ b/src/platform/tests/TestPlatformMgr.h
@@ -1,0 +1,29 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file declares test entry point for CHIP Platform Manager code unit tests.
+ *
+ */
+
+#ifndef TESTPLATFORMMGR_H
+#define TESTPLATFORMMGR_H
+
+int TestPlatformMgr(void);
+
+#endif // TESTPLATFORMMGR_H

--- a/src/platform/tests/TestPlatformMgrDriver.cpp
+++ b/src/platform/tests/TestPlatformMgrDriver.cpp
@@ -1,0 +1,30 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a standalone/native program executable
+ *      test driver for the Platform Manager code code unit tests.
+ *
+ */
+
+#include "TestPlatformMgr.h"
+
+int main(void)
+{
+    return (TestPlatformMgr());
+}

--- a/src/platform/tests/TestPlatformTime.cpp
+++ b/src/platform/tests/TestPlatformTime.cpp
@@ -15,6 +15,15 @@
  *    limitations under the License.
  */
 
+/**
+ *    @file
+ *      This file implements a unit test suite for the Platform Time
+ *      code functionality.
+ *
+ */
+
+#include "TestPlatformTime.h"
+
 #include <inttypes.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -193,7 +202,7 @@ static const nlTest sTests[] = {
     NL_TEST_SENTINEL()
 };
 
-int main(void)
+int TestPlatformTime(void)
 {
     nlTestSuite theSuite = { "CHIP DeviceLayer tests", &sTests[0], NULL, NULL };
 

--- a/src/platform/tests/TestPlatformTime.h
+++ b/src/platform/tests/TestPlatformTime.h
@@ -1,0 +1,29 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file declares test entry point for CHIP Platform Time code unit tests.
+ *
+ */
+
+#ifndef TESTPLATFORMTIME_H
+#define TESTPLATFORMTIME_H
+
+int TestPlatformTime(void);
+
+#endif // TESTCONFIGURATIONMGR_H

--- a/src/platform/tests/TestPlatformTimeDriver.cpp
+++ b/src/platform/tests/TestPlatformTimeDriver.cpp
@@ -1,0 +1,30 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a standalone/native program executable
+ *      test driver for the Platform Time code code unit tests.
+ *
+ */
+
+#include "TestPlatformTime.h"
+
+int main(void)
+{
+    return (TestPlatformTime());
+}


### PR DESCRIPTION
[linux] Refactor the platfomr test modules into two parts (per the pattern in the rest of the tree) (#614)
    
* A test library that can be invoked by any test driver.
* A test driver containing main() that invokes test lib.

fixes #<614>
