### PR TITLE
Add a src/platform/Darwin and get it to link with the iOS demo app

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -996,11 +996,11 @@ AC_DEFINE_UNQUOTED([CONFIG_NETWORK_LAYER_INET],[${CONFIG_NETWORK_LAYER_INET}],[D
 AC_MSG_CHECKING([device layer])
 AC_ARG_WITH(device-layer,
     [AS_HELP_STRING([--with-device-layer=LAYER],
-        [Specify the target environment for the CHIP Device Layer.  Choose one of: efr32, esp32, nrf5, linux, or none @<:@default=none@:>@.])],
+        [Specify the target environment for the CHIP Device Layer.  Choose one of: darwin, efr32, esp32, nrf5, linux, or none @<:@default=none@:>@.])],
     [
         case "${with_device_layer}" in
 
-        efr32|esp32|nrf5|linux|none)
+        darwin|efr32|esp32|nrf5|linux|none)
             ;;
 
         *)
@@ -1013,16 +1013,24 @@ AC_ARG_WITH(device-layer,
 AC_MSG_RESULT(${with_device_layer})
 
 # Disable all device layer targets by default
-CHIP_DEVICE_LAYER_TARGET_LINUX=0
+CHIP_DEVICE_LAYER_TARGET_DARWIN=0
+CHIP_DEVICE_LAYER_TARGET_EFR32=0
 CHIP_DEVICE_LAYER_TARGET_ESP32=0
 CHIP_DEVICE_LAYER_TARGET_NRF5=0
-CHIP_DEVICE_LAYER_TARGET_EFR32=0
+CHIP_DEVICE_LAYER_TARGET_LINUX=0
 
 case "${with_device_layer}" in
-linux)
+
+darwin)
       CONFIG_DEVICE_LAYER=1
-      CHIP_DEVICE_LAYER_TARGET=Linux
-      CHIP_DEVICE_LAYER_TARGET_LINUX=1
+      CHIP_DEVICE_LAYER_TARGET=Darwin
+      CHIP_DEVICE_LAYER_TARGET_DARWIN=1
+      ;;
+
+efr32)
+      CONFIG_DEVICE_LAYER=1
+      CHIP_DEVICE_LAYER_TARGET=EFR32
+      CHIP_DEVICE_LAYER_TARGET_EFR32=1
       ;;
 
 esp32)
@@ -1037,10 +1045,10 @@ nrf5)
       CHIP_DEVICE_LAYER_TARGET_NRF5=1
       ;;
 
-efr32)
+linux)
       CONFIG_DEVICE_LAYER=1
-      CHIP_DEVICE_LAYER_TARGET=EFR32
-      CHIP_DEVICE_LAYER_TARGET_EFR32=1
+      CHIP_DEVICE_LAYER_TARGET=Linux
+      CHIP_DEVICE_LAYER_TARGET_LINUX=1
       ;;
 
 none)
