### PR TITLE
[OpenThread] Disable IPv6 MLD on Thread Netif

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.ipp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.ipp
@@ -279,7 +279,7 @@ err_t GenericThreadStackManagerImpl_OpenThread_LwIP<ImplClass>::DoInitThreadNetI
     netif->output = NULL;
 #endif /* LWIP_IPV4 || LWIP_VERSION_MAJOR < 2 */
     netif->linkoutput = NULL;
-    netif->flags      = NETIF_FLAG_UP | NETIF_FLAG_LINK_UP | NETIF_FLAG_BROADCAST | NETIF_FLAG_MLD6;
+    netif->flags      = NETIF_FLAG_UP | NETIF_FLAG_LINK_UP | NETIF_FLAG_BROADCAST;
     netif->mtu        = CHIP_DEVICE_CONFIG_THREAD_IF_MTU;
     return ERR_OK;
 }


### PR DESCRIPTION
 #### Problem

Thread does not support IPv6 MLD (multicast listener discovery), let's disable it. This will be a issue on devices supports IPv6 ND (on netif other than thread).
