### PR TITLE
Run the bloat check script as a scheduled github workflow.

### DIFF
--- a/.github/workflows/bloat_check.yaml
+++ b/.github/workflows/bloat_check.yaml
@@ -1,0 +1,23 @@
+name: Bloat Check
+on:
+    schedule:
+        - cron: '*/10 * * * *'
+
+
+jobs:
+    pull_request_update:
+        name: Report on pull requests
+
+        runs-on: ubuntu-latest
+
+        container:
+            image: "connectedhomeip/chip-build-openssl:0.2.18"
+
+        steps:
+            - name: Report
+              run: |
+                  scripts/helpers/bloat_check.py                        \
+                       --github-repository project-chip/connectedhomeip \
+                       --github-api-token "${{ secrets.GITHUB_TOKEN }}"
+
+


### PR DESCRIPTION
Should generate bloat reports on any pull requests.

 #### Problem
Bloat reports are not working since we switched from circleci to github actions

 #### Summary of Changes
Run the bloat report on a scheduled basis. This is so that the token used is not based on a forked repo and as a result it should have rights to comment on PRs as well as access artifacts and perform periodic cleanup.

I tested the script manually, however I am unsure on how to test it as a workflow. Hoping that things will just go well,
