### PR TITLE
Increase CHIP task stack size for ESP32 app

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -323,7 +323,7 @@ menu "CHIP Device Layer"
         config CHIP_TASK_STACK_SIZE
             int "CHIP Task Stack Size"
             range 0 65535
-            default 4608
+            default 8192
             help
                 The size (in bytes) of the CHIP task stack.
 


### PR DESCRIPTION
 #### Problem
Occasionally seeing stack overflow on ESP32 m5Stack demo app.

 #### Summary of Changes
Increase CHIP task stack size to 8K

fixes #1144 