### PR TITLE
[Rendezvous] Add BLEEndPoint support to the iOS app

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
+++ b/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		0C47BE4324885B97005E97F6 /* CHIPViewControllerBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CHIPViewControllerBase.m; sourceTree = "<group>"; };
 		0CA0E0CD248599BB009087B9 /* OnOffViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OnOffViewController.h; sourceTree = "<group>"; };
 		0CA0E0CE248599BB009087B9 /* OnOffViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OnOffViewController.m; sourceTree = "<group>"; };
+		1E42A3FF24B3679400E2BAD0 /* CoreBluetooth.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreBluetooth.framework; path = System/Library/Frameworks/CoreBluetooth.framework; sourceTree = SDKROOT; };
 		1E87C7B424A5E57100457C90 /* BLEConnectionController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BLEConnectionController.h; sourceTree = "<group>"; };
 		1E87C7B524A5E74E00457C90 /* BLEConnectionController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BLEConnectionController.m; sourceTree = "<group>"; };
 		515C401824868BF0004C4DB3 /* CHIPViewControllerBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPViewControllerBase.h; sourceTree = "<group>"; };
@@ -123,6 +124,7 @@
 		B20252DE2459EC7600F97062 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				1E42A3FF24B3679400E2BAD0 /* CoreBluetooth.framework */,
 				B2E0D7BE245B0C59003C5B48 /* CHIP.framework */,
 			);
 			name = Frameworks;

--- a/src/darwin/CHIPTool/CHIPTool/QRCode/BLEConnectionController.m
+++ b/src/darwin/CHIPTool/CHIPTool/QRCode/BLEConnectionController.m
@@ -16,6 +16,7 @@
  */
 
 #import "BLEConnectionController.h"
+#import <CHIP/CHIP.h>
 
 @interface BLEConnectionController ()
 
@@ -72,6 +73,14 @@
         [self connect:peripheral];
         [self stopScanning];
     }
+}
+
+- (void)centralManager:(CBCentralManager *)central didConnectPeripheral:(CBPeripheral *)peripheral
+{
+    NSLog(@"Did connect to peripheral: %@", peripheral);
+
+    [peripheral setDelegate:[[CHIPDeviceController sharedController] mBleDelegate]];
+    [[CHIPDeviceController sharedController] connectBle:peripheral];
 }
 
 - (void)start

--- a/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1E42A3FD24B3422E00E2BAD0 /* ChipBleDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1E42A3FC24B3422D00E2BAD0 /* ChipBleDelegate.mm */; };
+		1E42A40224B367C200E2BAD0 /* CoreBluetooth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E42A40124B367C200E2BAD0 /* CoreBluetooth.framework */; };
+		1E42A40524B369E800E2BAD0 /* ChipBleDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E42A3F524B33D1100E2BAD0 /* ChipBleDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2C4DF09E248B2C60009307CB /* libmbedtls.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2C4DF09D248B2C60009307CB /* libmbedtls.a */; };
 		515C401C2486BF43004C4DB3 /* CHIPOnOff.mm in Sources */ = {isa = PBXBuildFile; fileRef = 515C401A2486BF43004C4DB3 /* CHIPOnOff.mm */; };
 		515C401D2486BF43004C4DB3 /* CHIPOnOff.h in Headers */ = {isa = PBXBuildFile; fileRef = 515C401B2486BF43004C4DB3 /* CHIPOnOff.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -41,6 +44,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1E42A3F524B33D1100E2BAD0 /* ChipBleDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ChipBleDelegate.h; sourceTree = "<group>"; };
+		1E42A3FC24B3422D00E2BAD0 /* ChipBleDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ChipBleDelegate.mm; sourceTree = "<group>"; };
+		1E42A3FE24B342FE00E2BAD0 /* ChipBleDelegate_Protected.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ChipBleDelegate_Protected.h; sourceTree = "<group>"; };
+		1E42A40124B367C200E2BAD0 /* CoreBluetooth.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreBluetooth.framework; path = System/Library/Frameworks/CoreBluetooth.framework; sourceTree = SDKROOT; };
 		2C4DF09D248B2C60009307CB /* libmbedtls.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libmbedtls.a; path = lib/libmbedtls.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		515C401A2486BF43004C4DB3 /* CHIPOnOff.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPOnOff.mm; sourceTree = "<group>"; };
 		515C401B2486BF43004C4DB3 /* CHIPOnOff.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPOnOff.h; sourceTree = "<group>"; };
@@ -72,6 +79,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1E42A40224B367C200E2BAD0 /* CoreBluetooth.framework in Frameworks */,
 				BA09EB43247477BA00605257 /* libCHIP.a in Frameworks */,
 				2C4DF09E248B2C60009307CB /* libmbedtls.a in Frameworks */,
 				BA09EB44247477BC00605257 /* libSetupPayload.a in Frameworks */,
@@ -128,6 +136,9 @@
 				515C401B2486BF43004C4DB3 /* CHIPOnOff.h */,
 				515C401A2486BF43004C4DB3 /* CHIPOnOff.mm */,
 				B20252912459E34F00F97062 /* Info.plist */,
+				1E42A3F524B33D1100E2BAD0 /* ChipBleDelegate.h */,
+				1E42A3FC24B3422D00E2BAD0 /* ChipBleDelegate.mm */,
+				1E42A3FE24B342FE00E2BAD0 /* ChipBleDelegate_Protected.h */,
 			);
 			path = CHIP;
 			sourceTree = "<group>";
@@ -144,6 +155,7 @@
 		BA09EB3E2474762900605257 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				1E42A40124B367C200E2BAD0 /* CoreBluetooth.framework */,
 				2C4DF09D248B2C60009307CB /* libmbedtls.a */,
 				BA09EB3F2474762900605257 /* libCHIP.a */,
 				BA09EB402474762900605257 /* libSetupPayload.a */,
@@ -163,6 +175,7 @@
 				B2E0D7B1245B0B5C003C5B48 /* CHIP.h in Headers */,
 				B2E0D7B8245B0B5C003C5B48 /* CHIPSetupPayload.h in Headers */,
 				B2E0D7B5245B0B5C003C5B48 /* CHIPQRCodeSetupPayloadParser.h in Headers */,
