### PR TITLE
[SetupPayload] SetupPayload.requiresCustomFlow is not set by ManualSe…

### DIFF
--- a/src/darwin/Framework/CHIPTests/CHIPSetupPayloadParserTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPSetupPayloadParserTests.m
@@ -47,7 +47,7 @@
     XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 2345);
     XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
-    XCTAssertFalse(payload.requiresCustomFlow);
+    XCTAssertTrue(payload.requiresCustomFlow);
     XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
     XCTAssertEqual(payload.rendezvousInformation.unsignedIntegerValue, 0);
 }

--- a/src/setup_payload/ManualSetupPayloadParser.cpp
+++ b/src/setup_payload/ManualSetupPayloadParser.cpp
@@ -197,8 +197,9 @@ CHIP_ERROR ManualSetupPayloadParser::populatePayload(SetupPayload & outPayload)
         outPayload.vendorID  = vendorID;
         outPayload.productID = productID;
     }
-    outPayload.setUpPINCode  = setUpPINCode;
-    outPayload.discriminator = discriminator;
+    outPayload.requiresCustomFlow = isLongCode ? 1 : 0;
+    outPayload.setUpPINCode       = setUpPINCode;
+    outPayload.discriminator      = discriminator;
 
     return result;
 }

--- a/src/setup_payload/tests/TestManualCode.cpp
+++ b/src/setup_payload/tests/TestManualCode.cpp
@@ -256,6 +256,35 @@ void TestPayloadParser_PartialPayload(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
+void TestShortCodeReadWrite(nlTestSuite * inSuite, void * context)
+{
+    SetupPayload inPayload = GetDefaultPayload();
+    SetupPayload outPayload;
+
+    string result;
+    ManualSetupPayloadGenerator generator(inPayload);
+    generator.payloadDecimalStringRepresentation(result);
+    ManualSetupPayloadParser(result).populatePayload(outPayload);
+
+    NL_TEST_ASSERT(inSuite, inPayload == outPayload);
+}
+
+void TestLongCodeReadWrite(nlTestSuite * inSuite, void * context)
+{
+    SetupPayload inPayload       = GetDefaultPayload();
+    inPayload.requiresCustomFlow = true;
+    inPayload.vendorID           = 1;
+    inPayload.productID          = 1;
+    SetupPayload outPayload;
+
+    string result;
+    ManualSetupPayloadGenerator generator(inPayload);
+    generator.payloadDecimalStringRepresentation(result);
+    ManualSetupPayloadParser(result).populatePayload(outPayload);
+
+    NL_TEST_ASSERT(inSuite, inPayload == outPayload);
+}
+
 void TestExtractBits(nlTestSuite * inSuite, void * inContext)
 {
     uint64_t dest;
@@ -479,6 +508,8 @@ static const nlTest sTests[] =
     NL_TEST_DEF("Parse from Partial Payload",                                           TestPayloadParser_PartialPayload),
     NL_TEST_DEF("Parse from Full Payload",                                              TestPayloadParser_FullPayload),
     NL_TEST_DEF("Test Invalid Entry To QR Code Parser",                                 TestPayloadParser_InvalidEntry),
+    NL_TEST_DEF("Test Short Read Write",                                                TestShortCodeReadWrite),
+    NL_TEST_DEF("Test Long Read Write",                                                 TestLongCodeReadWrite),
     NL_TEST_DEF("Test Extract Bits",                                                    TestExtractBits),
     NL_TEST_DEF("Check Decimal String Validity",                                        TestCheckDecimalStringValidity),
     NL_TEST_DEF("Check QR Code Length Validity",                                        TestCheckCodeLengthValidity),


### PR DESCRIPTION
…tupPayloadParser

 #### Problem
When building a manual code, if the requiresCustomFlow option is set, it is not retrieve when decoding.

 #### Summary of Changes
 * Set it correctly
 * Add a few tests

fixes #1208 
