### PR TITLE
Add PeerAddress and PeerConnectionState to track communication among peers.

### DIFF
--- a/examples/wifi-echo/server/esp32/Makefile
+++ b/examples/wifi-echo/server/esp32/Makefile
@@ -25,4 +25,8 @@ EXTRA_COMPONENT_DIRS += $(PROJECT_PATH)/third_party/connectedhomeip/config/esp32
                         $(PROJECT_PATH)/../../../common/m5stack-tft/repo/components \
                         $(PROJECT_PATH)/../../../common/QRCode \
 
+CXXFLAGS += -std=c++11 -Os
+CPPFLAGS += -Os
+CLAGS += -Os
+
 include $(IDF_PATH)/make/project.mk

--- a/examples/wifi-echo/server/esp32/main/EchoServer.cpp
+++ b/examples/wifi-echo/server/esp32/main/EchoServer.cpp
@@ -23,8 +23,11 @@
 #include "freertos/task.h"
 #include "nvs_flash.h"
 #include "tcpip_adapter.h"
+
 #include <string.h>
 #include <sys/param.h>
+
+#include <algorithm>
 
 #include "lwip/err.h"
 #include "lwip/sockets.h"
@@ -47,46 +50,96 @@ static const char * TAG = "echo_server";
 
 using namespace ::chip;
 using namespace ::chip::Inet;
+using namespace ::chip::Transport;
 
 constexpr NodeId kLocalNodeId = 12344321;
 extern LEDWidget statusLED; // In wifi-echo.cpp
 
