### PR TITLE
Added a class to track multime connections and handle expiration

### DIFF
--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -2271,6 +2271,18 @@
 #endif // CHIP_CONFIG_ENABLE_IFJ_SERVICE_FABRIC_JOIN
 
 /**
+ * @def CHIP_CONFIG_PEER_CONNECTION_POOL_SIZE
+ *
+ * @brief Define the size of the pool used for tracking CHIP
+ * Peer connections. This defines maximum number of concurrent
+ * device connections across all supported transports.
+ */
+#ifndef CHIP_CONFIG_PEER_CONNECTION_POOL_SIZE
+#define CHIP_CONFIG_PEER_CONNECTION_POOL_SIZE                   16
+#endif // CHIP_CONFIG_PEER_CONNECTION_POOL_SIZE
+
+
+/**
  * @def CHIP_NON_PRODUCTION_MARKER
  *
  * @brief Defines the name of a mark symbol whose presence signals that the chip code

--- a/src/lib/support/CodeUtils.h
+++ b/src/lib/support/CodeUtils.h
@@ -404,4 +404,12 @@ inline void chipDie(void)
 
 #endif // defined(__cplusplus) && (__cplusplus >= 201103L)
 
+#if defined(__GNUC__) && (__GNUC__ >= 4)
+#define CHECK_RETURN_VALUE __attribute__((warn_unused_result))
+#elif defined(_MSC_VER) && (_MSC_VER >= 1700)
+#define CHECK_RETURN_VALUE _Check_return_
+#else
+#define CHECK_RETURN_VALUE
+#endif
+
 #endif /* CODEUTILS_H_ */

--- a/src/transport/PeerAddress.h
+++ b/src/transport/PeerAddress.h
@@ -81,9 +81,16 @@ public:
         return *this;
     }
 
+    bool IsInitialized() const { return mTransportType != Type::kUndefined; }
+
+    bool operator==(const PeerAddress & other)
+    {
+        return (mTransportType == other.mTransportType) && (mIPAddress == other.mIPAddress);
+    }
+
     /****** Factory methods for convenience ******/
 
-    static PeerAddress Uninitialized() { return PeerAddress(IPAddress::Any, Type::kUndefined); }
+    static PeerAddress Uninitialized() { return PeerAddress(Inet::IPAddress::Any, Type::kUndefined); }
 
     static PeerAddress UDP(const Inet::IPAddress & addr) { return PeerAddress(addr, Type::kUdp); }
     static PeerAddress UDP(const Inet::IPAddress & addr, uint16_t port) { return UDP(addr).SetPort(port); }

--- a/src/transport/PeerAddress.h
+++ b/src/transport/PeerAddress.h
@@ -85,7 +85,7 @@ public:
 
     bool operator==(const PeerAddress & other)
     {
-        return (mTransportType == other.mTransportType) && (mIPAddress == other.mIPAddress);
+        return (mTransportType == other.mTransportType) && (mIPAddress == other.mIPAddress) && (mPort == other.mPort);
     }
 
     /****** Factory methods for convenience ******/

--- a/src/transport/PeerConnectionState.h
+++ b/src/transport/PeerConnectionState.h
@@ -65,12 +65,6 @@ public:
     uint64_t GetLastActivityTimeMs() const { return mLastActityTimeMs; }
     void SetLastActivityTimeMs(uint64_t value) { mLastActityTimeMs = value; }
 
-    template <class TimeSource>
-    void SetLastActivityTimeMs(TimeSource source)
-    {
-        mLastActityTimeMs = source.GetCurrentMonotonicTimeMs();
-    }
-
 private:
     PeerAddress mPeerAddress;
     NodeId mPeerNodeId         = kUndefinedNodeId;

