### PR TITLE
[QRCodeTool] Remove duplicates #include in qrcodetool/setup_payload_c…

### DIFF
--- a/src/qrcodetool/setup_payload_commands.cpp
+++ b/src/qrcodetool/setup_payload_commands.cpp
@@ -18,8 +18,6 @@
 #include "setup_payload_commands.h"
 
 #include <setup_payload/SetupPayloadHelper.h>
-#include <support/logging/CHIPLogging.h>
-
 #include <stdio.h>
 #include <support/logging/CHIPLogging.h>
 #include <unistd.h>


### PR DESCRIPTION
…ommands.cpp

 #### Problem
There is a duplicate #include <support/logging/CHIPLogging.h> in qrcodetool/setup_payload_commands.cpp
