### PR TITLE
SDKCONFIG_DEFAULTS is invalid and ends up in no default config

### DIFF
--- a/scripts/examples/esp_echo_app.sh
+++ b/scripts/examples/esp_echo_app.sh
@@ -8,13 +8,15 @@ root=examples/wifi-echo/server/esp32/
 make -j -f Makefile-bootstrap repos
 source "$root"/idf.sh
 
-SDKCONFIG_DEFAULTS=$root/sdkconfig_devkit.defaults idf make -j V=1 -C "$root" defconfig
+rm -f "$root"/sdkconfig
+SDKCONFIG_DEFAULTS=sdkconfig_devkit.defaults idf make -j V=1 -C "$root" defconfig
 idf make -j V=1 -C "$root" || {
     echo 'build DevKit-C failed'
     exit 1
 }
 
-SDKCONFIG_DEFAULTS=$root/sdkconfig_m5stack.defaults idf make -j V=1 -C "$root" defconfig
+rm -f "$root"/sdkconfig
+SDKCONFIG_DEFAULTS=sdkconfig_m5stack.defaults idf make -j V=1 -C "$root" defconfig
 idf make -j V=1 -C "$root" || {
     echo 'build M5Stack failed'
     exit 1

--- a/src/test_driver/esp32/qemu_setup.sh
+++ b/src/test_driver/esp32/qemu_setup.sh
@@ -34,5 +34,6 @@ die() {
 cd "$here" || die 'ack!, where am I?!?'
 
 source idf.sh
+rm -f ./build/sdkconfig
 SDKCONFIG=./build/sdkconfig SDKCONFIG_DEFAULTS=sdkconfig_qemu.defaults idf make defconfig
 SDKCONFIG=./build/sdkconfig idf make esp32_elf_builder


### PR DESCRIPTION
 #### Problem

This is a followup for #1248 

SDKCONFIG_DEFAULTS should not contain the path, it should just say the file name. Otherwise we end up without any default config since it points to a non-existing file.

