### PR TITLE
Fix missing support/logging/CHIPLogging.h header for iOS

### DIFF
--- a/src/lib/support/Makefile.am
+++ b/src/lib/support/Makefile.am
@@ -45,6 +45,10 @@ libSupportLayer_adir                = $(includedir)/support
 
 dist_libSupportLayer_a_HEADERS      = $(CHIP_BUILD_SUPPORT_LAYER_HEADER_FILES)
 
+Loggingdir                          = $(includedir)/support/logging
+
+dist_Logging_HEADERS                = $(CHIP_BUILD_SUPPORT_LAYER_LOGGING_HEADER_FILES)
+
 EXTRA_DIST                          = $(CHIP_BUILD_SUPPORT_LAYER_VERHOEFF_HEADER_FILES)
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/lib/support/SupportLayer.am
+++ b/src/lib/support/SupportLayer.am
@@ -60,6 +60,10 @@ CHIP_BUILD_SUPPORT_LAYER_HEADER_FILES                        = \
     @top_builddir@/src/lib/support/TimeUtils.h                 \
     $(NULL)
 
+CHIP_BUILD_SUPPORT_LAYER_LOGGING_HEADER_FILES                = \
+    @top_builddir@/src/lib/support/logging/CHIPLogging.h       \
+    $(NULL)
+
 CHIP_BUILD_SUPPORT_LAYER_VERHOEFF_HEADER_FILES               = \
     @top_builddir@/src/lib/support/verhoeff/Verhoeff.h         \
     $(NULL)


### PR DESCRIPTION
 #### Problem

The iOS can not be build since support/logging/CHIPLogging.h can not be found and has been imported by a dependency.
This patch export correctly it so it can be found.