### PR TITLE
Glue standalone application to a device layer for POSIX platforms

### DIFF
--- a/config/standalone/standalone-chip.mk
+++ b/config/standalone/standalone-chip.mk
@@ -58,10 +58,10 @@ CHIP_OUTPUT_DIR = $(OUTPUT_DIR)/chip
 # An optional file containing application-specific configuration overrides.
 CHIP_PROJECT_CONFIG = $(wildcard $(PROJECT_ROOT)/include/CHIPProjectConfig.h)
 
-# Architcture on which CHIP is being built.
+# Architecture on which CHIP is being built.
 CHIP_BUILD_ARCH = $(shell $(CHIP_ROOT)/third_party/nlbuild-autotools/repo/third_party/autoconf/config.guess | sed -e 's/[[:digit:].]*$$//g')
 
-# Archtecture for which CHIP will be built.
+# Architecture for which CHIP will be built.
 CHIP_HOST_ARCH := $(CHIP_BUILD_ARCH)
 
 
@@ -135,11 +135,17 @@ STD_LDFLAGS += -L$(CHIP_OUTPUT_DIR)/lib
 # Add CHIP libraries to standard libraries list.
 STD_LIBS += \
     -lCHIP \
+    -lDeviceLayer \
     -lInetLayer \
     -lnlfaultinjection \
     -lSystemLayer
 
 STD_LIBS += $(shell pkg-config --libs openssl)
+
+ifeq ($(findstring linux,$(CHIP_HOST_ARCH)),linux)
+STD_LIBS += $(shell pkg-config --libs gio-2.0)
+STD_CFLAGS += $(shell pkg-config --cflags gio-2.0)
+endif
 
 # Add the appropriate CHIP target as a prerequisite to all application
 # compilation targets to ensure that CHIP gets built and its header
@@ -149,6 +155,7 @@ STD_COMPILE_PREREQUISITES += install-chip
 # Add the CHIP libraries as prerequisites for linking the application.
 STD_LINK_PREREQUISITES += \
     $(CHIP_OUTPUT_DIR)/lib/libCHIP.a \
+    $(CHIP_OUTPUT_DIR)/lib/libDeviceLayer.a \
     $(CHIP_OUTPUT_DIR)/lib/libInetLayer.a \
     $(CHIP_OUTPUT_DIR)/lib/libnlfaultinjection.a \
     $(CHIP_OUTPUT_DIR)/lib/libSystemLayer.a

--- a/configure.ac
+++ b/configure.ac
@@ -966,11 +966,11 @@ AC_DEFINE_UNQUOTED([CONFIG_NETWORK_LAYER_INET],[${CONFIG_NETWORK_LAYER_INET}],[D
 AC_MSG_CHECKING([device layer])
 AC_ARG_WITH(device-layer,
     [AS_HELP_STRING([--with-device-layer=LAYER],
-        [Specify the target environment for the CHIP Device Layer.  Choose one of: darwin, efr32, esp32, nrf5, linux, or none @<:@default=none@:>@.])],
+        [Specify the target environment for the CHIP Device Layer.  Choose one of: auto, darwin, efr32, esp32, nrf5, linux, or none @<:@default=auto@:>@.])],
     [
         case "${with_device_layer}" in
 
-        darwin|efr32|esp32|nrf5|linux|none)
+        auto|darwin|efr32|esp32|nrf5|linux|none)
             ;;
 
         *)
@@ -979,7 +979,7 @@ AC_ARG_WITH(device-layer,
 
         esac
     ],
-    [with_device_layer=none])
+    [with_device_layer=auto])
 AC_MSG_RESULT(${with_device_layer})
 
 # Disable all device layer targets by default
@@ -988,6 +988,24 @@ CHIP_DEVICE_LAYER_TARGET_EFR32=0
 CHIP_DEVICE_LAYER_TARGET_ESP32=0
 CHIP_DEVICE_LAYER_TARGET_NRF5=0
 CHIP_DEVICE_LAYER_TARGET_LINUX=0
+
+if test "${with_device_layer}" = "auto"; then
+    case ${target_os} in
+
+	*darwin*)
+            with_device_layer=darwin
+	    ;;
+
+	*linux*)
+            with_device_layer=linux
+	    ;;
+
+	*)
+            with_device_layer=none
+	    ;;
+
+    esac
+fi
 
 case "${with_device_layer}" in
 

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -275,6 +275,7 @@ typedef void (*AsyncWorkFunct)(intptr_t arg);
 #include CHIPDEVICEPLATFORMEVENT_HEADER
 #endif
 
