### PR TITLE
Multiple PeerConnections with the same nodeId but different PeerAddress

### DIFF
--- a/src/transport/PeerConnections.h
+++ b/src/transport/PeerConnections.h
@@ -134,6 +134,17 @@ public:
         state->SetLastActivityTimeMs(mTimeSource.GetCurrentMonotonicTimeMs());
     }
 
+    /// Convenience method to expired a peer connection state and fired the related callback
+    void MarkConnectionExpired(PeerConnectionState * state)
+    {
+        if (OnConnectionExpired)
+        {
+            OnConnectionExpired(*state, mConnectionExpiredArgument);
+        }
+
+        *state = PeerConnectionState(PeerAddress::Uninitialized());
+    }
+
     /**
      * Iterates through all active connections and expires any connection with an idle time
      * larger than the given amount.
@@ -157,13 +168,7 @@ public:
                 continue; // not expired
             }
 
-            if (OnConnectionExpired)
-            {
-                OnConnectionExpired(mStates[i], mConnectionExpiredArgument);
-            }
-
-            // Connection is assumed expired, marking it as invalid
-            mStates[i] = PeerConnectionState(PeerAddress::Uninitialized());
+            MarkConnectionExpired(&mStates[i]);
         }
     }
 

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -205,6 +205,16 @@ void SecureSessionMgr::HandleDataReceived(const MessageHeader & header, const Pe
     {
         if (!connection->mPeerConnections.FindPeerConnectionState(peerAddress, &state))
         {
+            if (header.GetSourceNodeId().HasValue())
+            {
+                // If the data is from a new address BUT the node id is the same as a previous
+                // connection, mark the previous connection invalid in order to not have duplicate node ids.
+                if (connection->mPeerConnections.FindPeerConnectionState(header.GetSourceNodeId().Value(), &state))
+                {
+                    connection->mPeerConnections.MarkConnectionExpired(state);
+                }
+            }
+
             ChipLogProgress(Inet, "New peer connection received.");
 
             err = connection->AllocateNewConnection(header, peerAddress, &state);


### PR DESCRIPTION
 #### Problem
 * when someone connects to a peripheral using a secure connection,  the platform trust the nodeid from the message header. But if a there is a second connection (made from a different address:port) with the same nodeid then some messages will be sent to the first node in reaction to messages from the second node.
The second node can also forced the connection to the first node to stay active.

I was unsure of what is the expected behavior here, so I made a tentative patch that consider the last connection to be the right one.