### PR TITLE
Attempt to Re-enable the TestInetEndPoint Unit Test

### DIFF
--- a/src/inet/tests/Makefile.am
+++ b/src/inet/tests/Makefile.am
@@ -142,17 +142,16 @@ else # CHIP_DEVICE_LAYER_TARGET_ESP32
 #
 # These will NOT be part of the externally-consumable binary SDK.
 #
-# XXX - At this point TestInetEndPoint and TestInetLayerDNS are stranded
-#       here until a solution for enabling IPv6 on Linux containers for
-#       Docker on macOS can be resolved as that test involves
-#       executing APIs that exercise bind, listen, connect, accept,
-#       etc. on IPv4 and IPv6 IP end points. When that issue has been
-#       resolved, move these tests to check_PROGRAMS.
+# XXX - At this point TestInetLayerDNS is stranded here until a
+#       solution for enabling IPv6 on Linux containers for Docker
+#       on macOS can be resolved as that test involves executing
+#       APIs that exercise bind, listen, connect, accept, etc. on
+#       IPv4 and IPv6 IP end points. When that issue has been
+#       resolved, move this test to check_PROGRAMS.
 
 # Build and run these test targets only on standalone device targets
 noinst_PROGRAMS                                       = \
     TestLwIPDNS                                         \
-    TestInetEndPoint                                    \
     TestInetLayer                                       \
     TestInetLayerDNS                                    \
     TestInetLayerMulticast                              \
@@ -160,6 +159,7 @@ noinst_PROGRAMS                                       = \
 
 check_PROGRAMS                                       += \
     TestInetAddress                                     \
+    TestInetEndPoint                                    \
     TestInetErrorStr                                    \
     $(NULL)
 


### PR DESCRIPTION
#### Problem
The CI systems that Project CHIP has employed have historically not supported IPv6. Now that Circle CI has migrated to GitHub Actions, attempt to re-enable tests that require IPv6 support.

#### Summary of Changes
Moves `TestInetEndPoint` from `noinst_PROGRAMS` back to `check_PROGRAMS`.

Fixes #323