### PR TITLE
[WIP][linux] add ThreadStackManager for Linux Device layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ third_party/nlunit-test/
 third_party/mbedtls/
 examples/common/m5stack-tft/
 examples/common/QRCode/repo/
+third_party/ot-br-posix/repo
 
 # Example specific rules
 examples/**/sdkconfig

--- a/configure.ac
+++ b/configure.ac
@@ -1773,6 +1773,63 @@ if test "${nl_cv_build_tests}" = "yes"; then
     fi
 fi
 
+#
+# otbr-client
+#
+
+NL_WITH_PACKAGE(
+    [otbrclient],
+    [OTBRCLIENT],
+    [otbrclient],
+    [],
+    [
+        OTBRCLIENT_CPPFLAGS=
+        OTBRCLIENT_LDFLAGS=
+        OTBRCLIENT_LIBS=
+    ],
+    [
+        AC_LANG_PUSH([C++])
+        AC_LANG_POP([C++])
+    ]
+)
+
+AC_MSG_NOTICE("nl_with_otbrclient=${nl_with_otbrclient}")
+
+# Depending on whether nlfaultinjection has been configured for an internal
+# location, its directory stem within this package needs to be set
+# accordingly. In addition, if the location is internal, then we need
+# to attempt to pull it down using the bootstrap makefile.
+
+if test "${nl_with_otbrclient}" = "internal"; then
+    maybe_otbrclient_dirstem="ot-br-posix"
+    otbrclient_dirstem="third_party/${maybe_otbrclient_dirstem}/repo"
+
+    AC_MSG_NOTICE([attempting to create internal ${otbrclient_dirstem}])
+
+    ${MAKE-make} --no-print-directory -C ${srcdir} -f Makefile-bootstrap ${otbrclient_dirstem}
+
+    if test $? -ne 0; then
+        AC_MSG_ERROR([failed to create ${otbrclient_dirstem}. Please check your network connection or the correctness of 'repos.conf'])
+    fi
+
+    # otbrclient requires dbus
+    PKG_CHECK_MODULES(DBUS, dbus-1 >= 1.4)
+    AC_SUBST([DBUS_CFLAGS])
+    AC_SUBST([DBUS_LIBS])
+else
+    AC_MSG_ERROR("not copying!! nl_with_otbrclient=${nl_with_otbrclient}")
+    maybe_otbrclient_dirstem=""
+fi
+
+AC_SUBST(OTBRCLIENT_SUBDIRS, [${maybe_otbrclient_dirstem}])
+AM_CONDITIONAL([CHIP_WITH_OTBRCLIENT], [test "${nl_with_otbrclient}" != "no"])
+AM_CONDITIONAL([CHIP_WITH_OTBRCLIENT_INTERNAL], [test "${nl_with_otbrclient}" = "internal"])
+
+if test "${nl_with_otbrclient}" = "no"; then
+    AC_DEFINE([CHIP_WITH_OTBRCLIENT], [0], [Define to 1 to build CHIP with otbr client features])
+else
+    AC_DEFINE([CHIP_WITH_OTBRCLIENT], [1], [Define to 1 to build CHIP with otbr client features])
+fi
 
 #
 # Nlunit-test
@@ -2102,6 +2159,7 @@ examples/Makefile
 third_party/Makefile
 third_party/lwip/Makefile
 third_party/mbedtls/Makefile
+third_party/ot-br-posix/Makefile
 src/Makefile
 src/include/Makefile
 src/app/Makefile

--- a/repos.conf
+++ b/repos.conf
@@ -33,3 +33,8 @@
 	url = https://github.com/jeremyjh/ESP32_TFT_library.git
 	branch = master
 	update = none
+[submodule "ot-br-posix"]
+	path = third_party/ot-br-posix/repo
+	url = https://github.com/openthread/ot-br-posix.git
+	branch = master
+	update = none

--- a/scripts/setup/linux/install_packages.sh
+++ b/scripts/setup/linux/install_packages.sh
@@ -22,6 +22,7 @@ apt-get install -fy \
     libssl-dev \
     unzip \
     wget \
+    libdbus-1-dev \
     libmbedtls-dev
 
 if [[ ! -f 'ci-cache-persistent/openssl/open_ssl_1.1.1f_installed' ]]; then

--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -46,6 +46,7 @@ class PlatformManagerImpl;
 class ConnectivityManagerImpl;
 class ConfigurationManagerImpl;
 class TraitManager;
