### PR TITLE
Move java out of clang restyler and into google-java-format restyler

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -70,6 +70,16 @@ restylers:
           - "**/*.json"
           - "**/*.m"
           - "**/*.mm"
+    - name: google-java-format
+      enabled: true
+      image: restyled/restyler-google-java-format:v1.6
+      command:
+          - google-java-format
+          - "--replace"
+      arguments: []
+      include:
+          - "**/*.java"
+      interpreters: []
     - name: clang-format
       enabled: true
       image: restyled/restyler-clang-format:v9.0.0
@@ -91,7 +101,6 @@ restylers:
           - "**/*.hxx"
           - "**/*.h++"
           - "**/*.H"
-          - "**/*.java"
           - "**/*.js"
           - "**/*.m"
           - "**/*.mm"


### PR DESCRIPTION
 #### Problem
clang-format does not work on java which blocks PRs with java source

 #### Summary of Changes
moving java pattern out of clang-format restyler and into google-java-format restyler

