### PR TITLE
Create a basic allocation pool for usage outside the system layer

### DIFF
--- a/src/lib/core/AllocationPool.h
+++ b/src/lib/core/AllocationPool.h
@@ -1,0 +1,182 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @file Defines an allocation pool for objects.
+ */
+
+#ifndef ALLOCATION_POOL_H_
+#define ALLOCATION_POOL_H_
+
+#include <cstdint>
+#include <new>
+#include <utility>
+
+#include <string.h>
+
+#include <core/CHIPError.h>
+#include <support/CodeUtils.h>
+
+namespace chip {
+
+/**
+ * Defines an allocation pool for objects.
+ *
+ * Allows for static allocation of resources. As opposed to System::ObjectPool,
+ * this class does not require reference counting or the use of a System Layer.
+ */
+template <class T, size_t kMaxItems>
+class AllocationPool
+{
+public:
+    AllocationPool()
+    {
+        memset(mInUse, 0, sizeof(mInUse)); // nothing is used
+    }
+
+    // Destructor will attempt to free any items that are still in use.
+    ~AllocationPool()
+    {
+        for (size_t i = 0; i < kMaxItems; i++)
+        {
+            if (IsInUseIndex(i))
+            {
+                FreeIndex(i);
+            }
+        }
+    }
+
+    /**
+     * Attempts to allocate a new object from the allocation pool.
+     *
+     * Returns NULL if no free instances are available in the pool.
+     */
+    template <typename... Args>
+    T * Allocate(Args &&... value)
+    {
+        T * result = nullptr;
+
+        size_t i = 0;
+        while (result == nullptr && i < kMaxItems)
+        {
+            if (IsInUseIndex(i))
+            {
+                i++;
+            }
+            else
+            {
+                // memory available
+                result = new ((void *) MemoryForIndex(i)) T(std::forward<Args &&>(value)...);
+                MarkInUseIndex(i);
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Frees a previously allocated object from the pool
+     */
+    CHIP_ERROR Free(T * ptr)
+    {
+        CHIP_ERROR err = CHIP_NO_ERROR;
+        uint8_t * rawPointer;
+        size_t offset;
+        size_t index;
+
+        // Allow null free any time
+        VerifyOrExit(ptr != NULL, err = CHIP_NO_ERROR);
+
+        rawPointer = reinterpret_cast<uint8_t *>(ptr);
+
+        // in range
+        VerifyOrExit(rawPointer >= mMemory, err = CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrExit(rawPointer < mMemory + sizeof(mMemory), err = CHIP_ERROR_INVALID_ARGUMENT);
+
+        // correct alignment
+        offset = rawPointer - mMemory;
+        VerifyOrExit(offset % sizeof(T) == 0, err = CHIP_ERROR_DATA_NOT_ALIGNED);
+        index = offset / sizeof(T);
+
+        VerifyOrDie(ptr == MemoryForIndex(index));
+
+        err = FreeIndex(index);
+    exit:
+        return err;
+    }
+
+private:
+    CHIP_ERROR FreeIndex(size_t index)
+    {
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        // item should be in use (no double frees)
+        VerifyOrExit(IsInUseIndex(index), err = CHIP_ERROR_INCORRECT_STATE);
+
+        MemoryForIndex(index)->~T();
+        MarkNotInUseIndex(index);
+    exit:
+        return err;
+    }
+
+    /// Checks if the specified index is in use
+    bool IsInUseIndex(size_t index)
+    {
+        VerifyOrDie(index < kMaxItems);
+
+        size_t offs = index / 32;
+        size_t bit  = index % 32;
+
+        return (mInUse[offs] & (1 << bit)) != 0;
+    }
+
+    /// Marks the specified indes in the in use bitset as currently in use
+    void MarkInUseIndex(size_t index)
+    {
+        VerifyOrDie(index < kMaxItems);
+
+        size_t offs = index / 32;
+        size_t bit  = index % 32;
+
+        mInUse[offs] |= (1 << bit);
+    }
+
+    /// Marks the specified indes in the in use bitset as not in use
+    void MarkNotInUseIndex(size_t index)
+    {
+        VerifyOrDie(index < kMaxItems);
+
+        size_t offs = index / 32;
+        size_t bit  = index % 32;
+
+        mInUse[offs] &= ~(1 << bit);
+    }
+
+    // Get the raw memory pointer to the specified index.
+    T * MemoryForIndex(size_t index)
+    {
+        VerifyOrDie(index < kMaxItems);
+        return reinterpret_cast<T *>(mMemory + index * sizeof(T));
+    }
+
+    uint32_t mInUse[(kMaxItems + 31) / 32];                     // in use bitset
+    alignas(alignof(T)) uint8_t mMemory[sizeof(T) * kMaxItems]; // storage for data
+};
+
+} // namespace chip
+
+#endif // ALLOCATION_POOL_H_

--- a/src/lib/core/CoreLayer.am
+++ b/src/lib/core/CoreLayer.am
@@ -35,6 +35,7 @@ CHIP_BUILD_CORE_LAYER_SOURCE_FILES                        = \
     $(NULL)
 
 CHIP_BUILD_CORE_LAYER_HEADER_FILES                        = \
+    @top_builddir@/src/lib/core/AllocationPool.h            \
     @top_builddir@/src/lib/core/CHIPCircularTLVBuffer.h     \
     @top_builddir@/src/lib/core/CHIPConfig.h                \
     @top_builddir@/src/lib/core/CHIPCore.h                  \

--- a/src/lib/core/tests/Makefile.am
+++ b/src/lib/core/tests/Makefile.am
@@ -41,6 +41,7 @@ lib_LIBRARIES                                         = \
     $(NULL)
 
 libCoreTests_a_SOURCES                                = \
+    TestAllocationPool.cpp                              \
     TestCHIPErrorStr.cpp                                \
     TestCHIPTLV.cpp                                     \
     $(NULL)
@@ -85,6 +86,7 @@ COMMON_LDADD                                          =  \
 # Test applications that should be run when the 'check' target is run.
 
 check_PROGRAMS                                        = \
+    TestAllocationPool                                  \
     TestCHIPErrorStr                                    \
     TestCHIPTLV                                         \
     $(NULL)
@@ -103,6 +105,9 @@ TESTS_ENVIRONMENT                                     = \
     $(NULL)
 
 # Source, compiler, and linker options for test programs.
+
+TestAllocationPool_SOURCES                            = TestAllocationPoolDriver.cpp
+TestAllocationPool_LDADD                              = $(COMMON_LDADD)
 
 TestCHIPErrorStr_SOURCES                              = TestCHIPErrorStrDriver.cpp
 TestCHIPErrorStr_LDADD                                = $(COMMON_LDADD)

--- a/src/lib/core/tests/TestAllocationPool.cpp
+++ b/src/lib/core/tests/TestAllocationPool.cpp
@@ -1,0 +1,150 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements unit tests for the CHIP Allocation pool.
+ *
+ */
+
+#include "TestCore.h"
+
+#include <nlbyteorder.h>
+#include <nlunit-test.h>
+
+#include <core/AllocationPool.h>
+
+namespace {
+
+void CheckBasicAllocation(nlTestSuite * inSuite, void * context)
+{
+    CHIP_ERROR err;
+    chip::AllocationPool<int, 3> testPool;
+
+    int * v1 = testPool.Allocate(1);
+
+    NL_TEST_ASSERT(inSuite, v1 != nullptr);
+    NL_TEST_ASSERT(inSuite, *v1 == 1);
+
+    int * v2 = testPool.Allocate(2);
+
+    NL_TEST_ASSERT(inSuite, v2 != nullptr);
+    NL_TEST_ASSERT(inSuite, *v2 == 2);
+
+    int * v3 = testPool.Allocate(3);
+
+    NL_TEST_ASSERT(inSuite, v3 != nullptr);
+    NL_TEST_ASSERT(inSuite, *v3 == 3);
+
+    // 3 items allocated. Insufficient space
+    NL_TEST_ASSERT(inSuite, testPool.Allocate() == nullptr);
+
+    // Free an item and reallocate
+    err = testPool.Free(v2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    // cannot free twice
+    err = testPool.Free(v2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
+
+    int * v2_copy = testPool.Allocate(100);
+    NL_TEST_ASSERT(inSuite, v2_copy != nullptr);
+    NL_TEST_ASSERT(inSuite, *v2_copy == 100);
+    // memory is reused
+    NL_TEST_ASSERT(inSuite, v2_copy == v2);
+
+    // Free everything
+    err = testPool.Free(v1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    err = testPool.Free(v2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    err = testPool.Free(v3);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+}
+
+class ConstructorDestructorTracked
+{
+public:
+    ConstructorDestructorTracked(int index, const char * extra) : mIndex(index), mExtra(extra) { lastCreated = index; }
+    ~ConstructorDestructorTracked() { lastDestroyed = mIndex; }
+
+    static int GetLastCreated() { return lastCreated; }
+
+    static int GetLastDestroyed() { return lastDestroyed; }
+
+private:
+    static int lastCreated;
+    static int lastDestroyed;
+
+    int mIndex;
+    const char * mExtra;
+};
+
+int ConstructorDestructorTracked::lastCreated   = 0;
+int ConstructorDestructorTracked::lastDestroyed = 0;
+
+void ConstructorDestructorTest(nlTestSuite * inSuite, void * context)
+{
+    {
+        chip::AllocationPool<ConstructorDestructorTracked, 2> pool;
+
+        ConstructorDestructorTracked * a = pool.Allocate(123, "first object");
+        NL_TEST_ASSERT(inSuite, a != nullptr);
+        NL_TEST_ASSERT(inSuite, ConstructorDestructorTracked::GetLastCreated() == 123);
+
+        ConstructorDestructorTracked * b = pool.Allocate(222, "second object");
+        NL_TEST_ASSERT(inSuite, b != nullptr);
+        NL_TEST_ASSERT(inSuite, ConstructorDestructorTracked::GetLastCreated() == 222);
+
+        CHIP_ERROR err = pool.Free(a);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, ConstructorDestructorTracked::GetLastDestroyed() == 123);
+
+        a = pool.Allocate(321, "anothr object");
+        NL_TEST_ASSERT(inSuite, a != nullptr);
+        NL_TEST_ASSERT(inSuite, ConstructorDestructorTracked::GetLastCreated() == 321);
+
+        err = pool.Free(b);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, ConstructorDestructorTracked::GetLastDestroyed() == 222);
+    }
+
+    // Pool destructor clears everything. Only one object was active.
+    NL_TEST_ASSERT(inSuite, ConstructorDestructorTracked::GetLastDestroyed() == 321);
+}
+
+} // namespace
+
+/**
+ *  Test Suite that lists all the test functions.
+ */
+// clang-format off
+static const nlTest sTests[] =
+{
+    NL_TEST_DEF("BasicAllocation",    CheckBasicAllocation),
+    NL_TEST_DEF("BasicAllocation",    ConstructorDestructorTest),
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+int TestAllocationPool(void)
+{
+    nlTestSuite theSuite = { "chip-allocationpool", &sTests[0], NULL, NULL };
+    nlTestRunner(&theSuite, NULL /* context */);
+    return (nlTestRunnerStats(&theSuite));
+}

--- a/src/lib/core/tests/TestAllocationPoolDriver.cpp
+++ b/src/lib/core/tests/TestAllocationPoolDriver.cpp
@@ -17,24 +17,21 @@
 
 /**
  *    @file
- *      This file declares test entry points for CHIP core library
- *      unit tests.
+ *      This file implements a standalone/native program executable
+ *      test driver for the CHIP Allocation pool unit tests.
  *
  */
 
-#ifndef TESTCORE_H
-#define TESTCORE_H
+#include "TestCore.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include <core/CHIPConfig.h>
 
-int TestCHIPErrorStr(void);
-int TestCHIPTLV(void);
-int TestAllocationPool(void);
+#include <nlunit-test.h>
 
-#ifdef __cplusplus
+int main(void)
+{
+    // Generate machine-readable, comma-separated value (CSV) output.
+    nlTestSetOutputStyle(OUTPUT_CSV);
+
+    return (TestAllocationPool());
 }
-#endif
-
-#endif // TESTCORE_H


### PR DESCRIPTION
 #### Problem
'Dynamic' memory allocation is required for things like active connections and state, however we generally want to allow for static memory allocation for embeded devices.

The System layer has an object pool, however it is tied into the system layer (object creation require layer) and is very rigid in mandating reference counting, disallowing destructors (but using reference counts as destructors) and imposing an object overhead for reference tracking and parent object tracking.

 #### Summary of Changes
This change creates a object allocation pool that acts similar to a typesafe heap: allows alloc and free. It is not optimized for speed, but it should do its job especially for low number of objects (e.g. number of active connections).

this is work towards #1088 and #1070 , intended to add support for multiple active sessions. We will have a pool of active session states which we will be able to expire or close (e.g. on TCP close requests).
