### PR TITLE
Rename SecureTransport to SecureSessionMgr

### DIFF
--- a/examples/wifi-echo/server/esp32/main/EchoServer.cpp
+++ b/examples/wifi-echo/server/esp32/main/EchoServer.cpp
@@ -40,7 +40,7 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <support/ErrorStr.h>
 #include <system/SystemPacketBuffer.h>
-#include <transport/SecureTransport.h>
+#include <transport/SecureSessionMgr.h>
 #include <transport/UDP.h>
 
 #include "DataModelHandler.h"
@@ -85,7 +85,7 @@ exit:
     return isPrintable;
 }
 
-void newConnectionHandler(const MessageHeader & header, const IPPacketInfo & packet_info, SecureTransport * transport)
+void newConnectionHandler(const MessageHeader & header, const IPPacketInfo & packet_info, SecureSessionMgr * transport)
 {
     CHIP_ERROR err;
 
@@ -106,7 +106,7 @@ exit:
 
 // Transport Callbacks
 void echo(const MessageHeader & header, const IPPacketInfo & packet_info, System::PacketBuffer * buffer,
-          SecureTransport * transport)
+          SecureSessionMgr * transport)
 {
     CHIP_ERROR err;
     const size_t data_len = buffer->DataLength();
@@ -162,7 +162,7 @@ exit:
 } // namespace
 
 // The echo server assumes the platform's networking has been setup already
-void setupTransport(IPAddressType type, SecureTransport * transport)
+void setupTransport(IPAddressType type, SecureSessionMgr * transport)
 {
     CHIP_ERROR err       = CHIP_NO_ERROR;
     struct netif * netif = NULL;
@@ -190,7 +190,7 @@ exit:
 }
 
 // The echo server assumes the platform's networking has been setup already
