### PR TITLE
Add .rej and .orig patch files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ TAGS
 
 # Text editors
 .*.sw[a-z]
+
+# Patch files
+*.rej
+*.orig


### PR DESCRIPTION
 #### Problem

When applying a patch the old style way with 'patch -p1 < patch_file.patch there could be .rej(ected) file and .orig(inal) files lurking into the repo.