### PR TITLE
Shellcheck considers directories as targets

### DIFF
--- a/scripts/helpers/shellcheck_tree.sh
+++ b/scripts/helpers/shellcheck_tree.sh
@@ -56,5 +56,5 @@ else
         pattern_args+=(-o -name "$pattern")
     done
 
-    find . "${exclude_args[@]}" '(' "${pattern_args[@]:1}" ')' -exec shellcheck -f gcc {} +
+    find . "${exclude_args[@]}" '(' "${pattern_args[@]:1}" ')' -type f -exec shellcheck -f gcc {} +
 fi


### PR DESCRIPTION
 #### Problem

While running ./scripts/helpers/shellcheck.sh it consider directories with profile* in their name as valid target:
It cause this type of outputs:
./output/include/lib/profiles: ./output/include/lib/profiles: openBinaryFile: inappropriate type (is a directory)

 #### Summary of Changes
 * Add a '-type f' option to the find command to make sure it looks for files 