### PR TITLE
Add a "TimeSource" class 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,12 @@ jobs:
     - run:
         command: scripts/tests/esp32_qemu_tests.sh
         name: Build ESP32 QEMU and Run Tests
+    - run:
+        command: scripts/tests/save_logs.sh /tmp/test_logs
+        name: Save test log files
+        when: on_fail
+    - store_artifacts:
+        path: /tmp/test_logs
   Build CHIP [mbedtls-build]:
     docker:
     - image: connectedhomeip/chip-build:0.2.14

--- a/.circleci/config/jobs/test_esp32_qemu.yml
+++ b/.circleci/config/jobs/test_esp32_qemu.yml
@@ -6,3 +6,9 @@ steps:
     - run:
           name: Build ESP32 QEMU and Run Tests
           command: scripts/tests/esp32_qemu_tests.sh
+    - run:
+          name: Save test log files
+          command: scripts/tests/save_logs.sh /tmp/test_logs
+          when: on_fail
+    - store_artifacts:
+          path: /tmp/test_logs

--- a/src/system/SystemLayer.am
+++ b/src/system/SystemLayer.am
@@ -50,4 +50,5 @@ CHIP_BUILD_SYSTEM_LAYER_HEADER_FILES                  = \
     @top_builddir@/src/system/SystemObject.h            \
     @top_builddir@/src/system/SystemTimer.h             \
     @top_builddir@/src/system/SystemPacketBuffer.h      \
+    @top_builddir@/src/system/TimeSource.h              \
     $(NULL)

--- a/src/system/TimeSource.h
+++ b/src/system/TimeSource.h
@@ -1,0 +1,90 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @brief defines a generic time source interface that uses a real clock
+ *        at runtime but can be substituted by a test one for unit tests.
+ */
+#ifndef TIME_SOURCE_H_
+#define TIME_SOURCE_H_
+
+#include <system/SystemClock.h>
+
+namespace chip {
+namespace Time {
+
+enum class Source
+{
+    kSystem, // System time source
+    kTest,   // Test time source
+};
+
+/**
+ * Defines a generic time source within a system. System time and test times
+ * are available.
+ */
+template <Source kSource>
+class TimeSource
+{
+public:
+    /**
+     * Returns a monotonically increasing time in milliseconds since an arbitrary, platform-defined
+     * epoch.
+     *
+     * Maintains requirements for the System::Platform::Layer clock implementation:
+     *
+     *  - Return a value that is ever-increasing (i.e. never * wraps) between reboots of the system.
+     *  - The underlying time source is required to tick continuously during any system sleep modes
+     *    such that the values do not entail a restart upon wake.
+     *  - This function is expected to be thread-safe on any platform that employs threading.
+     */
+    uint64_t GetCurrentMonotonicTimeMs();
+};
+
+/**
+ * A system time source, based on the system platform layer.
+ */
+template <>
+class TimeSource<Source::kSystem>
+{
+public:
+    uint64_t GetCurrentMonotonicTimeMs() { return System::Platform::Layer::GetClock_MonotonicMS(); }
+};
+
+/**
+ * A test time source. Allows setting the current time.
+ */
+template <>
+class TimeSource<Source::kTest>
+{
+public:
+    uint64_t GetCurrentMonotonicTimeMs() { return mCurrentTimeMs; }
+
+    void SetCurrentMonotonicTimeMs(uint64_t value)
+    {
+        VerifyOrDie(value >= mCurrentTimeMs); // required contract
+        mCurrentTimeMs = value;
+    }
+
+private:
+    uint64_t mCurrentTimeMs = 0;
+};
+
+} // namespace Time
+} // namespace chip
+
+#endif // TIME_SOURCE_H_

--- a/src/system/tests/Makefile.am
+++ b/src/system/tests/Makefile.am
@@ -47,6 +47,7 @@ libSystemLayerTests_a_SOURCES                         = \
     TestSystemObject.cpp                                \
     TestSystemPacketBuffer.cpp                          \
     TestSystemTimer.cpp                                 \
+    TestTimeSource.cpp                                  \
     $(NULL)
 
 libSystemLayerTests_adir                              = $(includedir)/system
@@ -118,6 +119,7 @@ check_PROGRAMS                                       += \
     TestSystemObject                                    \
     TestSystemPacketBuffer                              \
     TestSystemTimer                                     \
+    TestTimeSource                                      \
     $(NULL)
 
 endif # CHIP_DEVICE_LAYER_TARGET_ESP32
@@ -143,6 +145,9 @@ TestSystemPacketBuffer_LDADD                          = $(COMMON_LDADD)
 
 TestSystemTimer_SOURCES                               = TestSystemTimerDriver.cpp
 TestSystemTimer_LDADD                                 = $(COMMON_LDADD)
+
+TestTimeSource_SOURCES                               = TestTimeSourceDriver.cpp
+TestTimeSource_LDADD                                 = $(COMMON_LDADD)
 
 #
 # Foreign make dependencies

