### PR TITLE
gn_build.sh: Don't forget to build libCHIP.a

### DIFF
--- a/gn_build.sh
+++ b/gn_build.sh
@@ -54,7 +54,7 @@ gn --root="$CHIP_ROOT" gen --check "$CHIP_ROOT/out/release" --args='target_os="a
 
 _chip_banner "Build: Ninja build"
 
-time ninja -C "$CHIP_ROOT/out/debug" check
+time ninja -C "$CHIP_ROOT/out/debug" all check
 
 echo
 echo 'To activate existing build environment in your shell, run (do this first):'


### PR DESCRIPTION
Building "check" builds all tests, which builds most of the code, but
doesn't produce libCHIP.a. Fix this by also building "all".

The instructions are correct, it's just the script assuming check
implies a full build (it could, but maybe it's better to preserve a way
to only run tests?)