### PR TITLE
Fix GN build warnings due to objects with no symbols on Mac

### DIFF
--- a/src/lib/core/BUILD.gn
+++ b/src/lib/core/BUILD.gn
@@ -89,6 +89,26 @@ config("chip_config") {
     defines += [ "CHIP_LOGGING_STYLE_STDIO_WEAK=0" ]
   }
 
+  if (chip_config_memory_management == "malloc") {
+    defines += [
+      "CHIP_CONFIG_MEMORY_MGMT_MALLOC=1",
+      "HAVE_MALLOC=1",
+      "HAVE_FREE=1",
+    ]
+  } else {
+    defines += [ "CHIP_CONFIG_MEMORY_MGMT_MALLOC=0" ]
+  }
+  if (chip_config_memory_management == "simple") {
+    defines += [ "CHIP_CONFIG_MEMORY_MGMT_SIMPLE=1" ]
+  } else {
+    defines += [ "CHIP_CONFIG_MEMORY_MGMT_SIMPLE=0" ]
+  }
+  if (chip_config_memory_management == "platform") {
+    defines += [ "CHIP_CONFIG_MEMORY_MGMT_PLATFORM=1" ]
+  } else {
+    defines += [ "CHIP_CONFIG_MEMORY_MGMT_PLATFORM=0" ]
+  }
+
   include_dirs = [ target_gen_dir ]
 
   configs = [

--- a/src/lib/core/core.gni
+++ b/src/lib/core/core.gni
@@ -38,6 +38,9 @@ declare_args() {
 
   # Enable argument parser.
   chip_config_enable_arg_parser = true
+
+  # Memory management style: malloc, simple, platform.
+  chip_config_memory_management = "malloc"
 }
 
 if (chip_target_style == "") {
@@ -63,3 +66,9 @@ assert(
     chip_logging_style == "android" || chip_logging_style == "external" ||
         chip_logging_style == "stdio" || chip_logging_style == "stdio_weak",
     "Please select a valid logging style: android, external, stdio, stdio_weak")
+
+assert(
+    chip_config_memory_management == "malloc" ||
+        chip_config_memory_management == "simple" ||
+        chip_config_memory_management == "platform",
+    "Please select a valid memory management style: malloc, simple, platform")

--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -19,6 +19,7 @@ import("//build_overrides/nlio.gni")
 
 import("${chip_root}/gn/chip/chip_version.gni")
 import("${chip_root}/gn/chip/tests.gni")
+import("${chip_root}/src/lib/core/core.gni")
 
 action("gen_chip_version") {
   script = "${chip_root}/scripts/gen_chip_version.py"
@@ -73,8 +74,6 @@ static_library("support") {
     "Base64.cpp",
     "CHIPArgParser.cpp",
     "CHIPCounter.cpp",
-    "CHIPMem-Malloc.cpp",
-    "CHIPMem-SimpleAlloc.cpp",
     "ErrorStr.cpp",
     "FibonacciUtils.cpp",
     "PersistedCounter.cpp",
@@ -101,6 +100,12 @@ static_library("support") {
 
   public_configs = [ ":support_config" ]
 
+  if (chip_config_memory_management == "simple") {
+    sources += [ "CHIPMem-SimpleAlloc.cpp" ]
+  }
+  if (chip_config_memory_management == "malloc") {
+    sources += [ "CHIPMem-Malloc.cpp" ]
+  }
   if (chip_with_nlfaultinjection) {
     sources += [ "CHIPFaultInjection.cpp" ]
     public += [ "CHIPFaultInjection.h" ]

--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -97,11 +97,6 @@ config("system_config") {
   } else {
     defines += [ "CHIP_SYSTEM_CONFIG_PROVIDE_STATISTICS=0" ]
   }
-  if (chip_system_config_use_malloc) {
-    defines += [ "CONFIG_HAVE_HEAP=1" ]
-    defines += [ "HAVE_MALLOC=1" ]
-    defines += [ "HAVE_FREE=1" ]
-  }
   if (chip_system_config_clock == "clock_gettime") {
     defines += [ "HAVE_CLOCK_GETTIME=1" ]
     defines += [ "HAVE_CLOCK_SETTIME=1" ]

--- a/src/system/system.gni
+++ b/src/system/system.gni
@@ -13,12 +13,6 @@
 # limitations under the License.
 
 declare_args() {
-  # Build tests.
-  chip_system_config_test = true
-
-  # Use malloc.
-  chip_system_config_use_malloc = current_os != "freertos"
-
   # Use the lwIP library.
   chip_system_config_use_lwip = current_os == "freertos"
 


### PR DESCRIPTION
Add support for selecting one of CHIPMem-Malloc.cpp and
CHIPMem-Simple.cpp to avoid warnings from compiling files with no
symbols.