### PR TITLE
Swap the IPv6 and IPv4 Server init order

### DIFF
--- a/examples/wifi-echo/server/esp32/main/EchoServer.cpp
+++ b/examples/wifi-echo/server/esp32/main/EchoServer.cpp
@@ -149,6 +149,6 @@ void setupTransport(IPAddressType type, SecureTransport * transport)
 // The echo server assumes the platform's networking has been setup already
 void startServer(SecureTransport * transport_ipv4, SecureTransport * transport_ipv6)
 {
-    setupTransport(kIPAddressType_IPv4, transport_ipv4);
     setupTransport(kIPAddressType_IPv6, transport_ipv6);
+    setupTransport(kIPAddressType_IPv4, transport_ipv4);
 }


### PR DESCRIPTION
 #### Problem
The Echo Server seems to have regressed recently. The IPv6 socket isn't receiving any data currently. See: https://github.com/project-chip/connectedhomeip/issues/1083

 #### Summary of Changes
Swap the order of the calls to get the IPv6 bit up and running again for the time being. 
