### PR TITLE
Remove SoftAP SSID from the QRCode for the demo app

### DIFF
--- a/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
+++ b/examples/wifi-echo/server/esp32/main/QRCodeWidget.cpp
@@ -21,8 +21,7 @@
  * @file QRCodeWidget.cpp
  *
  * This file implements the QRCodeWidget that displays a QRCode centered on the screen
- * It generates a CHIP SetupPayload containing the device's Soft-AP SSID and then
- * encodes that into a QRCode.
+ * It generates a CHIP SetupPayload for onboarding.
  *
  */
 
@@ -41,7 +40,6 @@
 #include "Display.h"
 #include "QRCodeWidget.h"
 
-#define MAX_SSID_LEN 32
 // A temporary value assigned for this example's QRCode
 // Spells CHIP on a dialer
 #define EXAMPLE_VENDOR_ID 2447
@@ -52,13 +50,9 @@
 // Used to discriminate the device
 #define EXAMPLE_DISCRIMINATOR 0X0F00
 // Used to indicate that the device supports both Soft-AP and BLE for rendezvous
-#define EXAMPLE_RENDEZVOUS_INFO RendezvousInformationFlags::kBLE
-// Used to indicate that an SSID has been added to the QRCode
-#define EXAMPLE_VENDOR_TAG_SSID 1
+#define EXAMPLE_RENDEZVOUS_INFO RendezvousInformationFlags::kSoftAP
 // Used to indicate that an IP address has been added to the QRCode
-#define EXAMPLE_VENDOR_TAG_IP 2
-// Used to discriminate the device if there are many of them
-#define EXAMPLE_DISCRIMINATOR 0x0F00
+#define EXAMPLE_VENDOR_TAG_IP 1
 
 #if CONFIG_HAVE_DISPLAY
 
@@ -75,15 +69,8 @@ enum
     kQRCodePadding       = 2
 };
 
-// TODO Pull this from the configuration manager
-void GetAPName(char * ssid, size_t ssid_len)
-{
-    snprintf(ssid, ssid_len, "%s%03" PRIX16, "CHIP-", EXAMPLE_DISCRIMINATOR);
-}
-
 void GetGatewayIP(char * ip_buf, size_t ip_len)
 {
-
     tcpip_adapter_ip_info_t ip;
     tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_AP, &ip);
     IPAddress::FromIPv4(ip.ip).ToString(ip_buf, ip_len);
@@ -100,17 +87,13 @@ string createSetupPayload()
     payload.vendorID              = EXAMPLE_VENDOR_ID;
     payload.productID             = EXAMPLE_PRODUCT_ID;
 
-    char ap_ssid[MAX_SSID_LEN];
-    GetAPName(ap_ssid, sizeof(ap_ssid));
-    payload.addOptionalVendorData(EXAMPLE_VENDOR_TAG_SSID, ap_ssid);
-
     char gw_ip[INET6_ADDRSTRLEN];
     GetGatewayIP(gw_ip, sizeof(gw_ip));
     payload.addOptionalVendorData(EXAMPLE_VENDOR_TAG_IP, gw_ip);
 
     QRCodeSetupPayloadGenerator generator(payload);
     string result;
-    size_t tlvDataLen = sizeof(ap_ssid) + sizeof(gw_ip);
+    size_t tlvDataLen = sizeof(gw_ip);
     uint8_t tlvDataStart[tlvDataLen];
     CHIP_ERROR err = generator.payloadBase41Representation(result, tlvDataStart, tlvDataLen);
     if (err != CHIP_NO_ERROR)

--- a/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.h
+++ b/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.h
@@ -33,7 +33,6 @@
 @property (weak, nonatomic) IBOutlet UILabel * errorLabel;
 
 @property (strong, nonatomic) BLEConnectionController * ble;
-@property (strong, nonatomic) NSString * ssidKey;
 
 @property (weak, nonatomic) IBOutlet UIView * setupPayloadView;
 @property (weak, nonatomic) IBOutlet UILabel * manualCodeLabel;

--- a/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
@@ -30,13 +30,11 @@
 // The expected Vendor ID for CHIP demos
 // Spells CHIP on a dialer
 #define EXAMPLE_VENDOR_ID 2447
-#define EXAMPLE_VENDOR_TAG_SSID 1
-#define MAX_SSID_LEN 32
 
-#define EXAMPLE_VENDOR_TAG_IP 2
+#define EXAMPLE_VENDOR_TAG_IP 1
 #define MAX_IP_LEN 46
 
-#define BLE_CHIP_PREFIX @"CHIP-"
+#define NETWORK_CHIP_PREFIX @"CHIP-"
 
 #define NOT_APPLICABLE_STRING @"N/A"
 