-// Transport Callbacks
-static void echo(const MessageHeader & header, const IPPacketInfo & packet_info, System::PacketBuffer * buffer,
-                 SecureTransport * transport)
-{
-    bool status = transport != NULL && buffer != NULL;
+namespace {
 
-    if (status)
+const unsigned char local_private_key[] = { 0xc6, 0x1a, 0x2f, 0x89, 0x36, 0x67, 0x2b, 0x26, 0x12, 0x47, 0x4f,
+                                            0x11, 0x0e, 0x34, 0x15, 0x81, 0x81, 0x12, 0xfc, 0x36, 0xeb, 0x65,
+                                            0x61, 0x07, 0xaa, 0x63, 0xe8, 0xc5, 0x22, 0xac, 0x52, 0xa1 };
+
+const unsigned char remote_public_key[] = { 0x04, 0x30, 0x77, 0x2c, 0xe7, 0xd4, 0x0a, 0xf2, 0xf3, 0x19, 0xbd, 0xfb, 0x1f,
+                                            0xcc, 0x88, 0xd9, 0x83, 0x25, 0x89, 0xf2, 0x09, 0xf3, 0xab, 0xe4, 0x33, 0xb6,
+                                            0x7a, 0xff, 0x73, 0x3b, 0x01, 0x35, 0x34, 0x92, 0x73, 0x14, 0x59, 0x0b, 0xbd,
+                                            0x44, 0x72, 0x1b, 0xcd, 0xb9, 0x02, 0x53, 0xd9, 0xaf, 0xcc, 0x1a, 0xcd, 0xae,
+                                            0xe8, 0x87, 0x2e, 0x52, 0x3b, 0x98, 0xf0, 0xa1, 0x88, 0x4a, 0xe3, 0x03, 0x75 };
+
+/// A printable string has all characters printable and ends with a '\0'
+bool ContentIsAPrintableString(System::PacketBuffer * buffer)
+{
+    const size_t data_len = buffer->DataLength();
+    const uint8_t * data  = buffer->Start();
+    bool isPrintable      = true;
+
+    // Has to end with a 0 terminator
+    VerifyOrExit(data_len > 0, isPrintable = false);
+    VerifyOrExit(data[data_len - 1] == 0, isPrintable = false);
+
+    // all other characters are printable
+    isPrintable = std::all_of(data, data + data_len - 1, isprint);
+
+exit:
+    return isPrintable;
+}
+
+void newConnectionHandler(const MessageHeader & header, const IPPacketInfo & packet_info, SecureTransport * transport)
+{
+    CHIP_ERROR err;
+
+    ESP_LOGI(TAG, "Received a new connection.");
+
+    VerifyOrExit(header.GetSourceNodeId().HasValue(), ESP_LOGE(TAG, "Unknown source for received message"));
+    VerifyOrExit(transport->GetPeerNodeId() != header.GetSourceNodeId().Value(), ESP_LOGI(TAG, "Node already known."));
+
+    err = transport->Connect(header.GetSourceNodeId().Value(), PeerAddress::UDP(packet_info.SrcAddress, packet_info.SrcPort));
+    VerifyOrExit(err == CHIP_NO_ERROR, ESP_LOGE(TAG, "Failed to connect transport"));
+
+    err = transport->ManualKeyExchange(remote_public_key, sizeof(remote_public_key), local_private_key, sizeof(local_private_key));
+    VerifyOrExit(err == CHIP_NO_ERROR, ESP_LOGE(TAG, "Failed to setup encryption"));
+
+exit:
+    return;
+}
+
+// Transport Callbacks
+void echo(const MessageHeader & header, const IPPacketInfo & packet_info, System::PacketBuffer * buffer,
+          SecureTransport * transport)
+{
+    CHIP_ERROR err;
+    const size_t data_len = buffer->DataLength();
+
+    // as soon as a client connects, assume it is connected
+    VerifyOrExit(transport != NULL && buffer != NULL, ESP_LOGE(TAG, "Received data but couldn't process it..."));
+
+    VerifyOrExit(header.GetSourceNodeId().HasValue(), ESP_LOGE(TAG, "Unknown source for received message"));
+
     {
         char src_addr[INET_ADDRSTRLEN];
         char dest_addr[INET_ADDRSTRLEN];
-        const size_t data_len = buffer->DataLength();
-
         packet_info.SrcAddress.ToString(src_addr, sizeof(src_addr));
         packet_info.DestAddress.ToString(dest_addr, sizeof(dest_addr));
 
         ESP_LOGI(TAG, "UDP packet received from %s:%u to %s:%u (%zu bytes)", src_addr, packet_info.SrcPort, dest_addr,
                  packet_info.DestPort, static_cast<size_t>(data_len));
+    }
 
-        if (data_len > 0 && buffer->Start()[0] < 0x20)
-        {
-            // Non-ACII; assume it's a data model message.
-            HandleDataModelMessage(buffer);
-            return;
-        }
+    if (!ContentIsAPrintableString(buffer))
+    {
+        // Non-ACII; assume it's a data model message.
+        HandleDataModelMessage(buffer);
+        buffer = NULL;
+    }
+    else
+    {
 
         ESP_LOGI(TAG, "Client sent: \"%.*s\"", data_len, buffer->Start());
 
-        MessageHeader sendHeader;
-
-        sendHeader
-            .SetSourceNodeId(kLocalNodeId)                  //
-            .SetDestinationNodeId(header.GetSourceNodeId()) //
-            .SetMessageId(header.GetMessageId());
-
         // Attempt to echo back
-        CHIP_ERROR err = transport->SendMessage(sendHeader, packet_info.SrcAddress, buffer);
+        err    = transport->SendMessage(header.GetSourceNodeId().Value(), buffer);
+        buffer = NULL;
         if (err != CHIP_NO_ERROR)
         {
             ESP_LOGE(TAG, "Unable to echo back to client: %s", ErrorStr(err));
@@ -97,27 +150,16 @@ static void echo(const MessageHeader & header, const IPPacketInfo & packet_info,
         }
     }
 
-    if (!status)
-    {
-        ESP_LOGE(TAG, "Received data but couldn't process it...");
+exit:
 
-        // SendTo calls Free on the buffer without an AddRef, if SendTo was not called, free the buffer.
-        if (buffer != NULL)
-        {
-            System::PacketBuffer::Free(buffer);
-        }
+    // SendTo calls Free on the buffer without an AddRef, if SendTo was not called, free the buffer.
+    if (buffer != NULL)
+    {
+        System::PacketBuffer::Free(buffer);
     }
 }
 
-static const unsigned char local_private_key[] = { 0xc6, 0x1a, 0x2f, 0x89, 0x36, 0x67, 0x2b, 0x26, 0x12, 0x47, 0x4f,
-                                                   0x11, 0x0e, 0x34, 0x15, 0x81, 0x81, 0x12, 0xfc, 0x36, 0xeb, 0x65,
-                                                   0x61, 0x07, 0xaa, 0x63, 0xe8, 0xc5, 0x22, 0xac, 0x52, 0xa1 };
-
-static const unsigned char remote_public_key[] = { 0x04, 0x30, 0x77, 0x2c, 0xe7, 0xd4, 0x0a, 0xf2, 0xf3, 0x19, 0xbd, 0xfb, 0x1f,
-                                                   0xcc, 0x88, 0xd9, 0x83, 0x25, 0x89, 0xf2, 0x09, 0xf3, 0xab, 0xe4, 0x33, 0xb6,
-                                                   0x7a, 0xff, 0x73, 0x3b, 0x01, 0x35, 0x34, 0x92, 0x73, 0x14, 0x59, 0x0b, 0xbd,
-                                                   0x44, 0x72, 0x1b, 0xcd, 0xb9, 0x02, 0x53, 0xd9, 0xaf, 0xcc, 0x1a, 0xcd, 0xae,
-                                                   0xe8, 0x87, 0x2e, 0x52, 0x3b, 0x98, 0xf0, 0xa1, 0x88, 0x4a, 0xe3, 0x03, 0x75 };
+} // namespace
 
 // The echo server assumes the platform's networking has been setup already
 void setupTransport(IPAddressType type, SecureTransport * transport)
@@ -130,13 +172,11 @@ void setupTransport(IPAddressType type, SecureTransport * transport)
         tcpip_adapter_get_netif(TCPIP_ADAPTER_IF_AP, (void **) &netif);
     }
 
-    err = transport->Init(&DeviceLayer::InetLayer, Transport::UdpListenParameters().SetAddressType(type).SetInterfaceId(netif));
+    err = transport->Init(kLocalNodeId, &DeviceLayer::InetLayer, UdpListenParameters().SetAddressType(type).SetInterfaceId(netif));
     SuccessOrExit(err);
 
     transport->SetMessageReceiveHandler(echo, transport);
-
-    err = transport->ManualKeyExchange(remote_public_key, sizeof(remote_public_key), local_private_key, sizeof(local_private_key));
-    SuccessOrExit(err);
+    transport->SetNewConnectionHandler(newConnectionHandler, transport);
 
 exit:
     if (err != CHIP_NO_ERROR)

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -55,7 +55,7 @@ public:
 
     void * AppState;
 
-    CHIP_ERROR Init();
+    CHIP_ERROR Init(NodeId localDeviceId);
     CHIP_ERROR Shutdown();
 
     // ----- Connection Management -----
@@ -63,7 +63,7 @@ public:
      * @brief
      *   Connect to a CHIP device at a given address and an optional port
      *
-     * @param[in] deviceId              A device identifier. Currently unused and can be set to any value
+     * @param[in] remoteDeviceId        The remote device Id.
      * @param[in] deviceAddr            The IPAddress of the requested Device
      * @param[in] appReqState           Application specific context to be passed back when a message is received or on error
      * @param[in] onMessageReceived     Callback for when a message is received
@@ -71,8 +71,8 @@ public:
      * @param[in] devicePort            [Optional] The CHIP Device's port, defaults to CHIP_PORT
      * @return CHIP_ERROR           The connection status
      */
-    CHIP_ERROR ConnectDevice(uint64_t deviceId, IPAddress deviceAddr, void * appReqState, MessageReceiveHandler onMessageReceived,
-                             ErrorHandler onError, uint16_t devicePort = CHIP_PORT);
+    CHIP_ERROR ConnectDevice(NodeId remoteDeviceId, IPAddress deviceAddr, void * appReqState,
+                             MessageReceiveHandler onMessageReceived, ErrorHandler onError, uint16_t devicePort = CHIP_PORT);
 
     /**
      * @brief
@@ -88,16 +88,6 @@ public:
      */
     CHIP_ERROR ManualKeyExchange(const unsigned char * remote_public_key, const size_t public_key_length,
                                  const unsigned char * local_private_key, const size_t private_key_length);
-
-    /**
-     * @brief
-     *   Get the address and port of a connected device
-     *
-     * @param[out] deviceAddr   The IPAddress of the connected device
-     * @param[out] devicePort   The port of the econnected device
-     * @return CHIP_ERROR   An error if there's no active connection
-     */
-    CHIP_ERROR GetDeviceAddress(IPAddress * deviceAddr, uint16_t * devicePort);
 
     /**
      * @brief
@@ -183,7 +173,7 @@ private:
     ErrorHandler mOnError;
     System::PacketBuffer * mCurReqMsg;
 
-    NodeId mDeviceId;
+    NodeId mLocalDeviceId;
     IPAddress mDeviceAddr;
     uint16_t mDevicePort;
     Optional<NodeId> mRemoteDeviceId;

--- a/src/lib/core/Optional.h
+++ b/src/lib/core/Optional.h
@@ -61,13 +61,13 @@ public:
     /** Checks if the optional contains a value or not */
     bool HasValue() const { return mHasValue; }
 
-    /** Comparison operator, hadling missing values. */
+    /** Comparison operator, handling missing values. */
     bool operator==(const Optional & other) const
     {
         return (mHasValue == other.mHasValue) && (!other.mHasValue || (mValue == other.mValue));
     }
 
-    /** Comparison operator, hadling missing values. */
+    /** Comparison operator, handling missing values. */
     bool operator!=(const Optional & other) const { return !(*this == other); }
 
     /** Convenience method to create an optional without a valid value. */

--- a/src/transport/Base.h
+++ b/src/transport/Base.h
@@ -29,27 +29,10 @@
 #include <inet/UDPEndPoint.h>
 #include <system/SystemPacketBuffer.h>
 #include <transport/MessageHeader.h>
+#include <transport/PeerAddress.h>
 
 namespace chip {
 namespace Transport {
-
-/**
- * Communication path defines how two peers communicate.
- *
- * When a peer contacts another peer, it defines how the peers communicate.
- *
- * Once communication between two peers is established, the same transport
- * path should be used: a peer contacting another peer over UDP will receive
- * messages back over UDP. A communication channel established over TCP
- * will keep the same TCP channel.
- *
- */
-enum class Type
-{
-    kUndefined,
-    kUdp,
-    // More constants to be added later, such as TCP and BLE
-};
 
 /**
  * Transport class base, defining common methods among transports (message
@@ -82,17 +65,9 @@ public:
      * @details
      *   This method calls <tt>chip::System::PacketBuffer::Free</tt> on
      *   behalf of the caller regardless of the return status.
-     *
-     * @details
-     *   Point to Point transports (e.g. TCP) MUST have a connection already
-     *   established and the send will occur over an existing connection.
-     *   Connectionless transports (e.g. UDP) are able to attempt a message send
-     *   at any time.
-     *
-     * TODO: if CHIP decides to use ULA, we may be able to remove redundant bits
-     *       as node and address could be interchangeable (although some fabric logic may be needed).
      */
-    virtual CHIP_ERROR SendMessage(const MessageHeader & header, Inet::IPAddress address, System::PacketBuffer * msgBuf) = 0;
+    virtual CHIP_ERROR SendMessage(const MessageHeader & header, const Transport::PeerAddress & address,
+                                   System::PacketBuffer * msgBuf) = 0;
 
     /**
      * Get the path that this transport is associated with.

--- a/src/transport/MessageHeader.h
+++ b/src/transport/MessageHeader.h
@@ -33,6 +33,8 @@ namespace chip {
 /// Convenience type to make it clear a number represents a node id.
 typedef uint64_t NodeId;
 
+constexpr NodeId kUndefinedNodeId = 0xFFFFFFFFFFFFFFFFll;
+
 /** Handles encoding/decoding of CHIP message headers */
 class MessageHeader
 {

--- a/src/transport/PeerAddress.h
+++ b/src/transport/PeerAddress.h
@@ -1,0 +1,100 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @brief
+ *    File contains definitions on how a connection to a peer can be defined.
+ *
+ */
+
+#ifndef PEER_ADDRESS_H_
+#define PEER_ADDRESS_H_
+
+#include <inet/IPAddress.h>
+
+namespace chip {
+namespace Transport {
+
+/**
+ * Communication path defines how two peers communicate.
+ *
+ * When a peer contacts another peer, it defines how the peers communicate.
+ *
+ * Once communication between two peers is established, the same transport
+ * path should be used: a peer contacting another peer over UDP will receive
+ * messages back over UDP. A communication channel established over TCP
+ * will keep the same TCP channel.
+ *
+ */
+enum class Type
+{
+    kUndefined,
+    kUdp,
+    // More constants to be added later, such as TCP and BLE
+};
+
+/**
+ * Describes how a peer on a CHIP network can be addressed.
+ */
+class PeerAddress
+{
+public:
+    PeerAddress(const Inet::IPAddress & addr, Type type) : mIPAddress(addr), mTransportType(type) {}
+
+    PeerAddress(PeerAddress &&)      = default;
+    PeerAddress(const PeerAddress &) = default;
+    PeerAddress & operator=(const PeerAddress &) = default;
+    PeerAddress & operator=(PeerAddress &&) = default;
+
+    const Inet::IPAddress & GetIPAddress() const { return mIPAddress; }
+    PeerAddress & SetIPAddress(const Inet::IPAddress & addr)
+    {
+        mIPAddress = addr;
+        return *this;
+    }
+
+    Type GetTransportType() const { return mTransportType; }
+    PeerAddress & SetTransportType(Type type)
+    {
+        mTransportType = type;
+        return *this;
+    }
+
+    uint16_t GetPort() const { return mPort; }
+    PeerAddress & SetPort(uint16_t port)
+    {
+        mPort = port;
+        return *this;
+    }
+
+    /****** Factory methods for convenience ******/
+
+    static PeerAddress Uninitialized() { return PeerAddress(IPAddress::Any, Type::kUndefined); }
+
+    static PeerAddress UDP(const Inet::IPAddress & addr) { return PeerAddress(addr, Type::kUdp); }
+    static PeerAddress UDP(const Inet::IPAddress & addr, uint16_t port) { return UDP(addr).SetPort(port); }
+
+private:
+    Inet::IPAddress mIPAddress;
+    Type mTransportType;
+    uint16_t mPort = CHIP_PORT; ///< Relevant for UDP data sending.
+};
+
+} // namespace Transport
+} // namespace chip
+
+#endif // PEER_ADDRESS_H_

--- a/src/transport/PeerConnectionState.h
+++ b/src/transport/PeerConnectionState.h
@@ -1,0 +1,62 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @brief Defines state relevant for an active connection to a peer.
+ */
+
+#ifndef PEER_CONNCTION_STATE_H_
+#define PEER_CONNCTION_STATE_H_
+
+#include <transport/MessageHeader.h>
+#include <transport/PeerAddress.h>
+
+namespace chip {
+namespace Transport {
+
+/**
+ * Defines state of a peer connection at a transport layer.
+ *
+ * Examples of connection specific state includes: message counters and ack,
+ * timeouts, addressing information and encryption data.
+ */
+class PeerConnectionState
+{
+public:
+    PeerConnectionState(const PeerAddress & addr) : mPeerAddress(addr) {}
+    PeerConnectionState(PeerAddress && addr) : mPeerAddress(addr) {}
+
+    const PeerAddress & GetPeerAddress() const { return mPeerAddress; }
+    PeerAddress & GetPeerAddress() { return mPeerAddress; }
+    void SetPeerAddress(const PeerAddress & address) { mPeerAddress = address; }
+
+    NodeId GetPeerNodeId() const { return mPeerNodeId; }
+    void SetPeerNodeId(NodeId peerNodeId) { mPeerNodeId = peerNodeId; }
+
+    uint32_t GetSendMessageIndex() const { return mSendMessageIndex; }
+    void IncrementSendMessageIndex() { mSendMessageIndex++; }
+
+private:
+    PeerAddress mPeerAddress;
+    NodeId mPeerNodeId         = kUndefinedNodeId;
+    uint32_t mSendMessageIndex = 0;
+};
+
+} // namespace Transport
+} // namespace chip
+
+#endif // PEER_CONNCTION_STATE_H_

--- a/src/transport/SecureTransport.h
+++ b/src/transport/SecureTransport.h
@@ -33,6 +33,7 @@
 #include <inet/IPAddress.h>
 #include <inet/IPEndPointBasis.h>
 #include <transport/CHIPSecureChannel.h>
+#include <transport/PeerConnectionState.h>
 #include <transport/UDP.h>
 
 namespace chip {
@@ -43,16 +44,13 @@ class DLL_EXPORT SecureTransport : public ReferenceCounted<SecureTransport>
 {
 public:
     /**
-     *  @enum State
-     *
-     *  @brief
-     *    The State of the CHIP connection object.
-     *
+     *    The State of a secure transport object.
      */
     enum class State
     {
         kNotReady,        /**< State before initialization. */
-        kInitialized,     /**< State when the connection has been established. */
+        kInitialized,     /**< State when the object is ready to connect. */
+        kConnected,       /**< State when the remte peer is connected. */
         kSecureConnected, /**< State when the security of the connection has been established. */
     };
 
@@ -67,7 +65,7 @@ public:
      * separate Transports (UDP, BLE, TCP, optional ipv4 for testing etc.). This API is currently
      * UDP-specific and that will change.
      */
-    CHIP_ERROR Init(Inet::InetLayer * inet, const Transport::UdpListenParameters & listenParams);
+    CHIP_ERROR Init(NodeId localNodeId, Inet::InetLayer * inet, const Transport::UdpListenParameters & listenParams);
 
     /**
      * @brief
@@ -85,14 +83,21 @@ public:
                                  const unsigned char * local_private_key, const size_t private_key_length);
 
     /**
+     * Establishes a connection to the given peer node.
+     *
+     * A connection needs to be established before SendMessage can be called.
+     */
+    CHIP_ERROR Connect(NodeId peerNodeId, const Transport::PeerAddress & peerAddress);
+
+    /**
      * @brief
-     *   Send a message to the currently connected peer
+     *   Send a message to a currently connected peer
      *
      * @details
      *   This method calls <tt>chip::System::PacketBuffer::Free</tt> on
      *   behalf of the caller regardless of the return status.
      */
-    CHIP_ERROR SendMessage(const MessageHeader & header, Inet::IPAddress address, System::PacketBuffer * msgBuf);
+    CHIP_ERROR SendMessage(NodeId peerNodeId, System::PacketBuffer * msgBuf);
 
     SecureTransport();
     virtual ~SecureTransport() {}
@@ -112,18 +117,40 @@ public:
         OnMessageReceived        = reinterpret_cast<MessageReceiveHandler>(handler);
     }
 
+    /**
+     * Sets the new connection handler and associated argument
+     *
+     * @param[in] handler The callback to call when a message is received
+     * @param[in] param   The argument to pass in to the handler function
+     *
+     */
+    template <class T>
+    void SetNewConnectionHandler(void (*handler)(const MessageHeader &, const Inet::IPPacketInfo &, T *), T * param)
+    {
+        mNewConnectionArgument = param;
+        OnNewConnection        = reinterpret_cast<NewConnectionHandler>(handler);
+    }
+
+    /**
+     * TEMPORARY method for current connection until multi-session handling support
+     * is added to this class.
+     */
+    NodeId GetPeerNodeId() const { return mConnectionState.GetPeerNodeId(); };
+
 private:
     // TODO: settings below are single-transport and single-peer. Long term
     // intent for the class is to do session management and there will be
     // multiple transports and multiple peers supported.
     // Expected changes:
     //    - Transports including UDP, TCP, BLE as needed
-    //    - Multiple peers with separate states (encryption settings and handshak state)
+    //    - Multiple peers with separate states (encryption settings and handshake state)
     //    - Global state is only a ready/notready and connection state is deferred into
     //      individual connections.
 
     Transport::UDP mTransport;
 
+    Transport::PeerConnectionState mConnectionState;
+    NodeId mLocalNodeId;
     State mState;
     ChipSecureChannel mSecureChannel;
 
@@ -141,6 +168,11 @@ private:
 
     MessageReceiveHandler OnMessageReceived = nullptr; ///< Callback on message receiving
     void * mMessageReceivedArgument         = nullptr; ///< Argument for callback
+
+    typedef void (*NewConnectionHandler)(const MessageHeader & header, const Inet::IPPacketInfo & source, void * param);
+
+    NewConnectionHandler OnNewConnection = nullptr; ///< Callback for new connection received
+    void * mNewConnectionArgument        = nullptr; ///< Argument for callback
 
     static void HandleDataReceived(const MessageHeader & header, const Inet::IPPacketInfo & source, System::PacketBuffer * msgBuf,
                                    SecureTransport * transport);

--- a/src/transport/TransportLayer.am
+++ b/src/transport/TransportLayer.am
@@ -31,10 +31,12 @@ CHIP_BUILD_TRANSPORT_LAYER_SOURCE_FILES                  = \
     @top_builddir@/src/transport/UDP.cpp                   \
     $(NULL)
 
-CHIP_BUILD_TRANSPORT_LAYER_HEADER_FILES             = \
-    @top_builddir@/src/transport/Base.h               \
-    @top_builddir@/src/transport/CHIPSecureChannel.h  \
-    @top_builddir@/src/transport/MessageHeader.h      \
-    @top_builddir@/src/transport/SecureTransport.h    \
-    @top_builddir@/src/transport/UDP.h                \
+CHIP_BUILD_TRANSPORT_LAYER_HEADER_FILES              = \
+    @top_builddir@/src/transport/Base.h                \
+    @top_builddir@/src/transport/CHIPSecureChannel.h   \
+    @top_builddir@/src/transport/MessageHeader.h       \
+    @top_builddir@/src/transport/PeerAddress.h         \
+    @top_builddir@/src/transport/PeerConnectionState.h \
+    @top_builddir@/src/transport/SecureTransport.h     \
+    @top_builddir@/src/transport/UDP.h                 \
     $(NULL)

--- a/src/transport/UDP.cpp
+++ b/src/transport/UDP.cpp
@@ -81,20 +81,21 @@ exit:
     return err;
 }
 
-CHIP_ERROR UDP::SendMessage(const MessageHeader & header, Inet::IPAddress address, System::PacketBuffer * msgBuf)
+CHIP_ERROR UDP::SendMessage(const MessageHeader & header, const Transport::PeerAddress & address, System::PacketBuffer * msgBuf)
 {
     const size_t headerSize = header.EncodeSizeBytes();
     size_t actualEncodedHeaderSize;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
+    VerifyOrExit(address.GetTransportType() == Type::kUdp, err = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(mState == State::kInitialized, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mUDPEndPoint != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     IPPacketInfo addrInfo;
     addrInfo.Clear();
 
-    addrInfo.DestAddress = address;
-    addrInfo.DestPort    = mSendPort;
+    addrInfo.DestAddress = address.GetIPAddress();
+    addrInfo.DestPort    = address.GetPort();
 
     VerifyOrExit(msgBuf->EnsureReservedSize(headerSize), err = CHIP_ERROR_NO_MEMORY);
 

--- a/src/transport/UDP.h
+++ b/src/transport/UDP.h
@@ -120,7 +120,8 @@ public:
     CHIP_ERROR Init(Inet::InetLayer * inetLayer) { return Init(inetLayer, UdpListenParameters()); }
 
     Type GetType() override { return Type::kUdp; }
-    CHIP_ERROR SendMessage(const MessageHeader & header, Inet::IPAddress address, System::PacketBuffer * msgBuf) override;
+    CHIP_ERROR SendMessage(const MessageHeader & header, const Transport::PeerAddress & address,
+                           System::PacketBuffer * msgBuf) override;
 
 private:
     // UDP message receive handler.

--- a/src/transport/tests/TestUDP.cpp
+++ b/src/transport/tests/TestUDP.cpp
@@ -176,7 +176,7 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext, const IPAddress &
     header.SetSourceNodeId(kSourceNodeId).SetDestinationNodeId(kDestinationNodeId).SetMessageId(kMessageId);
 
     // Should be able to send a message to itself by just calling send.
-    err = udp.SendMessage(header, addr, buffer);
+    err = udp.SendMessage(header, Transport::PeerAddress::UDP(addr), buffer);
     if (err == System::MapErrorPOSIX(EADDRNOTAVAIL))
     {
         // TODO: the underlying system does not support IPV6. This early return should


### PR DESCRIPTION
This a patch on top of #1040  

#### Problem
Need to track peer states independently as SecureTransport requires multiple connection handling and individual states should depend on connection.

This also defines a generic PeerAddress (may rename to binding or similar if need be) to identify how a peer is to be contacted (e.g. should BLE or UDP or TCP be used). Only UDP defines exist currently.

 #### Summary of Changes
- Defines PeerAddress and PeerConnectionState
- Updated code to use the new constructs
- Node ID is now useful and tracked/verified.

fixes #1089 