### PR TITLE
[linux] Add GDBus support in PlatformMgr to drive DBUS communication.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1933,7 +1933,16 @@ fi
 
 if test "${CHIP_DEVICE_LAYER_TARGET_LINUX}" = 1; then
     PKG_CHECK_MODULES([GIO], [gio-2.0])
-    PKG_CHECK_MODULES([GIO_UNIX], [gio-unix-2.0])
+
+    # Check for GIO library is available.
+    AC_CHECK_LIB([gio-2.0], [g_bus_get_sync],
+    [
+        AC_DEFINE([CHIP_WITH_GIO], [1], [Define to 1 to build CHIP with GIO])
+    ],
+    [
+        AC_DEFINE([CHIP_WITH_GIO], [0], [Define to 0 to build CHIP without GIO])
+    ]
+    )
 fi
 
 #
@@ -2361,7 +2370,6 @@ AC_MSG_NOTICE([
   PThreads link libraries                          : ${PTHREAD_LIBS:--}
   IniPP compile flags                              : ${INIPP_CPPFLAGS:--}
   GIO compile flags                                : ${GIO_CFLAGS:--}
-  GIO Unix compile flags                           : ${GIO_UNIX_CFLAGS:--}
   C Preprocessor                                   : ${CPP}
   C Compiler                                       : ${CC}
   C++ Preprocessor                                 : ${CXXCPP}

--- a/configure.ac
+++ b/configure.ac
@@ -1927,6 +1927,16 @@ if test "${CHIP_DEVICE_LAYER_TARGET_LINUX}" = 1; then
 fi
 
 #
+#
+# GIO
+#
+
+if test "${CHIP_DEVICE_LAYER_TARGET_LINUX}" = 1; then
+    PKG_CHECK_MODULES([GIO], [gio-2.0])
+    PKG_CHECK_MODULES([GIO_UNIX], [gio-unix-2.0])
+fi
+
+#
 # Sockets
 #
 
@@ -2350,6 +2360,8 @@ AC_MSG_NOTICE([
   PThreads compile flags                           : ${PTHREAD_CFLAGS:--}
   PThreads link libraries                          : ${PTHREAD_LIBS:--}
   IniPP compile flags                              : ${INIPP_CPPFLAGS:--}
+  GIO compile flags                                : ${GIO_CFLAGS:--}
+  GIO Unix compile flags                           : ${GIO_UNIX_CFLAGS:--}
   C Preprocessor                                   : ${CPP}
   C Compiler                                       : ${CC}
   C++ Preprocessor                                 : ${CXXCPP}

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -34,6 +34,7 @@ namespace DeviceLayer {
 
 PlatformManagerImpl PlatformManagerImpl::sInstance;
 
+#if CHIP_WITH_GIO
 static void GDBus_Thread()
 {
     GMainLoop * loop = g_main_loop_new(nullptr, false);
@@ -41,17 +42,21 @@ static void GDBus_Thread()
     g_main_loop_run(loop);
     g_main_loop_unref(loop);
 }
+#endif
 
 CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 {
     CHIP_ERROR err;
+
+#if CHIP_WITH_GIO
     GError * error = NULL;
 
     this->mpGDBusConnection = UniqueGDBusConnection(g_bus_get_sync(G_BUS_TYPE_SYSTEM, NULL, &error));
 
     std::thread gdbusThread(GDBus_Thread);
     gdbusThread.detach();
-    
+#endif
+
     // Initialize the configuration system.
     err = Internal::PosixConfig::Init();
     SuccessOrExit(err);
@@ -65,10 +70,12 @@ exit:
     return err;
 }
 
+#if CHIP_WITH_GIO
 GDBusConnection * PlatformManagerImpl::GetGDBusConnection()
 {
     return this->mpGDBusConnection.get();
 }
+#endif
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Linux/PlatformManagerImpl.h
+++ b/src/platform/Linux/PlatformManagerImpl.h
@@ -24,9 +24,12 @@
 #ifndef PLATFORM_MANAGER_IMPL_H
 #define PLATFORM_MANAGER_IMPL_H
 
-#include <platform/internal/GenericPlatformManagerImpl_POSIX.h>
 #include <memory>
+#include <platform/internal/GenericPlatformManagerImpl_POSIX.h>
+
+#if CHIP_WITH_GIO
 #include <gio/gio.h>
+#endif
 
 namespace chip {
 namespace DeviceLayer {
@@ -46,8 +49,9 @@ class PlatformManagerImpl final : public PlatformManager, public Internal::Gener
 
 public:
     // ===== Platform-specific members that may be accessed directly by the application.
-
+#if CHIP_WITH_GIO
     GDBusConnection * GetGDBusConnection();
+#endif
 
 private:
     // ===== Methods that implement the PlatformManager abstract interface.
@@ -62,12 +66,14 @@ private:
 
     static PlatformManagerImpl sInstance;
 
+#if CHIP_WITH_GIO
     struct GDBusConnectionDeleter
     {
-        void operator()(GDBusConnection *conn) { g_object_unref(conn); }
+        void operator()(GDBusConnection * conn) { g_object_unref(conn); }
     };
     using UniqueGDBusConnection = std::unique_ptr<GDBusConnection, GDBusConnectionDeleter>;
     UniqueGDBusConnection mpGDBusConnection;
+#endif
 };
 
 /**

--- a/src/platform/Linux/PlatformManagerImpl.h
+++ b/src/platform/Linux/PlatformManagerImpl.h
@@ -25,6 +25,8 @@
 #define PLATFORM_MANAGER_IMPL_H
 
 #include <platform/internal/GenericPlatformManagerImpl_POSIX.h>
+#include <memory>
+#include <gio/gio.h>
 
 namespace chip {
 namespace DeviceLayer {
@@ -45,7 +47,7 @@ class PlatformManagerImpl final : public PlatformManager, public Internal::Gener
 public:
     // ===== Platform-specific members that may be accessed directly by the application.
 
-    /* none so far */
+    GDBusConnection * GetGDBusConnection();
 
 private:
     // ===== Methods that implement the PlatformManager abstract interface.
@@ -59,6 +61,13 @@ private:
     friend class Internal::BLEManagerImpl;
 
     static PlatformManagerImpl sInstance;
+
+    struct GDBusConnectionDeleter
+    {
+        void operator()(GDBusConnection *conn) { g_object_unref(conn); }
+    };
+    using UniqueGDBusConnection = std::unique_ptr<GDBusConnection, GDBusConnectionDeleter>;
+    UniqueGDBusConnection mpGDBusConnection;
 };
 
 /**

--- a/src/platform/Makefile.am
+++ b/src/platform/Makefile.am
@@ -155,7 +155,6 @@ SUBDIRS                                += tests
 
 libDeviceLayer_a_CPPFLAGS              += \
     $(GIO_CFLAGS)                         \
-    $(GIO_UNIX_CFLAGS)                    \
     $(INIPP_CPPFLAGS)                     \
     $(NULL)
 

--- a/src/platform/Makefile.am
+++ b/src/platform/Makefile.am
@@ -154,6 +154,8 @@ if CHIP_DEVICE_LAYER_TARGET_LINUX
 SUBDIRS                                += tests
 
 libDeviceLayer_a_CPPFLAGS              += \
+    $(GIO_CFLAGS)                         \
+    $(GIO_UNIX_CFLAGS)                    \
     $(INIPP_CPPFLAGS)                     \
     $(NULL)
 

--- a/src/platform/tests/Makefile.am
+++ b/src/platform/tests/Makefile.am
@@ -71,7 +71,6 @@ AM_CPPFLAGS                                    = \
 if CHIP_DEVICE_LAYER_TARGET_LINUX
 AM_CPPFLAGS                                   += \
     $(GIO_CFLAGS)                                \
-    $(GIO_UNIX_CFLAGS)                           \
     $(NULL)
 
 if CHIP_WITH_OT_BR_POSIX
@@ -94,7 +93,6 @@ CHIP_LDADD                                      = \
 if CHIP_DEVICE_LAYER_TARGET_LINUX
 CHIP_LDADD                                    += \
     $(GIO_CFLAGS) $(GIO_LIBS)                    \
-    $(GIO_UNIX_CFLAGS) $(GIO_UNIX_LIBS)          \
     $(NULL)
 
 if CHIP_WITH_OT_BR_POSIX

--- a/src/platform/tests/Makefile.am
+++ b/src/platform/tests/Makefile.am
@@ -69,14 +69,20 @@ AM_CPPFLAGS                                    = \
     $(NULL)
 
 if CHIP_DEVICE_LAYER_TARGET_LINUX
+AM_CPPFLAGS                                   += \
+    $(GIO_CFLAGS)                                \
+    $(GIO_UNIX_CFLAGS)                           \
+    $(NULL)
+
 if CHIP_WITH_OT_BR_POSIX
 AM_CPPFLAGS                                   += \
     $(DBUS_CFLAGS)                               \
     $(OT_BR_POSIX_CPPFLAGS)                     \
     $(NULL)
 libPlatformTests_a_SOURCES += TestThreadStackMgr.cpp
-endif
-endif
+endif # CHIP_WITH_OT_BR_POSIX
+endif # CHIP_DEVICE_LAYER_TARGET_LINUX
+
 
 CHIP_LDADD                                      = \
     $(top_builddir)/src/platform/libDeviceLayer.a \
@@ -86,13 +92,18 @@ CHIP_LDADD                                      = \
     $(NULL)
 
 if CHIP_DEVICE_LAYER_TARGET_LINUX
+CHIP_LDADD                                    += \
+    $(GIO_CFLAGS) $(GIO_LIBS)                    \
+    $(GIO_UNIX_CFLAGS) $(GIO_UNIX_LIBS)          \
+    $(NULL)
+
 if CHIP_WITH_OT_BR_POSIX
 CHIP_LDADD                                    += \
     $(DBUS_LIBS)                                 \
     $(OT_BR_POSIX_LDFLAGS) $(OT_BR_POSIX_LIBS) \
     $(NULL)
-endif
-endif
+endif # CHIP_WITH_OT_BR_POSIX
+endif # CHIP_DEVICE_LAYER_TARGET_LINUX
 
 COMMON_LDADD                                          = \
     libPlatformTests.a                                  \


### PR DESCRIPTION
Problem
Extend PlatformMgr to allow service share DBus connection.
Need a consistent way to register such services to drive DBUS in a common way

Summary of Changes
* Add GDBus support in PlatformMgr to drive DBUS: Thread, BLE, WiFi.
* Add dedicated I/O thread for DBUS.

fixes #<1084>