@@ -214,15 +212,6 @@ static NSString * const ipKey = @"ipk";
 
         NSString * infoValue = info.stringValue;
         switch (tag.unsignedCharValue) {
-        case EXAMPLE_VENDOR_TAG_SSID:
-            if ([infoValue length] > MAX_SSID_LEN) {
-                NSLog(@"Unexpected SSID String...");
-            } else {
-                NSLog(@"Got SSID String... %@", infoValue);
-                _ssidKey = infoValue;
-            }
-            break;
-
         case EXAMPLE_VENDOR_TAG_IP:
             if ([infoValue length] > MAX_IP_LEN) {
                 NSLog(@"Unexpected IP String... %@", infoValue);
@@ -246,31 +235,31 @@ static NSString * const ipKey = @"ipk";
         break;
     case kRendezvousInformationSoftAP:
         NSLog(@"Rendezvous SoftAP");
-        [self handleRendezVousSoftAP:_ssidKey];
+        [self handleRendezVousSoftAP:[self getNetworkName:payload.discriminator]];
         break;
     case kRendezvousInformationBLE:
         NSLog(@"Rendezvous BLE");
-        [self handleRendezVousBLE:payload.discriminator];
+        [self handleRendezVousBLE:[self getNetworkName:payload.discriminator]];
         break;
     }
 }
 
-- (void)handleRendezVousBLE:(NSNumber *)discriminator
+- (NSString *)getNetworkName:(NSNumber *)discriminator
 {
-    NSString * peripheralDiscriminator = [NSString stringWithFormat:@"0%hX", discriminator.unsignedShortValue];
-    NSString * peripheralFullName = [NSString stringWithFormat:@"%@%@", BLE_CHIP_PREFIX, peripheralDiscriminator];
-    _ble = [[BLEConnectionController alloc] initWithName:peripheralFullName];
+    NSString * peripheralDiscriminator = [NSString stringWithFormat:@"%hX", discriminator.unsignedShortValue];
+    NSString * peripheralFullName = [NSString stringWithFormat:@"%@%@", NETWORK_CHIP_PREFIX, peripheralDiscriminator];
+    return peripheralFullName;
+}
+
+- (void)handleRendezVousBLE:(NSString *)name
+{
+    _ble = [[BLEConnectionController alloc] initWithName:name];
     [_ble start];
 }
 
-- (void)handleRendezVousSoftAP:(NSString *)ssid
+- (void)handleRendezVousSoftAP:(NSString *)name
 {
-    if (!ssid) {
-        NSLog(@"Can not retrieved SSID");
-        return;
-    }
-
-    NSString * message = [NSString stringWithFormat:@"SSID: %@\n\nUse WiFi Settings to connect to it.", ssid];
+    NSString * message = [NSString stringWithFormat:@"SSID: %@\n\nUse WiFi Settings to connect to it.", name];
     UIAlertController * alert = [UIAlertController alertControllerWithTitle:@"SoftAP Detected"
                                                                     message:message
                                                              preferredStyle:UIAlertControllerStyleActionSheet];

--- a/src/platform/ESP32/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/BLEManagerImpl.cpp
@@ -624,7 +624,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     // bottom digits of the Chip device id.
 
     // TODO Pull this from the configuration manager
-    uint16_t discriminator = 0x0F00;
+    const uint16_t discriminator = 0x0F00;
     if (!GetFlag(mFlags, kFlag_UseCustomDeviceName))
     {
         snprintf(mDeviceName, sizeof(mDeviceName), "%s%03" PRIX16, CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, discriminator);

--- a/src/platform/ESP32/ConnectivityManagerImpl.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl.cpp
@@ -908,7 +908,7 @@ CHIP_ERROR ConnectivityManagerImpl::ConfigureWiFiAP()
     memset(&wifiConfig, 0, sizeof(wifiConfig));
 
     // TODO Pull this from the configuration manager
-    uint16_t discriminator = 0x0F00;
+    const uint16_t discriminator = 0x0F00;
 
     snprintf((char *) wifiConfig.ap.ssid, sizeof(wifiConfig.ap.ssid), "%s%03" PRIX16, CHIP_DEVICE_CONFIG_WIFI_AP_SSID_PREFIX,
              discriminator);


### PR DESCRIPTION
 #### Problem
Since #1359 has landed we can safely remove the SSID embedded into the QRCode displayed on the screen of the M5Stack.

 #### Summary of Changes
 * Remove the SSID from the optional field of the QRCode
 * Remove the parsing code from the iOS app