--- a/src/transport/PeerConnections.cpp
+++ b/src/transport/PeerConnections.cpp
@@ -1,0 +1,112 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <transport/PeerConnections.h>
+
+namespace chip {
+namespace Transport {
+
+CHIP_ERROR PeerConnectionsBase::CreateNewPeerConnectionState(const PeerAddress & address, PeerConnectionState ** state)
+{
+    CHIP_ERROR err = CHIP_ERROR_NO_MEMORY;
+
+    if (state)
+    {
+        *state = nullptr;
+    }
+
+    for (size_t i = 0; i < mConnectionStateArraySize; i++)
+    {
+        if (!mConnectionStateArray[i].GetPeerAddress().IsInitialized())
+        {
+            mConnectionStateArray[i] = PeerConnectionState(address);
+            mConnectionStateArray[i].SetLastActivityTimeMs(GetCurrentMonotonicTimeMs());
+
+            if (state)
+            {
+                *state = &mConnectionStateArray[i];
+            }
+
+            err = CHIP_NO_ERROR;
+            break;
+        }
+    }
+
+    return err;
+}
+
+bool PeerConnectionsBase::FindPeerConnectionState(const PeerAddress & address, PeerConnectionState ** state)
+{
+    *state = nullptr;
+    for (size_t i = 0; i < mConnectionStateArraySize; i++)
+    {
+        if (mConnectionStateArray[i].GetPeerAddress() == address)
+        {
+            *state = &mConnectionStateArray[i];
+            break;
+        }
+    }
+    return *state != nullptr;
+}
+
+bool PeerConnectionsBase::FindPeerConnectionState(NodeId nodeId, PeerConnectionState ** state)
+{
+    *state = nullptr;
+    for (size_t i = 0; i < mConnectionStateArraySize; i++)
+    {
+        if (!mConnectionStateArray[i].GetPeerAddress().IsInitialized())
+        {
+            continue;
+        }
+        if (mConnectionStateArray[i].GetPeerNodeId() == nodeId)
+        {
+            *state = &mConnectionStateArray[i];
+            break;
+        }
+    }
+    return *state != nullptr;
+}
+
+void PeerConnectionsBase::ExpireInactiveConnections(uint64_t maxIdleTimeMs)
+{
+    const uint64_t currentTime = GetCurrentMonotonicTimeMs();
+
+    for (size_t i = 0; i < mConnectionStateArraySize; i++)
+    {
+        if (!mConnectionStateArray[i].GetPeerAddress().IsInitialized())
+        {
+            continue; // not an active connection
+        }
+
+        uint64_t connectionActiveTime = mConnectionStateArray[i].GetLastActivityTimeMs();
+        if (connectionActiveTime + maxIdleTimeMs >= currentTime)
+        {
+            continue; // not expired
+        }
+
+        if (OnConnectionExpired)
+        {
+            OnConnectionExpired(mConnectionStateArray[i], mConnectionExpiredArgument);
+        }
+
+        // Connection is assumed expired, marking it as invalid
+        mConnectionStateArray[i] = PeerConnectionState(PeerAddress::Uninitialized());
+    }
+}
+
+} // namespace Transport
+} // namespace chip

--- a/src/transport/PeerConnections.h
+++ b/src/transport/PeerConnections.h
@@ -17,8 +17,6 @@
 #ifndef PEER_CONNECTIONS_H_
 #define PEER_CONNECTIONS_H_
 
-#include <array>
-
 #include <core/CHIPConfig.h>
 #include <core/CHIPError.h>
 #include <support/CodeUtils.h>

