### PR TITLE
Use a default value in the message field of the echo client view in t…

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/Echo client/EchoViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/Echo client/EchoViewController.m
@@ -48,9 +48,9 @@
 
 - (IBAction)sendAction:(id)sender
 {
-    if (self.messageTextField.text.length == 0) {
-        [self postResult:@"Error: Message cannot be empty"];
-        return;
+    NSString * msg = [self.messageTextField text];
+    if (msg.length == 0) {
+        msg = [self.messageTextField placeholder];
     }
 
     [self reconnectIfNeeded];
@@ -58,8 +58,7 @@
     // send message
     if ([self.chipController isConnected]) {
         NSError * error;
-        BOOL didSend = [self.chipController sendMessage:[self.messageTextField.text dataUsingEncoding:NSUTF8StringEncoding]
-                                                  error:&error];
+        BOOL didSend = [self.chipController sendMessage:[msg dataUsingEncoding:NSUTF8StringEncoding] error:&error];
         if (!didSend) {
             [self postResult:[@"Error: " stringByAppendingString:error.localizedDescription]];
         } else {


### PR DESCRIPTION
…he iOS app

 #### Problem

The echo view message textfield in the iOS app shows a placeholder with "Hello from iOS!" but when you click on the send button it complains about an empty text field.

It would be simpler if you can just hit send by using the placeholder text. This will save me some time while testing the NW backend.
