### PR TITLE
ignore dirty submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,32 +1,32 @@
 [submodule "third_party/nlunit-test/repo"]
-	path = third_party/nlunit-test/repo
-	url = https://github.com/nestlabs/nlunit-test.git
+        path = third_party/nlunit-test/repo
+        url = https://github.com/nestlabs/nlunit-test.git
         ignore = dirty
 [submodule "third_party/nlio/repo"]
-	path = third_party/nlio/repo
-	url = https://github.com/nestlabs/nlio.git
+        path = third_party/nlio/repo
+        url = https://github.com/nestlabs/nlio.git
         ignore = dirty
 [submodule "third_party/nlfaultinjection/repo"]
-	path = third_party/nlfaultinjection/repo
-	url = https://github.com/nestlabs/nlfaultinjection.git
+        path = third_party/nlfaultinjection/repo
+        url = https://github.com/nestlabs/nlfaultinjection.git
         ignore = dirty
 [submodule "third_party/nlassert/repo"]
-	path = third_party/nlassert/repo
-	url = https://github.com/nestlabs/nlassert.git
+        path = third_party/nlassert/repo
+        url = https://github.com/nestlabs/nlassert.git
         ignore = dirty
 [submodule "third_party/mbedtls/repo"]
-	path = third_party/mbedtls/repo
-	url = https://github.com/ARMmbed/mbedtls.git
+        path = third_party/mbedtls/repo
+        url = https://github.com/ARMmbed/mbedtls.git
         ignore = dirty
 [submodule "examples/common/QRCode/repo"]
-	path = examples/common/QRCode/repo
-	url = https://github.com/nayuki/QR-Code-generator.git
+        path = examples/common/QRCode/repo
+        url = https://github.com/nayuki/QR-Code-generator.git
         ignore = dirty
 [submodule "examples/common/m5stack-tft/repo"]
-	path = examples/common/m5stack-tft/repo
-	url = https://github.com/jeremyjh/ESP32_TFT_library.git
+        path = examples/common/m5stack-tft/repo
+        url = https://github.com/jeremyjh/ESP32_TFT_library.git
         ignore = dirty
 [submodule "third_party/pigweed"]
-	path = third_party/pigweed
-	url = https://pigweed.googlesource.com/pigweed/pigweed
+        path = third_party/pigweed
+        url = https://pigweed.googlesource.com/pigweed/pigweed
         ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,24 +1,32 @@
 [submodule "third_party/nlunit-test/repo"]
 	path = third_party/nlunit-test/repo
 	url = https://github.com/nestlabs/nlunit-test.git
+        ignore = dirty
 [submodule "third_party/nlio/repo"]
 	path = third_party/nlio/repo
 	url = https://github.com/nestlabs/nlio.git
+        ignore = dirty
 [submodule "third_party/nlfaultinjection/repo"]
 	path = third_party/nlfaultinjection/repo
 	url = https://github.com/nestlabs/nlfaultinjection.git
+        ignore = dirty
 [submodule "third_party/nlassert/repo"]
 	path = third_party/nlassert/repo
 	url = https://github.com/nestlabs/nlassert.git
+        ignore = dirty
 [submodule "third_party/mbedtls/repo"]
 	path = third_party/mbedtls/repo
 	url = https://github.com/ARMmbed/mbedtls.git
+        ignore = dirty
 [submodule "examples/common/QRCode/repo"]
 	path = examples/common/QRCode/repo
 	url = https://github.com/nayuki/QR-Code-generator.git
+        ignore = dirty
 [submodule "examples/common/m5stack-tft/repo"]
 	path = examples/common/m5stack-tft/repo
 	url = https://github.com/jeremyjh/ESP32_TFT_library.git
+        ignore = dirty
 [submodule "third_party/pigweed"]
 	path = third_party/pigweed
 	url = https://pigweed.googlesource.com/pigweed/pigweed
+        ignore = dirty


### PR DESCRIPTION
#### Problem
 annoyance that results from CHIP's autotools-based make system combined with
  "real" submodule-ing in CHIP
 ```
 [rwalker@rejectamenta connectedhomeip]$ git status
On branch master
Your branch is up to date with 'origin/master'.
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
  (commit or discard the untracked or modified content in submodules)
        modified:   third_party/nlassert/repo (modified content, untracked content)
        modified:   third_party/nlfaultinjection/repo (modified content, untracked content)
        modified:   third_party/nlio/repo (modified content, untracked content)
        modified:   third_party/nlunit-test/repo (modified content)
no changes added to commit (use "git add" and/or "git commit -a")
```

 #### Summary of Changes
 ignore dirty submodules because CHIP's processes do not include maintenance of upstream repositories in-situ