### PR TITLE
Remove PlatformMgrImpl().InitLwIPCoreLock() from wifi-echo.cpp

### DIFF
--- a/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
@@ -124,15 +124,6 @@ extern "C" void app_main()
         return;
     }
 
-    // Initialize the LwIP core lock.  This must be done before the ESP
-    // tcpip_adapter layer is initialized.
-    err = PlatformMgrImpl().InitLwIPCoreLock();
-    if (err != CHIP_NO_ERROR)
-    {
-        ESP_LOGE(TAG, "PlatformMgr().InitLocks() failed: %s", ErrorStr(err));
-        return;
-    }
-
     // Initialize the CHIP stack.
     err = PlatformMgr().InitChipStack();
     if (err != CHIP_NO_ERROR)


### PR DESCRIPTION
 #### Problem

The call to https://github.com/project-chip/connectedhomeip/blob/53afa15b098040b00600197a6211bf39d8dd3b98/examples/wifi-echo/server/esp32/main/wifi-echo.cpp#L129 does not seems necessary since it is already done by PlatformMgr().InitChipStack() at https://github.com/project-chip/connectedhomeip/blob/bed6fd5f7fc8b3ce1d2fa283bde4399c265d0585/src/platform/ESP32/PlatformManagerImpl.cpp#L61
