### PR TITLE
Integrate transport tests to QEMU

### DIFF
--- a/scripts/tests/esp32_qemu_tests.sh
+++ b/scripts/tests/esp32_qemu_tests.sh
@@ -32,3 +32,4 @@ source "$chip_dir"/src/test_driver/esp32/idf.sh
 idf make V=1 -C "$chip_dir"/src/test_driver/esp32/build/chip/src/crypto check
 idf make V=1 -C "$chip_dir"/src/test_driver/esp32/build/chip/src/inet check
 idf make V=1 -C "$chip_dir"/src/test_driver/esp32/build/chip/src/system check
+idf make V=1 -C "$chip_dir"/src/test_driver/esp32/build/chip/src/transport check

--- a/src/transport/tests/Makefile.am
+++ b/src/transport/tests/Makefile.am
@@ -76,34 +76,58 @@ COMMON_LDADD                                          = \
     libTransportLayerTests.a                            \
     $(COMMON_LDFLAGS)                                   \
     $(CHIP_LDADD)                                       \
-    $(NLFAULTINJECTION_LDFLAGS) $(NLFAULTINJECTION_LIBS) \
+    $(NLFAULTINJECTION_LDFLAGS)                         \
+    $(NLFAULTINJECTION_LIBS)                            \
     $(NLUNIT_TEST_LDFLAGS) $(NLUNIT_TEST_LIBS)          \
     $(LWIP_LDFLAGS) $(LWIP_LIBS)                        \
     $(SOCKETS_LDFLAGS) $(SOCKETS_LIBS)                  \
     $(PTHREAD_CFLAGS) $(PTHREAD_LIBS)                   \
     $(NULL)
 
+# The additional environment variables and their values that will be
+# made available to all programs and scripts in TESTS.
+
+TESTS_ENVIRONMENT                                     = \
+    $(NULL)
+
 # Test applications that should be run when the 'check' target is run.
 
-check_PROGRAMS             = \
-    TestMessageHeader        \
-    TestPeerConnections      \
-    TestSecureSessionMgr     \
-    TestSecureSession        \
-    TestUDP                  \
+check_PROGRAMS                                        = \
     $(NULL)
+
+check_SCRIPTS                                         = \
+    $(NULL)
+
+if CHIP_DEVICE_LAYER_TARGET_ESP32
+
+check_SCRIPTS                                        += \
+    qemu_transport_tests.sh                             \
+    $(NULL)
+
+TESTS_ENVIRONMENT                                    += \
+    abs_top_srcdir='$(abs_top_srcdir)'                  \
+    abs_top_builddir='$(abs_top_builddir)'              \
+    QEMU_TEST_TARGET=libTransportLayerTests.a           \
+    $(NULL)
+
+else # CHIP_DEVICE_LAYER_TARGET_ESP32
+
+check_PROGRAMS                                       += \
+    TestMessageHeader                                   \
+    TestPeerConnections                                 \
+    TestSecureSessionMgr                                \
+    TestSecureSession                                   \
+    TestUDP                                             \
+    $(NULL)
+
+endif # CHIP_DEVICE_LAYER_TARGET_ESP32
 
 # Test applications and scripts that should be built and run when the
 # 'check' target is run.
 
-TESTS                       = \
-    $(check_PROGRAMS)         \
-    $(NULL)
-
-# The additional environment variables and their values that will be
-# made available to all programs and scripts in TESTS.
-
-TESTS_ENVIRONMENT             = \
+TESTS                                                 = \
+    $(check_PROGRAMS)                                   \
+    $(check_SCRIPTS)                                    \
     $(NULL)
 
 # Source, compiler, and linker options for test programs.

--- a/src/transport/tests/TestMessageHeader.cpp
+++ b/src/transport/tests/TestMessageHeader.cpp
@@ -24,8 +24,8 @@
  */
 #include "TestTransportLayer.h"
 
-#include <support/ErrorStr.h>
 #include <support/CodeUtils.h>
+#include <support/ErrorStr.h>
 #include <support/TestUtils.h>
 #include <transport/MessageHeader.h>
 

--- a/src/transport/tests/TestMessageHeader.cpp
+++ b/src/transport/tests/TestMessageHeader.cpp
@@ -25,6 +25,8 @@
 #include "TestTransportLayer.h"
 
 #include <support/ErrorStr.h>
+#include <support/CodeUtils.h>
+#include <support/TestUtils.h>
 #include <transport/MessageHeader.h>
 
 #include <nlunit-test.h>
