### PR TITLE
Let nRF5 LockApp be controlled by zcl

### DIFF
--- a/examples/lock-app/nrf5/Makefile
+++ b/examples/lock-app/nrf5/Makefile
@@ -37,6 +37,8 @@ SRCS = \
     $(PROJECT_ROOT)/main/AppTask.cpp \
     $(PROJECT_ROOT)/main/LEDWidget.cpp \
     $(PROJECT_ROOT)/main/BoltLockManager.cpp \
+    $(PROJECT_ROOT)/main/Server.cpp \
+    $(PROJECT_ROOT)/main/DataModelHandler.cpp \
     $(PROJECT_ROOT)/main/support/CXXExceptionStubs.cpp \
     $(PROJECT_ROOT)/main/support/nRF5Sbrk.c \
     $(PROJECT_ROOT)/main/support/FreeRTOSNewlibLockSupport.c \

--- a/examples/lock-app/nrf5/main/AppTask.cpp
+++ b/examples/lock-app/nrf5/main/AppTask.cpp
@@ -19,7 +19,9 @@
 
 #include "AppTask.h"
 #include "AppEvent.h"
+#include "DataModelHandler.h"
 #include "LEDWidget.h"
+#include "Server.h"
 
 #include "app_button.h"
 #include "app_config.h"
@@ -60,6 +62,7 @@ static bool sHaveServiceConnectivity = false;
 using namespace ::chip::DeviceLayer;
 
 AppTask AppTask::sAppTask;
+chip::SecureSessionMgr sTransportIPv6;
 
 int AppTask::StartAppTask()
 {
@@ -146,6 +149,10 @@ int AppTask::Init()
         NRF_LOG_INFO("xSemaphoreCreateMutex() failed");
         APP_ERROR_HANDLER(NRF_ERROR_NULL);
     }
+
+    // Init ZCL Data Model
+    InitDataModelHandler();
+    StartServer(&sTransportIPv6);
 
     return ret;
 }

--- a/examples/lock-app/nrf5/main/DataModelHandler.cpp
+++ b/examples/lock-app/nrf5/main/DataModelHandler.cpp
@@ -1,0 +1,81 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @file
+ *   This file implements the handler for data model messages.
+ */
+
+#include <system/SystemPacketBuffer.h>
+
+#include "BoltLockManager.h"
+#include "DataModelHandler.h"
+#include "nrf_log.h"
+
+#include "chip-zcl/chip-zcl.h"
+
+extern "C" {
+#include "gen/gen-cluster-id.h"
+#include "gen/gen-types.h"
+}
+
+using namespace ::chip;
+
+void InitDataModelHandler()
+{
+    chipZclEndpointInit();
+}
+
+void HandleDataModelMessage(System::PacketBuffer * buffer)
+{
+    ChipZclStatus_t zclStatus = chipZclProcessIncoming((ChipZclBuffer_t *) buffer);
+    if (zclStatus == CHIP_ZCL_STATUS_SUCCESS)
+    {
+        NRF_LOG_INFO("Data model processing success!");
+    }
+    else
+    {
+        NRF_LOG_INFO("Data model processing failure: %d", zclStatus);
+    }
+    System::PacketBuffer::Free(buffer);
+}
+
+extern "C" void chipZclPostAttributeChangeCallback(uint8_t endpoint, ChipZclClusterId clusterId, ChipZclAttributeId attributeId,
+                                                   uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size,
+                                                   uint8_t * value)
+{
+    if (clusterId != CHIP_ZCL_CLUSTER_ON_OFF)
+    {
+        NRF_LOG_INFO("Unknown cluster ID: %d", clusterId);
+        return;
+    }
+
+    if (attributeId != CHIP_ZCL_CLUSTER_ON_OFF_SERVER_ATTRIBUTE_ON_OFF)
+    {
+        NRF_LOG_INFO("Unknown attribute ID: %d", attributeId);
+        return;
+    }
+
+    if (*value)
+    {
+        BoltLockMgr().InitiateAction(0, BoltLockManager::LOCK_ACTION);
+    }
+    else
+    {
+        BoltLockMgr().InitiateAction(0, BoltLockManager::UNLOCK_ACTION);
+    }
+}