--- a/src/transport/PeerConnections.h
+++ b/src/transport/PeerConnections.h
@@ -29,7 +29,7 @@ namespace chip {
 namespace Transport {
 
 /**
- * Handles a set of Peer connection states.
+ * Handles a set of peer connection states.
  *
  * Intended for:
  *   - handle connection active time and expiration
@@ -61,7 +61,7 @@ public:
     CHIP_ERROR CreateNewPeerConnectionState(const PeerAddress & address, PeerConnectionState ** state);
 
     /**
-     * Get a peer connection state given a Peer address.
+     * Get a peer connection state given a peer address.
      *
      * @param address is the connection to find (based on address)
      * @param state [out] the connection if found, null otherwise. MUST not be null.

--- a/src/transport/PeerConnections.h
+++ b/src/transport/PeerConnections.h
@@ -29,7 +29,7 @@ namespace chip {
 namespace Transport {
 
 /**
- * Handles a set of peer connection states.
+ * Handles a set of Peer connection states.
  *
  * Intended for:
  *   - handle connection active time and expiration

--- a/src/transport/PeerConnections.h
+++ b/src/transport/PeerConnections.h
@@ -1,0 +1,199 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#ifndef PEER_CONNECTIONS_H_
+#define PEER_CONNECTIONS_H_
+
+#include <array>
+
+#include <core/CHIPError.h>
+#include <support/CodeUtils.h>
+#include <system/TimeSource.h>
+#include <transport/PeerConnectionState.h>
+
+namespace chip {
+namespace Transport {
+
+/**
+ * Handles a set of peer connection states.
+ *
+ * Intended for:
+ *   - handle connection active time and expiration
+ *   - allocate and free space for connection states.
+ */
+template <size_t kMaxConnectionCount, Time::Source kTimeSource = Time::Source::kSystem>
+class PeerConnections
+{
+public:
+    /**
+     * Allocates a new peer connection state state object out of the internal resource pool.
+     *
+     * @param address represents the connection state address
+     * @param state [out] will contain the connection state if one was available. May be null if no return value is desired.
+     *
+     * @note the newly created state will have an 'active' time set based on the current time source.
+     *
+     * @returns CHIP_NO_ERROR if state could be initialized. May fail if maximum connection count
+     *          has been reached (with CHIP_ERROR_NO_MEMORY).
+     */
+    CHECK_RETURN_VALUE
+    CHIP_ERROR CreateNewPeerConnectionState(const PeerAddress & address, PeerConnectionState ** state)
+    {
+        CHIP_ERROR err = CHIP_ERROR_NO_MEMORY;
+
+        if (state)
+        {
+            *state = nullptr;
+        }
+
+        for (size_t i = 0; i < kMaxConnectionCount; i++)
+        {
+            if (!mStates[i].GetPeerAddress().IsInitialized())
+            {
+                mStates[i] = PeerConnectionState(address);
+                mStates[i].SetLastActivityTimeMs(mTimeSource);
+
+                if (state)
+                {
+                    *state = &mStates[i];
+                }
+
+                err = CHIP_NO_ERROR;
+                break;
+            }
+        }
+
+        return err;
+    }
+
+    /**
+     * Get a peer connection state given a Peer address.
+     *
+     * @param address is the connection to find (based on address)
+     * @param state [out] the connection if found, null otherwise. MUST not be null.
+     *
+     * @return true if a corresponding state was found.
+     */
+    CHECK_RETURN_VALUE
+    bool FindPeerConnectionState(const PeerAddress & address, PeerConnectionState ** state)
+    {
+        *state = nullptr;
+        for (size_t i = 0; i < kMaxConnectionCount; i++)
+        {
+            if (mStates[i].GetPeerAddress() == address)
+            {
+                *state = &mStates[i];
+                break;
+            }
+        }
+        return *state != nullptr;
+    }
+
+    /**
+     * Get a peer connection state given a Node Id.
+     *
+     * @param nodeId is the connection to find (based on nodeId). Note that initial connections
+     *        do not have a node id set. Use this if you know the node id should be set.
+     * @param state [out] the connection if found, null otherwise. MUST not be null.
+     *
+     * @return true if a corresponding state was found.
+     */
+    CHECK_RETURN_VALUE
+    bool FindPeerConnectionState(NodeId nodeId, PeerConnectionState ** state)
+    {
+        *state = nullptr;
+        for (size_t i = 0; i < kMaxConnectionCount; i++)
+        {
+            if (!mStates[i].GetPeerAddress().IsInitialized())
+            {
+                continue;
+            }
+            if (mStates[i].GetPeerNodeId() == nodeId)
+            {
+                *state = &mStates[i];
+                break;
+            }
+        }
+        return *state != nullptr;
+    }
+
+    /// Convenience method to mark a peer connection state as active
+    void MarkConnectionActive(PeerConnectionState * state) { state->SetLastActivityTimeMs(mTimeSource); }
+
+    /**
+     * Iterates through all active connections and expires any connection with an idle time
+     * larger than the given amount.
+     *
+     * Expiring a connection involves callback execution and then clearing the internal state.
+     */
+    void ExpireInactiveConnections(uint64_t maxIdleTimeMs)
+    {
+        const uint64_t currentTime = mTimeSource.GetCurrentMonotonicTimeMs();
+
+        for (size_t i = 0; i < kMaxConnectionCount; i++)
+        {
+            if (!mStates[i].GetPeerAddress().IsInitialized())
+            {
+                continue; // not an active connection
+            }
+
+            uint64_t connectionActiveTime = mStates[i].GetLastActivityTimeMs();
+            if (connectionActiveTime + maxIdleTimeMs >= currentTime)
+            {
+                continue; // not expired
+            }
+
+            if (OnConnectionExpired)
+            {
+                OnConnectionExpired(mStates[i], mConnectionExpiredArgument);
+            }
+
+            // Connection is assumed expired, marking it as invalid
+            mStates[i] = PeerConnectionState(PeerAddress::Uninitialized());
+        }
+    }
+
+    /// Allows access to the underlying time source used for keeping track of connection active time
+    Time::TimeSource<kTimeSource> & GetTimeSource() { return mTimeSource; }
+
+    /**
+     * Sets the handler for expired connections
+     *
+     * @param[in] handler The callback to call when a connection is marked as expired
+     * @param[in] param   The argument to pass in to the handler function
+     *
+     */
+    template <class T>
+    void SetConnectionExpiredHandler(void (*handler)(const PeerConnectionState &, T *), T * param)
+    {
+        mConnectionExpiredArgument = param;
+        OnConnectionExpired        = reinterpret_cast<ConnectionExpiredHandler>(handler);
+    }
+
+private:
+    Time::TimeSource<kTimeSource> mTimeSource;
+    PeerConnectionState mStates[kMaxConnectionCount];
+
+    typedef void (*ConnectionExpiredHandler)(const PeerConnectionState & state, void * param);
+
+    ConnectionExpiredHandler OnConnectionExpired = nullptr; ///< Callback for when a connection expires
+    void * mConnectionExpiredArgument            = nullptr; ///< Argument for callback
+};
+
+} // namespace Transport
+} // namespace chip
+
+#endif // PEER_CONNECTIONS_H_

