### PR TITLE
PBKDF2 crypto APIs and tests

### DIFF
--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -201,6 +201,20 @@ typedef int (*entropy_source)(void * data, unsigned char * output, size_t len, s
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  **/
 CHIP_ERROR add_entropy_source(entropy_source fn_source, void * p_source, size_t threshold);
+
+/** @brief Function to derive key using password. SHA256 hashing algorithm is used for calculating hmac.
+ * @param password password used for key derivation
+ * @param plen length of buffer containing password
+ * @param salt salt to use as input to the KDF
+ * @param slen length of salt
+ * @param iteration_count number of iterations to run
+ * @param key_length length of output key
+ * @param output output buffer where the key will be written
+ * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+ **/
+CHIP_ERROR pbkdf2_hmac(const unsigned char * password, size_t plen, const unsigned char * salt, size_t slen,
+                       unsigned int iteration_count, uint32_t key_length, unsigned char * output);
+
 } // namespace Crypto
 } // namespace chip
 

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -380,6 +380,41 @@ exit:
     return error;
 }
 
+CHIP_ERROR pbkdf2_hmac(const unsigned char * password, size_t plen, const unsigned char * salt, size_t slen,
+                       unsigned int iteration_count, uint32_t key_length, unsigned char * output)
+{
+    CHIP_ERROR error  = CHIP_NO_ERROR;
+    int result        = 1;
+    const EVP_MD * md = NULL;
+
+    VerifyOrExit(password != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(plen > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+
+    // Salt is optional
+    if (slen > 0)
+    {
+        VerifyOrExit(salt != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    }
+
+    VerifyOrExit(key_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(output != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+
+    md = _digestForType(DigestType::SHA256);
+    VerifyOrExit(md != NULL, error = CHIP_ERROR_INTERNAL);
+
+    result = PKCS5_PBKDF2_HMAC((const char *) password, plen, salt, slen, iteration_count, md, key_length, output);
+
+    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
+
+exit:
+    if (error != CHIP_NO_ERROR)
+    {
+        _logSSLError();
+    }
+
+    return error;
+}
+
 CHIP_ERROR add_entropy_source(entropy_source fn_source, void * p_source, size_t threshold)
 {
     return CHIP_NO_ERROR;

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -389,13 +389,8 @@ CHIP_ERROR pbkdf2_hmac(const unsigned char * password, size_t plen, const unsign
 
     VerifyOrExit(password != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(plen > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-
-    // Salt is optional
-    if (slen > 0)
-    {
-        VerifyOrExit(salt != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
-    }
-
+    VerifyOrExit(salt != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(slen > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(key_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(output != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
 

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -264,13 +264,8 @@ CHIP_ERROR pbkdf2_hmac(const unsigned char * password, size_t plen, const unsign
 
     VerifyOrExit(password != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(plen > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-
-    // Salt is optional
-    if (slen > 0)
-    {
-        VerifyOrExit(salt != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
-    }
-
+    VerifyOrExit(salt != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(slen > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(key_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(output != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
 

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -22,6 +22,7 @@
 #include "ECDH_P256_test_vectors.h"
 #include "HKDF_SHA256_test_vectors.h"
 #include "Hash_SHA256_test_vectors.h"
+#include "PBKDF2_SHA256_test_vectors.h"
 
 #include <CHIPCryptoPAL.h>
 #include <nlunit-test.h>
@@ -865,6 +866,31 @@ static void TestAddEntropySources(nlTestSuite * inSuite, void * inContext)
 #endif
 }
 
+static void TestPBKDF2_SHA256_TestVectors(nlTestSuite * inSuite, void * inContext)
+{
+    int numOfTestVectors = ArraySize(pbkdf2_sha256_test_vectors);
+    int numOfTestsRan    = 0;
+    for (int vectorIndex = 0; vectorIndex < numOfTestVectors; vectorIndex++)
+    {
+        const pbkdf2_test_vector * vector = pbkdf2_sha256_test_vectors[vectorIndex];
+        if (vector->plen > 0)
+        {
+            numOfTestsRan++;
+            unsigned char out_key[vector->key_len];
+
+            CHIP_ERROR err =
+                pbkdf2_hmac(vector->password, vector->plen, vector->salt, vector->slen, vector->iter, vector->key_len, out_key);
+            NL_TEST_ASSERT(inSuite, err == vector->result);
+
+            if (vector->result == CHIP_NO_ERROR)
+            {
+                NL_TEST_ASSERT(inSuite, memcmp(out_key, vector->key, vector->key_len) == 0);
+            }
+        }
+    }
+    NL_TEST_ASSERT(inSuite, numOfTestsRan > 0);
+}
+
 namespace chip {
 namespace Logging {
 void LogV(uint8_t module, uint8_t category, const char * format, va_list argptr)
@@ -914,6 +940,7 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("Test ECDH invalid params", TestECDH_InvalidParams),
     NL_TEST_DEF("Test ECDH sample vectors", TestECDH_SampleInputVectors),
     NL_TEST_DEF("Test adding entropy sources", TestAddEntropySources),
+    NL_TEST_DEF("Test PBKDF2 SHA56", TestPBKDF2_SHA256_TestVectors),
 
     NL_TEST_SENTINEL()
 };

--- a/src/crypto/tests/Makefile.am
+++ b/src/crypto/tests/Makefile.am
@@ -32,6 +32,7 @@ noinst_HEADERS                                 = \
     Hash_SHA256_test_vectors.h                   \
     HKDF_SHA256_test_vectors.h                   \
     ECDH_P256_test_vectors.h                     \
+    PBKDF2_SHA256_test_vectors.h                 \
     $(NULL)
 
 #

--- a/src/crypto/tests/PBKDF2_SHA256_test_vectors.h
+++ b/src/crypto/tests/PBKDF2_SHA256_test_vectors.h
@@ -151,14 +151,14 @@ static const struct pbkdf2_test_vector chiptest_test_vector_10 = { .password = (
                                                                    .tcId     = 10,
                                                                    .result   = CHIP_ERROR_INVALID_ARGUMENT };
 
-static const struct pbkdf2_test_vector * pbkdf2_sha256_test_vectors[] = { &chiptest_test_vector_1, &chiptest_test_vector_2,
-                                                                          &chiptest_test_vector_3,
+static const struct pbkdf2_test_vector * pbkdf2_sha256_test_vectors[] = {
+    &chiptest_test_vector_1, &chiptest_test_vector_2, &chiptest_test_vector_3,
 #if !CHIP_TARGET_STYLE_EMBEDDED
-// The following test vector takes excessive time to run on an embedded target
-                                                                          &chiptest_test_vector_4,
+    // The following test vector takes excessive time to run on an embedded target
+    &chiptest_test_vector_4,
 #endif
-                                                                          &chiptest_test_vector_5, &chiptest_test_vector_6,
-                                                                          &chiptest_test_vector_7, &chiptest_test_vector_8,
-                                                                          &chiptest_test_vector_9, &chiptest_test_vector_10 };
+    &chiptest_test_vector_5, &chiptest_test_vector_6, &chiptest_test_vector_7, &chiptest_test_vector_8, &chiptest_test_vector_9,
+    &chiptest_test_vector_10
+};
 
 #endif // _PBKDF2_SHA256_TEST_VECTORS_H_

--- a/src/crypto/tests/PBKDF2_SHA256_test_vectors.h
+++ b/src/crypto/tests/PBKDF2_SHA256_test_vectors.h
@@ -151,6 +151,16 @@ static const struct pbkdf2_test_vector chiptest_test_vector_10 = { .password = (
                                                                    .tcId     = 10,
                                                                    .result   = CHIP_ERROR_INVALID_ARGUMENT };
 
+static const struct pbkdf2_test_vector chiptest_test_vector_11 = { .password = (const unsigned char *) "password",
+                                                                   .plen     = 8,
+                                                                   .salt     = (const unsigned char *) NULL,
+                                                                   .slen     = 0,
+                                                                   .iter     = 16777216,
+                                                                   .key_len  = 20,
+                                                                   .key      = chiptest_key4,
+                                                                   .tcId     = 8,
+                                                                   .result   = CHIP_ERROR_INVALID_ARGUMENT };
+
 static const struct pbkdf2_test_vector * pbkdf2_sha256_test_vectors[] = {
     &chiptest_test_vector_1, &chiptest_test_vector_2, &chiptest_test_vector_3,
 #if !CHIP_TARGET_STYLE_EMBEDDED
@@ -158,7 +168,7 @@ static const struct pbkdf2_test_vector * pbkdf2_sha256_test_vectors[] = {
     &chiptest_test_vector_4,
 #endif
     &chiptest_test_vector_5, &chiptest_test_vector_6, &chiptest_test_vector_7, &chiptest_test_vector_8, &chiptest_test_vector_9,
-    &chiptest_test_vector_10
+    &chiptest_test_vector_10, &chiptest_test_vector_11
 };
 
 #endif // _PBKDF2_SHA256_TEST_VECTORS_H_

--- a/src/crypto/tests/PBKDF2_SHA256_test_vectors.h
+++ b/src/crypto/tests/PBKDF2_SHA256_test_vectors.h
@@ -151,9 +151,14 @@ static const struct pbkdf2_test_vector chiptest_test_vector_10 = { .password = (
                                                                    .tcId     = 10,
                                                                    .result   = CHIP_ERROR_INVALID_ARGUMENT };
 
-static const struct pbkdf2_test_vector * pbkdf2_sha256_test_vectors[] = {
-    &chiptest_test_vector_1, &chiptest_test_vector_2, &chiptest_test_vector_3, &chiptest_test_vector_4, &chiptest_test_vector_5,
-    &chiptest_test_vector_6, &chiptest_test_vector_7, &chiptest_test_vector_8, &chiptest_test_vector_9, &chiptest_test_vector_10
-};
+static const struct pbkdf2_test_vector * pbkdf2_sha256_test_vectors[] = { &chiptest_test_vector_1, &chiptest_test_vector_2,
+                                                                          &chiptest_test_vector_3,
+#if !CHIP_TARGET_STYLE_EMBEDDED
+// The following test vector takes excessive time to run on an embedded target
+                                                                          &chiptest_test_vector_4,
+#endif
+                                                                          &chiptest_test_vector_5, &chiptest_test_vector_6,
+                                                                          &chiptest_test_vector_7, &chiptest_test_vector_8,
+                                                                          &chiptest_test_vector_9, &chiptest_test_vector_10 };
 
 #endif // _PBKDF2_SHA256_TEST_VECTORS_H_

--- a/src/crypto/tests/PBKDF2_SHA256_test_vectors.h
+++ b/src/crypto/tests/PBKDF2_SHA256_test_vectors.h
@@ -1,0 +1,159 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @file - This file contains PBKDF2 SHA256 test vectors.
+ */
+
+#ifndef _PBKDF2_SHA256_TEST_VECTORS_H_
+#define _PBKDF2_SHA256_TEST_VECTORS_H_
+
+#include <stddef.h>
+
+#include <core/CHIPError.h>
+
+struct pbkdf2_test_vector
+{
+    const unsigned char * password;
+    size_t plen;
+    const unsigned char * salt;
+    size_t slen;
+    unsigned int iter;
+    size_t key_len;
+    const unsigned char * key;
+    unsigned tcId;
+    int result;
+};
+
+static const unsigned char chiptest_key1[]                    = { 0x12, 0x0f, 0xb6, 0xcf, 0xfc, 0xf8, 0xb3, 0x2c, 0x43, 0xe7,
+                                               0x22, 0x52, 0x56, 0xc4, 0xf8, 0x37, 0xa8, 0x65, 0x48, 0xc9 };
+static const struct pbkdf2_test_vector chiptest_test_vector_1 = { .password = (const unsigned char *) "password",
+                                                                  .plen     = 8,
+                                                                  .salt     = (const unsigned char *) "salt",
+                                                                  .slen     = 4,
+                                                                  .iter     = 1,
+                                                                  .key_len  = 20,
+                                                                  .key      = chiptest_key1,
+                                                                  .tcId     = 1,
+                                                                  .result   = CHIP_NO_ERROR };
+
+static const unsigned char chiptest_key2[]                    = { 0xae, 0x4d, 0x0c, 0x95, 0xaf, 0x6b, 0x46, 0xd3, 0x2d, 0x0a,
+                                               0xdf, 0xf9, 0x28, 0xf0, 0x6d, 0xd0, 0x2a, 0x30, 0x3f, 0x8e };
+static const struct pbkdf2_test_vector chiptest_test_vector_2 = { .password = (const unsigned char *) "password",
+                                                                  .plen     = 8,
+                                                                  .salt     = (const unsigned char *) "salt",
+                                                                  .slen     = 4,
+                                                                  .iter     = 2,
+                                                                  .key_len  = 20,
+                                                                  .key      = chiptest_key2,
+                                                                  .tcId     = 2,
+                                                                  .result   = CHIP_NO_ERROR };
+
+static const unsigned char chiptest_key3[]                    = { 0xc5, 0xe4, 0x78, 0xd5, 0x92, 0x88, 0xc8, 0x41, 0xaa, 0x53,
+                                               0x0d, 0xb6, 0x84, 0x5c, 0x4c, 0x8d, 0x96, 0x28, 0x93, 0xa0 };
+static const struct pbkdf2_test_vector chiptest_test_vector_3 = { .password = (const unsigned char *) "password",
+                                                                  .plen     = 8,
+                                                                  .salt     = (const unsigned char *) "salt",
+                                                                  .slen     = 4,
+                                                                  .iter     = 4096,
+                                                                  .key_len  = 20,
+                                                                  .key      = chiptest_key3,
+                                                                  .tcId     = 3,
+                                                                  .result   = CHIP_NO_ERROR };
+
+static const unsigned char chiptest_key4[]                    = { 0xcf, 0x81, 0xc6, 0x6f, 0xe8, 0xcf, 0xc0, 0x4d, 0x1f, 0x31,
+                                               0xec, 0xb6, 0x5d, 0xab, 0x40, 0x89, 0xf7, 0xf1, 0x79, 0xe8 };
+static const struct pbkdf2_test_vector chiptest_test_vector_4 = { .password = (const unsigned char *) "password",
+                                                                  .plen     = 8,
+                                                                  .salt     = (const unsigned char *) "salt",
+                                                                  .slen     = 4,
+                                                                  .iter     = 16777216,
+                                                                  .key_len  = 20,
+                                                                  .key      = chiptest_key4,
+                                                                  .tcId     = 4,
+                                                                  .result   = CHIP_NO_ERROR };
+
+static const unsigned char chiptest_key5[] = { 0x34, 0x8c, 0x89, 0xdb, 0xcb, 0xd3, 0x2b, 0x2f, 0x32, 0xd8, 0x14, 0xb8, 0x11,
+                                               0x6e, 0x84, 0xcf, 0x2b, 0x17, 0x34, 0x7e, 0xbc, 0x18, 0x00, 0x18, 0x1c };
+static const struct pbkdf2_test_vector chiptest_test_vector_5 = {
+    .password = (const unsigned char *) "passwordPASSWORDpassword",
+    .plen     = 24,
+    .salt     = (const unsigned char *) "saltSALTsaltSALTsaltSALTsaltSALTsalt",
+    .slen     = 36,
+    .iter     = 4096,
+    .key_len  = 25,
+    .key      = chiptest_key5,
+    .tcId     = 5,
+    .result   = CHIP_NO_ERROR
+};
+
+static const struct pbkdf2_test_vector chiptest_test_vector_6 = { .password = (const unsigned char *) NULL,
+                                                                  .plen     = 8,
+                                                                  .salt     = (const unsigned char *) "salt",
+                                                                  .slen     = 4,
+                                                                  .iter     = 16777216,
+                                                                  .key_len  = 20,
+                                                                  .key      = chiptest_key4,
+                                                                  .tcId     = 6,
+                                                                  .result   = CHIP_ERROR_INVALID_ARGUMENT };
+
+static const struct pbkdf2_test_vector chiptest_test_vector_7 = { .password = (const unsigned char *) "password",
+                                                                  .plen     = 0,
+                                                                  .salt     = (const unsigned char *) "salt",
+                                                                  .slen     = 4,
+                                                                  .iter     = 16777216,
+                                                                  .key_len  = 20,
+                                                                  .key      = chiptest_key4,
+                                                                  .tcId     = 7,
+                                                                  .result   = CHIP_ERROR_INVALID_ARGUMENT };
+
+static const struct pbkdf2_test_vector chiptest_test_vector_8 = { .password = (const unsigned char *) "password",
+                                                                  .plen     = 8,
+                                                                  .salt     = (const unsigned char *) NULL,
+                                                                  .slen     = 4,
+                                                                  .iter     = 16777216,
+                                                                  .key_len  = 20,
+                                                                  .key      = chiptest_key4,
+                                                                  .tcId     = 8,
+                                                                  .result   = CHIP_ERROR_INVALID_ARGUMENT };
+
+static const struct pbkdf2_test_vector chiptest_test_vector_9 = { .password = (const unsigned char *) "password",
+                                                                  .plen     = 0,
+                                                                  .salt     = (const unsigned char *) "salt",
+                                                                  .slen     = 4,
+                                                                  .iter     = 16777216,
+                                                                  .key_len  = 0,
+                                                                  .key      = chiptest_key4,
+                                                                  .tcId     = 9,
+                                                                  .result   = CHIP_ERROR_INVALID_ARGUMENT };
+
+static const struct pbkdf2_test_vector chiptest_test_vector_10 = { .password = (const unsigned char *) "password",
+                                                                   .plen     = 0,
+                                                                   .salt     = (const unsigned char *) "salt",
+                                                                   .slen     = 4,
+                                                                   .iter     = 16777216,
+                                                                   .key_len  = 20,
+                                                                   .key      = NULL,
+                                                                   .tcId     = 10,
+                                                                   .result   = CHIP_ERROR_INVALID_ARGUMENT };
+
+static const struct pbkdf2_test_vector * pbkdf2_sha256_test_vectors[] = {
+    &chiptest_test_vector_1, &chiptest_test_vector_2, &chiptest_test_vector_3, &chiptest_test_vector_4, &chiptest_test_vector_5,
+    &chiptest_test_vector_6, &chiptest_test_vector_7, &chiptest_test_vector_8, &chiptest_test_vector_9, &chiptest_test_vector_10
+};
+
+#endif // _PBKDF2_SHA256_TEST_VECTORS_H_

--- a/src/test_driver/esp32/Makefile
+++ b/src/test_driver/esp32/Makefile
@@ -5,7 +5,7 @@
 
 PROJECT_NAME := chip-tests
 
-CXXFLAGS += -DCHIP_SUPPORT_FOREIGN_TEST_DRIVERS -Wno-deprecated-declarations
+CXXFLAGS += -DCHIP_SUPPORT_FOREIGN_TEST_DRIVERS -DCHIP_TARGET_STYLE_EMBEDDED -Wno-deprecated-declarations
 
 EXTRA_COMPONENT_DIRS += $(PROJECT_PATH)/third_party/connectedhomeip/config/esp32/components
 


### PR DESCRIPTION
 #### Problem
Missing APIs and tests for `PBKDF2`

 #### Summary of Changes
- Implement APIs for `mbedTLS` and `OpenSSL`
- Add test vectors and unit tests

fixes #285 
fixes #286 