### PR TITLE
Integrate system tests to ESP32 QEMU and run in CI

### DIFF
--- a/config/esp32/components/chip/component.mk
+++ b/config/esp32/components/chip/component.mk
@@ -115,7 +115,7 @@ CONFIGURE_OPTIONS       	:= -C AR="$(AR)" CC="$(CC)" CXX="$(CXX)" LD="$(LD)" OBJ
                                --disable-device-manager
 
 ifneq (,$(findstring CHIP_SUPPORT_FOREIGN_TEST_DRIVERS,$(CXXFLAGS)))
-CONFIGURE_OPTIONS           += --enable-tests
+CONFIGURE_OPTIONS           += --enable-tests --enable-nlfaultinjection
 else
 CONFIGURE_OPTIONS           += --disable-tests
 endif

--- a/scripts/tests/esp32_qemu_tests.sh
+++ b/scripts/tests/esp32_qemu_tests.sh
@@ -26,7 +26,9 @@ chip_dir="$here"/../..
 source "$chip_dir"/src/test_driver/esp32/idf.sh
 "$chip_dir"/src/test_driver/esp32/qemu_setup.sh
 
-# Currently only crypto tests are configured to run on QEMU.
-# The "src/crypto" qualifier will be removed, once all CHIP unit tests are
+# Currently only crypto, inet, and system tests are configured to run on QEMU.
+# The specific qualifiers will be removed, once all CHIP unit tests are
 # updated to run on QEMU.
 idf make V=1 -C "$chip_dir"/src/test_driver/esp32/build/chip/src/crypto check
+idf make V=1 -C "$chip_dir"/src/test_driver/esp32/build/chip/src/inet check
+idf make V=1 -C "$chip_dir"/src/test_driver/esp32/build/chip/src/system check

--- a/src/crypto/tests/Makefile.am
+++ b/src/crypto/tests/Makefile.am
@@ -92,7 +92,7 @@ check_SCRIPTS                                  = \
 TESTS_ENVIRONMENT                              = \
     $(NULL)
 
-if CHIP_TARGET_STYLE_EMBEDDED
+if CHIP_DEVICE_LAYER_TARGET_ESP32
 
 check_SCRIPTS                                 += \
     qemu_crypto_tests.sh                         \
@@ -104,13 +104,13 @@ TESTS_ENVIRONMENT                             += \
     QEMU_TEST_TARGET=libCryptoLayerTests.a       \
     $(NULL)
 
-else # CHIP_TARGET_STYLE_EMBEDDED
+else # CHIP_DEVICE_LAYER_TARGET_ESP32
 
 check_PROGRAMS                                += \
     TestCryptoPAL                                \
     $(NULL)
 
-endif # CHIP_TARGET_STYLE_EMBEDDED
+endif # CHIP_DEVICE_LAYER_TARGET_ESP32
 
 # Test applications and scripts that should be built and run when the
 # 'check' target is run.

--- a/src/inet/tests/Makefile.am
+++ b/src/inet/tests/Makefile.am
@@ -123,7 +123,7 @@ check_SCRIPTS                                         = \
 TESTS_ENVIRONMENT                                     = \
     $(NULL)
 
-if CHIP_TARGET_STYLE_EMBEDDED
+if CHIP_DEVICE_LAYER_TARGET_ESP32
 
 check_SCRIPTS                                        += \
     qemu_inet_tests.sh                                  \
@@ -135,7 +135,7 @@ TESTS_ENVIRONMENT                                    += \
     QEMU_TEST_TARGET=libInetLayerTests.a                \
     $(NULL)
 
-else # CHIP_TARGET_STYLE_EMBEDDED
+else # CHIP_DEVICE_LAYER_TARGET_ESP32
 
 # Test executables that should be built but not installed and should
 # always be built to ensure overall "build sanity".
@@ -163,7 +163,7 @@ check_PROGRAMS                                       += \
     TestInetErrorStr                                    \
     $(NULL)
 
-endif # CHIP_TARGET_STYLE_EMBEDDED
+endif # CHIP_DEVICE_LAYER_TARGET_ESP32
 
 # Test applications and scripts that should be built and run when the
 # 'check' target is run.

--- a/src/system/tests/Makefile.am
+++ b/src/system/tests/Makefile.am
@@ -89,23 +89,45 @@ COMMON_LDADD                                           = \
 # Test applications that should be run when the 'check' target is run.
 
 check_PROGRAMS                                        = \
+    $(NULL)
+
+check_SCRIPTS                                         = \
+    $(NULL)
+
+# The additional environment variables and their values that will be
+# made available to all programs and scripts in TESTS.
+TESTS_ENVIRONMENT                                      = \
+    $(NULL)
+
+if CHIP_TARGET_STYLE_EMBEDDED
+
+check_SCRIPTS                                         += \
+    qemu_system_tests.sh                                 \
+    $(NULL)
+
+TESTS_ENVIRONMENT                                     += \
+    abs_top_srcdir='$(abs_top_srcdir)'                   \
+    abs_top_builddir='$(abs_top_builddir)'               \
+    QEMU_TEST_TARGET=libSystemLayerTests.a               \
+    $(NULL)
+
+else # CHIP_TARGET_STYLE_EMBEDDED
+
+check_PROGRAMS                                       += \
     TestSystemErrorStr                                  \
     TestSystemObject                                    \
     TestSystemPacketBuffer                              \
     TestSystemTimer                                     \
     $(NULL)
 
