### PR TITLE
SecureSessionMgr to callback app on receive errors

### DIFF
--- a/examples/wifi-echo/server/esp32/main/EchoServer.cpp
+++ b/examples/wifi-echo/server/esp32/main/EchoServer.cpp
@@ -160,6 +160,12 @@ exit:
     }
 }
 
+void error(CHIP_ERROR error, const IPPacketInfo & pi)
+{
+    ESP_LOGE(TAG, "ERROR: %s\n Got UDP error", ErrorStr(error));
+    statusLED.BlinkOnError();
+}
+
 } // namespace
 
 // The echo server assumes the platform's networking has been setup already
@@ -177,6 +183,7 @@ void setupTransport(IPAddressType type, SecureSessionMgr * transport)
     SuccessOrExit(err);
 
     transport->SetMessageReceiveHandler(echo, transport);
+    transport->SetReceiveErrorHandler(error);
     transport->SetNewConnectionHandler(newConnectionHandler, transport);
 
 exit:

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -200,6 +200,10 @@ void SecureSessionMgr::HandleDataReceived(const MessageHeader & header, const IP
         }
         else
         {
+            if (connection->OnReceiveError)
+            {
+                connection->OnReceiveError(CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE_FROM_PEER, pktInfo);
+            }
             PacketBuffer::Free(msg);
             ChipLogProgress(Inet, "Secure transport failed to decrypt msg: err %d", err);
         }

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -118,6 +118,17 @@ public:
     }
 
     /**
+     * Sets the receive error handler and associated argument
+     *
+     * @param[in] handler The callback to call on receive error
+     *
+     */
+    void SetReceiveErrorHandler(void (*handler)(CHIP_ERROR, const Inet::IPPacketInfo &))
+    {
+        OnReceiveError = reinterpret_cast<ReceiveErrorHandler>(handler);
+    }
+
+    /**
      * Sets the new connection handler and associated argument
      *
      * @param[in] handler The callback to call when a message is received
@@ -168,6 +179,10 @@ private:
 
     MessageReceiveHandler OnMessageReceived = nullptr; ///< Callback on message receiving
     void * mMessageReceivedArgument         = nullptr; ///< Argument for callback
+
+    typedef void (*ReceiveErrorHandler)(CHIP_ERROR error, const Inet::IPPacketInfo & source);
+
+    ReceiveErrorHandler OnReceiveError = nullptr; ///< Callback on error in message receiving
 
     typedef void (*NewConnectionHandler)(const MessageHeader & header, const Inet::IPPacketInfo & source, void * param);
 


### PR DESCRIPTION
 #### Problem
The ESP32 demo app is no longer showing error when it fails to decrypt received packets.

 #### Summary of Changes
The refactor of UDP transport removed the error handler from Secure transport APIs. That mechanism was being used to propagate errors to the application. This PR reintroduces the callback for error handling. 
