### PR TITLE
Add callback object to secure sesion mgr

### DIFF
--- a/examples/lock-app/nrf5/main/Server.cpp
+++ b/examples/lock-app/nrf5/main/Server.cpp
@@ -116,7 +116,7 @@ void SetupTransport(IPAddressType type, SecureSessionMgr * transport)
     err = transport->Init(EXAMPLE_SERVER_NODEID, &DeviceLayer::InetLayer, UdpListenParameters().SetAddressType(type));
     SuccessOrExit(err);
 
-    transport->AssignCallbackObject(&gCallbacks);
+    transport->SetDelegate(&gCallbacks);
 
 exit:
     if (err != CHIP_NO_ERROR)

--- a/examples/lock-app/nrf5/main/Server.cpp
+++ b/examples/lock-app/nrf5/main/Server.cpp
@@ -63,7 +63,7 @@ class ServerCallback : public SecureSessionMgrCallback
 {
 public:
     virtual void OnMessageReceived(const MessageHeader & header, Transport::PeerConnectionState * state,
-                                   System::PacketBuffer * buffer, SecureSessionMgr* mgr)
+                                   System::PacketBuffer * buffer, SecureSessionMgr * mgr)
     {
         const size_t data_len = buffer->DataLength();
         char src_addr[PeerAddress::kMaxToStringSize];
@@ -89,7 +89,7 @@ public:
         }
     }
 
-    virtual void OnNewConnection(Transport::PeerConnectionState * state, SecureSessionMgr* mgr)
+    virtual void OnNewConnection(Transport::PeerConnectionState * state, SecureSessionMgr * mgr)
     {
         CHIP_ERROR err;
 

--- a/examples/lock-app/nrf5/main/Server.cpp
+++ b/examples/lock-app/nrf5/main/Server.cpp
@@ -63,7 +63,7 @@ class ServerCallback : public SecureSessionMgrCallback
 {
 public:
     virtual void OnMessageReceived(const MessageHeader & header, Transport::PeerConnectionState * state,
-                          System::PacketBuffer * buffer)
+                                   System::PacketBuffer * buffer)
     {
         const size_t data_len = buffer->DataLength();
         char src_addr[PeerAddress::kMaxToStringSize];
@@ -89,13 +89,14 @@ public:
         }
     }
 
-    virtual void OnNewConnection(Transport::PeerConnectionState * state) {
+    virtual void OnNewConnection(Transport::PeerConnectionState * state)
+    {
         CHIP_ERROR err;
 
         NRF_LOG_INFO("Received a new connection.");
 
         err = state->GetSecureSession().TemporaryManualKeyExchange(remote_public_key, sizeof(remote_public_key), local_private_key,
-                                                                sizeof(local_private_key));
+                                                                   sizeof(local_private_key));
         VerifyOrExit(err == CHIP_NO_ERROR, NRF_LOG_INFO("Failed to setup encryption"));
 
     exit:
@@ -111,7 +112,6 @@ static ServerCallback gCallbacks;
 void SetupTransport(IPAddressType type, SecureSessionMgr * transport)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    
 
     err = transport->Init(EXAMPLE_SERVER_NODEID, &DeviceLayer::InetLayer, UdpListenParameters().SetAddressType(type));
     SuccessOrExit(err);

--- a/examples/lock-app/nrf5/main/Server.cpp
+++ b/examples/lock-app/nrf5/main/Server.cpp
@@ -63,7 +63,7 @@ class ServerCallback : public SecureSessionMgrCallback
 {
 public:
     virtual void OnMessageReceived(const MessageHeader & header, Transport::PeerConnectionState * state,
-                                   System::PacketBuffer * buffer)
+                                   System::PacketBuffer * buffer, SecureSessionMgr* mgr)
     {
         const size_t data_len = buffer->DataLength();
         char src_addr[PeerAddress::kMaxToStringSize];
@@ -89,7 +89,7 @@ public:
         }
     }
 
