### PR TITLE
[Rendezvous] Get the iOS app to filter BLE devices based on discrimin…

### DIFF
--- a/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
+++ b/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
@@ -49,6 +49,8 @@
 #define EXAMPLE_PRODUCT_ID 37732
 // Used to have an initial shared secret
 #define EXAMPLE_SETUP_CODE 123456789
+// Used to discriminate the device
+#define EXAMPLE_DISCRIMINATOR 0X0F00
 // Used to indicate that the device supports both Soft-AP and BLE for rendezvous
 #define EXAMPLE_RENDEZVOUS_INFO RendezvousInformationFlags::kBLE
 // Used to indicate that an SSID has been added to the QRCode
@@ -94,12 +96,9 @@ void GetGatewayIP(char * ip_buf, size_t ip_len)
 
 string createSetupPayload()
 {
-    // The discriminator is generated randomly so different devices can be turned on at the same time for testing.
-    uint16_t discriminator = (esp_random() * 1.0 / UINT32_MAX * ((1 << kPayloadDiscriminatorFieldLengthInBits) + 1));
-
     SetupPayload payload;
     payload.version               = 1;
-    payload.discriminator         = discriminator;
+    payload.discriminator         = EXAMPLE_DISCRIMINATOR;
     payload.setUpPINCode          = EXAMPLE_SETUP_CODE;
     payload.rendezvousInformation = EXAMPLE_RENDEZVOUS_INFO;
     payload.vendorID              = EXAMPLE_VENDOR_ID;

--- a/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
+++ b/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0C47BE4424885B97005E97F6 /* CHIPViewControllerBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C47BE4324885B97005E97F6 /* CHIPViewControllerBase.m */; };
 		0CA0E0CF248599BB009087B9 /* OnOffViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CA0E0CE248599BB009087B9 /* OnOffViewController.m */; };
+		1E87C7B624A5E74E00457C90 /* BLEConnectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E87C7B524A5E74E00457C90 /* BLEConnectionController.m */; };
 		991DC091247747F500C13860 /* EchoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 991DC090247747F500C13860 /* EchoViewController.m */; };
 		B204A621244E1D0600C7C0E1 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = B204A620244E1D0600C7C0E1 /* AppDelegate.m */; };
 		B204A624244E1D0600C7C0E1 /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = B204A623244E1D0600C7C0E1 /* SceneDelegate.m */; };
@@ -49,6 +50,8 @@
 		0C47BE4324885B97005E97F6 /* CHIPViewControllerBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CHIPViewControllerBase.m; sourceTree = "<group>"; };
 		0CA0E0CD248599BB009087B9 /* OnOffViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OnOffViewController.h; sourceTree = "<group>"; };
 		0CA0E0CE248599BB009087B9 /* OnOffViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OnOffViewController.m; sourceTree = "<group>"; };
+		1E87C7B424A5E57100457C90 /* BLEConnectionController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BLEConnectionController.h; sourceTree = "<group>"; };
+		1E87C7B524A5E74E00457C90 /* BLEConnectionController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BLEConnectionController.m; sourceTree = "<group>"; };
 		515C401824868BF0004C4DB3 /* CHIPViewControllerBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPViewControllerBase.h; sourceTree = "<group>"; };
 		991DC08F247747F500C13860 /* EchoViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EchoViewController.h; sourceTree = "<group>"; };
 		991DC090247747F500C13860 /* EchoViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EchoViewController.m; sourceTree = "<group>"; };
@@ -93,6 +96,8 @@
 			children = (
 				B204A625244E1D0600C7C0E1 /* QRCodeViewController.h */,
 				B204A626244E1D0600C7C0E1 /* QRCodeViewController.m */,
+				1E87C7B424A5E57100457C90 /* BLEConnectionController.h */,
+				1E87C7B524A5E74E00457C90 /* BLEConnectionController.m */,
 			);
 			path = QRCode;
 			sourceTree = "<group>";
