### PR TITLE
Disable some QEMU tests that are timing out

### DIFF
--- a/src/transport/tests/TestSecureSession.cpp
+++ b/src/transport/tests/TestSecureSession.cpp
@@ -31,7 +31,6 @@
 
 #include <stdarg.h>
 #include <support/CodeUtils.h>
-#include <support/TestUtils.h>
 
 using namespace chip;
 
@@ -207,11 +206,6 @@ int TestSecureSession()
     nlTestRunner(&sSuite, NULL);
 
     return (nlTestRunnerStats(&sSuite));
-}
-
-static void __attribute__((constructor)) TestSecureSessionCtor(void)
-{
-    VerifyOrDie(RegisterUnitTests(&TestSecureSession) == CHIP_NO_ERROR);
 }
 
 namespace chip {


### PR DESCRIPTION
 #### Problem
Some QEMU based tests are flaky in CI

 #### Summary of Changes
Secure Channel tests are sporadically timing out in CI, but are running fine locally. Disabling the offending tests in QEMU for time being, as its marking CI failure for some PRs.

Reference: #1222