--- a/src/transport/TransportLayer.am
+++ b/src/transport/TransportLayer.am
@@ -33,10 +33,11 @@ CHIP_BUILD_TRANSPORT_LAYER_SOURCE_FILES                  = \
 
 CHIP_BUILD_TRANSPORT_LAYER_HEADER_FILES              = \
     @top_builddir@/src/transport/Base.h                \
-    @top_builddir@/src/transport/SecureSession.h   \
+    @top_builddir@/src/transport/SecureSession.h       \
     @top_builddir@/src/transport/MessageHeader.h       \
     @top_builddir@/src/transport/PeerAddress.h         \
     @top_builddir@/src/transport/PeerConnectionState.h \
-    @top_builddir@/src/transport/SecureSessionMgr.h     \
+    @top_builddir@/src/transport/PeerConnections.h     \
+    @top_builddir@/src/transport/SecureSessionMgr.h    \
     @top_builddir@/src/transport/UDP.h                 \
     $(NULL)

--- a/src/transport/TransportLayer.am
+++ b/src/transport/TransportLayer.am
@@ -25,9 +25,10 @@
 #
 
 CHIP_BUILD_TRANSPORT_LAYER_SOURCE_FILES                  = \
-    @top_builddir@/src/transport/SecureSession.cpp     \
+    @top_builddir@/src/transport/SecureSession.cpp         \
     @top_builddir@/src/transport/MessageHeader.cpp         \
