### PR TITLE
Fix crash in ReferenceCounted Retain and Release

### DIFF
--- a/src/lib/core/ReferenceCounted.h
+++ b/src/lib/core/ReferenceCounted.h
@@ -41,7 +41,7 @@ public:
     /** Adds one to the usage count of this class */
     SUBCLASS * Retain(void)
     {
-        if (mRefCount < UINT8_MAX)
+        if (mRefCount == UINT8_MAX)
         {
             abort();
         }
@@ -53,7 +53,7 @@ public:
     /** Release usage of this class */
     void Release(void)
     {
-        if (mRefCount != 0)
+        if (mRefCount == 0)
         {
             abort();
         }

--- a/src/lib/core/tests/Makefile.am
+++ b/src/lib/core/tests/Makefile.am
@@ -43,6 +43,7 @@ lib_LIBRARIES                                         = \
 libCoreTests_a_SOURCES                                = \
     TestCHIPErrorStr.cpp                                \
     TestCHIPTLV.cpp                                     \
+    TestReferenceCounted.cpp                            \
     $(NULL)
 
 libCoreTests_adir                                     = $(includedir)/core
@@ -87,6 +88,7 @@ COMMON_LDADD                                          =  \
 check_PROGRAMS                                        = \
     TestCHIPErrorStr                                    \
     TestCHIPTLV                                         \
+    TestReferenceCounted                                \
     $(NULL)
 
 # Test applications and scripts that should be built and run when the
@@ -109,6 +111,9 @@ TestCHIPErrorStr_LDADD                                = $(COMMON_LDADD)
 
 TestCHIPTLV_SOURCES                                   = TestCHIPTLVDriver.cpp
 TestCHIPTLV_LDADD                                     = $(COMMON_LDADD)
+
+TestReferenceCounted_SOURCES                          = TestReferenceCountedDriver.cpp
+TestReferenceCounted_LDADD                            = $(COMMON_LDADD)
 
 #
 # Foreign make dependencies

--- a/src/lib/core/tests/TestReferenceCounted.cpp
+++ b/src/lib/core/tests/TestReferenceCounted.cpp
@@ -1,0 +1,76 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2016-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a test for  CHIP core library reference counted object.
+ *
+ */
+
+#include "TestCore.h"
+
+#include <inttypes.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <lib/core/ReferenceCounted.h>
+
+#include <nlunit-test.h>
+
+using namespace chip;
+
+static void TestRetainRelease(nlTestSuite * inSuite, void * inContext)
+{
+    ReferenceCounted<int> testObj;
+    NL_TEST_ASSERT(inSuite, testObj.GetReferenceCount() == 1);
+    testObj.Retain();
+    NL_TEST_ASSERT(inSuite, testObj.GetReferenceCount() == 2);
+    testObj.Release();
+    NL_TEST_ASSERT(inSuite, testObj.GetReferenceCount() == 1);
+}
+
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+
+// clang-format off
+static const nlTest sTests[] =
+{
+    NL_TEST_DEF("ReferenceCountedRetain", TestRetainRelease),
+
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+int TestReferenceCounted(void)
+{
+    // clang-format off
+    nlTestSuite theSuite =
+	{
+        "Reference-Counted",
+        &sTests[0],
+        NULL,
+        NULL
+    };
+    // clang-format on
+
+    nlTestRunner(&theSuite, NULL);
+
+    return (nlTestRunnerStats(&theSuite));
+}

--- a/src/lib/core/tests/TestReferenceCountedDriver.cpp
+++ b/src/lib/core/tests/TestReferenceCountedDriver.cpp
@@ -17,24 +17,19 @@
 
 /**
  *    @file
- *      This file declares test entry points for CHIP core library
- *      unit tests.
+ *      This file implements a standalone/native program executable
+ *      test driver for the CHIP core library reference counted object tests.
  *
  */
 
-#ifndef TESTCORE_H
-#define TESTCORE_H
+#include "TestCore.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include <nlunit-test.h>
 
-int TestCHIPErrorStr(void);
-int TestCHIPTLV(void);
-int TestReferenceCounted(void);
+int main(void)
+{
+    // Generate machine-readable, comma-separated value (CSV) output.
+    nlTestSetOutputStyle(OUTPUT_CSV);
 
-#ifdef __cplusplus
+    return (TestReferenceCounted());
 }
-#endif
-
-#endif // TESTCORE_H


### PR DESCRIPTION
 #### Problem
The call to ReferenceCounted::Retain()' and Release()` function crashes

 #### Summary of Changes
The checks for overflow and underflow look incorrect. This PR fixes the checks.

fixes #1304