### PR TITLE
Build errors with './bootstrap-configure --with-device-layer=linux' o…

### DIFF
--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -138,8 +138,8 @@ private:
     template <class>
     friend class ::chip::DeviceLayer::Internal::GenericPlatformManagerImpl_POSIX;
     // Parentheses used to fix clang parsing issue with these declarations
-    friend CHIP_ERROR ::chip::Platform::PersistedStorage::Read(::chip::Platform::PersistedStorage::Key key, uint32_t & value);
-    friend CHIP_ERROR ::chip::Platform::PersistedStorage::Write(::chip::Platform::PersistedStorage::Key key, uint32_t value);
+    friend CHIP_ERROR(::chip::Platform::PersistedStorage::Read)(::chip::Platform::PersistedStorage::Key key, uint32_t & value);
+    friend CHIP_ERROR(::chip::Platform::PersistedStorage::Write)(::chip::Platform::PersistedStorage::Key key, uint32_t value);
 
     using ImplClass = ::chip::DeviceLayer::ConfigurationManagerImpl;
 

--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -116,14 +116,14 @@ private:
     template <class>
     friend class Internal::GenericConfigurationManagerImpl;
     // Parentheses used to fix clang parsing issue with these declarations
-    friend ::chip::System::Error ::chip::System::Platform::Layer::PostEvent(::chip::System::Layer & aLayer, void * aContext,
-                                                                            ::chip::System::Object & aTarget,
-                                                                            ::chip::System::EventType aType, uintptr_t aArgument);
-    friend ::chip::System::Error ::chip::System::Platform::Layer::DispatchEvents(::chip::System::Layer & aLayer, void * aContext);
-    friend ::chip::System::Error ::chip::System::Platform::Layer::DispatchEvent(::chip::System::Layer & aLayer, void * aContext,
-                                                                                ::chip::System::Event aEvent);
-    friend ::chip::System::Error ::chip::System::Platform::Layer::StartTimer(::chip::System::Layer & aLayer, void * aContext,
-                                                                             uint32_t aMilliseconds);
+    friend ::chip::System::Error(::chip::System::Platform::Layer::PostEvent)(::chip::System::Layer & aLayer, void * aContext,
+                                                                             ::chip::System::Object & aTarget,
+                                                                             ::chip::System::EventType aType, uintptr_t aArgument);
+    friend ::chip::System::Error(::chip::System::Platform::Layer::DispatchEvents)(::chip::System::Layer & aLayer, void * aContext);
+    friend ::chip::System::Error(::chip::System::Platform::Layer::DispatchEvent)(::chip::System::Layer & aLayer, void * aContext,
+                                                                                 ::chip::System::Event aEvent);
+    friend ::chip::System::Error(::chip::System::Platform::Layer::StartTimer)(::chip::System::Layer & aLayer, void * aContext,
+                                                                              uint32_t aMilliseconds);
 
     void PostEvent(const ChipDeviceEvent * event);
     void DispatchEvent(const ChipDeviceEvent * event);

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -40,9 +40,6 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-// Fully instantiate the generic implementation class in whatever compilation unit includes this file.
-template class GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
-
 template <class ImplClass>
 CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_Init()
 {
@@ -1049,6 +1046,9 @@ void GenericConfigurationManagerImpl<ImplClass>::LogDeviceConfig()
 }
 
 #endif // CHIP_PROGRESS_LOGGING
+
+// Fully instantiate the generic implementation class in whatever compilation unit includes this file.
+template class GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/include/platform/internal/GenericPlatformManagerImpl.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.ipp
@@ -39,9 +39,6 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-// Fully instantiate the generic implementation class in whatever compilation unit includes this file.
-template class GenericPlatformManagerImpl<PlatformManagerImpl>;
-
 extern CHIP_ERROR InitEntropy();
 
 template <class ImplClass>
@@ -269,6 +266,9 @@ void GenericPlatformManagerImpl<ImplClass>::HandleMessageLayerActivityChanged(bo
 #endif
     }
 }
+
+// Fully instantiate the generic implementation class in whatever compilation unit includes this file.
+template class GenericPlatformManagerImpl<PlatformManagerImpl>;
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
@@ -24,8 +24,8 @@
 #ifndef GENERIC_PLATFORM_MANAGER_IMPL_POSIX_IPP
 #define GENERIC_PLATFORM_MANAGER_IMPL_POSIX_IPP
 
-#include <platform/internal/CHIPDeviceLayerInternal.h>
 #include <platform/PlatformManager.h>
+#include <platform/internal/CHIPDeviceLayerInternal.h>
 #include <platform/internal/GenericPlatformManagerImpl_POSIX.h>
 
 // Include the non-inline definitions for the GenericPlatformManagerImpl<> template,
@@ -34,13 +34,13 @@
 
 #include <system/SystemLayer.h>
 
-#include <poll.h>
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <poll.h>
 #include <sched.h>
-#include <unistd.h>
 #include <sys/select.h>
+#include <unistd.h>
 
 #define DEFAULT_MIN_SLEEP_PERIOD (60 * 60 * 24 * 30) // Month [sec]
 
@@ -48,15 +48,18 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-// Fully instantiate the generic implementation class in whatever compilation unit includes this file.
-template class GenericPlatformManagerImpl_POSIX<PlatformManagerImpl>;
-
 template <class ImplClass>
 CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_InitChipStack(void)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
+#if defined(PTHREAD_RECURSIVE_MUTEX_INITIALIZER)
+    mChipStackLock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER;
+#elif defined(PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP)
     mChipStackLock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
+#else
+#error "No defined static initializer for POSIX Threads recursive mutex!"
+#endif // defined(PTHREAD_RECURSIVE_MUTEX_INITIALIZER)
 
     // Initialize the Configuration Manager object.
     err = ConfigurationMgr().Init();
@@ -216,6 +219,9 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_StartEventLoopTask(void
 exit:
     return System::MapErrorPOSIX(err);
 }
+
+// Fully instantiate the generic implementation class in whatever compilation unit includes this file.
+template class GenericPlatformManagerImpl_POSIX<PlatformManagerImpl>;
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/platform/Linux/CHIPLinuxStorageIni.cpp
+++ b/src/platform/Linux/CHIPLinuxStorageIni.cpp
@@ -74,7 +74,7 @@ CHIP_ERROR ChipLinuxStorageIni::AddConfig(const std::string & configFile)
     }
     else
     {
-        ChipLogError(DeviceLayer, "Failed to open config file: %s", configFile);
+        ChipLogError(DeviceLayer, "Failed to open config file: %s", configFile.c_str());
         retval = CHIP_ERROR_PERSISTED_STORAGE_FAIL;
     }
 


### PR DESCRIPTION
…n macOS with clang

 #### Problem

While doing `./bootstrap-configure --with-device-layer=linux` and `make`the build fails. Note that while device-layer says Linux there is not really anything specific there.

Also I add to move the template instantiation at the bottom of the file otherwise I was unable to run the platform tests (`make -C src/platform/tests check) because of linking errors.