### PR TITLE
[linux] Use new chip SHA256 class to re-implement CHIP provisioning HASH

### DIFF
--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -215,6 +215,13 @@ CHIP_ERROR add_entropy_source(entropy_source fn_source, void * p_source, size_t 
 CHIP_ERROR pbkdf2_sha256(const unsigned char * password, size_t plen, const unsigned char * salt, size_t slen,
                          unsigned int iteration_count, uint32_t key_length, unsigned char * output);
 
+/** @brief Clears the first `len` bytes of memory area `buf`.
+ * @param buf Pointer to a memory buffer holding secret data that should be cleared.
+ * @param len Specifies secret data size in bytes.
+ * @return void
+ **/
+void ClearSecretData(uint8_t * buf, uint32_t len);
+
 } // namespace Crypto
 } // namespace chip
 

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -776,5 +776,10 @@ exit:
     return error;
 }
 
+void ClearSecretData(uint8_t * buf, uint32_t len)
+{
+    memset(buf, 0, len);
+}
+
 } // namespace Crypto
 } // namespace chip

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -497,5 +497,10 @@ exit:
     return error;
 }
 
+void ClearSecretData(uint8_t * buf, uint32_t len)
+{
+    memset(buf, 0, len);
+}
+
 } // namespace Crypto
 } // namespace chip

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -31,9 +31,14 @@
 #include <platform/internal/GenericConfigurationManagerImpl.h>
 #include <support/Base64.h>
 #include <support/CodeUtils.h>
+#include <support/CHIPMem.h>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 #include <platform/ThreadStackManager.h>
+#endif
+
+#if CHIP_DEVICE_CONFIG_LOG_PROVISIONING_HASH
+#include <crypto/CHIPCryptoPAL.h>
 #endif
 
 namespace chip {
@@ -94,7 +99,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_ConfigureChipStack()
 
 #if CHIP_DEVICE_CONFIG_LOG_PROVISIONING_HASH
     {
-        uint8_t provHash[Platform::Security::SHA256::kHashLength];
+        uint8_t provHash[chip::Crypto::kSHA256_Hash_Length];
         char provHashBase64[BASE64_ENCODED_LEN(sizeof(provHash)) + 1];
         err = Impl()->_ComputeProvisioningHash(provHash, sizeof(provHash));
         if (err == CHIP_NO_ERROR)
@@ -821,15 +826,14 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_ComputeProvisioningHash(
     CHIP_ERROR err = CHIP_NO_ERROR;
 
 #if CHIP_DEVICE_CONFIG_LOG_PROVISIONING_HASH
-    using HashAlgo = Platform::Security::SHA256;
+    using HashAlgo = chip::Crypto::Hash_SHA256_stream;
 
-    CHIP_ERROR err = CHIP_NO_ERROR;
     HashAlgo hash;
     uint8_t * dataBuf = NULL;
     size_t dataBufSize;
     constexpr uint16_t kLenFieldLen = 4; // 4 hex characters
 
-    VerifyOrExit(hashBufSize >= HashAlgo::kHashLength, err = CHIP_ERROR_BUFFER_TOO_SMALL);
+    VerifyOrExit(hashBufSize >= chip::Crypto::kSHA256_Hash_Length, err = CHIP_ERROR_BUFFER_TOO_SMALL);
 
     // Compute a hash of the device's provisioning data.  The generated hash value confirms to the form
     // described in the CHIP Chip: Factory Provisioning Specification.
@@ -902,7 +906,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_ComputeProvisioningHash(
             chip::Platform::MemoryFree(dataBuf);
 
             dataBufSize = certsLen;
-            dataBuf     = (uint8_t *) Platform::Security::MemoryAlloc(dataBufSize);
+            dataBuf     = (uint8_t *) chip::Platform::MemoryAlloc(dataBufSize);
             VerifyOrExit(dataBuf != NULL, err = CHIP_ERROR_NO_MEMORY);
         }
 
@@ -951,8 +955,8 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_ComputeProvisioningHash(
 exit:
     if (dataBuf != NULL)
     {
-        Crypto::ClearSecretData(dataBuf, dataBufSize);
-        Platform::Security::MemoryFree(dataBuf);
+        chip::Crypto::ClearSecretData(dataBuf, dataBufSize);
+        chip::Platform::MemoryFree(dataBuf);
     }
 #endif // CHIP_DEVICE_CONFIG_LOG_PROVISIONING_HASH
 

--- a/src/platform/tests/Makefile.am
+++ b/src/platform/tests/Makefile.am
@@ -82,6 +82,7 @@ CHIP_LDADD                                      = \
     $(top_builddir)/src/platform/libDeviceLayer.a \
     $(top_builddir)/src/inet/libInetLayer.a       \
     $(top_builddir)/src/system/libSystemLayer.a   \
+    $(top_builddir)/src/crypto/libChipCrypto.a    \
     $(top_builddir)/src/lib/support/libSupportLayer.a   \
     $(NULL)
 


### PR DESCRIPTION
Problem
CHIP provisioning hash logic within configuration manager is temporarily disabled and wait for final CHIP SHA256 implementation.

Summary of Changes
* SHA256 class for CHIP is merged. Replace legacy SHA256 with chip::Crypto::Hash_SHA256_stream in configuration manager
* Enable flag CHIP_DEVICE_CONFIG_LOG_PROVISIONING_HASH

fixes #<1166>