+				1E42A40524B369E800E2BAD0 /* ChipBleDelegate.h in Headers */,
 				515C401D2486BF43004C4DB3 /* CHIPOnOff.h in Headers */,
 				991DC08B247704DC00C13860 /* CHIPLogging.h in Headers */,
 				B2E0D7B4245B0B5C003C5B48 /* CHIPError.h in Headers */,
@@ -292,6 +305,7 @@
 			files = (
 				515C401C2486BF43004C4DB3 /* CHIPOnOff.mm in Sources */,
 				991DC0892475F47D00C13860 /* CHIPDeviceController.mm in Sources */,
+				1E42A3FD24B3422E00E2BAD0 /* ChipBleDelegate.mm in Sources */,
 				B2E0D7B7245B0B5C003C5B48 /* CHIPQRCodeSetupPayloadParser.mm in Sources */,
 				C4C222C02475A38700984173 /* CHIPLogging.mm in Sources */,
 				B2E0D7B3245B0B5C003C5B48 /* CHIPError.mm in Sources */,

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -19,6 +19,8 @@
 #define CHIP_DEVICE_CONTROLLER_H
 
 #import "CHIPError.h"
+#import "ChipBleDelegate.h"
+#import <CoreBluetooth/CoreBluetooth.h>
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -46,6 +48,13 @@ typedef void (^ControllerOnErrorBlock)(NSError * error);
 - (BOOL)sendCHIPCommand:(uint16_t)cluster command:(uint16_t)command;
 - (BOOL)disconnect:(NSError * __autoreleasing *)error;
 - (BOOL)isConnected;
+
+@property (strong) PreparationCompleteHandler BleConnectionPreparationCompleteHandler;
+@property (readonly) CBPeripheral * blePeripheral;
+@property (atomic, readonly) dispatch_queue_t WorkQueue;
+@property (atomic, strong, readonly) ChipBleDelegate * mBleDelegate;
+
+- (void)connectBle:(CBPeripheral *)peripheral;
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;

--- a/src/darwin/Framework/CHIP/ChipBleDelegate.h
+++ b/src/darwin/Framework/CHIP/ChipBleDelegate.h
@@ -1,0 +1,131 @@
+/**
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2015-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines ChipBleDelegate interface
+ *
+ */
+
+#import "CHIPError.h"
+#import <CoreBluetooth/CoreBluetooth.h>
+
+@class CHIPDeviceController;
+
+typedef void (^PreparationCompleteHandler)(CHIPDeviceController * dm, CHIP_ERROR err);
+
+@interface ChipBleDelegate : NSObject <CBPeripheralDelegate>
+
+/*
+ * \defgroup BlePlatformDelegate
+ * @{
+ */
+
+/*
+ *  @brief Command from BleLayer to subscribe to a characteristic
+ */
+- (bool)SubscribeCharacteristic:(id)connObj service:(const CBUUID *)svcId characteristic:(const CBUUID *)charId;
+
+/*
+ *  @brief Command from BleLayer to unsubscribe a characteristic
+ */
+- (bool)UnsubscribeCharacteristic:(id)connObj service:(const CBUUID *)svcId characteristic:(const CBUUID *)charId;
+
+/*
+ *  @brief Command from BleLayer to close the underlying BLE connection
+ */
+- (bool)CloseConnection:(id)connObj;
+
+/*
+ *  @brief Command from BleLayer to retrieve the current MTU of the BLE connection
+ */
+- (uint16_t)GetMTU:(id)connObj;
+
+/*
+ *  @brief Command from BleLayer to send indication
+ */
+- (bool)SendIndication:(id)connObj service:(const CBUUID *)svcId characteristic:(const CBUUID *)charId data:(const NSData *)buf;
+
+/*
+ *  @brief Command from BleLayer to send write request
+ */
+- (bool)SendWriteRequest:(id)connObj service:(const CBUUID *)svcId characteristic:(const CBUUID *)charId data:(const NSData *)buf;
+
+/*
+ *  @brief Command from BleLayer to send read request
+ */
+- (bool)SendReadRequest:(id)connObj service:(const CBUUID *)svcId characteristic:(const CBUUID *)charId data:(const NSData *)buf;
+
+/*
+ *  @brief Command from BleLayer to send read response
+ */
+- (bool)SendReadResponse:(id)connObj
+          requestContext:(id)readContext
+                 service:(const CBUUID *)svcId
+          characteristic:(const CBUUID *)charId;
+
+/*
+ * @}
+ */
+
+/*
+ * \defgroup BleApplicationDelegate
+ * @{
+ */
+
+/*
+ *  @brief Notification from BleLayer when the BLE connection is no longer needed by CHIP
+ */
+- (void)NotifyChipConnectionClosed:(id)connObj;
+/*
+ * @}
+ */
+
+/*
+ *  @brief Create an instance which fails all BLE activity
+ */
+- (instancetype)initDummyDelegate;
+
+/*
+ *  @brief Create an instance which drives all BLE activity in given CoreBluetooth work queue
+ */
+- (instancetype)init:(dispatch_queue_t)cbWorkQueue;
+
+/*
+ *  @brief Returns true if the CBPeripheral passed in is under management
+ */
+- (bool)isPeripheralValid:(CBPeripheral *)peripheral;
+
+/*
+ *  @brief Command from ChipDeviceController to prepare the CBPeripheral contained in the ChipDeviceController for WoBLE
+ */
+
+- (void)prepareNewBleConnection:(CHIPDeviceController *)dm;
+
+/*
+ *  @brief Send async notification to BleLayer when the underlying BLE connection is broken
+ */
+- (void)notifyBleDisconnected:(CBPeripheral *)peripheral;
+
+/*
+ *  @brief Command from ChipDeviceController to BleLayer so this connection is no longer managed
+ */
+- (void)forceBleDisconnect_Sync:(CBPeripheral *)peripheral;
+
+@end

--- a/src/darwin/Framework/CHIP/ChipBleDelegate.mm
+++ b/src/darwin/Framework/CHIP/ChipBleDelegate.mm
@@ -1,0 +1,861 @@
+/**
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2015-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file provides base implementation for ChipBleDelegate interface
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "CHIPDeviceController.h"
+#import "CHIPLogging.h"
+#import "ChipBleDelegate_Protected.h"
+
+#include <ble/BleApplicationDelegate.h>
+#include <ble/BleError.h>
+#include <ble/BleLayer.h>
+#include <ble/BlePlatformDelegate.h>
+#include <support/CodeUtils.h>
+
+namespace chip {
+namespace Ble {
+    class BleDelegateTrampoline;
+}
+}
+
+using chip::System::PacketBuffer;
+
+@interface ChipBleDelegate () {
+    chip::Ble::BleDelegateTrampoline * _mTrampoline;
+    dispatch_queue_t _mCbWorkQueue;
+    NSMapTable * _mMapFromPeripheralToDc;
+
+    // cached static Chip service UUID
+    CBUUID * _mChipServiceUUID;
+
+    chip::Ble::BleLayer * _mBleLayer;
+}
+
++ (CBUUID *)GetShortestServiceUUID:(const chip::Ble::ChipBleUUID *)svcId;
+
+@end
+
+namespace chip {
+namespace Ble {
+
+    class BleDelegateTrampoline : public BleApplicationDelegate, public BlePlatformDelegate {
+    public:
+        BleDelegateTrampoline(ChipBleDelegate * pBleDelegate);
+        virtual bool SubscribeCharacteristic(BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId);
+        virtual bool UnsubscribeCharacteristic(
+            BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId);
+        virtual bool CloseConnection(BLE_CONNECTION_OBJECT connObj);
+        virtual uint16_t GetMTU(BLE_CONNECTION_OBJECT connObj) const;
+        virtual bool SendIndication(
+            BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId, PacketBuffer * pBuf);
+        virtual bool SendWriteRequest(
+            BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId, PacketBuffer * pBuf);
+        virtual bool SendReadRequest(
+            BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId, PacketBuffer * pBuf);
+        virtual bool SendReadResponse(BLE_CONNECTION_OBJECT connObj, BLE_READ_REQUEST_CONTEXT requestContext,
+            const Ble::ChipBleUUID * svcId, const ChipBleUUID * charId);
+
+        virtual void NotifyChipConnectionClosed(BLE_CONNECTION_OBJECT connObj);
+
+    private:
+        /**
+            An weak reference to the parenting delegate object, can be nil.
+            @note
+              It has to be weak to avoid circular references
+         */
+        __weak ChipBleDelegate * mBleDelegate;
+    };
+
+    BleDelegateTrampoline::BleDelegateTrampoline(ChipBleDelegate * pBleDelegate)
+        : mBleDelegate(pBleDelegate)
+    {
+    }
+
+    /**
+        @note
+          This method is only called from BleLayer
+     */
+    bool BleDelegateTrampoline::SubscribeCharacteristic(
+        BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId)
+    {
+        bool result = false;
+        CBUUID * service = nil;
+        CBUUID * characteristic = nil;
+
+        VerifyOrExit(mBleDelegate, CHIP_LOG_ERROR("BLE not configured properly\n"));
+
+        if (NULL != svcId) {
+            service = [ChipBleDelegate GetShortestServiceUUID:svcId];
+        }
+        if (NULL != charId) {
+            characteristic = [CBUUID UUIDWithData:[NSData dataWithBytes:charId->bytes length:sizeof(charId->bytes)]];
+        }
+
+        result = [mBleDelegate SubscribeCharacteristic:(__bridge id) connObj service:service characteristic:characteristic];
+
+    exit:
+        return result;
+    }
+
+    /**
+        @note
+          This method is only called from BleLayer
+     */
+    bool BleDelegateTrampoline::UnsubscribeCharacteristic(
+        BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId)
+    {
+        bool result = false;
+        CBUUID * service = nil;
+        CBUUID * characteristic = nil;
+
+        VerifyOrExit(mBleDelegate, CHIP_LOG_ERROR("BLE not configured properly\n"));
+
+        if (NULL != svcId) {
+            service = [ChipBleDelegate GetShortestServiceUUID:svcId];
+        }
+        if (NULL != charId) {
+            characteristic = [CBUUID UUIDWithData:[NSData dataWithBytes:charId->bytes length:sizeof(charId->bytes)]];
+        }
+
+        result = [mBleDelegate UnsubscribeCharacteristic:(__bridge id) connObj service:service characteristic:characteristic];
+
+    exit:
+        return result;
+    }
+
+    /**
+        @note
+          This method is only called from BleLayer
+     */
+    bool BleDelegateTrampoline::CloseConnection(BLE_CONNECTION_OBJECT connObj)
+    {
+        bool result = false;
+
+        VerifyOrExit(mBleDelegate, CHIP_LOG_ERROR("BLE not configured properly\n"));
+
+        result = [mBleDelegate CloseConnection:(__bridge id) connObj];
+
+    exit:
+        return result;
+    }
+
+    /**
+        @note
+          This method is only called from BleLayer
+     */
+    uint16_t BleDelegateTrampoline::GetMTU(BLE_CONNECTION_OBJECT connObj) const
+    {
+        bool result = false;
+
+        VerifyOrExit(mBleDelegate, CHIP_LOG_ERROR("BLE not configured properly\n"));
+
+        result = [mBleDelegate GetMTU:(__bridge id) connObj];
+
+    exit:
+        return result;
+    }
+
+    /**
+        @note
+          This method is only called from BleLayer
+     */
+    bool BleDelegateTrampoline::SendIndication(
+        BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId, PacketBuffer * pBuf)
+    {
+        bool result = false;
+        CBUUID * service = nil;
+        CBUUID * characteristic = nil;
+        NSData * data = nil;
+
+        VerifyOrExit(mBleDelegate, CHIP_LOG_ERROR("BLE not configured properly\n"));
+
+        if (NULL != svcId) {
+            service = [ChipBleDelegate GetShortestServiceUUID:svcId];
+        }
+        if (NULL != charId) {
+            characteristic = [CBUUID UUIDWithData:[NSData dataWithBytes:charId->bytes length:sizeof(charId->bytes)]];
+        }
+        if (NULL != pBuf) {
+            data = [NSData dataWithBytes:pBuf->Start() length:pBuf->DataLength()];
+        }
+
+        result = [mBleDelegate SendIndication:(__bridge id) connObj service:service characteristic:characteristic data:data];
+
+    exit:
+        // Release delegate's reference to pBuf. pBuf will be freed when both platform delegate and Chip stack free their
+        // references to it. We release pBuf's reference here since its payload bytes were copied into a new NSData object
+        PacketBuffer::Free(pBuf);
+
+        return result;
+    }
+
+    /**
+        @note
+          This method is only called from BleLayer
+     */
+    bool BleDelegateTrampoline::SendWriteRequest(
+        BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId, PacketBuffer * pBuf)
+    {
+        bool result = false;
+        CBUUID * service = nil;
+        CBUUID * characteristic = nil;
+        NSData * data = nil;
+
+        VerifyOrExit(mBleDelegate, CHIP_LOG_ERROR("BLE not configured properly\n"));
+
+        if (NULL != svcId) {
+            service = [ChipBleDelegate GetShortestServiceUUID:svcId];
+        }
+        if (NULL != charId) {
+            characteristic = [CBUUID UUIDWithData:[NSData dataWithBytes:charId->bytes length:sizeof(charId->bytes)]];
+        }
+        if (NULL != pBuf) {
+            data = [NSData dataWithBytes:pBuf->Start() length:pBuf->DataLength()];
+        }
+
+        result = [mBleDelegate SendWriteRequest:(__bridge id) connObj service:service characteristic:characteristic data:data];
+
+    exit:
+        // Release delegate's reference to pBuf. pBuf will be freed when both platform delegate and Chip stack free their
+        // references to it. We release pBuf's reference here since its payload bytes were copied into a new NSData object
+        PacketBuffer::Free(pBuf);
+
+        return result;
+    }
+
+    /**
+        @note
+          This method is only called from BleLayer
+     */
+    bool BleDelegateTrampoline::SendReadRequest(
+        BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId, PacketBuffer * pBuf)
+    {
+        bool result = false;
+        CBUUID * service = nil;
+        CBUUID * characteristic = nil;
+        NSData * data = nil;
+
+        VerifyOrExit(mBleDelegate, CHIP_LOG_ERROR("BLE not configured properly\n"));
+
+        if (NULL != svcId) {
+            service = [ChipBleDelegate GetShortestServiceUUID:svcId];
+        }
+        if (NULL != charId) {
+            characteristic = [CBUUID UUIDWithData:[NSData dataWithBytes:charId->bytes length:sizeof(charId->bytes)]];
+        }
+        if (NULL != pBuf) {
+            data = [NSData dataWithBytes:pBuf->Start() length:pBuf->DataLength()];
+        }
+
+        // Release delegate's reference to pBuf. pBuf will be freed when both platform delegate and Chip stack free their
+        // references to it. We release pBuf's reference here since its payload bytes were copied into a new NSData object
+        PacketBuffer::Free(pBuf);
+
+        result = [mBleDelegate SendReadRequest:(__bridge id) connObj service:service characteristic:characteristic data:data];
+
+    exit:
+        // Release delegate's reference to pBuf. pBuf will be freed when both platform delegate and Chip stack free their
+        // references to it. We release pBuf's reference here since its payload bytes were copied into a new NSData object
+        PacketBuffer::Free(pBuf);
+
+        return result;
+    }
+
+    /**
+        @note
+          This method is only called from BleLayer
+     */
+    bool BleDelegateTrampoline::SendReadResponse(BLE_CONNECTION_OBJECT connObj, BLE_READ_REQUEST_CONTEXT requestContext,
+        const ChipBleUUID * svcId, const ChipBleUUID * charId)
+    {
+        bool result = false;
+        CBUUID * service = nil;
+        CBUUID * characteristic = nil;
+
+        VerifyOrExit(mBleDelegate, CHIP_LOG_ERROR("BLE not configured properly\n"));
+
+        if (NULL != svcId) {
+            service = [ChipBleDelegate GetShortestServiceUUID:svcId];
+        }
+        if (NULL != charId) {
+            characteristic = [CBUUID UUIDWithData:[NSData dataWithBytes:charId->bytes length:sizeof(charId->bytes)]];
+        }
+
+        result = [mBleDelegate SendReadResponse:(__bridge id) connObj
+                                 requestContext:(__bridge id) requestContext
+                                        service:service
+                                 characteristic:characteristic];
+
+    exit:
+        return result;
+    }
+
+    /**
+        @note
+          This method is only called from BleLayer
+     */
+    void BleDelegateTrampoline::NotifyChipConnectionClosed(BLE_CONNECTION_OBJECT connObj)
+    {
+        VerifyOrExit(mBleDelegate, CHIP_LOG_ERROR("BLE not configured properly\n"));
+
+        [mBleDelegate NotifyChipConnectionClosed:(__bridge id) connObj];
+
+    exit:;
+    }
+
+} /* namespace Ble */
+} /* namespace chip*/
+
+@implementation ChipBleDelegate
+
+- (instancetype)initDummyDelegate
+{
+    self = [super init];
+    VerifyOrExit(self, CHIP_LOG_ERROR("Memory allocation failure\n"));
+
+    _mTrampoline = new chip::Ble::BleDelegateTrampoline(NULL);
+
+exit:
+    return self;
+}
+
+- (instancetype)init:(dispatch_queue_t)cbWorkQueue
+{
+    self = [super init];
+    VerifyOrExit(self, CHIP_LOG_ERROR("Memory allocation failure\n"));
+
+    _mTrampoline = new chip::Ble::BleDelegateTrampoline(self);
+
+    _mCbWorkQueue = cbWorkQueue;
+
+    _mMapFromPeripheralToDc = [NSMapTable strongToWeakObjectsMapTable];
+
+    _mChipServiceUUID = [ChipBleDelegate GetShortestServiceUUID:&chip::Ble::CHIP_BLE_SVC_ID];
+
+exit:
+    return self;
+}
+
+- (void)dealloc
+{
+    delete _mTrampoline;
+    _mTrampoline = NULL;
+}
+
+/**
+ @note
+ This method is only called from BleLayer
+ */
+- (chip::Ble::BlePlatformDelegate *)GetPlatformDelegate
+{
+    return _mTrampoline;
+}
+
+/**
+ @note
+ This method is only called from BleLayer
+ */
+- (chip::Ble::BleApplicationDelegate *)GetApplicationDelegate
+{
+    return _mTrampoline;
+}
+
+- (void)SetBleLayer:(chip::Ble::BleLayer *)BleLayer
+{
+    _mBleLayer = BleLayer;
+}
+
++ (CBUUID *)GetShortestServiceUUID:(const chip::Ble::ChipBleUUID *)svcId
+{
+    // TODO Implement and validate that all the code paths works with a shorter service uuid
+    return [CBUUID UUIDWithData:[NSData dataWithBytes:svcId->bytes length:16]];
+}
+
+/**
+ * private static method to copy service and characteristic UUIDs from CBCharacteristic to a pair of ChipBleUUID objects.
+ * this is used in calls into Chip layer to decouple it from CoreBluetooth
+ *
+ * @param[in] characteristic the source characteristic
+ * @param[in] svcId the destination service UUID
+ * @param[in] charId the destination characteristic UUID
+ *
+ */
++ (void)fillServiceWithCharacteristicUuids:(CBCharacteristic *)characteristic
+                                     svcId:(chip::Ble::ChipBleUUID *)svcId
+                                    charId:(chip::Ble::ChipBleUUID *)charId
+{
+    static const size_t FullUUIDLength = 16;
+    if ((FullUUIDLength != sizeof(charId->bytes)) || (FullUUIDLength != sizeof(svcId->bytes))
+        || (FullUUIDLength != characteristic.UUID.data.length)) {
+        // we're dead. we expect the data length to be the same (16-byte) across the board
+        CHIP_LOG_ERROR("[%s] UUID of characteristic is incompatible", __PRETTY_FUNCTION__);
+        return;
+    }
+
+    memcpy(charId->bytes, characteristic.UUID.data.bytes, sizeof(charId->bytes));
+    memset(svcId->bytes, 0, sizeof(svcId->bytes));
+
+    // Expand service UUID back to 16-byte long as that's what the BLE Layer expects
+    // this is a buffer pre-filled with BLE service UUID Base
+    // byte 0 to 3 are reserved for shorter versions of BLE service UUIDs
+    // For 4-byte service UUIDs, all bytes from 0 to 3 are used
+    // For 2-byte service UUIDs, byte 0 and 1 shall be 0
+    uint8_t serviceFullUUID[FullUUIDLength]
+        = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0x80, 0x5F, 0x9B, 0x34, 0xFB };
+
+    switch (characteristic.service.UUID.data.length) {
+    case 2:
+        // copy the 2-byte service UUID onto the right offset
+        memcpy(serviceFullUUID + 2, characteristic.service.UUID.data.bytes, 2);
+        break;
+    case 4:
+        // flow through
+    case 16:
+        memcpy(serviceFullUUID, characteristic.service.UUID.data.bytes, characteristic.service.UUID.data.length);
+        break;
+    default:
+        // we're dead. we expect the data length to be the same (16-byte) across the board
+        CHIP_LOG_ERROR("[%s] Service UUIDs are incompatible", __PRETTY_FUNCTION__);
+    }
+    memcpy(svcId->bytes, serviceFullUUID, sizeof(svcId->bytes));
+}
+
+// This is only used by ChipDeviceController
+- (void)prepareNewBleConnection:(CHIPDeviceController *)dc
+{
+    CHIP_LOG_DEBUG("Mapping device manager %@ to peripheral %@", dc, dc.blePeripheral);
+
+    dispatch_async(_mCbWorkQueue, ^{
+        [_mMapFromPeripheralToDc setObject:dc forKey:dc.blePeripheral];
+
+        [dc.blePeripheral discoverServices:@[ _mChipServiceUUID ]];
+    });
+}
+
+- (bool)isPeripheralValid:(CBPeripheral *)peripheral
+{
+    CHIPDeviceController * dc = [_mMapFromPeripheralToDc objectForKey:peripheral];
+    return (dc != nil) ? true : false;
+}
+
+- (void)forceBleDisconnect_Sync:(CBPeripheral *)peripheral
+{
+    // force BleLayer to forget about this connObj
+    _mBleLayer->HandleConnectionError((__bridge void *) peripheral, BLE_ERROR_REMOTE_DEVICE_DISCONNECTED);
+}
+
+- (void)notifyBleDisconnected:(CBPeripheral *)peripheral
+{
+    CHIPDeviceController * dc = [_mMapFromPeripheralToDc objectForKey:peripheral];
+    if (dc == nil) {
+        CHIP_LOG_ERROR("[%s] Cannot find a matching device manager for peripheral %@", __PRETTY_FUNCTION__, peripheral);
+    }
+
+    if (dc == nil || dc.BleConnectionPreparationCompleteHandler == nil) {
+        dispatch_async([[CHIPDeviceController sharedController] WorkQueue], ^{
+            _mBleLayer->HandleConnectionError((__bridge void *) peripheral, BLE_ERROR_REMOTE_DEVICE_DISCONNECTED);
+        });
+    } else {
+        dispatch_async([[CHIPDeviceController sharedController] WorkQueue], ^{
+            PreparationCompleteHandler handler = dc.BleConnectionPreparationCompleteHandler;
+            dc.BleConnectionPreparationCompleteHandler = nil;
+            handler(dc, BLE_ERROR_REMOTE_DEVICE_DISCONNECTED);
+        });
+    }
+}
+
+/**
+ * part of CBPeripheralDelegate.
+ * called after service discovery is done. report failure to attach completed block on error, otherwise
+ * proceed with characteristic discovery
+ */
+- (void)peripheral:(CBPeripheral *)peripheral didDiscoverServices:(NSError *)error
+{
+    // we're in Core Bluetooth work queue
+
+    CHIPDeviceController * dc = [_mMapFromPeripheralToDc objectForKey:peripheral];
+    if (dc == nil) {
+        CHIP_LOG_ERROR("[%s] Cannot find a matching device manager for peripheral %@", __PRETTY_FUNCTION__, peripheral);
+        return;
+    }
+
+    bool found = false;
+
+    if (nil != error) {
+        CHIP_LOG_ERROR("[%s] BLE:Error finding Chip Service in the device: [%@]", __PRETTY_FUNCTION__, error.localizedDescription);
+    } else {
+        for (CBService * service in peripheral.services) {
+            CHIP_LOG_DEBUG("Found service in device: %@", service.UUID);
+
+            // XXX for some reason one is short the other is not...
+            if ([service.UUID.data isEqualToData:_mChipServiceUUID.data]) {
+                found = true;
+
+                [peripheral discoverCharacteristics:nil forService:service];
+
+                break;
+            }
+        }
+    }
+
+    if (!found) {
+        CHIP_LOG_ERROR("[%s] Cannot find Chip service on peripheral %@", __PRETTY_FUNCTION__, peripheral);
+        dispatch_async([[CHIPDeviceController sharedController] WorkQueue], ^{
+            PreparationCompleteHandler handler = dc.BleConnectionPreparationCompleteHandler;
+            dc.BleConnectionPreparationCompleteHandler = nil;
+            handler(dc, BLE_ERROR_NOT_CHIP_DEVICE);
+        });
+    }
+}
+
+/**
+ * part of CBPeripheralDelegate.
+ * called after characteristic discovery is done. execute attach completed block and report error or success
+ */
+- (void)peripheral:(CBPeripheral *)peripheral didDiscoverCharacteristicsForService:(CBService *)service error:(NSError *)error
+{
+    // we're in Core Bluetooth work queue
+
+    CHIPDeviceController * dc = [_mMapFromPeripheralToDc objectForKey:peripheral];
+    if (dc == nil) {
+        CHIP_LOG_ERROR("[%s] Cannot find a matching device manager for peripheral %@", __PRETTY_FUNCTION__, peripheral);
+        return;
+    }
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (nil != error) {
+        CHIP_LOG_ERROR("[%s] BLE:Error finding Characteristics in Chip service on the device: [%@]", __PRETTY_FUNCTION__,
+            error.localizedDescription);
+        err = BLE_ERROR_NOT_CHIP_DEVICE;
+    }
+
+    // we're good to go
+    dispatch_async([[CHIPDeviceController sharedController] WorkQueue], ^{
+        PreparationCompleteHandler handler = dc.BleConnectionPreparationCompleteHandler;
+        dc.BleConnectionPreparationCompleteHandler = nil;
+        handler(dc, err);
+    });
+}
+
+/**
+ * part of CBPeripheralDelegate.
+ * called after writing completes. call BleLayer for both error and success
+ */
+- (void)peripheral:(CBPeripheral *)peripheral
+    didWriteValueForCharacteristic:(CBCharacteristic *)characteristic
+                             error:(NSError *)error
+{
+    // we're in Core Bluetooth work queue
+    CHIPDeviceController * dc = [_mMapFromPeripheralToDc objectForKey:peripheral];
+    if (dc == nil) {
+        CHIP_LOG_ERROR("[%s] Cannot find a matching device manager for peripheral %@", __PRETTY_FUNCTION__, peripheral);
+        return;
+    }
+
+    if (nil == error) {
+        dispatch_async([[CHIPDeviceController sharedController] WorkQueue], ^{
+            chip::Ble::ChipBleUUID svcId;
+            chip::Ble::ChipBleUUID charId;
+            [ChipBleDelegate fillServiceWithCharacteristicUuids:characteristic svcId:&svcId charId:&charId];
+            _mBleLayer->HandleWriteConfirmation((__bridge void *) peripheral, &svcId, &charId);
+        });
+    } else {
+        CHIP_LOG_ERROR("[%s] BLE:Error writing Characteristics in Chip service on the device: [%@]", __PRETTY_FUNCTION__,
+            error.localizedDescription);
+
+        dispatch_async([[CHIPDeviceController sharedController] WorkQueue], ^{
+            _mBleLayer->HandleConnectionError((__bridge void *) peripheral, BLE_ERROR_GATT_WRITE_FAILED);
+        });
+    }
+}
+
+/**
+ * part of CBPeripheralDelegate.
+ * called after characteristic subscription update is done. call BleLayer for both error and success
+ */
+- (void)peripheral:(CBPeripheral *)peripheral
+    didUpdateNotificationStateForCharacteristic:(CBCharacteristic *)characteristic
+                                          error:(NSError *)error
+{
+    // we're in Core Bluetooth work queue
+
+    CHIPDeviceController * dc = [_mMapFromPeripheralToDc objectForKey:peripheral];
+    if (dc == nil) {
+        CHIP_LOG_ERROR("[%s] Cannot find a matching device manager for peripheral %@", __PRETTY_FUNCTION__, peripheral);
+        return;
+    }
+
+    bool isNotifying = characteristic.isNotifying;
+
+    if (nil == error) {
+        dispatch_async([[CHIPDeviceController sharedController] WorkQueue], ^{
+            chip::Ble::ChipBleUUID svcId;
+            chip::Ble::ChipBleUUID charId;
+            [ChipBleDelegate fillServiceWithCharacteristicUuids:characteristic svcId:&svcId charId:&charId];
+
+            if (isNotifying) {
+                _mBleLayer->HandleSubscribeComplete((__bridge void *) peripheral, &svcId, &charId);
+            } else {
+                _mBleLayer->HandleUnsubscribeComplete((__bridge void *) peripheral, &svcId, &charId);
+            }
+        });
+    } else {
+        CHIP_LOG_ERROR("[%s] BLE:Error subscribing/unsubcribing some characteristic on the device: [%@]", __PRETTY_FUNCTION__,
+            error.localizedDescription);
+
+        dispatch_async([[CHIPDeviceController sharedController] WorkQueue], ^{
+            if (isNotifying) {
+                // we're still notifying, so we must failed the unsubscription
+                _mBleLayer->HandleConnectionError((__bridge void *) peripheral, BLE_ERROR_GATT_UNSUBSCRIBE_FAILED);
+            } else {
+                // we're not notifying, so we must failed the subscription
+                _mBleLayer->HandleConnectionError((__bridge void *) peripheral, BLE_ERROR_GATT_SUBSCRIBE_FAILED);
+            }
+        });
+    }
+}
+
+/**
+ * part of CBPeripheralDelegate.
+ * called when indication of some characteristic arrives. call BleLayer for both error and success
+ */
+- (void)peripheral:(CBPeripheral *)peripheral
+    didUpdateValueForCharacteristic:(CBCharacteristic *)characteristic
+                              error:(NSError *)error
+{
+    // we're in Core Bluetooth work queue
+
+    CHIPDeviceController * dc = [_mMapFromPeripheralToDc objectForKey:peripheral];
+    if (dc == nil) {
+        CHIP_LOG_ERROR("[%s] Cannot find a matching device manager for peripheral %@", __PRETTY_FUNCTION__, peripheral);
+        return;
+    }
+
+    if (nil == error) {
+        dispatch_async([[CHIPDeviceController sharedController] WorkQueue], ^{
+            chip::Ble::ChipBleUUID svcId;
+            chip::Ble::ChipBleUUID charId;
+            [ChipBleDelegate fillServiceWithCharacteristicUuids:characteristic svcId:&svcId charId:&charId];
+
+            PacketBuffer * msgBuf;
+            // build a inet buffer from the rxEv and send to blelayer.
+            msgBuf = PacketBuffer::New();
+
+            if (NULL != msgBuf) {
+                memcpy(msgBuf->Start(), characteristic.value.bytes, characteristic.value.length);
+                msgBuf->SetDataLength(characteristic.value.length);
+
+                if (!_mBleLayer->HandleIndicationReceived((__bridge void *) peripheral, &svcId, &charId, msgBuf)) {
+                    // since this error comes from device manager core
+                    // we assume it would do the right thing, like closing the connection
+                    CHIP_LOG_ERROR("[%s] Failed at handling incoming BLE data", __PRETTY_FUNCTION__);
+                }
+            } else {
+                CHIP_LOG_ERROR("[%s] Failed at allocating buffer for incoming BLE data", __PRETTY_FUNCTION__);
+
+                _mBleLayer->HandleConnectionError((__bridge void *) peripheral, CHIP_ERROR_NO_MEMORY);
+            }
+        });
+    } else {
+        CHIP_LOG_ERROR("[%s] BLE:Error receiving indication of Characteristics on the device: [%@]", __PRETTY_FUNCTION__,
+            error.localizedDescription);
+
+        dispatch_async([[CHIPDeviceController sharedController] WorkQueue], ^{
+            _mBleLayer->HandleConnectionError((__bridge void *) peripheral, BLE_ERROR_GATT_INDICATE_FAILED);
+        });
+    }
+}
+
+/**
+ @note
+ This method is only called from BleLayer
+ */
+- (bool)SubscribeCharacteristic:(id)connObj service:(const CBUUID *)svcId characteristic:(const CBUUID *)charId
+{
+    dispatch_async(_mCbWorkQueue, ^{
+        CBPeripheral * peripheral = (CBPeripheral *) connObj;
+        CHIPDeviceController * dc = [_mMapFromPeripheralToDc objectForKey:peripheral];
+
+        bool found = false;
+
+        for (CBService * service in dc.blePeripheral.services) {
+            if ([service.UUID.data isEqualToData:svcId.data]) {
+                for (CBCharacteristic * characteristic in service.characteristics) {
+                    if ([characteristic.UUID.data isEqualToData:charId.data]) {
+                        found = true;
+                        dispatch_async(_mCbWorkQueue, ^{
+                            [dc.blePeripheral setNotifyValue:true forCharacteristic:characteristic];
+                        });
+                    }
+                }
+            }
+        }
+
+        if (!found) {
+            CHIP_LOG_ERROR("[%s] Target peripheral doesn't have the specified service or characteristic", __PRETTY_FUNCTION__);
+
+            dispatch_async([[CHIPDeviceController sharedController] WorkQueue], ^{
+                _mBleLayer->HandleConnectionError((__bridge void *) dc.blePeripheral, BLE_ERROR_NOT_CHIP_DEVICE);
+            });
+        }
+    });
+
+    return true;
+}
+
+/**
+ @note
+ This method is only called from BleLayer
+ */
+- (bool)UnsubscribeCharacteristic:(id)connObj service:(const CBUUID *)svcId characteristic:(const CBUUID *)charId
+{
+    dispatch_async(_mCbWorkQueue, ^{
+        CBPeripheral * peripheral = (CBPeripheral *) connObj;
+        CHIPDeviceController * dc = [_mMapFromPeripheralToDc objectForKey:peripheral];
+
+        bool found = false;
+
+        for (CBService * service in dc.blePeripheral.services) {
+            if ([service.UUID.data isEqualToData:svcId.data]) {
+                for (CBCharacteristic * characteristic in service.characteristics) {
+                    if ([characteristic.UUID.data isEqualToData:charId.data]) {
+                        found = true;
+                        dispatch_async(_mCbWorkQueue, ^{
+                            [dc.blePeripheral setNotifyValue:false forCharacteristic:characteristic];
+                        });
+                    }
+                }
+            }
+        }
+
+        if (!found) {
+            CHIP_LOG_ERROR("[%s] Target peripheral doesn't have the specified service or characteristic", __PRETTY_FUNCTION__);
+
+            dispatch_async([[CHIPDeviceController sharedController] WorkQueue], ^{
+                _mBleLayer->HandleConnectionError((__bridge void *) dc.blePeripheral, BLE_ERROR_NOT_CHIP_DEVICE);
+            });
+        }
+    });
+
+    return true;
+}
+
+/**
+ @note
+ This method is only called from BleLayer
+ */
+- (bool)CloseConnection:(id)connObj
+{
+    return true;
+}
+
+/**
+ @note
+ This method is only called from BleLayer
+ */
+- (uint16_t)GetMTU:(id)connObj
+{
+    return 0;
+}
+
+/**
+ @note
+ This method is only called from BleLayer
+ */
+- (bool)SendIndication:(id)connObj service:(const CBUUID *)svcId characteristic:(const CBUUID *)charId data:(const NSData *)buf
+{
+    return false;
+}
+
+/**
+ @note
+ This method is only called from BleLayer
+ */
+- (bool)SendWriteRequest:(id)connObj service:(const CBUUID *)svcId characteristic:(CBUUID *)charId data:(NSData *)buf
+{
+    dispatch_async(_mCbWorkQueue, ^{
+        CBPeripheral * peripheral = (CBPeripheral *) connObj;
+        CHIPDeviceController * dc = [_mMapFromPeripheralToDc objectForKey:peripheral];
+
+        bool found = false;
+
+        for (CBService * service in dc.blePeripheral.services) {
+            if ([service.UUID.data isEqualToData:svcId.data]) {
+                for (CBCharacteristic * characteristic in service.characteristics) {
+                    if ([characteristic.UUID.data isEqualToData:charId.data]) {
+                        found = true;
+                        dispatch_async(_mCbWorkQueue, ^{
+                            [dc.blePeripheral writeValue:buf
+                                       forCharacteristic:characteristic
+                                                    type:CBCharacteristicWriteWithResponse];
+                        });
+                    }
+                }
+            }
+        }
+
+        if (!found) {
+            CHIP_LOG_ERROR("[%s] Target peripheral doesn't have the specified service or characteristic", __PRETTY_FUNCTION__);
+
+            dispatch_async([[CHIPDeviceController sharedController] WorkQueue], ^{
+                _mBleLayer->HandleConnectionError((__bridge void *) dc.blePeripheral, BLE_ERROR_NOT_CHIP_DEVICE);
+            });
+        }
+    });
+
+    return true;
+}
+
+/**
+ @note
+ This method is only called from BleLayer
+ */
+- (bool)SendReadRequest:(id)connObj service:(const CBUUID *)svcId characteristic:(const CBUUID *)charId data:(const NSData *)buf
+{
+    return false;
+}
+
+/**
+ @note
+ This method is only called from BleLayer
+ */
+- (bool)SendReadResponse:(id)connObj
+          requestContext:(id)readContext
+                 service:(const CBUUID *)svcId
+          characteristic:(const CBUUID *)charId
+{
+    return false;
+}
+
+/**
+ @note
+ This method is only called from BleLayer
+ */
+- (void)NotifyChipConnectionClosed:(id)connObj
+{
+}
+
+@end

