### PR TITLE
Call InitChipStack from the device controller

### DIFF
--- a/config/standalone/standalone-chip.mk
+++ b/config/standalone/standalone-chip.mk
@@ -138,6 +138,7 @@ STD_LIBS += \
     -lDeviceLayer \
     -lInetLayer \
     -lnlfaultinjection \
+    -lSupportLayer \
     -lSystemLayer
 
 STD_LIBS += $(shell pkg-config --libs openssl)
@@ -158,6 +159,7 @@ STD_LINK_PREREQUISITES += \
     $(CHIP_OUTPUT_DIR)/lib/libDeviceLayer.a \
     $(CHIP_OUTPUT_DIR)/lib/libInetLayer.a \
     $(CHIP_OUTPUT_DIR)/lib/libnlfaultinjection.a \
+    $(CHIP_OUTPUT_DIR)/lib/libSupportLayer.a \
     $(CHIP_OUTPUT_DIR)/lib/libSystemLayer.a
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -2475,6 +2475,7 @@ AC_MSG_NOTICE([
   PThreads link libraries                          : ${PTHREAD_LIBS:--}
   IniPP compile flags                              : ${INIPP_CPPFLAGS:--}
   GIO compile flags                                : ${GIO_CFLAGS:--}
+  GIO link flags                                   : ${GIO_LIBS:--}
   C Preprocessor                                   : ${CPP}
   C Compiler                                       : ${CC}
   C++ Preprocessor                                 : ${CXXCPP}

--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -258,8 +258,6 @@ void DoEcho(DeviceController::ChipDeviceController * controller, const IPAddress
         controller->SendMessage(NULL, buffer);
         printf("Msg sent to server at %s:%d\n", host_ip_str, port);
 
-        controller->ServiceEvents();
-
         sleep(SEND_DELAY);
     }
 }
@@ -316,7 +314,6 @@ void DoOnOff(DeviceController::ChipDeviceController * controller, Command comman
 #endif
 
     controller->SendMessage(NULL, buffer);
-    controller->ServiceEvents();
 }
 
 // ================================================================================
@@ -340,6 +337,9 @@ int main(int argc, char * argv[])
     err               = controller->Init(kLocalDeviceId);
     VerifyOrExit(err == CHIP_NO_ERROR, fprintf(stderr, "Failed to initialize the device controller"));
 
+    err = controller->ServiceEvents();
+    SuccessOrExit(err);
+
     err = controller->ConnectDevice(kRemoteDeviceId, host_addr, NULL, EchoKeyExchange, EchoResponse, ReceiveError, port);
     VerifyOrExit(err == CHIP_NO_ERROR, fprintf(stderr, "Failed to connect to the device"));
 
@@ -350,6 +350,7 @@ int main(int argc, char * argv[])
     else
     {
         DoOnOff(controller, command, commandArgs.endpointId);
+        controller->ServiceEventSignal();
     }
 
 exit:

--- a/src/ble/BUILD.gn
+++ b/src/ble/BUILD.gn
@@ -14,14 +14,12 @@
 
 import("//build_overrides/chip.gni")
 
+import("${chip_root}/src/platform/device.gni")
 import("ble.gni")
 
 declare_args() {
   # Extra header to include in BleConfig.h for project.
   ble_project_config_include = ""
-
-  # Extra header to include in BleConfig.h for platform.
-  ble_platform_config_include = ""
 }
 
 config("ble_config") {

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -142,21 +142,18 @@ public:
     // ----- IO -----
     /**
      * @brief
-     *   Allow the CHIP Stack to process any pending events
-     *   This can be called in an event handler loop to tigger callbacks within the CHIP stack
-     *   Note - Some platforms might need to implement their own event handler
+     * Start the event loop task within the CHIP stack
+     * @return CHIP_ERROR   The return status
      */
-    void ServiceEvents();
+    CHIP_ERROR ServiceEvents();
 
     /**
      * @brief
-     *   Get pointers to the Layers ownerd by the controller
-     *
-     * @param[out] systemLayer   A pointer to the SystemLayer object
-     * @param[out] inetLayer     A pointer to the InetLayer object
-     * @return CHIP_ERROR   Indicates whether the layers were populated correctly
+     *   Allow the CHIP Stack to process any pending events
+     *   This can be called in an event handler loop to tigger callbacks within the CHIP stack
+     * @return CHIP_ERROR   The return status
      */
-    CHIP_ERROR GetLayers(Layer ** systemLayer, InetLayer ** inetLayer);
+    CHIP_ERROR ServiceEventSignal();
 
     virtual void OnMessageReceived(const MessageHeader & header, Transport::PeerConnectionState * state,
                                    System::PacketBuffer * msgBuf, SecureSessionMgrBase * mgr);
@@ -176,9 +173,6 @@ private:
         kConnectionState_Connected       = 1,
         kConnectionState_SecureConnected = 2,
     };
-
-    System::Layer * mSystemLayer;
-    Inet::InetLayer * mInetLayer;
 
     SecureSessionMgr<Transport::UDP> * mSessionManager;
 

--- a/src/inet/BUILD.gn
+++ b/src/inet/BUILD.gn
@@ -17,15 +17,13 @@ import("//build_overrides/nlassert.gni")
 import("//build_overrides/nlfaultinjection.gni")
 import("//build_overrides/nlio.gni")
 
+import("${chip_root}/src/platform/device.gni")
 import("${chip_root}/gn/chip/tests.gni")
 import("inet.gni")
 
 declare_args() {
   # Extra header to include in SystemConfig.h for project.
   inet_project_config_include = ""
-
-  # Extra header to include in SystemConfig.h for platform.
-  inet_platform_config_include = ""
 }
 
 config("inet_config") {

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -70,6 +70,12 @@ libCHIP_a_CPPFLAGS                  =                         \
     $(SOCKETS_CPPFLAGS)                                       \
     $(NULL)
 
+if CHIP_DEVICE_LAYER_TARGET_LINUX
+libCHIP_a_CPPFLAGS                                         += \
+    $(GIO_CFLAGS)                                             \
+    $(NULL)
+endif
+
 libCHIP_a_SOURCES                   = $(CHIP_BUILD_SYSTEM_LAYER_SOURCE_FILES)
 libCHIP_a_SOURCES                  += $(CHIP_BUILD_INET_LAYER_SOURCE_FILES)
 libCHIP_a_SOURCES                  += $(CHIP_BUILD_CORE_LAYER_SOURCE_FILES)

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -21,9 +21,6 @@ if (device_platform != "none") {
   declare_args() {
     # Extra header to include in CHIPDeviceConfig.h for project.
     chip_device_project_config_include = ""
-
-    # Extra header to include in CHIPDeviceConfig.h for platform.
-    chip_device_platform_config_include = ""
   }
 
   config("platform_config") {
@@ -104,6 +101,7 @@ if (device_platform != "none") {
 
     public_deps = [
       "${chip_root}/src/ble",
+      "${chip_root}/src/inet",
       "${chip_root}/src/lib/core:chip_config_header",
       "${chip_root}/src/lib/support",
       "${nlio_root}:nlio",

--- a/src/platform/Linux/args.gni
+++ b/src/platform/Linux/args.gni
@@ -13,9 +13,3 @@
 # limitations under the License.
 
 device_platform = "linux"
-
-ble_platform_config_include = "<platform/Linux/BlePlatformConfig.h>"
-chip_device_platform_config_include = "<platform/Linux/CHIPDevicePlatformConfig.h>"
-chip_platform_config_include = "<platform/Linux/CHIPPlatformConfig.h>"
-inet_platform_config_include = "<platform/Linux/InetPlatformConfig.h>"
-system_platform_config_include = "<platform/Linux/SystemPlatformConfig.h>"

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -12,19 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//build_overrides/chip.gni")
+
 declare_args() {
   # Device platform layer: freertos, nrf5, none.
-  device_platform = ""
+  device_platform = "auto"
 
   # Enable openthread support.
   chip_enable_openthread = false
 }
 
-if (device_platform == "") {
-  if (current_os != "freertos") {
+if (device_platform == "auto") {
+  if (current_os == "linux") {
+    device_platform = "linux"
+  } else {
     device_platform = "none"
   }
 }
+
+device_layer = "none"
+if (device_platform == "linux") {
+  device_layer = "Linux"
+} else if (device_platform == "nrf5") {
+  device_layer = "nRF5"
+}
+
+ble_platform_config_include = "<platform/" + device_layer + "/BlePlatformConfig.h>"
+chip_device_platform_config_include = "<platform/" + device_layer + "/CHIPDevicePlatformConfig.h>"
+chip_platform_config_include = "<platform/" + device_layer + "/CHIPPlatformConfig.h>"
+inet_platform_config_include = "<platform/" + device_layer + "/InetPlatformConfig.h>"
+system_platform_config_include = "<platform/" + device_layer + "/SystemPlatformConfig.h>"
 
 assert((current_os != "freertos" && device_platform == "none") ||
            device_platform == "nrf5" || device_platform == "linux",

--- a/src/platform/nRF5/args.gni
+++ b/src/platform/nRF5/args.gni
@@ -23,10 +23,3 @@ inet_config_enable_ipv4 = false
 inet_config_enable_dns_resolver = false
 
 chip_build_tests = false
-
-ble_platform_config_include = "<platform/nRF5/BlePlatformConfig.h>"
-chip_device_platform_config_include =
-    "<platform/nRF5/CHIPDevicePlatformConfig.h>"
-chip_platform_config_include = "<platform/nRF5/CHIPPlatformConfig.h>"
-inet_platform_config_include = "<platform/nRF5/InetPlatformConfig.h>"
-system_platform_config_include = "<platform/nRF5/SystemPlatformConfig.h>"

--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -16,6 +16,7 @@ import("//build_overrides/chip.gni")
 import("//build_overrides/nlassert.gni")
 import("//build_overrides/nlfaultinjection.gni")
 
+import("${chip_root}/src/platform/device.gni")
 import("${chip_root}/gn/chip/tests.gni")
 import("system.gni")
 
@@ -24,15 +25,8 @@ declare_args() {
   # TODO - This should probably be in src/core but src/system also uses it.
   chip_project_config_include = "<CHIPProjectConfig.h>"
 
-  # Extra header to include in CHIPConfig.h for platform.
-  # TODO - This should probably be in src/core but src/system also uses it.
-  chip_platform_config_include = ""
-
   # Extra header to include in SystemConfig.h for project.
   system_project_config_include = "<SystemProjectConfig.h>"
-
-  # Extra header to include in SystemConfig.h for platform.
-  system_platform_config_include = ""
 
   # Extra include dirs for project configs.
   project_config_include_dirs = []


### PR DESCRIPTION
 #### Problem

This is an example of how I would change the event loop code from the Darwin framework to ChipDeviceController if #1497 lands. The current code is not ready to be merged yet. It needs some more love since in the current shape it will likely break examples/chip-tool and we need to determine if CHIPDeviceController always expect a device layer or not.