### PR TITLE
Prefix includes in src/inet and src/lib/core & remove leaves from search path

### DIFF
--- a/src/inet/AsyncDNSResolverSockets.cpp
+++ b/src/inet/AsyncDNSResolverSockets.cpp
@@ -22,7 +22,7 @@
  *      Asynchronous Domain Name System (DNS) resolution in InetLayer.
  *
  */
-#include <InetLayer.h>
+#include <inet/InetLayer.h>
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
 

--- a/src/inet/DNSResolver.cpp
+++ b/src/inet/DNSResolver.cpp
@@ -23,10 +23,10 @@
  *
  */
 
-#include <DNSResolver.h>
+#include <inet/DNSResolver.h>
 
-#include <InetLayer.h>
-#include <InetLayerEvents.h>
+#include <inet/InetLayer.h>
+#include <inet/InetLayerEvents.h>
 
 #include <support/CodeUtils.h>
 

--- a/src/inet/EndPointBasis.cpp
+++ b/src/inet/EndPointBasis.cpp
@@ -23,9 +23,9 @@
  *      in the Inet layer, i.e. TCP, UDP, Raw and Tun.
  */
 
-#include <EndPointBasis.h>
+#include <inet/EndPointBasis.h>
 
-#include <InetLayer.h>
+#include <inet/InetLayer.h>
 
 namespace chip {
 namespace Inet {

--- a/src/inet/IPAddress-StringFuncts.cpp
+++ b/src/inet/IPAddress-StringFuncts.cpp
@@ -29,7 +29,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <InetLayer.h>
+#include <inet/InetLayer.h>
 
 #if !CHIP_SYSTEM_CONFIG_USE_LWIP
 #include <arpa/inet.h>

--- a/src/inet/IPAddress.cpp
+++ b/src/inet/IPAddress.cpp
@@ -31,7 +31,7 @@
 #define __STDC_LIMIT_MACROS
 #endif
 
-#include <IPAddress.h>
+#include <inet/IPAddress.h>
 
 #include <core/CHIPEncoding.h>
 

--- a/src/inet/IPEndPointBasis.cpp
+++ b/src/inet/IPEndPointBasis.cpp
@@ -31,9 +31,9 @@
 
 #include <string.h>
 
-#include <EndPointBasis.h>
-#include <InetInterface.h>
-#include <InetLayer.h>
+#include <inet/EndPointBasis.h>
+#include <inet/InetInterface.h>
+#include <inet/InetLayer.h>
 
 #include <support/CodeUtils.h>
 

--- a/src/inet/InetError.cpp
+++ b/src/inet/InetError.cpp
@@ -23,8 +23,8 @@
 
 #include <stddef.h>
 
-#include <Inet.h>
-#include <InetError.h>
+#include <inet/Inet.h>
+#include <inet/InetError.h>
 
 #include <support/ErrorStr.h>
 

--- a/src/inet/InetUtils.cpp
+++ b/src/inet/InetUtils.cpp
@@ -28,7 +28,7 @@
 
 #include <support/DLLUtil.h>
 
-#include <InetLayer.h>
+#include <inet/InetLayer.h>
 
 namespace chip {
 namespace Inet {

--- a/src/inet/RawEndPoint.cpp
+++ b/src/inet/RawEndPoint.cpp
@@ -32,7 +32,7 @@
 #include "RawEndPoint.h"
 
 #include "InetFaultInjection.h"
-#include <InetLayer.h>
+#include <inet/InetLayer.h>
 
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>

--- a/src/inet/TCPEndPoint.cpp
+++ b/src/inet/TCPEndPoint.cpp
@@ -35,7 +35,7 @@
 #include "TCPEndPoint.h"
 
 #include "InetFaultInjection.h"
-#include <InetLayer.h>
+#include <inet/InetLayer.h>
 
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>

--- a/src/inet/TunEndPoint.cpp
+++ b/src/inet/TunEndPoint.cpp
@@ -31,7 +31,7 @@
 
 #include <core/CHIPTunnelConfig.h>
 
-#include <InetLayer.h>
+#include <inet/InetLayer.h>
 
 #include <core/CHIPEncoding.h>
 #include <support/CodeUtils.h>

--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -31,7 +31,7 @@
 #include "UDPEndPoint.h"
 
 #include "InetFaultInjection.h"
-#include <InetLayer.h>
+#include <inet/InetLayer.h>
 
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -59,14 +59,9 @@ lib_LIBRARIES                       = libCHIP.a
 libCHIP_a_CPPFLAGS                  =                         \
     -I$(top_srcdir)/src                                       \
     -I$(top_srcdir)/src/include                               \
-    -I$(top_srcdir)/src/inet                                  \
     -I$(top_srcdir)/src/lib                                   \
-    -I$(top_srcdir)/src/lib/core                              \
-    -I$(top_srcdir)/src/lib/support                           \
-    -I$(top_srcdir)/src/system                                \
     -I$(top_srcdir)/src/app/chip-zcl                          \
     -I$(top_srcdir)/src/app/gen                               \
-    -I$(top_srcdir)/src/transport                             \
     $(NLASSERT_CPPFLAGS)                                      \
     $(NLFAULTINJECTION_CPPFLAGS)                              \
     $(NLIO_CPPFLAGS)                                          \

--- a/src/lib/core/CHIPTLVDebug.cpp
+++ b/src/lib/core/CHIPTLVDebug.cpp
@@ -31,9 +31,9 @@
 #include <inttypes.h>
 #include <string.h>
 
-#include <CHIPTLV.h>
-#include <CHIPTLVDebug.hpp>
-#include <CHIPTLVUtilities.hpp>
+#include <core/CHIPTLV.h>
+#include <core/CHIPTLVDebug.hpp>
+#include <core/CHIPTLVUtilities.hpp>
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
 

--- a/src/lib/core/CHIPTLVReader.cpp
+++ b/src/lib/core/CHIPTLVReader.cpp
@@ -24,9 +24,9 @@
 
 #include <stdlib.h>
 
-#include <CHIPCore.h>
-#include <CHIPEncoding.h>
-#include <CHIPTLV.h>
+#include <core/CHIPCore.h>
+#include <core/CHIPEncoding.h>
+#include <core/CHIPTLV.h>
 #include <support/CodeUtils.h>
 #include <system/SystemPacketBuffer.h>
 

--- a/src/lib/core/CHIPTLVUpdater.cpp
+++ b/src/lib/core/CHIPTLVUpdater.cpp
@@ -23,9 +23,9 @@
  *
  */
 
-#include <CHIPCore.h>
-#include <CHIPEncoding.h>
-#include <CHIPTLV.h>
+#include <core/CHIPCore.h>
+#include <core/CHIPEncoding.h>
+#include <core/CHIPTLV.h>
 #include <support/CodeUtils.h>
 
 namespace chip {

--- a/src/lib/core/CHIPTLVUtilities.cpp
+++ b/src/lib/core/CHIPTLVUtilities.cpp
@@ -23,8 +23,8 @@
  *
  */
 
-#include <CHIPTLVDebug.hpp>
-#include <CHIPTLVUtilities.hpp>
+#include <core/CHIPTLVDebug.hpp>
+#include <core/CHIPTLVUtilities.hpp>
 #include <support/CodeUtils.h>
 
 namespace chip {

--- a/src/lib/core/CHIPTLVWriter.cpp
+++ b/src/lib/core/CHIPTLVWriter.cpp
@@ -25,10 +25,10 @@
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS
 #endif
-#include <CHIPTLV.h>
+#include <core/CHIPTLV.h>
 
-#include <CHIPCore.h>
-#include <CHIPEncoding.h>
+#include <core/CHIPCore.h>
+#include <core/CHIPEncoding.h>
 
 #include <support/CodeUtils.h>
 #include <system/SystemPacketBuffer.h>


### PR DESCRIPTION
 #### Problem
We are #including the same headers using different paths. Ideally each header would have a canonical path for includes that has at least one directory specified, so it's easy to identify which component the header is located in.

 #### Summary of Changes
Add the parent directory to several component's #includes, and remove most leaf directories from the includes search path.

fixes #1260 