### PR TITLE
[openthread] Add openthread to third_party.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,5 +31,6 @@
         url = https://pigweed.googlesource.com/pigweed/pigweed
         ignore = dirty
 [submodule "third_party/openthread/repo"]
-	path = third_party/openthread/repo
-	url = https://github.com/openthread/openthread
+        path = third_party/openthread/repo
+        url = https://github.com/openthread/openthread
+        ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -30,3 +30,6 @@
         path = third_party/pigweed
         url = https://pigweed.googlesource.com/pigweed/pigweed
         ignore = dirty
+[submodule "third_party/openthread/repo"]
+	path = third_party/openthread/repo
+	url = https://github.com/openthread/openthread

--- a/repos.conf
+++ b/repos.conf
@@ -33,3 +33,8 @@
 	url = https://github.com/jeremyjh/ESP32_TFT_library.git
 	branch = master
 	update = none
+[submodule "openthread"]
+	path = third_party/openthread/repo
+	url = https://github.com/openthread/openthread.git
+	branch = master
+	update = none


### PR DESCRIPTION
 #### Problem
OpenThread is not yet in third_party to ease integration with the library in examples.

 #### Summary of Changes
Add OpenThread to third_party.