### PR TITLE
[nrf5-example] Use ConfigurationMgr().InitiateFactoryReset()

### DIFF
--- a/examples/lock-app/nrf5/main/AppTask.cpp
+++ b/examples/lock-app/nrf5/main/AppTask.cpp
@@ -338,7 +338,7 @@ void AppTask::FunctionTimerEventHandler(AppEvent * aEvent)
     {
         // Actually trigger Factory Reset
         sAppTask.mFunction = kFunction_NoneSelected;
-        ThreadStackMgr().FactoryReset();
+        ConfigurationMgr().InitiateFactoryReset();
     }
 }
 

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -136,7 +136,7 @@ public:
     CHIP_ERROR SetThreadPollingConfig(const ThreadPollingConfig & pollingConfig);
     bool IsThreadAttached(void);
     bool IsThreadProvisioned(void);
-    void ClearThreadProvision(void);
+    void ErasePersistentInfo(void);
     bool HaveServiceConnectivityViaThread(void);
 
     // Internet connectivity methods
@@ -441,9 +441,9 @@ inline bool ConnectivityManager::IsThreadProvisioned(void)
     return static_cast<ImplClass *>(this)->_IsThreadProvisioned();
 }
 
-inline void ConnectivityManager::ClearThreadProvision(void)
+inline void ConnectivityManager::ErasePersistentInfo(void)
 {
-    static_cast<ImplClass *>(this)->_ClearThreadProvision();
+    static_cast<ImplClass *>(this)->_ErasePersistentInfo();
 }
 
 inline bool ConnectivityManager::HaveServiceConnectivityViaThread(void)

--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -106,7 +106,7 @@ private:
     bool IsThreadAttached(void);
     CHIP_ERROR GetThreadProvision(Internal::DeviceNetworkInfo & netInfo, bool includeCredentials);
     CHIP_ERROR SetThreadProvision(const Internal::DeviceNetworkInfo & netInfo);
-    void ClearThreadProvision(void);
+    void ErasePersistentInfo(void);
     ConnectivityManager::ThreadDeviceType GetThreadDeviceType(void);
     CHIP_ERROR SetThreadDeviceType(ConnectivityManager::ThreadDeviceType threadRole);
     void GetThreadPollingConfig(ConnectivityManager::ThreadPollingConfig & pollingConfig);
@@ -232,9 +232,9 @@ inline CHIP_ERROR ThreadStackManager::SetThreadProvision(const Internal::DeviceN
     return static_cast<ImplClass *>(this)->_SetThreadProvision(netInfo);
 }
 
-inline void ThreadStackManager::ClearThreadProvision(void)
+inline void ThreadStackManager::ErasePersistentInfo(void)
 {
-    static_cast<ImplClass *>(this)->_ClearThreadProvision();
+    static_cast<ImplClass *>(this)->_ErasePersistentInfo();
 }
 
 inline ConnectivityManager::ThreadDeviceType ThreadStackManager::GetThreadDeviceType(void)
@@ -295,11 +295,6 @@ inline CHIP_ERROR ThreadStackManager::GetAndLogThreadTopologyFull(void)
 inline CHIP_ERROR ThreadStackManager::GetPrimary802154MACAddress(uint8_t * buf)
 {
     return static_cast<ImplClass *>(this)->_GetPrimary802154MACAddress(buf);
-}
-
-inline void ThreadStackManager::FactoryReset()
-{
-    return static_cast<ImplClass *>(this)->_FactoryReset();
 }
 
 } // namespace DeviceLayer

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_NoThread.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_NoThread.h
@@ -53,7 +53,7 @@ protected:
     CHIP_ERROR _SetThreadPollingConfig(const ConnectivityManager::ThreadPollingConfig & pollingConfig);
     bool _IsThreadAttached(void);
     bool _IsThreadProvisioned(void);
-    void _ClearThreadProvision(void);
+    void _ErasePersistentInfo(void);
     bool _HaveServiceConnectivityViaThread(void);
 
     ImplClass * Impl() { return static_cast<ImplClass *>(this); }
@@ -96,7 +96,7 @@ inline bool GenericConnectivityManagerImpl_NoThread<ImplClass>::_IsThreadProvisi
 }
 
 template <class ImplClass>
-inline void GenericConnectivityManagerImpl_NoThread<ImplClass>::_ClearThreadProvision(void)
+inline void GenericConnectivityManagerImpl_NoThread<ImplClass>::_ErasePersistentInfo(void)
 {}
 
 template <class ImplClass>

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.h
@@ -64,7 +64,7 @@ protected:
     CHIP_ERROR _SetThreadPollingConfig(const ConnectivityManager::ThreadPollingConfig & pollingConfig);
     bool _IsThreadAttached(void);
     bool _IsThreadProvisioned(void);
-    void _ClearThreadProvision(void);
+    void _ErasePersistentInfo(void);
     bool _HaveServiceConnectivityViaThread(void);
 
     // ===== Members for use by the implementation subclass.
@@ -119,9 +119,9 @@ inline bool GenericConnectivityManagerImpl_Thread<ImplClass>::_IsThreadProvision
 }
 
 template <class ImplClass>
-inline void GenericConnectivityManagerImpl_Thread<ImplClass>::_ClearThreadProvision(void)
+inline void GenericConnectivityManagerImpl_Thread<ImplClass>::_ErasePersistentInfo(void)
 {
-    ThreadStackMgrImpl().ClearThreadProvision();
+    ThreadStackMgrImpl().ErasePersistentInfo();
 }
 
 template <class ImplClass>

