### PR TITLE
Add default build with linux device layer

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -137,7 +137,8 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
 
   if (host_os == "linux") {
     chip_build("linux_embedded") {
-      toolchain = "${chip_root}/config/linux/toolchain:linux_embedded"
+      toolchain =
+          "${chip_root}/config/linux/toolchain:linux_${host_cpu}_gcc_embedded"
     }
   }
 

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -104,8 +104,11 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
     # Enable building chip with gcc.
     enable_host_gcc_build = enable_default_builds
 
-    # Build building chip with gcc & mbedtls.
-    enable_host_gcc_mbdtls_build = enable_default_builds
+    # Enable building chip with gcc & mbedtls.
+    enable_host_gcc_mbedtls_build = enable_default_builds
+
+    # Enable building chip for linux embedded.
+    enable_linux_embedded_build = enable_default_builds && host_os == "linux"
 
     # Build the chip-tool example.
     enable_standalone_chip_tool_build = enable_default_builds
@@ -130,6 +133,12 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
 
   chip_build("host_gcc_mbedtls") {
     toolchain = "${chip_root}/config/mbedtls/toolchain:${host_os}_${host_cpu}_gcc_mbedtls"
+  }
+
+  if (host_os == "linux") {
+    chip_build("linux_embedded") {
+      toolchain = "${chip_root}/config/linux/toolchain:linux_embedded"
+    }
   }
 
   standalone_toolchain = "${chip_root}/config/standalone/toolchain:standalone"
@@ -162,8 +171,11 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
     if (enable_host_gcc_build) {
       deps += [ ":all_host_gcc" ]
     }
-    if (enable_host_gcc_mbdtls_build) {
+    if (enable_host_gcc_mbedtls_build) {
       deps += [ ":all_host_gcc_mbedtls" ]
+    }
+    if (enable_linux_embedded_build) {
+      deps += [ ":all_linux_embedded" ]
     }
     if (enable_standalone_chip_tool_build) {
       deps += [ ":standalone_chip_tool" ]
@@ -188,8 +200,11 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
       if (enable_host_gcc_build) {
         deps += [ ":check_host_gcc" ]
       }
-      if (enable_host_gcc_mbdtls_build) {
+      if (enable_host_gcc_mbedtls_build) {
         deps += [ ":check_host_gcc_mbedtls" ]
+      }
+      if (enable_linux_embedded_build) {
+        deps += [ ":check_linux_embedded" ]
       }
     }
   }

--- a/config/linux/toolchain/BUILD.gn
+++ b/config/linux/toolchain/BUILD.gn
@@ -1,0 +1,26 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+import("//build/toolchain/gcc_toolchain.gni")
+
+gcc_toolchain("linux_embedded") {
+  toolchain_args = {
+    current_os = "linux"
+    current_cpu = host_cpu
+    is_clang = false
+    import("${chip_root}/src/platform/Linux/args.gni")
+  }
+}

--- a/config/linux/toolchain/BUILD.gn
+++ b/config/linux/toolchain/BUILD.gn
@@ -16,7 +16,7 @@ import("//build_overrides/chip.gni")
 
 import("//build/toolchain/gcc_toolchain.gni")
 
-gcc_toolchain("linux_embedded") {
+gcc_toolchain("linux_${host_cpu}_gcc_embedded") {
   toolchain_args = {
     current_os = "linux"
     current_cpu = host_cpu


### PR DESCRIPTION
 #### Problem
Currently src/platform (device layer) tests will not be run by default because only standalone configs are used.

 #### Summary of Changes
Add another variant that enables linux device layer.
