### PR TITLE
Use implicit IV for encryption

### DIFF
--- a/src/transport/MessageHeader.cpp
+++ b/src/transport/MessageHeader.cpp
@@ -34,7 +34,6 @@
  *  16 bit: | Secure message type                             |
  *  32 bit: | MESSAGE_ID                                      |
  *  32 bit: | Secure Session ID                               |
- *  64 bit: | Encryption Initialization Vector (nonce)        |
  *  64 bit: | Message Authentication Tag                      |
  *  64 bit: | SOURCE_NODE_ID (iff source node flag is set)    |
  *  64 bit: | DEST_NODE_ID (iff destination node flag is set) |
@@ -47,7 +46,7 @@ namespace {
 using namespace chip::Encoding;
 
 /// size of the fixed portion of the header
-constexpr size_t kFixedHeaderSizeBytes = 28;
+constexpr size_t kFixedHeaderSizeBytes = 20;
 
 /// size of a serialized node id inside a header
 constexpr size_t kNodeIdSizeBytes = 8;
@@ -97,7 +96,6 @@ CHIP_ERROR MessageHeader::Decode(const uint8_t * data, size_t size, size_t * dec
     mSecureMsgType   = LittleEndian::Read16(p);
     mMessageId       = LittleEndian::Read32(p);
     mSecureSessionID = LittleEndian::Read32(p);
-    mIV              = LittleEndian::Read64(p);
     mTag             = LittleEndian::Read64(p);
 
     assert(p - data == kFixedHeaderSizeBytes);
@@ -153,7 +151,6 @@ CHIP_ERROR MessageHeader::Encode(uint8_t * data, size_t size, size_t * encode_si
     LittleEndian::Write16(p, mSecureMsgType);
     LittleEndian::Write32(p, mMessageId);
     LittleEndian::Write32(p, mSecureSessionID);
-    LittleEndian::Write64(p, mIV);
     LittleEndian::Write64(p, mTag);
     if (mSourceNodeId.HasValue())
     {

--- a/src/transport/MessageHeader.h
+++ b/src/transport/MessageHeader.h
@@ -67,9 +67,6 @@ public:
     /** Get the Session ID from this header. */
     uint32_t GetSecureSessionID(void) const { return mSecureSessionID; }
 
-    /** Get the initialization vector from this header. */
-    uint64_t GetIV(void) const { return mIV; }
-
     /** Get the message auth tag from this header. */
     uint64_t GetTag(void) const { return mTag; }
 
@@ -142,13 +139,6 @@ public:
         return *this;
     }
 
-    /** Set the initialization vector for this header. */
-    MessageHeader & SetIV(uint64_t IV)
-    {
-        mIV = IV;
-        return *this;
-    }
-
     /** Set the message auth tag for this header. */
     MessageHeader & SetTag(uint64_t tag)
     {
@@ -212,9 +202,6 @@ private:
 
     /// Security session identifier
     uint32_t mSecureSessionID = 0;
-
-    /// Initialization vector used for encryption of the message.
-    uint64_t mIV = 0;
 
     /// Message authentication tag generated at encryption of the message.
     uint64_t mTag = 0;

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -81,7 +81,10 @@ void SecureSession::Reset(void)
 
 uint64_t SecureSession::GetIV(const MessageHeader & header)
 {
-    uint64_t IV = header.GetMessageId();
+    // The message ID is a 4 byte value. It's assumed that the security
+    // session will be rekeyed before (or on) message ID rollover.
+    uint64_t IV = header.GetMessageId() & 0xffffffff;
+
     if (header.GetSourceNodeId().HasValue())
     {
         uint64_t nodeID = header.GetSourceNodeId().Value();

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -39,7 +39,7 @@ const char * kManualKeyExchangeChannelInfo = "Manual Key Exchanged Channel";
 
 using namespace Crypto;
 
-SecureSession::SecureSession() : mKeyAvailable(false), mNextIV(0) {}
+SecureSession::SecureSession() : mKeyAvailable(false) {}
 
 CHIP_ERROR SecureSession::Init(const unsigned char * remote_public_key, const size_t public_key_length,
                                const unsigned char * local_private_key, const size_t private_key_length, const unsigned char * salt,
@@ -62,8 +62,6 @@ CHIP_ERROR SecureSession::Init(const unsigned char * remote_public_key, const si
     VerifyOrExit(info_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(info != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    mNextIV = 0;
-
     error = ECDH_derive_secret(remote_public_key, public_key_length, local_private_key, private_key_length, secret, secret_size);
     if (error == CHIP_NO_ERROR)
     {
@@ -78,27 +76,37 @@ exit:
 void SecureSession::Reset(void)
 {
     mKeyAvailable = false;
-    mNextIV       = 0;
     memset(mKey, 0, sizeof(mKey));
+}
+
+uint64_t SecureSession::GetIV(const MessageHeader & header)
+{
+    uint64_t IV = header.GetMessageId();
+    if (header.GetSourceNodeId().HasValue())
+    {
+        uint64_t nodeID = header.GetSourceNodeId().Value();
+        IV |= nodeID & 0xffffffff00000000;
+        IV |= (nodeID & 0xffffffff) << 32;
+    }
+    return IV;
 }
 
 CHIP_ERROR SecureSession::Encrypt(const unsigned char * input, size_t input_length, unsigned char * output, MessageHeader & header)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     uint64_t tag     = 0;
+    uint64_t IV      = SecureSession::GetIV(header);
 
     VerifyOrExit(mKeyAvailable, error = CHIP_ERROR_INVALID_USE_OF_SESSION_KEY);
     VerifyOrExit(input != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(input_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(output != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    error = AES_CCM_encrypt(input, input_length, NULL, 0, mKey, sizeof(mKey), (const unsigned char *) &mNextIV, sizeof(mNextIV),
-                            output, (unsigned char *) &tag, sizeof(tag));
+    error = AES_CCM_encrypt(input, input_length, NULL, 0, mKey, sizeof(mKey), (const unsigned char *) &IV, sizeof(IV), output,
+                            (unsigned char *) &tag, sizeof(tag));
     SuccessOrExit(error);
 
-    header.SetIV(mNextIV).SetTag(tag);
-
-    mNextIV++;
+    header.SetTag(tag);
 
 exit:
     return error;
@@ -109,7 +117,7 @@ CHIP_ERROR SecureSession::Decrypt(const unsigned char * input, size_t input_leng
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     uint64_t tag     = header.GetTag();
-    uint64_t IV      = header.GetIV();
+    uint64_t IV      = SecureSession::GetIV(header);
 
     VerifyOrExit(mKeyAvailable, error = CHIP_ERROR_INVALID_USE_OF_SESSION_KEY);
     VerifyOrExit(input != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -113,8 +113,9 @@ private:
     static constexpr size_t kAES_CCM128_Key_Length = 16;
 
     bool mKeyAvailable;
-    uint64_t mNextIV;
     uint8_t mKey[kAES_CCM128_Key_Length];
+
+    static uint64_t GetIV(const MessageHeader & header);
 };
 
 } // namespace chip

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -119,15 +119,15 @@ CHIP_ERROR SecureSessionMgr::SendMessage(NodeId peerNodeId, System::PacketBuffer
         uint8_t * data = msgBuf->Start();
         MessageHeader header;
 
-        err = state->GetSecureSession().Encrypt(data, msgBuf->TotalLength(), data, header);
-        SuccessOrExit(err);
-
-        ChipLogProgress(Inet, "Secure transport transmitting msg %u after encryption", state->GetSendMessageIndex());
-
         header
             .SetSourceNodeId(mLocalNodeId)    //
             .SetDestinationNodeId(peerNodeId) //
             .SetMessageId(state->GetSendMessageIndex());
+
+        err = state->GetSecureSession().Encrypt(data, msgBuf->TotalLength(), data, header);
+        SuccessOrExit(err);
+
+        ChipLogProgress(Inet, "Secure transport transmitting msg %u after encryption", state->GetSendMessageIndex());
 
         err    = mTransport.SendMessage(header, state->GetPeerAddress(), msgBuf);
         msgBuf = NULL;

--- a/src/transport/tests/TestMessageHeader.cpp
+++ b/src/transport/tests/TestMessageHeader.cpp
@@ -41,7 +41,6 @@ void TestHeaderInitialState(nlTestSuite * inSuite, void * inContext)
 
     NL_TEST_ASSERT(inSuite, header.GetSecureMsgType() == 0);
     NL_TEST_ASSERT(inSuite, header.GetSecureSessionID() == 0);
-    NL_TEST_ASSERT(inSuite, header.GetIV() == 0);
     NL_TEST_ASSERT(inSuite, header.GetTag() == 0);
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 0);
     NL_TEST_ASSERT(inSuite, !header.GetDestinationNodeId().HasValue());
@@ -102,12 +101,12 @@ void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77));
 
     header.SetMessageId(234).SetSourceNodeId(77).SetDestinationNodeId(88);
-    header.SetSecureMsgType(1122).SetSessionID(2233).SetIV(334455).SetTag(12345);
+    header.SetSecureMsgType(1122).SetSessionID(2233).SetTag(12345);
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
 
     // change it to verify decoding
     header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
-    header.SetSecureMsgType(2211).SetSessionID(3322).SetIV(554433).SetTag(54321);
+    header.SetSecureMsgType(2211).SetSessionID(3322).SetTag(54321);
     NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen, &decodeLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, encodeLen == decodeLen);
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 234);
@@ -115,7 +114,6 @@ void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77));
     NL_TEST_ASSERT(inSuite, header.GetSecureMsgType() == 1122);
     NL_TEST_ASSERT(inSuite, header.GetSecureSessionID() == 2233);
-    NL_TEST_ASSERT(inSuite, header.GetIV() == 334455);
     NL_TEST_ASSERT(inSuite, header.GetTag() == 12345);
 }
 


### PR DESCRIPTION
 #### Problem
The encryption IV can be derived from other fields in message header. It'll save `8` bytes per message.

 #### Summary of Changes
Use `Message ID` (monotonically increasing number per peer connection), and `Source Node ID` to derive the IV.