### PR TITLE
ESP32 build issue: EXAMPLE_RENDEZVOUS_INFO is an int instead of a Ren…

### DIFF
--- a/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
+++ b/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
@@ -50,7 +50,7 @@
 // Used to have an initial shared secret
 #define EXAMPLE_SETUP_CODE 123456789
 // Used to indicate that the device supports both Soft-AP and BLE for rendezvous
-#define EXAMPLE_RENDEZVOUS_INFO 3
+#define EXAMPLE_RENDEZVOUS_INFO RendezvousInformationFlags::kBLE
 // Used to indicate that an SSID has been added to the QRCode
 #define EXAMPLE_VENDOR_TAG_SSID 1
 // Used to indicate that an IP address has been added to the QRCode

--- a/src/darwin/Framework/CHIP/CHIPSetupPayload.h
+++ b/src/darwin/Framework/CHIP/CHIPSetupPayload.h
@@ -24,6 +24,17 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSUInteger, RendezvousInformationFlags) {
+    kRendezvousInformationNone = 0, // Device does not support any method for rendezvous
+    kRendezvousInformationSoftAP = 1 << 0, // Device supports hosting a SoftAP
+    kRendezvousInformationBLE = 1 << 1, // Device supports BLE
+    kRendezvousInformationThread = 1 << 2, // Device supports Thread
+    kRendezvousInformationEthernet = 1 << 3, // Device MAY be attached to a wired 802." connection"
+
+    kRendezvousInformationAllMask
+    = kRendezvousInformationSoftAP | kRendezvousInformationBLE | kRendezvousInformationThread | kRendezvousInformationEthernet,
+};
+
 typedef NS_ENUM(NSUInteger, OptionalQRCodeInfoType) {
     kOptionalQRCodeInfoTypeUnknown,
     kOptionalQRCodeInfoTypeString,
@@ -43,7 +54,7 @@ typedef NS_ENUM(NSUInteger, OptionalQRCodeInfoType) {
 @property (nonatomic, strong) NSNumber * vendorID;
 @property (nonatomic, strong) NSNumber * productID;
 @property (nonatomic, assign) BOOL requiresCustomFlow;
-@property (nonatomic, strong) NSNumber * rendezvousInformation;
+@property (nonatomic, assign) RendezvousInformationFlags rendezvousInformation;
 @property (nonatomic, strong) NSNumber * discriminator;
 @property (nonatomic, strong) NSNumber * setUpPINCode;
 
@@ -52,6 +63,7 @@ typedef NS_ENUM(NSUInteger, OptionalQRCodeInfoType) {
 
 #ifdef __cplusplus
 - (id)initWithSetupPayload:(chip::SetupPayload)setupPayload;
+- (RendezvousInformationFlags)valueOf:(chip::RendezvousInformationFlags)value;
 #endif
 
 @end

--- a/src/darwin/Framework/CHIP/CHIPSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/CHIPSetupPayload.mm
@@ -25,6 +25,32 @@
     chip::SetupPayload _chipSetupPayload;
 }
 
+- (RendezvousInformationFlags)valueOf:(chip::RendezvousInformationFlags)value
+{
+    RendezvousInformationFlags rv = kRendezvousInformationNone;
+    switch (value) {
+    case chip::RendezvousInformationFlags::kNone:
+        rv = kRendezvousInformationNone;
+        break;
+    case chip::RendezvousInformationFlags::kSoftAP:
+        rv = kRendezvousInformationSoftAP;
+        break;
+    case chip::RendezvousInformationFlags::kBLE:
+        rv = kRendezvousInformationBLE;
+        break;
+    case chip::RendezvousInformationFlags::kThread:
+        rv = kRendezvousInformationThread;
+        break;
+    case chip::RendezvousInformationFlags::kEthernet:
+        rv = kRendezvousInformationEthernet;
+        break;
+    case chip::RendezvousInformationFlags::kAllMask:
+        rv = kRendezvousInformationAllMask;
+        break;
+    }
+    return rv;
+}
+
 - (id)initWithSetupPayload:(chip::SetupPayload)setupPayload
 {
     if (self = [super init]) {
@@ -33,7 +59,7 @@
         _vendorID = [NSNumber numberWithUnsignedShort:setupPayload.vendorID];
         _productID = [NSNumber numberWithUnsignedShort:setupPayload.productID];
         _requiresCustomFlow = setupPayload.requiresCustomFlow == 1;
-        _rendezvousInformation = [NSNumber numberWithUnsignedShort:setupPayload.rendezvousInformation];
+        _rendezvousInformation = [self valueOf:setupPayload.rendezvousInformation];
         _discriminator = [NSNumber numberWithUnsignedShort:setupPayload.discriminator];
         _setUpPINCode = [NSNumber numberWithUnsignedLong:setupPayload.setUpPINCode];
 

--- a/src/darwin/Framework/CHIPTests/CHIPSetupPayloadParserTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPSetupPayloadParserTests.m
@@ -49,7 +49,7 @@
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
     XCTAssertTrue(payload.requiresCustomFlow);
     XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
-    XCTAssertEqual(payload.rendezvousInformation.unsignedIntegerValue, 0);
+    XCTAssertEqual(payload.rendezvousInformation, kRendezvousInformationNone);
 }
 
 - (void)testManualParser_Error
@@ -89,7 +89,7 @@
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
     XCTAssertFalse(payload.requiresCustomFlow);
     XCTAssertEqual(payload.version.unsignedIntegerValue, 5);
-    XCTAssertEqual(payload.rendezvousInformation.unsignedIntegerValue, 1);
+    XCTAssertEqual(payload.rendezvousInformation, kRendezvousInformationSoftAP);
 }
 
 - (void)testQRCodeParserWithOptionalData
@@ -108,7 +108,7 @@
     XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 12);
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
     XCTAssertFalse(payload.requiresCustomFlow);
-    XCTAssertEqual(payload.rendezvousInformation.unsignedIntegerValue, 1);
+    XCTAssertEqual(payload.rendezvousInformation, kRendezvousInformationSoftAP);
     XCTAssertTrue([payload.serialNumber isEqualToString:@"1"]);
 
     NSArray<CHIPOptionalQRCodeInfo *> * vendorOptionalInfo = [payload getAllOptionalVendorData:&error];

--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -384,7 +384,7 @@ CHIP_ERROR QRCodeSetupPayloadParser::populatePayload(SetupPayload & outPayload)
 
     err = readBits(buf, indexToReadFrom, dest, kRendezvousInfoFieldLengthInBits);
     SuccessOrExit(err);
-    outPayload.rendezvousInformation = (RendezvousInformationFlags) dest;
+    outPayload.rendezvousInformation = static_cast<RendezvousInformationFlags>(dest);
 
     err = readBits(buf, indexToReadFrom, dest, kPayloadDiscriminatorFieldLengthInBits);
     SuccessOrExit(err);

--- a/src/setup_payload/SetupPayloadHelper.cpp
+++ b/src/setup_payload/SetupPayloadHelper.cpp
@@ -123,7 +123,7 @@ static CHIP_ERROR addParameter(SetupPayload & setupPayload, SetupPayloadParamete
         break;
     case SetupPayloadKey_RendezVousInformation:
         ChipLogDetail(SetupPayload, "Loaded rendezvousInfo: %u", (uint16_t) parameter.uintValue);
-        setupPayload.rendezvousInformation = (RendezvousInformationFlags) parameter.uintValue;
+        setupPayload.rendezvousInformation = static_cast<RendezvousInformationFlags>(parameter.uintValue);
         break;
     case SetupPayloadKey_Discriminator:
         ChipLogDetail(SetupPayload, "Loaded discriminator: %u", (uint16_t) parameter.uintValue);

--- a/src/setup_payload/tests/TestQRCode.cpp
+++ b/src/setup_payload/tests/TestQRCode.cpp
@@ -189,12 +189,13 @@ void TestSetupPayloadVerify(nlTestSuite * inSuite, void * inContext)
 
     // test invalid rendezvousInformation
     test_payload                       = payload;
-    test_payload.rendezvousInformation = (RendezvousInformationFlags)(1 << kRendezvousInfoFieldLengthInBits);
+    test_payload.rendezvousInformation = static_cast<RendezvousInformationFlags>(1 << kRendezvousInfoFieldLengthInBits);
     NL_TEST_ASSERT(inSuite, test_payload.isValidQRCodePayload() == false);
 
     // test invalid rendezvousInformation
-    test_payload                       = payload;
-    test_payload.rendezvousInformation = (RendezvousInformationFlags)((uint16_t) RendezvousInformationFlags::kAllMask + 1);
+    test_payload = payload;
+    test_payload.rendezvousInformation =
+        static_cast<RendezvousInformationFlags>(static_cast<uint16_t>(RendezvousInformationFlags::kAllMask) + 1);
     NL_TEST_ASSERT(inSuite, test_payload.isValidQRCodePayload() == false);
 
     // test invalid discriminator


### PR DESCRIPTION
 #### Problem

While fixing some nits in #1247 I accidentally force-push and older commit of the work and revert some of the changes (and the nits fixes disappeared too...) which cause the esp32 m5Stack build to fail

FTR the change that prevent the build to break was visible at https://github.com/project-chip/connectedhomeip/pull/1247/files#diff-80f12f80261d47ade3d6954222814090L53 but I reverted it by mistakes.

Hopefully this kind of thing should not happen for this brittle m5Stack demo once #1248 lands.

