### PR TITLE
Fix some configuration differences between GN & automake

### DIFF
--- a/config/standalone/args.gni
+++ b/config/standalone/args.gni
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Options from standalone-chip.mk that differ from configure defaults. These
+# options are used from examples/.
 chip_build_tests = false
-
 config_network_layer_ble = false
-inet_config_enable_async_dns_sockets = false
-
-project_config_include_dirs = rebase_path([ "." ])
-chip_project_config_include = "<CHIPProjectConfig.h>"
-system_project_config_include = "<SystemProjectConfig.h>"
+inet_config_enable_tun_endpoint = false
+inet_config_enable_raw_endpoint = false
+inet_config_enable_dns_resolver = false

--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -98,6 +98,14 @@ static_library("support") {
     "${nlassert_root}:nlassert",
   ]
 
+  # These are needed because we include CHIPCore.h, which uses config
+  # options for src/ble and src/inet, however we cannot depend on those
+  # directly as such a dependency is cyclic.
+  public_deps += [
+    "${chip_root}/src/ble:ble_config_header",
+    "${chip_root}/src/inet:inet_config_header",
+  ]
+
   public_configs = [ ":support_config" ]
 
   if (chip_config_memory_management == "simple") {

--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -22,20 +22,26 @@ import("system.gni")
 declare_args() {
   # Extra header to include in CHIPConfig.h for project.
   # TODO - This should probably be in src/core but src/system also uses it.
-  chip_project_config_include = ""
+  chip_project_config_include = "<CHIPProjectConfig.h>"
 
   # Extra header to include in CHIPConfig.h for platform.
   # TODO - This should probably be in src/core but src/system also uses it.
   chip_platform_config_include = ""
 
   # Extra header to include in SystemConfig.h for project.
-  system_project_config_include = ""
+  system_project_config_include = "<SystemProjectConfig.h>"
 
   # Extra header to include in SystemConfig.h for platform.
   system_platform_config_include = ""
 
   # Extra include dirs for project configs.
   project_config_include_dirs = []
+}
+
+if (project_config_include_dirs == [] &&
+    chip_project_config_include == "<CHIPProjectConfig.h>" &&
+    system_project_config_include == "<SystemProjectConfig.h>") {
+  project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 }
 
 config("system_config") {


### PR DESCRIPTION
The standalone project configs now apply unless specifically overriden,
which matches configure's behavior. Previously the project configs were
disabled by default, so the defaults inline in CHIPConfig.h applied.

Note there are at 3 sources of defaults here which lead to this
confusion:

(1) The defaults used by scripts/build/bootstrap.sh, which calls
    configure with few arguments. This uses the standalone
    project configs and builds tests.

(2) The defaults used by config/standalone/standalone-chip.mk, which
    calls configure and overrides some arguments. This uses the
    standalone project configs, but disables some components, and
    does not build tests.

(3) The defaults specified directly in CHIPConfig.h et al. These
    defaults may have no effect because configure always overrides
    them using BuildConfig.h. GN currently doesn't use BuildConfig.h,
    but uses the command line to get the same result.