### PR TITLE
Fix the mbedtls, clang, & linux-embedded builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v2
-            - name: Setup Build Type
+            - name: Bootstrap
               run: |
                   case $BUILD_TYPE in
                      "main") export BOOTSTRAP_ARGUMENTS="";;
@@ -37,8 +37,7 @@ jobs:
                      *) ;;
                   esac
 
-            - name: Bootstrap
-              run: scripts/build/bootstrap.sh $BOOTSTRAP_ARGUMENTS
+                  scripts/build/bootstrap.sh $BOOTSTRAP_ARGUMENTS
             - name: Run Build
               run: scripts/build/default.sh
             - name: Run mbedTLS Tests


### PR DESCRIPTION
It appears each step is run a new shell, so the environment is lost
so all build types are the same.

Merge "Setup Build Type" with bootstrap so we set up the right build
type.