### PR TITLE
Enable System timers with the NW backend

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -271,12 +271,12 @@ CHIP_ERROR ChipDeviceController::GetLayers(Layer ** systemLayer, InetLayer ** in
 
 void ChipDeviceController::ServiceEvents()
 {
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
-
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
     if (mState != kState_Initialized)
     {
         return;
     }
+
     // Set the select timeout to 100ms
     struct timeval aSleepTime;
     aSleepTime.tv_sec  = 0;
@@ -299,10 +299,16 @@ void ChipDeviceController::ServiceEvents()
     FD_ZERO(&exceptFDs);
 
     if (mSystemLayer->State() == System::kLayerState_Initialized)
+    {
         mSystemLayer->PrepareSelect(numFDs, &readFDs, &writeFDs, &exceptFDs, aSleepTime);
+    }
 
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
     if (mInetLayer->State == Inet::InetLayer::kState_Initialized)
+    {
         mInetLayer->PrepareSelect(numFDs, &readFDs, &writeFDs, &exceptFDs, aSleepTime);
+    }
+#endif
 
     int selectRes = select(numFDs, &readFDs, &writeFDs, &exceptFDs, &aSleepTime);
     if (selectRes < 0)
@@ -316,11 +322,14 @@ void ChipDeviceController::ServiceEvents()
         mSystemLayer->HandleSelectResult(selectRes, &readFDs, &writeFDs, &exceptFDs);
     }
 
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
     if (mInetLayer->State == Inet::InetLayer::kState_Initialized)
     {
         mInetLayer->HandleSelectResult(selectRes, &readFDs, &writeFDs, &exceptFDs);
     }
 #endif
+
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 }
 
 void ChipDeviceController::ClearRequestState()

--- a/src/system/SystemLayer.h
+++ b/src/system/SystemLayer.h
@@ -146,11 +146,11 @@ public:
 
     Error ScheduleWork(TimerCompleteFunct aComplete, void * aAppState);
 
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
     void PrepareSelect(int & aSetSize, fd_set * aReadSet, fd_set * aWriteSet, fd_set * aExceptionSet, struct timeval & aSleepTime);
     void HandleSelectResult(int aSetSize, fd_set * aReadSet, fd_set * aWriteSet, fd_set * aExceptionSet);
     void WakeSelect(void);
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     typedef Error (*EventHandler)(Object & aTarget, EventType aEventType, uintptr_t aArgument);
@@ -187,14 +187,14 @@ private:
     bool mTimerComplete;
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
     int mWakePipeIn;
     int mWakePipeOut;
 
 #if CHIP_SYSTEM_CONFIG_POSIX_LOCKING
     pthread_t mHandleSelectThread;
 #endif // CHIP_SYSTEM_CONFIG_POSIX_LOCKING
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     static Error HandleSystemLayerEvent(Object & aTarget, EventType aEventType, uintptr_t aArgument);


### PR DESCRIPTION
 #### Problem

System timers will never fired at the moment with the NW backend since the code is behind CHIP_SYSTEM_CONFIG_USE_SOCKETS
Also the NW backend does not need the Inet select code.

This patch enable System timers for the NW backend.
