### PR TITLE
Fix iOS app info message for encryption switch toggle

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/CHIPViewControllerBase.m
+++ b/src/darwin/CHIPTool/CHIPTool/CHIPViewControllerBase.m
@@ -144,10 +144,10 @@ static NSString * const ipKey = @"ipk";
 {
     if ([self.encryptionKeySwitch isOn]) {
         self.useIncorrectKey = YES;
-        [self postResult:@"App will use correct key"];
+        [self postResult:@"App will use incorrect key"];
     } else {
         self.useIncorrectKey = NO;
-        [self postResult:@"App will use incorrect key"];
+        [self postResult:@"App will use correct key"];
     }
     self.useIncorrectKeyStateChanged = YES;
 }


### PR DESCRIPTION
 #### Problem
The information message in the iOS app is incorrect, since we reversed the meaning of the switch.

 #### Summary of Changes
Fix the message to match the switch.