### PR TITLE
When using the network framework backend, the main thread can be stuc…

### DIFF
--- a/src/inet/IPEndPointBasis.h
+++ b/src/inet/IPEndPointBasis.h
@@ -159,6 +159,7 @@ protected:
     nw_connection_t mConnection;
     dispatch_semaphore_t mConnectionSemaphore;
     dispatch_queue_t mDispatchQueue;
+    dispatch_semaphore_t mSendSemaphore;
 
     INET_ERROR Bind(IPAddressType aAddressType, IPAddress aAddress, uint16_t aPort, nw_parameters_t aParameters);
     INET_ERROR ConfigureProtocol(IPAddressType aAddressType, nw_parameters_t aParameters);


### PR DESCRIPTION
…k waiting for a send to complete while the network is down

 #### Problem
 
If the network is changing between 2 send calls, the NW backend may be stuck in the SendMsg method if the connection end up failing.
