### PR TITLE
[SetupPayload] Add some flags to configure the rendezvousInformation …

### DIFF
--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -199,7 +199,8 @@ static CHIP_ERROR generateBitSet(SetupPayload & payload, uint8_t * bits, uint8_t
     err = populateBits(bits, offset, payload.vendorID, kVendorIDFieldLengthInBits, kTotalPayloadDataSizeInBits);
     err = populateBits(bits, offset, payload.productID, kProductIDFieldLengthInBits, kTotalPayloadDataSizeInBits);
     err = populateBits(bits, offset, payload.requiresCustomFlow, kCustomFlowRequiredFieldLengthInBits, kTotalPayloadDataSizeInBits);
-    err = populateBits(bits, offset, payload.rendezvousInformation, kRendezvousInfoFieldLengthInBits, kTotalPayloadDataSizeInBits);
+    err = populateBits(bits, offset, (uint16_t) payload.rendezvousInformation, kRendezvousInfoFieldLengthInBits,
+                       kTotalPayloadDataSizeInBits);
     err = populateBits(bits, offset, payload.discriminator, kPayloadDiscriminatorFieldLengthInBits, kTotalPayloadDataSizeInBits);
     err = populateBits(bits, offset, payload.setUpPINCode, kSetupPINCodeFieldLengthInBits, kTotalPayloadDataSizeInBits);
     err = populateBits(bits, offset, 0, kPaddingFieldLengthInBits, kTotalPayloadDataSizeInBits);

--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -384,7 +384,7 @@ CHIP_ERROR QRCodeSetupPayloadParser::populatePayload(SetupPayload & outPayload)
 
     err = readBits(buf, indexToReadFrom, dest, kRendezvousInfoFieldLengthInBits);
     SuccessOrExit(err);
-    outPayload.rendezvousInformation = dest;
+    outPayload.rendezvousInformation = (RendezvousInformationFlags) dest;
 
     err = readBits(buf, indexToReadFrom, dest, kPayloadDiscriminatorFieldLengthInBits);
     SuccessOrExit(err);

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -57,8 +57,7 @@ bool SetupPayload::isValidQRCodePayload()
         return false;
     }
 
-    size_t rendezvousInfoAllowedFieldLengthInBits = kRendezvousInfoFieldLengthInBits - kRendezvousInfoReservedFieldLengthInBits;
-    if (rendezvousInformation >= 1 << rendezvousInfoAllowedFieldLengthInBits)
+    if (rendezvousInformation > RendezvousInformationFlags::kAllMask)
     {
         return false;
     }
@@ -73,7 +72,7 @@ bool SetupPayload::isValidQRCodePayload()
         return false;
     }
 
-    if (version == 0 && rendezvousInformation == 0 && discriminator == 0 && setUpPINCode == 0)
+    if (version == 0 && rendezvousInformation == RendezvousInformationFlags::kNone && discriminator == 0 && setUpPINCode == 0)
     {
         return false;
     }

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -46,8 +46,7 @@ const int kManualSetupDiscriminatorFieldLengthInBits = 4;
 const int kSetupPINCodeFieldLengthInBits             = 27;
 const int kPaddingFieldLengthInBits                  = 5;
 
-const int kRendezvousInfoReservedFieldLengthInBits = 4;
-const int kRawVendorTagLengthInBits                = 7;
+const int kRawVendorTagLengthInBits = 7;
 
 const int kManualSetupShortCodeCharLength = 10;
 const int kManualSetupLongCodeCharLength  = 20;
@@ -72,6 +71,17 @@ const int kTotalPayloadDataSizeInBits =
 const int kTotalPayloadDataSizeInBytes = kTotalPayloadDataSizeInBits / 8;
 
 const char * const kQRCodePrefix = "CH:";
