### PR TITLE
Use message header flag to distinguish secure session control msgs

### DIFF
--- a/src/transport/MessageHeader.h
+++ b/src/transport/MessageHeader.h
@@ -61,8 +61,8 @@ public:
      */
     uint32_t GetMessageId() const { return mMessageId; }
 
-    /** Get the secure msg type from this header. */
-    uint16_t GetSecureMsgType(void) const { return mSecureMsgType; }
+    /** Check if it's a secure session control message. */
+    bool IsSecureSessionControlMsg(void) const { return mSecureSessionControlMsg; }
 
     /** Get the Session ID from this header. */
     uint32_t GetSecureSessionID(void) const { return mSecureSessionID; }
@@ -126,9 +126,9 @@ public:
     }
 
     /** Set the secure message type for this header. */
-    MessageHeader & SetSecureMsgType(uint16_t type)
+    MessageHeader & SetSecureSessionControlMsg()
     {
-        mSecureMsgType = type;
+        mSecureSessionControlMsg = true;
         return *this;
     }
 
@@ -198,7 +198,7 @@ private:
     Optional<NodeId> mDestinationNodeId;
 
     /// Packet type (application data, security control packets, e.g. pairing, configuration, rekey etc)
-    uint16_t mSecureMsgType = 0;
+    bool mSecureSessionControlMsg = false;
 
     /// Security session identifier
     uint32_t mSecureSessionID = 0;

--- a/src/transport/tests/TestMessageHeader.cpp
+++ b/src/transport/tests/TestMessageHeader.cpp
@@ -39,7 +39,7 @@ void TestHeaderInitialState(nlTestSuite * inSuite, void * inContext)
 {
     MessageHeader header;
 
-    NL_TEST_ASSERT(inSuite, header.GetSecureMsgType() == 0);
+    NL_TEST_ASSERT(inSuite, !header.IsSecureSessionControlMsg());
     NL_TEST_ASSERT(inSuite, header.GetSecureSessionID() == 0);
     NL_TEST_ASSERT(inSuite, header.GetTag() == 0);
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 0);
@@ -101,18 +101,18 @@ void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77));
 
     header.SetMessageId(234).SetSourceNodeId(77).SetDestinationNodeId(88);
-    header.SetSecureMsgType(1122).SetSessionID(2233).SetTag(12345);
+    header.SetSecureSessionControlMsg().SetSessionID(2233).SetTag(12345);
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
 
     // change it to verify decoding
     header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
-    header.SetSecureMsgType(2211).SetSessionID(3322).SetTag(54321);
+    header.SetSecureSessionControlMsg().SetSessionID(3322).SetTag(54321);
     NL_TEST_ASSERT(inSuite, header.Decode(buffer, encodeLen, &decodeLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, encodeLen == decodeLen);
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 234);
     NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(88));
     NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77));
-    NL_TEST_ASSERT(inSuite, header.GetSecureMsgType() == 1122);
+    NL_TEST_ASSERT(inSuite, header.IsSecureSessionControlMsg());
     NL_TEST_ASSERT(inSuite, header.GetSecureSessionID() == 2233);
     NL_TEST_ASSERT(inSuite, header.GetTag() == 12345);
 }


### PR DESCRIPTION
 #### Problem
We are using two bytes in every message (including data packets) to identify secure session control message type. The field is applicable to only control messages. Also, the secure session control message type should be in the encrypted section of the message.

 #### Summary of Changes
Reserve one bit in the `flags` to distinguish secure session control message from data message. The actual message type will be moved into encrypted section. 