+class ThreadStackManagerImpl;
 class TimeSyncManager;
 namespace Internal {
 class FabricProvisioningServer;
@@ -97,6 +98,7 @@ private:
     friend class ConnectivityManagerImpl;
     friend class ConfigurationManagerImpl;
     friend class TraitManager;
+    friend class ThreadStackManagerImpl;
     friend class TimeSyncManager;
     friend class Internal::FabricProvisioningServer;
     friend class Internal::ServiceProvisioningServer;

--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -67,7 +67,7 @@ public:
     void LockThreadStack(void);
     bool TryLockThreadStack(void);
     void UnlockThreadStack(void);
-    bool HaveRouteToAddress(const IPAddress & destAddr);
+    bool HaveRouteToAddress(const Inet::IPAddress & destAddr);
     CHIP_ERROR GetAndLogThreadStatsCounters(void);
     CHIP_ERROR GetAndLogThreadTopologyMinimal(void);
     CHIP_ERROR GetAndLogThreadTopologyFull(void);

--- a/src/include/platform/internal/DeviceNetworkInfo.h
+++ b/src/include/platform/internal/DeviceNetworkInfo.h
@@ -1,0 +1,74 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2018 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef DEVICE_NETWORK_INFO_H
+#define DEVICE_NETWORK_INFO_H
+
+#include <stdint.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+/**
+ * Ids for well-known network provision types.
+ */
+enum
+{
+    kThreadNetworkId            = 1,
+    kWiFiStationNetworkId       = 2,
+    kMaxThreadNetworkNameLength = 16,
+    kThreadExtendedPANIdLength  = 8,
+    kThreadMeshPrefixLength     = 8,
+    kThreadNetworkKeyLength     = 16,
+    kThreadPSKcLength           = 16,
+    kThreadChannel_NotSpecified = UINT8_MAX,
+    kThreadPANId_NotSpecified   = UINT16_MAX,
+};
+
+class DeviceNetworkInfo
+{
+public:
+    // ---- Thread-specific Fields ----
+    char ThreadNetworkName[kMaxThreadNetworkNameLength + 1];
+    /**< The Thread network name as a NULL-terminated string. */
+    uint8_t ThreadExtendedPANId[kThreadExtendedPANIdLength];
+    /**< The Thread extended PAN ID. */
+    uint8_t ThreadMeshPrefix[kThreadMeshPrefixLength];
+    /**< The Thread mesh prefix. */
+    uint8_t ThreadNetworkKey[kThreadNetworkKeyLength];
+    /**< The Thread master network key (NOT NULL-terminated). */
+    uint8_t ThreadPSKc[kThreadPSKcLength];
+    /**< The Thread pre-shared commissioner key (NOT NULL-terminated). */
+    uint16_t ThreadPANId;  /**< The 16-bit Thread PAN ID, or kThreadPANId_NotSpecified */
+    uint8_t ThreadChannel; /**< The Thread channel (currently [11..26]), or kThreadChannel_NotSpecified */
+
+    struct
+    {
+        bool ThreadExtendedPANId : 1;
+        bool ThreadMeshPrefix : 1;
+        bool ThreadPSKc : 1;
+    } FieldPresent;
+};
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip
+
+#endif // DEVICE_NETWORK_INFO_H

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -1,0 +1,405 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <limits.h>
+#include <string.h>
+
+#include "platform/internal/CHIPDeviceLayerInternal.h"
+#include "platform/internal/DeviceNetworkInfo.h"
+
+#include "platform/PlatformManager.h"
+#include "platform/ThreadStackManager.h"
+#include "support/CodeUtils.h"
+#include "support/logging/CHIPLogging.h"
+
+#include "dbus/client/thread_api_dbus.hpp"
+
+using chip::DeviceLayer::Internal::DeviceNetworkInfo;
+using otbr::DBus::ClientError;
+using otbr::DBus::DeviceRole;
+using otbr::DBus::IpCounters;
+using otbr::DBus::LinkModeConfig;
+using otbr::DBus::MacCounters;
+using otbr::DBus::NeighborInfo;
+
+#ifndef CHIP_CONFIG_OTBR_CLIENT_ERROR_MIN
+#define CHIP_CONFIG_OTBR_CLIENT_ERROR_MIN 8000000
+#endif
+
+#define OTBR_TO_CHIP_ERROR(x)                                                                                                      \
+    (x == ClientError::ERROR_NONE ? CHIP_NO_ERROR : _CHIP_ERROR(CHIP_CONFIG_OTBR_CLIENT_ERROR_MIN + static_cast<int>(x)))
+
+#define LogClientError(error)                                                                                                      \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        if (error != ClientError::ERROR_NONE)                                                                                      \
+        {                                                                                                                          \
+            ChipLogError(DeviceLayer, __FILE__ " %d: Otbr ClientError %d", __LINE__, static_cast<int>(error));                     \
+        }                                                                                                                          \
+    } while (0)
+
+namespace chip {
+namespace DeviceLayer {
+
+ThreadStackManagerImpl::ThreadStackManagerImpl() : mNetworkInfo(), mAttached(false) {}
+
+CHIP_ERROR ThreadStackManagerImpl::_InitThreadStack()
+{
+    ClientError error;
+    DeviceRole role;
+    DBusConnection * connection = &PlatformMgrImpl().GetSystemDBusConnection();
+
+    VerifyOrExit(connection != nullptr, error = ClientError::ERROR_DBUS);
+    mThreadApi = std::unique_ptr<otbr::DBus::ThreadApiDBus>(new otbr::DBus::ThreadApiDBus(connection));
+    mThreadApi->AddDeviceRoleHandler([this](DeviceRole newRole) { this->_ThreadDevcieRoleChangedHandler(newRole); });
+
+    SuccessOrExit(error = mThreadApi->GetDeviceRole(role));
+    _ThreadDevcieRoleChangedHandler(role);
+    mAttached = (role != DeviceRole::OTBR_DEVICE_ROLE_DETACHED && role != DeviceRole::OTBR_DEVICE_ROLE_DISABLED);
+exit:
+    LogClientError(error);
+    return OTBR_TO_CHIP_ERROR(error);
+}
+
+void ThreadStackManagerImpl::_ThreadDevcieRoleChangedHandler(DeviceRole role)
+{
+    bool attached         = (role != DeviceRole::OTBR_DEVICE_ROLE_DETACHED && role != DeviceRole::OTBR_DEVICE_ROLE_DISABLED);
+    ChipDeviceEvent event = ChipDeviceEvent{};
+
+    if (attached != mAttached)
+    {
+        event.Type = DeviceEventType::kThreadConnectivityChange;
+        event.ThreadConnectivityChange.Result =
+            attached ? ConnectivityChange::kConnectivity_Established : ConnectivityChange::kConnectivity_Lost;
+        PlatformMgr().PostEvent(&event);
+    }
+
+    event.Type                          = DeviceEventType::kThreadStateChange;
+    event.ThreadStateChange.RoleChanged = true;
+    PlatformMgr().PostEvent(&event);
+}
+
+CHIP_ERROR ThreadStackManagerImpl::_ProcessThreadActivity()
+{
+    return CHIP_NO_ERROR;
+}
+
+static bool RouteMatch(const otbr::DBus::Ip6Prefix & prefix, const Inet::IPAddress & addr)
+{
+    bool match = true;
+    const uint8_t * prefixBuffer;
+    const uint8_t * addrBuffer;
+    uint8_t wholeBytes  = prefix.mLength / CHAR_BIT;
+    uint8_t pendingBits = prefix.mLength % CHAR_BIT;
+
+    VerifyOrExit(addr.IsIPv6(), match = false);
+    VerifyOrExit(prefix.mLength > 0, match = false);
+
+    prefixBuffer = static_cast<const uint8_t *>(&prefix.mPrefix[0]);
+    addrBuffer   = reinterpret_cast<const uint8_t *>(&addr.Addr);
+    VerifyOrExit(memcmp(addrBuffer, prefixBuffer, wholeBytes) == 0, match = false);
+    if (pendingBits)
+    {
+        uint8_t mask = static_cast<uint8_t>(((UINT8_MAX >> pendingBits) << (CHAR_BIT - pendingBits)));
+
+        VerifyOrExit((addrBuffer[wholeBytes] & mask) == (addrBuffer[wholeBytes] & mask), match = false);
+    }
+    VerifyOrExit(memcmp(addrBuffer, prefixBuffer, wholeBytes) == 0, match = false);
+
+exit:
+    return match;
+}
+
+bool ThreadStackManagerImpl::_HaveRouteToAddress(const Inet::IPAddress & destAddr)
+{
+    std::vector<otbr::DBus::ExternalRoute> routes;
+    bool match = false;
+
+    VerifyOrExit(mThreadApi->GetExternalRoutes(routes) == ClientError::ERROR_NONE, match = false);
+    VerifyOrExit(_IsThreadAttached(), match = false);
+    VerifyOrExit(destAddr.IsIPv6LinkLocal(), match = true);
+    for (const auto & route : routes)
+    {
+        VerifyOrExit(!(match = RouteMatch(route.mPrefix, destAddr)), );
+    }
+
+exit:
+    return match;
+}
+
+void ThreadStackManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
+{
+    (void) event;
+    // The otbr-agent processes the Thread state handling by itself so there
+    // isn't much to do in the Chip stack.
+}
+
+CHIP_ERROR ThreadStackManagerImpl::_SetThreadProvision(const Internal::DeviceNetworkInfo & netInfo)
+{
+    mNetworkInfo = netInfo;
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ThreadStackManagerImpl::_GetThreadProvision(Internal::DeviceNetworkInfo & netInfo, bool includeCredentials)
+{
+    netInfo = mNetworkInfo;
+
+    if (!includeCredentials)
+    {
+        memset(&netInfo.ThreadNetworkKey, 0, sizeof(netInfo.ThreadNetworkKey));
+        memset(&netInfo.ThreadPSKc, 0, sizeof(netInfo.ThreadPSKc));
+        netInfo.FieldPresent.ThreadPSKc = false;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+bool ThreadStackManagerImpl::_IsThreadProvisioned()
+{
+    return mNetworkInfo.ThreadNetworkName[0] != '\0';
+}
+
+void ThreadStackManagerImpl::_ClearThreadProvision()
+{
+    mNetworkInfo = Internal::DeviceNetworkInfo{};
+}
+
+bool ThreadStackManagerImpl::_IsThreadEnabled()
+{
+    bool enabled = false;
+    DeviceRole role;
+    ClientError error;
+
+    SuccessOrExit(error = mThreadApi->GetDeviceRole(role));
+    enabled = (role != DeviceRole::OTBR_DEVICE_ROLE_DISABLED);
+exit:
+    LogClientError(error);
+    return enabled;
+}
+
+bool ThreadStackManagerImpl::_IsThreadAttached()
+{
+    return mAttached;
+}
+
+CHIP_ERROR ThreadStackManagerImpl::_SetThreadEnabled(bool val)
+{
+    ClientError error = ClientError::ERROR_NONE;
+
+    if (val)
+    {
+        std::vector<uint8_t> masterkey(std::begin(mNetworkInfo.ThreadNetworkKey), std::end(mNetworkInfo.ThreadNetworkKey));
+        std::vector<uint8_t> pskc;
+        uint64_t extPanId    = UINT64_MAX;
+        uint32_t channelMask = UINT32_MAX;
+
+        if (mNetworkInfo.FieldPresent.ThreadExtendedPANId)
+        {
+            extPanId = 0;
+            for (size_t i = 0; i < extPanId; i++)
+            {
+                extPanId <<= CHAR_BIT;
+                extPanId |= mNetworkInfo.ThreadExtendedPANId[i];
+            }
+        }
+        if (mNetworkInfo.FieldPresent.ThreadPSKc)
+        {
+            pskc = std::vector<uint8_t>(std::begin(mNetworkInfo.ThreadPSKc), std::end(mNetworkInfo.ThreadPSKc));
+        }
+        if (mNetworkInfo.ThreadChannel != Internal::kThreadChannel_NotSpecified)
+        {
+            channelMask = 1 << mNetworkInfo.ThreadChannel;
+        }
+
+        if (mNetworkInfo.FieldPresent.ThreadMeshPrefix)
+        {
+            std::array<uint8_t, Internal::kThreadMeshPrefixLength> prefix;
+
+            std::copy(std::begin(mNetworkInfo.ThreadMeshPrefix), std::end(mNetworkInfo.ThreadMeshPrefix), std::begin(prefix));
+            SuccessOrExit(error = mThreadApi->SetMeshLocalPrefix(prefix));
+        }
+
+        mThreadApi->Attach(mNetworkInfo.ThreadNetworkName, mNetworkInfo.ThreadPANId, extPanId, masterkey, pskc, channelMask,
+                           [](ClientError result) { ChipLogProgress(DeviceLayer, "Thread attach result %d", result); });
+    }
+    else
+    {
+        mThreadApi->Reset();
+    }
+exit:
+    LogClientError(error);
+    return OTBR_TO_CHIP_ERROR(error);
+}
+
+ConnectivityManager::ThreadDeviceType ThreadStackManagerImpl::_GetThreadDeviceType()
+{
+    ClientError error;
+    DeviceRole role;
+    LinkModeConfig linkMode;
+    ConnectivityManager::ThreadDeviceType type = ConnectivityManager::ThreadDeviceType::kThreadDeviceType_NotSupported;
+
+    SuccessOrExit(error = mThreadApi->GetDeviceRole(role));
+
+    switch (role)
+    {
+    case DeviceRole::OTBR_DEVICE_ROLE_DISABLED:
+    case DeviceRole::OTBR_DEVICE_ROLE_DETACHED:
+        break;
+    case DeviceRole::OTBR_DEVICE_ROLE_CHILD:
+        SuccessOrExit(error = mThreadApi->GetLinkMode(linkMode));
+        if (!linkMode.mRxOnWhenIdle)
+        {
+            type = ConnectivityManager::ThreadDeviceType::kThreadDeviceType_SleepyEndDevice;
+        }
+        else
+        {
+            type = linkMode.mDeviceType ? ConnectivityManager::ThreadDeviceType::kThreadDeviceType_FullEndDevice
+                                        : ConnectivityManager::ThreadDeviceType::kThreadDeviceType_MinimalEndDevice;
+        }
+    case DeviceRole::OTBR_DEVICE_ROLE_ROUTER:
+    case DeviceRole::OTBR_DEVICE_ROLE_LEADER:
+        type = ConnectivityManager::ThreadDeviceType::kThreadDeviceType_Router;
+    default:
+        break;
+    }
+
+exit:
+    LogClientError(error);
+    return type;
+}
+
+CHIP_ERROR ThreadStackManagerImpl::_SetThreadDeviceType(ConnectivityManager::ThreadDeviceType deviceType)
+{
+    LinkModeConfig linkMode{ true, true, true, true };
+    ClientError error = ClientError::ERROR_NONE;
+
+    if (deviceType == ConnectivityManager::ThreadDeviceType::kThreadDeviceType_MinimalEndDevice)
+    {
+        linkMode.mNetworkData = false;
+    }
+    else if (deviceType == ConnectivityManager::ThreadDeviceType::kThreadDeviceType_SleepyEndDevice)
+    {
+        linkMode.mRxOnWhenIdle = false;
+        linkMode.mNetworkData  = false;
+    }
+
+    if (!linkMode.mNetworkData)
+    {
+        error = mThreadApi->SetLinkMode(linkMode);
+    }
+
+    LogClientError(error);
+    return OTBR_TO_CHIP_ERROR(error);
+}
+
+void ThreadStackManagerImpl::_GetThreadPollingConfig(ConnectivityManager::ThreadPollingConfig & pollingConfig)
+{
+    (void) pollingConfig;
+
+    ChipLogError(DeviceLayer, "Polling config is not supported on linux");
+}
+
+CHIP_ERROR ThreadStackManagerImpl::_SetThreadPollingConfig(const ConnectivityManager::ThreadPollingConfig & pollingConfig)
+{
+    (void) pollingConfig;
+
+    ChipLogError(DeviceLayer, "Polling config is not supported on linux");
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+bool ThreadStackManagerImpl::_HaveMeshConnectivity()
+{
+    DeviceRole role;
+    ClientError error;
+    bool hasConnectivity = false;
+    std::vector<NeighborInfo> neighbors;
+
+    SuccessOrExit(error = mThreadApi->GetDeviceRole(role));
+    VerifyOrExit(role != DeviceRole::OTBR_DEVICE_ROLE_DETACHED && role != DeviceRole::OTBR_DEVICE_ROLE_DISABLED, );
+    if (role == DeviceRole::OTBR_DEVICE_ROLE_CHILD || role == DeviceRole::OTBR_DEVICE_ROLE_ROUTER)
+    {
+        hasConnectivity = true;
+    }
+
+    SuccessOrExit(error = mThreadApi->GetNeighborTable(neighbors));
+    for (const auto & neighbor : neighbors)
+    {
+        if (!neighbor.mIsChild)
+        {
+            hasConnectivity = true;
+            break;
+        }
+    }
+
+exit:
+    LogClientError(error);
+    return hasConnectivity;
+}
+
+void ThreadStackManagerImpl::_OnMessageLayerActivityChanged(bool messageLayerIsActive)
+{
+    (void) messageLayerIsActive;
+}
+
+void ThreadStackManagerImpl::_OnCHIPoBLEAdvertisingStart() {}
+
+void ThreadStackManagerImpl::_OnCHIPoBLEAdvertisingStop() {}
+
+CHIP_ERROR ThreadStackManagerImpl::_GetAndLogThreadStatsCounters()
+{
+    // TODO: implement after we decide on the profiling protocol
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ThreadStackManagerImpl::_GetAndLogThreadTopologyMinimal()
+{
+    // TODO: implement after we decide on the profiling protocol
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ThreadStackManagerImpl::_GetAndLogThreadTopologyFull()
+{
+    // TODO: implement after we decide on the profiling protocol
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ThreadStackManagerImpl::_GetPrimary802154MACAddress(uint8_t * buf)
+{
+    uint64_t extAddr;
+    ClientError error;
+    SuccessOrExit(error = mThreadApi->GetExtendedAddress(extAddr));
+
+    for (size_t i = 0; i < sizeof(extAddr); i++)
+    {
+        buf[sizeof(uint64_t) - i - 1] = (extAddr & UINT8_MAX);
+        extAddr >>= UINT8_MAX;
+    }
+
+exit:
+    LogClientError(error);
+    return OTBR_TO_CHIP_ERROR(error);
+}
+
+// TODO: Implement after we decide on the dbus message loop
+extern ThreadStackManager & ThreadStackMgr(void);
+
+// TODO: Implement after we decide on the dbus message loop
+extern ThreadStackManagerImpl & ThreadStackMgrImpl(void);
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -1,0 +1,100 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef CHIP_PLATFORM_LINUX_THREAD_STACK_MANAGER_IMPL_H
+#define CHIP_PLATFORM_LINUX_THREAD_STACK_MANAGER_IMPL_H
+
+#include <memory>
+
+#include "platform/internal/CHIPDeviceLayerInternal.h"
+
+#include "dbus/client/thread_api_dbus.hpp"
+#include "platform/internal/DeviceNetworkInfo.h"
+
+namespace chip {
+namespace DeviceLayer {
+
+class ThreadStackManagerImpl : public ThreadStackManager
+{
+public:
+    ThreadStackManagerImpl();
+
+    CHIP_ERROR _InitThreadStack();
+    CHIP_ERROR _ProcessThreadActivity();
+
+    CHIP_ERROR _StartThreadTask() { return CHIP_NO_ERROR; }    // Intentionally left blank
+    CHIP_ERROR _LockThreadStack() { return CHIP_NO_ERROR; }    // Intentionally left blank
+    CHIP_ERROR _TryLockThreadStack() { return CHIP_NO_ERROR; } // Intentionally left blank
+    CHIP_ERROR _UnlockThreadStack() { return CHIP_NO_ERROR; }  // Intentionally left blank
+
+    bool _HaveRouteToAddress(const Inet::IPAddress & destAddr);
+
+    void _OnPlatformEvent(const ChipDeviceEvent * event);
+
+    CHIP_ERROR _GetThreadProvision(Internal::DeviceNetworkInfo & netInfo, bool includeCredentials);
+
+    CHIP_ERROR _SetThreadProvision(const Internal::DeviceNetworkInfo & netInfo);
+
+    void _ClearThreadProvision();
+
+    bool _IsThreadProvisioned();
+
+    bool _IsThreadEnabled();
+
+    bool _IsThreadAttached();
+
+    CHIP_ERROR _SetThreadEnabled(bool val);
+
+    ConnectivityManager::ThreadDeviceType _GetThreadDeviceType();
+
+    CHIP_ERROR _SetThreadDeviceType(ConnectivityManager::ThreadDeviceType deviceType);
+
+    void _GetThreadPollingConfig(ConnectivityManager::ThreadPollingConfig & pollingConfig);
+
+    CHIP_ERROR _SetThreadPollingConfig(const ConnectivityManager::ThreadPollingConfig & pollingConfig);
+
+    bool _HaveMeshConnectivity();
+
+    void _OnMessageLayerActivityChanged(bool messageLayerIsActive);
+
+    void _OnCHIPoBLEAdvertisingStart();
+
+    void _OnCHIPoBLEAdvertisingStop();
+
+    CHIP_ERROR _GetAndLogThreadStatsCounters();
+
+    CHIP_ERROR _GetAndLogThreadTopologyMinimal();
+
+    CHIP_ERROR _GetAndLogThreadTopologyFull();
+
+    CHIP_ERROR _GetPrimary802154MACAddress(uint8_t * buf);
+
+    ~ThreadStackManagerImpl() = default;
+
+private:
+    void _ThreadDevcieRoleChangedHandler(otbr::DBus::DeviceRole role);
+
+    std::unique_ptr<otbr::DBus::ThreadApiDBus> mThreadApi;
+    DBusConnection * mConnection;
+    Internal::DeviceNetworkInfo mNetworkInfo;
+    bool mAttached;
+};
+
+} // namespace DeviceLayer
+} // namespace chip
+
+#endif // CHIP_PLATFORM_LINUX_THREAD_STACK_MANAGER_IMPL_H

--- a/src/platform/Linux/ThreadStackManagerTest.cpp
+++ b/src/platform/Linux/ThreadStackManagerTest.cpp
@@ -1,0 +1,4 @@
+int main()
+{
+    return 0;
+}

--- a/src/platform/Linux/otbr_client_test.cpp
+++ b/src/platform/Linux/otbr_client_test.cpp
@@ -1,0 +1,188 @@
+/*
+ *    Copyright (c) 2020, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <memory>
+
+#include <dbus/dbus.h>
+
+#include "dbus/client/thread_api_dbus.hpp"
+#include "dbus/common/constants.hpp"
+
+using otbr::DBus::ActiveScanResult;
+using otbr::DBus::ClientError;
+using otbr::DBus::DeviceRole;
+using otbr::DBus::ExternalRoute;
+using otbr::DBus::Ip6Prefix;
+using otbr::DBus::LinkModeConfig;
+using otbr::DBus::OnMeshPrefix;
+using otbr::DBus::ThreadApiDBus;
+
+struct DBusConnectionDeleter
+{
+    void operator()(DBusConnection *aConnection) { dbus_connection_unref(aConnection); }
+};
+
+using UniqueDBusConnection = std::unique_ptr<DBusConnection, DBusConnectionDeleter>;
+
+static bool operator==(const otbr::DBus::Ip6Prefix &aLhs, const otbr::DBus::Ip6Prefix &aRhs)
+{
+    bool prefixDataEquality = (aLhs.mPrefix.size() == aRhs.mPrefix.size()) &&
+                              (memcmp(&aLhs.mPrefix[0], &aRhs.mPrefix[0], aLhs.mPrefix.size()) == 0);
+
+    return prefixDataEquality && aLhs.mLength == aRhs.mLength;
+}
+
+static void CheckExternalRoute(ThreadApiDBus *aApi, const Ip6Prefix &aPrefix)
+{
+    ExternalRoute              route;
+    std::vector<ExternalRoute> externalRouteTable;
+
+    route.mPrefix     = aPrefix;
+    route.mStable     = true;
+    route.mPreference = 0;
+
+    assert(aApi->AddExternalRoute(route) == OTBR_ERROR_NONE);
+    assert(aApi->GetExternalRoutes(externalRouteTable) == OTBR_ERROR_NONE);
+    assert(externalRouteTable.size() == 1);
+    assert(externalRouteTable[0].mPrefix == aPrefix);
+    assert(externalRouteTable[0].mPreference == 0);
+    assert(externalRouteTable[0].mStable);
+    assert(externalRouteTable[0].mNextHopIsThisDevice);
+    assert(aApi->RemoveExternalRoute(aPrefix) == OTBR_ERROR_NONE);
+}
+
+int main()
+{
+    DBusError                      error;
+    UniqueDBusConnection           connection;
+    std::unique_ptr<ThreadApiDBus> api;
+    uint64_t                       extpanid = 0xdead00beaf00cafe;
+
+    dbus_error_init(&error);
+    connection = UniqueDBusConnection(dbus_bus_get(DBUS_BUS_SYSTEM, &error));
+
+    VerifyOrExit(connection != nullptr);
+
+    VerifyOrExit(dbus_bus_register(connection.get(), &error) == true);
+
+    api = std::unique_ptr<ThreadApiDBus>(new ThreadApiDBus(connection.get()));
+
+    api->AddDeviceRoleHandler(
+        [](DeviceRole aRole) { printf("Device role changed to %d\n", static_cast<uint8_t>(aRole)); });
+
+    api->Scan([&api, extpanid](const std::vector<ActiveScanResult> &aResult) {
+        LinkModeConfig cfg = {true, true, false, true};
+
+        for (auto &&result : aResult)
+        {
+            printf("%s channel %d rssi %d\n", result.mNetworkName.c_str(), result.mChannel, result.mRssi);
+        }
+
+        api->SetLinkMode(cfg);
+        api->GetLinkMode(cfg);
+        printf("LinkMode %d %d %d %d\n", cfg.mRxOnWhenIdle, cfg.mSecureDataRequests, cfg.mDeviceType, cfg.mNetworkData);
+
+        cfg.mDeviceType = true;
+        api->SetLinkMode(cfg);
+
+        api->Attach("Test", 0x3456, extpanid, {}, {}, UINT32_MAX, [&api, extpanid](ClientError aError) {
+            printf("Attach result %d\n", static_cast<int>(aError));
+            uint64_t extpanidCheck;
+            if (aError == OTBR_ERROR_NONE)
+            {
+                std::string                           name;
+                uint64_t                              extAddress = 0;
+                uint16_t                              rloc16     = 0xffff;
+                uint8_t                               routerId;
+                std::vector<uint8_t>                  networkData;
+                std::vector<uint8_t>                  stableNetworkData;
+                otbr::DBus::LeaderData                leaderData;
+                uint8_t                               leaderWeight;
+                int8_t                                rssi;
+                int8_t                                txPower;
+                std::vector<otbr::DBus::ChildInfo>    childTable;
+                std::vector<otbr::DBus::NeighborInfo> neighborTable;
+                uint32_t                              partitionId;
+                Ip6Prefix                             prefix;
+                OnMeshPrefix                          onMeshPrefix = {};
+
+                prefix.mPrefix = {0xfd, 0xcd, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
+                prefix.mLength = 64;
+
+                onMeshPrefix.mPrefix     = prefix;
+                onMeshPrefix.mPreference = 0;
+                onMeshPrefix.mStable     = true;
+
+                assert(api->GetNetworkName(name) == OTBR_ERROR_NONE);
+                assert(api->GetExtPanId(extpanidCheck) == OTBR_ERROR_NONE);
+                assert(api->GetRloc16(rloc16) == OTBR_ERROR_NONE);
+                assert(api->GetExtendedAddress(extAddress) == OTBR_ERROR_NONE);
+                assert(api->GetRouterId(routerId) == OTBR_ERROR_NONE);
+                assert(api->GetLeaderData(leaderData) == OTBR_ERROR_NONE);
+                assert(api->GetNetworkData(networkData) == OTBR_ERROR_NONE);
+                assert(api->GetStableNetworkData(stableNetworkData) == OTBR_ERROR_NONE);
+                assert(api->GetLocalLeaderWeight(leaderWeight) == OTBR_ERROR_NONE);
+                assert(api->GetChildTable(childTable) == OTBR_ERROR_NONE);
+                assert(api->GetNeighborTable(neighborTable) == OTBR_ERROR_NONE);
+                assert(api->GetPartitionId(partitionId) == OTBR_ERROR_NONE);
+                assert(api->GetInstantRssi(rssi) == OTBR_ERROR_NONE);
+                assert(api->GetRadioTxPower(txPower) == OTBR_ERROR_NONE);
+                CheckExternalRoute(api.get(), prefix);
+                assert(api->AddOnMeshPrefix(onMeshPrefix) == OTBR_ERROR_NONE);
+                assert(api->RemoveOnMeshPrefix(onMeshPrefix.mPrefix) == OTBR_ERROR_NONE);
+                api->FactoryReset(nullptr);
+                assert(api->GetNetworkName(name) == OTBR_ERROR_NONE);
+                assert(rloc16 != 0xffff);
+                assert(extAddress != 0);
+                assert(routerId == leaderData.mLeaderRouterId);
+                assert(!networkData.empty());
+                assert(childTable.empty());
+                assert(neighborTable.empty());
+            }
+            if (aError != OTBR_ERROR_NONE || extpanidCheck != extpanid)
+            {
+                exit(-1);
+            }
+            api->Attach("Test", 0x3456, extpanid, {}, {}, UINT32_MAX,
+                        [](ClientError aErr) { exit(static_cast<uint8_t>(aErr)); });
+        });
+    });
+
+    while (true)
+    {
+        dbus_connection_read_write_dispatch(connection.get(), 0);
+    }
+
+exit:
+    dbus_error_free(&error);
+    return 0;
+};

--- a/src/platform/Makefile.am
+++ b/src/platform/Makefile.am
@@ -130,6 +130,13 @@ libDeviceLayer_a_SOURCES               += \
     Linux/PosixConfig.cpp                 \
     Linux/PlatformManagerImpl.cpp         \
     Linux/SystemTimeSupport.cpp           \
+    Linux/ThreadStackManagerImpl.cpp      \
+    $(NULL)
+
+libDeviceLayer_a_CPPFLAGS              += \
+    -I$(top_srcdir)/third_party/ot-br-posix/repo/include    \
+    -I$(top_srcdir)/third_party/ot-br-posix/repo/src        \
+    $(DBUS_CFLAGS)                                          \
     $(NULL)
 
 endif # CHIP_DEVICE_LAYER_TARGET_LINUX
@@ -186,5 +193,34 @@ libDeviceLayer_a_SOURCES               +=       \
 endif # CHIP_DEVICE_LAYER_TARGET_ESP32
 
 endif # CONFIG_DEVICE_LAYER
+
+bin_PROGRAMS = otbr_client_test
+
+otbr_client_test_SOURCES = Linux/ThreadStackManagerTest.cpp
+
+otbr_client_test_CPPFLAGS = \
+    -I$(top_srcdir)/src/include           \
+    -I$(top_srcdir)/src/lib               \
+    -I$(top_srcdir)/src/system            \
+    -I$(top_srcdir)/src                   \
+    -I$(top_srcdir)/third_party/ot-br-posix/repo/include    \
+    -I$(top_srcdir)/third_party/ot-br-posix/repo/src        \
+    $(DBUS_CFLAGS)                                          \
+    $(NLASSERT_CPPFLAGS)                  \
+    $(NLIO_CPPFLAGS)                      \
+    $(LWIP_CPPFLAGS)                      \
+    $(SOCKETS_CPPFLAGS)                   \
+    $(NULL)
+
+otbr_client_test_LDADD = \
+    $(top_builddir)/src/platform/libDeviceLayer.a \
+    $(top_builddir)/src/inet/libInetLayer.a       \
+    $(top_builddir)/src/system/libSystemLayer.a   \
+    $(top_builddir)/src/lib/support/libSupportLayer.a   \
+    $(NLFAULTINJECTION_LDFLAGS) $(NLFAULTINJECTION_LIBS)\
+    $(top_builddir)/third_party/ot-br-posix/libotbrclient.a \
+    $(DBUS_LIBS)                                            \
+    -lpthread                                               \
+    $(NULL)
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/platform/tests/Makefile.am
+++ b/src/platform/tests/Makefile.am
@@ -43,6 +43,7 @@ lib_LIBRARIES                                  = \
 libPlatformTests_a_SOURCES                     = \
     TestPlatformMgr.cpp                          \
     TestPlatformTime.cpp                         \
+    TestThreadStackMgr.cpp                       \
     $(NULL)
 
 libPlatformTests_adir                          = $(includedir)/platform
@@ -66,12 +67,27 @@ AM_CPPFLAGS                                    = \
     $(NLUNIT_TEST_CPPFLAGS)                      \
     $(NULL)
 
+if CHIP_DEVICE_LAYER_TARGET_LINUX
+AM_CPPFLAGS                                   += \
+    $(DBUS_CFLAGS)                               \
+    -I$(top_srcdir)/third_party/ot-br-posix/repo/include    \
+    -I$(top_srcdir)/third_party/ot-br-posix/repo/src        \
+    $(NULL)
+endif
+
 CHIP_LDADD                                      = \
     $(top_builddir)/src/platform/libDeviceLayer.a \
     $(top_builddir)/src/inet/libInetLayer.a       \
     $(top_builddir)/src/system/libSystemLayer.a   \
     $(top_builddir)/src/lib/support/libSupportLayer.a   \
     $(NULL)
+
+if CHIP_DEVICE_LAYER_TARGET_LINUX
+CHIP_LDADD                                    += \
+    $(DBUS_LIBS)                                 \
+    $(top_builddir)/third_party/ot-br-posix/libotbrclient.a \
+    $(NULL)
+endif
 
 COMMON_LDADD                                          = \
     libPlatformTests.a                                  \
@@ -88,6 +104,7 @@ COMMON_LDADD                                          = \
 check_PROGRAMS                                 = \
     TestPlatformTime                             \
     TestPlatformMgr                              \
+    TestThreadStackMgr                           \
     $(NULL)
 
 # Test applications and scripts that should be built and run when the
@@ -110,6 +127,9 @@ TestPlatformTime_SOURCES                       = TestPlatformTimeDriver.cpp
 
 TestPlatformMgr_LDADD                          = $(COMMON_LDADD)
 TestPlatformMgr_SOURCES                        = TestPlatformMgrDriver.cpp
+
+TestThreadStackMgr_LDADD                       = $(COMMON_LDADD)
+TestThreadStackMgr_SOURCES                     = TestThreadStackMgrDriver.cpp
 
 #
 # Foreign make dependencies

--- a/src/platform/tests/TestThreadStackMgr.cpp
+++ b/src/platform/tests/TestThreadStackMgr.cpp
@@ -1,0 +1,32 @@
+#include "platform/internal/CHIPDeviceLayerInternal.h"
+
+#include "platform/ThreadStackManager.h"
+#include "platform/PlatformManager.h"
+
+int TestThreadStackManager(void)
+{
+    chip::DeviceLayer::ThreadStackManagerImpl impl;
+    chip::DeviceLayer::Internal::DeviceNetworkInfo info;
+    uint16_t masterKey[16] = { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff };
+
+    strncpy(info.ThreadNetworkName, "CHIP-TEST", sizeof(info.ThreadNetworkName));
+    info.ThreadChannel                    = UINT8_MAX;
+    info.ThreadPANId                      = 0x3455;
+    info.FieldPresent.ThreadExtendedPANId = false;
+    info.FieldPresent.ThreadMeshPrefix    = false;
+    info.FieldPresent.ThreadPSKc          = false;
+    memcpy(&info.ThreadNetworkKey, &masterKey, sizeof(masterKey));
+
+    chip::DeviceLayer::PlatformMgrImpl().InitChipStack();
+
+    impl.InitThreadStack();
+    impl.StartThreadTask();
+    impl._SetThreadProvision(info);
+    impl._SetThreadEnabled(true);
+
+    printf("Start Thread task done\n");
+
+    //chip::DeviceLayer::PlatformMgrImpl().RunEventLoop();
+
+    return 0;
+}

--- a/src/platform/tests/TestThreadStackMgr.h
+++ b/src/platform/tests/TestThreadStackMgr.h
@@ -1,0 +1,29 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file declares test entry point for CHIP Platform Manager code unit tests.
+ *
+ */
+
+#ifndef CHIP_TEST_THREAD_STACK_MGR_H
+#define CHIP_TEST_THREAD_STACK_MGR_H
+
+int TestThreadStackManager(void);
+
+#endif // CHIP_TEST_THREAD_STACK_MGR_H 

--- a/src/platform/tests/TestThreadStackMgrDriver.cpp
+++ b/src/platform/tests/TestThreadStackMgrDriver.cpp
@@ -1,0 +1,6 @@
+#include "TestThreadStackMgr.h"
+
+int main()
+{
+    TestThreadStackManager();
+}

--- a/third_party/Makefile.am
+++ b/third_party/Makefile.am
@@ -33,6 +33,7 @@ EXTRA_DIST                                   = \
 DIST_SUBDIRS                                 = \
     lwip                                       \
     mbedtls                                    \
+    ot-br-posix                                \
     $(NULL)
 
 # <any of the third-party packages listed in repos.conf>_SUBDIRS are
@@ -42,7 +43,7 @@ DIST_SUBDIRS                                 = \
 # of the 'distclean' target. Consequently, we conditionally include
 # them in DIST_SUBDIRS on invocation of 'distclean-recursive'
 
-distclean-recursive: DIST_SUBDIRS += $(NLASSERT_SUBDIRS) $(NLFAULTINJECTION_SUBDIRS) $(NLIO_SUBDIRS) $(NLUNIT_TEST_SUBDIRS) $(MBEDTLS_SUBDIRS)
+distclean-recursive: DIST_SUBDIRS += $(NLASSERT_SUBDIRS) $(NLFAULTINJECTION_SUBDIRS) $(NLIO_SUBDIRS) $(NLUNIT_TEST_SUBDIRS) $(MBEDTLS_SUBDIRS) $(OTBRCLIENT_SUBDIRS)
 
 # Always build (e.g. for 'make all') these subdirectories.
 #
@@ -56,6 +57,7 @@ SUBDIRS                                      = \
     $(NLIO_SUBDIRS)                            \
     $(NLUNIT_TEST_SUBDIRS)                     \
     $(MBEDTLS_SUBDIRS)                         \
+    $(OTBRCLIENT_SUBDIRS)                      \
     $(NULL)
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/third_party/ot-br-posix/Makefile.am
+++ b/third_party/ot-br-posix/Makefile.am
@@ -1,0 +1,47 @@
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+
+#
+#    Description:
+#      This file is the GNU automake template for the CHIP in-package,
+#      otbr clientlibrary.
+#
+#
+
+include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
+
+if CHIP_WITH_OTBRCLIENT_INTERNAL
+
+lib_LIBRARIES = libotbrclient.a
+
+nodist_libotbrclient_a_SOURCES                            = \
+    repo/src/dbus/client/client_error.cpp                   \
+    repo/src/dbus/client/thread_api_dbus.cpp                \
+    repo/src/dbus/common/error.cpp                          \
+    repo/src/dbus/common/dbus_message_helper.cpp            \
+    repo/src/dbus/common/dbus_message_helper_openthread.cpp \
+    $(NULL)
+
+libotbrclient_a_CPPFLAGS                                  = \
+    -I$(top_srcdir)/third_party/ot-br-posix/repo/include    \
+    -I$(top_srcdir)/third_party/ot-br-posix/repo/src        \
+    $(OTBRCLIENT_CPPFLAGS)                                  \
+    $(DBUS_CFLAGS)                                          \
+    $(NULL)
+
+endif # CHIP_WITH_OTBRCLIENT_INTERNAL
+
+include $(abs_top_nlbuild_autotools_dir)/automake/post.am


### PR DESCRIPTION
 #### Problem
This PR adds ThreadStack manager in the linux device layer.
It relies on [otbr-agent](https://github.com/openthread/ot-br-posix) as the Thread daemon.

 #### Summary of Changes

* Implementation of ThreadStackManager
* DBus connection driver in the event loop
* Functional tests for ThreadStackManager

fixes https://github.com/project-chip/connectedhomeip/issues/740
