### PR TITLE
Architecture override warning while building the iOS app

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
+++ b/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
@@ -221,7 +221,7 @@
 		B204A614244E1D0600C7C0E1 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1140;
+				LastUpgradeCheck = 1150;
 				ORGANIZATIONNAME = CHIP;
 				TargetAttributes = {
 					B204A61B244E1D0600C7C0E1 = {
@@ -444,7 +444,6 @@
 		B204A64C244E1D0700C7C0E1 /* Debug iOS */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -468,7 +467,6 @@
 		B204A64D244E1D0700C7C0E1 /* Release iOS */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;

--- a/src/darwin/CHIPTool/CHIPTool.xcodeproj/xcshareddata/xcschemes/CHIP Tool App iOS.xcscheme
+++ b/src/darwin/CHIPTool/CHIPTool.xcodeproj/xcshareddata/xcschemes/CHIP Tool App iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1150"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/src/darwin/Framework/CHIP.xcodeproj/xcshareddata/xcschemes/Framework MacOS.xcscheme
+++ b/src/darwin/Framework/CHIP.xcodeproj/xcshareddata/xcschemes/Framework MacOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1150"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/src/darwin/Framework/CHIP.xcodeproj/xcshareddata/xcschemes/Framework Tests iOS.xcscheme
+++ b/src/darwin/Framework/CHIP.xcodeproj/xcshareddata/xcschemes/Framework Tests iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1150"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/src/darwin/Framework/CHIP.xcodeproj/xcshareddata/xcschemes/Framework iOS.xcscheme
+++ b/src/darwin/Framework/CHIP.xcodeproj/xcshareddata/xcschemes/Framework iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1150"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/src/darwin/Framework/CHIP.xcodeproj/xcshareddata/xcschemes/Tests macOS.xcscheme
+++ b/src/darwin/Framework/CHIP.xcodeproj/xcshareddata/xcschemes/Tests macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1150"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
 #### Problem

Maybe someone knows why the architecture has been overridden, and if so if the warning is legitimate...