@@ -147,4 +149,9 @@ int TestMessageHeader(void)
     nlTestSuite theSuite = { "Transport-MessageHeader", &sTests[0], NULL, NULL };
     nlTestRunner(&theSuite, NULL);
     return nlTestRunnerStats(&theSuite);
+}
+
+static void __attribute__((constructor)) TestMessageHeaderCtor(void)
+{
+    VerifyOrDie(RegisterUnitTests(&TestMessageHeader) == CHIP_NO_ERROR);
 }

--- a/src/transport/tests/TestPeerConnections.cpp
+++ b/src/transport/tests/TestPeerConnections.cpp
@@ -24,8 +24,8 @@
  */
 #include "TestTransportLayer.h"
 
-#include <support/ErrorStr.h>
 #include <support/CodeUtils.h>
+#include <support/ErrorStr.h>
 #include <support/TestUtils.h>
 #include <transport/PeerConnections.h>
 

--- a/src/transport/tests/TestPeerConnections.cpp
+++ b/src/transport/tests/TestPeerConnections.cpp
@@ -25,6 +25,8 @@
 #include "TestTransportLayer.h"
 
 #include <support/ErrorStr.h>
+#include <support/CodeUtils.h>
+#include <support/TestUtils.h>
 #include <transport/PeerConnections.h>
 
 #include <nlunit-test.h>
@@ -236,9 +238,14 @@ static const nlTest sTests[] =
 };
 // clang-format on
 
-int TestPeerConnections(void)
+int TestPeerConnectionsFn(void)
 {
     nlTestSuite theSuite = { "Transport-PeerConnections", &sTests[0], NULL, NULL };
     nlTestRunner(&theSuite, NULL);
     return nlTestRunnerStats(&theSuite);
+}
+
+static void __attribute__((constructor)) TestPeerConnectionsCtor(void)
+{
+    VerifyOrDie(RegisterUnitTests(&TestPeerConnectionsFn) == CHIP_NO_ERROR);
 }

--- a/src/transport/tests/TestPeerConnectionsDriver.cpp
+++ b/src/transport/tests/TestPeerConnectionsDriver.cpp
@@ -30,5 +30,5 @@
 int main(void)
 {
     nlTestSetOutputStyle(OUTPUT_CSV);
-    return TestPeerConnections();
+    return TestPeerConnectionsFn();
 }

--- a/src/transport/tests/TestSecureSession.cpp
+++ b/src/transport/tests/TestSecureSession.cpp
@@ -31,6 +31,7 @@
 
 #include <stdarg.h>
 #include <support/CodeUtils.h>
+#include <support/TestUtils.h>
 
 using namespace chip;
 
@@ -206,6 +207,11 @@ int TestSecureSession()
     nlTestRunner(&sSuite, NULL);
 
     return (nlTestRunnerStats(&sSuite));
+}
+
+static void __attribute__((constructor)) TestSecureSessionCtor(void)
+{
+    VerifyOrDie(RegisterUnitTests(&TestSecureSession) == CHIP_NO_ERROR);
 }
 
 namespace chip {

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -117,7 +117,7 @@ static void DriveIO(TestContext & ctx)
 #endif
 }
 
-CHIP_ERROR InitLayers(System::Layer & systemLayer, InetLayer & inetLayer)
+static CHIP_ERROR InitLayers(System::Layer & systemLayer, InetLayer & inetLayer)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     // Initialize the CHIP System Layer.

--- a/src/transport/tests/TestTransportLayer.h
+++ b/src/transport/tests/TestTransportLayer.h
@@ -30,7 +30,7 @@ extern "C" {
 #endif
 
 int TestMessageHeader(void);
-int TestPeerConnections(void);
+int TestPeerConnectionsFn(void);
 int TestSecureSession(void);
 int TestSecureSessionMgr(void);
 int TestUDP(void);

--- a/src/transport/tests/TestUDP.cpp
+++ b/src/transport/tests/TestUDP.cpp
@@ -112,7 +112,7 @@ void DriveIO(TestContext & ctx)
 
 } // namespace
 
-CHIP_ERROR InitLayers(System::Layer & systemLayer, InetLayer & inetLayer)
+static CHIP_ERROR InitLayers(System::Layer & systemLayer, InetLayer & inetLayer)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     // Initialize the CHIP System Layer.

--- a/src/transport/tests/qemu_transport_tests.sh
+++ b/src/transport/tests/qemu_transport_tests.sh
@@ -1,0 +1,1 @@
+../../../scripts/tools/qemu_run_test.sh


### PR DESCRIPTION
 #### Problem
Unit tests for `src/transport` are not executed on device/QEMU

 #### Summary of Changes
Integrate the tests to QEMU and CI