### PR TITLE
[openthread] fix build when thread disabled (CHIP_ENABLE_OPENTHREAD=0).

### DIFF
--- a/examples/lock-app/nrf5/main/main.cpp
+++ b/examples/lock-app/nrf5/main/main.cpp
@@ -62,9 +62,10 @@ extern "C" {
 #include <openthread/platform/openthread-system.h>
 #include <openthread/tasklet.h>
 #include <openthread/thread.h>
+#endif // CHIP_ENABLE_OPENTHREAD
+
 #include <platform/CHIPDeviceLayer.h>
 #include <support/logging/CHIPLogging.h>
-#endif // CHIP_ENABLE_OPENTHREAD
 
 using namespace ::chip;
 using namespace ::chip::Inet;

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.ipp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.ipp
@@ -812,10 +812,12 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::AdjustPollingInt
 template <class ImplClass>
 void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_FactoryReset(void)
 {
+#if CHIP_ENABLE_OPENTHREAD
     ChipLogProgress(DeviceLayer, "About to factory reset ...");
     Impl()->LockThreadStack();
     otInstanceFactoryReset(mOTInst);
     Impl()->UnlockThreadStack();
+#endif
 }
 
 } // namespace Internal


### PR DESCRIPTION
 #### Problem
There are build issues on NRF5 when OpenThread support is disabled.

 #### Summary of Changes
Fixes the issues.