### PR TITLE
Fix Example Vendor ID mismatch for demo

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
@@ -29,7 +29,7 @@
 
 // The expected Vendor ID for CHIP demos
 // Spells CHIP on a dialer
-#define EXAMPLE_VENDOR_ID 3447
+#define EXAMPLE_VENDOR_ID 2447
 #define EXAMPLE_VENDOR_TAG_SSID 1
 #define MAX_SSID_LEN 32
 


### PR DESCRIPTION
 #### Problem
The VendorID used in the QRCode on the M5Stack in the example doesn't match the VendorID the CHIP Tool iOS app expects. 
So scanning the QRCode doesn't result in a detection of the SoftAP.
 #### Summary of Changes
Fix the expected VendorID to match the M5Stack's Example VendorID.

