### PR TITLE
Add optional qr code info parsing to SetupPayload-JNI

### DIFF
--- a/src/setup_payload/java/Makefile.am
+++ b/src/setup_payload/java/Makefile.am
@@ -86,6 +86,7 @@ JARS                                                          = \
 SetupPayloadParser_jar_JAVA_SRCS                              = \
     chip/setuppayload/SetupPayload.java                         \
     chip/setuppayload/SetupPayloadParser.java                   \
+    chip/setuppayload/OptionalQRCodeInfo.java                   \
     $(NULL)
 
 SetupPayloadParser_jar_JFLAGS                      = -source 8 -target 8

--- a/src/setup_payload/java/SetupPayloadParser-JNI.cpp
+++ b/src/setup_payload/java/SetupPayloadParser-JNI.cpp
@@ -1,5 +1,5 @@
-#include "QRCodeSetupPayloadParser.h"
 #include "ManualSetupPayloadParser.h"
+#include "QRCodeSetupPayloadParser.h"
 
 #include <jni.h>
 
@@ -7,7 +7,7 @@ using namespace chip;
 
 #define JNI_METHOD(RETURN, METHOD_NAME) extern "C" JNIEXPORT RETURN JNICALL Java_chip_setuppayload_SetupPayloadParser_##METHOD_NAME
 
-static jobject TransformSetupPayload(JNIEnv * env, SetupPayload& payload);
+static jobject TransformSetupPayload(JNIEnv * env, SetupPayload & payload);
 
 JNI_METHOD(jobject, fetchPayloadFromQrCode)(JNIEnv * env, jobject self, jstring qrCodeObj)
 {
@@ -39,7 +39,7 @@ JNI_METHOD(jobject, fetchPayloadFromManualEntryCode)(JNIEnv * env, jobject self,
     return TransformSetupPayload(env, payload);
 }
 
-jobject TransformSetupPayload(JNIEnv * env, SetupPayload& payload)
+jobject TransformSetupPayload(JNIEnv * env, SetupPayload & payload)
 {
     jclass setupPayloadClass = env->FindClass("chip/setuppayload/SetupPayload");
     jmethodID setupConstr    = env->GetMethodID(setupPayloadClass, "<init>", "()V");
@@ -59,59 +59,62 @@ jobject TransformSetupPayload(JNIEnv * env, SetupPayload& payload)
     env->SetIntField(setupPayload, discriminator, payload.discriminator);
     env->SetLongField(setupPayload, setUpPinCode, payload.setUpPINCode);
 
-    jmethodID addOptionalInfoMid = env->GetMethodID(setupPayloadClass, "addOptionalQRCodeInfo", "(Lchip/setuppayload/OptionalQRCodeInfo;)V");
+    jmethodID addOptionalInfoMid =
+        env->GetMethodID(setupPayloadClass, "addOptionalQRCodeInfo", "(Lchip/setuppayload/OptionalQRCodeInfo;)V");
 
     vector<OptionalQRCodeInfo> optional_info = payload.getAllOptionalVendorData();
-    for (OptionalQRCodeInfo& info : optional_info) {
+    for (OptionalQRCodeInfo & info : optional_info)
+    {
 
-       jclass optionalInfoClass = env->FindClass("chip/setuppayload/OptionalQRCodeInfo");
-       jobject optionalInfo     = env->AllocObject(optionalInfoClass);
-       jfieldID tag             = env->GetFieldID(optionalInfoClass, "tag", "I");
-       jfieldID type            = env->GetFieldID(optionalInfoClass, "type", "Lchip/setuppayload/OptionalQRCodeInfo$optionalQRCodeInfoType;");
-       jfieldID data            = env->GetFieldID(optionalInfoClass, "data", "Ljava/lang/String;");
-       jfieldID int32           = env->GetFieldID(optionalInfoClass, "int32", "I");
+        jclass optionalInfoClass = env->FindClass("chip/setuppayload/OptionalQRCodeInfo");
+        jobject optionalInfo     = env->AllocObject(optionalInfoClass);
+        jfieldID tag             = env->GetFieldID(optionalInfoClass, "tag", "I");
+        jfieldID type = env->GetFieldID(optionalInfoClass, "type", "Lchip/setuppayload/OptionalQRCodeInfo$optionalQRCodeInfoType;");
+        jfieldID data = env->GetFieldID(optionalInfoClass, "data", "Ljava/lang/String;");
+        jfieldID int32 = env->GetFieldID(optionalInfoClass, "int32", "I");
 
-       env->SetIntField(optionalInfo, tag, info.tag);
+        env->SetIntField(optionalInfo, tag, info.tag);
 
-       jclass enumClass = env->FindClass("chip/setuppayload/OptionalQRCodeInfo$optionalQRCodeInfoType");
-       jfieldID enumType = nullptr;
+        jclass enumClass  = env->FindClass("chip/setuppayload/OptionalQRCodeInfo$optionalQRCodeInfoType");
+        jfieldID enumType = nullptr;
 
-       switch (info.tag) {
-         case optionalQRCodeInfoTypeUnknown:
+        switch (info.tag)
+        {
+        case optionalQRCodeInfoTypeUnknown:
             enumType = env->GetStaticFieldID(enumClass, "optionalQRCodeInfoTypeUnknown",
-               "Lchip/setuppayload/OptionalQRCodeInfo$optionalQRCodeInfoType;");
+                                             "Lchip/setuppayload/OptionalQRCodeInfo$optionalQRCodeInfoType;");
             break;
-         case optionalQRCodeInfoTypeString:
+        case optionalQRCodeInfoTypeString:
             enumType = env->GetStaticFieldID(enumClass, "optionalQRCodeInfoTypeString",
-                "Lchip/setuppayload/OptionalQRCodeInfo$optionalQRCodeInfoType;");
+                                             "Lchip/setuppayload/OptionalQRCodeInfo$optionalQRCodeInfoType;");
             break;
-         case optionalQRCodeInfoTypeInt32:
+        case optionalQRCodeInfoTypeInt32:
             enumType = env->GetStaticFieldID(enumClass, "optionalQRCodeInfoTypeInt32",
-                "Lchip/setuppayload/OptionalQRCodeInfo$optionalQRCodeInfoType;");
+                                             "Lchip/setuppayload/OptionalQRCodeInfo$optionalQRCodeInfoType;");
             break;
-         case optionalQRCodeInfoTypeInt64:
+        case optionalQRCodeInfoTypeInt64:
             enumType = env->GetStaticFieldID(enumClass, "optionalQRCodeInfoTypeInt64",
-                "Lchip/setuppayload/OptionalQRCodeInfo$optionalQRCodeInfoType;");
+                                             "Lchip/setuppayload/OptionalQRCodeInfo$optionalQRCodeInfoType;");
             break;
-         case optionalQRCodeInfoTypeUInt32:
+        case optionalQRCodeInfoTypeUInt32:
             enumType = env->GetStaticFieldID(enumClass, "optionalQRCodeInfoTypeUInt32",
-                 "Lchip/setuppayload/OptionalQRCodeInfo$optionalQRCodeInfoType;");
+                                             "Lchip/setuppayload/OptionalQRCodeInfo$optionalQRCodeInfoType;");
             break;
-         case optionalQRCodeInfoTypeUInt64:
+        case optionalQRCodeInfoTypeUInt64:
             enumType = env->GetStaticFieldID(enumClass, "optionalQRCodeInfoTypeUInt64",
-                 "Lchip/setuppayload/OptionalQRCodeInfo$optionalQRCodeInfoType;");
+                                             "Lchip/setuppayload/OptionalQRCodeInfo$optionalQRCodeInfoType;");
             break;
