### PR TITLE
Fix QEMU flaky test runs

### DIFF
--- a/config/esp32/components/chip/component.mk
+++ b/config/esp32/components/chip/component.mk
@@ -153,8 +153,11 @@ COMPONENT_ADD_LDFLAGS        = -L$(OUTPUT_DIR)/lib/ \
                                -lSystemLayer \
                                -lDeviceLayer \
                                -lChipCrypto \
-                               -lSetupPayload \
-                               -lnlfaultinjection
+                               -lSetupPayload
+
+ifneq (,$(findstring CHIP_SUPPORT_FOREIGN_TEST_DRIVERS,$(CXXFLAGS)))
+COMPONENT_ADD_LDFLAGS       += -lnlfaultinjection
+endif
 
 # Tell the ESP-IDF build system that the CHIP component defines its own build
 # and clean targets.

--- a/config/esp32/components/chip/component.mk
+++ b/config/esp32/components/chip/component.mk
@@ -153,7 +153,8 @@ COMPONENT_ADD_LDFLAGS        = -L$(OUTPUT_DIR)/lib/ \
                                -lSystemLayer \
                                -lDeviceLayer \
                                -lChipCrypto \
-                               -lSetupPayload
+                               -lSetupPayload \
+                               -lnlfaultinjection
 
 # Tell the ESP-IDF build system that the CHIP component defines its own build
 # and clean targets.

--- a/src/system/tests/TestSystemTimer.cpp
+++ b/src/system/tests/TestSystemTimer.cpp
@@ -231,8 +231,8 @@ static int TestSetup(void * aContext)
 
     sys_mbox_new(sLwIPEventQueue, 100);
     lLayerContext = &sLwIPEventQueue;
-#endif
     tcpip_init(NULL, NULL);
+#endif
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
     sLayer.Init(lLayerContext);

--- a/src/test_driver/esp32/main/main_app.cpp
+++ b/src/test_driver/esp32/main/main_app.cpp
@@ -15,17 +15,90 @@
  *    limitations under the License.
  */
 
+#include "esp_event_loop.h"
+#include "esp_heap_caps_init.h"
 #include "esp_log.h"
+#include "esp_spi_flash.h"
+#include "esp_system.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "nvs_flash.h"
+
+#include "tcpip_adapter.h"
 #include <stdio.h>
 
+#include <crypto/CHIPCryptoPAL.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <support/ErrorStr.h>
 #include <support/TestUtils.h>
 
 using namespace ::chip;
+using namespace ::chip::DeviceLayer;
 
 const char * TAG = "CHIP-tests";
 
