### PR TITLE
Add a method on the ConnectivityManager to let the application retrie…

### DIFF
--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -154,6 +154,9 @@ public:
     bool HaveServiceConnectivity(void);
 
     // CHIPoBLE service methods
+    typedef void (*BleConnectionReceivedFunct)(BLEEndPoint * endpoint);
+    void AddCHIPoBLEConnectionHandler(BleConnectionReceivedFunct handler);
+    void RemoveCHIPoBLEConnectionHandler(void);
     CHIPoBLEServiceMode GetCHIPoBLEServiceMode(void);
     CHIP_ERROR SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool IsBLEAdvertisingEnabled(void);
@@ -449,6 +452,16 @@ inline void ConnectivityManager::ErasePersistentInfo(void)
 inline bool ConnectivityManager::HaveServiceConnectivityViaThread(void)
 {
     return static_cast<ImplClass *>(this)->_HaveServiceConnectivityViaThread();
+}
+
+inline void ConnectivityManager::AddCHIPoBLEConnectionHandler(BleConnectionReceivedFunct handler)
+{
+    return static_cast<ImplClass *>(this)->_AddCHIPoBLEConnectionHandler(handler);
+}
+
+inline void ConnectivityManager::RemoveCHIPoBLEConnectionHandler(void)
+{
+    return static_cast<ImplClass *>(this)->_RemoveCHIPoBLEConnectionHandler();
 }
 
 inline ConnectivityManager::CHIPoBLEServiceMode ConnectivityManager::GetCHIPoBLEServiceMode(void)

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_BLE.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_BLE.h
@@ -52,6 +52,8 @@ class GenericConnectivityManagerImpl_BLE
 public:
     // ===== Methods that implement the ConnectivityManager abstract interface.
 
+    void _AddCHIPoBLEConnectionHandler(ConnectivityManager::BleConnectionReceivedFunct handler);
+    void _RemoveCHIPoBLEConnectionHandler(void);
     ConnectivityManager::CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(ConnectivityManager::CHIPoBLEServiceMode val);
     bool _IsBLEAdvertisingEnabled(void);
@@ -70,6 +72,21 @@ private:
 
 // Instruct the compiler to instantiate the template only when explicitly told to do so.
 extern template class GenericConnectivityManagerImpl_BLE<ConnectivityManagerImpl>;
+
+template <class ImplClass>
+inline void GenericConnectivityManagerImpl_BLE<ImplClass>::_AddCHIPoBLEConnectionHandler(
+    ConnectivityManager::BleConnectionReceivedFunct handler)
+{
+    BleLayer * bleLayer                = BLEMgr().GetBleLayer();
+    bleLayer->OnChipBleConnectReceived = handler;
+}
+
+template <class ImplClass>
+inline void GenericConnectivityManagerImpl_BLE<ImplClass>::_RemoveCHIPoBLEConnectionHandler(void)
+{
+    BleLayer * bleLayer                = BLEMgr().GetBleLayer();
+    bleLayer->OnChipBleConnectReceived = NULL;
+}
 
 template <class ImplClass>
 inline ConnectivityManager::CHIPoBLEServiceMode GenericConnectivityManagerImpl_BLE<ImplClass>::_GetCHIPoBLEServiceMode(void)

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_NoBLE.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_NoBLE.h
@@ -53,6 +53,8 @@ class GenericConnectivityManagerImpl_NoBLE
 public:
     // ===== Methods that implement the ConnectivityManager abstract interface.
 
+    void _AddCHIPoBLEConnectionHandler(ConnectivityManager::BleConnectionReceivedFunct handler);
+    void _RemoveCHIPoBLEConnectionHandler(void);
     ConnectivityManager::CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(ConnectivityManager::CHIPoBLEServiceMode val);
     bool _IsBLEAdvertisingEnabled(void);
@@ -68,6 +70,15 @@ public:
 private:
     ImplClass * Impl() { return static_cast<ImplClass *>(this); }
 };
+
+template <class ImplClass>
+inline void GenericConnectivityManagerImpl_NoBLE<ImplClass>::_AddCHIPoBLEConnectionHandler(
+    ConnectivityManager::BleConnectionReceivedFunct handler)
+{}
+
+template <class ImplClass>
+inline void GenericConnectivityManagerImpl_NoBLE<ImplClass>::_RemoveCHIPoBLEConnectionHandler(void)
+{}
 
 template <class ImplClass>
 inline ConnectivityManager::CHIPoBLEServiceMode GenericConnectivityManagerImpl_NoBLE<ImplClass>::_GetCHIPoBLEServiceMode(void)


### PR DESCRIPTION
…ve opened BLEEndPoint

 #### Problem

Currently the esp32 demo application can not retrieved opened BLEEndPoint. For OW this is done under WML but we do not have it here. So this patch add a method to ConnectivityManager to register an handler for new connections.