### PR TITLE
Use discriminator for WiFi/Ble access point

### DIFF
--- a/examples/wifi-echo/server/esp32/README.md
+++ b/examples/wifi-echo/server/esp32/README.md
@@ -141,8 +141,8 @@ Alternatively, you can connect to the ESP32's Soft-AP directly.
 
 1.  After the application has been flashed, connect to the ESP32's Soft-AP. If
     you use the M5Stack, the Soft-AP's SSID is encoded in the TLV section of the
-    QRCode on screen. It's usually something like `CHIP_DEMO-XXXX` where the
-    last 4 digits are from the device's MAC address.
+    QRCode on screen. It's usually something like `CHIP-XXX` where the last 3
+    digits are from the setup payload discriminator.
 
 2.  Once you're connected, the server's IP can be found at the gateway address.
 

--- a/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
+++ b/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
@@ -55,6 +55,8 @@
 #define EXAMPLE_VENDOR_TAG_SSID 1
 // Used to indicate that an IP address has been added to the QRCode
 #define EXAMPLE_VENDOR_TAG_IP 2
+// Used to discriminate the device if there are many of them
+#define EXAMPLE_DISCRIMINATOR 0x0F00
 
 #if CONFIG_HAVE_DISPLAY
 
@@ -74,13 +76,7 @@ enum
 // TODO Pull this from the configuration manager
 void GetAPName(char * ssid, size_t ssid_len)
 {
-    uint8_t mac[6];
-    CHIP_ERROR err = esp_wifi_get_mac(ESP_IF_WIFI_STA, mac);
-    if (err != ESP_OK)
-    {
-        ESP_LOGE(TAG, "esp_wifi_get_mac(ESP_IF_WIFI_STA) failed: %s", chip::ErrorStr(err));
-    }
-    snprintf(ssid, ssid_len, "%s%02X%02X", "CHIP_DEMO-", mac[4], mac[5]);
+    snprintf(ssid, ssid_len, "%s%03" PRIX16, "CHIP-", EXAMPLE_DISCRIMINATOR);
 }
 
 void GetGatewayIP(char * ip_buf, size_t ip_len)
@@ -94,12 +90,9 @@ void GetGatewayIP(char * ip_buf, size_t ip_len)
 
 string createSetupPayload()
 {
-    // The discriminator is generated randomly so different devices can be turned on at the same time for testing.
-    uint16_t discriminator = (esp_random() * 1.0 / UINT32_MAX * ((1 << kPayloadDiscriminatorFieldLengthInBits) + 1));
-
     SetupPayload payload;
     payload.version               = 1;
-    payload.discriminator         = discriminator;
+    payload.discriminator         = EXAMPLE_DISCRIMINATOR;
     payload.setUpPINCode          = EXAMPLE_SETUP_CODE;
     payload.rendezvousInformation = EXAMPLE_RENDEZVOUS_INFO;
     payload.vendorID              = EXAMPLE_VENDOR_ID;

--- a/src/platform/ESP32/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/BLEManagerImpl.cpp
@@ -623,11 +623,11 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     // If a custom device name has not been specified, generate a CHIP-standard name based on the
     // bottom digits of the Chip device id.
 
-    // TODO Get a real device id
-    uint16_t deviceId = 0x0F00;
+    // TODO Pull this from the configuration manager
+    uint16_t discriminator = 0x0F00;
     if (!GetFlag(mFlags, kFlag_UseCustomDeviceName))
     {
-        snprintf(mDeviceName, sizeof(mDeviceName), "%s%04" PRIX16, CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, deviceId);
+        snprintf(mDeviceName, sizeof(mDeviceName), "%s%03" PRIX16, CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, discriminator);
         mDeviceName[kMaxDeviceNameLength] = 0;
     }
 

--- a/src/platform/ESP32/ConnectivityManagerImpl.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl.cpp
@@ -908,15 +908,10 @@ CHIP_ERROR ConnectivityManagerImpl::ConfigureWiFiAP()
     memset(&wifiConfig, 0, sizeof(wifiConfig));
 
     // TODO Pull this from the configuration manager
-    uint8_t mac[6];
-    err = esp_wifi_get_mac(ESP_IF_WIFI_STA, mac);
-    if (err != ESP_OK)
-    {
-        ChipLogError(DeviceLayer, "esp_wifi_get_mac(ESP_IF_WIFI_STA) failed: %s", chip::ErrorStr(err));
-    }
-    SuccessOrExit(err);
+    uint16_t discriminator = 0x0F00;
 
-    snprintf((char *) wifiConfig.ap.ssid, sizeof(wifiConfig.ap.ssid), "%s%02X%02X", "CHIP_DEMO-", mac[4], mac[5]);
+    snprintf((char *) wifiConfig.ap.ssid, sizeof(wifiConfig.ap.ssid), "%s%03" PRIX16, CHIP_DEVICE_CONFIG_WIFI_AP_SSID_PREFIX,
+             discriminator);
     wifiConfig.ap.channel         = CHIP_DEVICE_CONFIG_WIFI_AP_CHANNEL;
     wifiConfig.ap.authmode        = WIFI_AUTH_OPEN;
     wifiConfig.ap.max_connection  = CHIP_DEVICE_CONFIG_WIFI_AP_MAX_STATIONS;


### PR DESCRIPTION
 #### Problem

Currently the SoftAP SSID for the esp32 demo app is passed as a string into the QRCode. This patch get the SoftAP (as well as the advertissemement name for BLE) be CHIP-XXX where XXX is the 3 characters of the 12 bits discriminator.

This would let us know the name of both when doing rendezvous and so we should be able to get rid of the optional data that lives into the QRCode at some point.