### PR TITLE
[platform] Fix friend functions to handle strict C++11 toolchains.

### DIFF
--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -134,8 +134,8 @@ private:
     template <class>
     friend class ::chip::DeviceLayer::Internal::GenericPlatformManagerImpl_POSIX;
     // Parentheses used to fix clang parsing issue with these declarations
-    friend CHIP_ERROR ::chip::Platform::PersistedStorage::Read(::chip::Platform::PersistedStorage::Key key, uint32_t & value);
-    friend CHIP_ERROR ::chip::Platform::PersistedStorage::Write(::chip::Platform::PersistedStorage::Key key, uint32_t value);
+    friend CHIP_ERROR(::chip::Platform::PersistedStorage::Read(::chip::Platform::PersistedStorage::Key key, uint32_t & value));
+    friend CHIP_ERROR(::chip::Platform::PersistedStorage::Write(::chip::Platform::PersistedStorage::Key key, uint32_t value));
 
     using ImplClass = ::chip::DeviceLayer::ConfigurationManagerImpl;
 

--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -116,14 +116,14 @@ private:
     template <class>
     friend class Internal::GenericConfigurationManagerImpl;
     // Parentheses used to fix clang parsing issue with these declarations
-    friend ::chip::System::Error ::chip::System::Platform::Layer::PostEvent(::chip::System::Layer & aLayer, void * aContext,
+    friend ::chip::System::Error(::chip::System::Platform::Layer::PostEvent(::chip::System::Layer & aLayer, void * aContext,
                                                                             ::chip::System::Object & aTarget,
-                                                                            ::chip::System::EventType aType, uintptr_t aArgument);
-    friend ::chip::System::Error ::chip::System::Platform::Layer::DispatchEvents(::chip::System::Layer & aLayer, void * aContext);
-    friend ::chip::System::Error ::chip::System::Platform::Layer::DispatchEvent(::chip::System::Layer & aLayer, void * aContext,
-                                                                                ::chip::System::Event aEvent);
-    friend ::chip::System::Error ::chip::System::Platform::Layer::StartTimer(::chip::System::Layer & aLayer, void * aContext,
-                                                                             uint32_t aMilliseconds);
+                                                                            ::chip::System::EventType aType, uintptr_t aArgument));
+    friend ::chip::System::Error(::chip::System::Platform::Layer::DispatchEvents(::chip::System::Layer & aLayer, void * aContext));
+    friend ::chip::System::Error(::chip::System::Platform::Layer::DispatchEvent(::chip::System::Layer & aLayer, void * aContext,
+                                                                                ::chip::System::Event aEvent));
+    friend ::chip::System::Error(::chip::System::Platform::Layer::StartTimer(::chip::System::Layer & aLayer, void * aContext,
+                                                                             uint32_t aMilliseconds));
 
     void PostEvent(const ChipDeviceEvent * event);
     void DispatchEvent(const ChipDeviceEvent * event);


### PR DESCRIPTION
 #### Problem
Some toolchains report an error if the friend functions in device layer aren't in parenthesis.

 #### Summary of Changes
Fix the friend functions as required.