+static int app_entropy_source(void * data, unsigned char * output, size_t len, size_t * olen)
+{
+    esp_fill_random(output, len);
+    *olen = len;
+    return 0;
+}
+
 extern "C" void app_main()
 {
+    esp_chip_info_t chip_info;
+    esp_chip_info(&chip_info);
+
+    ESP_LOGI(TAG, "This is ESP32 chip with %d CPU cores, WiFi%s%s, ", chip_info.cores,
+             (chip_info.features & CHIP_FEATURE_BT) ? "/BT" : "", (chip_info.features & CHIP_FEATURE_BLE) ? "/BLE" : "");
+
+    ESP_LOGI(TAG, "silicon revision %d, ", chip_info.revision);
+
+    ESP_LOGI(TAG, "%dMB %s flash\n", spi_flash_get_chip_size() / (1024 * 1024),
+             (chip_info.features & CHIP_FEATURE_EMB_FLASH) ? "embedded" : "external");
+
+    CHIP_ERROR err; // A quick note about errors: CHIP adopts the error type and numbering
+                    // convention of the environment into which it is ported.  Thus esp_err_t
+                    // and CHIP_ERROR are in fact the same type, and both ESP-IDF errors
+                    // and CHIO-specific errors can be stored in the same value without
+                    // ambiguity.  For convenience, ESP_OK and CHIP_NO_ERROR are mapped
+                    // to the same value.
+
+    // Initialize the ESP NVS layer.
+    err = nvs_flash_init();
+    if (err != CHIP_NO_ERROR)
+    {
+        ESP_LOGE(TAG, "nvs_flash_init() failed: %s", ErrorStr(err));
+        exit(err);
+    }
+
+    // Initialize the LwIP core lock.  This must be done before the ESP
+    // tcpip_adapter layer is initialized.
+    err = PlatformMgrImpl().InitLwIPCoreLock();
+    if (err != CHIP_NO_ERROR)
+    {
+        ESP_LOGE(TAG, "PlatformMgr().InitLocks() failed: %s", ErrorStr(err));
+        exit(err);
+    }
+
+    // Initialize the ESP tcpip adapter.
+    tcpip_adapter_init();
+
+    // Arrange for the ESP event loop to deliver events into the CHIP Device layer.
+    err = esp_event_loop_init(PlatformManagerImpl::HandleESPSystemEvent, NULL);
+    if (err != CHIP_NO_ERROR)
+    {
+        ESP_LOGE(TAG, "esp_event_loop_init() failed: %s", ErrorStr(err));
+        exit(err);
+    }
+
+    err = Crypto::add_entropy_source(app_entropy_source, NULL, 16);
+    if (err != CHIP_NO_ERROR)
+    {
+        ESP_LOGE(TAG, "add_entropy_source() failed: %s", ErrorStr(err));
+        exit(err);
+    }
+
     ESP_LOGI(TAG, "Starting CHIP tests!");
     int status = RunRegisteredUnitTests();
     ESP_LOGI(TAG, "CHIP test status: %d", status);

--- a/src/test_driver/esp32/main/main_app.cpp
+++ b/src/test_driver/esp32/main/main_app.cpp
@@ -44,6 +44,14 @@ static int app_entropy_source(void * data, unsigned char * output, size_t len, s
     return 0;
 }
 
+static void tester_task(void * pvParameters)
+{
+    ESP_LOGI(TAG, "Starting CHIP tests!");
+    int status = RunRegisteredUnitTests();
+    ESP_LOGI(TAG, "CHIP test status: %d", status);
+    exit(status);
+}
+
 extern "C" void app_main()
 {
     esp_chip_info_t chip_info;
@@ -99,8 +107,10 @@ extern "C" void app_main()
         exit(err);
     }
 
-    ESP_LOGI(TAG, "Starting CHIP tests!");
-    int status = RunRegisteredUnitTests();
-    ESP_LOGI(TAG, "CHIP test status: %d", status);
-    exit(status);
+    xTaskCreate(tester_task, "tester", 8192, (void *) NULL, tskIDLE_PRIORITY+10, NULL);
+
+    while(1)
+    {
+        vTaskDelay(50 / portTICK_PERIOD_MS);
+    }
 }

--- a/src/test_driver/esp32/main/main_app.cpp
+++ b/src/test_driver/esp32/main/main_app.cpp
@@ -107,9 +107,9 @@ extern "C" void app_main()
         exit(err);
     }
 
-    xTaskCreate(tester_task, "tester", 8192, (void *) NULL, tskIDLE_PRIORITY+10, NULL);
+    xTaskCreate(tester_task, "tester", 8192, (void *) NULL, tskIDLE_PRIORITY + 10, NULL);
 
-    while(1)
+    while (1)
     {
         vTaskDelay(50 / portTICK_PERIOD_MS);
     }

--- a/src/transport/tests/TestSecureSession.cpp
+++ b/src/transport/tests/TestSecureSession.cpp
@@ -31,6 +31,7 @@
 
 #include <stdarg.h>
 #include <support/CodeUtils.h>
+#include <support/TestUtils.h>
 
 using namespace chip;
 
@@ -206,6 +207,11 @@ int TestSecureSession()
     nlTestRunner(&sSuite, NULL);
 
     return (nlTestRunnerStats(&sSuite));
+}
+
+static void __attribute__((constructor)) TestSecureSessionCtor(void)
+{
+    VerifyOrDie(RegisterUnitTests(&TestSecureSession) == CHIP_NO_ERROR);
 }
 
 namespace chip {


### PR DESCRIPTION
### Problem
Some QEMU tests are showing flaky behavior. Those tests were removed from QEMU in previous PR. But, we need to analyze the root cause and fix it.

### Summary of Changes
- Add more CHIP related initialization to QEMU
- Move testing to its own FreeRTOS task
- Some more tweaks to fix failures

Tested current PR on CI machine. A continuous run of test worked fine for over 50 iterations.

Fixes #1222