### PR TITLE
warning: 'void TimerCallback(TimerHandle_t)' defined but not used

### DIFF
--- a/examples/wifi-echo/server/esp32/main/Display.cpp
+++ b/examples/wifi-echo/server/esp32/main/Display.cpp
@@ -64,7 +64,9 @@ uint16_t DisplayWidth  = 0;
 TimerHandle_t displayTimer = NULL;
 #endif
 
+#if CONFIG_DISPLAY_AUTO_OFF
 static void TimerCallback(TimerHandle_t xTimer);
+#endif
 static void SetupBrightnessControl();
 static void SetBrightness(uint16_t brightness_percent);
 


### PR DESCRIPTION
 #### Problem

Basically a warning if you do not use the auto-turn off feature of the ESP32 demo app.