### PR TITLE
Do not enforce socket for --with-device-layer=linux since it may conf…

### DIFF
--- a/src/platform/Linux/SystemPlatformConfig.h
+++ b/src/platform/Linux/SystemPlatformConfig.h
@@ -43,9 +43,6 @@ struct ChipDeviceEvent;
 
 #define CHIP_SYSTEM_CONFIG_USE_POSIX_TIME_FUNCTS 1
 
-#define CHIP_SYSTEM_CONFIG_USE_LWIP 0
-#define CHIP_SYSTEM_CONFIG_USE_SOCKETS 1
-
 // ========== Platform-specific Configuration Overrides =========
 
 #ifndef CHIP_SYSTEM_CONFIG_NUM_TIMERS


### PR DESCRIPTION
…lics with other network backend

 #### Problem

The --with-device-layer=linux option assume SOCKETS for the InetBackend. Socket is already the default in configure.ac so it is not needed and conflicts if you want to enable an other Inet backend.