### PR TITLE
[ble] update ble advertisement packet format

### DIFF
--- a/src/ble/CHIPBleServiceData.h
+++ b/src/ble/CHIPBleServiceData.h
@@ -48,33 +48,16 @@ struct ChipBLEDeviceIdentificationInfo
 {
     enum
     {
-        kMajorVersion = 0,
-        kMinorVersion = 1,
-    };
-
-    enum
-    {
         kPairingStatus_Unpaired = 0,
         kPairingStatus_Paired   = 1,
     };
 
-    uint8_t BlockLen;
-    uint8_t BlockType;
-    uint8_t MajorVersion;
-    uint8_t MinorVersion;
+    uint8_t PairingStatus;
+    uint8_t DeviceDiscriminator[2];
     uint8_t DeviceVendorId[2];
     uint8_t DeviceProductId[2];
-    uint8_t DeviceId[8];
-    uint8_t PairingStatus;
 
-    void Init()
-    {
-        memset(this, 0, sizeof(*this));
-        BlockLen     = sizeof(*this) - sizeof(BlockLen); // size of all fields EXCEPT BlockLen
-        BlockType    = kchipBLEServiceDataType_DeviceIdentificationInfo;
-        MajorVersion = kMajorVersion;
-        MinorVersion = kMinorVersion;
-    }
+    void Init() { memset(this, 0, sizeof(*this)); }
 
     uint16_t GetVendorId(void) { return chip::Encoding::LittleEndian::Get16(DeviceVendorId); }
 
@@ -84,9 +67,19 @@ struct ChipBLEDeviceIdentificationInfo
 
     void SetProductId(uint16_t productId) { chip::Encoding::LittleEndian::Put16(DeviceProductId, productId); }
 
-    uint64_t GetDeviceId(void) { return chip::Encoding::LittleEndian::Get64(DeviceId); }
+    uint16_t GetDeviceDiscriminator(void)
+    {
+        uint16_t discriminator                = chip::Encoding::LittleEndian::Get16(DeviceDiscriminator);
+        constexpr uint16_t kDiscriminatorMask = 0x7f;
 
-    void SetDeviceId(uint64_t deviceId) { chip::Encoding::LittleEndian::Put64(DeviceId, deviceId); }
+        return discriminator & kDiscriminatorMask;
+    }
+
+    void SetDeviceDiscriminator(uint16_t deviceDiscriminator)
+    {
+        chip::Encoding::LittleEndian::Put16(DeviceDiscriminator, deviceDiscriminator);
+        DeviceDiscriminator[1] &= 0x0f;
+    }
 } __attribute__((packed));
 
 } /* namespace Ble */

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -83,7 +83,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_ConfigureChipStack()
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
         FabricState.FabricId = kFabricIdNotSpecified;
-        err = CHIP_NO_ERROR;
+        err                  = CHIP_NO_ERROR;
     }
     SuccessOrExit(err);
 #endif // CHIP_CONFIG_ENABLE_FABRIC_STATE
@@ -756,6 +756,7 @@ GenericConfigurationManagerImpl<ImplClass>::_GetBLEDeviceIdentificationInfo(Ble:
 {
     CHIP_ERROR err;
     uint16_t id;
+    uint16_t discriminator = 0x0ABC; // FIXME: use discriminator from factory data
 
     deviceIdInfo.Init();
 
@@ -766,10 +767,7 @@ GenericConfigurationManagerImpl<ImplClass>::_GetBLEDeviceIdentificationInfo(Ble:
     err = Impl()->_GetProductId(id);
     SuccessOrExit(err);
     deviceIdInfo.SetProductId(id);
-
-#if CHIP_CONFIG_ENABLE_FABRIC_STATE
-    deviceIdInfo.SetDeviceId(FabricState.LocalNodeId);
-#endif
+    deviceIdInfo.SetDeviceDiscriminator(discriminator);
 
     deviceIdInfo.PairingStatus = Impl()->_IsPairedToAccount() ? Ble::ChipBLEDeviceIdentificationInfo::kPairingStatus_Paired
                                                               : Ble::ChipBLEDeviceIdentificationInfo::kPairingStatus_Unpaired;
@@ -960,7 +958,7 @@ exit:
 }
 
 #if defined(DEBUG)
-template<class ImplClass>
+template <class ImplClass>
 CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_RunUnitTests()
 {
     ChipLogProgress(DeviceLayer, "Running configuration unit test");

--- a/src/platform/nRF5/BLEManagerImpl.cpp
+++ b/src/platform/nRF5/BLEManagerImpl.cpp
@@ -253,6 +253,7 @@ CHIP_ERROR BLEManagerImpl::_SetDeviceName(const char * devName)
     }
     else
     {
+        // FIXME: the name should be derived from factory data
         snprintf(devNameBuf, sizeof(devNameBuf), "%s%04" PRIX32, CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, (uint32_t) 0);
         devNameBuf[kMaxDeviceNameLength] = 0;
     }


### PR DESCRIPTION
Update the packet format to be coherent with the current [specification](https://github.com/project-chip/chip-specification-playground/blob/master/src/rendezvous/DeviceDiscovery.adoc).


 #### Summary of Changes

This PR will send CHIP specified BLE advertisement packets. The discriminator is now hardcoded and shall be derived from the factory data in future changes.

fixes https://github.com/project-chip/connectedhomeip/issues/1648
