### PR TITLE
LGTM This parameter of type OptionalQRCodeInfoExtension/SetupPayload …

### DIFF
--- a/src/setup_payload/ManualSetupPayloadGenerator.cpp
+++ b/src/setup_payload/ManualSetupPayloadGenerator.cpp
@@ -28,7 +28,7 @@
 
 using namespace chip;
 
-static uint32_t shortPayloadRepresentation(SetupPayload payload)
+static uint32_t shortPayloadRepresentation(const SetupPayload & payload)
 {
     int offset      = 1;
     uint32_t result = payload.requiresCustomFlow ? 1 : 0;

--- a/src/setup_payload/ManualSetupPayloadGenerator.h
+++ b/src/setup_payload/ManualSetupPayloadGenerator.h
@@ -49,7 +49,7 @@ private:
     SetupPayload mSetupPayload;
 
 public:
-    ManualSetupPayloadGenerator(SetupPayload payload) : mSetupPayload(payload){};
+    ManualSetupPayloadGenerator(const SetupPayload & payload) : mSetupPayload(payload){};
 
     // Populates decimal string representation of the payload into outDecimalString
     CHIP_ERROR payloadDecimalStringRepresentation(string & outDecimalString);

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.h
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.h
@@ -43,7 +43,7 @@ private:
     SetupPayload mPayload;
 
 public:
-    QRCodeSetupPayloadGenerator(SetupPayload setupPayload) : mPayload(setupPayload){};
+    QRCodeSetupPayloadGenerator(const SetupPayload & setupPayload) : mPayload(setupPayload){};
 
     /**
      * This function is called to encode the binary data of a payload to a

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -213,7 +213,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR SetupPayload::addOptionalVendorData(OptionalQRCodeInfo info)
+CHIP_ERROR SetupPayload::addOptionalVendorData(const OptionalQRCodeInfo & info)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     VerifyOrExit(IsVendorTag(info.tag), err = CHIP_ERROR_INVALID_ARGUMENT);
@@ -223,7 +223,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR SetupPayload::addOptionalExtensionData(OptionalQRCodeInfoExtension info)
+CHIP_ERROR SetupPayload::addOptionalExtensionData(const OptionalQRCodeInfoExtension & info)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     VerifyOrExit(IsCHIPTag(info.tag), err = CHIP_ERROR_INVALID_ARGUMENT);

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -207,13 +207,13 @@ private:
      * @param info Optional QR code info object to add
      * @return Returns a CHIP_ERROR_INVALID_ARGUMENT on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR addOptionalVendorData(OptionalQRCodeInfo info);
+    CHIP_ERROR addOptionalVendorData(const OptionalQRCodeInfo & info);
 
     /** @brief A function to add an optional QR Code info CHIP object
      * @param info Optional QR code info object to add
      * @return Returns a CHIP_ERROR_INVALID_ARGUMENT on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR addOptionalExtensionData(OptionalQRCodeInfoExtension info);
+    CHIP_ERROR addOptionalExtensionData(const OptionalQRCodeInfoExtension & info);
 
     /**
      * @brief A function to retrieve the vector of CHIPQRCodeInfo infos


### PR DESCRIPTION
…is 72/112 bytes - consider passing a const pointer/reference instead.

 #### Problem

LGTM is not happy because of the size of the object. Let's use a const reference instead.
