### PR TITLE
Run IPv6 tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,6 +446,25 @@ jobs:
         when: on_fail
     - store_artifacts:
         path: /tmp/test_logs
+  Run Tests [IPv6]:
+    machine:
+      image: ubuntu-1604:201903-01
+    environment:
+    - BUILD_TYPE: vm-exec-build
+    steps:
+    - checkout
+    - run:
+        command: scripts/tools/ipv6_container_setup.sh
+        name: Config Docker container
+    - run:
+        command: scripts/tests/ipv6_container_tests.sh
+        name: Run tests in the Docker container
+    - run:
+        command: scripts/tests/save_logs.sh /tmp/test_logs
+        name: Save test log files
+        when: on_fail
+    - store_artifacts:
+        path: /tmp/test_logs
 workflows:
   Main:
     jobs:
@@ -498,6 +517,11 @@ workflows:
         requires:
         - Build CHIP [linux-embedded]
     - Run Tests [ESP32-QEMU]:
+        filters:
+          branches:
+            ignore:
+            - /restyled.*/
+    - Run Tests [IPv6]:
         filters:
           branches:
             ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -450,7 +450,7 @@ jobs:
     machine:
       image: ubuntu-1604:201903-01
     environment:
-    - BUILD_TYPE: vm-exec-build
+    - BUILD_TYPE: ipv6-tests
     steps:
     - checkout
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -526,6 +526,8 @@ workflows:
           branches:
             ignore:
             - /restyled.*/
+        requires:
+        - Build CHIP [main-build]
     - Deploy [main-build]:
         filters:
           branches:

--- a/.circleci/config/executors/@executors.yml
+++ b/.circleci/config/executors/@executors.yml
@@ -25,6 +25,6 @@ clang-build:
         BOOTSTRAP_ARGUMENTS: " CC=clang-9 CXX=clang++-9"
     docker:
         - image: connectedhomeip/chip-build:0.2.14
-vm-exec-build:
+ipv6-tests:
     machine:
         image: ubuntu-1604:201903-01

--- a/.circleci/config/executors/@executors.yml
+++ b/.circleci/config/executors/@executors.yml
@@ -25,3 +25,6 @@ clang-build:
         BOOTSTRAP_ARGUMENTS: " CC=clang-9 CXX=clang++-9"
     docker:
         - image: connectedhomeip/chip-build:0.2.14
+vm-exec-build:
+    machine:
+        image: ubuntu-1604:201903-01

--- a/.circleci/config/jobs/test_ipv6.yml
+++ b/.circleci/config/jobs/test_ipv6.yml
@@ -2,8 +2,8 @@ parameters:
       builder:
             type: string
 environment:
-    BUILD_TYPE: vm-exec-build
-executor: vm-exec-build
+    BUILD_TYPE: ipv6-tests
+executor: ipv6-tests
 steps:
     - checkout
     - run:

--- a/.circleci/config/jobs/test_ipv6.yml
+++ b/.circleci/config/jobs/test_ipv6.yml
@@ -1,0 +1,17 @@
+environment:
+    BUILD_TYPE: vm-exec-build
+executor: vm-exec-build
+steps:
+    - checkout
+    - run:
+          name: Config Docker container
+          command: scripts/tools/ipv6_container_setup.sh
+    - run:
+          name: Run tests in the Docker container
+          command: scripts/tests/ipv6_container_tests.sh
+    - run:
+          name: Save test log files
+          command: scripts/tests/save_logs.sh /tmp/test_logs
+          when: on_fail
+    - store_artifacts:
+          path: /tmp/test_logs

--- a/.circleci/config/jobs/test_ipv6.yml
+++ b/.circleci/config/jobs/test_ipv6.yml
@@ -1,3 +1,6 @@
+parameters:
+      builder:
+            type: string
 environment:
     BUILD_TYPE: vm-exec-build
 executor: vm-exec-build

--- a/.circleci/config/workflows/Main.yml
+++ b/.circleci/config/workflows/Main.yml
@@ -27,6 +27,11 @@ jobs:
                       - /restyled.*/
     - test_ipv6:
           name: Run Tests [IPv6]
+          matrix:
+              parameters:
+                  builder: ["main-build"]
+          requires:
+              - Build CHIP [<< matrix.builder >>]
           filters:
               branches:
                   ignore:

--- a/.circleci/config/workflows/Main.yml
+++ b/.circleci/config/workflows/Main.yml
@@ -25,6 +25,12 @@ jobs:
               branches:
                   ignore:
                       - /restyled.*/
+    - test_ipv6:
+          name: Run Tests [IPv6]
+          filters:
+              branches:
+                  ignore:
+                      - /restyled.*/
     # - code-coverage:
     #       name: Code Coverage [<< matrix.builder >>]
     #       matrix:

