### PR TITLE
Add an option in KConfig for the esp32 demo app to choose the Rendezv…

### DIFF
--- a/examples/wifi-echo/server/esp32/main/Kconfig.projbuild
+++ b/examples/wifi-echo/server/esp32/main/Kconfig.projbuild
@@ -35,6 +35,22 @@ menu "WiFi Echo Demo"
             bool "M5Stack"
     endchoice
 
+    choice
+      prompt "Rendezvous Mode"
+      default RENDEZVOUS_MODE_SOFTAP
+      help
+          Specifies the Rendezvous mode of the peripheral.
+
+      config RENDEZVOUS_MODE_SOFTAP
+          bool "Soft-AP"
+      config RENDEZVOUS_MODE_BLE
+          bool "BLE"
+      config RENDEZVOUS_MODE_THREAD
+          bool "Thread"
+      config RENDEZVOUS_MODE_ETHERNET
+          bool "Ethernet"
+    endchoice
+
     config USE_ECHO_CLIENT
         bool "Enable the built-in Echo Client"
         default "n"
@@ -58,12 +74,19 @@ menu "WiFi Echo Demo"
         default 3 if DEVICE_TYPE_M5STACK
         default 0 if DEVICE_TYPE_ESP32_DEVKITC
 
+    config RENDEZVOUS_MODE
+       int
+       range 0 8
+       default 1 if RENDEZVOUS_MODE_SOFTAP
+       default 2 if RENDEZVOUS_MODE_BLE
+       default 4 if RENDEZVOUS_MODE_THREAD
+       default 8 if RENDEZVOUS_MODE_ETHERNET
+
     config DISPLAY_AUTO_OFF
         bool "Automatically turn off the M5Stack's Display after a few seconds"
         default "y"
         depends on DEVICE_TYPE_M5STACK
         help
             To reduce wear and heat the M5Stack's Display is automatically switched off after a few seconds
-
 
 endmenu

--- a/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
+++ b/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
@@ -49,8 +49,6 @@
 #define EXAMPLE_SETUP_CODE 123456789
 // Used to discriminate the device
 #define EXAMPLE_DISCRIMINATOR 0X0F00
-// Used to indicate that the device supports both Soft-AP and BLE for rendezvous
-#define EXAMPLE_RENDEZVOUS_INFO RendezvousInformationFlags::kSoftAP
 // Used to indicate that an IP address has been added to the QRCode
 #define EXAMPLE_VENDOR_TAG_IP 1
 
@@ -83,7 +81,7 @@ string createSetupPayload()
     payload.version               = 1;
     payload.discriminator         = EXAMPLE_DISCRIMINATOR;
     payload.setUpPINCode          = EXAMPLE_SETUP_CODE;
-    payload.rendezvousInformation = EXAMPLE_RENDEZVOUS_INFO;
+    payload.rendezvousInformation = static_cast<RendezvousInformationFlags>(CONFIG_RENDEZVOUS_MODE);
     payload.vendorID              = EXAMPLE_VENDOR_ID;
     payload.productID             = EXAMPLE_PRODUCT_ID;
 


### PR DESCRIPTION
…ous mode of the peripheral

 Add an option in Kconfig for the esp32 demo app to choose the Rendezvous mode of the peripheral. It will allow more customisation of the startup process of the demo app.

By default the rendezvous mode is set to SoftAP since the Ble part if not fully ready right now.