--- a/examples/lock-app/nrf5/main/Server.cpp
+++ b/examples/lock-app/nrf5/main/Server.cpp
@@ -1,0 +1,137 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "FreeRTOS.h"
+#include "nrf_log.h"
+#include "task.h"
+#include <string.h>
+#include <sys/param.h>
+
+#include "lwip/err.h"
+#include "lwip/sockets.h"
+#include "lwip/sys.h"
+#include <lwip/netdb.h>
+
+#include <inet/IPAddress.h>
+#include <inet/InetError.h>
+#include <inet/InetLayer.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <support/CodeUtils.h>
+#include <support/ErrorStr.h>
+#include <system/SystemPacketBuffer.h>
+#include <transport/SecureSessionMgr.h>
+
+#include "DataModelHandler.h"
+
+using namespace ::chip;
+using namespace ::chip::Inet;
+using namespace ::chip::Transport;
+
+// Transport Callbacks
+namespace {
+
+#ifndef EXAMPLE_SERVER_NODEID
+// "lock"
+#define EXAMPLE_SERVER_NODEID 0x6c6f636b
+#endif // EXAMPLE_SERVER_NODEID
+
+const uint8_t local_private_key[] = { 0xc6, 0x1a, 0x2f, 0x89, 0x36, 0x67, 0x2b, 0x26, 0x12, 0x47, 0x4f,
+                                      0x11, 0x0e, 0x34, 0x15, 0x81, 0x81, 0x12, 0xfc, 0x36, 0xeb, 0x65,
+                                      0x61, 0x07, 0xaa, 0x63, 0xe8, 0xc5, 0x22, 0xac, 0x52, 0xa1 };
+
+const uint8_t remote_public_key[] = { 0x04, 0x30, 0x77, 0x2c, 0xe7, 0xd4, 0x0a, 0xf2, 0xf3, 0x19, 0xbd, 0xfb, 0x1f,
+                                      0xcc, 0x88, 0xd9, 0x83, 0x25, 0x89, 0xf2, 0x09, 0xf3, 0xab, 0xe4, 0x33, 0xb6,
+                                      0x7a, 0xff, 0x73, 0x3b, 0x01, 0x35, 0x34, 0x92, 0x73, 0x14, 0x59, 0x0b, 0xbd,
+                                      0x44, 0x72, 0x1b, 0xcd, 0xb9, 0x02, 0x53, 0xd9, 0xaf, 0xcc, 0x1a, 0xcd, 0xae,
+                                      0xe8, 0x87, 0x2e, 0x52, 0x3b, 0x98, 0xf0, 0xa1, 0x88, 0x4a, 0xe3, 0x03, 0x75 };
+
+void newConnectionHandler(const MessageHeader & header, const IPPacketInfo & packet_info, SecureSessionMgr * transport)
+{
+    CHIP_ERROR err;
+
+    NRF_LOG_INFO("Received a new connection.");
+
+    VerifyOrExit(header.GetSourceNodeId().HasValue(), NRF_LOG_INFO("Unknown source for received message"));
+    VerifyOrExit(transport->GetPeerNodeId() != header.GetSourceNodeId().Value(), NRF_LOG_INFO("Node already known."));
+
+    err = transport->Connect(header.GetSourceNodeId().Value(), PeerAddress::UDP(packet_info.SrcAddress, packet_info.SrcPort));
+    VerifyOrExit(err == CHIP_NO_ERROR, NRF_LOG_INFO("Failed to connect transport"));
+
+    err = transport->ManualKeyExchange(remote_public_key, sizeof(remote_public_key), local_private_key, sizeof(local_private_key));
+    VerifyOrExit(err == CHIP_NO_ERROR, NRF_LOG_INFO("Failed to setup encryption"));
+
+exit:
+    return;
+}
+
+static void OnRecv(const MessageHeader & header, const IPPacketInfo & packet_info, System::PacketBuffer * buffer,
+                   SecureSessionMgr * transport)
+{
+    const size_t data_len = buffer->DataLength();
+    char src_addr[INET6_ADDRSTRLEN];
+    char dest_addr[INET6_ADDRSTRLEN];
+
+    // as soon as a client connects, assume it is connected
+    VerifyOrExit(transport != NULL && buffer != NULL, NRF_LOG_INFO("Received data but couldn't process it..."));
+    VerifyOrExit(header.GetSourceNodeId().HasValue(), NRF_LOG_INFO("Unknown source for received message"));
+
+    packet_info.SrcAddress.ToString(src_addr, sizeof(src_addr));
+    packet_info.DestAddress.ToString(dest_addr, sizeof(dest_addr));
+
+    NRF_LOG_INFO("UDP packet received from %s:%u to %s:%u (%zu bytes)", src_addr, packet_info.SrcPort, dest_addr,
+                 packet_info.DestPort, static_cast<size_t>(data_len));
+
+    HandleDataModelMessage(buffer);
+    buffer = NULL;
+
+exit:
+    // SendTo calls Free on the buffer without an AddRef, if SendTo was not called, free the buffer.
+    if (buffer != NULL)
+    {
+        System::PacketBuffer::Free(buffer);
+    }
+}
+
+} // namespace
+
+// The echo server assumes the platform's networking has been setup already
+void SetupTransport(IPAddressType type, SecureSessionMgr * transport)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    err = transport->Init(EXAMPLE_SERVER_NODEID, &DeviceLayer::InetLayer, UdpListenParameters().SetAddressType(type));
+    SuccessOrExit(err);
+
+    transport->SetMessageReceiveHandler(OnRecv, transport);
+    transport->SetNewConnectionHandler(newConnectionHandler, transport);
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        NRF_LOG_ERROR("ERROR setting up transport: %s", ErrorStr(err));
+    }
+    else
+    {
+        NRF_LOG_INFO("Lock Server Listening...");
+    }
+}
+
+// The echo server assumes the platform's networking has been setup already
+void StartServer(SecureSessionMgr * transport_ipv6)
+{
+    SetupTransport(kIPAddressType_IPv6, transport_ipv6);
+}