-    virtual void OnNewConnection(Transport::PeerConnectionState * state)
+    virtual void OnNewConnection(Transport::PeerConnectionState * state, SecureSessionMgr* mgr)
     {
         CHIP_ERROR err;
 

--- a/examples/wifi-echo/server/esp32/main/EchoServer.cpp
+++ b/examples/wifi-echo/server/esp32/main/EchoServer.cpp
@@ -134,7 +134,7 @@ class EchoServerCallback : public SecureSessionMgrCallback
 {
 public:
     virtual void OnMessageReceived(const MessageHeader & header, Transport::PeerConnectionState * state,
-                          System::PacketBuffer * buffer)
+                                   System::PacketBuffer * buffer)
     {
         CHIP_ERROR err;
         const size_t data_len = buffer->DataLength();
@@ -197,13 +197,14 @@ public:
         statusLED.BlinkOnError();
     }
 
-    virtual void OnNewConnection(Transport::PeerConnectionState * state) {
+    virtual void OnNewConnection(Transport::PeerConnectionState * state)
+    {
         CHIP_ERROR err;
 
         ESP_LOGI(TAG, "Received a new connection.");
 
         err = state->GetSecureSession().TemporaryManualKeyExchange(remote_public_key, sizeof(remote_public_key), local_private_key,
-                                                                sizeof(local_private_key));
+                                                                   sizeof(local_private_key));
         VerifyOrExit(err == CHIP_NO_ERROR, ESP_LOGE(TAG, "Failed to setup encryption"));
 
     exit:
@@ -211,6 +212,7 @@ public:
     }
 
     SecureSessionMgr * mTransport = nullptr;
+
 private:
     /**
      * A data model message has nonzero length and always has a first byte whose
@@ -242,7 +244,7 @@ static EchoServerCallback gCallbacks_v4, gCallbacks_v6;
 } // namespace
 
 // The echo server assumes the platform's networking has been setup already
-void setupTransport(IPAddressType type, SecureSessionMgr * transport, EchoServerCallback* cb)
+void setupTransport(IPAddressType type, SecureSessionMgr * transport, EchoServerCallback * cb)
 {
     CHIP_ERROR err       = CHIP_NO_ERROR;
     struct netif * netif = NULL;

--- a/examples/wifi-echo/server/esp32/main/EchoServer.cpp
+++ b/examples/wifi-echo/server/esp32/main/EchoServer.cpp
@@ -134,7 +134,7 @@ class EchoServerCallback : public SecureSessionMgrCallback
 {
 public:
     virtual void OnMessageReceived(const MessageHeader & header, Transport::PeerConnectionState * state,
-                                   System::PacketBuffer * buffer, SecureSessionMgr* mgr)
+                                   System::PacketBuffer * buffer, SecureSessionMgr * mgr)
     {
         CHIP_ERROR err;
         const size_t data_len = buffer->DataLength();
@@ -191,13 +191,13 @@ public:
         }
     }
 
-    virtual void OnReceiveError(CHIP_ERROR error, const IPPacketInfo & source, SecureSessionMgr* mgr)
+    virtual void OnReceiveError(CHIP_ERROR error, const IPPacketInfo & source, SecureSessionMgr * mgr)
     {
         ESP_LOGE(TAG, "ERROR: %s\n Got UDP error", ErrorStr(error));
         statusLED.BlinkOnError();
     }
 
-    virtual void OnNewConnection(Transport::PeerConnectionState * state, SecureSessionMgr* mgr)
+    virtual void OnNewConnection(Transport::PeerConnectionState * state, SecureSessionMgr * mgr)
     {
         CHIP_ERROR err;
 

--- a/examples/wifi-echo/server/esp32/main/EchoServer.cpp
+++ b/examples/wifi-echo/server/esp32/main/EchoServer.cpp
@@ -70,44 +70,6 @@ const unsigned char remote_public_key[] = { 0x04, 0x30, 0x77, 0x2c, 0xe7, 0xd4, 
                                             0xe8, 0x87, 0x2e, 0x52, 0x3b, 0x98, 0xf0, 0xa1, 0x88, 0x4a, 0xe3, 0x03, 0x75 };
 
 /**
- * A data model message has nonzero length and always has a first byte whose
- * value is one of: 0x00, 0x01, 0x02, 0x03.  See chipZclEncodeZclHeader for the
- * construction of the message and in particular the first byte.
- *
- * Echo messages should generally not have a first byte with those values, so we
- * can use that to try to distinguish between the two.
- */
-static bool ContentMayBeADataModelMessage(System::PacketBuffer * buffer)
-{
-    const size_t data_len      = buffer->DataLength();
-    const uint8_t * data       = buffer->Start();
-    bool maybeDataModelMessage = true;
-
-    // Has to have nonzero length.
-    VerifyOrExit(data_len > 0, maybeDataModelMessage = false);
-
-    // Has to have a valid first byte value.
-    VerifyOrExit(data[0] < 0x04, maybeDataModelMessage = false);
-
-exit:
-    return maybeDataModelMessage;
-}
-
-void newConnectionHandler(PeerConnectionState * state, SecureSessionMgr * transport)
-{
-    CHIP_ERROR err;
-
-    ESP_LOGI(TAG, "Received a new connection.");
-
-    err = state->GetSecureSession().TemporaryManualKeyExchange(remote_public_key, sizeof(remote_public_key), local_private_key,
-                                                               sizeof(local_private_key));
-    VerifyOrExit(err == CHIP_NO_ERROR, ESP_LOGE(TAG, "Failed to setup encryption"));
-
-exit:
-    return;
-}
-
-/**
  * @brief implements something like "od -c", changes an arbitrary byte string
  *   into a single-line of ascii.  Destroys any byte-wise encoding that
  *   might be present, e.g. utf-8.
@@ -168,75 +130,119 @@ static size_t odc(const uint8_t * bytes, size_t bytes_len, char * out, size_t ou
     return required;
 }
 
-// Transport Callbacks
-void receiveHandler(const MessageHeader & header, Transport::PeerConnectionState * state, System::PacketBuffer * buffer,
-                    SecureSessionMgr * transport)
+class EchoServerCallback : public SecureSessionMgrCallback
 {
-    CHIP_ERROR err;
-    const size_t data_len = buffer->DataLength();
-
-    // as soon as a client connects, assume it is connected
-    VerifyOrExit(transport != NULL && buffer != NULL, ESP_LOGE(TAG, "Received data but couldn't process it..."));
-    VerifyOrExit(state->GetPeerNodeId() != kUndefinedNodeId, ESP_LOGE(TAG, "Unknown source for received message"));
-
+public:
+    virtual void OnMessageReceived(const MessageHeader & header, Transport::PeerConnectionState * state,
+                          System::PacketBuffer * buffer)
     {
-        char src_addr[Transport::PeerAddress::kMaxToStringSize];
+        CHIP_ERROR err;
+        const size_t data_len = buffer->DataLength();
 
-        state->GetPeerAddress().ToString(src_addr, sizeof(src_addr));
+        // as soon as a client connects, assume it is connected
+        VerifyOrExit(mTransport != NULL && buffer != NULL, ESP_LOGE(TAG, "Received data but couldn't process it..."));
+        VerifyOrExit(state->GetPeerNodeId() != kUndefinedNodeId, ESP_LOGE(TAG, "Unknown source for received message"));
 
-        ESP_LOGI(TAG, "Packet received from %s: %zu bytes", src_addr, static_cast<size_t>(data_len));
-    }
-
-    // FIXME: Long-term we shouldn't be guessing what sort of message this is
-    // based on the message bytes.  We're doing this for now to support both
-    // data model messages and text echo messages, but in the long term we
-    // should either do echo via a data model command or do echo on a separate
-    // port from data model processing.
-    if (ContentMayBeADataModelMessage(buffer))
-    {
-        HandleDataModelMessage(buffer);
-        buffer = NULL;
-    }
-    else
-    {
-        char logmsg[512];
-
-        odc(buffer->Start(), data_len, logmsg, sizeof(logmsg));
-
-        ESP_LOGI(TAG, "Client sent: %s", logmsg);
-
-        // Attempt to echo back
-        err    = transport->SendMessage(header.GetSourceNodeId().Value(), buffer);
-        buffer = NULL;
-        if (err != CHIP_NO_ERROR)
         {
-            ESP_LOGE(TAG, "Unable to echo back to client: %s", ErrorStr(err));
+            char src_addr[Transport::PeerAddress::kMaxToStringSize];
+
+            state->GetPeerAddress().ToString(src_addr, sizeof(src_addr));
+
+            ESP_LOGI(TAG, "Packet received from %s: %zu bytes", src_addr, static_cast<size_t>(data_len));
+        }
+
+        // FIXME: Long-term we shouldn't be guessing what sort of message this is
+        // based on the message bytes.  We're doing this for now to support both
+        // data model messages and text echo messages, but in the long term we
+        // should either do echo via a data model command or do echo on a separate
+        // port from data model processing.
+        if (ContentMayBeADataModelMessage(buffer))
+        {
+            HandleDataModelMessage(buffer);
+            buffer = NULL;
         }
         else
         {
-            ESP_LOGI(TAG, "Echo sent");
+            char logmsg[512];
+
+            odc(buffer->Start(), data_len, logmsg, sizeof(logmsg));
+
+            ESP_LOGI(TAG, "Client sent: %s", logmsg);
+
+            // Attempt to echo back
+            err    = mTransport->SendMessage(header.GetSourceNodeId().Value(), buffer);
+            buffer = NULL;
+            if (err != CHIP_NO_ERROR)
+            {
+                ESP_LOGE(TAG, "Unable to echo back to client: %s", ErrorStr(err));
+            }
+            else
+            {
+                ESP_LOGI(TAG, "Echo sent");
+            }
+        }
+
+    exit:
+
+        // SendTo calls Free on the buffer without an AddRef, if SendTo was not called, free the buffer.
+        if (buffer != NULL)
+        {
+            System::PacketBuffer::Free(buffer);
         }
     }
 
-exit:
-
-    // SendTo calls Free on the buffer without an AddRef, if SendTo was not called, free the buffer.
-    if (buffer != NULL)
+    virtual void OnReceiveError(CHIP_ERROR error, const IPPacketInfo & source)
     {
-        System::PacketBuffer::Free(buffer);
+        ESP_LOGE(TAG, "ERROR: %s\n Got UDP error", ErrorStr(error));
+        statusLED.BlinkOnError();
     }
-}
 
-void error(CHIP_ERROR error, const IPPacketInfo & pi)
-{
-    ESP_LOGE(TAG, "ERROR: %s\n Got UDP error", ErrorStr(error));
-    statusLED.BlinkOnError();
-}
+    virtual void OnNewConnection(Transport::PeerConnectionState * state) {
+        CHIP_ERROR err;
+
+        ESP_LOGI(TAG, "Received a new connection.");
+
+        err = state->GetSecureSession().TemporaryManualKeyExchange(remote_public_key, sizeof(remote_public_key), local_private_key,
+                                                                sizeof(local_private_key));
+        VerifyOrExit(err == CHIP_NO_ERROR, ESP_LOGE(TAG, "Failed to setup encryption"));
+
+    exit:
+        return;
+    }
+
+    SecureSessionMgr * mTransport = nullptr;
+private:
+    /**
+     * A data model message has nonzero length and always has a first byte whose
+     * value is one of: 0x00, 0x01, 0x02, 0x03.  See chipZclEncodeZclHeader for the
+     * construction of the message and in particular the first byte.
+     *
+     * Echo messages should generally not have a first byte with those values, so we
+     * can use that to try to distinguish between the two.
+     */
+    bool ContentMayBeADataModelMessage(System::PacketBuffer * buffer)
+    {
+        const size_t data_len      = buffer->DataLength();
+        const uint8_t * data       = buffer->Start();
+        bool maybeDataModelMessage = true;
+
+        // Has to have nonzero length.
+        VerifyOrExit(data_len > 0, maybeDataModelMessage = false);
+
+        // Has to have a valid first byte value.
+        VerifyOrExit(data[0] < 0x04, maybeDataModelMessage = false);
+
+    exit:
+        return maybeDataModelMessage;
+    }
+};
+
+static EchoServerCallback gCallbacks_v4, gCallbacks_v6;
 
 } // namespace
 
 // The echo server assumes the platform's networking has been setup already
