### PR TITLE
Rename SoftAP to WiFi in the codebase

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
@@ -233,9 +233,9 @@ static NSString * const ipKey = @"ipk";
     case kRendezvousInformationAllMask:
         NSLog(@"Rendezvous Unknown");
         break;
-    case kRendezvousInformationSoftAP:
-        NSLog(@"Rendezvous SoftAP");
-        [self handleRendezVousSoftAP:[self getNetworkName:payload.discriminator]];
+    case kRendezvousInformationWiFi:
+        NSLog(@"Rendezvous Wi-Fi");
+        [self handleRendezVousWiFi:[self getNetworkName:payload.discriminator]];
         break;
     case kRendezvousInformationBLE:
         NSLog(@"Rendezvous BLE");
@@ -257,7 +257,7 @@ static NSString * const ipKey = @"ipk";
     [_ble start];
 }
 
-- (void)handleRendezVousSoftAP:(NSString *)name
+- (void)handleRendezVousWiFi:(NSString *)name
 {
     NSString * message = [NSString stringWithFormat:@"SSID: %@\n\nUse WiFi Settings to connect to it.", name];
     UIAlertController * alert = [UIAlertController alertControllerWithTitle:@"SoftAP Detected"

--- a/src/darwin/Framework/CHIP/CHIPSetupPayload.h
+++ b/src/darwin/Framework/CHIP/CHIPSetupPayload.h
@@ -26,13 +26,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSUInteger, RendezvousInformationFlags) {
     kRendezvousInformationNone = 0, // Device does not support any method for rendezvous
-    kRendezvousInformationSoftAP = 1 << 0, // Device supports hosting a SoftAP
+    kRendezvousInformationWiFi = 1 << 0, // Device supports WiFi
     kRendezvousInformationBLE = 1 << 1, // Device supports BLE
     kRendezvousInformationThread = 1 << 2, // Device supports Thread
     kRendezvousInformationEthernet = 1 << 3, // Device MAY be attached to a wired 802." connection"
 
     kRendezvousInformationAllMask
-    = kRendezvousInformationSoftAP | kRendezvousInformationBLE | kRendezvousInformationThread | kRendezvousInformationEthernet,
+    = kRendezvousInformationWiFi | kRendezvousInformationBLE | kRendezvousInformationThread | kRendezvousInformationEthernet,
 };
 
 typedef NS_ENUM(NSUInteger, OptionalQRCodeInfoType) {

--- a/src/darwin/Framework/CHIP/CHIPSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/CHIPSetupPayload.mm
@@ -32,8 +32,8 @@
     case chip::RendezvousInformationFlags::kNone:
         rv = kRendezvousInformationNone;
         break;
-    case chip::RendezvousInformationFlags::kSoftAP:
-        rv = kRendezvousInformationSoftAP;
+    case chip::RendezvousInformationFlags::kWiFi:
+        rv = kRendezvousInformationWiFi;
         break;
     case chip::RendezvousInformationFlags::kBLE:
         rv = kRendezvousInformationBLE;

--- a/src/darwin/Framework/CHIPTests/CHIPSetupPayloadParserTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPSetupPayloadParserTests.m
@@ -89,7 +89,7 @@
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
     XCTAssertFalse(payload.requiresCustomFlow);
     XCTAssertEqual(payload.version.unsignedIntegerValue, 5);
-    XCTAssertEqual(payload.rendezvousInformation, kRendezvousInformationSoftAP);
+    XCTAssertEqual(payload.rendezvousInformation, kRendezvousInformationWiFi);
 }
 
 - (void)testQRCodeParserWithOptionalData
@@ -108,7 +108,7 @@
     XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 12);
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
     XCTAssertFalse(payload.requiresCustomFlow);
-    XCTAssertEqual(payload.rendezvousInformation, kRendezvousInformationSoftAP);
+    XCTAssertEqual(payload.rendezvousInformation, kRendezvousInformationWiFi);
     XCTAssertTrue([payload.serialNumber isEqualToString:@"1"]);
 
     NSArray<CHIPOptionalQRCodeInfo *> * vendorOptionalInfo = [payload getAllOptionalVendorData:&error];

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -72,15 +72,18 @@ const int kTotalPayloadDataSizeInBytes = kTotalPayloadDataSizeInBits / 8;
 
 const char * const kQRCodePrefix = "CH:";
 
+/**
+ * The rendezvous type this device supports.
+ */
 enum class RendezvousInformationFlags : uint16_t
 {
-    kNone     = 0,      // Device does not support any method for rendezvous
-    kSoftAP   = 1 << 0, // Device supports hosting a SoftAP
-    kBLE      = 1 << 1, // Device supports BLE
-    kThread   = 1 << 2, // Device supports Thread
-    kEthernet = 1 << 3, // Device MAY be attached to a wired 802." connection"
+    kNone     = 0,      //< Device does not support any method for rendezvous
+    kWiFi     = 1 << 0, //< Device supports Wi-Fi
+    kBLE      = 1 << 1, //< Device supports BLE
+    kThread   = 1 << 2, //< Device supports Thread
+    kEthernet = 1 << 3, //< Device MAY be attached to a wired 802.3 connection
 
-    kAllMask = kSoftAP | kBLE | kThread | kEthernet,
+    kAllMask = kWiFi | kBLE | kThread | kEthernet,
 };
 
 enum optionalQRCodeInfoType

--- a/src/setup_payload/tests/TestHelpers.h
+++ b/src/setup_payload/tests/TestHelpers.h
@@ -42,7 +42,7 @@ SetupPayload GetDefaultPayload()
     payload.vendorID              = 12;
     payload.productID             = 1;
     payload.requiresCustomFlow    = 0;
-    payload.rendezvousInformation = RendezvousInformationFlags::kSoftAP;
+    payload.rendezvousInformation = RendezvousInformationFlags::kWiFi;
     payload.discriminator         = 128;
     payload.setUpPINCode          = 2048;
 

--- a/src/setup_payload/tests/TestQRCode.cpp
+++ b/src/setup_payload/tests/TestQRCode.cpp
@@ -39,7 +39,7 @@ void TestRendezvousFlags(nlTestSuite * inSuite, void * inContext)
     inPayload.rendezvousInformation = RendezvousInformationFlags::kNone;
     NL_TEST_ASSERT(inSuite, CheckWriteRead(inPayload));
 
-    inPayload.rendezvousInformation = RendezvousInformationFlags::kSoftAP;
+    inPayload.rendezvousInformation = RendezvousInformationFlags::kWiFi;
     NL_TEST_ASSERT(inSuite, CheckWriteRead(inPayload));
 
     inPayload.rendezvousInformation = RendezvousInformationFlags::kBLE;


### PR DESCRIPTION
 #### Problem

Based on a comment (https://github.com/project-chip/connectedhomeip/pull/1329#discussion_r448594136), let's rename SoftAP -> WiFi in the codebase.

 #### Summary of Changes
 * SoftAP -> WiFi