### PR TITLE
[NW] nw_error_get_error_code called with null error

### DIFF
--- a/src/inet/IPEndPointBasis.cpp
+++ b/src/inet/IPEndPointBasis.cpp
@@ -1202,7 +1202,10 @@ INET_ERROR IPEndPointBasis::SendMsg(const IPPacketInfo * aPktInfo, chip::System:
     send_semaphore = dispatch_semaphore_create(0);
     content = dispatch_data_create(aBuffer->Start(), aBuffer->DataLength(), mDispatchQueue, DISPATCH_DATA_DESTRUCTOR_DEFAULT);
     nw_connection_send(mConnection, content, NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, true, ^(nw_error_t error) {
-        res = chip::System::MapErrorPOSIX(nw_error_get_error_code(error));
+        if (error)
+        {
+            res = chip::System::MapErrorPOSIX(nw_error_get_error_code(error));
+        }
         dispatch_semaphore_signal(send_semaphore);
     });
     dispatch_release(content);


### PR DESCRIPTION
 #### Problem

Under iOS the send callback error parameter can be NULL. Which result into a crash of the application when using the Network.Framework backend.

 #### Summary of Changes
 * Check that error is not null before calling nw_get_error_code
