### PR TITLE
Fix crash in chip-tool iOS app

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
@@ -167,7 +167,7 @@ static NSString * const ipKey = @"ipk";
         self->_versionLabel.text = [NSString stringWithFormat:@"%@", payload.version];
         self->_discriminatorLabel.text = [NSString stringWithFormat:@"%@", payload.discriminator];
         self->_setupPinCodeLabel.text = [NSString stringWithFormat:@"%@", payload.setUpPINCode];
-        self->_rendezVousInformation.text = [NSString stringWithFormat:@"%@", payload.rendezvousInformation];
+        self->_rendezVousInformation.text = [NSString stringWithFormat:@"%lu", payload.rendezvousInformation];
         if ([payload.serialNumber length] > 0) {
             self->_serialNumber.text = payload.serialNumber;
         } else {


### PR DESCRIPTION
 #### Problem
`CHIPTool` iOS crashes when QR code is scanned.

The backtrace is
<img width="483" alt="image" src="https://user-images.githubusercontent.com/61470527/85799551-3c68d480-b6f4-11ea-8a42-111105ba8b16.png">

<img width="873" alt="image" src="https://user-images.githubusercontent.com/61470527/85799683-7a65f880-b6f4-11ea-9d88-6f4a7cc1b5ed.png">


 #### Summary of Changes
Fix the format specifier.