-void setupTransport(IPAddressType type, SecureSessionMgr * transport)
+void setupTransport(IPAddressType type, SecureSessionMgr * transport, EchoServerCallback* cb)
 {
     CHIP_ERROR err       = CHIP_NO_ERROR;
     struct netif * netif = NULL;
@@ -249,9 +255,9 @@ void setupTransport(IPAddressType type, SecureSessionMgr * transport)
     err = transport->Init(kLocalNodeId, &DeviceLayer::InetLayer, UdpListenParameters().SetAddressType(type).SetInterfaceId(netif));
     SuccessOrExit(err);
 
-    transport->SetMessageReceiveHandler(receiveHandler, transport);
-    transport->SetReceiveErrorHandler(error);
-    transport->SetNewConnectionHandler(newConnectionHandler, transport);
+    cb->mTransport = transport;
+
+    transport->AssignCallbackObject(cb);
 
 exit:
     if (err != CHIP_NO_ERROR)
@@ -267,6 +273,6 @@ exit:
 // The echo server assumes the platform's networking has been setup already
 void startServer(SecureSessionMgr * transport_ipv4, SecureSessionMgr * transport_ipv6)
 {
-    setupTransport(kIPAddressType_IPv6, transport_ipv6);
-    setupTransport(kIPAddressType_IPv4, transport_ipv4);
+    setupTransport(kIPAddressType_IPv6, transport_ipv6, &gCallbacks_v6);
+    setupTransport(kIPAddressType_IPv4, transport_ipv4, &gCallbacks_v4);
 }

--- a/examples/wifi-echo/server/esp32/main/EchoServer.cpp
+++ b/examples/wifi-echo/server/esp32/main/EchoServer.cpp
@@ -259,7 +259,7 @@ void setupTransport(IPAddressType type, SecureSessionMgr * transport, EchoServer
 
     cb->mTransport = transport;
 
-    transport->AssignCallbackObject(cb);
+    transport->SetDelegate(cb);
 
 exit:
     if (err != CHIP_NO_ERROR)

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -62,6 +62,7 @@ ChipDeviceController::ChipDeviceController()
     mDevicePort      = CHIP_PORT;
     mLocalDeviceId   = 0;
     memset(&mOnComplete, 0, sizeof(mOnComplete));
+    mCallback.SetController(this);
 }
 
 CHIP_ERROR ChipDeviceController::Init(NodeId localNodeId)
@@ -149,9 +150,6 @@ CHIP_ERROR ChipDeviceController::ConnectDevice(NodeId remoteDeviceId, IPAddress 
 
     err = mSessionManager->Init(mLocalDeviceId, mInetLayer, Transport::UdpListenParameters().SetAddressType(deviceAddr.Type()));
     SuccessOrExit(err);
-
-    mSessionManager->SetMessageReceiveHandler(OnReceiveMessage, this);
-    mSessionManager->SetNewConnectionHandler(OnNewConnection, this);
 
     // connected state before 'OnConnect' so that key exchange is accepted
     mConState = kConnectionState_Connected;
@@ -333,32 +331,32 @@ void ChipDeviceController::ClearRequestState()
     }
 }
 
