### PR TITLE
Fix data race in GenericPlatformManagerImpl_POSIX.ipp

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h
@@ -34,6 +34,7 @@
 #include <unistd.h>
 
 #include <pthread.h>
+#include <atomic>
 #include <queue>
 
 namespace chip {
@@ -93,7 +94,7 @@ private:
 
     void ProcessDeviceEvents();
 
-    bool mShouldRunEventLoop;
+    std::atomic<bool> mShouldRunEventLoop;
     static void * EventLoopTaskMain(void * arg);
 };
 

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h
@@ -33,8 +33,8 @@
 #include <sys/time.h>
 #include <unistd.h>
 
-#include <pthread.h>
 #include <atomic>
+#include <pthread.h>
 #include <queue>
 
 namespace chip {

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
@@ -73,7 +73,7 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_InitChipStack(void)
     err = GenericPlatformManagerImpl<ImplClass>::_InitChipStack();
     SuccessOrExit(err);
 
-    mShouldRunEventLoop = true;
+    mShouldRunEventLoop.store(true, std::memory_order_relaxed);
 
 exit:
     return err;
@@ -196,7 +196,7 @@ void GenericPlatformManagerImpl_POSIX<ImplClass>::_RunEventLoop(void)
     {
         SysUpdate();
         SysProcess();
-    } while (mShouldRunEventLoop);
+    } while (mShouldRunEventLoop.load(std::memory_order_relaxed));
 
     Impl()->UnlockChipStack();
 
@@ -232,7 +232,7 @@ template <class ImplClass>
 CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_Shutdown(void)
 {
     int err;
-    mShouldRunEventLoop = false;
+    mShouldRunEventLoop.store(false, std::memory_order_relaxed);;
     err                 = pthread_join(mChipTask, NULL);
     SuccessOrExit(err);
 


### PR DESCRIPTION
The mShouldRunEventLoop member variable is used for cross thread
communication without synchronization. This is a data race unless an
atomic variable is used. Make it so.

Noticed while fixing #1584.