### PR TITLE
third_party/Makefile.am distclean rule use OTBR_CLIENT_SUBDIRS instea…

### DIFF
--- a/third_party/Makefile.am
+++ b/third_party/Makefile.am
@@ -44,7 +44,7 @@ DIST_SUBDIRS                                 = \
 # of the 'distclean' target. Consequently, we conditionally include
 # them in DIST_SUBDIRS on invocation of 'distclean-recursive'
 
-distclean-recursive: DIST_SUBDIRS += $(NLASSERT_SUBDIRS) $(NLFAULTINJECTION_SUBDIRS) $(NLIO_SUBDIRS) $(NLUNIT_TEST_SUBDIRS) $(MBEDTLS_SUBDIRS) $(OPENTHREAD_SUBDIRS) $(OTBR_CLIENT_SUBDIRS)
+distclean-recursive: DIST_SUBDIRS += $(NLASSERT_SUBDIRS) $(NLFAULTINJECTION_SUBDIRS) $(NLIO_SUBDIRS) $(NLUNIT_TEST_SUBDIRS) $(MBEDTLS_SUBDIRS) $(OPENTHREAD_SUBDIRS) $(OT_BR_POSIX_SUBDIRS)
 
 # Always build (e.g. for 'make all') these subdirectories.
 #


### PR DESCRIPTION
…d of OT_BR_POSIX_SUBDIRS

 #### Problem

I assume this is a typo since OTBR_CLIENT_SUBDIRS is not defined anywhere.