-         default:
+        default:
             break;
-       }
+        }
 
-       jobject enumObj = env->GetStaticObjectField(enumClass, enumType);
-       env->SetObjectField(optionalInfo, type, enumObj);
+        jobject enumObj = env->GetStaticObjectField(enumClass, enumType);
+        env->SetObjectField(optionalInfo, type, enumObj);
 
-       env->SetObjectField(optionalInfo, data, env->NewStringUTF(info.data.c_str()));
-       env->SetIntField(optionalInfo, int32, info.int32);
+        env->SetObjectField(optionalInfo, data, env->NewStringUTF(info.data.c_str()));
+        env->SetIntField(optionalInfo, int32, info.int32);
 
-       env->CallVoidMethod(setupPayload, addOptionalInfoMid, optionalInfo);
+        env->CallVoidMethod(setupPayload, addOptionalInfoMid, optionalInfo);
     }
 
     return setupPayload;

--- a/src/setup_payload/java/SetupPayloadParser-JNI.cpp
+++ b/src/setup_payload/java/SetupPayloadParser-JNI.cpp
@@ -1,5 +1,5 @@
-#include "ManualSetupPayloadParser.h"
 #include "QRCodeSetupPayloadParser.h"
+#include "ManualSetupPayloadParser.h"
 
 #include <jni.h>
 
@@ -7,7 +7,7 @@ using namespace chip;
 
 #define JNI_METHOD(RETURN, METHOD_NAME) extern "C" JNIEXPORT RETURN JNICALL Java_chip_setuppayload_SetupPayloadParser_##METHOD_NAME
 
