### PR TITLE
[NW] Get TestSystemTimer to work with the Network.framework backend

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
@@ -24,8 +24,8 @@
 #ifndef GENERIC_PLATFORM_MANAGER_IMPL_POSIX_IPP
 #define GENERIC_PLATFORM_MANAGER_IMPL_POSIX_IPP
 
-#include <platform/internal/CHIPDeviceLayerInternal.h>
 #include <platform/PlatformManager.h>
+#include <platform/internal/CHIPDeviceLayerInternal.h>
 #include <platform/internal/GenericPlatformManagerImpl_POSIX.h>
 
 // Include the non-inline definitions for the GenericPlatformManagerImpl<> template,
@@ -34,13 +34,13 @@
 
 #include <system/SystemLayer.h>
 
-#include <poll.h>
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <poll.h>
 #include <sched.h>
-#include <unistd.h>
 #include <sys/select.h>
+#include <unistd.h>
 
 #define DEFAULT_MIN_SLEEP_PERIOD (60 * 60 * 24 * 30) // Month [sec]
 
@@ -139,10 +139,12 @@ void GenericPlatformManagerImpl_POSIX<ImplClass>::SysUpdate()
         SystemLayer.PrepareSelect(mMaxFd, &mReadSet, &mWriteSet, &mErrorSet, mNextTimeout);
     }
 
+#if !(CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK)
     if (InetLayer.State == InetLayer::kState_Initialized)
     {
         InetLayer.PrepareSelect(mMaxFd, &mReadSet, &mWriteSet, &mErrorSet, mNextTimeout);
     }
+#endif // !(CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK)
 }
 
 template <class ImplClass>
@@ -170,10 +172,12 @@ void GenericPlatformManagerImpl_POSIX<ImplClass>::SysProcess()
         SystemLayer.HandleSelectResult(mMaxFd, &mReadSet, &mWriteSet, &mErrorSet);
     }
 
+#if !(CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK)
     if (InetLayer.State == InetLayer::kState_Initialized)
     {
         InetLayer.HandleSelectResult(mMaxFd, &mReadSet, &mWriteSet, &mErrorSet);
     }
+#endif // !(CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK)
 
     ProcessDeviceEvents();
 }

--- a/src/system/SystemTimer.cpp
+++ b/src/system/SystemTimer.cpp
@@ -169,9 +169,9 @@ Error Timer::Start(uint32_t aDelayMilliseconds, OnCompleteFunct aOnComplete, voi
         lTimer->mNextTimer = this;
     }
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
     lLayer.WakeSelect();
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
     return CHIP_SYSTEM_NO_ERROR;
 }
@@ -191,9 +191,9 @@ Error Timer::ScheduleWork(OnCompleteFunct aOnComplete, void * aAppState)
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     err = lLayer.PostEvent(*this, chip::System::kEvent_ScheduleWork, 0);
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
     lLayer.WakeSelect();
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
     return err;
 }

--- a/src/system/tests/TestSystemTimer.cpp
+++ b/src/system/tests/TestSystemTimer.cpp
@@ -46,9 +46,9 @@
 #include <lwip/tcpip.h>
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 #include <sys/select.h>
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
 #include <errno.h>
 #include <stdint.h>
@@ -59,7 +59,7 @@ using namespace chip::System;
 
 static void ServiceEvents(Layer & aLayer, ::timeval & aSleepTime)
 {
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
     fd_set readFDs, writeFDs, exceptFDs;
     int numFDs = 0;
 
@@ -76,13 +76,13 @@ static void ServiceEvents(Layer & aLayer, ::timeval & aSleepTime)
         printf("select failed: %s\n", ErrorStr(MapErrorPOSIX(errno)));
         return;
     }
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
     if (aLayer.State() == kLayerState_Initialized)
     {
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
         aLayer.HandleSelectResult(selectRes, &readFDs, &writeFDs, &exceptFDs);
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
         if (aLayer.State() == kLayerState_Initialized)


### PR DESCRIPTION
 #### Problem

src/platform/test/TestSystemTimer does not run with the NW backend at the moment since the timer code is hidden behind some SOCKET ifdef.