--- a/src/darwin/Framework/CHIP/ChipBleDelegate_Protected.h
+++ b/src/darwin/Framework/CHIP/ChipBleDelegate_Protected.h
@@ -1,6 +1,8 @@
 /**
  *
  *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2015-2017 Nest Labs, Inc.
+ *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,20 +17,26 @@
  *    limitations under the License.
  */
 
-// pull together CHIP headers
-#import <CHIP/CHIPDeviceController.h>
-#import <CHIP/CHIPError.h>
-#import <CHIP/CHIPManualSetupPayloadParser.h>
-#import <CHIP/CHIPOnOff.h>
-#import <CHIP/CHIPQRCodeSetupPayloadParser.h>
-#import <CHIP/CHIPSetupPayload.h>
-#import <CHIP/ChipBleDelegate.h>
+/**
+ *    @file
+ *      This file defines the protected part of NLWeaveBleDelegate interface
+ *
+ */
 
-#import <Foundation/Foundation.h>
-//! Project version number for CHIP.
-FOUNDATION_EXPORT double CHIPVersionNumber;
+#import "ChipBleDelegate.h"
 
-//! Project version string for CHIP.
-FOUNDATION_EXPORT const unsigned char CHIPVersionString[];
+namespace chip {
+namespace Ble {
+    class BleLayer;
+    class BlePlatformDelegate;
+    class BleApplicationDelegate;
+}
+}
 
