### PR TITLE
Update version for android image, fix dpkg install error in nrf conne…

### DIFF
--- a/integrations/docker/images/chip-build-android/version
+++ b/integrations/docker/images/chip-build-android/version
@@ -1,1 +1,1 @@
-0.2.18
+../chip-build/version

--- a/integrations/docker/images/chip-build-nrfconnect-platform/Dockerfile
+++ b/integrations/docker/images/chip-build-nrfconnect-platform/Dockerfile
@@ -11,8 +11,8 @@ RUN set -x \
     # nRF Tools for flashing software on Nordic devices, and accessing device logs
     && wget -qO- https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/10-7-0/nRFCommandLineTools1070Linuxamd64tar.gz \
         | tar xz -C /tmp \
-    && dpkg -i /tmp/JLink_Linux_*.deb \
-    && dpkg -i /tmp/nRF-Command-Line-Tools_*.deb \
+    && dpkg -i --force-depends /tmp/JLink_Linux_*.deb \
+    && dpkg -i --force-depends /tmp/nRF-Command-Line-Tools_*.deb \
     # nRF Connect SDK dependencies
     && pip3 install --no-cache-dir setuptools wheel cmake west pyyaml \
     # nRF Connect SDK 1.3.0 sources & requirements


### PR DESCRIPTION
…ct image

 #### Problem
NRf image fails to build. Android image is setting 0.2.18 version.

 #### Summary of Changes
- add force dpkg install for nrf build
- update android image to use a symlink for versioning

fixes #1558 