@@ -275,6 +280,7 @@
 				B204A627244E1D0600C7C0E1 /* QRCodeViewController.m in Sources */,
 				991DC091247747F500C13860 /* EchoViewController.m in Sources */,
 				B204A621244E1D0600C7C0E1 /* AppDelegate.m in Sources */,
+				1E87C7B624A5E74E00457C90 /* BLEConnectionController.m in Sources */,
 				B204A632244E1D0700C7C0E1 /* main.m in Sources */,
 				B204A624244E1D0600C7C0E1 /* SceneDelegate.m in Sources */,
 				0C47BE4424885B97005E97F6 /* CHIPViewControllerBase.m in Sources */,

--- a/src/darwin/CHIPTool/CHIPTool/Info.plist
+++ b/src/darwin/CHIPTool/CHIPTool/Info.plist
@@ -20,6 +20,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Used to connect to the peripheral</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Used to scan QR code</string>
 	<key>UIApplicationSceneManifest</key>

--- a/src/darwin/CHIPTool/CHIPTool/QRCode/BLEConnectionController.h
+++ b/src/darwin/CHIPTool/CHIPTool/QRCode/BLEConnectionController.h
@@ -1,0 +1,31 @@
+/**
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <CoreBluetooth/CoreBluetooth.h>
+#import <UIKit/UIKit.h>
+
+@interface BLEConnectionController : NSObject <CBCentralManagerDelegate>
+
+@property (strong, nonatomic) CBCentralManager * centralManager;
+@property (strong, nonatomic) NSString * peripheralName;
+@property (strong, nonatomic) CBPeripheral * peripheral;
+
+- (id)initWithName:(NSString *)peripheralName;
+- (void)start;
+- (void)stop;
+
+@end

--- a/src/darwin/CHIPTool/CHIPTool/QRCode/BLEConnectionController.m
+++ b/src/darwin/CHIPTool/CHIPTool/QRCode/BLEConnectionController.m
@@ -1,0 +1,128 @@
+/**
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "BLEConnectionController.h"
+
+@interface BLEConnectionController ()
+
+@end
+
+@implementation BLEConnectionController
+
+- (id)initWithName:(NSString *)peripheralName
+{
+    self = [super init];
+    if (self) {
+        _centralManager = [[CBCentralManager alloc] initWithDelegate:self queue:nil];
+        _peripheralName = peripheralName;
+    }
+
+    return self;
+}
+
+- (void)centralManagerDidUpdateState:(CBCentralManager *)central
+{
+    switch (central.state) {
+    case CBManagerStatePoweredOn:
+        NSLog(@"CBManagerState: ON");
+        [self start];
+        break;
+    case CBManagerStatePoweredOff:
+        NSLog(@"CBManagerState: OFF");
+        [self stop];
+        break;
+    case CBManagerStateUnauthorized:
+        NSLog(@"CBManagerState: Unauthorized");
+        break;
+    case CBManagerStateResetting:
+        NSLog(@"CBManagerState: RESETTING");
+        break;
+    case CBManagerStateUnsupported:
+        NSLog(@"CBManagerState: UNSUPPORTED");
+        break;
+    case CBManagerStateUnknown:
+        NSLog(@"CBManagerState: UNKNOWN");
+        break;
+    }
+}
+
+- (void)centralManager:(CBCentralManager *)central
+    didDiscoverPeripheral:(CBPeripheral *)peripheral
+        advertisementData:(NSDictionary *)advertisementData
+                     RSSI:(NSNumber *)RSSI
+{
+    BOOL isConnectable = [advertisementData objectForKey:CBAdvertisementDataIsConnectable];
+    NSString * localNameKey = [advertisementData objectForKey:CBAdvertisementDataLocalNameKey];
+    if (isConnectable && [localNameKey isEqual:_peripheralName]) {
+        NSLog(@"Connecting to device: %@", _peripheralName);
+        [self connect:peripheral];
+        [self stopScanning];
+    }
+}
+
+- (void)start
+{
+    [self startScanning];
+}
+
+- (void)stop
+{
+    [self stopScanning];
+    [self disconnect];
+    _centralManager = nil;
+    _peripheral = nil;
+}
+
+- (void)startScanning
+{
+    if (!_centralManager) {
+        return;
+    }
+
+    [_centralManager scanForPeripheralsWithServices:nil options:nil];
+}
+
+- (void)stopScanning
+{
+    if (!_centralManager) {
+        return;
+    }
+
+    [_centralManager stopScan];
+}
+
+- (void)connect:(CBPeripheral *)peripheral
+{
+    if (!_centralManager || !peripheral) {
+        return;
+    }
+
+    [_centralManager connectPeripheral:peripheral options:nil];
+    _peripheral = peripheral;
+}
+
+- (void)disconnect
+{
+    if (!_centralManager || !_peripheral) {
+        return;
+    }
+
+    [_centralManager cancelPeripheralConnection:_peripheral];
+    _peripheral = nil;
+}
+
+@end

--- a/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.h
+++ b/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.h
@@ -18,6 +18,8 @@
 #import <AVFoundation/AVFoundation.h>
 #import <UIKit/UIKit.h>
 
+#import "BLEConnectionController.h"
+
 @interface QRCodeViewController : UIViewController <AVCaptureMetadataOutputObjectsDelegate>
 
 @property (weak, nonatomic) IBOutlet UIView * qrCodeViewPreview;
@@ -29,6 +31,9 @@
 
 @property (weak, nonatomic) IBOutlet UIActivityIndicatorView * activityIndicator;
 @property (weak, nonatomic) IBOutlet UILabel * errorLabel;
+
+@property (strong, nonatomic) BLEConnectionController * ble;
+@property (strong, nonatomic) NSString * ssidKey;
 
 @property (weak, nonatomic) IBOutlet UIView * setupPayloadView;
 @property (weak, nonatomic) IBOutlet UILabel * manualCodeLabel;

--- a/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
@@ -29,12 +29,14 @@
 
 // The expected Vendor ID for CHIP demos
 // Spells CHIP on a dialer
-#define EXAMPLE_VENDOR_ID 3447
+#define EXAMPLE_VENDOR_ID 2447
 #define EXAMPLE_VENDOR_TAG_SSID 1
 #define MAX_SSID_LEN 32
 
 #define EXAMPLE_VENDOR_TAG_IP 2
 #define MAX_IP_LEN 46
+
+#define BLE_CHIP_PREFIX @"CHIP-"
 
 #define NOT_APPLICABLE_STRING @"N/A"
 
@@ -66,6 +68,12 @@ static NSString * const ipKey = @"ipk";
 
     [self manualCodeInitialState];
     [self qrCodeInitialState];
+}
+
+- (void)viewDidDisappear:(BOOL)animated
+{
+    [super viewDidDisappear:animated];
+    [_ble stop];
 }
 
 - (void)dismissKeyboard
@@ -150,74 +158,119 @@ static NSString * const ipKey = @"ipk";
     if ([self hasScannedConnectionInfo]) {
         [[NSUserDefaults standardUserDefaults] removeObjectForKey:ipKey];
     }
+    self->_setupPayloadView.hidden = NO;
+    self->_resetButton.hidden = NO;
 
+    [self updateUIFields:payload decimalString:decimalString];
+    [self parseOptionalData:payload];
+    [self handleRendezVous:payload];
+}
+
+- (void)updateUIFields:(CHIPSetupPayload *)payload decimalString:(nullable NSString *)decimalString
+{
     if (decimalString) {
-        self->_manualCodeLabel.hidden = NO;
-        self->_manualCodeLabel.text = decimalString;
-        self->_versionLabel.text = NOT_APPLICABLE_STRING;
-        self->_discriminatorLabel.text = [NSString stringWithFormat:@"%@", payload.discriminator];
-        self->_setupPinCodeLabel.text = [NSString stringWithFormat:@"%@", payload.setUpPINCode];
-        self->_rendezVousInformation.text = NOT_APPLICABLE_STRING;
-        self->_serialNumber.text = NOT_APPLICABLE_STRING;
-        // TODO: Only display vid and pid if present
-        self->_vendorID.text = [NSString stringWithFormat:@"%@", payload.vendorID];
-        self->_productID.text = [NSString stringWithFormat:@"%@", payload.productID];
+        _manualCodeLabel.hidden = NO;
+        _manualCodeLabel.text = decimalString;
+        _versionLabel.text = NOT_APPLICABLE_STRING;
+        _rendezVousInformation.text = NOT_APPLICABLE_STRING;
+        _serialNumber.text = NOT_APPLICABLE_STRING;
     } else {
-        self->_manualCodeLabel.hidden = YES;
-        self->_versionLabel.text = [NSString stringWithFormat:@"%@", payload.version];
-        self->_discriminatorLabel.text = [NSString stringWithFormat:@"%@", payload.discriminator];
-        self->_setupPinCodeLabel.text = [NSString stringWithFormat:@"%@", payload.setUpPINCode];
-        self->_rendezVousInformation.text = [NSString stringWithFormat:@"%lu", payload.rendezvousInformation];
+        _manualCodeLabel.hidden = YES;
+        _versionLabel.text = [NSString stringWithFormat:@"%@", payload.version];
+        _rendezVousInformation.text = [NSString stringWithFormat:@"%lu", payload.rendezvousInformation];
         if ([payload.serialNumber length] > 0) {
             self->_serialNumber.text = payload.serialNumber;
         } else {
             self->_serialNumber.text = NOT_APPLICABLE_STRING;
         }
-        // TODO: Only display vid and pid if present
-        self->_vendorID.text = [NSString stringWithFormat:@"%@", payload.vendorID];
-        self->_productID.text = [NSString stringWithFormat:@"%@", payload.productID];
     }
-    self->_setupPayloadView.hidden = NO;
-    self->_resetButton.hidden = NO;
 
+    _discriminatorLabel.text = [NSString stringWithFormat:@"%@", payload.discriminator];
+    _setupPinCodeLabel.text = [NSString stringWithFormat:@"%@", payload.setUpPINCode];
+    // TODO: Only display vid and pid if present
+    _vendorID.text = [NSString stringWithFormat:@"%@", payload.vendorID];
+    _productID.text = [NSString stringWithFormat:@"%@", payload.productID];
+}
+
+- (void)parseOptionalData:(CHIPSetupPayload *)payload
+{
     NSLog(@"Payload vendorID %@", payload.vendorID);
-    if ([payload.vendorID isEqualToNumber:[NSNumber numberWithInt:EXAMPLE_VENDOR_ID]]) {
-        NSArray * optionalInfo = [payload getAllOptionalVendorData:nil];
-        NSLog(@"Count of payload info %@", @(optionalInfo.count));
-        for (CHIPOptionalQRCodeInfo * info in optionalInfo) {
-            NSNumber * tag = info.tag;
-            if (tag) {
-                switch (tag.unsignedCharValue) {
-                case EXAMPLE_VENDOR_TAG_SSID:
-                    if ([info.infoType isEqualToNumber:[NSNumber numberWithInt:kOptionalQRCodeInfoTypeString]]) {
-                        if ([info.stringValue length] > MAX_SSID_LEN) {
-                            NSLog(@"Unexpected SSID String...");
-                        } else {
-                            // show SoftAP detection
-                            [self RequestConnectSoftAPWithSSID:info.stringValue];
-                        }
-                    }
-                    break;
-                case EXAMPLE_VENDOR_TAG_IP:
-                    if ([info.infoType isEqualToNumber:[NSNumber numberWithInt:kOptionalQRCodeInfoTypeString]]) {
-                        if ([info.stringValue length] > MAX_IP_LEN) {
-                            NSLog(@"Unexpected IP String... %@", info.stringValue);
-                        } else {
-                            NSLog(@"Got IP String... %@", info.stringValue);
-                            [[NSUserDefaults standardUserDefaults] setObject:info.stringValue forKey:ipKey];
-                        }
-                    }
-                    break;
-                }
+    BOOL isSameVendorID = [payload.vendorID isEqualToNumber:[NSNumber numberWithInt:EXAMPLE_VENDOR_ID]];
+    if (!isSameVendorID) {
+        return;
+    }
+
+    NSArray * optionalInfo = [payload getAllOptionalVendorData:nil];
+    for (CHIPOptionalQRCodeInfo * info in optionalInfo) {
+        NSNumber * tag = info.tag;
+        if (!tag) {
+            continue;
+        }
+
+        BOOL isTypeString = [info.infoType isEqualToNumber:[NSNumber numberWithInt:kOptionalQRCodeInfoTypeString]];
+        if (!isTypeString) {
+            return;
+        }
+
+        NSString * infoValue = info.stringValue;
+        switch (tag.unsignedCharValue) {
+        case EXAMPLE_VENDOR_TAG_SSID:
+            if ([infoValue length] > MAX_SSID_LEN) {
+                NSLog(@"Unexpected SSID String...");
+            } else {
+                NSLog(@"Got SSID String... %@", infoValue);
+                _ssidKey = infoValue;
             }
+            break;
+
+        case EXAMPLE_VENDOR_TAG_IP:
+            if ([infoValue length] > MAX_IP_LEN) {
+                NSLog(@"Unexpected IP String... %@", infoValue);
+            } else {
+                NSLog(@"Got IP String... %@", infoValue);
+                [[NSUserDefaults standardUserDefaults] setObject:infoValue forKey:ipKey];
+            }
+            break;
         }
     }
 }
 
-- (void)RequestConnectSoftAPWithSSID:(NSString *)ssid
+- (void)handleRendezVous:(CHIPSetupPayload *)payload
 {
-    NSString * message = [NSString
-        stringWithFormat:@"The scanned CHIP accessory supports a SoftAP.\n\nSSID: %@\n\nUse WiFi Settings to connect to it.", ssid];
+    switch (payload.rendezvousInformation) {
+    case kRendezvousInformationNone:
+    case kRendezvousInformationThread:
+    case kRendezvousInformationEthernet:
+    case kRendezvousInformationAllMask:
+        NSLog(@"Rendezvous Unknown");
+        break;
+    case kRendezvousInformationSoftAP:
+        NSLog(@"Rendezvous SoftAP");
+        [self handleRendezVousSoftAP:_ssidKey];
+        break;
+    case kRendezvousInformationBLE:
+        NSLog(@"Rendezvous BLE");
+        [self handleRendezVousBLE:payload.discriminator];
+        break;
+    }
+}
+
+- (void)handleRendezVousBLE:(NSNumber *)discriminator
+{
+    NSString * peripheralDiscriminator = [NSString stringWithFormat:@"0%hX", discriminator.unsignedShortValue];
+    NSString * peripheralFullName = [NSString stringWithFormat:@"%@%@", BLE_CHIP_PREFIX, peripheralDiscriminator];
+    _ble = [[BLEConnectionController alloc] initWithName:peripheralFullName];
+    [_ble start];
+}
+
+- (void)handleRendezVousSoftAP:(NSString *)ssid
+{
+    if (!ssid) {
+        NSLog(@"Can not retrieved SSID");
+        return;
+    }
+
+    NSString * message = [NSString stringWithFormat:@"SSID: %@\n\nUse WiFi Settings to connect to it.", ssid];
     UIAlertController * alert = [UIAlertController alertControllerWithTitle:@"SoftAP Detected"
                                                                     message:message
                                                              preferredStyle:UIAlertControllerStyleActionSheet];


### PR DESCRIPTION
…ator if rendezvous is set to BLE

 #### Problem
The iOS app should scan BLE devices and filter them based on the discriminator from the QRCode before connecting to it.

 #### Summary of Changes
 * Add BLE support to the iOS app
* When a QRCode is scanned and rendezvousInformation is set to BLE, try to find and connect to the target peripheral
 * Change the discriminator in the QRCodeWidget on the esp32 side to be static.

fixes #1293
