### PR TITLE
warning: unused variable 'test_entropy_source_call_count' in CHIPCryp…

### DIFF
--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -855,7 +855,9 @@ static void TestAddEntropySources(nlTestSuite * inSuite, void * inContext)
     CHIP_ERROR error = add_entropy_source(test_entropy_source, NULL, 10);
     NL_TEST_ASSERT(inSuite, error == CHIP_NO_ERROR);
     unsigned char buffer[5];
+#if CHIP_CRYPTO_MBEDTLS
     uint32_t test_entropy_source_call_count = gs_test_entropy_source_called;
+#endif
     NL_TEST_ASSERT(inSuite, DRBG_get_bytes(buffer, sizeof(buffer)) == CHIP_NO_ERROR);
 #if CHIP_CRYPTO_MBEDTLS
     for (int i = 0; i < 5000 * 2; i++)


### PR DESCRIPTION
…toPALTest.cpp

 #### Problem

Warning since the variable is only used inside an ifdef.