### PR TITLE
propose Callback

### DIFF
--- a/src/lib/core/CHIPCallback.h
+++ b/src/lib/core/CHIPCallback.h
@@ -53,9 +53,9 @@ public:
     uint64_t mInfoScalar;
 
     /**
-     * when non-null, indicates the Callback is registered with
-     *        a subsystem and that Cancelable members belong to
-     *        that subsystem
+     * @brief when non-null, indicates the Callback is registered with
+     *   a subsystem and that Cancelable members belong to
+     *   that subsystem
      */
     void (*mCancel)(Cancelable *);
 
@@ -65,6 +65,10 @@ public:
         mCancel       = nullptr;
     };
 
+    /**
+     * @brief run whatever function the callee/registrar has specified in order
+     *  to cleanup resources and surrender ownership of the Cancelable's fields
+     */
     Cancelable * Cancel()
     {
         if (mCancel != nullptr)
@@ -283,8 +287,7 @@ private:
         where->mPrev        = ca;
         ca->mNext           = where;
     }
-
-}; // namespace Callback
+};
 
 } // namespace Callback
 } // namespace chip

--- a/src/lib/core/CHIPCallback.h
+++ b/src/lib/core/CHIPCallback.h
@@ -21,8 +21,8 @@
  *     Clusters and the Device
  */
 
-#ifndef CHIP_ZCL_CALLBACK_H_
-#define CHIP_ZCL_CALLBACK_H_
+#ifndef CHIP_CALLBACK_H_
+#define CHIP_CALLBACK_H_
 
 #include <stddef.h>
 #include <stdint.h>
@@ -121,8 +121,24 @@ public:
 
     /**
      * Cancel, i.e. de-register interest in the event,
-     *  this is the only way to get access to the Cancelable, to enqueue,
-     *  store any per-registration state
+     * This is the only way to get access to the Cancelable, to enqueue,
+     *  store any per-registration state.
+     * There are 3 primary use cases for this API:
+     *   1. For the owner of the Callback, Cancel() means "where-ever this Callback
+     *       was put in a list or registered for an event, gimme back, remove interest".
+     *   2. To a new registrar, during a registration call, it means "hey cleanup any
+     *       current registrations, let me use the internal fields of Cancelable
+     *       to keep track of what the owner is interested in.
+     *   3. To any current registrar (i.e. when mCancel is non-null), Cancel() means:
+     *       "remove this Callback from any internal lists and free any resources
+     *        you've allocated to track the interest".
+     *
+     *  For example: a sockets library with an API like Socket::Readable(Callback<> *cb)
+     *    using an underlying persistent registration API with the OS (like epoll())
+     *    might store the file descriptor and interest mask in the scalar, put the
+     *    Callback in a list.  Cancel() would dequeue the callback and remove
+     *    the socket from the interest set
+     *
      */
     Cancelable * Cancel() { return Cancelable::Cancel(); };
 
@@ -273,4 +289,4 @@ private:
 } // namespace Callback
 } // namespace chip
 
-#endif /* CHIP_ZCL_CALLBACK_H_ */
+#endif /* CHIP_CALLBACK_H_ */

--- a/src/lib/core/CHIPCallback.h
+++ b/src/lib/core/CHIPCallback.h
@@ -132,7 +132,8 @@ public:
     Callback(T call, void * context) : mContext(context), mCall(call) { Inner(); };
 
     /**
-     * TODO: type-safety?
+     * TODO: type-safety? It'd be nice if Inners that aren't Callbacks returned null
+     *    here.  https://github.com/project-chip/connectedhomeip/issues/1350
      */
     static Callback * FromInner(Inner * inner) { return static_cast<Callback *>(inner); }
 };

