### PR TITLE
Decouple transport from session management.

### DIFF
--- a/examples/lock-app/nrf5/main/Server.cpp
+++ b/examples/lock-app/nrf5/main/Server.cpp
@@ -109,14 +109,17 @@ static ServerCallback gCallbacks;
 } // namespace
 
 // The echo server assumes the platform's networking has been setup already
-void SetupTransport(IPAddressType type, SecureSessionMgr * transport)
+void SetupTransport(IPAddressType type, SecureSessionMgr * sessions, Transport::UDP * transport)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    err = transport->Init(EXAMPLE_SERVER_NODEID, &DeviceLayer::InetLayer, UdpListenParameters().SetAddressType(type));
+    err = transport->Init(&DeviceLayer::InetLayer, UdpListenParameters().SetAddressType(type));
     SuccessOrExit(err);
 
-    transport->SetDelegate(&gCallbacks);
+    err = sessions->Init(EXAMPLE_SERVER_NODEID, &DeviceLayer::SystemLayer, transport);
+    SuccessOrExit(err);
+
+    sessions->SetDelegate(&gCallbacks);
 
 exit:
     if (err != CHIP_NO_ERROR)
@@ -129,8 +132,10 @@ exit:
     }
 }
 
+static Transport::UDP transport;
+
 // The echo server assumes the platform's networking has been setup already
-void StartServer(SecureSessionMgr * transport_ipv6)
+void StartServer(SecureSessionMgr * sessions)
 {
-    SetupTransport(kIPAddressType_IPv6, transport_ipv6);
+    SetupTransport(kIPAddressType_IPv6, sessions, &transport);
 }

