### PR TITLE
System layer needs initialization before network initialization

### DIFF
--- a/src/transport/tests/NetworkTestHelpers.cpp
+++ b/src/transport/tests/NetworkTestHelpers.cpp
@@ -29,6 +29,8 @@ CHIP_ERROR IOContext::Init(nlTestSuite * suite)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
+    gSystemLayer.Init(NULL);
+
     InitNetwork();
 
     mSuite       = suite;


### PR DESCRIPTION
 #### Problem
InitNetwork() does not initialize the system layer.

 #### Summary of Changes
Initialize the system layer in tests.

fixes #1345 