### PR TITLE
[SetupPayload] Use ChipLogging instead of printf

### DIFF
--- a/src/lib/support/logging/CHIPLogging.h
+++ b/src/lib/support/logging/CHIPLogging.h
@@ -110,6 +110,7 @@ enum LogModule
     kLogModule_Zcl,
     kLogModule_Shell,
     kLogModule_DeviceLayer,
+    kLogModule_SetupPayload,
 
     kLogModule_Max
 };

--- a/src/setup_payload/ManualSetupPayloadGenerator.cpp
+++ b/src/setup_payload/ManualSetupPayloadGenerator.cpp
@@ -23,6 +23,7 @@
 
 #include "ManualSetupPayloadGenerator.h"
 
+#include <support/logging/CHIPLogging.h>
 #include <support/verhoeff/Verhoeff.h>
 
 using namespace chip;
@@ -49,7 +50,7 @@ CHIP_ERROR ManualSetupPayloadGenerator::payloadDecimalStringRepresentation(strin
 {
     if (!mSetupPayload.isValidManualCode())
     {
-        fprintf(stderr, "\nFailed encoding invalid payload\n");
+        ChipLogError(SetupPayload, "Failed encoding invalid payload");
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 

--- a/src/setup_payload/ManualSetupPayloadParser.cpp
+++ b/src/setup_payload/ManualSetupPayloadParser.cpp
@@ -23,6 +23,7 @@
 
 #include "ManualSetupPayloadParser.h"
 
+#include <support/logging/CHIPLogging.h>
 #include <support/verhoeff/Verhoeff.h>
 
 #include <iostream>
@@ -37,7 +38,7 @@ static CHIP_ERROR checkDecimalStringValidity(string decimalString, string & deci
 {
     if (decimalString.length() < 2)
     {
-        fprintf(stderr, "\nFailed decoding base10. Input was empty. %zu\n", decimalString.length());
+        ChipLogError(SetupPayload, "Failed decoding base10. Input was empty. %zu", decimalString.length());
         return CHIP_ERROR_INVALID_STRING_LENGTH;
     }
     string repWithoutCheckChar = decimalString.substr(0, decimalString.length() - 1);
@@ -56,8 +57,8 @@ static CHIP_ERROR checkCodeLengthValidity(string decimalString, bool isLongCode)
     size_t expectedCharLength = isLongCode ? kManualSetupLongCodeCharLength : kManualSetupShortCodeCharLength;
     if (decimalString.length() != expectedCharLength)
     {
-        fprintf(stderr, "\nFailed decoding base10. Input length %zu was not expected length %zu\n", decimalString.length(),
-                expectedCharLength);
+        ChipLogError(SetupPayload, "Failed decoding base10. Input length %zu was not expected length %zu", decimalString.length(),
+                     expectedCharLength);
         return CHIP_ERROR_INVALID_STRING_LENGTH;
     }
     return CHIP_NO_ERROR;
@@ -68,7 +69,7 @@ static CHIP_ERROR extractBits(uint32_t number, uint64_t & dest, int index, int n
 {
     if ((index + numberBits) > maxBits)
     {
-        fprintf(stderr, "\nNumber %u maxBits %d index %d n %d\n", number, maxBits, index, numberBits);
+        ChipLogError(SetupPayload, "Number %u maxBits %d index %d n %d", number, maxBits, index, numberBits);
         return CHIP_ERROR_INVALID_STRING_LENGTH;
     }
     dest = (((1 << numberBits) - 1) & (number >> index));
@@ -82,7 +83,7 @@ static CHIP_ERROR toNumber(string decimalString, uint64_t & dest)
     {
         if (!isdigit(decimalString[i]))
         {
-            fprintf(stderr, "\nFailed decoding base10. Character was invalid %c\n", decimalString[i]);
+            ChipLogError(SetupPayload, "Failed decoding base10. Character was invalid %c", decimalString[i]);
             return CHIP_ERROR_INVALID_INTEGER_VALUE;
         }
         number *= 10;
@@ -97,12 +98,12 @@ static CHIP_ERROR readDigitsFromDecimalString(string decimalString, int & index,
 {
     if (decimalString.length() < numberOfCharsToRead || (numberOfCharsToRead + index > decimalString.length()))
     {
-        fprintf(stderr, "\nFailed decoding base10. Input was too short. %zu\n", decimalString.length());
+        ChipLogError(SetupPayload, "Failed decoding base10. Input was too short. %zu", decimalString.length());
         return CHIP_ERROR_INVALID_STRING_LENGTH;
     }
     else if (index < 0)
     {
-        fprintf(stderr, "\nFailed decoding base10. Index was negative. %d\n", index);
+        ChipLogError(SetupPayload, "Failed decoding base10. Index was negative. %d", index);
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
@@ -163,7 +164,7 @@ CHIP_ERROR ManualSetupPayloadParser::populatePayload(SetupPayload & outPayload)
     }
     else if (setUpPINCode == 0)
     {
-        fprintf(stderr, "\nFailed decoding base10. SetUpPINCode was 0.\n");
+        ChipLogError(SetupPayload, "Failed decoding base10. SetUpPINCode was 0.");
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 

--- a/src/setup_payload/SetupPayloadHelper.cpp
+++ b/src/setup_payload/SetupPayloadHelper.cpp
@@ -22,6 +22,7 @@
 #include <fstream>
 
 #include <support/CodeUtils.h>
+#include <support/logging/CHIPLogging.h>
 
 using namespace chip;
 
@@ -105,31 +106,31 @@ static CHIP_ERROR addParameter(SetupPayload & setupPayload, SetupPayloadParamete
     switch (parameter.key)
     {
     case SetupPayloadKey_Version:
-        printf("Loaded version: %u\n", (uint8_t) parameter.uintValue);
+        ChipLogDetail(SetupPayload, "Loaded version: %u", (uint8_t) parameter.uintValue);
         setupPayload.version = (uint8_t) parameter.uintValue;
         break;
     case SetupPayloadKey_VendorID:
-        printf("Loaded vendorID: %u\n", (uint16_t) parameter.uintValue);
+        ChipLogDetail(SetupPayload, "Loaded vendorID: %u", (uint16_t) parameter.uintValue);
         setupPayload.vendorID = (uint16_t) parameter.uintValue;
         break;
     case SetupPayloadKey_ProductID:
-        printf("Loaded productID: %u\n", (uint16_t) parameter.uintValue);
+        ChipLogDetail(SetupPayload, "Loaded productID: %u", (uint16_t) parameter.uintValue);
         setupPayload.productID = (uint16_t) parameter.uintValue;
         break;
     case SetupPayloadKey_RequiresCustomFlowTrue:
-        printf("Requires custom flow was set to true\n");
+        ChipLogDetail(SetupPayload, "Requires custom flow was set to true");
         setupPayload.requiresCustomFlow = true;
         break;
     case SetupPayloadKey_RendezVousInformation:
-        printf("Loaded rendezvousInfo: %u\n", (uint16_t) parameter.uintValue);
+        ChipLogDetail(SetupPayload, "Loaded rendezvousInfo: %u", (uint16_t) parameter.uintValue);
         setupPayload.rendezvousInformation = (uint16_t) parameter.uintValue;
         break;
     case SetupPayloadKey_Discriminator:
-        printf("Loaded discriminator: %u\n", (uint16_t) parameter.uintValue);
+        ChipLogDetail(SetupPayload, "Loaded discriminator: %u", (uint16_t) parameter.uintValue);
         setupPayload.discriminator = (uint16_t) parameter.uintValue;
         break;
     case SetupPayloadKey_SetupPINCode:
-        printf("Loaded setupPinCode: %lu\n", (unsigned long) parameter.uintValue);
+        ChipLogDetail(SetupPayload, "Loaded setupPinCode: %lu", (unsigned long) parameter.uintValue);
         setupPayload.setUpPINCode = (uint32_t) parameter.uintValue;
         break;
     default:


### PR DESCRIPTION
 #### Problem

Using SetupPayload's APIs on an accessory doesn't show any logs because of the printfs everywhere.

 #### Summary of Changes

Uses ChipLogging instead of printf's calls.

fixes #888 