### PR TITLE
[nrf5] support make -j

### DIFF
--- a/config/nrf5/nrf5-chip.mk
+++ b/config/nrf5/nrf5-chip.mk
@@ -201,11 +201,11 @@ config-chip : $(CHIP_OUTPUT_DIR)/config.status | $(OPENTHREAD_PREREQUISITE)
 
 build-chip : config-chip
 	@echo "$(HDR_PREFIX)BUILD CHIP..."
-	$(NO_ECHO)MAKEFLAGS= make -C $(CHIP_OUTPUT_DIR) --no-print-directory all V=$(VERBOSE)
+	$(NO_ECHO) $(MAKE) -C $(CHIP_OUTPUT_DIR) --no-print-directory all V=$(VERBOSE)
 
 install-chip : | build-chip
 	@echo "$(HDR_PREFIX)INSTALL CHIP..."
-	$(NO_ECHO)MAKEFLAGS= make -C $(CHIP_OUTPUT_DIR) --no-print-directory install V=$(VERBOSE)
+	$(NO_ECHO) $(MAKE) -C $(CHIP_OUTPUT_DIR) --no-print-directory install V=$(VERBOSE)
 
 clean-chip:
 	@echo "$(HDR_PREFIX)RM $(CHIP_OUTPUT_DIR)"
@@ -217,6 +217,7 @@ $(CHIP_OUTPUT_DIR) :
 
 endef
 
+$(STD_LINK_PREREQUISITES): build-chip
 
 # ==================================================
 # CHIP-specific help definitions

--- a/scripts/examples/nrf_lock_app.sh
+++ b/scripts/examples/nrf_lock_app.sh
@@ -19,4 +19,4 @@
 set -x
 env
 
-make VERBOSE=1 -C examples/lock-app/nrf5
+make -j VERBOSE=1 -C examples/lock-app/nrf5


### PR DESCRIPTION
This commit adds build-chip to dependecies of application's link targets
so that it will not output error for missing those targets if `-j` is
given.

 #### Problem
Run make -j under gets the following errors:
```bash
make: *** No rule to make target '/usr/local/google/home/xyk/Code/connectedhomeip/examples/lock-app/nrf5/build/chip/lib/libDeviceLayer.a', needed by '/usr/local/google/home/xyk/Code/connectedhomeip/examples/lock-app/nrf5/build/chip-nrf52840-lock-example.out'.  Stop.
make: *** Waiting for unfinished jobs....
```

 #### Summary of Changes
* add build-chip to dependencies of app's link targets
* use $(MAKE) so that it can get make parameters.