-static jobject TransformSetupPayload(JNIEnv * env, SetupPayload payload);
+static jobject TransformSetupPayload(JNIEnv * env, SetupPayload& payload);
 
 JNI_METHOD(jobject, fetchPayloadFromQrCode)(JNIEnv * env, jobject self, jstring qrCodeObj)
 {
@@ -39,10 +39,11 @@ JNI_METHOD(jobject, fetchPayloadFromManualEntryCode)(JNIEnv * env, jobject self,
     return TransformSetupPayload(env, payload);
 }
 
-jobject TransformSetupPayload(JNIEnv * env, SetupPayload payload)
+jobject TransformSetupPayload(JNIEnv * env, SetupPayload& payload)
 {
     jclass setupPayloadClass = env->FindClass("chip/setuppayload/SetupPayload");
-    jobject setupPayload     = env->AllocObject(setupPayloadClass);
+    jmethodID setupConstr    = env->GetMethodID(setupPayloadClass, "<init>", "()V");
+    jobject setupPayload     = env->NewObject(setupPayloadClass, setupConstr);
 
     jfieldID version            = env->GetFieldID(setupPayloadClass, "version", "I");
     jfieldID vendorId           = env->GetFieldID(setupPayloadClass, "vendorId", "I");
@@ -57,6 +58,61 @@ jobject TransformSetupPayload(JNIEnv * env, SetupPayload payload)
     env->SetBooleanField(setupPayload, requiresCustomFlow, payload.requiresCustomFlow);
     env->SetIntField(setupPayload, discriminator, payload.discriminator);
     env->SetLongField(setupPayload, setUpPinCode, payload.setUpPINCode);
+
+    jmethodID addOptionalInfoMid = env->GetMethodID(setupPayloadClass, "addOptionalQRCodeInfo", "(Lchip/setuppayload/OptionalQRCodeInfo;)V");
+
+    vector<OptionalQRCodeInfo> optional_info = payload.getAllOptionalVendorData();
+    for (OptionalQRCodeInfo& info : optional_info) {
+
+       jclass optionalInfoClass = env->FindClass("chip/setuppayload/OptionalQRCodeInfo");
+       jobject optionalInfo     = env->AllocObject(optionalInfoClass);
+       jfieldID tag             = env->GetFieldID(optionalInfoClass, "tag", "I");
+       jfieldID type            = env->GetFieldID(optionalInfoClass, "type", "Lchip/setuppayload/OptionalQRCodeInfo$optionalQRCodeInfoType;");
+       jfieldID data            = env->GetFieldID(optionalInfoClass, "data", "Ljava/lang/String;");
+       jfieldID int32           = env->GetFieldID(optionalInfoClass, "int32", "I");
+
+       env->SetIntField(optionalInfo, tag, info.tag);
+
+       jclass enumClass = env->FindClass("chip/setuppayload/OptionalQRCodeInfo$optionalQRCodeInfoType");
+       jfieldID enumType = nullptr;
+
+       switch (info.tag) {
+         case optionalQRCodeInfoTypeUnknown:
+            enumType = env->GetStaticFieldID(enumClass, "optionalQRCodeInfoTypeUnknown",
+               "Lchip/setuppayload/OptionalQRCodeInfo$optionalQRCodeInfoType;");
+            break;
+         case optionalQRCodeInfoTypeString:
+            enumType = env->GetStaticFieldID(enumClass, "optionalQRCodeInfoTypeString",
+                "Lchip/setuppayload/OptionalQRCodeInfo$optionalQRCodeInfoType;");
+            break;
+         case optionalQRCodeInfoTypeInt32:
+            enumType = env->GetStaticFieldID(enumClass, "optionalQRCodeInfoTypeInt32",
+                "Lchip/setuppayload/OptionalQRCodeInfo$optionalQRCodeInfoType;");
+            break;
+         case optionalQRCodeInfoTypeInt64:
+            enumType = env->GetStaticFieldID(enumClass, "optionalQRCodeInfoTypeInt64",
+                "Lchip/setuppayload/OptionalQRCodeInfo$optionalQRCodeInfoType;");
+            break;
+         case optionalQRCodeInfoTypeUInt32:
+            enumType = env->GetStaticFieldID(enumClass, "optionalQRCodeInfoTypeUInt32",
+                 "Lchip/setuppayload/OptionalQRCodeInfo$optionalQRCodeInfoType;");
+            break;
+         case optionalQRCodeInfoTypeUInt64:
+            enumType = env->GetStaticFieldID(enumClass, "optionalQRCodeInfoTypeUInt64",
+                 "Lchip/setuppayload/OptionalQRCodeInfo$optionalQRCodeInfoType;");
+            break;
+         default:
+            break;
+       }
+
+       jobject enumObj = env->GetStaticObjectField(enumClass, enumType);
+       env->SetObjectField(optionalInfo, type, enumObj);
+
+       env->SetObjectField(optionalInfo, data, env->NewStringUTF(info.data.c_str()));
+       env->SetIntField(optionalInfo, int32, info.int32);
+
+       env->CallVoidMethod(setupPayload, addOptionalInfoMid, optionalInfo);
+    }
 
     return setupPayload;
 }

--- a/src/setup_payload/java/src/chip/setuppayload/OptionalQRCodeInfo.java
+++ b/src/setup_payload/java/src/chip/setuppayload/OptionalQRCodeInfo.java
@@ -1,18 +1,17 @@
 package chip.setuppayload;
 
-public class OptionalQRCodeInfo
-{
-    enum optionalQRCodeInfoType {
-       optionalQRCodeInfoTypeUnknown,
-       optionalQRCodeInfoTypeString,
-       optionalQRCodeInfoTypeInt32,
-       optionalQRCodeInfoTypeInt64,
-       optionalQRCodeInfoTypeUInt32,
-       optionalQRCodeInfoTypeUInt64
-    };
+public class OptionalQRCodeInfo {
+  enum optionalQRCodeInfoType {
+    optionalQRCodeInfoTypeUnknown,
+    optionalQRCodeInfoTypeString,
+    optionalQRCodeInfoTypeInt32,
+    optionalQRCodeInfoTypeInt64,
+    optionalQRCodeInfoTypeUInt32,
+    optionalQRCodeInfoTypeUInt64
+  };
 
-    public int tag;
-    public optionalQRCodeInfoType type;
-    public String data;
-    public int int32;
+  public int tag;
+  public optionalQRCodeInfoType type;
+  public String data;
+  public int int32;
 };

--- a/src/setup_payload/java/src/chip/setuppayload/OptionalQRCodeInfo.java
+++ b/src/setup_payload/java/src/chip/setuppayload/OptionalQRCodeInfo.java
@@ -1,0 +1,18 @@
+package chip.setuppayload;
+
+public class OptionalQRCodeInfo
+{
+    enum optionalQRCodeInfoType {
+       optionalQRCodeInfoTypeUnknown,
+       optionalQRCodeInfoTypeString,
+       optionalQRCodeInfoTypeInt32,
+       optionalQRCodeInfoTypeInt64,
+       optionalQRCodeInfoTypeUInt32,
+       optionalQRCodeInfoTypeUInt64
+    };
+
+    public int tag;
+    public optionalQRCodeInfoType type;
+    public String data;
+    public int int32;
+};

--- a/src/setup_payload/java/src/chip/setuppayload/SetupPayload.java
+++ b/src/setup_payload/java/src/chip/setuppayload/SetupPayload.java
@@ -1,7 +1,7 @@
 package chip.setuppayload;
 
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
 
 /** Class to hold the data from the scanned QR code or manual entry code. */
 public class SetupPayload {

--- a/src/setup_payload/java/src/chip/setuppayload/SetupPayload.java
+++ b/src/setup_payload/java/src/chip/setuppayload/SetupPayload.java
@@ -1,5 +1,8 @@
 package chip.setuppayload;
 
+import java.util.Map;
+import java.util.HashMap;
+
 /** Class to hold the data from the scanned QR code or manual entry code. */
 public class SetupPayload {
   /** Version info of the SetupPayload */
@@ -17,7 +20,7 @@ public class SetupPayload {
   /** The CHIP device manual setup code */
   public long setupPinCode;
 
-  public SetupPayload() {}
+    public Map<Integer, OptionalQRCodeInfo> optionalQRCodeInfo;
 
   public SetupPayload(
       int version,
@@ -34,5 +37,6 @@ public class SetupPayload {
     this.rendezvousInformation = rendezvousInfo;
     this.discriminator = discriminator;
     this.setupPinCode = setupPinCode;
+    this.optionalQRCodeInfo = new HashMap<Integer, OptionalQRCodeInfo>();
   }
 }

--- a/src/setup_payload/java/src/chip/setuppayload/SetupPayload.java
+++ b/src/setup_payload/java/src/chip/setuppayload/SetupPayload.java
@@ -20,7 +20,11 @@ public class SetupPayload {
   /** The CHIP device manual setup code */
   public long setupPinCode;
 
-    public Map<Integer, OptionalQRCodeInfo> optionalQRCodeInfo;
+  public Map<Integer, OptionalQRCodeInfo> optionalQRCodeInfo;
+
+  public SetupPayload() {
+    this.optionalQRCodeInfo = new HashMap<Integer, OptionalQRCodeInfo>();
+  }
 
   public SetupPayload(
       int version,


### PR DESCRIPTION
 #### Problem
Parse optional qr code info in SetupPayload JNI layer

 #### Summary of Changes
Parse optional qr code info out of native setup payload
object and make it available to SetupPayload java class.