-    @top_builddir@/src/transport/SecureSessionMgr.cpp       \
+    @top_builddir@/src/transport/PeerConnections.cpp       \
+    @top_builddir@/src/transport/SecureSessionMgr.cpp      \
     @top_builddir@/src/transport/UDP.cpp                   \
     $(NULL)
 

--- a/src/transport/tests/Makefile.am
+++ b/src/transport/tests/Makefile.am
@@ -42,9 +42,10 @@ lib_LIBRARIES                                         = \
 
 libTransportLayerTests_a_SOURCES                      = \
     TestMessageHeader.cpp                               \
+    TestPeerConnections.cpp                             \
+    TestSecureSession.cpp                               \
     TestSecureSessionMgr.cpp                            \
     TestUDP.cpp                                         \
-    TestSecureSession.cpp                               \
     $(NULL)
 
 libTransportLayerTests_adir                           = $(includedir)/transport
@@ -86,6 +87,7 @@ COMMON_LDADD                                          = \
 
 check_PROGRAMS             = \
     TestMessageHeader        \
+    TestPeerConnections      \
     TestSecureSessionMgr     \
     TestSecureSession        \
     TestUDP                  \
@@ -117,6 +119,9 @@ TestSecureSession_LDADD       = $(COMMON_LDADD)
 
 TestUDP_SOURCES               = TestUDPDriver.cpp
 TestUDP_LDADD                 = $(COMMON_LDADD)
+
+TestPeerConnections_SOURCES   = TestPeerConnectionsDriver.cpp
+TestPeerConnections_LDADD     = $(COMMON_LDADD)
 
 #
 # Foreign make dependencies