--- a/src/lib/core/CHIPCallback.h
+++ b/src/lib/core/CHIPCallback.h
@@ -1,0 +1,199 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *  @file
+ *    This file contains definitions for Callback objects for registering with
+ *     Clusters and the Device
+ */
+
+#ifndef CHIP_ZCL_CALLBACK_H_
+#define CHIP_ZCL_CALLBACK_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace chip {
+
+namespace Callback {
+
+/**
+ *  @class Inner
+ *
+ *    "Private" members of a Callback used by subsystems while a callback is
+ *     registered with them.
+ *
+ */
+class Inner
+{
+public:
+    /**
+     *  @brief for use by callees, i.e. those that accept callbacks for
+     *   event registration.  The names suggest how to use them, but
+     *   implementations can choose.
+     */
+    Inner * mNext;
+    Inner * mPrev;
+
+    void * mInfoPtr;
+    uint64_t mInfoScalar;
+
+    /**
+     * when non-null, indicates the Callback is registered with
+     *        a subsystem and that Inner members belong to
+     *        that subsystem
+     */
+    void (*mCancel)(Inner *);
+
+    Inner()
+    {
+        mNext = mPrev = this;
+        mCancel       = nullptr;
+    };
+
+    Inner * Cancel()
+    {
+        if (mCancel != nullptr)
+        {
+            void (*cancel)(Inner *) = mCancel;
+            mCancel                 = nullptr;
+            cancel(this);
+        }
+        return this;
+    }
+    ~Inner() { Cancel(); };
+};
+
+/**
+ *  @class Callback
+ *
+ *    Base struct used for registration of items of interest, includes
+ *     memory for list management and storing information about the registration's
+ *     meaning.  Callback also defines cancellation.
+ *    Callbacks can be registered with exactly one callee at a time. While
+ *     registered (as indicated by a non-null mCancel function), all fields of
+ *     the Callback save usercontext are "owned" by the callee, and should not
+ *     be touched unless Cancel() has first been called.
+ *    When a callee accepts a Callback for registration, step one is always Cancel(),
+ *     in order to take ownership of Inner members next, prev, info_ptr, and info_scalar.
+ *    This template class also defines a default notification function prototype.
+ *
+ *   One-shot semantics can be accomplished by calling Cancel() on
+ *
+ *
+ */
+template <class T = void (*)(void *)>
+class Callback : private Inner
+{
+public:
+    /**
+     * pointer to owner context, normally passed to the run function
+     */
+    void * mContext;
+
+    /**
+     * where to call when the event of interest has occured
+     */
+    T mCall;
+
+    /**
+     * Indication that the Callback is registered with a notifier
+     */
+    bool IsRegistered() { return (mCancel != nullptr); }
+
+    /**
+     * Cancel, i.e. de-register interest in the event,
+     *  this is the only way to get access to the Inner, to enqueue,
+     *  store any per-registration state
+     */
+    Inner * Cancel() { return Inner::Cancel(); };
+
+    /**
+     * public constructor
+     */
+    Callback(T call, void * context) : mContext(context), mCall(call) { Inner(); };
+
+    /**
+     * TODO: type-safety?
+     */
+    static Callback * FromInner(Inner * inner) { return static_cast<Callback *>(inner); }
+};
+
+/**
+ * @brief core of a simple doubly-linked list Callback keeper-tracker-of
+ *
+ */
+class CallbackDeque
+{
+public:
+    /**
+     * @brief appends
+     */
+    void Enqueue(Inner * inner) { Enqueue(inner, Dequeue); };
+
+    /**
+     * @brief appends with overridden cancel function, in case the
+     *   list change requires some other state update.
+     */
+    void Enqueue(Inner * inner, void (*cancel)(Inner *))
+    {
+        // add to a doubly-linked list, set cancel function
+        inner->Cancel(); // make doubly-sure we're not corrupting another list somewhere
+        inner->mPrev       = mHead.mPrev;
+        mHead.mPrev->mNext = inner;
+        mHead.mPrev        = inner;
+        inner->mNext       = &mHead;
+        inner->mCancel     = cancel;
+    };
+
+    CallbackDeque() : mHead() { mHead.mNext = mHead.mPrev = &mHead; };
+
+    /**
+     * Dequeue all, return in a stub. does not cancel the inners, as the list
+     *   members are still in use
+     */
+    Inner DequeueAll()
+    {
+        Inner ready;
+
+        if (mHead.mNext != &mHead)
+        {
+            ready.mNext        = mHead.mNext;
+            ready.mPrev        = mHead.mPrev;
+            ready.mPrev->mNext = &ready;
+            ready.mNext->mPrev = &ready;
+
+            mHead.mNext = mHead.mPrev = &mHead;
+        }
+        return ready;
+    }
+
+    static void Dequeue(Inner * inner)
+    {
+        inner->mNext->mPrev = inner->mPrev;
+        inner->mPrev->mNext = inner->mNext;
+        inner->mNext = inner->mPrev = inner;
+        inner->mCancel              = nullptr;
+    }
+
+    Inner mHead;
+};
+
+} // namespace Callback
+} // namespace chip
+
+#endif /* CHIP_ZCL_CALLBACK_H_ */

