### PR TITLE
Fix CFLAGS in Makefile

### DIFF
--- a/examples/wifi-echo/server/esp32/Makefile
+++ b/examples/wifi-echo/server/esp32/Makefile
@@ -27,6 +27,6 @@ EXTRA_COMPONENT_DIRS += $(PROJECT_PATH)/third_party/connectedhomeip/config/esp32
 
 CXXFLAGS += -std=c++11 -Os
 CPPFLAGS += -Os
-CLAGS += -Os
+CFLAGS += -Os
 
 include $(IDF_PATH)/make/project.mk


### PR DESCRIPTION
Noticed a typo in ESP32 demo Makefile which likely explains why are
builds are unexpectedly large.
