### PR TITLE
Fix activate.sh to find CHIP_ROOT

### DIFF
--- a/scripts/activate.sh
+++ b/scripts/activate.sh
@@ -13,9 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-if [[ ! -d "${CHIP_ROOT}" ]]; then
-    CHIP_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+if [[ ! -d ${CHIP_ROOT} ]]; then
+    if [[ -n ${BASH_SOURCE[0]} ]]; then
+        CHIP_ROOT=$(cd "${BASH_SOURCE[0]%/*}/.." && pwd)
+    else
+        CHIP_ROOT=$(cd "${0%/*}/.." && pwd)
+    fi
 fi
 
 export PW_BRANDING_BANNER="$CHIP_ROOT/.chip-banner.txt"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -14,7 +14,13 @@
 # limitations under the License.
 #
 
-CHIP_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+if [[ ! -d ${CHIP_ROOT} ]]; then
+    if [[ -n ${BASH_SOURCE[0]} ]]; then
+        CHIP_ROOT=$(cd "${BASH_SOURCE[0]%/*}/.." && pwd)
+    else
+        CHIP_ROOT=$(cd "${0%/*}/.." && pwd)
+    fi
+fi
 
 export PW_BRANDING_BANNER="$CHIP_ROOT/.chip-banner.txt"
 export PW_BRANDING_BANNER_COLOR="bold_white"


### PR DESCRIPTION
#### Problem
 if CHIP_ROOT is unset when sourcing activate.sh from bash, activate.sh erroneously uses $0 (which is "bash" when in bash) to locate the tree

  ```bash
  source <(echo echo $0)
  ```

 #### Summary of Changes
 fix for bash (tested with zsh, too)