### PR TITLE
[SetupPayload] Order of bits in manual setup code is incorrect

### DIFF
--- a/src/setup_payload/ManualSetupPayloadGenerator.cpp
+++ b/src/setup_payload/ManualSetupPayloadGenerator.cpp
@@ -31,10 +31,9 @@ static uint32_t shortPayloadRepresentation(SetupPayload payload)
 {
     int offset      = 1;
     uint32_t result = payload.requiresCustomFlow ? 1 : 0;
-    result |= payload.setUpPINCode << offset;
-    offset += kSetupPINCodeFieldLengthInBits;
-
     result |= payload.discriminator << offset;
+    offset += kManualSetupDiscriminatorFieldLengthInBits;
+    result |= payload.setUpPINCode << offset;
     return result;
 }
 

--- a/src/setup_payload/ManualSetupPayloadParser.cpp
+++ b/src/setup_payload/ManualSetupPayloadParser.cpp
@@ -156,6 +156,15 @@ CHIP_ERROR ManualSetupPayloadParser::populatePayload(SetupPayload & outPayload)
     int numberOffset = 1;
     uint64_t setUpPINCode;
     size_t maxShortCodeBitsLength = 1 + kSetupPINCodeFieldLengthInBits + kManualSetupDiscriminatorFieldLengthInBits;
+
+    uint64_t discriminator;
+    result = readBitsFromNumber(shortCode, numberOffset, discriminator, kManualSetupDiscriminatorFieldLengthInBits,
+                                maxShortCodeBitsLength);
+    if (result != CHIP_NO_ERROR)
+    {
+        return result;
+    }
+
     result = readBitsFromNumber(shortCode, numberOffset, setUpPINCode, kSetupPINCodeFieldLengthInBits, maxShortCodeBitsLength);
     if (result != CHIP_NO_ERROR)
     {
@@ -165,14 +174,6 @@ CHIP_ERROR ManualSetupPayloadParser::populatePayload(SetupPayload & outPayload)
     {
         fprintf(stderr, "\nFailed decoding base10. SetUpPINCode was 0.\n");
         return CHIP_ERROR_INVALID_ARGUMENT;
-    }
-
-    uint64_t discriminator;
-    result = readBitsFromNumber(shortCode, numberOffset, discriminator, kManualSetupDiscriminatorFieldLengthInBits,
-                                maxShortCodeBitsLength);
-    if (result != CHIP_NO_ERROR)
-    {
-        return result;
     }
 
     if (isLongCode)


### PR DESCRIPTION
 #### Problem
Order of bits in manual set up code is incorrect
The discriminator needs to come after the PIN code.
This was agreed upon after the first implementation

 #### Summary of Changes
* Invert discriminator <-> setUpPINCode
* Fix the various tests failing because of it...

fixes #607 