--- a/src/lib/core/CHIPCallback.h
+++ b/src/lib/core/CHIPCallback.h
@@ -92,8 +92,12 @@ public:
  *     in order to take ownership of Inner members next, prev, info_ptr, and info_scalar.
  *    This template class also defines a default notification function prototype.
  *
- *   One-shot semantics can be accomplished by calling Cancel() on
+ *   One-shot semantics can be accomplished by calling Cancel() before calling mCall.
+ *     Persistent registration semantics would skip that.
  *
+ *   There is no provision for queueing data passed as arguments to a Callback's mCall
+ *     function.  If such a thing is required, the normal pattern is to take an output
+ *     parameter at Callback registration time.
  *
  */
 template <class T = void (*)(void *)>

--- a/src/lib/core/CoreLayer.am
+++ b/src/lib/core/CoreLayer.am
@@ -35,6 +35,7 @@ CHIP_BUILD_CORE_LAYER_SOURCE_FILES                        = \
     $(NULL)
 
 CHIP_BUILD_CORE_LAYER_HEADER_FILES                        = \
+    @top_builddir@/src/lib/core/CHIPCallback.h              \
     @top_builddir@/src/lib/core/CHIPCircularTLVBuffer.h     \
     @top_builddir@/src/lib/core/CHIPConfig.h                \
     @top_builddir@/src/lib/core/CHIPCore.h                  \

--- a/src/lib/core/tests/Makefile.am
+++ b/src/lib/core/tests/Makefile.am
@@ -41,6 +41,7 @@ lib_LIBRARIES                                         = \
     $(NULL)
 
 libCoreTests_a_SOURCES                                = \
+    TestCHIPCallback.cpp                                \
     TestCHIPErrorStr.cpp                                \
     TestCHIPTLV.cpp                                     \
     TestReferenceCounted.cpp                            \
@@ -86,6 +87,7 @@ COMMON_LDADD                                          =  \
 # Test applications that should be run when the 'check' target is run.
 
 check_PROGRAMS                                        = \
+    TestCHIPCallback                                    \
     TestCHIPErrorStr                                    \
     TestCHIPTLV                                         \
     TestReferenceCounted                                \
@@ -105,6 +107,9 @@ TESTS_ENVIRONMENT                                     = \
     $(NULL)
 
 # Source, compiler, and linker options for test programs.
+
+TestCHIPCallback_SOURCES                              = TestCHIPCallbackDriver.cpp
+TestCHIPCallback_LDADD                                = $(COMMON_LDADD)
 
 TestCHIPErrorStr_SOURCES                              = TestCHIPErrorStrDriver.cpp
 TestCHIPErrorStr_LDADD                                = $(COMMON_LDADD)

