### PR TITLE
Place secure channel into the session state

### DIFF
--- a/examples/lock-app/nrf5/main/Server.cpp
+++ b/examples/lock-app/nrf5/main/Server.cpp
@@ -68,9 +68,6 @@ void newConnectionHandler(const MessageHeader & header, const IPPacketInfo & pac
     VerifyOrExit(header.GetSourceNodeId().HasValue(), NRF_LOG_INFO("Unknown source for received message"));
     VerifyOrExit(transport->GetPeerNodeId() != header.GetSourceNodeId().Value(), NRF_LOG_INFO("Node already known."));
 
-    err = transport->Connect(header.GetSourceNodeId().Value(), PeerAddress::UDP(packet_info.SrcAddress, packet_info.SrcPort));
-    VerifyOrExit(err == CHIP_NO_ERROR, NRF_LOG_INFO("Failed to connect transport"));
-
     err = transport->ManualKeyExchange(remote_public_key, sizeof(remote_public_key), local_private_key, sizeof(local_private_key));
     VerifyOrExit(err == CHIP_NO_ERROR, NRF_LOG_INFO("Failed to setup encryption"));
 

--- a/examples/wifi-echo/server/esp32/main/EchoServer.cpp
+++ b/examples/wifi-echo/server/esp32/main/EchoServer.cpp
@@ -101,9 +101,6 @@ void newConnectionHandler(const MessageHeader & header, const IPPacketInfo & pac
     VerifyOrExit(header.GetSourceNodeId().HasValue(), ESP_LOGE(TAG, "Unknown source for received message"));
     VerifyOrExit(transport->GetPeerNodeId() != header.GetSourceNodeId().Value(), ESP_LOGI(TAG, "Node already known."));
 
-    err = transport->Connect(header.GetSourceNodeId().Value(), PeerAddress::UDP(packet_info.SrcAddress, packet_info.SrcPort));
-    VerifyOrExit(err == CHIP_NO_ERROR, ESP_LOGE(TAG, "Failed to connect transport"));
-
     err = transport->ManualKeyExchange(remote_public_key, sizeof(remote_public_key), local_private_key, sizeof(local_private_key));
     VerifyOrExit(err == CHIP_NO_ERROR, ESP_LOGE(TAG, "Failed to setup encryption"));
 

--- a/src/transport/PeerConnectionState.h
+++ b/src/transport/PeerConnectionState.h
@@ -24,6 +24,7 @@
 
 #include <transport/MessageHeader.h>
 #include <transport/PeerAddress.h>
+#include <transport/SecureSession.h>
 
 namespace chip {
 namespace Transport {
@@ -37,8 +38,9 @@ namespace Transport {
  *   - SendMessageIndex is an ever increasing index for sending messages
  *   - LastActivityTimeMs is a monotonic timestamp of when this connection was
  *     last used. Inactive connections can expire.
+ *   - SecureSession contains the encryption context of a connection
  *
- * TODO: to add encryption data and any message ACK information
+ * TODO: to add  any message ACK information
  */
 class PeerConnectionState
 {
@@ -65,11 +67,27 @@ public:
     uint64_t GetLastActivityTimeMs() const { return mLastActityTimeMs; }
     void SetLastActivityTimeMs(uint64_t value) { mLastActityTimeMs = value; }
 
+    SecureSession & GetSecureSession() { return mSecureSession; }
+    const SecureSession & GetSecureSession() const { return mSecureSession; }
+
+    /**
+     *  Reset the connection state to a completely uninitialized status.
+     */
+    void Reset()
+    {
+        mPeerAddress      = PeerAddress::Uninitialized();
+        mPeerNodeId       = kUndefinedNodeId;
+        mSendMessageIndex = 0;
+        mLastActityTimeMs = 0;
+        mSecureSession.Reset();
+    }
+
 private:
     PeerAddress mPeerAddress;
     NodeId mPeerNodeId         = kUndefinedNodeId;
     uint32_t mSendMessageIndex = 0;
     uint64_t mLastActityTimeMs = 0;
+    SecureSession mSecureSession;
 };
 
 } // namespace Transport

--- a/src/transport/PeerConnectionState.h
+++ b/src/transport/PeerConnectionState.h
@@ -40,7 +40,7 @@ namespace Transport {
  *     last used. Inactive connections can expire.
  *   - SecureSession contains the encryption context of a connection
  *
- * TODO: to add  any message ACK information
+ * TODO: to add any message ACK information
  */
 class PeerConnectionState
 {

--- a/src/transport/PeerConnections.cpp
+++ b/src/transport/PeerConnections.cpp
@@ -104,7 +104,7 @@ void PeerConnectionsBase::ExpireInactiveConnections(uint64_t maxIdleTimeMs)
         }
 
         // Connection is assumed expired, marking it as invalid
-        mConnectionStateArray[i] = PeerConnectionState(PeerAddress::Uninitialized());
+        mConnectionStateArray[i].Reset();
     }
 }
 

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -69,10 +69,11 @@ exit:
     return error;
 }
 
-void SecureSession::Close(void)
+void SecureSession::Reset(void)
 {
     mKeyAvailable = false;
     mNextIV       = 0;
+    memset(mKey, 0, sizeof(mKey));
 }
 
 CHIP_ERROR SecureSession::Encrypt(const unsigned char * input, size_t input_length, unsigned char * output, MessageHeader & header)

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -34,6 +34,12 @@ namespace chip {
 class DLL_EXPORT SecureSession
 {
 public:
+    SecureSession(void);
+    SecureSession(SecureSession &&)      = default;
+    SecureSession(const SecureSession &) = default;
+    SecureSession & operator=(const SecureSession &) = default;
+    SecureSession & operator=(SecureSession &&) = default;
+
     /**
      * @brief
      *   Derive a shared key. The derived key will be used for encryting/decrypting
@@ -82,12 +88,13 @@ public:
      */
     size_t EncryptionOverhead(void);
 
-    void Close(void);
-
-    SecureSession(void);
+    /**
+     * Clears the internal state of secure session back to the state of a new object.
+     */
+    void Reset(void);
 
 private:
-    static const size_t kAES_CCM128_Key_Length = 16;
+    static constexpr size_t kAES_CCM128_Key_Length = 16;
 
     bool mKeyAvailable;
     uint64_t mNextIV;

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -150,6 +150,10 @@ void SecureSessionMgr::HandleDataReceived(const MessageHeader & header, const IP
             connection->OnNewConnection(header, pktInfo, connection->mNewConnectionArgument);
         }
         err = CHIP_NO_ERROR;
+    }
+
+    if (!connection->StateAllowsReceive())
+    {
         ExitNow(ChipLogProgress(Inet, "Secure transport failed: state does not allow receive"));
     }
 

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -83,8 +83,8 @@ CHIP_ERROR SecureSessionMgr::ManualKeyExchange(const unsigned char * remote_publ
 
     VerifyOrExit(mState == State::kConnected, err = CHIP_ERROR_INCORRECT_STATE);
 
-    err = mSecureChannel.Init(remote_public_key, public_key_length, local_private_key, private_key_length, NULL, 0,
-                              (const unsigned char *) kManualKeyExchangeChannelInfo, info_len);
+    err = mConnectionState.GetSecureSession().Init(remote_public_key, public_key_length, local_private_key, private_key_length,
+                                                   NULL, 0, (const unsigned char *) kManualKeyExchangeChannelInfo, info_len);
     SuccessOrExit(err);
     mState = State::kSecureConnected;
 
@@ -106,7 +106,7 @@ CHIP_ERROR SecureSessionMgr::SendMessage(NodeId peerNodeId, System::PacketBuffer
         uint8_t * data = msgBuf->Start();
         MessageHeader header;
 
-        err = mSecureChannel.Encrypt(data, msgBuf->TotalLength(), data, header);
+        err = mConnectionState.GetSecureSession().Encrypt(data, msgBuf->TotalLength(), data, header);
         SuccessOrExit(err);
 
         ChipLogProgress(Inet, "Secure transport transmitting msg %u after encryption", mConnectionState.GetSendMessageIndex());
@@ -169,7 +169,7 @@ void SecureSessionMgr::HandleDataReceived(const MessageHeader & header, const IP
 #endif
         plainText = msg->Start();
 
-        err = connection->mSecureChannel.Decrypt(data, len, plainText, header);
+        err = connection->mConnectionState.GetSecureSession().Decrypt(data, len, plainText, header);
         VerifyOrExit(err == CHIP_NO_ERROR, ChipLogProgress(Inet, "Secure transport failed to decrypt msg: err %d", err));
 
         if (connection->OnMessageReceived)

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -81,8 +81,7 @@ CHIP_ERROR SecureSessionMgr::ManualKeyExchange(const unsigned char * remote_publ
     CHIP_ERROR err  = CHIP_NO_ERROR;
     size_t info_len = strlen(kManualKeyExchangeChannelInfo);
 
-    VerifyOrExit(mState == State::kConnected, err = CHIP_ERROR_INCORRECT_STATE);
-
+    VerifyOrExit(mState == State::kConnected || mState == State::kInitialized, err = CHIP_ERROR_INCORRECT_STATE);
     err = mConnectionState.GetSecureSession().Init(remote_public_key, public_key_length, local_private_key, private_key_length,
                                                    NULL, 0, (const unsigned char *) kManualKeyExchangeChannelInfo, info_len);
     SuccessOrExit(err);

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -163,7 +163,6 @@ private:
     Transport::PeerConnectionState mConnectionState;
     NodeId mLocalNodeId;
     State mState;
-    SecureSession mSecureChannel;
 
     bool StateAllowsSend(void) const { return mState != State::kNotReady; }
     bool StateAllowsReceive(void) const { return mState == State::kSecureConnected; }


### PR DESCRIPTION
#### Problem
Encryption data needs to be a part of a active peer connection state. 

#### Summary of Changes
Places the encryption state as a connection state member. This way, when we move to supporting multiple connections, each connection maintains its own encryption status and information.

Working towards #1070.