-void ChipDeviceController::OnNewConnection(Transport::PeerConnectionState * state, ChipDeviceController * mgr)
+void ChipDeviceControllerCallback::OnNewConnection(Transport::PeerConnectionState * state)
 {
-    if (mgr->mOnNewConnection)
+    if (mController->mOnNewConnection)
     {
-        mgr->mOnNewConnection(mgr, state, mgr->mAppReqState);
+        mController->mOnNewConnection(mController, state, mController->mAppReqState);
     }
 }
 
-void ChipDeviceController::OnReceiveMessage(const MessageHeader & header, Transport::PeerConnectionState * state,
-                                            System::PacketBuffer * msgBuf, ChipDeviceController * mgr)
+void ChipDeviceControllerCallback::OnMessageReceived(const MessageHeader & header, Transport::PeerConnectionState * state,
+                                                     System::PacketBuffer * msgBuf)
 {
     if (header.GetSourceNodeId().HasValue())
     {
-        if (!mgr->mRemoteDeviceId.HasValue())
+        if (!mController->mRemoteDeviceId.HasValue())
         {
             ChipLogProgress(Controller, "Learned remote device id");
-            mgr->mRemoteDeviceId = header.GetSourceNodeId();
+            mController->mRemoteDeviceId = header.GetSourceNodeId();
         }
-        else if (mgr->mRemoteDeviceId != header.GetSourceNodeId())
+        else if (mController->mRemoteDeviceId != header.GetSourceNodeId())
         {
             ChipLogError(Controller, "Received message from an unexpected source node id.");
         }
     }
-    if (mgr->IsSecurelyConnected() && mgr->mOnComplete.Response != NULL)
+    if (mController->IsSecurelyConnected() && mController->mOnComplete.Response != NULL)
     {
-        mgr->mOnComplete.Response(mgr, mgr->mAppReqState, msgBuf);
+        mController->mOnComplete.Response(mController, mController->mAppReqState, msgBuf);
     }
 }
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -333,7 +333,7 @@ void ChipDeviceController::ClearRequestState()
     }
 }
 
