### PR TITLE
Change Google code owner from 'gerickson' to 'andy31415'.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @anush-apple @chrisdecenzo @hawk248 @gerickson @robszewczyk @woody-apple @BroderickCarlin @saurabhst @jelderton
+* @anush-apple @chrisdecenzo @hawk248 @andy31415 @robszewczyk @woody-apple @BroderickCarlin @saurabhst @jelderton

--- a/REVIEWERS.md
+++ b/REVIEWERS.md
@@ -8,7 +8,7 @@ PR
 | [chrisdecenzo](https://github.com/chrisdecenzo)       | Amazon, Inc.        |
 | [hawk248](https://github.com/hawk248)                 | Comcast, Inc.       |
 | [jelderton](https://github.com/jelderton)             | Comcast, Inc.       |
-| [gerickson](https://github.com/gerickson)             | Google, Inc.        |
+| [andy31415](https://github.com/andy31415)             | Google, Inc.        |
 | [robszewczyk](https://github.com/robszewczyk)         | Google, Inc.        |
 | [saurabhst](https://github.com/saurabhst)             | Samsung SmartThings |
 | [woody-apple](https://github.com/woody-apple)         | Apple, Inc.         |


### PR DESCRIPTION
 #### Problem
Google is switching PR review code ownership from @gerickson to @andy31415.

#### Summary of Changes
Change Google code ownership from @gerickson to @andy31415.