### PR TITLE
[docs] Update Nordic SDK version to match download link.

### DIFF
--- a/examples/lock-app/nrf5/README.md
+++ b/examples/lock-app/nrf5/README.md
@@ -137,7 +137,7 @@ Alternatively, you can run `Build nRF5 Lock App` VSCode task.
 -   Set the following environment variables based on the locations/versions of
     the packages installed above:
 
-          export NRF5_SDK_ROOT=${HOME}/tools/nRF5_SDK_for_Thread_and_Zigbee_v3.1.0
+          export NRF5_SDK_ROOT=${HOME}/tools/nRF5_SDK_for_Thread_and_Zigbee_v4.0.0
           export NRF5_TOOLS_ROOT=${HOME}/tools/nRF-Command-Line-Tools
           export ARM_GCC_INSTALL_ROOT=${HOME}/tools/gcc-arm-none-eabi-9-2019-q4-major/bin
           export PATH=${PATH}:${NRF5_TOOLS_ROOT}/nrfjprog


### PR DESCRIPTION
 #### Problem
Nordic SDK was updated to v4.0.0, but the instructions still refer to v3.1.0 for env settings.

 #### Summary of Changes
Fix the README to reference v4.0.0.