--- a/src/system/tests/TestTimeSource.cpp
+++ b/src/system/tests/TestTimeSource.cpp
@@ -1,0 +1,98 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @file
+ *    This is a unit test suite for <tt>chip::Time::TimeSource</tt>. Tests mainly
+ *    the ability to compile and use the test implementation of the time source.
+ */
+
+#ifndef __STDC_LIMIT_MACROS
+#define __STDC_LIMIT_MACROS
+#endif
+// config
+#include <system/SystemConfig.h>
+
+// module header
+#include "TestSystemLayer.h"
+
+#include <nlunit-test.h>
+#include <support/CodeUtils.h>
+#include <support/ErrorStr.h>
+#include <support/TestUtils.h>
+#include <system/TimeSource.h>
+
+namespace {
+
+void TestTimeSourceSetAndGet(nlTestSuite * inSuite, void * inContext)
+{
+
+    chip::Time::TimeSource<chip::Time::Source::kTest> source;
+
+    NL_TEST_ASSERT(inSuite, source.GetCurrentMonotonicTimeMs() == 0);
+
+    source.SetCurrentMonotonicTimeMs(1234);
+    NL_TEST_ASSERT(inSuite, source.GetCurrentMonotonicTimeMs() == 1234);
+}
+
+void SystemTimeSourceGet(nlTestSuite * inSuite, void * inContext)
+{
+
+    chip::Time::TimeSource<chip::Time::Source::kSystem> source;
+
+    uint64_t oldValue = source.GetCurrentMonotonicTimeMs();
+
+    // a basic monotonic test. This is likely to take less than 1ms, so the
+    // actual test value lies mostly in ensuring things compile.
+    for (int i = 0; i < 100; i++)
+    {
+        uint64_t newValue = source.GetCurrentMonotonicTimeMs();
+        NL_TEST_ASSERT(inSuite, newValue >= oldValue);
+        oldValue = newValue;
+    }
+}
+
+} // namespace
+
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+// clang-format off
+static const nlTest sTests[] =
+{
+    NL_TEST_DEF("TimeSource<Test>::SetAndGet", TestTimeSourceSetAndGet),
+    NL_TEST_DEF("TimeSource<System>::SetAndGet", SystemTimeSourceGet),
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+int TestTimeSource(void)
+{
+    nlTestSuite theSuite = {
+        "chip-timesource", &sTests[0], NULL /* setup */, NULL /* teardown */
+    };
+
+    // Run test suit againt one context.
+    nlTestRunner(&theSuite, NULL /* context */);
+
+    return (nlTestRunnerStats(&theSuite));
+}
+
+static void __attribute__((constructor)) TestTimeSourceCtor(void)
+{
+    VerifyOrDie(chip::RegisterUnitTests(&TestSystemPacketBuffer) == CHIP_NO_ERROR);
+}

--- a/src/system/tests/TestTimeSource.cpp
+++ b/src/system/tests/TestTimeSource.cpp
@@ -94,5 +94,5 @@ int TestTimeSource(void)
 
 static void __attribute__((constructor)) TestTimeSourceCtor(void)
 {
-    VerifyOrDie(chip::RegisterUnitTests(&TestSystemPacketBuffer) == CHIP_NO_ERROR);
+    VerifyOrDie(chip::RegisterUnitTests(&TestTimeSource) == CHIP_NO_ERROR);
 }

--- a/src/system/tests/TestTimeSourceDriver.cpp
+++ b/src/system/tests/TestTimeSourceDriver.cpp
@@ -17,26 +17,20 @@
 
 /**
  *    @file
- *      This file declares test entry points for CHIP system layer
- *      library unit tests.
+ *      This file implements a standalone/native program executable
+ *      test driver for the CHIP system layer library timer unit
+ *      tests.
  *
  */
 
-#ifndef TESTSYSTEMLAYER_H
-#define TESTSYSTEMLAYER_H
+#include "TestSystemLayer.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include <nlunit-test.h>
 
-int TestSystemErrorStr(void);
-int TestSystemObject(void);
-int TestSystemPacketBuffer(void);
-int TestSystemTimer(void);
-int TestTimeSource(void);
+int main(int argc, char * argv[])
+{
+    // Generate machine-readable, comma-separated value (CSV) output.
+    nlTestSetOutputStyle(OUTPUT_CSV);
 
-#ifdef __cplusplus
+    return TestTimeSource();
 }
-#endif
-
-#endif // TESTSYSTEMLAYER_H


### PR DESCRIPTION
 #### Problem
System layer time source is a 'real' time source, making it hard to unit test time-dependent things. I would like to implement connection expiring logic, and controlling system time seems very useful in those instances.

 #### Summary of Changes
Adds a templated 'time source' class which can be switched to either the test time source or keep using the system time.

This was my first idea, but it will start propagating templates around. if there are other suggestions to be able to control time for tests (maybe weak linkage or maybe our extern timesources could be swizzled at link time) please let me know. I find this should be clean enough, but if other methods are considered cleaner I would be interested to see them. This should have been a problem already in all other projects that handle time.

This is working towards #1088
fixes #1156 because I had qemu errors and I needed to see what failed.