### PR TITLE
Display error on m5Stack in case of packet recv error

### DIFF
--- a/examples/wifi-echo/server/esp32/main/EchoServer.cpp
+++ b/examples/wifi-echo/server/esp32/main/EchoServer.cpp
@@ -40,11 +40,14 @@
 #include <transport/SecureTransport.h>
 
 #include "DataModelHandler.h"
+#include "LEDWidget.h"
 
 static const char * TAG = "echo_server";
 
 using namespace ::chip;
 using namespace ::chip::Inet;
+
+extern LEDWidget statusLED; // In wifi-echo.cpp
 
 // Transport Callbacks
 static void echo(SecureTransport * transport, System::PacketBuffer * buffer, const IPPacketInfo * packet_info)
@@ -99,6 +102,7 @@ static void echo(SecureTransport * transport, System::PacketBuffer * buffer, con
 static void error(SecureTransport * st, CHIP_ERROR error, const IPPacketInfo * pi)
 {
     ESP_LOGE(TAG, "ERROR: %s\n Got UDP error", ErrorStr(error));
+    statusLED.BlinkOnError();
 }
 
 static const unsigned char local_private_key[] = { 0xc6, 0x1a, 0x2f, 0x89, 0x36, 0x67, 0x2b, 0x26, 0x12, 0x47, 0x4f,

--- a/examples/wifi-echo/server/esp32/main/LEDWidget.cpp
+++ b/examples/wifi-echo/server/esp32/main/LEDWidget.cpp
@@ -85,8 +85,8 @@ void LEDWidget::Blink(uint32_t onTimeMS, uint32_t offTimeMS)
 void ClearErrorState(TimerHandle_t handle)
 {
 #if CONFIG_HAVE_DISPLAY
-    LEDWidget* pWidget = (LEDWidget*) pvTimerGetTimerID(handle);
-    pWidget->mError = false;
+    LEDWidget * pWidget = (LEDWidget *) pvTimerGetTimerID(handle);
+    pWidget->mError     = false;
     pWidget->Display();
     // If a status change occured, wake the display
     WakeDisplay();

--- a/examples/wifi-echo/server/esp32/main/include/LEDWidget.h
+++ b/examples/wifi-echo/server/esp32/main/include/LEDWidget.h
@@ -24,6 +24,10 @@
 
 #include "driver/gpio.h"
 
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/timers.h"
+
 class LEDWidget
 {
 public:
@@ -31,10 +35,13 @@ public:
     void Set(bool state);
     void Blink(uint32_t changeRateMS);
     void Blink(uint32_t onTimeMS, uint32_t offTimeMS);
+    void BlinkOnError();
     void Animate();
 #if CONFIG_HAVE_DISPLAY
     void Display();
 #endif
+    bool mError;
+    TimerHandle_t errorTimer;
 
 private:
     int64_t mLastChangeTimeUS;

--- a/src/transport/SecureTransport.cpp
+++ b/src/transport/SecureTransport.cpp
@@ -204,6 +204,7 @@ void SecureTransport::HandleDataReceived(IPEndPointBasis * endPoint, chip::Syste
         }
         else
         {
+            connection->OnReceiveError(connection, CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE_FROM_PEER, pktInfo);
             PacketBuffer::Free(msg);
             ChipLogProgress(Inet, "Secure transport failed to decrypt msg: err %d", err);
         }


### PR DESCRIPTION
 #### Problem
ESP32 m5Stack does not have any indicator of failed decryption attempts for received packets.

 #### Summary of Changes
Added a red circle that blinks when there's a decryption error for received packets.