@@ -1055,6 +1063,10 @@ AC_DEFINE_UNQUOTED([CONFIG_DEVICE_LAYER],[${CONFIG_DEVICE_LAYER}],[Define to 1 i
 
 AC_SUBST(CHIP_DEVICE_LAYER_TARGET)
 AC_DEFINE_UNQUOTED([CHIP_DEVICE_LAYER_TARGET],[${CHIP_DEVICE_LAYER_TARGET}],[Target platform name for CHIP Device Layer.])
+
+AC_SUBST(CHIP_DEVICE_LAYER_TARGET_DARWIN)
+AM_CONDITIONAL([CHIP_DEVICE_LAYER_TARGET_DARWIN],    [test "${CHIP_DEVICE_LAYER_TARGET_DARWIN}" = 1])
+AC_DEFINE_UNQUOTED([CHIP_DEVICE_LAYER_TARGET_DARWIN],[${CHIP_DEVICE_LAYER_TARGET_DARWIN}],[Define to 1 if you want to build the CHIP Device Layer for Darwin platforms.])
 
 AC_SUBST(CHIP_DEVICE_LAYER_TARGET_EFR32)
 AM_CONDITIONAL([CHIP_DEVICE_LAYER_TARGET_EFR32],    [test "${CHIP_DEVICE_LAYER_TARGET_EFR32}" = 1])

--- a/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1E3DE6E124AF86F50028DC40 /* libDeviceLayer.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E3DE6E024AF86F50028DC40 /* libDeviceLayer.a */; };
 		2C4DF09E248B2C60009307CB /* libmbedtls.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2C4DF09D248B2C60009307CB /* libmbedtls.a */; };
 		515C401C2486BF43004C4DB3 /* CHIPOnOff.mm in Sources */ = {isa = PBXBuildFile; fileRef = 515C401A2486BF43004C4DB3 /* CHIPOnOff.mm */; };
 		515C401D2486BF43004C4DB3 /* CHIPOnOff.h in Headers */ = {isa = PBXBuildFile; fileRef = 515C401B2486BF43004C4DB3 /* CHIPOnOff.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -41,6 +42,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1E3DE6E024AF86F50028DC40 /* libDeviceLayer.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libDeviceLayer.a; path = "lib/libDeviceLayer.a"; sourceTree = BUILD_PRODUCT_DIR; };
 		2C4DF09D248B2C60009307CB /* libmbedtls.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libmbedtls.a; path = lib/libmbedtls.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		515C401A2486BF43004C4DB3 /* CHIPOnOff.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPOnOff.mm; sourceTree = "<group>"; };
 		515C401B2486BF43004C4DB3 /* CHIPOnOff.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPOnOff.h; sourceTree = "<group>"; };
@@ -72,6 +74,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1E3DE6E124AF86F50028DC40 /* libDeviceLayer.a in Frameworks */,
 				BA09EB43247477BA00605257 /* libCHIP.a in Frameworks */,
 				2C4DF09E248B2C60009307CB /* libmbedtls.a in Frameworks */,
 				BA09EB44247477BC00605257 /* libSetupPayload.a in Frameworks */,
@@ -147,6 +150,7 @@
 				2C4DF09D248B2C60009307CB /* libmbedtls.a */,
 				BA09EB3F2474762900605257 /* libCHIP.a */,
 				BA09EB402474762900605257 /* libSetupPayload.a */,
+				1E3DE6E024AF86F50028DC40 /* libDeviceLayer.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/src/darwin/Framework/chip_xcode_build_connector.sh
+++ b/src/darwin/Framework/chip_xcode_build_connector.sh
@@ -89,6 +89,7 @@ configure_OPTIONS+=(
     --disable-shared
     --disable-tests
     --disable-tools
+    --with-device-layer=darwin
     --with-logging-style=external
     --with-chip-system-project-includes=no
     --with-chip-inet-project-includes=no
@@ -114,6 +115,7 @@ configure_OPTIONS+=(
 
     make V=1 install-data                   # all the headers
     make V=1 -C src/lib install             # libCHIP.a
+    make V=1 -C src/platform install        # libDeviceLayer.a
     make V=1 -C src/setup_payload install   # libSetupPayload.a
     make V=1 -C third_party/mbedtls install # libmbedtls.a
 )

--- a/src/platform/Darwin/BlePlatformConfig.h
+++ b/src/platform/Darwin/BlePlatformConfig.h
@@ -1,0 +1,38 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Platform-specific configuration overrides for the CHIP BLE
+ *          Layer on Darwin platforms.
+ *
+ */
+
+#ifndef BLE_PLATFORM_CONFIG_H
+#define BLE_PLATFORM_CONFIG_H
+
+// ==================== Platform Adaptations ====================
+
+#define BLE_CONNECTION_OBJECT uint16_t
+#define BLE_CONNECTION_UNINITIALIZED ((uint16_t) -1)
+#define BLE_MAX_RECEIVE_WINDOW_SIZE 5
+
+// ========== Platform-specific Configuration Overrides =========
+
+/* none so far */
+
+#endif // BLE_PLATFORM_CONFIG_H

--- a/src/platform/Darwin/CHIPDevicePlatformConfig.h
+++ b/src/platform/Darwin/CHIPDevicePlatformConfig.h
@@ -1,0 +1,87 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Platform-specific configuration overrides for the chip Device Layer
+ *          on Darwin platforms.
+ */
+
+#ifndef CHIP_DEVICE_PLATFORM_CONFIG_H
+#define CHIP_DEVICE_PLATFORM_CONFIG_H
+
+// ==================== Platform Adaptations ====================
+
+#define CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION 0
+#define CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP 0
+
+#define CHIP_DEVICE_CONFIG_ENABLE_THREAD 0
+
+#define CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE 0
+
+#define CHIP_DEVICE_CONFIG_ENABLE_CHIP_TIME_SERVICE_TIME_SYNC 0
+#define CHIP_DEVICE_CONFIG_ENABLE_SERVICE_DIRECTORY_TIME_SYNC 0
+
+#define CHIP_DEVICE_CONFIG_PERSISTED_STORAGE_CRIT_EIDC_KEY 2
+#define CHIP_DEVICE_CONFIG_PERSISTED_STORAGE_PROD_EIDC_KEY 3
+#define CHIP_DEVICE_CONFIG_PERSISTED_STORAGE_INFO_EIDC_KEY 4
+#define CHIP_DEVICE_CONFIG_PERSISTED_STORAGE_DEBUG_EIDC_KEY 5
+
+// ========== Platform-specific Configuration =========
+
+// These are configuration options that are unique to Darwin platforms.
+// These can be overridden by the application as needed.
+
+/**
+ * @def CHIP_DEVICE_LAYER_BLE_OBSERVER_PRIORITY
+ *
+ * The priority of the SoftDevice observer event handler registered by the
+ * CHIP BleLayer.
+ */
+#ifndef CHIP_DEVICE_LAYER_BLE_OBSERVER_PRIORITY
+#define CHIP_DEVICE_LAYER_BLE_OBSERVER_PRIORITY 3
+#endif // CHIP_DEVICE_LAYER_BLE_OBSERVER_PRIORITY
+
+/**
+ * @def CHIP_DEVICE_LAYER_BLE_CONN_CFG_TAG
+ *
+ * The SoftDevice BLE connection configuration tag used by the CHIP
+ * BleLayer.
+ */
+#ifndef CHIP_DEVICE_LAYER_BLE_CONN_CFG_TAG
+#define CHIP_DEVICE_LAYER_BLE_CONN_CFG_TAG 1
+#endif // CHIP_DEVICE_LAYER_BLE_CONN_CFG_TAG
+
+// ========== Platform-specific Configuration Overrides =========
+
+#ifndef CHIP_DEVICE_CONFIG_CHIP_TASK_STACK_SIZE
+#define CHIP_DEVICE_CONFIG_CHIP_TASK_STACK_SIZE 8192
+#endif // CHIP_DEVICE_CONFIG_CHIP_TASK_STACK_SIZE
+
+#ifndef CHIP_DEVICE_CONFIG_THREAD_TASK_STACK_SIZE
+#define CHIP_DEVICE_CONFIG_THREAD_TASK_STACK_SIZE 8192
+#endif // CHIP_DEVICE_CONFIG_THREAD_TASK_STACK_SIZE
+
+#define CHIP_DEVICE_CONFIG_ENABLE_WIFI_TELEMETRY 0
+#define CHIP_DEVICE_CONFIG_ENABLE_THREAD_TELEMETRY 0
+#define CHIP_DEVICE_CONFIG_ENABLE_THREAD_TELEMETRY_FULL 0
+#define CHIP_DEVICE_CONFIG_ENABLE_TUNNEL_TELEMETRY 0
+
+// TODO: CHIP has redesigned the crypto interface, pending on the final version of CHIP HASH APIs
+#define CHIP_DEVICE_CONFIG_LOG_PROVISIONING_HASH 0
+
+#endif // CHIP_DEVICE_PLATFORM_CONFIG_H

--- a/src/platform/Darwin/CHIPDevicePlatformEvent.h
+++ b/src/platform/Darwin/CHIPDevicePlatformEvent.h
@@ -1,0 +1,78 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Defines platform-specific event types and data for the chip
+ *          Device Layer on Darwin platforms.
+ */
+
+#ifndef CHIP_DEVICE_PLATFORM_EVENT_H
+#define CHIP_DEVICE_PLATFORM_EVENT_H
+
+#include <platform/CHIPDeviceEvent.h>
+
+namespace chip {
+namespace System {
+class PacketBuffer;
+}
+} // namespace chip
+
+namespace chip {
+namespace DeviceLayer {
+
+namespace DeviceEventType {
+
+/**
+ * Enumerates platform-specific event types that are visible to the application.
+ */
+enum PublicPlatformSpecificEventTypes
+{
+    /* None currently defined */
+};
+
+/**
+ * Enumerates platform-specific event types that are internal to the chip Device Layer.
+ */
+enum InternalPlatformSpecificEventTypes
+{
+    kPlatformDarwinEvent = kRange_InternalPlatformSpecific,
+    kPlatformDarwinBleC1WriteEvent,
+    kPlatformDarwinBleOutOfBuffersEvent,
+};
+
+} // namespace DeviceEventType
+
+/**
+ * Represents platform-specific event information for Linux platforms.
+ */
+struct ChipDevicePlatformEvent final
+{
+    union
+    {
+        struct
+        {
+            uint16_t ConnId;
+            ::chip::System::PacketBuffer * Data;
+        } BleC1WriteEvent;
+    };
+};
+
+} // namespace DeviceLayer
+} // namespace chip
+
+#endif // CHIP_DEVICE_PLATFORM_EVENT_H

--- a/src/platform/Darwin/CHIPPlatformConfig.h
+++ b/src/platform/Darwin/CHIPPlatformConfig.h
@@ -1,0 +1,118 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Platform-specific configuration overrides for CHIP on
+ *          Darwin platforms.
+ */
+
+#ifndef CHIP_PLATFORM_CONFIG_H
+#define CHIP_PLATFORM_CONFIG_H
+
+// ==================== General Platform Adaptations ====================
+
+#define ChipDie() abort()
+
+//#define CHIP_CONFIG_ENABLE_TUNNELING 0
+//#define CHIP_CONFIG_MAX_TUNNELS 0
+
+#define CHIP_CONFIG_ENABLE_SERVICE_DIRECTORY 0
+
+// TODO:(#756) Add FabricState support
+#define CHIP_CONFIG_ENABLE_FABRIC_STATE 0
+
+using CHIP_CONFIG_PERSISTED_STORAGE_KEY_TYPE = const char *;
+#define CHIP_CONFIG_PERSISTED_STORAGE_MAX_KEY_LENGTH 16
+
+#define CHIP_CONFIG_TIME_ENABLE_CLIENT 1
+#define CHIP_CONFIG_TIME_ENABLE_SERVER 0
+
+// ==================== Security Adaptations ====================
+
+#define CHIP_CONFIG_USE_OPENSSL_ECC 0
+#define CHIP_CONFIG_USE_MICRO_ECC 1
+
+#define CHIP_CONFIG_HASH_IMPLEMENTATION_OPENSSL 0
+#define CHIP_CONFIG_HASH_IMPLEMENTATION_MINCRYPT 1
+#define CHIP_CONFIG_HASH_IMPLEMENTATION_MBEDTLS 0
+#define CHIP_CONFIG_HASH_IMPLEMENTATION_PLATFORM 0
+
+#define CHIP_CONFIG_AES_IMPLEMENTATION_OPENSSL 0
+#define CHIP_CONFIG_AES_IMPLEMENTATION_AESNI 0
+#define CHIP_CONFIG_AES_IMPLEMENTATION_MBEDTLS 1
+#define CHIP_CONFIG_AES_IMPLEMENTATION_PLATFORM 0
+
+#define CHIP_CONFIG_RNG_IMPLEMENTATION_OPENSSL 0
+#define CHIP_CONFIG_RNG_IMPLEMENTATION_CHIPDRBG 1
+#define CHIP_CONFIG_RNG_IMPLEMENTATION_PLATFORM 0
+
+#define CHIP_CONFIG_ENABLE_PASE_INITIATOR 0
+#define CHIP_CONFIG_ENABLE_PASE_RESPONDER 1
+#define CHIP_CONFIG_ENABLE_CASE_INITIATOR 1
+
+#define CHIP_CONFIG_SUPPORT_PASE_CONFIG0 0
+#define CHIP_CONFIG_SUPPORT_PASE_CONFIG1 0
+#define CHIP_CONFIG_SUPPORT_PASE_CONFIG2 0
+#define CHIP_CONFIG_SUPPORT_PASE_CONFIG3 0
+#define CHIP_CONFIG_SUPPORT_PASE_CONFIG4 1
+
+#define CHIP_CONFIG_ENABLE_KEY_EXPORT_INITIATOR 0
+
+#define CHIP_CONFIG_ENABLE_PROVISIONING_BUNDLE_SUPPORT 0
+
+// ==================== General Configuration Overrides ====================
+
+#ifndef CHIP_CONFIG_MAX_PEER_NODES
+#define CHIP_CONFIG_MAX_PEER_NODES 16
+#endif // CHIP_CONFIG_MAX_PEER_NODES
+
+#ifndef CHIP_CONFIG_MAX_UNSOLICITED_MESSAGE_HANDLERS
+#define CHIP_CONFIG_MAX_UNSOLICITED_MESSAGE_HANDLERS 16
+#endif // CHIP_CONFIG_MAX_UNSOLICITED_MESSAGE_HANDLERS
+
+#ifndef CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS
+#define CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS 8
+#endif // CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS
+
+#ifndef CHIP_CONFIG_WRMP_TIMER_DEFAULT_PERIOD
+#define CHIP_CONFIG_WRMP_TIMER_DEFAULT_PERIOD 50
+#endif // CHIP_CONFIG_WRMP_TIMER_DEFAULT_PERIOD
+
+#ifndef CHIP_LOG_FILTERING
+#define CHIP_LOG_FILTERING 0
+#endif // CHIP_LOG_FILTERING
+
+#ifndef CHIP_CONFIG_BDX_MAX_NUM_TRANSFERS
+#define CHIP_CONFIG_BDX_MAX_NUM_TRANSFERS 1
+#endif // CHIP_CONFIG_BDX_MAX_NUM_TRANSFERS
+
+// ==================== Security Configuration Overrides ====================
+
+#ifndef CHIP_CONFIG_MAX_APPLICATION_GROUPS
+#define CHIP_CONFIG_MAX_APPLICATION_GROUPS 4
+#endif // CHIP_CONFIG_MAX_APPLICATION_GROUPS
+
+#ifndef CHIP_CONFIG_DEBUG_CERT_VALIDATION
+#define CHIP_CONFIG_DEBUG_CERT_VALIDATION 0
+#endif // CHIP_CONFIG_DEBUG_CERT_VALIDATION
+
+#ifndef CHIP_CONFIG_ENABLE_CASE_RESPONDER
+#define CHIP_CONFIG_ENABLE_CASE_RESPONDER 1
+#endif // CHIP_CONFIG_ENABLE_CASE_RESPONDER
+
+#endif /* CHIP_PLATFORM_CONFIG_H */

--- a/src/platform/Darwin/ConfigurationManagerImpl.cpp
+++ b/src/platform/Darwin/ConfigurationManagerImpl.cpp
@@ -1,0 +1,157 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2018 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Provides the implementation of the Device Layer ConfigurationManager object
+ *          for Darwin platforms.
+ */
+
+#include <platform/internal/CHIPDeviceLayerInternal.h>
+
+#include <core/CHIPVendorIdentifiers.hpp>
+#include <platform/ConfigurationManager.h>
+#include <platform/Darwin/PosixConfig.h>
+#include <platform/internal/GenericConfigurationManagerImpl.ipp>
+
+#include <support/CodeUtils.h>
+#include <support/logging/CHIPLogging.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+using namespace ::chip::DeviceLayer::Internal;
+
+/** Singleton instance of the ConfigurationManager implementation object.
+ */
+ConfigurationManagerImpl ConfigurationManagerImpl::sInstance;
+
+CHIP_ERROR ConfigurationManagerImpl::_Init()
+{
+    CHIP_ERROR err;
+
+    // Initialize the generic implementation base class.
+    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::_Init();
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR ConfigurationManagerImpl::_GetPrimaryWiFiMACAddress(uint8_t * buf)
+{
+    // TODO(#739): add WiFi support
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+bool ConfigurationManagerImpl::_CanFactoryReset()
+{
+    // TODO(#742): query the application to determine if factory reset is allowed.
+    return true;
+}
+
+void ConfigurationManagerImpl::_InitiateFactoryReset()
+{
+    PlatformMgr().ScheduleWork(DoFactoryReset);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::_ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
+{
+    PosixConfig::Key configKey{ kConfigNamespace_ChipCounters, key };
+
+    CHIP_ERROR err = ReadConfigValue(configKey, value);
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+    return err;
+}
+
+CHIP_ERROR ConfigurationManagerImpl::_WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
+{
+    PosixConfig::Key configKey{ kConfigNamespace_ChipCounters, key };
+    return WriteConfigValue(configKey, value);
+}
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
+CHIP_ERROR ConfigurationManagerImpl::GetWiFiStationSecurityType(Profiles::NetworkProvisioning::WiFiSecurityType & secType)
+{
+    CHIP_ERROR err;
+    uint32_t secTypeInt;
+
+    err = ReadConfigValue(kConfigKey_WiFiStationSecType, secTypeInt);
+    if (err == CHIP_NO_ERROR)
+    {
+        secType = (Profiles::NetworkProvisioning::WiFiSecurityType) secTypeInt;
+    }
+    return err;
+}
+
+CHIP_ERROR ConfigurationManagerImpl::UpdateWiFiStationSecurityType(Profiles::NetworkProvisioning::WiFiSecurityType secType)
+{
+    CHIP_ERROR err;
+    Profiles::NetworkProvisioning::WiFiSecurityType curSecType;
+
+    if (secType != Profiles::NetworkProvisioning::kWiFiSecurityType_NotSpecified)
+    {
+        err = GetWiFiStationSecurityType(curSecType);
+        if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND || (err == CHIP_NO_ERROR && secType != curSecType))
+        {
+            uint32_t secTypeInt = secType;
+            err                 = WriteConfigValue(kConfigKey_WiFiStationSecType, secTypeInt);
+        }
+        SuccessOrExit(err);
+    }
+    else
+    {
+        err = ClearConfigValue(kConfigKey_WiFiStationSecType);
+        SuccessOrExit(err);
+    }
+
+exit:
+    return err;
+}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
+
+void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
+{
+    CHIP_ERROR err;
+
+    ChipLogProgress(DeviceLayer, "Performing factory reset");
+
+    err = FactoryResetConfig();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %s", ErrorStr(err));
+    }
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+
+    ChipLogProgress(DeviceLayer, "Clearing Thread provision");
+    ThreadStackMgr().ErasePersistentInfo();
+
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
+
+    // Restart the system.
+    ChipLogProgress(DeviceLayer, "System restarting (not implemented)");
+    // TODO(#742): restart CHIP exe
+}
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/Darwin/ConfigurationManagerImpl.h
+++ b/src/platform/Darwin/ConfigurationManagerImpl.h
@@ -1,0 +1,98 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Provides an implementation of the ConfigurationManager object
+ *          for Darwin platforms.
+ */
+
+#ifndef CONFIGURATION_MANAGER_IMPL_H
+#define CONFIGURATION_MANAGER_IMPL_H
+
+#include <platform/internal/GenericConfigurationManagerImpl.h>
+
+#include <platform/Darwin/PosixConfig.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+/**
+ * Concrete implementation of the ConfigurationManager singleton object for the Darwin platform.
+ */
+class ConfigurationManagerImpl final : public ConfigurationManager,
+                                       public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
+                                       private Internal::PosixConfig
+{
+    // Allow the ConfigurationManager interface class to delegate method calls to
+    // the implementation methods provided by this class.
+    friend class ConfigurationManager;
+
+    // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
+    // defined on this class.
+    friend class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
+
+private:
+    // ===== Members that implement the ConfigurationManager public interface.
+
+    CHIP_ERROR _Init(void);
+    CHIP_ERROR _GetPrimaryWiFiMACAddress(uint8_t * buf);
+    bool _CanFactoryReset(void);
+    void _InitiateFactoryReset(void);
+    CHIP_ERROR _ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value);
+    CHIP_ERROR _WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value);
+
+    // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
+
+    // ===== Members for internal use by the following friends.
+
+    friend ConfigurationManager & ConfigurationMgr(void);
+    friend ConfigurationManagerImpl & ConfigurationMgrImpl(void);
+
+    static ConfigurationManagerImpl sInstance;
+
+    // ===== Private members reserved for use by this class only.
+
+    static void DoFactoryReset(intptr_t arg);
+};
+
+/**
+ * Returns the public interface of the ConfigurationManager singleton object.
+ *
+ * chip applications should use this to access features of the ConfigurationManager object
+ * that are common to all platforms.
+ */
+inline ConfigurationManager & ConfigurationMgr(void)
+{
+    return ConfigurationManagerImpl::sInstance;
+}
+
+/**
+ * Returns the platform-specific implementation of the ConfigurationManager singleton object.
+ *
+ * chip applications can use this to gain access to features of the ConfigurationManager
+ * that are specific to the ESP32 platform.
+ */
+inline ConfigurationManagerImpl & ConfigurationMgrImpl(void)
+{
+    return ConfigurationManagerImpl::sInstance;
+}
+
+} // namespace DeviceLayer
+} // namespace chip
+
+#endif // CONFIGURATION_MANAGER_IMPL_H