--- a/src/transport/tests/TestPeerConnections.cpp
+++ b/src/transport/tests/TestPeerConnections.cpp
@@ -1,0 +1,229 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a process to effect a functional test for
+ *      the Message Header class within the transport layer
+ *
+ */
+#include "TestTransportLayer.h"
+
+#include <support/ErrorStr.h>
+#include <transport/PeerConnections.h>
+
+#include <nlunit-test.h>
+
+namespace {
+
+using namespace chip;
+using namespace chip::Transport;
+
+PeerAddress AddressFromString(const char * str)
+{
+    Inet::IPAddress addr;
+
+    VerifyOrDie(Inet::IPAddress::FromString(str, addr));
+
+    return PeerAddress::UDP(addr);
+}
+
+const PeerAddress kPeer1Addr = AddressFromString("10.1.2.3");
+const PeerAddress kPeer2Addr = AddressFromString("10.0.0.32");
+const PeerAddress kPeer3Addr = AddressFromString("100.200.0.1");
+
+const NodeId kPeer1NodeId = 123;
+const NodeId kPeer2NodeId = 6;
+const NodeId kPeer3NodeId = 81;
+
+void TestBasicFunctionality(nlTestSuite * inSuite, void * inContext)
+{
+    CHIP_ERROR err;
+    PeerConnectionState * statePtr;
+    PeerConnections<2, Time::Source::kTest> connections;
+    connections.GetTimeSource().SetCurrentMonotonicTimeMs(100);
+
+    err = connections.CreateNewPeerConnectionState(kPeer1Addr, nullptr);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = connections.CreateNewPeerConnectionState(kPeer2Addr, &statePtr);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, statePtr != nullptr);
+    NL_TEST_ASSERT(inSuite, statePtr->GetPeerAddress() == kPeer2Addr);
+    NL_TEST_ASSERT(inSuite, statePtr->GetLastActivityTimeMs() == 100);
+
+    // Insufficient space for new connections. Object is max size 2
+    err = connections.CreateNewPeerConnectionState(kPeer3Addr, &statePtr);
+    NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
+}
+
+void TestFindByAddress(nlTestSuite * inSuite, void * inContext)
+{
+    CHIP_ERROR err;
+    PeerConnectionState * statePtr;
+    PeerConnections<2, Time::Source::kTest> connections;
+
+    err = connections.CreateNewPeerConnectionState(kPeer1Addr, nullptr);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = connections.CreateNewPeerConnectionState(kPeer2Addr, nullptr);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, connections.FindPeerConnectionState(kPeer1Addr, &statePtr));
+    NL_TEST_ASSERT(inSuite, statePtr->GetPeerAddress() == kPeer1Addr);
+    NL_TEST_ASSERT(inSuite, connections.FindPeerConnectionState(kPeer2Addr, &statePtr));
+    NL_TEST_ASSERT(inSuite, statePtr->GetPeerAddress() == kPeer2Addr);
+
+    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer3Addr, &statePtr));
+    NL_TEST_ASSERT(inSuite, statePtr == nullptr);
+}
+
+void TestFindByNodeId(nlTestSuite * inSuite, void * inContext)
+{
+    CHIP_ERROR err;
+    PeerConnectionState * statePtr;
+    PeerConnections<2, Time::Source::kTest> connections;
+
+    err = connections.CreateNewPeerConnectionState(kPeer1Addr, &statePtr);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    statePtr->SetPeerNodeId(kPeer1NodeId);
+
+    err = connections.CreateNewPeerConnectionState(kPeer2Addr, &statePtr);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    statePtr->SetPeerNodeId(kPeer2NodeId);
+
+    NL_TEST_ASSERT(inSuite, connections.FindPeerConnectionState(kPeer1NodeId, &statePtr));
+    NL_TEST_ASSERT(inSuite, statePtr->GetPeerAddress() == kPeer1Addr);
+    NL_TEST_ASSERT(inSuite, statePtr->GetPeerNodeId() == kPeer1NodeId);
+
+    NL_TEST_ASSERT(inSuite, connections.FindPeerConnectionState(kPeer2NodeId, &statePtr));
+    NL_TEST_ASSERT(inSuite, statePtr->GetPeerAddress() == kPeer2Addr);
+    NL_TEST_ASSERT(inSuite, statePtr->GetPeerNodeId() == kPeer2NodeId);
+
+    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer3NodeId, &statePtr));
+    NL_TEST_ASSERT(inSuite, statePtr == nullptr);
+}
+
+struct ExpiredCallInfo
+{
+    int callCount                   = 0;
+    NodeId lastCallNodeId           = 0;
+    PeerAddress lastCallPeerAddress = PeerAddress::Uninitialized();
+};
+
+void OnConnectionExpired(const PeerConnectionState & state, ExpiredCallInfo * info)
+{
+    info->callCount++;
+    info->lastCallNodeId      = state.GetPeerNodeId();
+    info->lastCallPeerAddress = state.GetPeerAddress();
+}
+
+void TestExpireConnections(nlTestSuite * inSuite, void * inContext)
+{
+    CHIP_ERROR err;
+    ExpiredCallInfo callInfo;
+    PeerConnectionState * statePtr;
+    PeerConnections<2, Time::Source::kTest> connections;
+
+    connections.SetConnectionExpiredHandler(OnConnectionExpired, &callInfo);
+
+    connections.GetTimeSource().SetCurrentMonotonicTimeMs(100);
+
+    err = connections.CreateNewPeerConnectionState(kPeer1Addr, nullptr);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    connections.GetTimeSource().SetCurrentMonotonicTimeMs(200);
+    err = connections.CreateNewPeerConnectionState(kPeer2Addr, &statePtr);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    statePtr->SetPeerNodeId(kPeer2NodeId);
+
+    // cannot add before expiry
+    connections.GetTimeSource().SetCurrentMonotonicTimeMs(300);
+    err = connections.CreateNewPeerConnectionState(kPeer3Addr, &statePtr);
+    NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
+
+    // at time 300, this expires ip addr 1
+    connections.ExpireInactiveConnections(150);
+    NL_TEST_ASSERT(inSuite, callInfo.callCount == 1);
+    NL_TEST_ASSERT(inSuite, callInfo.lastCallNodeId == kUndefinedNodeId);
+    NL_TEST_ASSERT(inSuite, callInfo.lastCallPeerAddress == kPeer1Addr);
+    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer1NodeId, &statePtr));
+
+    // now that the connections were expired, we can add peer3
+    connections.GetTimeSource().SetCurrentMonotonicTimeMs(300);
+    err = connections.CreateNewPeerConnectionState(kPeer3Addr, &statePtr);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    statePtr->SetPeerNodeId(kPeer3NodeId);
+
+    connections.GetTimeSource().SetCurrentMonotonicTimeMs(400);
+    NL_TEST_ASSERT(inSuite, connections.FindPeerConnectionState(kPeer2NodeId, &statePtr));
+
+    connections.MarkConnectionActive(statePtr);
+    NL_TEST_ASSERT(inSuite, statePtr->GetLastActivityTimeMs() == connections.GetTimeSource().GetCurrentMonotonicTimeMs());
+
+    // At this time:
+    //   Peer 3 active at time 300
+    //   Peer 2 active at time 400
+
+    connections.GetTimeSource().SetCurrentMonotonicTimeMs(500);
+    callInfo.callCount = 0;
+    connections.ExpireInactiveConnections(150);
+
+    // peer 2 stays active
+    NL_TEST_ASSERT(inSuite, callInfo.callCount == 1);
+    NL_TEST_ASSERT(inSuite, callInfo.lastCallNodeId == kPeer3NodeId);
+    NL_TEST_ASSERT(inSuite, callInfo.lastCallPeerAddress == kPeer3Addr);
+    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer1Addr, &statePtr));
+    NL_TEST_ASSERT(inSuite, connections.FindPeerConnectionState(kPeer2Addr, &statePtr));
+    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer3Addr, &statePtr));
+
+    err = connections.CreateNewPeerConnectionState(kPeer1Addr, nullptr);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, connections.FindPeerConnectionState(kPeer1Addr, &statePtr));
+    NL_TEST_ASSERT(inSuite, connections.FindPeerConnectionState(kPeer2Addr, &statePtr));
+    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer3Addr, &statePtr));
+
+    // peer 1 and 2 are active
+    connections.GetTimeSource().SetCurrentMonotonicTimeMs(1000);
+    callInfo.callCount = 0;
+    connections.ExpireInactiveConnections(100);
+    NL_TEST_ASSERT(inSuite, callInfo.callCount == 2); // everything expired
+    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer1Addr, &statePtr));
+    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer2Addr, &statePtr));
+    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer3Addr, &statePtr));
+}
+
+} // namespace
+
+// clang-format off
+static const nlTest sTests[] =
+{
+    NL_TEST_DEF("BasicFunctionality", TestBasicFunctionality),
+    NL_TEST_DEF("FindByPeerAddress", TestFindByAddress),
+    NL_TEST_DEF("FindByNodeId", TestFindByNodeId),
+    NL_TEST_DEF("ExpireConnections", TestExpireConnections),
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+int TestPeerConnections(void)
+{
+    nlTestSuite theSuite = { "Transport-PeerConnections", &sTests[0], NULL, NULL };
+    nlTestRunner(&theSuite, NULL);
+    return nlTestRunnerStats(&theSuite);
+}

--- a/src/transport/tests/TestPeerConnections.cpp
+++ b/src/transport/tests/TestPeerConnections.cpp
@@ -51,11 +51,26 @@ const NodeId kPeer1NodeId = 123;
 const NodeId kPeer2NodeId = 6;
 const NodeId kPeer3NodeId = 81;
 
+/// A Peer connections that supports exactly 2 connections and a test time source.
+class TestPeerConnections : public PeerConnectionsBase
+{
+public:
+    TestPeerConnections() : PeerConnectionsBase(mState, ArraySize(mState)) {}
+    Time::TimeSource<Time::Source::kTest> & GetTimeSource() { return mTimeSource; }
+
+protected:
+    uint64_t GetCurrentMonotonicTimeMs() override { return mTimeSource.GetCurrentMonotonicTimeMs(); }
+
+private:
+    PeerConnectionState mState[2];
+    Time::TimeSource<Time::Source::kTest> mTimeSource;
+};
+
 void TestBasicFunctionality(nlTestSuite * inSuite, void * inContext)
 {
     CHIP_ERROR err;
     PeerConnectionState * statePtr;
-    PeerConnections<2, Time::Source::kTest> connections;
+    TestPeerConnections connections;
     connections.GetTimeSource().SetCurrentMonotonicTimeMs(100);
 
     err = connections.CreateNewPeerConnectionState(kPeer1Addr, nullptr);
@@ -76,7 +91,7 @@ void TestFindByAddress(nlTestSuite * inSuite, void * inContext)
 {
     CHIP_ERROR err;
     PeerConnectionState * statePtr;
-    PeerConnections<2, Time::Source::kTest> connections;
+    TestPeerConnections connections;
 
     err = connections.CreateNewPeerConnectionState(kPeer1Addr, nullptr);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -97,7 +112,7 @@ void TestFindByNodeId(nlTestSuite * inSuite, void * inContext)
 {
     CHIP_ERROR err;
     PeerConnectionState * statePtr;
-    PeerConnections<2, Time::Source::kTest> connections;
+    TestPeerConnections connections;
 
     err = connections.CreateNewPeerConnectionState(kPeer1Addr, &statePtr);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -138,7 +153,7 @@ void TestExpireConnections(nlTestSuite * inSuite, void * inContext)
     CHIP_ERROR err;
     ExpiredCallInfo callInfo;
     PeerConnectionState * statePtr;
-    PeerConnections<2, Time::Source::kTest> connections;
+    TestPeerConnections connections;
 
     connections.SetConnectionExpiredHandler(OnConnectionExpired, &callInfo);
 

--- a/src/transport/tests/TestPeerConnections.cpp
+++ b/src/transport/tests/TestPeerConnections.cpp
@@ -19,7 +19,7 @@
 /**
  *    @file
  *      This file implements a process to effect a functional test for
- *      the Message Header class within the transport layer
+ *      the PeerConnections class within the transport layer
  *
  */
 #include "TestTransportLayer.h"

--- a/src/transport/tests/TestPeerConnectionsDriver.cpp
+++ b/src/transport/tests/TestPeerConnectionsDriver.cpp
@@ -18,7 +18,7 @@
 /**
  *    @file
  *      This file implements a standalone/native program executable
- *      test driver for the CHIP Transport Layer Message header unit
+ *      test driver for the CHIP Transport Layer PeerConnections class unit
  *      tests.
  *
  */

--- a/src/transport/tests/TestPeerConnectionsDriver.cpp
+++ b/src/transport/tests/TestPeerConnectionsDriver.cpp
@@ -17,26 +17,18 @@
 
 /**
  *    @file
- *      This file declares test entry points for CHIP Transport layer
- *      layer library unit tests.
+ *      This file implements a standalone/native program executable
+ *      test driver for the CHIP Transport Layer Message header unit
+ *      tests.
  *
  */
 
-#ifndef TESTTRANSPORTLAYER_H
-#define TESTTRANSPORTLAYER_H
+#include "TestTransportLayer.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include <nlunit-test.h>
 
-int TestMessageHeader(void);
-int TestPeerConnections(void);
-int TestSecureSession(void);
-int TestSecureSessionMgr(void);
-int TestUDP(void);
-
-#ifdef __cplusplus
+int main(void)
+{
+    nlTestSetOutputStyle(OUTPUT_CSV);
+    return TestPeerConnections();
 }
-#endif
-
-#endif // TESTTRANSPORTLAYER_H


### PR DESCRIPTION
 #### Problem
Current session manager only supports a single connection. We need multiple connection support (up to some reasonable limit, within device capabilities)

 #### Summary of Changes
Defines a PeerConnections class, which contains an array of connection states that can be created, queried, deleted and expired.

working towards #1088 and #1070, so that our session manager can actually manage multiple sessions.