--- a/scripts/tests/inet_tests.sh
+++ b/scripts/tests/inet_tests.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -x
+env
+
+here=$(cd "$(dirname "$0")" && pwd)
+CHIPDIR="$here"/../..
+cd "$CHIPDIR"
+
+mkdir -p build/default
+cd build/default
+"$CHIPDIR"/bootstrap-configure
+
+make V=1 -C src/include
+
+# Currently, only running inet tests
+# More/other tests can be added for IPV6 here.
+make V=1 -C src/inet check

--- a/scripts/tests/ipv6_container_tests.sh
+++ b/scripts/tests/ipv6_container_tests.sh
@@ -23,5 +23,6 @@ here=$(cd "$(dirname "$0")" && pwd)
 CHIPDIR="$here"/../..
 cd "$CHIPDIR"
 
-docker run --rm -v "$PWD":/workspaces/connectedhomeip connectedhomeip/chip-build:0.2.14 \
+dockerfile_version=$(cat "$CHIPDIR"/integrations/docker/images/chip-build/version)
+docker run --rm -v "$PWD":/workspaces/connectedhomeip connectedhomeip/chip-build:"$dockerfile_version" \
     /workspaces/connectedhomeip/scripts/tests/inet_tests.sh

--- a/scripts/tests/ipv6_container_tests.sh
+++ b/scripts/tests/ipv6_container_tests.sh
@@ -23,5 +23,5 @@ here=$(cd "$(dirname "$0")" && pwd)
 CHIPDIR="$here"/../..
 cd "$CHIPDIR"
 
-docker run --rm -v "$(pwd)":/workspaces/connectedhomeip connectedhomeip/chip-build:0.2.14 \
+docker run --rm -v "$PWD":/workspaces/connectedhomeip connectedhomeip/chip-build:0.2.14 \
     /workspaces/connectedhomeip/scripts/tests/inet_tests.sh

--- a/scripts/tests/ipv6_container_tests.sh
+++ b/scripts/tests/ipv6_container_tests.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -x
+env
+
+here=$(cd "$(dirname "$0")" && pwd)
+CHIPDIR="$here"/../..
+cd "$CHIPDIR"
+
+docker run --rm -v "$(pwd)":/workspaces/connectedhomeip connectedhomeip/chip-build:0.2.14 \
+    /workspaces/connectedhomeip/scripts/tests/inet_tests.sh

--- a/scripts/tools/ipv6_container_setup.sh
+++ b/scripts/tools/ipv6_container_setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -x
+
+cat <<'EOF' | sudo tee /etc/docker/daemon.json
+{
+    "ipv6": true,
+    "fixed-cidr-v6": "2001:db8:1::/64"
+}
+EOF
+
+sudo service docker restart

--- a/src/inet/tests/Makefile.am
+++ b/src/inet/tests/Makefile.am
@@ -152,15 +152,15 @@ else # CHIP_DEVICE_LAYER_TARGET_ESP32
 # Build and run these test targets only on standalone device targets
 noinst_PROGRAMS                                       = \
     TestLwIPDNS                                         \
-    TestInetEndPoint                                    \
     TestInetLayer                                       \
-    TestInetLayerDNS                                    \
     TestInetLayerMulticast                              \
     $(NULL)
 
 check_PROGRAMS                                       += \
     TestInetAddress                                     \
+    TestInetEndPoint                                    \
     TestInetErrorStr                                    \
+    TestInetLayerDNS                                    \
     $(NULL)
 
 endif # CHIP_DEVICE_LAYER_TARGET_ESP32

--- a/src/inet/tests/Makefile.am
+++ b/src/inet/tests/Makefile.am
@@ -152,15 +152,15 @@ else # CHIP_DEVICE_LAYER_TARGET_ESP32
 # Build and run these test targets only on standalone device targets
 noinst_PROGRAMS                                       = \
     TestLwIPDNS                                         \
+    TestInetEndPoint                                    \
     TestInetLayer                                       \
+    TestInetLayerDNS                                    \
     TestInetLayerMulticast                              \
     $(NULL)
 
 check_PROGRAMS                                       += \
     TestInetAddress                                     \
-    TestInetEndPoint                                    \
     TestInetErrorStr                                    \
-    TestInetLayerDNS                                    \
     $(NULL)
 
 endif # CHIP_DEVICE_LAYER_TARGET_ESP32


### PR DESCRIPTION
 #### Problem
Current CI does not support running IPv6 tests.

 #### Summary of Changes
Add `machine-executor` to CI, and spin up IPv6 enabled Docker container in it. Use this container to run tests.

- The workflow can be optimized to use cached builds