--- a/src/platform/Darwin/ConnectivityManagerImpl.cpp
+++ b/src/platform/Darwin/ConnectivityManagerImpl.cpp
@@ -1,0 +1,70 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2019 Nest Labs, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <platform/internal/CHIPDeviceLayerInternal.h>
+
+#include <platform/ConnectivityManager.h>
+#include <platform/internal/BLEManager.h>
+
+#include <new>
+
+#include <support/CodeUtils.h>
+#include <support/logging/CHIPLogging.h>
+
+#if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+#include <platform/internal/GenericConnectivityManagerImpl_BLE.ipp>
+#endif
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+#include <platform/internal/GenericConnectivityManagerImpl_Thread.ipp>
+#endif
+
+using namespace ::chip;
+using namespace ::chip::TLV;
+using namespace ::chip::DeviceLayer::Internal;
+
+namespace chip {
+namespace DeviceLayer {
+
+ConnectivityManagerImpl ConnectivityManagerImpl::sInstance;
+
+CHIP_ERROR ConnectivityManagerImpl::_Init()
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    // Initialize the generic base classes that require it.
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    GenericConnectivityManagerImpl_Thread<ConnectivityManagerImpl>::_Init();
+#endif
+
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
+{
+    // Forward the event to the generic base classes as needed.
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    GenericConnectivityManagerImpl_Thread<ConnectivityManagerImpl>::_OnPlatformEvent(event);
+#endif
+}
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/Darwin/ConnectivityManagerImpl.h
+++ b/src/platform/Darwin/ConnectivityManagerImpl.h
@@ -1,0 +1,126 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2018 Nest Labs, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef CONNECTIVITY_MANAGER_IMPL_H
+#define CONNECTIVITY_MANAGER_IMPL_H
+
+#include <platform/ConnectivityManager.h>
+#include <platform/internal/GenericConnectivityManagerImpl.h>
+#if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+#include <platform/internal/GenericConnectivityManagerImpl_BLE.h>
+#else
+#include <platform/internal/GenericConnectivityManagerImpl_NoBLE.h>
+#endif
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+#include <platform/internal/GenericConnectivityManagerImpl_Thread.h>
+#else
+#include <platform/internal/GenericConnectivityManagerImpl_NoThread.h>
+#endif
+#include <platform/internal/GenericConnectivityManagerImpl_NoTunnel.h>
+#include <platform/internal/GenericConnectivityManagerImpl_NoWiFi.h>
+#include <support/FlagUtils.hpp>
+
+namespace chip {
+namespace Inet {
+class IPAddress;
+} // namespace Inet
+} // namespace chip
+
+namespace chip {
+namespace DeviceLayer {
+
+/**
+ * Concrete implementation of the ConnectivityManager singleton object for Darwin platforms.
+ */
+class ConnectivityManagerImpl final : public ConnectivityManager,
+                                      public Internal::GenericConnectivityManagerImpl<ConnectivityManagerImpl>,
+#if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+                                      public Internal::GenericConnectivityManagerImpl_BLE<ConnectivityManagerImpl>,
+#else
+                                      public Internal::GenericConnectivityManagerImpl_NoBLE<ConnectivityManagerImpl>,
+#endif
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+                                      public Internal::GenericConnectivityManagerImpl_Thread<ConnectivityManagerImpl>,
+#else
+                                      public Internal::GenericConnectivityManagerImpl_NoThread<ConnectivityManagerImpl>,
+#endif
+                                      public Internal::GenericConnectivityManagerImpl_NoWiFi<ConnectivityManagerImpl>,
+                                      public Internal::GenericConnectivityManagerImpl_NoTunnel<ConnectivityManagerImpl>
+{
+    // Allow the ConnectivityManager interface class to delegate method calls to
+    // the implementation methods provided by this class.
+    friend class ConnectivityManager;
+
+private:
+    // ===== Members that implement the ConnectivityManager abstract interface.
+
+    bool _HaveIPv4InternetConnectivity(void);
+    bool _HaveIPv6InternetConnectivity(void);
+    bool _HaveServiceConnectivity(void);
+    CHIP_ERROR _Init(void);
+    void _OnPlatformEvent(const ChipDeviceEvent * event);
+
+    // ===== Members for internal use by the following friends.
+
+    friend ConnectivityManager & ConnectivityMgr(void);
+    friend ConnectivityManagerImpl & ConnectivityMgrImpl(void);
+
+    static ConnectivityManagerImpl sInstance;
+};
+
+inline bool ConnectivityManagerImpl::_HaveIPv4InternetConnectivity(void)
+{
+    return false;
+}
+
+inline bool ConnectivityManagerImpl::_HaveIPv6InternetConnectivity(void)
+{
+    return false;
+}
+
+inline bool ConnectivityManagerImpl::_HaveServiceConnectivity(void)
+{
+    return _HaveServiceConnectivityViaThread();
+}
+
+/**
+ * Returns the public interface of the ConnectivityManager singleton object.
+ *
+ * chip applications should use this to access features of the ConnectivityManager object
+ * that are common to all platforms.
+ */
+inline ConnectivityManager & ConnectivityMgr(void)
+{
+    return ConnectivityManagerImpl::sInstance;
+}
+
+/**
+ * Returns the platform-specific implementation of the ConnectivityManager singleton object.
+ *
+ * chip applications can use this to gain access to features of the ConnectivityManager
+ * that are specific to the Darwin platform.
+ */
+inline ConnectivityManagerImpl & ConnectivityMgrImpl(void)
+{
+    return ConnectivityManagerImpl::sInstance;
+}
+
+} // namespace DeviceLayer
+} // namespace chip
+
+#endif // CONNECTIVITY_MANAGER_IMPL_H

--- a/src/platform/Darwin/InetPlatformConfig.h
+++ b/src/platform/Darwin/InetPlatformConfig.h
@@ -1,0 +1,42 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Platform-specific configuration overrides for the CHIP Inet
+ *          Layer on Darwin platforms.
+ *
+ */
+
+#ifndef INET_PLATFORM_CONFIG_H
+#define INET_PLATFORM_CONFIG_H
+
+// ==================== Platform Adaptations ====================
+
+#define INET_CONFIG_ENABLE_IPV4 1
+
+// ========== Platform-specific Configuration Overrides =========
+
+#ifndef INET_CONFIG_NUM_TCP_ENDPOINTS
+#define INET_CONFIG_NUM_TCP_ENDPOINTS 4
+#endif // INET_CONFIG_NUM_TCP_ENDPOINTS
+
+#ifndef INET_CONFIG_NUM_UDP_ENDPOINTS
+#define INET_CONFIG_NUM_UDP_ENDPOINTS 4
+#endif // INET_CONFIG_NUM_UDP_ENDPOINTS
+
+#endif // INET_PLATFORM_CONFIG_H

--- a/src/platform/Darwin/PlatformManagerImpl.cpp
+++ b/src/platform/Darwin/PlatformManagerImpl.cpp
@@ -1,0 +1,53 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2018 Nest Labs, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Provides an implementation of the PlatformManager object
+ *          for Darwin platforms.
+ */
+
+#include <platform/internal/CHIPDeviceLayerInternal.h>
+
+#include <platform/PlatformManager.h>
+#include <platform/internal/GenericPlatformManagerImpl_POSIX.ipp>
+
+namespace chip {
+namespace DeviceLayer {
+
+PlatformManagerImpl PlatformManagerImpl::sInstance;
+
+CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
+{
+    CHIP_ERROR err;
+
+    // Initialize the configuration system.
+    err = Internal::PosixConfig::Init();
+    SuccessOrExit(err);
+
+    // Call _InitChipStack() on the generic implementation base class
+    // to finish the initialization process.
+    err = Internal::GenericPlatformManagerImpl_POSIX<PlatformManagerImpl>::_InitChipStack();
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/Darwin/PlatformManagerImpl.h
+++ b/src/platform/Darwin/PlatformManagerImpl.h
@@ -1,0 +1,89 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2018 Nest Labs, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Provides an implementation of the PlatformManager object.
+ */
+
+#ifndef PLATFORM_MANAGER_IMPL_H
+#define PLATFORM_MANAGER_IMPL_H
+
+#include <platform/internal/GenericPlatformManagerImpl_POSIX.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+/**
+ * Concrete implementation of the PlatformManager singleton object for Darwin platforms.
+ */
+class PlatformManagerImpl final : public PlatformManager, public Internal::GenericPlatformManagerImpl_POSIX<PlatformManagerImpl>
+{
+    // Allow the PlatformManager interface class to delegate method calls to
+    // the implementation methods provided by this class.
+    friend PlatformManager;
+
+    // Allow the generic implementation base class to call helper methods on
+    // this class.
+    friend Internal::GenericPlatformManagerImpl_POSIX<PlatformManagerImpl>;
+
+public:
+    // ===== Platform-specific members that may be accessed directly by the application.
+
+    /* none so far */
+
+private:
+    // ===== Methods that implement the PlatformManager abstract interface.
+
+    CHIP_ERROR _InitChipStack(void);
+
+    // ===== Members for internal use by the following friends.
+
+    friend PlatformManager & PlatformMgr(void);
+    friend PlatformManagerImpl & PlatformMgrImpl(void);
+    friend class Internal::BLEManagerImpl;
+
+    static PlatformManagerImpl sInstance;
+};
+
+/**
+ * Returns the public interface of the PlatformManager singleton object.
+ *
+ * chip applications should use this to access features of the PlatformManager object
+ * that are common to all platforms.
+ */
+inline PlatformManager & PlatformMgr(void)
+{
+    return PlatformManagerImpl::sInstance;
+}
+
+/**
+ * Returns the platform-specific implementation of the PlatformManager singleton object.
+ *
+ * chip applications can use this to gain access to features of the PlatformManager
+ * that are specific to the ESP32 platform.
+ */
+inline PlatformManagerImpl & PlatformMgrImpl(void)
+{
+    return PlatformManagerImpl::sInstance;
+}
+
+} // namespace DeviceLayer
+} // namespace chip
+
+#endif // PLATFORM_MANAGER_IMPL_H

--- a/src/platform/Darwin/PosixConfig.cpp
+++ b/src/platform/Darwin/PosixConfig.cpp
@@ -1,0 +1,223 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2019-2020 Google LLC.
+ *    Copyright (c) 2018 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Utilities for interacting with multiple file partitions and maps
+ *          key-value config calls to the correct partition.
+ */
+
+#include <platform/internal/CHIPDeviceLayerInternal.h>
+#include <platform/internal/testing/ConfigUnitTest.h>
+
+#include <core/CHIPEncoding.h>
+#include <platform/Darwin/PosixConfig.h>
+#include <support/CodeUtils.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+// *** CAUTION ***: Changing the names or namespaces of these values will *break* existing devices.
+
+// NVS namespaces used to store device configuration information.
+const char PosixConfig::kConfigNamespace_ChipFactory[]  = "chip-factory";
+const char PosixConfig::kConfigNamespace_ChipConfig[]   = "chip-config";
+const char PosixConfig::kConfigNamespace_ChipCounters[] = "chip-counters";
+
+// Keys stored in the Chip-factory namespace
+const PosixConfig::Key PosixConfig::kConfigKey_SerialNum           = { kConfigNamespace_ChipFactory, "serial-num" };
+const PosixConfig::Key PosixConfig::kConfigKey_MfrDeviceId         = { kConfigNamespace_ChipFactory, "device-id" };
+const PosixConfig::Key PosixConfig::kConfigKey_MfrDeviceCert       = { kConfigNamespace_ChipFactory, "device-cert" };
+const PosixConfig::Key PosixConfig::kConfigKey_MfrDeviceICACerts   = { kConfigNamespace_ChipFactory, "device-ca-certs" };
+const PosixConfig::Key PosixConfig::kConfigKey_MfrDevicePrivateKey = { kConfigNamespace_ChipFactory, "device-key" };
+const PosixConfig::Key PosixConfig::kConfigKey_ProductRevision     = { kConfigNamespace_ChipFactory, "product-rev" };
+const PosixConfig::Key PosixConfig::kConfigKey_ManufacturingDate   = { kConfigNamespace_ChipFactory, "mfg-date" };
+const PosixConfig::Key PosixConfig::kConfigKey_PairingCode         = { kConfigNamespace_ChipFactory, "pairing-code" };
+
+// Keys stored in the Chip-config namespace
+const PosixConfig::Key PosixConfig::kConfigKey_FabricId                    = { kConfigNamespace_ChipConfig, "fabric-id" };
+const PosixConfig::Key PosixConfig::kConfigKey_ServiceConfig               = { kConfigNamespace_ChipConfig, "service-config" };
+const PosixConfig::Key PosixConfig::kConfigKey_PairedAccountId             = { kConfigNamespace_ChipConfig, "account-id" };
+const PosixConfig::Key PosixConfig::kConfigKey_ServiceId                   = { kConfigNamespace_ChipConfig, "service-id" };
+const PosixConfig::Key PosixConfig::kConfigKey_FabricSecret                = { kConfigNamespace_ChipConfig, "fabric-secret" };
+const PosixConfig::Key PosixConfig::kConfigKey_GroupKeyIndex               = { kConfigNamespace_ChipConfig, "group-key-index" };
+const PosixConfig::Key PosixConfig::kConfigKey_LastUsedEpochKeyId          = { kConfigNamespace_ChipConfig, "last-ek-id" };
+const PosixConfig::Key PosixConfig::kConfigKey_FailSafeArmed               = { kConfigNamespace_ChipConfig, "fail-safe-armed" };
+const PosixConfig::Key PosixConfig::kConfigKey_WiFiStationSecType          = { kConfigNamespace_ChipConfig, "sta-sec-type" };
+const PosixConfig::Key PosixConfig::kConfigKey_OperationalDeviceId         = { kConfigNamespace_ChipConfig, "op-device-id" };
+const PosixConfig::Key PosixConfig::kConfigKey_OperationalDeviceCert       = { kConfigNamespace_ChipConfig, "op-device-cert" };
+const PosixConfig::Key PosixConfig::kConfigKey_OperationalDeviceICACerts   = { kConfigNamespace_ChipConfig, "op-device-ca-certs" };
+const PosixConfig::Key PosixConfig::kConfigKey_OperationalDevicePrivateKey = { kConfigNamespace_ChipConfig, "op-device-key" };
+
+// Prefix used for NVS keys that contain Chip group encryption keys.
+const char PosixConfig::kGroupKeyNamePrefix[] = "gk-";
+
+CHIP_ERROR PosixConfig::Init()
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    return err;
+}
+
+CHIP_ERROR PosixConfig::ReadConfigValue(Key key, bool & val)
+{
+    CHIP_ERROR err = CHIP_ERROR_PERSISTED_STORAGE_FAIL;
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR PosixConfig::ReadConfigValue(Key key, uint32_t & val)
+{
+    CHIP_ERROR err = CHIP_ERROR_PERSISTED_STORAGE_FAIL;
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR PosixConfig::ReadConfigValue(Key key, uint64_t & val)
+{
+    CHIP_ERROR err = CHIP_ERROR_PERSISTED_STORAGE_FAIL;
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR PosixConfig::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
+{
+    CHIP_ERROR err = CHIP_ERROR_PERSISTED_STORAGE_FAIL;
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR PosixConfig::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
+{
+    CHIP_ERROR err = CHIP_ERROR_PERSISTED_STORAGE_FAIL;
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR PosixConfig::WriteConfigValue(Key key, bool val)
+{
+    CHIP_ERROR err = CHIP_ERROR_PERSISTED_STORAGE_FAIL;
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR PosixConfig::WriteConfigValue(Key key, uint32_t val)
+{
+    CHIP_ERROR err = CHIP_ERROR_PERSISTED_STORAGE_FAIL;
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR PosixConfig::WriteConfigValue(Key key, uint64_t val)
+{
+    CHIP_ERROR err = CHIP_ERROR_PERSISTED_STORAGE_FAIL;
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR PosixConfig::WriteConfigValueStr(Key key, const char * str)
+{
+    CHIP_ERROR err = CHIP_ERROR_PERSISTED_STORAGE_FAIL;
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR PosixConfig::WriteConfigValueStr(Key key, const char * str, size_t strLen)
+{
+    CHIP_ERROR err = CHIP_ERROR_PERSISTED_STORAGE_FAIL;
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR PosixConfig::WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)
+{
+    CHIP_ERROR err = CHIP_ERROR_PERSISTED_STORAGE_FAIL;
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR PosixConfig::ClearConfigValue(Key key)
+{
+    CHIP_ERROR err = CHIP_ERROR_PERSISTED_STORAGE_FAIL;
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+bool PosixConfig::ConfigValueExists(Key key)
+{
+    return false;
+}
+
+CHIP_ERROR PosixConfig::EnsureNamespace(const char * ns)
+{
+    CHIP_ERROR err = CHIP_ERROR_PERSISTED_STORAGE_FAIL;
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR PosixConfig::ClearNamespace(const char * ns)
+{
+    CHIP_ERROR err = CHIP_ERROR_PERSISTED_STORAGE_FAIL;
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR PosixConfig::FactoryResetConfig(void)
+{
+    CHIP_ERROR err = CHIP_ERROR_PERSISTED_STORAGE_FAIL;
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+void PosixConfig::RunConfigUnitTest() {}
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/Darwin/PosixConfig.h
+++ b/src/platform/Darwin/PosixConfig.h
@@ -1,0 +1,123 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Utilities for accessing persisted device configuration on
+ *          Darwin platforms.
+ */
+
+#ifndef POSIX_CONFIG_H
+#define POSIX_CONFIG_H
+
+#include <functional>
+#include <inttypes.h>
+
+#include <platform/internal/CHIPDeviceLayerInternal.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+/**
+ * Provides functions and definitions for accessing device configuration information on the Posix.
+ *
+ * This class is designed to be mixed-in to concrete implementation classes as a means to
+ * provide access to configuration information to generic base classes.
+ */
+class PosixConfig
+{
+public:
+    struct Key;
+
+    // Maximum length of an NVS key name.
+    static constexpr size_t kMaxConfigKeyNameLength = 15;
+
+    // NVS namespaces used to store device configuration information.
+    static const char kConfigNamespace_ChipFactory[];
+    static const char kConfigNamespace_ChipConfig[];
+    static const char kConfigNamespace_ChipCounters[];
+
+    // Key definitions for well-known keys.
+    static const Key kConfigKey_SerialNum;
+    static const Key kConfigKey_MfrDeviceId;
+    static const Key kConfigKey_MfrDeviceCert;
+    static const Key kConfigKey_MfrDeviceICACerts;
+    static const Key kConfigKey_MfrDevicePrivateKey;
+    static const Key kConfigKey_ProductRevision;
+    static const Key kConfigKey_ManufacturingDate;
+    static const Key kConfigKey_PairingCode;
+    static const Key kConfigKey_FabricId;
+    static const Key kConfigKey_ServiceConfig;
+    static const Key kConfigKey_PairedAccountId;
+    static const Key kConfigKey_ServiceId;
+    static const Key kConfigKey_FabricSecret;
+    static const Key kConfigKey_GroupKeyIndex;
+    static const Key kConfigKey_LastUsedEpochKeyId;
+    static const Key kConfigKey_FailSafeArmed;
+    static const Key kConfigKey_WiFiStationSecType;
+    static const Key kConfigKey_OperationalDeviceId;
+    static const Key kConfigKey_OperationalDeviceCert;
+    static const Key kConfigKey_OperationalDeviceICACerts;
+    static const Key kConfigKey_OperationalDevicePrivateKey;
+
+    static const char kGroupKeyNamePrefix[];
+
+    static CHIP_ERROR Init(void);
+
+    // Config value accessors.
+    static CHIP_ERROR ReadConfigValue(Key key, bool & val);
+    static CHIP_ERROR ReadConfigValue(Key key, uint32_t & val);
+    static CHIP_ERROR ReadConfigValue(Key key, uint64_t & val);
+    static CHIP_ERROR ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen);
+    static CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen);
+    static CHIP_ERROR WriteConfigValue(Key key, bool val);
+    static CHIP_ERROR WriteConfigValue(Key key, uint32_t val);
+    static CHIP_ERROR WriteConfigValue(Key key, uint64_t val);
+    static CHIP_ERROR WriteConfigValueStr(Key key, const char * str);
+    static CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen);
+    static CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen);
+    static CHIP_ERROR ClearConfigValue(Key key);
+    static bool ConfigValueExists(Key key);
+    static CHIP_ERROR FactoryResetConfig(void);
+
+    static void RunConfigUnitTest(void);
+
+protected:
+    // NVS Namespace helper functions.
+    static CHIP_ERROR EnsureNamespace(const char * ns);
+    static CHIP_ERROR ClearNamespace(const char * ns);
+};
+
+struct PosixConfig::Key
+{
+    const char * Namespace;
+    const char * Name;
+
+    bool operator==(const Key & other) const;
+};
+
+inline bool PosixConfig::Key::operator==(const Key & other) const
+{
+    return strcmp(Namespace, other.Namespace) == 0 && strcmp(Name, other.Name) == 0;
+}
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip
+
+#endif // POSIX_CONFIG_H

--- a/src/platform/Darwin/SystemPlatformConfig.h
+++ b/src/platform/Darwin/SystemPlatformConfig.h
@@ -1,0 +1,52 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Platform-specific configuration overrides for the CHIP System
+ *          Layer on Darwin platforms.
+ *
+ */
+
+#ifndef SYSTEM_PLATFORM_CONFIG_H
+#define SYSTEM_PLATFORM_CONFIG_H
+
+#include <stdint.h>
+
+namespace chip {
+namespace DeviceLayer {
+struct ChipDeviceEvent;
+} // namespace DeviceLayer
+} // namespace chip
+
+// ==================== Platform Adaptations ====================
+
+#define CHIP_SYSTEM_CONFIG_POSIX_LOCKING 1
+#define CHIP_SYSTEM_CONFIG_FREERTOS_LOCKING 0
+#define CHIP_SYSTEM_CONFIG_NO_LOCKING 0
+#define CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_EVENT_FUNCTIONS 1
+#define CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_TIME 0
+
+#define CHIP_SYSTEM_CONFIG_USE_POSIX_TIME_FUNCTS 1
+
+// ========== Platform-specific Configuration Overrides =========
+
+#ifndef CHIP_SYSTEM_CONFIG_NUM_TIMERS
+#define CHIP_SYSTEM_CONFIG_NUM_TIMERS 16
+#endif // CHIP_SYSTEM_CONFIG_NUM_TIMERS
+
+#endif // SYSTEM_PLATFORM_CONFIG_H

--- a/src/platform/Makefile.am
+++ b/src/platform/Makefile.am
@@ -59,6 +59,10 @@ noinst_HEADERS                          = \
     @top_srcdir@/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.h \
     @top_srcdir@/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp \
     @top_srcdir@/src/include/platform/internal/CHIPDeviceLayerInternal.h \
+    @top_srcdir@/src/platform/Darwin/CHIPDevicePlatformConfig.h \
+    @top_srcdir@/src/platform/Darwin/CHIPDevicePlatformEvent.h \
+    @top_srcdir@/src/platform/Darwin/ConfigurationManagerImpl.h \
+    @top_srcdir@/src/platform/Darwin/PlatformManagerImpl.h \
     @top_srcdir@/src/platform/nRF5/ConnectivityManagerImpl.h \
     @top_srcdir@/src/platform/nRF5/nRF5Config.h \
     @top_srcdir@/src/platform/nRF5/CHIPDevicePlatformConfig.h \
@@ -121,6 +125,29 @@ libDeviceLayer_a_SOURCES               += \
     OpenThread/OpenThreadUtils.cpp        \
     $(NULL)
 endif
+
+if CHIP_DEVICE_LAYER_TARGET_DARWIN
+
+libDeviceLayer_a_CPPFLAGS              += \
+    $(NULL)
+
+libDeviceLayer_a_SOURCES               += \
+    Darwin/ConfigurationManagerImpl.cpp   \
+    Darwin/ConnectivityManagerImpl.cpp    \
+    Darwin/PlatformManagerImpl.cpp        \
+    Darwin/PosixConfig.cpp                \
+    $(NULL)
+
+Platformdir                                                     = $(includedir)/platform/Darwin
+dist_Platform_HEADERS                                           = \
+    @top_srcdir@/src/platform/Darwin/BlePlatformConfig.h        \
+    @top_srcdir@/src/platform/Darwin/InetPlatformConfig.h       \
+    @top_srcdir@/src/platform/Darwin/CHIPPlatformConfig.h       \
+    @top_srcdir@/src/platform/Darwin/CHIPDevicePlatformConfig.h \
+    @top_srcdir@/src/platform/Darwin/SystemPlatformConfig.h     \
+    $(NULL)
+
+endif # CHIP_DEVICE_LAYER_TARGET_DARWIN
 
 if CHIP_DEVICE_LAYER_TARGET_LINUX
 

--- a/third_party/mbedtls/Makefile.am
+++ b/third_party/mbedtls/Makefile.am
@@ -115,6 +115,13 @@ nodist_libmbedtls_a_SOURCES                                                   +=
     $(NULL)
 endif
 
+if CHIP_DEVICE_LAYER_TARGET_DARWIN
+nodist_libmbedtls_a_SOURCES                                                   += \
+    repo/library/entropy_poll.c             \
+    repo/library/timing.c                   \
+    $(NULL)
+endif
+
 libmbedtls_a_CPPFLAGS                                                          = \
     -I$(top_srcdir)/third_party/mbedtls/repo/include                             \
     $(MBEDTLS_CPPFLAGS)                                                          \


### PR DESCRIPTION
 #### Problem

With the current setup a lot of logic code will lives into the Darwin Framework. An other approach would be to add a new Darwin platform under src/platform and use it for the underlying logic, such as the event loop control, the bluetooth implementation, ...

Then this code could be glued to the iOS app which will then call InitChipStack at some point.

As an example this approach will contradict #1460 where the BLEPlatformDelegate code lives into the Framework. 
Here it will lives into src/platform/Darwin/BleManagerImpl.cpp 

Also, in #1401 I removed the service events code from the Darwin Framework to use the one from CHIPDeviceController. One of the thing I have not added back yet is the lock/unlock mechanism that was used in order to not keep the lock for the whole duration of the `select`. The logical followup for this, if this PR ever lands, would be to use DeviceLayer::PlatformMgr().LockChipStack(); and DeviceLayer::PlatformMgr().UnlockChipStack(); in ChipDeviceController::ServiceEvents() to add it back.

So basically the idea is to move some of the logic from src/darwin/Framework to src/platform/Darwin