--- a/examples/lock-app/nrf5/main/include/DataModelHandler.h
+++ b/examples/lock-app/nrf5/main/include/DataModelHandler.h
@@ -1,0 +1,47 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @file
+ *   This file defines the API for the handler for data model messages.
+ */
+
+#ifndef DATA_MODEL_HANDLER_H
+#define DATA_MODEL_HANDLER_H
+
+namespace chip {
+namespace System {
+class PacketBuffer;
+} // namespace System
+} // namespace chip
+
+/**
+ * Initialize the data model handler.  This must be called once, and before any
+ * HandleDataModelMessage calls happen.
+ */
+void InitDataModelHandler();
+
+/**
+ * Handle a message that should be processed via our data model processing
+ * codepath.
+ *
+ * @param [in] buffer The buffer holding the message.  This function guarantees
+ *                    that it will free the buffer before returning.
+ */
+void HandleDataModelMessage(chip::System::PacketBuffer * buffer);
+
+#endif // DATA_MODEL_HANDLER_H

--- a/examples/lock-app/nrf5/main/include/Server.h
+++ b/examples/lock-app/nrf5/main/include/Server.h
@@ -1,0 +1,31 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef SERVER_H
+#define SERVER_H
+
+#include <inet/IPAddress.h>
+#include <inet/InetLayer.h>
+#include <system/SystemPacketBuffer.h>
+#include <transport/SecureSessionMgr.h>
+
+#include "DataModelHandler.h"
+
+void SetupTransport(chip::Inet::IPAddressType type, chip::SecureSessionMgr * transport);
+void StartServer(chip::SecureSessionMgr * transport_ipv6);
+
+#endif // SERVER_H


### PR DESCRIPTION
 #### Problem

The lock app example can only be controlled by button on DK. Since it supports Thread now, we can let it be controlled over ZCL.

 #### Summary of Changes

* Add ZCL server
* Listen secure transport

Currently, this example app is controlled by OnOffCluster, there will be another pr in the future to use the correct cluster.

To test the PR, build and flash a PR, setup a thread network and then join a thread network via thread cli in UART.
Then send zcl commands to the device by specify device's address on thread network, which can be found in device's log output.

A more detailed document about playing with the demo will be pushed later.

fixes #1117 