### PR TITLE
Remove unused member from transport base. 

### DIFF
--- a/src/transport/Base.h
+++ b/src/transport/Base.h
@@ -100,8 +100,6 @@ protected:
 
     MessageReceiveHandler OnMessageReceived = nullptr; ///< Callback on message receiving
     void * mMessageReceivedArgument         = nullptr; ///< Argument for callback
-
-    uint8_t mRefCount = 0;
 };
 
 } // namespace Transport


### PR DESCRIPTION
Reference counting is done by ReferenceCounted base class.

 #### Problem
Unused member in class.

 #### Summary of Changes
Deletes unused member.

