### PR TITLE
Test for adding entropy source

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1551,7 +1551,6 @@ if test "${with_crypto}" = "mbedtls"; then
 	    # variables and trust all will be well.
 
 	    MBEDTLS_CPPFLAGS="-I\${abs_top_srcdir}/third_party/mbedtls/repo/include"
-	    MBEDTLS_CPPFLAGS+=" -DMBEDTLS_NO_PLATFORM_ENTROPY -DMBEDTLS_TEST_NULL_ENTROPY -DMBEDTLS_NO_DEFAULT_ENTROPY_SOURCES"
 	    MBEDTLS_LDFLAGS="-L${ac_pwd}/third_party/mbedtls"
 	    MBEDTLS_LIBS="-lmbedtls"
 	],

--- a/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
@@ -33,6 +33,7 @@
 #include "tcpip_adapter.h"
 #include <stdio.h>
 
+#include <crypto/CHIPCryptoPAL.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <support/ErrorStr.h>
 #include <transport/SecureSessionMgr.h>
@@ -81,6 +82,13 @@ static Button attentionButton;
 const char * TAG = "wifi-echo-demo";
 
 static void DeviceEventHandler(const ChipDeviceEvent * event, intptr_t arg);
+
+static int app_entropy_source(void * data, unsigned char * output, size_t len, size_t * olen)
+{
+    esp_fill_random(output, len);
+    *olen = len;
+    return 0;
+}
 
 extern "C" void app_main()
 {
@@ -157,6 +165,13 @@ extern "C" void app_main()
     // Register a function to receive events from the CHIP device layer.  Note that calls to
     // this function will happen on the CHIP event loop thread, not the app_main thread.
     PlatformMgr().AddEventHandler(DeviceEventHandler, 0);
+
+    err = Crypto::add_entropy_source(app_entropy_source, NULL, 16);
+    if (err != CHIP_NO_ERROR)
+    {
+        ESP_LOGE(TAG, "add_entropy_source() failed: %s", ErrorStr(err));
+        return;
+    }
 
     // Start a task to run the CHIP Device event loop.
     err = PlatformMgr().StartEventLoopTask();

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -336,7 +336,7 @@ exit:
 
 CHIP_ERROR chip::Crypto::add_entropy_source(entropy_source fn_source, void * p_source, size_t threshold)
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR chip::Crypto::DRBG_get_bytes(unsigned char * out_buffer, const size_t out_length)


### PR DESCRIPTION
 #### Problem
Need to integrate and test `add_entropy_source` API

 #### Summary of Changes

- Added unit tests.
- Integrated the API to example app.
- Removed use of null entropy source from configuration file.

fixes #459