### PR TITLE
[gn] Simplify Support::CHIPMem build.

### DIFF
--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -74,6 +74,8 @@ static_library("support") {
     "Base64.cpp",
     "CHIPArgParser.cpp",
     "CHIPCounter.cpp",
+    "CHIPMem-SimpleAlloc.cpp",
+    "CHIPMem-Malloc.cpp",
     "ErrorStr.cpp",
     "FibonacciUtils.cpp",
     "PersistedCounter.cpp",
@@ -100,12 +102,6 @@ static_library("support") {
 
   public_configs = [ ":support_config" ]
 
-  if (chip_config_memory_management == "simple") {
-    sources += [ "CHIPMem-SimpleAlloc.cpp" ]
-  }
-  if (chip_config_memory_management == "malloc") {
-    sources += [ "CHIPMem-Malloc.cpp" ]
-  }
   if (chip_with_nlfaultinjection) {
     sources += [ "CHIPFaultInjection.cpp" ]
     public += [ "CHIPFaultInjection.h" ]


### PR DESCRIPTION
 #### Problem
When a source file is wrapped internally to only activate when the proper configuration macros are passed, then we can simplify the build to just include all files.

 #### Summary of Changes
Perform such a simplification for `support/CHIPMem`