### PR TITLE
[ESP32] Move platform-init specific pieces into PlatformMgrImpl

### DIFF
--- a/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
@@ -91,13 +91,6 @@ SecureSessionMgr sTransportIPv6;
 
 } // namespace
 
-static int app_entropy_source(void * data, unsigned char * output, size_t len, size_t * olen)
-{
-    esp_fill_random(output, len);
-    *olen = len;
-    return 0;
-}
-
 extern "C" void app_main()
 {
     ESP_LOGI(TAG, "WiFi Echo Demo!");
@@ -138,26 +131,6 @@ extern "C" void app_main()
         return;
     }
 
-    // Initialize the ESP tcpip adapter.
-    tcpip_adapter_init();
-
-    // Arrange for the ESP event loop to deliver events into the CHIP Device layer.
-    err = esp_event_loop_init(PlatformManagerImpl::HandleESPSystemEvent, NULL);
-    if (err != CHIP_NO_ERROR)
-    {
-        ESP_LOGE(TAG, "esp_event_loop_init() failed: %s", ErrorStr(err));
-        return;
-    }
-
-    // Initialize the ESP WiFi layer.
-    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
-    err                    = esp_wifi_init(&cfg);
-    if (err != CHIP_NO_ERROR)
-    {
-        ESP_LOGE(TAG, "esp_event_loop_init() failed: %s", ErrorStr(err));
-        return;
-    }
-
     // Initialize the CHIP stack.
     err = PlatformMgr().InitChipStack();
     if (err != CHIP_NO_ERROR)
@@ -174,12 +147,6 @@ extern "C" void app_main()
     // this function will happen on the CHIP event loop thread, not the app_main thread.
     PlatformMgr().AddEventHandler(DeviceEventHandler, 0);
 
-    err = Crypto::add_entropy_source(app_entropy_source, NULL, 16);
-    if (err != CHIP_NO_ERROR)
-    {
-        ESP_LOGE(TAG, "add_entropy_source() failed: %s", ErrorStr(err));
-        return;
-    }
 
     // Start a task to run the CHIP Device event loop.
     err = PlatformMgr().StartEventLoopTask();

--- a/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
@@ -147,7 +147,6 @@ extern "C" void app_main()
     // this function will happen on the CHIP event loop thread, not the app_main thread.
     PlatformMgr().AddEventHandler(DeviceEventHandler, 0);
 
-
     // Start a task to run the CHIP Device event loop.
     err = PlatformMgr().StartEventLoopTask();
     if (err != CHIP_NO_ERROR)


### PR DESCRIPTION
 #### Problem
Simplify application's makefile by moving CHIP dependencies on initialisation

 #### Summary of Changes
Moved platform-specific initialisation to PlatformMgr