-// In this header, you should import all the public headers of your framework using statements like #import <CHIP/PublicHeader.h>
+@interface ChipBleDelegate ()
+
+- (chip::Ble::BlePlatformDelegate *)GetPlatformDelegate;
+- (chip::Ble::BleApplicationDelegate *)GetApplicationDelegate;
+- (void)SetBleLayer:(chip::Ble::BleLayer *)BleLayer;
+
+@end


### PR DESCRIPTION
 #### Problem

This patch add BlePlatformDelegate and BleApplicationDelegate capabilities to the iOS app and allow the app to send a ping to an esp32 with a BLE echo server (#1458).

The current code of the patch basically setup a BLE connection if the QR code specify a BLE rendezvous and send a ping to the peripheral to check that the BLEEndPoint code is working.

The current patch still has some warnings about retain cycles and nil property that should not be assigned. That said those warnings comes from part of the code that I took from OW and I would like to fix them in followups since I would like to have this patch landed to move forwards.

That's a good base to move forward and the followups that I can foresee are:
 * Clean the `self`warnings
 * clean the `nil`warnings
 * Move the ble callbacks one level up so the app code access them
 * Add a view to send custom ble messages instead of the raw ping
 * show something on the UI saying that we are now connected to the peripheral and/or disconnected from the peripheral
 * while connected regularly send `ping` like commands to keep the connection active
 * Use the right callback queue
 * Unify the cpp callbacks between BLE and the transport code. Right now most of the callbacks for transports seems to assume IP and/or a secure session. We definitively needs more love there.