--- a/src/include/platform/internal/GenericNetworkProvisioningServerImpl.ipp
+++ b/src/include/platform/internal/GenericNetworkProvisioningServerImpl.ipp
@@ -27,8 +27,8 @@
 #define GENERIC_NETWORK_PROVISIONING_SERVER_IMPL_IPP
 
 #include <platform/internal/CHIPDeviceLayerInternal.h>
-#include <platform/internal/NetworkProvisioningServer.h>
 #include <platform/internal/GenericNetworkProvisioningServerImpl.h>
+#include <platform/internal/NetworkProvisioningServer.h>
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 #include <platform/ThreadStackManager.h>
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
@@ -431,7 +431,7 @@ CHIP_ERROR GenericNetworkProvisioningServerImpl<ImplClass>::HandleRemoveNetwork(
         }
 
         // Clear the Thread provision.
-        ThreadStackMgr().ClearThreadProvision();
+        ThreadStackMgr().ErasePersistentInfo();
 
         break;
 

--- a/src/platform/EFR32/ConfigurationManagerImpl.cpp
+++ b/src/platform/EFR32/ConfigurationManagerImpl.cpp
@@ -141,7 +141,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 
     ChipLogProgress(DeviceLayer, "Clearing Thread provision");
-    ThreadStackMgr().ClearThreadProvision();
+    ThreadStackMgr().ErasePersistentInfo();
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 

--- a/src/platform/Linux/ConfigurationManagerImpl.cpp
+++ b/src/platform/Linux/ConfigurationManagerImpl.cpp
@@ -162,7 +162,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 
     ChipLogProgress(DeviceLayer, "Clearing Thread provision");
-    ThreadStackMgr().ClearThreadProvision();
+    ThreadStackMgr().ErasePersistentInfo();
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -70,7 +70,7 @@ protected:
     bool _IsThreadAttached(void);
     CHIP_ERROR _GetThreadProvision(DeviceNetworkInfo & netInfo, bool includeCredentials);
     CHIP_ERROR _SetThreadProvision(const DeviceNetworkInfo & netInfo);
-    void _ClearThreadProvision(void);
+    void _ErasePersistentInfo(void);
     ConnectivityManager::ThreadDeviceType _GetThreadDeviceType(void);
     CHIP_ERROR _SetThreadDeviceType(ConnectivityManager::ThreadDeviceType deviceType);
     void _GetThreadPollingConfig(ConnectivityManager::ThreadPollingConfig & pollingConfig);
@@ -89,7 +89,6 @@ protected:
     CHIP_ERROR DoInit(otInstance * otInst);
     bool IsThreadAttachedNoLock(void);
     CHIP_ERROR AdjustPollingInterval(void);
-    void _FactoryReset(void);
 
 private:
     // ===== Private members for use by this class only.

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.ipp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.ipp
@@ -810,18 +810,9 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::AdjustPollingInt
 }
 
 template <class ImplClass>
-void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_FactoryReset(void)
+void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_ErasePersistentInfo(void)
 {
-    ChipLogProgress(DeviceLayer, "About to factory reset ...");
-    Impl()->LockThreadStack();
-    otInstanceFactoryReset(mOTInst);
-    Impl()->UnlockThreadStack();
-}
-
-template <class ImplClass>
-void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_ClearThreadProvision(void)
-{
-    ChipLogProgress(DeviceLayer, "About to clear thread provision...");
+    ChipLogProgress(DeviceLayer, "Erasing Thread persistent info...");
     Impl()->LockThreadStack();
     otThreadSetEnabled(mOTInst, false);
     otInstanceErasePersistentInfo(mOTInst);

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.ipp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.ipp
@@ -818,6 +818,16 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_FactoryReset(void)
     Impl()->UnlockThreadStack();
 }
 
+template <class ImplClass>
+void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_ClearThreadProvision(void)
+{
+    ChipLogProgress(DeviceLayer, "About to clear thread provision...");
+    Impl()->LockThreadStack();
+    otThreadSetEnabled(mOTInst, false);
+    otInstanceErasePersistentInfo(mOTInst);
+    Impl()->UnlockThreadStack();
+}
+
 } // namespace Internal
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/nRF5/ConfigurationManagerImpl.cpp
+++ b/src/platform/nRF5/ConfigurationManagerImpl.cpp
@@ -144,7 +144,6 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 
-    ChipLogProgress(DeviceLayer, "Erasing Thread provisioning info...");
     ThreadStackMgr().ErasePersistentInfo();
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD

--- a/src/platform/nRF5/ConfigurationManagerImpl.cpp
+++ b/src/platform/nRF5/ConfigurationManagerImpl.cpp
@@ -144,8 +144,8 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 
-    ChipLogProgress(DeviceLayer, "Clearing Thread provision");
-    ThreadStackMgr().ClearThreadProvision();
+    ChipLogProgress(DeviceLayer, "Erasing Thread provisioning info...");
+    ThreadStackMgr().ErasePersistentInfo();
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 


### PR DESCRIPTION
#### Problem

In #1196, `ThreadStackMgr().FactoryReset()` does not clear CHIP configurations

#### Summary of Changes

Use `ConfigurationMgr().InitiateFactoryReset()` instead of `ThreadStackMgr().FactoryReset()`