-void ChipDeviceControllerCallback::OnNewConnection(Transport::PeerConnectionState * state)
+void ChipDeviceControllerCallback::OnNewConnection(Transport::PeerConnectionState * state, SecureSessionMgr * mgr)
 {
     if (mController->mOnNewConnection)
     {
@@ -342,7 +342,7 @@ void ChipDeviceControllerCallback::OnNewConnection(Transport::PeerConnectionStat
 }
 
 void ChipDeviceControllerCallback::OnMessageReceived(const MessageHeader & header, Transport::PeerConnectionState * state,
-                                                     System::PacketBuffer * msgBuf)
+                                                     System::PacketBuffer * msgBuf, SecureSessionMgr * mgr)
 {
     if (header.GetSourceNodeId().HasValue())
     {

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -151,6 +151,8 @@ CHIP_ERROR ChipDeviceController::ConnectDevice(NodeId remoteDeviceId, IPAddress 
     err = mSessionManager->Init(mLocalDeviceId, mInetLayer, Transport::UdpListenParameters().SetAddressType(deviceAddr.Type()));
     SuccessOrExit(err);
 
+    mSessionManager->SetDelegate(&mCallback);
+
     // connected state before 'OnConnect' so that key exchange is accepted
     mConState = kConnectionState_Connected;
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -49,8 +49,24 @@ typedef void (*ErrorHandler)(ChipDeviceController * deviceController, void * app
 typedef void (*MessageReceiveHandler)(ChipDeviceController * deviceController, void * appReqState, System::PacketBuffer * payload);
 };
 
+class ChipDeviceControllerCallback : public SecureSessionMgrCallback
+{
+public:
+    virtual void OnMessageReceived(const MessageHeader & header, Transport::PeerConnectionState * state,
+                                   System::PacketBuffer * msgBuf);
+
+    virtual void OnNewConnection(Transport::PeerConnectionState * state);
+
+    void SetController(ChipDeviceController * controller) { mController = controller; }
+
+private:
+    ChipDeviceController * mController;
+};
+
 class DLL_EXPORT ChipDeviceController
 {
+    friend class ChipDeviceControllerCallback;
+
 public:
     ChipDeviceController();
 
@@ -191,6 +207,8 @@ private:
     NewConnectionHandler mOnNewConnection;
     System::PacketBuffer * mCurReqMsg;
 
+    ChipDeviceControllerCallback mCallback;
+
     NodeId mLocalDeviceId;
     IPAddress mDeviceAddr;
     uint16_t mDevicePort;
@@ -199,11 +217,6 @@ private:
 
     void ClearRequestState();
     void ClearOpState();
-
-    static void OnNewConnection(Transport::PeerConnectionState * state, ChipDeviceController * controller);
-
-    static void OnReceiveMessage(const MessageHeader & header, Transport::PeerConnectionState * state,
-                                 System::PacketBuffer * msgBuf, ChipDeviceController * controller);
 };
 
 } // namespace DeviceController

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -53,9 +53,9 @@ class ChipDeviceControllerCallback : public SecureSessionMgrCallback
 {
 public:
     virtual void OnMessageReceived(const MessageHeader & header, Transport::PeerConnectionState * state,
-                                   System::PacketBuffer * msgBuf);
+                                   System::PacketBuffer * msgBuf, SecureSessionMgr * mgr);
 
-    virtual void OnNewConnection(Transport::PeerConnectionState * state);
+    virtual void OnNewConnection(Transport::PeerConnectionState * state, SecureSessionMgr * mgr);
 
     void SetController(ChipDeviceController * controller) { mController = controller; }
 

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -46,6 +46,10 @@ SecureSessionMgr::SecureSessionMgr() : mState(State::kNotReady) {}
 SecureSessionMgr::~SecureSessionMgr()
 {
     CancelExpiryTimer();
+    if (mCB != nullptr)
+    {
+        mCB->Release();
+    }
 }
 
 CHIP_ERROR SecureSessionMgr::Init(NodeId localNodeId, Inet::InetLayer * inet, const Transport::UdpListenParameters & listenParams)

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -91,7 +91,7 @@ CHIP_ERROR SecureSessionMgr::Connect(NodeId peerNodeId, const Transport::PeerAdd
     //     same node or if some connection reuse is required.
     if (mCB != nullptr)
     {
-        mCB->OnNewConnection(state);
+        mCB->OnNewConnection(state, this);
     }
 
 exit:
@@ -161,7 +161,7 @@ CHIP_ERROR SecureSessionMgr::AllocateNewConnection(const MessageHeader & header,
 
     if (mCB != nullptr)
     {
-        mCB->OnNewConnection(*state);
+        mCB->OnNewConnection(*state, this);
     }
 
 exit:
@@ -229,7 +229,7 @@ void SecureSessionMgr::HandleUdpDataReceived(const MessageHeader & header, const
 
         if (connection->mCB != nullptr)
         {
-            connection->mCB->OnMessageReceived(header, state, msg);
+            connection->mCB->OnMessageReceived(header, state, msg, connection);
             msg = nullptr;
         }
     }
@@ -247,7 +247,7 @@ exit:
 
     if (err != CHIP_NO_ERROR && connection->mCB != nullptr)
     {
-        connection->mCB->OnReceiveError(err, pktInfo);
+        connection->mCB->OnReceiveError(err, pktInfo, connection);
     }
 }
 

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -85,9 +85,9 @@ CHIP_ERROR SecureSessionMgr::Connect(NodeId peerNodeId, const Transport::PeerAdd
     //   - on new connection for other transports may not be inline.
     //   - determine if logic is required to prevent multiple connections to the
     //     same node or if some connection reuse is required.
-    if (OnNewConnection)
+    if (mCB != nullptr)
     {
-        OnNewConnection(state, mNewConnectionArgument);
+        mCB->OnNewConnection(state);
     }
 
 exit:
@@ -155,9 +155,9 @@ CHIP_ERROR SecureSessionMgr::AllocateNewConnection(const MessageHeader & header,
         (*state)->SetPeerNodeId(header.GetSourceNodeId().Value());
     }
 
-    if (OnNewConnection)
+    if (mCB != nullptr)
     {
-        OnNewConnection(*state, mNewConnectionArgument);
+        mCB->OnNewConnection(*state);
     }
 
 exit:
@@ -223,9 +223,9 @@ void SecureSessionMgr::HandleUdpDataReceived(const MessageHeader & header, const
         err = state->GetSecureSession().Decrypt(data, len, plainText, header);
         VerifyOrExit(err == CHIP_NO_ERROR, ChipLogProgress(Inet, "Secure transport failed to decrypt msg: err %d", err));
 
-        if (connection->OnMessageReceived)
+        if (connection->mCB != nullptr)
         {
-            connection->OnMessageReceived(header, state, msg, connection->mMessageReceivedArgument);
+            connection->mCB->OnMessageReceived(header, state, msg);
             msg = nullptr;
         }
     }
@@ -241,12 +241,9 @@ exit:
         PacketBuffer::Free(msg);
     }
 
-    if (err != CHIP_NO_ERROR)
+    if (err != CHIP_NO_ERROR && connection->mCB != nullptr)
     {
-        if (connection->OnReceiveError)
-        {
-            connection->OnReceiveError(err, pktInfo);
-        }
+        connection->mCB->OnReceiveError(err, pktInfo);
     }
 }
 

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -126,13 +126,7 @@ public:
     CHIP_ERROR SendMessage(NodeId peerNodeId, System::PacketBuffer * msgBuf);
 
     SecureSessionMgr();
-    virtual ~SecureSessionMgr()
-    {
-        if (mCB != nullptr)
-        {
-            mCB->Release();
-        }
-    }
+    virtual ~SecureSessionMgr();
 
     /**
      * @brief

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -68,7 +68,7 @@ public:
      *   Called when received message processing resulted in error
      *
      * @param error error code
-     * @param source network entity that sent the message 
+     * @param source network entity that sent the message
      */
     virtual void OnReceiveError(CHIP_ERROR error, const Inet::IPPacketInfo & source) {}
 
@@ -141,7 +141,7 @@ public:
      * @details
      *   Release if there was an existing callback object
      */
-    void AssignCallbackObject(SecureSessionMgrCallback * cb)
+    void SetDelegate(SecureSessionMgrCallback * cb)
     {
         if (mCB != nullptr)
         {

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -40,6 +40,8 @@ namespace chip {
 
 using namespace System;
 
+class SecureSessionMgr;
+
 /**
  * @brief
  *   This class provides a skeleton for the callback functions. The functions will be
@@ -60,7 +62,7 @@ public:
      * @param msgBuf received message
      */
     virtual void OnMessageReceived(const MessageHeader & header, Transport::PeerConnectionState * state,
-                                   System::PacketBuffer * msgBuf)
+                                   System::PacketBuffer * msgBuf, SecureSessionMgr * mgr)
     {}
 
     /**
@@ -70,7 +72,7 @@ public:
      * @param error error code
      * @param source network entity that sent the message
      */
-    virtual void OnReceiveError(CHIP_ERROR error, const Inet::IPPacketInfo & source) {}
+    virtual void OnReceiveError(CHIP_ERROR error, const Inet::IPPacketInfo & source, SecureSessionMgr * mgr) {}
 
     /**
      * @brief
@@ -78,7 +80,7 @@ public:
      *
      * @param state connection state
      */
-    virtual void OnNewConnection(Transport::PeerConnectionState * state) {}
+    virtual void OnNewConnection(Transport::PeerConnectionState * state, SecureSessionMgr * mgr) {}
 
     virtual ~SecureSessionMgrCallback() {}
 };

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -99,6 +99,8 @@ void CheckSimpleInitTest(nlTestSuite * inSuite, void * inContext)
     SecureSessionMgr conn;
     CHIP_ERROR err;
 
+    ctx.GetInetLayer().SystemLayer()->Init(NULL);
+
     err = conn.Init(kSourceNodeId, &ctx.GetInetLayer(), Transport::UdpListenParameters());
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
@@ -108,6 +110,8 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
     size_t payload_len = sizeof(PAYLOAD);
+
+    ctx.GetInetLayer().SystemLayer()->Init(NULL);
 
     chip::System::PacketBuffer * buffer = chip::System::PacketBuffer::NewWithAvailableSize(payload_len);
     memmove(buffer->Start(), PAYLOAD, payload_len);

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -60,7 +60,7 @@ class TestSessMgrCallback : public SecureSessionMgrCallback
 {
 public:
     virtual void OnMessageReceived(const MessageHeader & header, Transport::PeerConnectionState * state,
-                                   System::PacketBuffer * msgBuf)
+                                   System::PacketBuffer * msgBuf, SecureSessionMgr * mgr)
     {
         NL_TEST_ASSERT(mSuite, header.GetSourceNodeId() == Optional<NodeId>::Value(kSourceNodeId));
         NL_TEST_ASSERT(mSuite, header.GetDestinationNodeId() == Optional<NodeId>::Value(kDestinationNodeId));
@@ -74,7 +74,7 @@ public:
         ReceiveHandlerCallCount++;
     }
 
-    virtual void OnNewConnection(Transport::PeerConnectionState * state)
+    virtual void OnNewConnection(Transport::PeerConnectionState * state, SecureSessionMgr * mgr)
     {
         CHIP_ERROR err;
 

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -123,7 +123,7 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
     TestSessMgrCallback cb;
     cb.mSuite = inSuite;
 
-    conn.AssignCallbackObject(&cb);
+    conn.SetDelegate(&cb);
 
     cb.NewConnectionHandlerCallCount = 0;
     err                              = conn.Connect(kDestinationNodeId, Transport::PeerAddress::UDP(addr));

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -56,34 +56,39 @@ static const char PAYLOAD[]         = "Hello!";
 constexpr NodeId kSourceNodeId      = 123654;
 constexpr NodeId kDestinationNodeId = 111222333;
 
-int ReceiveHandlerCallCount = 0;
-
-static void MessageReceiveHandler(const MessageHeader & header, Transport::PeerConnectionState * state,
-                                  System::PacketBuffer * msgBuf, nlTestSuite * inSuite)
+class TestSessMgrCallback : public SecureSessionMgrCallback
 {
-    NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<NodeId>::Value(kSourceNodeId));
-    NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<NodeId>::Value(kDestinationNodeId));
-    NL_TEST_ASSERT(inSuite, state->GetPeerNodeId() == kDestinationNodeId);
+public:
+    virtual void OnMessageReceived(const MessageHeader & header, Transport::PeerConnectionState * state,
+                                   System::PacketBuffer * msgBuf)
+    {
+        NL_TEST_ASSERT(mSuite, header.GetSourceNodeId() == Optional<NodeId>::Value(kSourceNodeId));
+        NL_TEST_ASSERT(mSuite, header.GetDestinationNodeId() == Optional<NodeId>::Value(kDestinationNodeId));
+        NL_TEST_ASSERT(mSuite, state->GetPeerNodeId() == kDestinationNodeId);
 
-    size_t data_len = msgBuf->DataLength();
+        size_t data_len = msgBuf->DataLength();
 
-    int compare = memcmp(msgBuf->Start(), PAYLOAD, data_len);
-    NL_TEST_ASSERT(inSuite, compare == 0);
+        int compare = memcmp(msgBuf->Start(), PAYLOAD, data_len);
+        NL_TEST_ASSERT(mSuite, compare == 0);
 
-    ReceiveHandlerCallCount++;
-}
+        ReceiveHandlerCallCount++;
+    }
 
-int NewConnectionHandlerCallCount = 0;
-static void NewConnectionHandler(Transport::PeerConnectionState * state, nlTestSuite * inSuite)
-{
-    CHIP_ERROR err;
+    virtual void OnNewConnection(Transport::PeerConnectionState * state)
+    {
+        CHIP_ERROR err;
 
-    NewConnectionHandlerCallCount++;
+        NewConnectionHandlerCallCount++;
 
-    err = state->GetSecureSession().TemporaryManualKeyExchange(remote_public_key, sizeof(remote_public_key), local_private_key,
-                                                               sizeof(local_private_key));
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-}
+        err = state->GetSecureSession().TemporaryManualKeyExchange(remote_public_key, sizeof(remote_public_key), local_private_key,
+                                                                   sizeof(local_private_key));
+        NL_TEST_ASSERT(mSuite, err == CHIP_NO_ERROR);
+    }
+
+    nlTestSuite * mSuite              = nullptr;
+    int ReceiveHandlerCallCount       = 0;
+    int NewConnectionHandlerCallCount = 0;
+};
 
 void CheckSimpleInitTest(nlTestSuite * inSuite, void * inContext)
 {
@@ -115,22 +120,24 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
     err = conn.Init(kSourceNodeId, &ctx.GetInetLayer(), Transport::UdpListenParameters().SetAddressType(addr.Type()));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    conn.SetNewConnectionHandler(NewConnectionHandler, inSuite);
-    conn.SetMessageReceiveHandler(MessageReceiveHandler, inSuite);
+    TestSessMgrCallback cb;
+    cb.mSuite = inSuite;
 
-    NewConnectionHandlerCallCount = 0;
-    err                           = conn.Connect(kDestinationNodeId, Transport::PeerAddress::UDP(addr));
+    conn.AssignCallbackObject(&cb);
+
+    cb.NewConnectionHandlerCallCount = 0;
+    err                              = conn.Connect(kDestinationNodeId, Transport::PeerAddress::UDP(addr));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, NewConnectionHandlerCallCount == 1);
+    NL_TEST_ASSERT(inSuite, cb.NewConnectionHandlerCallCount == 1);
 
     // Should be able to send a message to itself by just calling send.
-    ReceiveHandlerCallCount = 0;
-    err                     = conn.SendMessage(kDestinationNodeId, buffer);
+    cb.ReceiveHandlerCallCount = 0;
+    err                        = conn.SendMessage(kDestinationNodeId, buffer);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     ctx.DriveIOUntil(1000 /* ms */, []() { return ReceiveHandlerCallCount != 0; });
 
-    NL_TEST_ASSERT(inSuite, ReceiveHandlerCallCount == 1);
+    NL_TEST_ASSERT(inSuite, cb.ReceiveHandlerCallCount == 1);
 }
 
 // Test Suite


### PR DESCRIPTION
 #### Problem
`SecureSessionMgr` API is getting complicated due to multiple callback functions and their individual registrations.

 #### Summary of Changes
Defined a new callback class, that encapsulates the complexities of all callback functions. The entity that registers the callback object, can specialize the new class to carry additional parameters needed at the time of processing.

Also, updated ReferenceCounted class to handle leftover review comments from #1305 
