### PR TITLE
Remove recursive mutex & fix unbalanced locking in TestPlatformMgr

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
@@ -53,13 +53,7 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_InitChipStack(void)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-#if defined(PTHREAD_RECURSIVE_MUTEX_INITIALIZER)
-    mChipStackLock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER;
-#elif defined(PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP)
-    mChipStackLock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
-#else
-#error "No defined static initializer for POSIX Threads recursive mutex!"
-#endif // defined(PTHREAD_RECURSIVE_MUTEX_INITIALIZER)
+    mChipStackLock = PTHREAD_MUTEX_INITIALIZER;
 
     // Initialize the Configuration Manager object.
     err = ConfigurationMgr().Init();

--- a/src/platform/tests/TestPlatformMgr.cpp
+++ b/src/platform/tests/TestPlatformMgr.cpp
@@ -59,12 +59,8 @@ static void TestPlatformMgr_StartEventLoopTask(nlTestSuite * inSuite, void * inC
 static void TestPlatformMgr_TryLockChipStack(nlTestSuite * inSuite, void * inContext)
 {
     bool locked = PlatformMgr().TryLockChipStack();
-    NL_TEST_ASSERT(inSuite, locked);
-
-    PlatformMgr().LockChipStack();
-    locked = PlatformMgr().TryLockChipStack();
-    PlatformMgr().UnlockChipStack();
-    NL_TEST_ASSERT(inSuite, locked);
+    if (locked)
+        PlatformMgr().UnlockChipStack();
 }
 
 static int sEventRecieved = 0;


### PR DESCRIPTION
We shouldn't use recursive mutexes for synchronization as they greatly
complicate analysis and maintenance.

fixes #1584