+#include <ble/BleConfig.h>
 #include <system/SystemPacketBuffer.h>
 
 namespace chip {

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -154,7 +154,7 @@ public:
     bool HaveServiceConnectivity(void);
 
     // CHIPoBLE service methods
-    typedef void (*BleConnectionReceivedFunct)(BLEEndPoint * endpoint);
+    typedef void (*BleConnectionReceivedFunct)(Ble::BLEEndPoint * endpoint);
     void AddCHIPoBLEConnectionHandler(BleConnectionReceivedFunct handler);
     void RemoveCHIPoBLEConnectionHandler(void);
     CHIPoBLEServiceMode GetCHIPoBLEServiceMode(void);

--- a/src/platform/Makefile.am
+++ b/src/platform/Makefile.am
@@ -42,14 +42,26 @@ noinst_HEADERS                          = \
     @top_srcdir@/src/include/platform/PersistedStorage.h \
     @top_srcdir@/src/include/platform/SoftwareUpdateManager.h \
     @top_srcdir@/src/include/platform/TimeSyncManager.h \
+    @top_srcdir@/src/include/platform/ThreadStackManager.h \
     @top_srcdir@/src/include/platform/CHIPDeviceConfig.h \
     @top_srcdir@/src/include/platform/CHIPDeviceError.h \
     @top_srcdir@/src/include/platform/CHIPDeviceEvent.h \
     @top_srcdir@/src/include/platform/CHIPDeviceLayer.h \
     @top_srcdir@/src/include/platform/internal/BLEManager.h \
+    @top_srcdir@/src/include/platform/internal/CHIPDeviceLayerInternal.h \
+    @top_srcdir@/src/include/platform/internal/DeviceNetworkInfo.h \
     @top_srcdir@/src/include/platform/internal/EventLogging.h \
     @top_srcdir@/src/include/platform/internal/GenericConfigurationManagerImpl.h \
     @top_srcdir@/src/include/platform/internal/GenericConfigurationManagerImpl.ipp \
+    @top_srcdir@/src/include/platform/internal/GenericConnectivityManagerImpl.h \
+    @top_srcdir@/src/include/platform/internal/GenericConnectivityManagerImpl_BLE.h \
+    @top_srcdir@/src/include/platform/internal/GenericConnectivityManagerImpl_BLE.ipp \
+    @top_srcdir@/src/include/platform/internal/GenericConnectivityManagerImpl_NoBLE.h \
+    @top_srcdir@/src/include/platform/internal/GenericConnectivityManagerImpl_NoThread.h \
+    @top_srcdir@/src/include/platform/internal/GenericConnectivityManagerImpl_NoTunnel.h \
+    @top_srcdir@/src/include/platform/internal/GenericConnectivityManagerImpl_NoWiFi.h \
+    @top_srcdir@/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.h \
+    @top_srcdir@/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.ipp \
     @top_srcdir@/src/include/platform/internal/GenericPlatformManagerImpl.h \
     @top_srcdir@/src/include/platform/internal/GenericPlatformManagerImpl.ipp \
     @top_srcdir@/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h \
@@ -58,11 +70,16 @@ noinst_HEADERS                          = \
     @top_srcdir@/src/include/platform/internal/GenericSoftwareUpdateManagerImpl.ipp \
     @top_srcdir@/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.h \
     @top_srcdir@/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp \
-    @top_srcdir@/src/include/platform/internal/CHIPDeviceLayerInternal.h \
+    @top_srcdir@/src/platform/Darwin/BlePlatformConfig.h \
     @top_srcdir@/src/platform/Darwin/CHIPDevicePlatformConfig.h \
     @top_srcdir@/src/platform/Darwin/CHIPDevicePlatformEvent.h \
+    @top_srcdir@/src/platform/Darwin/CHIPPlatformConfig.h \
     @top_srcdir@/src/platform/Darwin/ConfigurationManagerImpl.h \
+    @top_srcdir@/src/platform/Darwin/ConnectivityManagerImpl.h \
+    @top_srcdir@/src/platform/Darwin/InetPlatformConfig.h \
     @top_srcdir@/src/platform/Darwin/PlatformManagerImpl.h \
+    @top_srcdir@/src/platform/Darwin/PosixConfig.h \
+    @top_srcdir@/src/platform/Darwin/SystemPlatformConfig.h \
     @top_srcdir@/src/platform/nRF5/ConnectivityManagerImpl.h \
     @top_srcdir@/src/platform/nRF5/nRF5Config.h \
     @top_srcdir@/src/platform/nRF5/CHIPDevicePlatformConfig.h \
@@ -91,10 +108,21 @@ noinst_HEADERS                          = \
     @top_srcdir@/src/platform/ESP32/NetworkProvisioningServerImpl.h \
     @top_srcdir@/src/platform/ESP32/ESP32Utils.h \
     @top_srcdir@/src/platform/ESP32/ESP32Config.h \
+    @top_srcdir@/src/platform/Linux/BLEManagerImpl.h \
+    @top_srcdir@/src/platform/Linux/BlePlatformConfig.h \
+    @top_srcdir@/src/platform/Linux/CHIPLinuxStorage.h \
+    @top_srcdir@/src/platform/Linux/CHIPLinuxStorageIni.h \
     @top_srcdir@/src/platform/Linux/CHIPDevicePlatformConfig.h \
     @top_srcdir@/src/platform/Linux/CHIPDevicePlatformEvent.h \
+    @top_srcdir@/src/platform/Linux/CHIPPlatformConfig.h \
     @top_srcdir@/src/platform/Linux/ConfigurationManagerImpl.h \
+    @top_srcdir@/src/platform/Linux/ConnectivityManagerImpl.h \
+    @top_srcdir@/src/platform/Linux/InetPlatformConfig.h \
     @top_srcdir@/src/platform/Linux/PlatformManagerImpl.h \
+    @top_srcdir@/src/platform/Linux/PosixConfig.h \
+    @top_srcdir@/src/platform/Linux/SystemPlatformConfig.h \
+    @top_srcdir@/src/platform/Linux/ThreadStackManagerImpl.h \
+    @top_srcdir@/src/include/platform/internal/testing/ConfigUnitTest.h \
     $(NULL)
 
 if CONFIG_DEVICE_LAYER

--- a/src/platform/tests/Makefile.am
+++ b/src/platform/tests/Makefile.am
@@ -76,9 +76,15 @@ AM_CPPFLAGS                                   += \
 if CHIP_WITH_OT_BR_POSIX
 AM_CPPFLAGS                                   += \
     $(DBUS_CFLAGS)                               \
-    $(OT_BR_POSIX_CPPFLAGS)                     \
+    $(OT_BR_POSIX_CPPFLAGS)                      \
     $(NULL)
+
 libPlatformTests_a_SOURCES += TestThreadStackMgr.cpp
+
+dist_libPlatformTests_a_HEADERS                += \
+    TestThreadStackMgr.h                          \
+    $(NULL)
+
 endif # CHIP_WITH_OT_BR_POSIX
 endif # CHIP_DEVICE_LAYER_TARGET_LINUX
 
@@ -91,27 +97,25 @@ CHIP_LDADD                                      = \
     $(NULL)
 
 if CHIP_DEVICE_LAYER_TARGET_LINUX
-CHIP_LDADD                                    += \
-    $(GIO_CFLAGS) $(GIO_LIBS)                    \
-    $(NULL)
-
-if CHIP_WITH_OT_BR_POSIX
-CHIP_LDADD                                    += \
-    $(DBUS_LIBS)                                 \
-    $(OT_BR_POSIX_LDFLAGS) $(OT_BR_POSIX_LIBS) \
-    $(NULL)
-endif # CHIP_WITH_OT_BR_POSIX
-endif # CHIP_DEVICE_LAYER_TARGET_LINUX
 
 COMMON_LDADD                                          = \
     libPlatformTests.a                                  \
     $(CHIP_LDADD)                                       \
+    $(GIO_CFLAGS) $(GIO_LIBS)                           \
     $(NLFAULTINJECTION_LDFLAGS) $(NLFAULTINJECTION_LIBS)\
     $(NLUNIT_TEST_LDFLAGS) $(NLUNIT_TEST_LIBS)          \
     $(LWIP_LDFLAGS) $(LWIP_LIBS)                        \
     $(SOCKETS_LDFLAGS) $(SOCKETS_LIBS)                  \
     $(PTHREAD_CFLAGS) $(PTHREAD_LIBS)                   \
     $(NULL)
+
+if CHIP_WITH_OT_BR_POSIX
+COMMON_LDADD                                   += \
+    $(DBUS_LIBS)                                  \
+    $(OT_BR_POSIX_LDFLAGS) $(OT_BR_POSIX_LIBS)    \
+    $(NULL)
+endif # CHIP_WITH_OT_BR_POSIX
+endif # CHIP_DEVICE_LAYER_TARGET_LINUX
 
 # Test applications that should be run when the 'check' target is run.
 

--- a/third_party/Makefile.am
+++ b/third_party/Makefile.am
@@ -29,6 +29,14 @@ EXTRA_DIST                                   = \
     nlbuild-autotools                          \
     $(NULL)
 
+if CHIP_DEVICE_LAYER_TARGET_LINUX
+if CHIP_WITH_OT_BR_POSIX
+EXTRA_DIST                                   += \
+    inipp                                       \
+    $(NULL)
+endif # CHIP_WITH_OT_BR_POSIX
+endif # CHIP_DEVICE_LAYER_TARGET_LINUX
+
 # Always package (e.g. for 'make dist') these subdirectories.
 
 DIST_SUBDIRS                                 = \

--- a/third_party/mbedtls/Makefile.am
+++ b/third_party/mbedtls/Makefile.am
@@ -122,6 +122,13 @@ nodist_libmbedtls_a_SOURCES                                                   +=
     $(NULL)
 endif
 
+if CHIP_DEVICE_LAYER_TARGET_LINUX
+nodist_libmbedtls_a_SOURCES                                                   += \
+    repo/library/entropy_poll.c             \
+    repo/library/timing.c                   \
+    $(NULL)
+endif
+
 libmbedtls_a_CPPFLAGS                                                          = \
     -I$(top_srcdir)/third_party/mbedtls/repo/include                             \
     $(MBEDTLS_CPPFLAGS)                                                          \


### PR DESCRIPTION
 #### Problem

This patch glue standalone apps to a device layer. Examples of such standalone builds are the one produce by:
 * make -f Makefile-Standalone
 * examples/chip-tool (which use config/standalone)
 * examples/shell (which use config/standalone)