--- a/src/lib/core/tests/TestCHIPCallback.cpp
+++ b/src/lib/core/tests/TestCHIPCallback.cpp
@@ -1,0 +1,237 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a test for  CHIP Callback
+ *
+ */
+
+#include "TestCore.h"
+
+#include "core/CHIPCallback.h"
+
+#include <nlunit-test.h>
+
+using namespace chip::Callback;
+
+class Resumer : private CallbackDeque
+{
+public:
+    /**
+     * @brief run this callback next Dispatch
+     */
+    void Resume(Callback<> * cb)
+    {
+        // always first thing: cancel to take ownership of
+        //  cb members
+        Enqueue(cb->Cancel());
+    };
+
+    void Dispatch()
+    {
+        Inner ready = DequeueAll();
+        // runs the ready list
+        while (ready.mNext != &ready)
+        {
+            Callback<> * cb = Callback<>::FromInner(ready.mNext);
+
+            // one-shot semantics
+            cb->Cancel();
+            cb->mCall(cb->mContext);
+        }
+    }
+};
+
+static void increment(int * v)
+{
+    (*v)++;
+}
+
+struct Resume
+{
+    Callback<> * cb;
+    Resumer * resumer;
+};
+
+static void resume(struct Resume * me)
+{
+    me->resumer->Resume(me->cb);
+}
+
+static void canceler(Inner * inner)
+{
+    inner->Cancel();
+}
+
+static void ResumerTest(nlTestSuite * inSuite, void * inContext)
+{
+
+    int n = 1;
+    Callback<> cb((void (*)(void *)) increment, &n);
+    Callback<> cancelcb((void (*)(void *)) canceler, cb.Cancel());
+    Resumer resumer;
+
+    // Resume() works
+    resumer.Resume(&cb);
+    resumer.Dispatch();
+    resumer.Resume(&cb);
+    resumer.Dispatch();
+    NL_TEST_ASSERT(inSuite, n == 3);
+
+    n = 1;
+    // Cancel cb before Dispatch() gets around to us (tests FIFO *and* cancel() from readylist)
+    resumer.Resume(&cancelcb);
+    resumer.Resume(&cb);
+    resumer.Dispatch();
+    NL_TEST_ASSERT(inSuite, n == 1);
+
+    n = 1;
+    // Resume() twice runs only once per
+    resumer.Resume(&cb);
+    resumer.Resume(&cb);
+    resumer.Dispatch();
+    resumer.Dispatch();
+    NL_TEST_ASSERT(inSuite, n == 2);
+
+    n = 1;
+    // Resume() twice runs only once per
+    resumer.Resume(&cb);
+    resumer.Dispatch();
+    resumer.Resume(&cb);
+    resumer.Dispatch();
+    NL_TEST_ASSERT(inSuite, n == 3);
+
+    n = 1;
+    // Resume() during Dispatch() runs only once, but does enqueue for next dispatch
+    struct Resume res = { .cb = &cb, .resumer = &resumer };
+    Callback<> resumecb((void (*)(void *)) resume, &res);
+    resumer.Resume(&cb);
+    resumer.Resume(&resumecb);
+    resumer.Dispatch();
+    NL_TEST_ASSERT(inSuite, n == 2);
+    resumer.Dispatch();
+    NL_TEST_ASSERT(inSuite, n == 3);
+
+    Callback<> * pcb = new Callback<>((void (*)(void *)) increment, &n);
+
+    n = 1;
+    // cancel on destruct
+    resumer.Resume(pcb);
+    resumer.Dispatch();
+    NL_TEST_ASSERT(inSuite, n == 2);
+
+    resumer.Resume(pcb);
+    delete pcb;
+    resumer.Dispatch();
+    NL_TEST_ASSERT(inSuite, n == 2);
+}
+
+class Notifier : private CallbackDeque
+{
+public:
+    typedef void (*NotifyFn)(void *, int);
+
+    /**
+     * run all the callers
+     */
+    void Notify(int v)
+    {
+        for (Inner * inner = mHead.mNext; inner != &mHead; inner = inner->mNext)
+        {
+            // persistent registration semantics, with data
+
+            Callback<NotifyFn> * cb = Callback<NotifyFn>::FromInner(inner);
+            cb->mCall(cb->mContext, v);
+        }
+    }
+
+    /**
+     * @brief example
+     */
+    static void Cancel(Inner * cb)
+    {
+        Dequeue(cb); // take off ready list
+    }
+
+    /**
+     * @brief illustrate a case where this needs notification of cancellation
+     */
+    void Register(Callback<NotifyFn> * cb) { Enqueue(cb->Cancel(), Cancel); }
+};
+
+static void increment_by(int * n, int by)
+{
+    *n += by;
+}
+
+static void NotifierTest(nlTestSuite * inSuite, void * inContext)
+{
+    int n = 1;
+    Callback<Notifier::NotifyFn> cb((Notifier::NotifyFn) increment_by, &n);
+    Callback<Notifier::NotifyFn> cancelcb((Notifier::NotifyFn) canceler, cb.Cancel());
+
+    // safe to call anytime
+    cb.Cancel();
+
+    Notifier notifier;
+
+    // Simple stuff works, e.g. and there's persistent registration
+    notifier.Register(&cb);
+    notifier.Notify(1);
+    notifier.Notify(8);
+    NL_TEST_ASSERT(inSuite, n == 10);
+
+    n = 1;
+    // Cancel cb before Dispatch() gets around to us (tests FIFO *and* cancel() from readylist)
+    notifier.Register(&cancelcb);
+    notifier.Register(&cb);
+    notifier.Notify(8);
+    NL_TEST_ASSERT(inSuite, n == 1);
+}
+
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+
+// clang-format off
+static const nlTest sTests[] =
+{
+    NL_TEST_DEF("ResumerTest", ResumerTest),
+    NL_TEST_DEF("NotifierTest", NotifierTest),
+
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+int TestCHIPCallback(void)
+{
+    // clang-format off
+    nlTestSuite theSuite =
+	{
+        "CHIPCallback",
+        &sTests[0],
+        NULL,
+        NULL
+    };
+    // clang-format on
+
+    nlTestRunner(&theSuite, NULL);
+
+    return (nlTestRunnerStats(&theSuite));
+}

--- a/src/lib/core/tests/TestCHIPCallback.cpp
+++ b/src/lib/core/tests/TestCHIPCallback.cpp
@@ -45,11 +45,11 @@ public:
 
     void Dispatch()
     {
-        Inner ready = DequeueAll();
+        Cancelable ready = DequeueAll();
         // runs the ready list
         while (ready.mNext != &ready)
         {
-            Callback<> * cb = Callback<>::FromInner(ready.mNext);
+            Callback<> * cb = Callback<>::FromCancelable(ready.mNext);
 
             // one-shot semantics
             cb->Cancel();
@@ -74,9 +74,9 @@ static void resume(struct Resume * me)
     me->resumer->Resume(me->cb);
 }
 
-static void canceler(Inner * inner)
+static void canceler(Cancelable * ca)
 {
-    inner->Cancel();
+    ca->Cancel();
 }
 
 static void ResumerTest(nlTestSuite * inSuite, void * inContext)
@@ -152,11 +152,11 @@ public:
      */
     void Notify(int v)
     {
-        for (Inner * inner = mNext; inner != this; inner = inner->mNext)
+        for (Cancelable * ca = mNext; ca != this; ca = ca->mNext)
         {
             // persistent registration semantics, with data
 
-            Callback<NotifyFn> * cb = Callback<NotifyFn>::FromInner(inner);
+            Callback<NotifyFn> * cb = Callback<NotifyFn>::FromCancelable(ca);
             cb->mCall(cb->mContext, v);
         }
     }
@@ -164,7 +164,7 @@ public:
     /**
      * @brief example
      */
-    static void Cancel(Inner * cb)
+    static void Cancel(Cancelable * cb)
     {
         Dequeue(cb); // take off ready list
     }

--- a/src/lib/core/tests/TestCHIPCallback.cpp
+++ b/src/lib/core/tests/TestCHIPCallback.cpp
@@ -152,7 +152,7 @@ public:
      */
     void Notify(int v)
     {
-        for (Inner * inner = mHead.mNext; inner != &mHead; inner = inner->mNext)
+        for (Inner * inner = mNext; inner != this; inner = inner->mNext)
         {
             // persistent registration semantics, with data
 

--- a/src/lib/core/tests/TestCHIPCallbackDriver.cpp
+++ b/src/lib/core/tests/TestCHIPCallbackDriver.cpp
@@ -17,25 +17,19 @@
 
 /**
  *    @file
- *      This file declares test entry points for CHIP core library
- *      unit tests.
+ *      This file implements a standalone/native program executable
+ *      test driver for the CHIP core library Callback classes
  *
  */
 
-#ifndef TESTCORE_H
-#define TESTCORE_H
+#include "TestCore.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include <nlunit-test.h>
 
-int TestCHIPCallback(void);
-int TestCHIPErrorStr(void);
-int TestCHIPTLV(void);
-int TestReferenceCounted(void);
+int main(void)
+{
+    // Generate machine-readable, comma-separated value (CSV) output.
+    nlTestSetOutputStyle(OUTPUT_CSV);
 
-#ifdef __cplusplus
+    return (TestCHIPCallback());
 }
-#endif
-
-#endif // TESTCORE_H


### PR DESCRIPTION
#### Problem
 Facilities for registering so-called "callbacks" are many and varied in CHIP

 #### Summary of Changes
 Propose yet another ;) .

 Seriously, though, Callbacks have:

 * caller-allocated list management and callee-registration fields that have clear "take ownership" semantics.
 * default, but configurable type signature for the callback function itself
 * auto-cancellation on destruction

 Callback assumptions/restrictions:
 * a single-threaded environment where a caller and callee live
 * callbacks can live on only one queue at a time, i.e. can be registered with only one subsystem at a time.

 Included with the tests are a couple of example use cases.  Callback should be able to support runtime registration of callbacks with the ZCL, timers, network events, etc.