--- a/examples/lock-app/nrf5/main/Server.cpp
+++ b/examples/lock-app/nrf5/main/Server.cpp
@@ -114,7 +114,7 @@ void SetupTransport(IPAddressType type, SecureSessionMgr * sessions, Transport::
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    err = transport->Init(&DeviceLayer::InetLayer, UdpListenParameters().SetAddressType(type));
+    err = transport->Init(UdpListenParameters(&DeviceLayer::InetLayer).SetAddressType(type));
     SuccessOrExit(err);
 
     err = sessions->Init(EXAMPLE_SERVER_NODEID, &DeviceLayer::SystemLayer, transport);

--- a/examples/lock-app/nrf5/main/Server.cpp
+++ b/examples/lock-app/nrf5/main/Server.cpp
@@ -34,6 +34,7 @@
 #include <support/ErrorStr.h>
 #include <system/SystemPacketBuffer.h>
 #include <transport/SecureSessionMgr.h>
+#include <transport/UDP.h>
 
 #include "DataModelHandler.h"
 

--- a/examples/lock-app/nrf5/main/include/Server.h
+++ b/examples/lock-app/nrf5/main/include/Server.h
@@ -25,7 +25,6 @@
 
 #include "DataModelHandler.h"
 
-void SetupTransport(chip::Inet::IPAddressType type, chip::SecureSessionMgr * transport);
 void StartServer(chip::SecureSessionMgr * transport_ipv6);
 
 #endif // SERVER_H

--- a/examples/wifi-echo/server/esp32/main/EchoServer.cpp
+++ b/examples/wifi-echo/server/esp32/main/EchoServer.cpp
@@ -133,8 +133,8 @@ static size_t odc(const uint8_t * bytes, size_t bytes_len, char * out, size_t ou
 class EchoServerCallback : public SecureSessionMgrCallback
 {
 public:
-    virtual void OnMessageReceived(const MessageHeader & header, Transport::PeerConnectionState * state,
-                                   System::PacketBuffer * buffer, SecureSessionMgr * mgr)
+    void OnMessageReceived(const MessageHeader & header, Transport::PeerConnectionState * state, System::PacketBuffer * buffer,
+                           SecureSessionMgr * mgr) override
     {
         CHIP_ERROR err;
         const size_t data_len = buffer->DataLength();
@@ -191,13 +191,13 @@ public:
         }
     }
 
-    virtual void OnReceiveError(CHIP_ERROR error, const IPPacketInfo & source, SecureSessionMgr * mgr)
+    void OnReceiveError(CHIP_ERROR error, const Transport::PeerAddress & source, SecureSessionMgr * mgr) override
     {
         ESP_LOGE(TAG, "ERROR: %s\n Got UDP error", ErrorStr(error));
         statusLED.BlinkOnError();
     }
 
-    virtual void OnNewConnection(Transport::PeerConnectionState * state, SecureSessionMgr * mgr)
+    void OnNewConnection(Transport::PeerConnectionState * state, SecureSessionMgr * mgr) override
     {
         CHIP_ERROR err;
 

--- a/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
@@ -41,7 +41,7 @@
 using namespace ::chip;
 using namespace ::chip::DeviceLayer;
 
-extern void startServer(SecureSessionMgr * transportIPv4, SecureSessionMgr * transportIPv6);
+extern void startServer(SecureSessionMgr * sessions);
 #if CONFIG_USE_ECHO_CLIENT
 extern void startClient(void);
 #endif // CONFIG_USE_ECHO_CLIENT
@@ -88,8 +88,7 @@ static void DeviceEventHandler(const ChipDeviceEvent * event, intptr_t arg);
 namespace {
 
 // Globals as these are large and will not fit onto the stack
-SecureSessionMgr sTransportIPv4;
-SecureSessionMgr sTransportIPv6;
+SecureSessionMgr sSessionsManager;
 
 } // namespace
 
@@ -152,7 +151,7 @@ extern "C" void app_main()
 
     // Start the Echo Server
     InitDataModelHandler();
-    startServer(&sTransportIPv4, &sTransportIPv6);
+    startServer(&sSessionsManager);
 #if CONFIG_USE_ECHO_CLIENT
     startClient();
 #endif

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -148,7 +148,7 @@ CHIP_ERROR ChipDeviceController::ConnectDevice(NodeId remoteDeviceId, IPAddress 
 
     mSessionManager = new SecureSessionMgr();
 
-    err = mUdpTransport.Init(mInetLayer, Transport::UdpListenParameters().SetAddressType(deviceAddr.Type()));
+    err = mUdpTransport.Init(Transport::UdpListenParameters(mInetLayer).SetAddressType(deviceAddr.Type()));
     SuccessOrExit(err);
 
     err = mSessionManager->Init(mLocalDeviceId, mSystemLayer, &mUdpTransport);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -148,7 +148,10 @@ CHIP_ERROR ChipDeviceController::ConnectDevice(NodeId remoteDeviceId, IPAddress 
 
     mSessionManager = new SecureSessionMgr();
 
-    err = mSessionManager->Init(mLocalDeviceId, mInetLayer, Transport::UdpListenParameters().SetAddressType(deviceAddr.Type()));
+    err = mUdpTransport.Init(mInetLayer, Transport::UdpListenParameters().SetAddressType(deviceAddr.Type()));
+    SuccessOrExit(err);
+
+    err = mSessionManager->Init(mLocalDeviceId, mSystemLayer, &mUdpTransport);
     SuccessOrExit(err);
 
     mSessionManager->SetDelegate(&mCallback);

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -63,6 +63,9 @@ private:
     ChipDeviceController * mController;
 };
 
+/**
+ * Handles a connection to a single device over UDP.
+ */
 class DLL_EXPORT ChipDeviceController
 {
     friend class ChipDeviceControllerCallback;
@@ -186,6 +189,7 @@ private:
         kConnectionState_SecureConnected = 2,
     };
 
+    Transport::UDP mUdpTransport;
     System::Layer * mSystemLayer;
     Inet::InetLayer * mInetLayer;
 

--- a/src/transport/Base.h
+++ b/src/transport/Base.h
@@ -69,11 +69,11 @@ public:
     virtual CHIP_ERROR SendMessage(const MessageHeader & header, const PeerAddress & address, System::PacketBuffer * msgBuf) = 0;
 
     /**
-     * Get the path that this transport is associated with.
+     * Determine if this transport can SendMessage to the specified peer address.
      *
-     * Within a system, only one transport should be associated with a path.
+     * Generally it is expected that a transport can send to any peer from which it receives a message.
      */
-    virtual Type GetType() = 0;
+    virtual bool CanSendToPeer(const Transport::PeerAddress & address) = 0;
 
 protected:
     /**

--- a/src/transport/Base.h
+++ b/src/transport/Base.h
@@ -52,7 +52,7 @@ public:
      *
      */
     template <class T>
-    void SetMessageReceiveHandler(void (*handler)(const MessageHeader &, const Inet::IPPacketInfo &, System::PacketBuffer *, T *),
+    void SetMessageReceiveHandler(void (*handler)(const MessageHeader &, const PeerAddress &, System::PacketBuffer *, T *),
                                   T * param)
     {
         mMessageReceivedArgument = param;
@@ -66,8 +66,7 @@ public:
      *   This method calls <tt>chip::System::PacketBuffer::Free</tt> on
      *   behalf of the caller regardless of the return status.
      */
-    virtual CHIP_ERROR SendMessage(const MessageHeader & header, const Transport::PeerAddress & address,
-                                   System::PacketBuffer * msgBuf) = 0;
+    virtual CHIP_ERROR SendMessage(const MessageHeader & header, const PeerAddress & address, System::PacketBuffer * msgBuf) = 0;
 
     /**
      * Get the path that this transport is associated with.
@@ -81,7 +80,7 @@ protected:
      * Method used by subclasses to notify that a packet has been received after
      * any associated headers have been decoded.
      */
-    void HandleMessageReceived(const MessageHeader & header, const Inet::IPPacketInfo & source, System::PacketBuffer * buffer)
+    void HandleMessageReceived(const MessageHeader & header, const PeerAddress & source, System::PacketBuffer * buffer)
     {
         if (OnMessageReceived)
         {
@@ -95,8 +94,8 @@ protected:
      *
      * @param[in]    msgBuf        A pointer to the PacketBuffer object holding the message.
      */
-    typedef void (*MessageReceiveHandler)(const MessageHeader & header, const Inet::IPPacketInfo & source,
-                                          System::PacketBuffer * msgBuf, void * param);
+    typedef void (*MessageReceiveHandler)(const MessageHeader & header, const PeerAddress & source, System::PacketBuffer * msgBuf,
+                                          void * param);
 
     MessageReceiveHandler OnMessageReceived = nullptr; ///< Callback on message receiving
     void * mMessageReceivedArgument         = nullptr; ///< Argument for callback

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -60,7 +60,7 @@ CHIP_ERROR SecureSessionMgr::Init(NodeId localNodeId, Inet::InetLayer * inet, co
     err = mTransport.Init(inet, listenParams);
     SuccessOrExit(err);
 
-    mTransport.SetMessageReceiveHandler(HandleUdpDataReceived, this);
+    mTransport.SetMessageReceiveHandler(HandleDataReceived, this);
     mPeerConnections.SetConnectionExpiredHandler(HandleConnectionExpired, this);
 
     mState       = State::kInitialized;
@@ -184,8 +184,8 @@ void SecureSessionMgr::CancelExpiryTimer(void)
     }
 }
 
-void SecureSessionMgr::HandleUdpDataReceived(const MessageHeader & header, const IPPacketInfo & pktInfo, System::PacketBuffer * msg,
-                                             SecureSessionMgr * connection)
+void SecureSessionMgr::HandleDataReceived(const MessageHeader & header, const PeerAddress & peerAddress, System::PacketBuffer * msg,
+                                          SecureSessionMgr * connection)
 
 {
     CHIP_ERROR err                 = CHIP_NO_ERROR;
@@ -195,8 +195,6 @@ void SecureSessionMgr::HandleUdpDataReceived(const MessageHeader & header, const
     VerifyOrExit(msg != nullptr, ChipLogError(Inet, "Secure transport received NULL packet, discarding"));
 
     {
-        PeerAddress peerAddress = PeerAddress::UDP(pktInfo.SrcAddress, pktInfo.SrcPort);
-
         if (!connection->mPeerConnections.FindPeerConnectionState(peerAddress, &state))
         {
             ChipLogProgress(Inet, "New peer connection received.");
@@ -247,7 +245,7 @@ exit:
 
     if (err != CHIP_NO_ERROR && connection->mCB != nullptr)
     {
-        connection->mCB->OnReceiveError(err, pktInfo, connection);
+        connection->mCB->OnReceiveError(err, peerAddress, connection);
     }
 }
 

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -72,7 +72,7 @@ public:
      * @param error error code
      * @param source network entity that sent the message
      */
-    virtual void OnReceiveError(CHIP_ERROR error, const Inet::IPPacketInfo & source, SecureSessionMgr * mgr) {}
+    virtual void OnReceiveError(CHIP_ERROR error, const Transport::PeerAddress & source, SecureSessionMgr * mgr) {}
 
     /**
      * @brief
@@ -173,13 +173,8 @@ private:
     CHIP_ERROR AllocateNewConnection(const MessageHeader & header, const Transport::PeerAddress & address,
                                      Transport::PeerConnectionState ** state);
 
-    /**
-     * Handle UDP data receiving. Each transport has separate data receiving as active sessions
-     * follow data receiving channels.
-     *
-     */
-    static void HandleUdpDataReceived(const MessageHeader & header, const Inet::IPPacketInfo & source,
-                                      System::PacketBuffer * msgBuf, SecureSessionMgr * transport);
+    static void HandleDataReceived(const MessageHeader & header, const Transport::PeerAddress & source,
+                                   System::PacketBuffer * msgBuf, SecureSessionMgr * transport);
 
     /**
      * Called when a specific connection expires.

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -32,9 +32,9 @@
 #include <core/ReferenceCounted.h>
 #include <inet/IPAddress.h>
 #include <inet/IPEndPointBasis.h>
+#include <transport/Base.h>
 #include <transport/PeerConnections.h>
 #include <transport/SecureSession.h>
-#include <transport/UDP.h>
 
 namespace chip {
 
@@ -99,16 +99,12 @@ public:
 
     /**
      * @brief
-     *   Initialize a Secure Transport
+     *   Initialize a Secure Session Manager
      *
-     * @param inet    Inet layer to use
-     * @param listenParams  Listen settings for the transport
-     *
-     * @note This is not a final API as it is UDP specific. Class will be updated to support
-     * separate Transports (UDP, BLE, TCP, optional ipv4 for testing etc.). This API is currently
-     * UDP-specific and that will change.
+     * @param systemLayer    System, layer to use
+     * @param transport Underlying Transport to use
      */
-    CHIP_ERROR Init(NodeId localNodeId, Inet::InetLayer * inet, const Transport::UdpListenParameters & listenParams);
+    CHIP_ERROR Init(NodeId localNodeId, System::Layer * systemLayer, Transport::Base * transport);
 
     /**
      * Establishes a connection to the given peer node.
@@ -147,9 +143,7 @@ public:
     }
 
 private:
-    // TODO: add support for multiple transports (TCP, BLE to be added)
-    Transport::UDP mTransport;
-
+    Transport::Base * mTransport = nullptr;
     System::Layer * mSystemLayer = nullptr;
     NodeId mLocalNodeId;                                                                //< Id of the current node
     Transport::PeerConnections<CHIP_CONFIG_PEER_CONNECTION_POOL_SIZE> mPeerConnections; //< Active connections to other peers

--- a/src/transport/Tuple.h
+++ b/src/transport/Tuple.h
@@ -1,0 +1,113 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef TRANSPORT_TUPLE_H_
+#define TRANSPORT_TUPLE_H_
+
+#include <tuple>
+#include <type_traits>
+
+#include <transport/Base.h>
+
+namespace chip {
+namespace Transport {
+
+/**
+ * Groups together several transports of different types and presents them as a unified transport.
+ */
+template <typename... TransportTypes>
+class Tuple : public Base
+{
+public:
+    CHIP_ERROR SendMessage(const MessageHeader & header, const Transport::PeerAddress & address,
+                           System::PacketBuffer * msgBuf) override
+    {
+        return SendMessageImpl<sizeof...(TransportTypes)>(header, address, msgBuf);
+    }
+
+    bool CanSendToPeer(const Transport::PeerAddress & address) override
+    {
+        return CanSendToPeerImpl<sizeof...(TransportTypes)>(address);
+    }
+
+    /**
+     * Initialization method that forwards arguments for initialization to each of the underlying
+     * transports.
+     */
+    template <typename... Args>
+    CHIP_ERROR Init(Args &&... args)
+    {
+        return InitImpl(std::forward<Args>(args)...);
+    }
+
+private:
+    /// Recursive cansend implementation iterating through transport members
+    template <size_t N, typename std::enable_if<(N > 0)>::type * = nullptr>
+    bool CanSendToPeerImpl(const Transport::PeerAddress & address)
+    {
+        return std::get<N - 1>(mTransports).CanSendToPeer(address) || CanSendToPeerImpl<N - 1>(address);
+    }
+
+    /// Final can send check , where message cannot be sent through any transport
+    template <size_t N, typename std::enable_if<(N == 0)>::type * = nullptr>
+    bool CanSendToPeerImpl(const Transport::PeerAddress & address)
+    {
+        return false;
+    }
+
+    /// Recursive sendmessage implementation iterating through transport members
+    template <size_t N, typename std::enable_if<(N > 0)>::type * = nullptr>
+    CHIP_ERROR SendMessageImpl(const MessageHeader & header, const Transport::PeerAddress & address, System::PacketBuffer * msgBuf)
+    {
+        Base * base = &std::get<N - 1>(mTransports);
+        if (base->CanSendToPeer(address))
+        {
+            return base->SendMessage(header, address, msgBuf);
+        }
+        return SendMessageImpl<N - 1>(header, address, msgBuf);
+    }
+
+    /// Final send message, where message cannot be sent through any transport
+    template <size_t N, typename std::enable_if<(N == 0)>::type * = nullptr>
+    CHIP_ERROR SendMessageImpl(const MessageHeader & header, const Transport::PeerAddress & address, System::PacketBuffer * msgBuf)
+    {
+        return CHIP_ERROR_NO_MESSAGE_HANDLER;
+    }
+
+    /// Recursive init implementation iterating through transport members
+    template <typename InitArg, typename... Rest>
+    CHIP_ERROR InitImpl(InitArg && arg, Rest &&... rest)
+    {
+        CHIP_ERROR err = std::get<sizeof...(TransportTypes) - sizeof...(Rest) - 1>(mTransports).Init(std::forward<InitArg>(arg));
+        if (err == CHIP_NO_ERROR)
+        {
+            return err;
+        }
+
+        return InitImpl(std::forward<Rest>(rest)...);
+    }
+
+    /// Base case where initialization finishes.
+    CHIP_ERROR InitImpl() { return CHIP_NO_ERROR; }
+
+    std::tuple<TransportTypes...> mTransports;
+};
+
+} // namespace Transport
+} // namespace chip
+
+#endif // TRANSPORT_TUPLE_H_

--- a/src/transport/UDP.cpp
+++ b/src/transport/UDP.cpp
@@ -122,16 +122,17 @@ exit:
 
 void UDP::OnUdpReceive(Inet::IPEndPointBasis * endPoint, System::PacketBuffer * buffer, const IPPacketInfo * pktInfo)
 {
-    CHIP_ERROR err    = CHIP_NO_ERROR;
-    UDP * udp         = reinterpret_cast<UDP *>(endPoint->AppState);
-    size_t headerSize = 0;
+    CHIP_ERROR err          = CHIP_NO_ERROR;
+    UDP * udp               = reinterpret_cast<UDP *>(endPoint->AppState);
+    size_t headerSize       = 0;
+    PeerAddress peerAddress = PeerAddress::UDP(pktInfo->SrcAddress, pktInfo->SrcPort);
 
     MessageHeader header;
     err = header.Decode(buffer->Start(), buffer->DataLength(), &headerSize);
     SuccessOrExit(err);
 
     buffer->ConsumeHead(headerSize);
-    udp->HandleMessageReceived(header, *pktInfo, buffer);
+    udp->HandleMessageReceived(header, peerAddress, buffer);
 
 exit:
     if (err != CHIP_NO_ERROR)

--- a/src/transport/UDP.cpp
+++ b/src/transport/UDP.cpp
@@ -64,6 +64,7 @@ CHIP_ERROR UDP::Init(Inet::InetLayer * inetLayer, const UdpListenParameters & pa
 
     mUDPEndPoint->AppState          = reinterpret_cast<void *>(this);
     mUDPEndPoint->OnMessageReceived = OnUdpReceive;
+    mUDPEndpointType                = params.GetAddressType();
 
     mState = State::kInitialized;
 

--- a/src/transport/UDP.cpp
+++ b/src/transport/UDP.cpp
@@ -68,6 +68,8 @@ CHIP_ERROR UDP::Init(UdpListenParameters & params)
 
     mState = State::kInitialized;
 
+    ChipLogError(Inet, "Transport bound and ready");
+
 exit:
     if (err != CHIP_NO_ERROR)
     {

--- a/src/transport/UDP.cpp
+++ b/src/transport/UDP.cpp
@@ -68,8 +68,6 @@ CHIP_ERROR UDP::Init(UdpListenParameters & params)
 
     mState = State::kInitialized;
 
-    ChipLogError(Inet, "Transport bound and ready");
-
 exit:
     if (err != CHIP_NO_ERROR)
     {

--- a/src/transport/UDP.cpp
+++ b/src/transport/UDP.cpp
@@ -45,7 +45,7 @@ UDP::~UDP()
     }
 }
 
-CHIP_ERROR UDP::Init(Inet::InetLayer * inetLayer, const UdpListenParameters & params)
+CHIP_ERROR UDP::Init(UdpListenParameters & params)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -53,7 +53,7 @@ CHIP_ERROR UDP::Init(Inet::InetLayer * inetLayer, const UdpListenParameters & pa
 
     mSendPort = params.GetMessageSendPort();
 
-    err = inetLayer->NewUDPEndPoint(&mUDPEndPoint);
+    err = params.GetInetLayer()->NewUDPEndPoint(&mUDPEndPoint);
     SuccessOrExit(err);
 
     err = mUDPEndPoint->Bind(params.GetAddressType(), IPAddress::Any, params.GetListenPort(), params.GetInterfaceId());

--- a/src/transport/UDP.h
+++ b/src/transport/UDP.h
@@ -119,17 +119,23 @@ public:
      */
     CHIP_ERROR Init(Inet::InetLayer * inetLayer) { return Init(inetLayer, UdpListenParameters()); }
 
-    Type GetType() override { return Type::kUdp; }
     CHIP_ERROR SendMessage(const MessageHeader & header, const Transport::PeerAddress & address,
                            System::PacketBuffer * msgBuf) override;
+
+    bool CanSendToPeer(const Transport::PeerAddress & address) override
+    {
+        return (mState == State::kInitialized) && (address.GetTransportType() == Type::kUdp) &&
+            (address.GetIPAddress().Type() == mUDPEndpointType);
+    }
 
 private:
     // UDP message receive handler.
     static void OnUdpReceive(Inet::IPEndPointBasis * endPoint, System::PacketBuffer * buffer, const IPPacketInfo * pktInfo);
 
-    Inet::UDPEndPoint * mUDPEndPoint = nullptr;          ///< UDP socket used by the transport
-    State mState                     = State::kNotReady; ///< State of the UDP transport
-    uint16_t mSendPort               = 0;                ///< Port where packets are sent by default
+    Inet::UDPEndPoint * mUDPEndPoint     = nullptr;                                     ///< UDP socket used by the transport
+    Inet::IPAddressType mUDPEndpointType = Inet::IPAddressType::kIPAddressType_Unknown; ///< Socket listening type
+    State mState                         = State::kNotReady;                            ///< State of the UDP transport
+    uint16_t mSendPort                   = 0;                                           ///< Port where packets are sent by default
 };
 
 } // namespace Transport

--- a/src/transport/UDP.h
+++ b/src/transport/UDP.h
@@ -42,9 +42,11 @@ namespace Transport {
 class UdpListenParameters
 {
 public:
-    UdpListenParameters() {}
+    explicit UdpListenParameters(Inet::InetLayer * layer) : mLayer(layer) {}
     UdpListenParameters(const UdpListenParameters &) = default;
     UdpListenParameters(UdpListenParameters &&)      = default;
+
+    Inet::InetLayer * GetInetLayer() { return mLayer; }
 
     Inet::IPAddressType GetAddressType() const { return mAddressType; }
     UdpListenParameters & SetAddressType(Inet::IPAddressType type)
@@ -79,6 +81,7 @@ public:
     }
 
 private:
+    Inet::InetLayer * mLayer         = nullptr;               ///< Associated inet layer
     Inet::IPAddressType mAddressType = kIPAddressType_IPv6;   ///< type of listening socket
     uint16_t mMessageSendPort        = CHIP_PORT;             ///< over what port to send requests
     uint16_t mListenPort             = CHIP_PORT;             ///< UDP listen port
@@ -104,7 +107,6 @@ public:
     /**
      * Initialize a UDP transport on a given port.
      *
-     * @param inetLayer    underlying communication channel
      * @param parms        UDP configuration parameters for this transport
      *
      * @details
@@ -112,12 +114,7 @@ public:
      *   The class allows separate definitions to allow local execution of several
      *   Nodes.
      */
-    CHIP_ERROR Init(Inet::InetLayer * inetLayer, const UdpListenParameters & params);
-
-    /**
-     * Convenience method to listen on IPv6 on chip standard ports
-     */
-    CHIP_ERROR Init(Inet::InetLayer * inetLayer) { return Init(inetLayer, UdpListenParameters()); }
+    CHIP_ERROR Init(UdpListenParameters & params);
 
     CHIP_ERROR SendMessage(const MessageHeader & header, const Transport::PeerAddress & address,
                            System::PacketBuffer * msgBuf) override;

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -34,12 +34,13 @@
 
 #include <errno.h>
 
-using namespace chip;
+namespace {
 
-static int Initialize(void * aContext);
-static int Finalize(void * aContext);
+using namespace chip;
+using namespace chip::Transport;
 
 using TestContext = chip::Test::IOContext;
+
 TestContext sContext;
 
 static const unsigned char local_private_key[] = { 0x00, 0xd1, 0x90, 0xd9, 0xb3, 0x95, 0x1c, 0x5f, 0xa4, 0xe7, 0x47,
@@ -56,11 +57,23 @@ static const char PAYLOAD[]         = "Hello!";
 constexpr NodeId kSourceNodeId      = 123654;
 constexpr NodeId kDestinationNodeId = 111222333;
 
+class LoopbackTransport : public Transport::Base
+{
+public:
+    CHIP_ERROR SendMessage(const MessageHeader & header, const PeerAddress & address, System::PacketBuffer * msgBuf) override
+    {
+        HandleMessageReceived(header, address, msgBuf);
+        return CHIP_NO_ERROR;
+    }
+
+    bool CanSendToPeer(const PeerAddress & address) override { return true; }
+};
+
 class TestSessMgrCallback : public SecureSessionMgrCallback
 {
 public:
-    virtual void OnMessageReceived(const MessageHeader & header, Transport::PeerConnectionState * state,
-                                   System::PacketBuffer * msgBuf, SecureSessionMgr * mgr)
+    virtual void OnMessageReceived(const MessageHeader & header, PeerConnectionState * state, System::PacketBuffer * msgBuf,
+                                   SecureSessionMgr * mgr)
     {
         NL_TEST_ASSERT(mSuite, header.GetSourceNodeId() == Optional<NodeId>::Value(kSourceNodeId));
         NL_TEST_ASSERT(mSuite, header.GetDestinationNodeId() == Optional<NodeId>::Value(kDestinationNodeId));
@@ -74,7 +87,7 @@ public:
         ReceiveHandlerCallCount++;
     }
 
-    virtual void OnNewConnection(Transport::PeerConnectionState * state, SecureSessionMgr * mgr)
+    virtual void OnNewConnection(PeerConnectionState * state, SecureSessionMgr * mgr)
     {
         CHIP_ERROR err;
 
@@ -96,12 +109,13 @@ void CheckSimpleInitTest(nlTestSuite * inSuite, void * inContext)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
+    LoopbackTransport transport;
     SecureSessionMgr conn;
     CHIP_ERROR err;
 
     ctx.GetInetLayer().SystemLayer()->Init(NULL);
 
-    err = conn.Init(kSourceNodeId, &ctx.GetInetLayer(), Transport::UdpListenParameters());
+    err = conn.Init(kSourceNodeId, ctx.GetInetLayer().SystemLayer(), &transport);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
@@ -121,9 +135,10 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
     IPAddress::FromString("127.0.0.1", addr);
     CHIP_ERROR err = CHIP_NO_ERROR;
 
+    LoopbackTransport transport;
     SecureSessionMgr conn;
 
-    err = conn.Init(kSourceNodeId, &ctx.GetInetLayer(), Transport::UdpListenParameters().SetAddressType(addr.Type()));
+    err = conn.Init(kSourceNodeId, ctx.GetInetLayer().SystemLayer(), &transport);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     callback.mSuite = inSuite;
@@ -132,7 +147,7 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
 
     callback.NewConnectionHandlerCallCount = 0;
 
-    err = conn.Connect(kDestinationNodeId, Transport::PeerAddress::UDP(addr));
+    err = conn.Connect(kDestinationNodeId, PeerAddress::UDP(addr));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, callback.NewConnectionHandlerCallCount == 1);
 
@@ -153,7 +168,7 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
  *  Test Suite that lists all the test functions.
  */
 // clang-format off
-static const nlTest sTests[] =
+const nlTest sTests[] =
 {
     NL_TEST_DEF("Simple Init Test",              CheckSimpleInitTest),
     NL_TEST_DEF("Message Self Test",             CheckMessageTest),
@@ -162,8 +177,11 @@ static const nlTest sTests[] =
 };
 // clang-format on
 
+int Initialize(void * aContext);
+int Finalize(void * aContext);
+
 // clang-format off
-static nlTestSuite sSuite =
+nlTestSuite sSuite =
 {
     "Test-CHIP-Connection",
     &sTests[0],
@@ -175,7 +193,7 @@ static nlTestSuite sSuite =
 /**
  *  Initialize the test suite.
  */
-static int Initialize(void * aContext)
+int Initialize(void * aContext)
 {
     CHIP_ERROR err = reinterpret_cast<TestContext *>(aContext)->Init(&sSuite);
     return (err == CHIP_NO_ERROR) ? SUCCESS : FAILURE;
@@ -184,11 +202,13 @@ static int Initialize(void * aContext)
 /**
  *  Finalize the test suite.
  */
-static int Finalize(void * aContext)
+int Finalize(void * aContext)
 {
     CHIP_ERROR err = reinterpret_cast<TestContext *>(aContext)->Shutdown();
     return (err == CHIP_NO_ERROR) ? SUCCESS : FAILURE;
 }
+
+} // namespace
 
 /**
  *  Main

--- a/src/transport/tests/TestUDP.cpp
+++ b/src/transport/tests/TestUDP.cpp
@@ -51,7 +51,7 @@ TestContext sContext;
 const char PAYLOAD[]        = "Hello!";
 int ReceiveHandlerCallCount = 0;
 
-void MessageReceiveHandler(const MessageHeader & header, const Inet::IPPacketInfo & source, System::PacketBuffer * msgBuf,
+void MessageReceiveHandler(const MessageHeader & header, const Transport::PeerAddress & source, System::PacketBuffer * msgBuf,
                            nlTestSuite * inSuite)
 {
     NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<NodeId>::Value(kSourceNodeId));

--- a/src/transport/tests/TestUDP.cpp
+++ b/src/transport/tests/TestUDP.cpp
@@ -75,7 +75,7 @@ void CheckSimpleInitTest(nlTestSuite * inSuite, void * inContext, Inet::IPAddres
 
     Transport::UDP udp;
 
-    CHIP_ERROR err = udp.Init(&ctx.GetInetLayer(), Transport::UdpListenParameters().SetAddressType(type));
+    CHIP_ERROR err = udp.Init(Transport::UdpListenParameters(&ctx.GetInetLayer()).SetAddressType(type));
 
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
@@ -108,7 +108,7 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext, const IPAddress &
 
     Transport::UDP udp;
 
-    err = udp.Init(&ctx.GetInetLayer(), Transport::UdpListenParameters().SetAddressType(addr.Type()));
+    err = udp.Init(Transport::UdpListenParameters(&ctx.GetInetLayer()).SetAddressType(addr.Type()));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     udp.SetMessageReceiveHandler(MessageReceiveHandler, inSuite);


### PR DESCRIPTION
 #### Problem
Currently a separate session manager is created for every transport (e.g. ESP creates 2: one for ipv4 and one for ipv6). There should be a central session and encryption management rather than per protocol.

 #### Summary of Changes
Decouples transport from session management.

fixes #1339 