### PR TITLE
Ensure 'doc' Make Target Is Supported; Add Diagnostic Information If Documentation Is Disabled

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -208,6 +208,14 @@ distclean-local:
 	$(MAKE) -C $(srcdir) -f Makefile-bootstrap clean-repos
 
 #
+# Top-level convenience target for making documentation.
+#
+
+.PHONY: doc
+doc: $(BUILT_SOURCES)
+	$(MAKE) -C docs $(@)
+
+#
 # Top-level convenience target for making a documentation-only
 # distribution whose results appear at the top level of the build tree
 # in the same fashion that the distribution would be for 'make dist'.

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -60,9 +60,11 @@ CLEANFILES                                      = \
     $(chip_docdist_archive)                      \
     $(NULL)
 
+.PHONY: doc docdist
+
 if CHIP_BUILD_DOCS
 
-all-local: html/index.html
+all-local doc: html/index.html
 
 #
 # We choose to manually transform Doxyfile.in into Doxyfile here in
@@ -105,6 +107,10 @@ docdist $(chip_docdist_alias): $(chip_docdist_archive)
 
 clean-local:
 	$(AM_V_at)rm -f -r html
+
+else
+
+$(error "Documentation support is disabled. Please explicitly enable documentation with `--enable-docs` via `configure` and/or ensure that Doxygen is installed")
 
 endif # CHIP_BUILD_DOCS
 

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -110,7 +110,8 @@ clean-local:
 
 else
 
-$(error "Documentation support is disabled. Please explicitly enable documentation with `--enable-docs` via `configure` and/or ensure that Doxygen is installed")
+doc docdist:
+	$(error "Documentation support is disabled. Please explicitly enable documentation with `--enable-docs` via `configure` and/or ensure that Doxygen is installed")
 
 endif # CHIP_BUILD_DOCS
 


### PR DESCRIPTION
#### Problem
If `make help` is invoked, it indicates that a `doc` target exists that will build documentation. However, there is not presently such a target.

#### Summary of Changes
Ensure the `doc` target is supported per `make help`. Also, provide useful diagnostic information if Doxygen is not available or if documentation support has been explicitly disabled.

Fixes #1498