### PR TITLE
Use a custom partition table: increase firmware partition's size

### DIFF
--- a/examples/wifi-echo/server/esp32/partitions.csv
+++ b/examples/wifi-echo/server/esp32/partitions.csv
@@ -1,0 +1,6 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+# Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
+nvs,      data, nvs,     ,        0x6000,
+phy_init, data, phy,     ,        0x1000,
+# Factory partition size about 1.9MB
+factory,  app,  factory, ,        1945K,

--- a/examples/wifi-echo/server/esp32/sdkconfig.defaults
+++ b/examples/wifi-echo/server/esp32/sdkconfig.defaults
@@ -29,3 +29,8 @@ CONFIG_MONITOR_BAUD=115200
 
 #enable lwip ipv6 autoconfig
 CONFIG_LWIP_IPV6_AUTOCONFIG=y
+
+# Use a custom partition table
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"
+


### PR DESCRIPTION
 #### Problem
Partition size for the firmware partition is small

 #### Summary of Changes
Increase the firmware's partition size to ~1.9MB
Addresses issue #1114 

For M5stack users:
I have checked online that M5Stack has about 4MB of flash (so even after this there should be enough space leftover). 
Can somebody with M5stack cross-check with this patch? You may have to delete `sdkconfig` and re-run the `menuconfig` step.