### PR TITLE
Attempt to Re-enable the TestInetLayerDNS Unit Test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,11 +37,6 @@ jobs:
                   esac
 
                   scripts/build/bootstrap.sh $BOOTSTRAP_ARGUMENTS
-            - name: Configure IPv6
-              run:
-                  sudo sed -i 's/::1 ip6-localhost
-                  ip6-loopback/::1     localhost ip6-localhost ip6-loopback/g'
-                  /etc/hosts
             - name: Run Build
               run: scripts/build/default.sh
             - name: Run mbedTLS Tests

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v2
               with:
-                 submodules: true
+                  submodules: true
             - name: Bootstrap
               run: |
                   case $BUILD_TYPE in
@@ -37,6 +37,10 @@ jobs:
                   esac
 
                   scripts/build/bootstrap.sh $BOOTSTRAP_ARGUMENTS
+            - name: Configure IPv6
+              run:
+                  sed -i 's/::1 ip6-localhost ip6-loopback/::1     localhost
+                  ip6-localhost ip6-loopback/g' /etc/hosts
             - name: Run Build
               run: scripts/build/default.sh
             - name: Run mbedTLS Tests
@@ -75,4 +79,3 @@ jobs:
             # - name: Upload Code Coverage
             #   if: ${{ contains('main', env.BUILD_TYPE) }}
             #   run: bash <(curl -s https://codecov.io/bash)
-

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,8 +39,9 @@ jobs:
                   scripts/build/bootstrap.sh $BOOTSTRAP_ARGUMENTS
             - name: Configure IPv6
               run:
-                  sed -i 's/::1 ip6-localhost ip6-loopback/::1     localhost
-                  ip6-localhost ip6-loopback/g' /etc/hosts
+                  sudo sed -i 's/::1 ip6-localhost
+                  ip6-loopback/::1     localhost ip6-localhost ip6-loopback/g'
+                  /etc/hosts
             - name: Run Build
               run: scripts/build/default.sh
             - name: Run mbedTLS Tests

--- a/src/inet/tests/Makefile.am
+++ b/src/inet/tests/Makefile.am
@@ -142,25 +142,25 @@ else # CHIP_DEVICE_LAYER_TARGET_ESP32
 #
 # These will NOT be part of the externally-consumable binary SDK.
 #
-# XXX - At this point TestInetEndPoint and TestInetLayerDNS are stranded
-#       here until a solution for enabling IPv6 on Linux containers for
-#       Docker on macOS can be resolved as that test involves
-#       executing APIs that exercise bind, listen, connect, accept,
-#       etc. on IPv4 and IPv6 IP end points. When that issue has been
-#       resolved, move these tests to check_PROGRAMS.
+# XXX - At this point TestInetEndPoint is stranded here until a
+#       solution for enabling IPv6 on Linux containers for Docker
+#       on macOS can be resolved as that test involves executing
+#       APIs that exercise bind, listen, connect, accept, etc. on
+#       IPv4 and IPv6 IP end points. When that issue has been
+#       resolved, move this test to check_PROGRAMS.
 
 # Build and run these test targets only on standalone device targets
 noinst_PROGRAMS                                       = \
     TestLwIPDNS                                         \
     TestInetEndPoint                                    \
     TestInetLayer                                       \
-    TestInetLayerDNS                                    \
     TestInetLayerMulticast                              \
     $(NULL)
 
 check_PROGRAMS                                       += \
     TestInetAddress                                     \
     TestInetErrorStr                                    \
+    TestInetLayerDNS                                    \
     $(NULL)
 
 endif # CHIP_DEVICE_LAYER_TARGET_ESP32


### PR DESCRIPTION
#### Problem
The CI systems that Project CHIP has employed have historically not supported IPv6. Now that Circle CI has migrated to GitHub Actions, attempt to re-enable tests that require IPv6 support.

#### Summary of Changes
Moves `TestInetLayerDNS` from `noinst_PROGRAMS` back to `check_PROGRAMS`.

Fixes #329