### PR TITLE
ESP32 build issue: addVendorOptionalData has been renamed addOptional…

### DIFF
--- a/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
+++ b/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
@@ -94,11 +94,11 @@ string createSetupPayload()
     payload.version   = 1;
     payload.vendorID  = EXAMPLE_VENDOR_ID;
     payload.productID = 1;
-    payload.addVendorOptionalData(EXAMPLE_VENDOR_TAG_SSID, ap_ssid);
+    payload.addOptionalVendorData(EXAMPLE_VENDOR_TAG_SSID, ap_ssid);
 
     char gw_ip[INET6_ADDRSTRLEN];
     GetGatewayIP(gw_ip, sizeof(gw_ip));
-    payload.addVendorOptionalData(EXAMPLE_VENDOR_TAG_IP, gw_ip);
+    payload.addOptionalVendorData(EXAMPLE_VENDOR_TAG_IP, gw_ip);
 
     QRCodeSetupPayloadGenerator generator(payload);
     string result;


### PR DESCRIPTION
…VendorData

 #### Problem

SetupPayload::addVendorOptionalData has been renamed to SetupPayload::addOptionalVendorData in #1043, but it has not been renamed correctly in examples/wifi-echo/server/main/QRCodeWidget.cpp, and so the demo does not build anymore...


 #### Summary of Changes
Rename it.