### PR TITLE
Make callbacks take a PeerAddress instead of a packet info.

### DIFF
--- a/examples/wifi-echo/server/esp32/main/EchoServer.cpp
+++ b/examples/wifi-echo/server/esp32/main/EchoServer.cpp
@@ -133,8 +133,8 @@ static size_t odc(const uint8_t * bytes, size_t bytes_len, char * out, size_t ou
 class EchoServerCallback : public SecureSessionMgrCallback
 {
 public:
-    virtual void OnMessageReceived(const MessageHeader & header, Transport::PeerConnectionState * state,
-                                   System::PacketBuffer * buffer, SecureSessionMgr * mgr)
+    void OnMessageReceived(const MessageHeader & header, Transport::PeerConnectionState * state, System::PacketBuffer * buffer,
+                           SecureSessionMgr * mgr) override
     {
         CHIP_ERROR err;
         const size_t data_len = buffer->DataLength();
@@ -191,13 +191,13 @@ public:
         }
     }
 
-    virtual void OnReceiveError(CHIP_ERROR error, const IPPacketInfo & source, SecureSessionMgr * mgr)
+    void OnReceiveError(CHIP_ERROR error, const Transport::PeerAddress & source, SecureSessionMgr * mgr) override
     {
         ESP_LOGE(TAG, "ERROR: %s\n Got UDP error", ErrorStr(error));
         statusLED.BlinkOnError();
     }
 
-    virtual void OnNewConnection(Transport::PeerConnectionState * state, SecureSessionMgr * mgr)
+    void OnNewConnection(Transport::PeerConnectionState * state, SecureSessionMgr * mgr) override
     {
         CHIP_ERROR err;
 

--- a/src/transport/Base.h
+++ b/src/transport/Base.h
@@ -52,7 +52,7 @@ public:
      *
      */
     template <class T>
-    void SetMessageReceiveHandler(void (*handler)(const MessageHeader &, const Inet::IPPacketInfo &, System::PacketBuffer *, T *),
+    void SetMessageReceiveHandler(void (*handler)(const MessageHeader &, const PeerAddress &, System::PacketBuffer *, T *),
                                   T * param)
     {
         mMessageReceivedArgument = param;
@@ -66,8 +66,7 @@ public:
      *   This method calls <tt>chip::System::PacketBuffer::Free</tt> on
      *   behalf of the caller regardless of the return status.
      */
-    virtual CHIP_ERROR SendMessage(const MessageHeader & header, const Transport::PeerAddress & address,
-                                   System::PacketBuffer * msgBuf) = 0;
+    virtual CHIP_ERROR SendMessage(const MessageHeader & header, const PeerAddress & address, System::PacketBuffer * msgBuf) = 0;
 
     /**
      * Get the path that this transport is associated with.
@@ -81,7 +80,7 @@ protected:
      * Method used by subclasses to notify that a packet has been received after
      * any associated headers have been decoded.
      */
-    void HandleMessageReceived(const MessageHeader & header, const Inet::IPPacketInfo & source, System::PacketBuffer * buffer)
+    void HandleMessageReceived(const MessageHeader & header, const PeerAddress & source, System::PacketBuffer * buffer)
     {
         if (OnMessageReceived)
         {
@@ -95,8 +94,8 @@ protected:
      *
      * @param[in]    msgBuf        A pointer to the PacketBuffer object holding the message.
      */
-    typedef void (*MessageReceiveHandler)(const MessageHeader & header, const Inet::IPPacketInfo & source,
-                                          System::PacketBuffer * msgBuf, void * param);
+    typedef void (*MessageReceiveHandler)(const MessageHeader & header, const PeerAddress & source, System::PacketBuffer * msgBuf,
+                                          void * param);
 
     MessageReceiveHandler OnMessageReceived = nullptr; ///< Callback on message receiving
     void * mMessageReceivedArgument         = nullptr; ///< Argument for callback

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -60,7 +60,7 @@ CHIP_ERROR SecureSessionMgr::Init(NodeId localNodeId, Inet::InetLayer * inet, co
     err = mTransport.Init(inet, listenParams);
     SuccessOrExit(err);
 
-    mTransport.SetMessageReceiveHandler(HandleUdpDataReceived, this);
+    mTransport.SetMessageReceiveHandler(HandleDataReceived, this);
     mPeerConnections.SetConnectionExpiredHandler(HandleConnectionExpired, this);
 
     mState       = State::kInitialized;
@@ -184,8 +184,8 @@ void SecureSessionMgr::CancelExpiryTimer(void)
     }
 }
 
-void SecureSessionMgr::HandleUdpDataReceived(const MessageHeader & header, const IPPacketInfo & pktInfo, System::PacketBuffer * msg,
-                                             SecureSessionMgr * connection)
+void SecureSessionMgr::HandleDataReceived(const MessageHeader & header, const PeerAddress & peerAddress, System::PacketBuffer * msg,
+                                          SecureSessionMgr * connection)
 
 {
     CHIP_ERROR err                 = CHIP_NO_ERROR;
@@ -195,8 +195,6 @@ void SecureSessionMgr::HandleUdpDataReceived(const MessageHeader & header, const
     VerifyOrExit(msg != nullptr, ChipLogError(Inet, "Secure transport received NULL packet, discarding"));
 
     {
-        PeerAddress peerAddress = PeerAddress::UDP(pktInfo.SrcAddress, pktInfo.SrcPort);
-
         if (!connection->mPeerConnections.FindPeerConnectionState(peerAddress, &state))
         {
             ChipLogProgress(Inet, "New peer connection received.");
@@ -247,7 +245,7 @@ exit:
 
     if (err != CHIP_NO_ERROR && connection->mCB != nullptr)
     {
-        connection->mCB->OnReceiveError(err, pktInfo, connection);
+        connection->mCB->OnReceiveError(err, peerAddress, connection);
     }
 }
 

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -72,7 +72,7 @@ public:
      * @param error error code
      * @param source network entity that sent the message
      */
-    virtual void OnReceiveError(CHIP_ERROR error, const Inet::IPPacketInfo & source, SecureSessionMgr * mgr) {}
+    virtual void OnReceiveError(CHIP_ERROR error, const Transport::PeerAddress & source, SecureSessionMgr * mgr) {}
 
     /**
      * @brief
@@ -173,13 +173,8 @@ private:
     CHIP_ERROR AllocateNewConnection(const MessageHeader & header, const Transport::PeerAddress & address,
                                      Transport::PeerConnectionState ** state);
 
-    /**
-     * Handle UDP data receiving. Each transport has separate data receiving as active sessions
-     * follow data receiving channels.
-     *
-     */
-    static void HandleUdpDataReceived(const MessageHeader & header, const Inet::IPPacketInfo & source,
-                                      System::PacketBuffer * msgBuf, SecureSessionMgr * transport);
+    static void HandleDataReceived(const MessageHeader & header, const Transport::PeerAddress & source,
+                                   System::PacketBuffer * msgBuf, SecureSessionMgr * transport);
 
     /**
      * Called when a specific connection expires.

--- a/src/transport/UDP.cpp
+++ b/src/transport/UDP.cpp
@@ -122,16 +122,17 @@ exit:
 
 void UDP::OnUdpReceive(Inet::IPEndPointBasis * endPoint, System::PacketBuffer * buffer, const IPPacketInfo * pktInfo)
 {
-    CHIP_ERROR err    = CHIP_NO_ERROR;
-    UDP * udp         = reinterpret_cast<UDP *>(endPoint->AppState);
-    size_t headerSize = 0;
+    CHIP_ERROR err          = CHIP_NO_ERROR;
+    UDP * udp               = reinterpret_cast<UDP *>(endPoint->AppState);
+    size_t headerSize       = 0;
+    PeerAddress peerAddress = PeerAddress::UDP(pktInfo->SrcAddress, pktInfo->SrcPort);
 
     MessageHeader header;
     err = header.Decode(buffer->Start(), buffer->DataLength(), &headerSize);
     SuccessOrExit(err);
 
     buffer->ConsumeHead(headerSize);
-    udp->HandleMessageReceived(header, *pktInfo, buffer);
+    udp->HandleMessageReceived(header, peerAddress, buffer);
 
 exit:
     if (err != CHIP_NO_ERROR)

--- a/src/transport/tests/TestUDP.cpp
+++ b/src/transport/tests/TestUDP.cpp
@@ -51,7 +51,7 @@ TestContext sContext;
 const char PAYLOAD[]        = "Hello!";
 int ReceiveHandlerCallCount = 0;
 
-void MessageReceiveHandler(const MessageHeader & header, const Inet::IPPacketInfo & source, System::PacketBuffer * msgBuf,
+void MessageReceiveHandler(const MessageHeader & header, const Transport::PeerAddress & source, System::PacketBuffer * msgBuf,
                            nlTestSuite * inSuite)
 {
     NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<NodeId>::Value(kSourceNodeId));


### PR DESCRIPTION
As we make transports generic, the source should be a peer address
rather than a packet info. This is because different transports may have
different address information (specifically type may be different).

 #### Problem
PacketInfo structure requires the session manager to know handle the source of the packet.
Instead, we should let the transport construct an associated address.

 #### Summary of Changes
Use PeerAddress for receive and error callbacks.
Mark virtual overrides as 'override' so that we get errors in case signatures change.

