### PR TITLE
/bin/bash to /usr/bin/env bash

### DIFF
--- a/gn_build.sh
+++ b/gn_build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright (c) 2020 Project CHIP Authors
 #
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+set -e
 
 CHIP_ROOT="$(dirname "$0")"
 


### PR DESCRIPTION
#### Problem
 gn_build.sh is shebanging /bin/bash on MacOS, which is old
 most CHIP devs on MacOS install newer bash with homebrew or other

 #### Summary of Changes
 use a better bash if in the path