### PR TITLE
Add PlatformManager::Shutdown to permit the event loop to terminate p…

### DIFF
--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -90,6 +90,7 @@ public:
     void LockChipStack(void);
     bool TryLockChipStack(void);
     void UnlockChipStack(void);
+    CHIP_ERROR Shutdown(void);
 
 private:
     // ===== Members for internal use by the following friends.
@@ -232,6 +233,11 @@ inline void PlatformManager::DispatchEvent(const ChipDeviceEvent * event)
 inline CHIP_ERROR PlatformManager::StartChipTimer(uint32_t durationMS)
 {
     return static_cast<ImplClass *>(this)->_StartChipTimer(durationMS);
+}
+
+inline CHIP_ERROR PlatformManager::Shutdown(void)
+{
+    return static_cast<ImplClass *>(this)->_Shutdown();
 }
 
 } // namespace DeviceLayer

--- a/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.h
@@ -72,6 +72,7 @@ protected:
     void _RunEventLoop(void);
     CHIP_ERROR _StartEventLoopTask(void);
     CHIP_ERROR _StartChipTimer(uint32_t durationMS);
+    CHIP_ERROR _Shutdown(void);
 
     // ===== Methods available to the implementation subclass.
 

--- a/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
@@ -25,14 +25,13 @@
 #ifndef GENERIC_PLATFORM_MANAGER_IMPL_FREERTOS_IPP
 #define GENERIC_PLATFORM_MANAGER_IMPL_FREERTOS_IPP
 
-#include <platform/internal/CHIPDeviceLayerInternal.h>
 #include <platform/PlatformManager.h>
+#include <platform/internal/CHIPDeviceLayerInternal.h>
 #include <platform/internal/GenericPlatformManagerImpl_FreeRTOS.h>
 
 // Include the non-inline definitions for the GenericPlatformManagerImpl<> template,
 // from which the GenericPlatformManagerImpl_FreeRTOS<> template inherits.
 #include <platform/internal/GenericPlatformManagerImpl.ipp>
-
 
 namespace chip {
 namespace DeviceLayer {
@@ -41,15 +40,15 @@ namespace Internal {
 // Fully instantiate the generic implementation class in whatever compilation unit includes this file.
 template class GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>;
 
-template<class ImplClass>
+template <class ImplClass>
 CHIP_ERROR GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_InitChipStack(void)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     vTaskSetTimeOutState(&mNextTimerBaseTime);
     mNextTimerDurationTicks = 0;
-    mEventLoopTask = NULL;
-    mChipTimerActive = false;
+    mEventLoopTask          = NULL;
+    mChipTimerActive        = false;
 
     mChipStackLock = xSemaphoreCreateMutex();
     if (mChipStackLock == NULL)
@@ -73,25 +72,25 @@ exit:
     return err;
 }
 
-template<class ImplClass>
+template <class ImplClass>
 void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_LockChipStack(void)
 {
     xSemaphoreTake(mChipStackLock, portMAX_DELAY);
 }
 
-template<class ImplClass>
+template <class ImplClass>
 bool GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_TryLockChipStack(void)
 {
     return xSemaphoreTake(mChipStackLock, 0) == pdTRUE;
 }
 
-template<class ImplClass>
+template <class ImplClass>
 void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_UnlockChipStack(void)
 {
     xSemaphoreGive(mChipStackLock);
 }
 
-template<class ImplClass>
+template <class ImplClass>
 void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_PostEvent(const ChipDeviceEvent * event)
 {
     if (mChipEventQueue != NULL)
@@ -103,7 +102,7 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_PostEvent(const ChipDevice
     }
 }
 
-template<class ImplClass>
+template <class ImplClass>
 void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_RunEventLoop(void)
 {
     CHIP_ERROR err;
@@ -180,29 +179,26 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_RunEventLoop(void)
     }
 }
 
-template<class ImplClass>
+template <class ImplClass>
 CHIP_ERROR GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_StartEventLoopTask(void)
 {
     BaseType_t res;
 
-    res = xTaskCreate(EventLoopTaskMain,
-                CHIP_DEVICE_CONFIG_CHIP_TASK_NAME,
-                CHIP_DEVICE_CONFIG_CHIP_TASK_STACK_SIZE / sizeof(StackType_t),
-                this,
-                CHIP_DEVICE_CONFIG_CHIP_TASK_PRIORITY,
-                NULL);
+    res = xTaskCreate(EventLoopTaskMain, CHIP_DEVICE_CONFIG_CHIP_TASK_NAME,
+                      CHIP_DEVICE_CONFIG_CHIP_TASK_STACK_SIZE / sizeof(StackType_t), this, CHIP_DEVICE_CONFIG_CHIP_TASK_PRIORITY,
+                      NULL);
 
     return (res == pdPASS) ? CHIP_NO_ERROR : CHIP_ERROR_NO_MEMORY;
 }
 
-template<class ImplClass>
+template <class ImplClass>
 void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::EventLoopTaskMain(void * arg)
 {
     ChipLogDetail(DeviceLayer, "CHIP task running");
-    static_cast<GenericPlatformManagerImpl_FreeRTOS<ImplClass>*>(arg)->Impl()->RunEventLoop();
+    static_cast<GenericPlatformManagerImpl_FreeRTOS<ImplClass> *>(arg)->Impl()->RunEventLoop();
 }
 
-template<class ImplClass>
+template <class ImplClass>
 CHIP_ERROR GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_StartChipTimer(uint32_t aMilliseconds)
 {
     mChipTimerActive = true;
@@ -222,7 +218,7 @@ CHIP_ERROR GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_StartChipTimer(uint3
     return CHIP_NO_ERROR;
 }
 
-template<class ImplClass>
+template <class ImplClass>
 void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::PostEventFromISR(const ChipDeviceEvent * event, BaseType_t & yieldRequired)
 {
     yieldRequired = pdFALSE;
@@ -234,6 +230,12 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::PostEventFromISR(const Chip
             ChipLogError(DeviceLayer, "Failed to post event to CHIP Platform event queue");
         }
     }
+}
+
+template <class ImplClass>
+CHIP_ERROR GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_Shutdown(void)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
 } // namespace Internal

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h
@@ -78,6 +78,7 @@ protected:
     void _RunEventLoop(void);
     CHIP_ERROR _StartEventLoopTask(void);
     CHIP_ERROR _StartChipTimer(uint32_t durationMS);
+    CHIP_ERROR _Shutdown(void);
 
     // ===== Methods available to the implementation subclass.
 
@@ -92,6 +93,7 @@ private:
 
     void ProcessDeviceEvents();
 
+    bool mShouldRunEventLoop;
     static void * EventLoopTaskMain(void * arg);
 };
 


### PR DESCRIPTION
…roperly for POSIX platforms

 #### Problem

Right now POSIX platforms (and FreeRTOS) expect the event loop to run forever. In order to allow the platform specific event loop for tool like chip-tool it would be useful to allow it to terminate properly if needed.
For example examples/chip-tool could be used to launch a single command and then terminate. At some points I would like to compile chip-tool against the host POSIX platform in order to emulate a high level controller and use the same codepaths.

 #### Summary of Changes
 * The patch add PlatformManager::Shutdown method
 * So far this method just allow the event loop thread to exit gracefully

I would like to say that this patch fixes #742 but it is only a subpart of it as far as I can tell.