### PR TITLE
Make fetching build artifacts from master an optional step

### DIFF
--- a/scripts/helpers/bloat_check.py
+++ b/scripts/helpers/bloat_check.py
@@ -140,8 +140,11 @@ def main():
         'Required arguments missing. Please specify at least job and token.')
     return
 
-  ci_fetch_artifacts.fetchArtifactsForJob(args.token, args.job,
-                                          args.artifact_download_dir)
+  try:
+    ci_fetch_artifacts.fetchArtifactsForJob(args.token, args.job,
+                                            args.artifact_download_dir)
+  except Exception as e:
+    logging.warning('Failed to fetch artifacts: %r', e)
 
   generateBloatReport(
       args.report_file,

--- a/scripts/helpers/bloat_check.py
+++ b/scripts/helpers/bloat_check.py
@@ -144,7 +144,7 @@ def main():
     ci_fetch_artifacts.fetchArtifactsForJob(args.token, args.job,
                                             args.artifact_download_dir)
   except Exception as e:
-    logging.warning('Failed to fetch artifacts: %r', e)
+    logging.warning('Failed to fetch artifacts: %r' % e)
 
   generateBloatReport(
       args.report_file,


### PR DESCRIPTION
 #### Problem
Failure to find build artifacts results in a critical CI failure even if builds themselves are ok.

 #### Summary of Changes
Make the artifact fetch optional (i.e. no artifacts will get compared as 'file is missing' rather than a complete build failure.

fixes #1134