-void startServer(SecureTransport * transport_ipv4, SecureTransport * transport_ipv6)
+void startServer(SecureSessionMgr * transport_ipv4, SecureSessionMgr * transport_ipv6)
 {
     setupTransport(kIPAddressType_IPv6, transport_ipv6);
     setupTransport(kIPAddressType_IPv4, transport_ipv4);

--- a/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
@@ -35,12 +35,12 @@
 
 #include <platform/CHIPDeviceLayer.h>
 #include <support/ErrorStr.h>
-#include <transport/SecureTransport.h>
+#include <transport/SecureSessionMgr.h>
 
 using namespace ::chip;
 using namespace ::chip::DeviceLayer;
 
-extern void startServer(SecureTransport * transportIPv4, SecureTransport * transportIPv6);
+extern void startServer(SecureSessionMgr * transportIPv4, SecureSessionMgr * transportIPv6);
 extern void startClient(void);
 
 #if CONFIG_DEVICE_TYPE_M5STACK
@@ -170,7 +170,7 @@ extern "C" void app_main()
 
     // Start the Echo Server
     InitDataModelHandler();
-    SecureTransport sTransportIPv4, sTransportIPv6;
+    SecureSessionMgr sTransportIPv4, sTransportIPv6;
     startServer(&sTransportIPv4, &sTransportIPv6);
 #if CONFIG_USE_ECHO_CLIENT
     startClient();

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -140,7 +140,7 @@ CHIP_ERROR ChipDeviceController::ConnectDevice(NodeId remoteDeviceId, IPAddress 
     mDeviceAddr     = deviceAddr;
     mDevicePort     = devicePort;
     mAppReqState    = appReqState;
-    mDeviceCon      = new SecureTransport();
+    mDeviceCon      = new SecureSessionMgr();
 
     err = mDeviceCon->Init(mLocalDeviceId, mInetLayer, Transport::UdpListenParameters().SetAddressType(deviceAddr.Type()));
     SuccessOrExit(err);

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -32,7 +32,7 @@
 #include <core/CHIPCore.h>
 #include <core/CHIPTLV.h>
 #include <support/DLLUtil.h>
-#include <transport/SecureTransport.h>
+#include <transport/SecureSessionMgr.h>
 #include <transport/UDP.h>
 
 namespace chip {
@@ -159,7 +159,7 @@ private:
 
     System::Layer * mSystemLayer;
     Inet::InetLayer * mInetLayer;
-    SecureTransport * mDeviceCon;
+    SecureSessionMgr * mDeviceCon;
 
     ConnectionState mConState;
     void * mAppReqState;

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -18,14 +18,14 @@
 
 /**
  *    @file
- *      This file implements the CHIP Secure Channel object.
+ *      This file implements the CHIP Secure Session object.
  *
  */
 
 #include <core/CHIPEncoding.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <support/CodeUtils.h>
-#include <transport/CHIPSecureChannel.h>
+#include <transport/SecureSession.h>
 
 #include <string.h>
 
@@ -40,12 +40,11 @@ typedef struct
     uint64_t tag;
 } security_header_t;
 
-ChipSecureChannel::ChipSecureChannel() : mKeyAvailable(false), mNextIV(0) {}
+SecureSession::SecureSession() : mKeyAvailable(false), mNextIV(0) {}
 
-CHIP_ERROR ChipSecureChannel::Init(const unsigned char * remote_public_key, const size_t public_key_length,
-                                   const unsigned char * local_private_key, const size_t private_key_length,
-                                   const unsigned char * salt, const size_t salt_length, const unsigned char * info,
-                                   const size_t info_length)
+CHIP_ERROR SecureSession::Init(const unsigned char * remote_public_key, const size_t public_key_length,
+                               const unsigned char * local_private_key, const size_t private_key_length, const unsigned char * salt,
+                               const size_t salt_length, const unsigned char * info, const size_t info_length)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     uint8_t secret[kMax_ECDH_Secret_Length];
@@ -77,14 +76,13 @@ exit:
     return error;
 }
 
-void ChipSecureChannel::Close(void)
+void SecureSession::Close(void)
 {
     mKeyAvailable = false;
     mNextIV       = 0;
 }
 
-CHIP_ERROR ChipSecureChannel::Encrypt(const unsigned char * input, size_t input_length, unsigned char * output,
-                                      size_t output_length)
+CHIP_ERROR SecureSession::Encrypt(const unsigned char * input, size_t input_length, unsigned char * output, size_t output_length)
 {
     security_header_t header;
 
@@ -118,8 +116,7 @@ exit:
     return error;
 }
 
-CHIP_ERROR ChipSecureChannel::Decrypt(const unsigned char * input, size_t input_length, unsigned char * output,
-                                      size_t & output_length)
+CHIP_ERROR SecureSession::Decrypt(const unsigned char * input, size_t input_length, unsigned char * output, size_t & output_length)
 {
     security_header_t header;
 
@@ -153,7 +150,7 @@ exit:
     return error;
 }
 
-size_t ChipSecureChannel::EncryptionOverhead(void)
+size_t SecureSession::EncryptionOverhead(void)
 {
     return sizeof(security_header_t);
 }

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -18,19 +18,19 @@
 
 /**
  *    @file
- *      This file defines the CHIP Secure Channel object that provides
+ *      This file defines the CHIP Secure Session object that provides
  *      APIs for encrypting/decryting data using cryptographic keys.
  *
  */
 
-#ifndef __CHIPSECURECHANNEL_H__
-#define __CHIPSECURECHANNEL_H__
+#ifndef __SECURESESSION_H__
+#define __SECURESESSION_H__
 
 #include <core/CHIPCore.h>
 
 namespace chip {
 
-class DLL_EXPORT ChipSecureChannel
+class DLL_EXPORT SecureSession
 {
 public:
     /**
@@ -83,7 +83,7 @@ public:
 
     void Close(void);
 
-    ChipSecureChannel(void);
+    SecureSession(void);
 
 private:
     static const size_t kAES_CCM128_Key_Length = 16;
@@ -95,4 +95,4 @@ private:
 
 } // namespace chip
 
-#endif // __CHIPSECURECHANNEL_H__
+#endif // __SECURESESSION_H__

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -27,7 +27,7 @@
 #include <string.h>
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
-#include <transport/SecureTransport.h>
+#include <transport/SecureSessionMgr.h>
 
 #include <inttypes.h>
 
@@ -39,12 +39,12 @@ namespace chip {
 static const size_t kMax_SecureSDU_Length         = 1024;
 static const char * kManualKeyExchangeChannelInfo = "Manual Key Exchanged Channel";
 
-SecureTransport::SecureTransport() : mConnectionState(Transport::PeerAddress::Uninitialized()), mState(State::kNotReady)
+SecureSessionMgr::SecureSessionMgr() : mConnectionState(Transport::PeerAddress::Uninitialized()), mState(State::kNotReady)
 {
     OnMessageReceived = NULL;
 }
 
-CHIP_ERROR SecureTransport::Init(NodeId localNodeId, Inet::InetLayer * inet, const Transport::UdpListenParameters & listenParams)
+CHIP_ERROR SecureSessionMgr::Init(NodeId localNodeId, Inet::InetLayer * inet, const Transport::UdpListenParameters & listenParams)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     VerifyOrExit(mState == State::kNotReady, err = CHIP_ERROR_INCORRECT_STATE);
@@ -60,7 +60,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR SecureTransport::Connect(NodeId peerNodeId, const Transport::PeerAddress & peerAddress)
+CHIP_ERROR SecureSessionMgr::Connect(NodeId peerNodeId, const Transport::PeerAddress & peerAddress)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -75,8 +75,8 @@ exit:
     return err;
 }
 
-CHIP_ERROR SecureTransport::ManualKeyExchange(const unsigned char * remote_public_key, const size_t public_key_length,
-                                              const unsigned char * local_private_key, const size_t private_key_length)
+CHIP_ERROR SecureSessionMgr::ManualKeyExchange(const unsigned char * remote_public_key, const size_t public_key_length,
+                                               const unsigned char * local_private_key, const size_t private_key_length)
 {
     CHIP_ERROR err  = CHIP_NO_ERROR;
     size_t info_len = strlen(kManualKeyExchangeChannelInfo);
@@ -92,7 +92,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR SecureTransport::SendMessage(NodeId peerNodeId, System::PacketBuffer * msgBuf)
+CHIP_ERROR SecureSessionMgr::SendMessage(NodeId peerNodeId, System::PacketBuffer * msgBuf)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -146,8 +146,8 @@ exit:
     return err;
 }
 
-void SecureTransport::HandleDataReceived(const MessageHeader & header, const IPPacketInfo & pktInfo, System::PacketBuffer * msg,
-                                         SecureTransport * connection)
+void SecureSessionMgr::HandleDataReceived(const MessageHeader & header, const IPPacketInfo & pktInfo, System::PacketBuffer * msg,
+                                          SecureSessionMgr * connection)
 {
     // TODO: actual key exchange should happen here
     if (!connection->StateAllowsReceive())

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef __SECURETRANSPORT_H__
-#define __SECURETRANSPORT_H__
+#ifndef __SECURESESSIONMGR_H__
+#define __SECURESESSIONMGR_H__
 
 #include <utility>
 
@@ -32,15 +32,15 @@
 #include <core/ReferenceCounted.h>
 #include <inet/IPAddress.h>
 #include <inet/IPEndPointBasis.h>
-#include <transport/CHIPSecureChannel.h>
 #include <transport/PeerConnectionState.h>
+#include <transport/SecureSession.h>
 #include <transport/UDP.h>
 
 namespace chip {
 
 using namespace System;
 
-class DLL_EXPORT SecureTransport : public ReferenceCounted<SecureTransport>
+class DLL_EXPORT SecureSessionMgr : public ReferenceCounted<SecureSessionMgr>
 {
 public:
     /**
@@ -99,8 +99,8 @@ public:
      */
     CHIP_ERROR SendMessage(NodeId peerNodeId, System::PacketBuffer * msgBuf);
 
-    SecureTransport();
-    virtual ~SecureTransport() {}
+    SecureSessionMgr();
+    virtual ~SecureSessionMgr() {}
 
     /**
      * Sets the message receive handler and associated argument
@@ -152,7 +152,7 @@ private:
     Transport::PeerConnectionState mConnectionState;
     NodeId mLocalNodeId;
     State mState;
-    ChipSecureChannel mSecureChannel;
+    SecureSession mSecureChannel;
 
     bool StateAllowsSend(void) const { return mState != State::kNotReady; }
     bool StateAllowsReceive(void) const { return mState == State::kSecureConnected; }
@@ -175,9 +175,9 @@ private:
     void * mNewConnectionArgument        = nullptr; ///< Argument for callback
 
     static void HandleDataReceived(const MessageHeader & header, const Inet::IPPacketInfo & source, System::PacketBuffer * msgBuf,
-                                   SecureTransport * transport);
+                                   SecureSessionMgr * transport);
 };
 
 } // namespace chip
 
-#endif // __SECURETRANSPORT_H__
+#endif // __SECURESESSIONMGR_H__

--- a/src/transport/TransportLayer.am
+++ b/src/transport/TransportLayer.am
@@ -25,18 +25,18 @@
 #
 
 CHIP_BUILD_TRANSPORT_LAYER_SOURCE_FILES                  = \
-    @top_builddir@/src/transport/CHIPSecureChannel.cpp     \
+    @top_builddir@/src/transport/SecureSession.cpp     \
     @top_builddir@/src/transport/MessageHeader.cpp         \
-    @top_builddir@/src/transport/SecureTransport.cpp       \
+    @top_builddir@/src/transport/SecureSessionMgr.cpp       \
     @top_builddir@/src/transport/UDP.cpp                   \
     $(NULL)
 
 CHIP_BUILD_TRANSPORT_LAYER_HEADER_FILES              = \
     @top_builddir@/src/transport/Base.h                \
-    @top_builddir@/src/transport/CHIPSecureChannel.h   \
+    @top_builddir@/src/transport/SecureSession.h   \
     @top_builddir@/src/transport/MessageHeader.h       \
     @top_builddir@/src/transport/PeerAddress.h         \
     @top_builddir@/src/transport/PeerConnectionState.h \
-    @top_builddir@/src/transport/SecureTransport.h     \
+    @top_builddir@/src/transport/SecureSessionMgr.h     \
     @top_builddir@/src/transport/UDP.h                 \
     $(NULL)

--- a/src/transport/tests/Makefile.am
+++ b/src/transport/tests/Makefile.am
@@ -42,9 +42,9 @@ lib_LIBRARIES                                         = \
 
 libTransportLayerTests_a_SOURCES                      = \
     TestMessageHeader.cpp                               \
-    TestSecureTransport.cpp                             \
+    TestSecureSessionMgr.cpp                            \
     TestUDP.cpp                                         \
-    TestCHIPSecureChannel.cpp                           \
+    TestSecureSession.cpp                               \
     $(NULL)
 
 libTransportLayerTests_adir                           = $(includedir)/transport
@@ -86,8 +86,8 @@ COMMON_LDADD                                          = \
 
 check_PROGRAMS             = \
     TestMessageHeader        \
-    TestSecureTransport      \
-    TestCHIPSecureChannel    \
+    TestSecureSessionMgr     \
+    TestSecureSession        \
     TestUDP                  \
     $(NULL)
 
@@ -109,11 +109,11 @@ TESTS_ENVIRONMENT             = \
 TestMessageHeader_SOURCES     = TestMessageHeaderDriver.cpp
 TestMessageHeader_LDADD       = $(COMMON_LDADD)
 
-TestSecureTransport_SOURCES   = TestSecureTransportDriver.cpp
-TestSecureTransport_LDADD     = $(COMMON_LDADD)
+TestSecureSessionMgr_SOURCES  = TestSecureSessionMgrDriver.cpp
+TestSecureSessionMgr_LDADD    = $(COMMON_LDADD)
 
-TestCHIPSecureChannel_SOURCES = TestCHIPSecureChannelDriver.cpp
-TestCHIPSecureChannel_LDADD   = $(COMMON_LDADD)
+TestSecureSession_SOURCES     = TestSecureSessionDriver.cpp
+TestSecureSession_LDADD       = $(COMMON_LDADD)
 
 TestUDP_SOURCES               = TestUDPDriver.cpp
 TestUDP_LDADD                 = $(COMMON_LDADD)

--- a/src/transport/tests/TestSecureSession.cpp
+++ b/src/transport/tests/TestSecureSession.cpp
@@ -18,7 +18,7 @@
 
 /**
  *    @file
- *      This file implements unit tests for the CHIPSecureChannel implementation.
+ *      This file implements unit tests for the SecureSession implementation.
  */
 
 #include "TestTransportLayer.h"
@@ -27,7 +27,7 @@
 #include <nlunit-test.h>
 
 #include <core/CHIPCore.h>
-#include <transport/CHIPSecureChannel.h>
+#include <transport/SecureSession.h>
 
 #include <stdarg.h>
 #include <support/CodeUtils.h>
@@ -59,7 +59,7 @@ static const unsigned char secure_channel_test_public_key2[] = { 0x04, 0x30, 0x7
 
 void SecureChannelInitTest(nlTestSuite * inSuite, void * inContext)
 {
-    ChipSecureChannel channel;
+    SecureSession channel;
     // Test all combinations of invalid parameters
     NL_TEST_ASSERT(inSuite, channel.Init(NULL, 0, NULL, 0, NULL, 0, NULL, 0) == CHIP_ERROR_INVALID_ARGUMENT);
     NL_TEST_ASSERT(inSuite,
@@ -94,7 +94,7 @@ void SecureChannelInitTest(nlTestSuite * inSuite, void * inContext)
 
     // Test the channel can be initialized with valid salt
     const char * salt = "Test Salt";
-    ChipSecureChannel channel2;
+    SecureSession channel2;
     NL_TEST_ASSERT(inSuite,
                    channel2.Init(secure_channel_test_public_key1, sizeof(secure_channel_test_public_key1),
                                  secure_channel_test_private_key2, sizeof(secure_channel_test_private_key2),
@@ -104,7 +104,7 @@ void SecureChannelInitTest(nlTestSuite * inSuite, void * inContext)
 
 void SecureChannelEncryptTest(nlTestSuite * inSuite, void * inContext)
 {
-    ChipSecureChannel channel;
+    SecureSession channel;
     const unsigned char plain_text[] = { 0x86, 0x74, 0x64, 0xe5, 0x0b, 0xd4, 0x0d, 0x90,
                                          0xe1, 0x17, 0xa3, 0x2d, 0x4b, 0xd4, 0xe1, 0xe6 };
     unsigned char output[128];
@@ -144,7 +144,7 @@ void SecureChannelEncryptTest(nlTestSuite * inSuite, void * inContext)
 
 void SecureChannelDecryptTest(nlTestSuite * inSuite, void * inContext)
 {
-    ChipSecureChannel channel;
+    SecureSession channel;
     const unsigned char plain_text[] = { 0x86, 0x74, 0x64, 0xe5, 0x0b, 0xd4, 0x0d, 0x90,
                                          0xe1, 0x17, 0xa3, 0x2d, 0x4b, 0xd4, 0xe1, 0xe6 };
     unsigned char encrypted[128];
@@ -161,7 +161,7 @@ void SecureChannelDecryptTest(nlTestSuite * inSuite, void * inContext)
                    channel.Encrypt(plain_text, sizeof(plain_text), encrypted, sizeof(plain_text) + channel.EncryptionOverhead()) ==
                        CHIP_NO_ERROR);
 
-    ChipSecureChannel channel2;
+    SecureSession channel2;
     unsigned char output[128];
     size_t output_length = sizeof(output);
     // Uninitialized channel
@@ -225,7 +225,7 @@ static nlTestSuite sSuite =
 /**
  *  Main
  */
-int TestCHIPSecureChannel()
+int TestSecureSession()
 {
     // Run test suit against one context
     nlTestRunner(&sSuite, NULL);

--- a/src/transport/tests/TestSecureSessionDriver.cpp
+++ b/src/transport/tests/TestSecureSessionDriver.cpp
@@ -31,5 +31,5 @@ int main(void)
     // Generate machine-readable, comma-separated value (CSV) output.
     nlTestSetOutputStyle(OUTPUT_CSV);
 
-    return (TestCHIPSecureChannel());
+    return (TestSecureSession());
 }

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -18,14 +18,14 @@
 
 /**
  *    @file
- *      This file implements unit tests for the SecureTransport implementation.
+ *      This file implements unit tests for the SecureSessionMgr implementation.
  */
 
 #include "TestTransportLayer.h"
 
 #include <core/CHIPCore.h>
 #include <support/CodeUtils.h>
-#include <transport/SecureTransport.h>
+#include <transport/SecureSessionMgr.h>
 
 #include <nlbyteorder.h>
 #include <nlunit-test.h>
@@ -136,7 +136,7 @@ void CheckSimpleInitTest(nlTestSuite * inSuite, void * inContext)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
-    SecureTransport conn;
+    SecureSessionMgr conn;
     CHIP_ERROR err;
 
     err = conn.Init(kSourceNodeId, &ctx.mInetLayer, Transport::UdpListenParameters());
@@ -157,7 +157,7 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
     IPAddress::FromString("127.0.0.1", addr);
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    SecureTransport conn;
+    SecureSessionMgr conn;
 
     err = conn.Init(kSourceNodeId, &ctx.mInetLayer, Transport::UdpListenParameters().SetAddressType(addr.Type()));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -252,7 +252,7 @@ static int Finalize(void * aContext)
 /**
  *  Main
  */
-int TestSecureTransport()
+int TestSecureSessionMgr()
 {
     // Run test suit against one context
     nlTestRunner(&sSuite, &sContext);

--- a/src/transport/tests/TestSecureSessionMgrDriver.cpp
+++ b/src/transport/tests/TestSecureSessionMgrDriver.cpp
@@ -31,5 +31,5 @@ int main(void)
     // Generate machine-readable, comma-separated value (CSV) output.
     nlTestSetOutputStyle(OUTPUT_CSV);
 
-    return (TestSecureTransport());
+    return (TestSecureSessionMgr());
 }

--- a/src/transport/tests/TestTransportLayer.h
+++ b/src/transport/tests/TestTransportLayer.h
@@ -30,8 +30,8 @@ extern "C" {
 #endif
 
 int TestMessageHeader(void);
-int TestSecureTransport(void);
-int TestCHIPSecureChannel(void);
+int TestSecureSessionMgr(void);
+int TestSecureSession(void);
 int TestUDP(void);
 
 #ifdef __cplusplus


### PR DESCRIPTION
 #### Problem
`SecureTransport` and `CHIPSecureChannel` classes are not correctly named.

 #### Summary of Changes
Renamed `SecureTransport` to `SecureSessionMgr`
Renamed `CHIPSecureChannel` to `SecureSession`

fixes #1087 