+endif # CHIP_TARGET_STYLE_EMBEDDED
+
 # Test applications and scripts that should be built and run when the
 # 'check' target is run.
 
 TESTS                                                 = \
     $(check_PROGRAMS)                                   \
-    $(NULL)
-
-# The additional environment variables and their values that will be
-# made available to all programs and scripts in TESTS.
-
-TESTS_ENVIRONMENT                                     = \
+    $(check_SCRIPTS)                                    \
     $(NULL)
 
 # Source, compiler, and linker options for test programs.

--- a/src/system/tests/Makefile.am
+++ b/src/system/tests/Makefile.am
@@ -99,7 +99,7 @@ check_SCRIPTS                                         = \
 TESTS_ENVIRONMENT                                      = \
     $(NULL)
 
-if CHIP_TARGET_STYLE_EMBEDDED
+if CHIP_DEVICE_LAYER_TARGET_ESP32
 
 check_SCRIPTS                                         += \
     qemu_system_tests.sh                                 \
@@ -111,7 +111,7 @@ TESTS_ENVIRONMENT                                     += \
     QEMU_TEST_TARGET=libSystemLayerTests.a               \
     $(NULL)
 
-else # CHIP_TARGET_STYLE_EMBEDDED
+else # CHIP_DEVICE_LAYER_TARGET_ESP32
 
 check_PROGRAMS                                       += \
     TestSystemErrorStr                                  \
@@ -120,7 +120,7 @@ check_PROGRAMS                                       += \
     TestSystemTimer                                     \
     $(NULL)
 
-endif # CHIP_TARGET_STYLE_EMBEDDED
+endif # CHIP_DEVICE_LAYER_TARGET_ESP32
 
 # Test applications and scripts that should be built and run when the
 # 'check' target is run.

--- a/src/system/tests/TestSystemErrorStr.cpp
+++ b/src/system/tests/TestSystemErrorStr.cpp
@@ -39,7 +39,9 @@
 #include <string.h>
 
 #include <inet/InetError.h>
+#include <support/CodeUtils.h>
 #include <support/ErrorStr.h>
+#include <support/TestUtils.h>
 
 #include <nlunit-test.h>
 
@@ -117,4 +119,9 @@ int TestSystemErrorStr(void)
     nlTestRunner(&theSuite, &sContext);
 
     return (nlTestRunnerStats(&theSuite));
+}
+
+static void __attribute__((constructor)) TestSystemErrorStrCtor(void)
+{
+    VerifyOrDie(RegisterUnitTests(&TestSystemErrorStr) == CHIP_NO_ERROR);
 }

--- a/src/system/tests/TestSystemObject.cpp
+++ b/src/system/tests/TestSystemObject.cpp
@@ -46,6 +46,7 @@
 #include <nlunit-test.h>
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
+#include <lwip/init.h>
 #include <lwip/tcpip.h>
 #include <lwip/sys.h>
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
@@ -492,8 +493,7 @@ static int Initialize(void * aContext)
     TestContext & lContext = *reinterpret_cast<TestContext *>(aContext);
     void * lLayerContext   = NULL;
 
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-#if !CHIP_DEVICE_LAYER_TARGET_ESP32
+#if CHIP_SYSTEM_CONFIG_USE_LWIP && LWIP_VERSION_MAJOR <= 2 && LWIP_VERSION_MINOR < 1
     static sys_mbox_t * sLwIPEventQueue = NULL;
 
     if (sLwIPEventQueue == NULL)
@@ -502,7 +502,6 @@ static int Initialize(void * aContext)
     }
 
     lLayerContext = &sLwIPEventQueue;
-#endif // CHIP_DEVICE_LAYER_TARGET_ESP32
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
     lContext.mTestSuite    = &sTestSuite;

--- a/src/system/tests/TestSystemObject.cpp
+++ b/src/system/tests/TestSystemObject.cpp
@@ -39,7 +39,9 @@
 
 #include <system/SystemLayer.h>
 
+#include <support/CodeUtils.h>
 #include <support/ErrorStr.h>
+#include <support/TestUtils.h>
 
 #include <nlunit-test.h>
 
@@ -491,6 +493,7 @@ static int Initialize(void * aContext)
     void * lLayerContext   = NULL;
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
+#if !CHIP_DEVICE_LAYER_TARGET_ESP32
     static sys_mbox_t * sLwIPEventQueue = NULL;
 
     if (sLwIPEventQueue == NULL)
@@ -499,6 +502,7 @@ static int Initialize(void * aContext)
     }
 
     lLayerContext = &sLwIPEventQueue;