+
+enum class RendezvousInformationFlags : uint16_t
+{
+    kNone     = 0,      // Device does not support any method for rendezvous
+    kSoftAP   = 1 << 0, // Device supports hosting a SoftAP
+    kBLE      = 1 << 1, // Device supports BLE
+    kThread   = 1 << 2, // Device supports Thread
+    kEthernet = 1 << 3, // Device MAY be attached to a wired 802." connection"
+
+    kAllMask = kSoftAP | kBLE | kThread | kEthernet,
+};
 
 enum optionalQRCodeInfoType
 {
@@ -121,7 +131,6 @@ struct OptionalQRCodeInfoExtension : OptionalQRCodeInfo
 
 bool IsCHIPTag(uint8_t tag);
 bool IsVendorTag(uint8_t tag);
-;
 
 class SetupPayload
 {
@@ -134,7 +143,7 @@ public:
     uint16_t vendorID;
     uint16_t productID;
     uint8_t requiresCustomFlow;
-    uint16_t rendezvousInformation;
+    RendezvousInformationFlags rendezvousInformation;
     uint16_t discriminator;
     uint32_t setUpPINCode;
 
@@ -188,7 +197,8 @@ public:
 
     // Test that the Setup Payload is within expected value ranges
     SetupPayload() :
-        version(0), vendorID(0), productID(0), requiresCustomFlow(0), rendezvousInformation(0), discriminator(0), setUpPINCode(0){};
+        version(0), vendorID(0), productID(0), requiresCustomFlow(0), rendezvousInformation(RendezvousInformationFlags::kNone),
+        discriminator(0), setUpPINCode(0){};
 
     bool isValidQRCodePayload();
     bool isValidManualCode();

--- a/src/setup_payload/SetupPayloadHelper.cpp
+++ b/src/setup_payload/SetupPayloadHelper.cpp
@@ -123,7 +123,7 @@ static CHIP_ERROR addParameter(SetupPayload & setupPayload, SetupPayloadParamete
         break;
     case SetupPayloadKey_RendezVousInformation:
         ChipLogDetail(SetupPayload, "Loaded rendezvousInfo: %u", (uint16_t) parameter.uintValue);
-        setupPayload.rendezvousInformation = (uint16_t) parameter.uintValue;
+        setupPayload.rendezvousInformation = (RendezvousInformationFlags) parameter.uintValue;
         break;
     case SetupPayloadKey_Discriminator:
         ChipLogDetail(SetupPayload, "Loaded discriminator: %u", (uint16_t) parameter.uintValue);

--- a/src/setup_payload/tests/TestHelpers.h
+++ b/src/setup_payload/tests/TestHelpers.h
@@ -42,7 +42,7 @@ SetupPayload GetDefaultPayload()
     payload.vendorID              = 12;
     payload.productID             = 1;
     payload.requiresCustomFlow    = 0;
-    payload.rendezvousInformation = 1;
+    payload.rendezvousInformation = RendezvousInformationFlags::kSoftAP;
     payload.discriminator         = 128;
     payload.setUpPINCode          = 2048;
 
@@ -141,4 +141,19 @@ bool CompareBinaryLength(SetupPayload & payload, size_t expectedTLVLengthInBytes
     string resultBinary           = toBinaryRepresentation(result);
     size_t resultTLVLengthInBytes = (resultBinary.size() - baseBinary.size()) / 8;
     return (expectedTLVLengthInBytes == resultTLVLengthInBytes);
+}
+
+bool CheckWriteRead(SetupPayload & inPayload)
+{
+    SetupPayload outPayload;
+    string result;
+
+    QRCodeSetupPayloadGenerator generator(inPayload);
+    uint8_t optionalInfo[kDefaultBufferSizeInBytes];
+    generator.payloadBase41Representation(result, optionalInfo, sizeof(optionalInfo));
+
+    QRCodeSetupPayloadParser parser = QRCodeSetupPayloadParser(result);
+    parser.populatePayload(outPayload);
+
+    return inPayload == outPayload;
 }

--- a/src/setup_payload/tests/TestQRCode.cpp
+++ b/src/setup_payload/tests/TestQRCode.cpp
@@ -32,6 +32,29 @@
 using namespace chip;
 using namespace std;
 
+void TestRendezvousFlags(nlTestSuite * inSuite, void * inContext)
+{
+    SetupPayload inPayload = GetDefaultPayload();
+
+    inPayload.rendezvousInformation = RendezvousInformationFlags::kNone;
+    NL_TEST_ASSERT(inSuite, CheckWriteRead(inPayload));
+
+    inPayload.rendezvousInformation = RendezvousInformationFlags::kSoftAP;
+    NL_TEST_ASSERT(inSuite, CheckWriteRead(inPayload));
+
+    inPayload.rendezvousInformation = RendezvousInformationFlags::kBLE;
+    NL_TEST_ASSERT(inSuite, CheckWriteRead(inPayload));
+
+    inPayload.rendezvousInformation = RendezvousInformationFlags::kThread;
+    NL_TEST_ASSERT(inSuite, CheckWriteRead(inPayload));
+
+    inPayload.rendezvousInformation = RendezvousInformationFlags::kEthernet;
+    NL_TEST_ASSERT(inSuite, CheckWriteRead(inPayload));
+
+    inPayload.rendezvousInformation = RendezvousInformationFlags::kAllMask;
+    NL_TEST_ASSERT(inSuite, CheckWriteRead(inPayload));
+}
+
 void TestPayloadByteArrayRep(nlTestSuite * inSuite, void * inContext)
 {
     SetupPayload payload = GetDefaultPayload();
@@ -166,12 +189,12 @@ void TestSetupPayloadVerify(nlTestSuite * inSuite, void * inContext)
 
     // test invalid rendezvousInformation
     test_payload                       = payload;
-    test_payload.rendezvousInformation = 1 << kRendezvousInfoFieldLengthInBits;
+    test_payload.rendezvousInformation = (RendezvousInformationFlags)(1 << kRendezvousInfoFieldLengthInBits);
     NL_TEST_ASSERT(inSuite, test_payload.isValidQRCodePayload() == false);
 
     // test invalid rendezvousInformation
     test_payload                       = payload;
-    test_payload.rendezvousInformation = 1 << (kRendezvousInfoFieldLengthInBits - kRendezvousInfoReservedFieldLengthInBits);
+    test_payload.rendezvousInformation = (RendezvousInformationFlags)((uint16_t) RendezvousInformationFlags::kAllMask + 1);
     NL_TEST_ASSERT(inSuite, test_payload.isValidQRCodePayload() == false);
 
     // test invalid discriminator
@@ -280,7 +303,7 @@ void TestExtractPayload(nlTestSuite * inSuite, void * inContext)
 // clang-format off
 static const nlTest sTests[] =
 {
-
+    NL_TEST_DEF("Test Rendezvous Flags",                                            TestRendezvousFlags),
     NL_TEST_DEF("Test Base 41",                                                     TestBase41),
     NL_TEST_DEF("Test Bitset Length",                                               TestBitsetLen),
     NL_TEST_DEF("Test Payload Byte Array Representation",                           TestPayloadByteArrayRep),

--- a/src/setup_payload/tests/TestQRCodeTLV.cpp
+++ b/src/setup_payload/tests/TestQRCodeTLV.cpp
@@ -24,22 +24,6 @@
 using namespace chip;
 using namespace std;
 
-void CompareWriteRead(nlTestSuite * inSuite, void * inContext, SetupPayload & inPayload)
-{
-    SetupPayload outPayload;
-
-    QRCodeSetupPayloadGenerator generator(inPayload);
-    string result;
-    uint8_t optionalInfo[kDefaultBufferSizeInBytes];
-    CHIP_ERROR err = generator.payloadBase41Representation(result, optionalInfo, sizeof(optionalInfo));
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    QRCodeSetupPayloadParser parser = QRCodeSetupPayloadParser(result);
-    err                             = parser.populatePayload(outPayload);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, inPayload == outPayload);
-}
-
 void TestOptionalDataAddRemove(nlTestSuite * inSuite, void * inContext)
 {
     SetupPayload payload = GetDefaultPayload();
@@ -188,10 +172,10 @@ void TestOptionalDataReadSerial(nlTestSuite * inSuite, void * inContext)
     SetupPayload inPayload = GetDefaultPayload();
 
     inPayload.addSerialNumber(kSerialNumberDefaultStringValue);
-    CompareWriteRead(inSuite, inContext, inPayload);
+    NL_TEST_ASSERT(inSuite, CheckWriteRead(inPayload));
 
     inPayload.addSerialNumber(kSerialNumberDefaultUInt32Value);
-    CompareWriteRead(inSuite, inContext, inPayload);
+    NL_TEST_ASSERT(inSuite, CheckWriteRead(inPayload));
 }
 
 void TestOptionalDataReadVendorInt(nlTestSuite * inSuite, void * inContext)
@@ -199,7 +183,7 @@ void TestOptionalDataReadVendorInt(nlTestSuite * inSuite, void * inContext)
     SetupPayload inPayload = GetDefaultPayload();
     inPayload.addOptionalVendorData(kOptionalDefaultIntTag, kOptionalDefaultIntValue);
 
-    CompareWriteRead(inSuite, inContext, inPayload);
+    NL_TEST_ASSERT(inSuite, CheckWriteRead(inPayload));
 }
 
 void TestOptionalDataReadVendorString(nlTestSuite * inSuite, void * inContext)
@@ -207,14 +191,14 @@ void TestOptionalDataReadVendorString(nlTestSuite * inSuite, void * inContext)
     SetupPayload inPayload = GetDefaultPayload();
     inPayload.addOptionalVendorData(kOptionalDefaultStringTag, kOptionalDefaultStringValue);
 
-    CompareWriteRead(inSuite, inContext, inPayload);
+    NL_TEST_ASSERT(inSuite, CheckWriteRead(inPayload));
 }
 
 void TestOptionalDataRead(nlTestSuite * inSuite, void * inContext)
 {
     SetupPayload inPayload = GetDefaultPayloadWithOptionalDefaults();
 
-    CompareWriteRead(inSuite, inContext, inPayload);
+    NL_TEST_ASSERT(inSuite, CheckWriteRead(inPayload));
 }
 
 void TestOptionalDataWriteNoBuffer(nlTestSuite * inSuite, void * inContext)


### PR DESCRIPTION
…field

 #### Problem
The payload rendezvousInformation fields values are specified as:

0 | 1 | Soft-AP:  1: Device supports hosting a Soft-AP for rendezvous
1 | 1 | BLE:  1: Device supports BLE for rendezvous
2 | 1 | Thread:  1: Device supports Thread for rendezvous
3 | 1 | Ethernet:  1: Device MAY be attached to a wired 802.3 connection
4..7 | 4 | Reserved (must be 0)

It would be easier and less error prone to configure them via flags instead of manually doing the maths.

 #### Summary of Changes
 * Expose a few flags that map to the spec.
 * Add some tests

fixes #1231 
