### PR TITLE
Prefix includes in src/crypto & remove leaves from search path

### DIFF
--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -24,7 +24,7 @@
 #include "Hash_SHA256_test_vectors.h"
 #include "PBKDF2_SHA256_test_vectors.h"
 
-#include <CHIPCryptoPAL.h>
+#include <crypto/CHIPCryptoPAL.h>
 #include <nlunit-test.h>
 #include <support/CodeUtils.h>
 #include <support/TestUtils.h>

--- a/src/crypto/tests/Makefile.am
+++ b/src/crypto/tests/Makefile.am
@@ -62,9 +62,7 @@ dist_libCryptoLayerTests_a_HEADERS             = \
 AM_CPPFLAGS                                    = \
     -I$(top_srcdir)/src/                         \
     -I$(top_srcdir)/src/lib                      \
-    -I$(top_srcdir)/src/system                   \
     -I$(top_srcdir)/src/include/                 \
-    -I$(top_srcdir)/src/crypto                   \
     $(LWIP_CPPFLAGS)                             \
     $(NLASSERT_CPPFLAGS)                         \
     $(NLUNIT_TEST_CPPFLAGS)                      \


### PR DESCRIPTION
This prefixes all includes in src/crypto with crypto/ for consistency
with the rest of the project.
