### PR TITLE
[OpenThread] ReceivePacket should use PBUF_LINK when allocating pbuf

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.ipp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.ipp
@@ -378,7 +378,7 @@ void GenericThreadStackManagerImpl_OpenThread_LwIP<ImplClass>::ReceivePacket(otM
     struct netif * threadNetIf = ThreadStackMgrImpl().ThreadNetIf();
 
     // Allocate an LwIP pbuf to hold the inbound packet.
-    pbuf = pbuf_alloc(PBUF_RAW, pktLen, PBUF_POOL);
+    pbuf = pbuf_alloc(PBUF_LINK, pktLen, PBUF_POOL);
     VerifyOrExit(pbuf != NULL, lwipErr = ERR_MEM);
 
     // Copy the packet data from the OpenThread message object to the pbuf.


### PR DESCRIPTION
 #### Problem

Currently, GenericThreadStackManagerImpl_OpenThread_LwIP<ImplClass>::ReceivePacket uses `pbuf_alloc(PBUF_RAW)` to allocate pbuf for lwip, however, according to lwip's doc, `PBUF_RAW` should be used for allocating L2 packets, but infact, this function reads L3 packets, which should use `PBUF_LINK` to avoid potential issues.

 #### Summary of Changes

Change `PBUF_RAW` to `PBUF_LINK`
