### PR TITLE
Test the M5Stack configuration for the ESP32 Example

### DIFF
--- a/examples/wifi-echo/server/esp32/sdkconfig.defaults
+++ b/examples/wifi-echo/server/esp32/sdkconfig.defaults
@@ -1,0 +1,35 @@
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#    Copyright (c) 2018 Nest Labs, Inc.
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+#    Description:
+#      Some useful defaults for the demo app configuration.
+#
+
+
+# Default to 921600 baud when flashing and monitoring device
+CONFIG_ESPTOOLPY_BAUD_921600B=y
+CONFIG_ESPTOOLPY_BAUD=921600
+CONFIG_ESPTOOLPY_COMPRESSED=y
+CONFIG_MONITOR_BAUD_115200B=y
+CONFIG_MONITOR_BAUD=115200
+
+#enable lwip ipv6 autoconfig
+CONFIG_LWIP_IPV6_AUTOCONFIG=y
+
+# Use a custom partition table
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"

--- a/examples/wifi-echo/server/esp32/sdkconfig_devkit.defaults
+++ b/examples/wifi-echo/server/esp32/sdkconfig_devkit.defaults
@@ -16,9 +16,10 @@
 #    limitations under the License.
 #
 #    Description:
-#      Some useful defaults for the demo app configuration.
+#      CI uses this to select the ESP32-DevKitC.
 #
 
+CONFIG_DEVICE_TYPE_ESP32_DEVKITC=y
 
 # Default to 921600 baud when flashing and monitoring device
 CONFIG_ESPTOOLPY_BAUD_921600B=y
@@ -33,4 +34,3 @@ CONFIG_LWIP_IPV6_AUTOCONFIG=y
 # Use a custom partition table
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"
-

--- a/examples/wifi-echo/server/esp32/sdkconfig_m5stack.defaults
+++ b/examples/wifi-echo/server/esp32/sdkconfig_m5stack.defaults
@@ -1,0 +1,36 @@
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#    Copyright (c) 2018 Nest Labs, Inc.
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+#    Description:
+#      CI uses this to select the ESP32 M5Stack.
+#
+
+CONFIG_DEVICE_TYPE_M5STACK=y
+
+# Default to 921600 baud when flashing and monitoring device
+CONFIG_ESPTOOLPY_BAUD_921600B=y
+CONFIG_ESPTOOLPY_BAUD=921600
+CONFIG_ESPTOOLPY_COMPRESSED=y
+CONFIG_MONITOR_BAUD_115200B=y
+CONFIG_MONITOR_BAUD=115200
+
+#enable lwip ipv6 autoconfig
+CONFIG_LWIP_IPV6_AUTOCONFIG=y
+
+# Use a custom partition table
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"

--- a/scripts/examples/esp_echo_app.sh
+++ b/scripts/examples/esp_echo_app.sh
@@ -9,7 +9,13 @@ make -j -f Makefile-bootstrap repos
 source "$root"/idf.sh
 
 SDKCONFIG_DEFAULTS=$root/sdkconfig_devkit.defaults idf make -j V=1 -C "$root" defconfig
-idf make -j V=1 -C "$root" || { echo 'build DevKit-C failed' ; exit 1; }
+idf make -j V=1 -C "$root" || {
+    echo 'build DevKit-C failed'
+    exit 1
+}
 
 SDKCONFIG_DEFAULTS=$root/sdkconfig_m5stack.defaults idf make -j V=1 -C "$root" defconfig
-idf make -j V=1 -C "$root" || { echo 'build M5Stack failed' ; exit 1; }
+idf make -j V=1 -C "$root" || {
+    echo 'build M5Stack failed'
+    exit 1
+}

--- a/scripts/examples/esp_echo_app.sh
+++ b/scripts/examples/esp_echo_app.sh
@@ -3,7 +3,13 @@
 set -x
 env
 
+root=examples/wifi-echo/server/esp32/
+
 make -j -f Makefile-bootstrap repos
-source examples/wifi-echo/server/esp32/idf.sh
-idf make -j V=1 -C examples/wifi-echo/server/esp32 defconfig
-idf make -j V=1 -C examples/wifi-echo/server/esp32
+source ${root}/idf.sh
+
+SDKCONFIG_DEFAULTS=${root}/sdkconfig_devkit.defaults idf make -j V=1 -C ${root} defconfig
+idf make -j V=1 -C ${root} || { echo 'build DevKit-C failed' ; exit 1; }
+
+SDKCONFIG_DEFAULTS=${root}/sdkconfig_m5stack.defaults idf make -j V=1 -C ${root} defconfig
+idf make -j V=1 -C ${root} || { echo 'build M5Stack failed' ; exit 1; }

--- a/scripts/examples/esp_echo_app.sh
+++ b/scripts/examples/esp_echo_app.sh
@@ -6,10 +6,10 @@ env
 root=examples/wifi-echo/server/esp32/
 
 make -j -f Makefile-bootstrap repos
-source ${root}/idf.sh
+source "$root"/idf.sh
 
-SDKCONFIG_DEFAULTS=${root}/sdkconfig_devkit.defaults idf make -j V=1 -C ${root} defconfig
-idf make -j V=1 -C ${root} || { echo 'build DevKit-C failed' ; exit 1; }
+SDKCONFIG_DEFAULTS=$root/sdkconfig_devkit.defaults idf make -j V=1 -C "$root" defconfig
+idf make -j V=1 -C "$root" || { echo 'build DevKit-C failed' ; exit 1; }
 
-SDKCONFIG_DEFAULTS=${root}/sdkconfig_m5stack.defaults idf make -j V=1 -C ${root} defconfig
-idf make -j V=1 -C ${root} || { echo 'build M5Stack failed' ; exit 1; }
+SDKCONFIG_DEFAULTS=$root/sdkconfig_m5stack.defaults idf make -j V=1 -C "$root" defconfig
+idf make -j V=1 -C "$root" || { echo 'build M5Stack failed' ; exit 1; }


### PR DESCRIPTION
 #### Problem
Not all the code in the ESP32 Example App is being built in CI
 #### Summary of Changes
Build and test both the DevKit-C and M5Stack versions of the ESP32 Example App

fixes https://github.com/project-chip/connectedhomeip/issues/1244