+#endif // CHIP_DEVICE_LAYER_TARGET_ESP32
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
     lContext.mTestSuite    = &sTestSuite;
@@ -530,4 +534,9 @@ int TestSystemObject(void)
     nlTestRunner(&sTestSuite, &chip::System::sContext);
 
     return nlTestRunnerStats(&sTestSuite);
+}
+
+static void __attribute__((constructor)) TestSystemObjectCtor(void)
+{
+    VerifyOrDie(chip::RegisterUnitTests(&TestSystemObject) == CHIP_NO_ERROR);
 }

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -34,6 +34,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <support/CodeUtils.h>
+#include <support/TestUtils.h>
 #include <system/SystemPacketBuffer.h>
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
@@ -1206,4 +1208,9 @@ int TestSystemPacketBuffer(void)
     nlTestRunner(&theSuite, &sContext);
 
     return (nlTestRunnerStats(&theSuite));
+}
+
+static void __attribute__((constructor)) TestSystemPacketBufferCtor(void)
+{
+    VerifyOrDie(chip::RegisterUnitTests(&TestSystemPacketBuffer) == CHIP_NO_ERROR);
 }

--- a/src/system/tests/TestSystemTimer.cpp
+++ b/src/system/tests/TestSystemTimer.cpp
@@ -33,7 +33,9 @@
 #include "TestSystemLayer.h"
 
 #include <nlunit-test.h>
+#include <support/CodeUtils.h>
 #include <support/ErrorStr.h>
+#include <support/TestUtils.h>
 #include <system/SystemError.h>
 #include <system/SystemLayer.h>
 #include <system/SystemTimer.h>
@@ -224,11 +226,13 @@ static int TestSetup(void * aContext)
     void * lLayerContext   = NULL;
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
+#if !CHIP_DEVICE_LAYER_TARGET_ESP32
     static sys_mbox_t * sLwIPEventQueue = NULL;
 
     sys_mbox_new(sLwIPEventQueue, 100);
-    tcpip_init(NULL, NULL);
     lLayerContext = &sLwIPEventQueue;
+#endif
+    tcpip_init(NULL, NULL);
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
     sLayer.Init(lLayerContext);
@@ -264,4 +268,9 @@ int TestSystemTimer(void)
     nlTestRunner(&kTheSuite, &sContext);
 
     return nlTestRunnerStats(&kTheSuite);
+}
+
+static void __attribute__((constructor)) TestSystemTimerCtor(void)
+{
+    VerifyOrDie(chip::RegisterUnitTests(&TestSystemTimer) == CHIP_NO_ERROR);
 }

--- a/src/system/tests/TestSystemTimer.cpp
+++ b/src/system/tests/TestSystemTimer.cpp
@@ -226,7 +226,7 @@ static int TestSetup(void * aContext)
     void * lLayerContext   = NULL;
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
-#if !CHIP_DEVICE_LAYER_TARGET_ESP32
+#if LWIP_VERSION_MAJOR <= 2 && LWIP_VERSION_MINOR < 1
     static sys_mbox_t * sLwIPEventQueue = NULL;
 
     sys_mbox_new(sLwIPEventQueue, 100);

--- a/src/system/tests/qemu_system_tests.sh
+++ b/src/system/tests/qemu_system_tests.sh
@@ -1,0 +1,1 @@
+../../../scripts/tools/qemu_run_test.sh

--- a/src/test_driver/esp32/Makefile
+++ b/src/test_driver/esp32/Makefile
@@ -14,7 +14,7 @@ include $(IDF_PATH)/make/project.mk
 esp32_elf_builder: all
 	mkdir -p build/chip/
 	echo $(CC) -L$(PROJECT_PATH)/build/chip/lib -Wl,--whole-archive '$$1' -Wl,--no-whole-archive \
-		 -lnlunit-test $(LDFLAGS) -o $(PROJECT_PATH)/build/chip-tests.elf -Wl,-Map=$(APP_MAP) > build/chip/esp32_elf_builder.sh
+		 -lnlunit-test $(LDFLAGS) -lnlfaultinjection -o $(PROJECT_PATH)/build/chip-tests.elf -Wl,-Map=$(APP_MAP) > build/chip/esp32_elf_builder.sh
 	echo $(ESPTOOLPY) elf2image $(ESPTOOL_FLASH_OPTIONS) $(ESPTOOL_ELF2IMAGE_OPTIONS) \
 		 -o $(PROJECT_PATH)/build/chip/chip-tests.bin $(PROJECT_PATH)/build/chip-tests.elf >> build/chip/esp32_elf_builder.sh
 	ln -sf $(PROJECT_PATH)/build/partitions_singleapp.bin $(PROJECT_PATH)/build/chip/partitions_singleapp.bin


### PR DESCRIPTION
 #### Problem
`system` tests are not run on ESP32 QEMU.

 #### Summary of Changes
Integrate tests to ESP32 QEMU and CI.
Also run `Inet` tests on QEMU in CI.