### PR TITLE
Add the CHIP Profile ID to the transport message header

### DIFF
--- a/src/transport/MessageHeader.cpp
+++ b/src/transport/MessageHeader.cpp
@@ -34,6 +34,7 @@
  *  16 bit: | Secure message type                             |
  *  32 bit: | MESSAGE_ID                                      |
  *  32 bit: | Secure Session ID                               |
+ *  16 bit: | Profile ID                                      |
  *  64 bit: | Message Authentication Tag                      |
  *  64 bit: | SOURCE_NODE_ID (iff source node flag is set)    |
  *  64 bit: | DEST_NODE_ID (iff destination node flag is set) |
@@ -96,6 +97,7 @@ CHIP_ERROR MessageHeader::Decode(const uint8_t * data, size_t size, size_t * dec
     mSecureMsgType   = LittleEndian::Read16(p);
     mMessageId       = LittleEndian::Read32(p);
     mSecureSessionID = LittleEndian::Read32(p);
+    mProfileID       = LittleEndian::Read16(p);
     mTag             = LittleEndian::Read64(p);
 
     assert(p - data == kFixedHeaderSizeBytes);
@@ -151,6 +153,7 @@ CHIP_ERROR MessageHeader::Encode(uint8_t * data, size_t size, size_t * encode_si
     LittleEndian::Write16(p, mSecureMsgType);
     LittleEndian::Write32(p, mMessageId);
     LittleEndian::Write32(p, mSecureSessionID);
+    LittleEndian::Write16(p, mProfileID);
     LittleEndian::Write64(p, mTag);
     if (mSourceNodeId.HasValue())
     {

--- a/src/transport/MessageHeader.h
+++ b/src/transport/MessageHeader.h
@@ -67,6 +67,9 @@ public:
     /** Get the Session ID from this header. */
     uint32_t GetSecureSessionID(void) const { return mSecureSessionID; }
 
+    /** Get the Profile ID from this header. */
+    uint32_t GetProfileID(void) const { return mProfileID; }
+
     /** Get the message auth tag from this header. */
     uint64_t GetTag(void) const { return mTag; }
 
@@ -74,6 +77,14 @@ public:
     MessageHeader & SetMessageId(uint32_t id)
     {
         mMessageId = id;
+
+        return *this;
+    }
+
+    /** Set the message id for this header. */
+    MessageHeader & SetProfileId(uint16_t id)
+    {
+        mProfileID = id;
 
         return *this;
     }
@@ -205,6 +216,9 @@ private:
 
     /// Message authentication tag generated at encryption of the message.
     uint64_t mTag = 0;
+
+    // CHIP Profile ID
+    uint16_t mProfileID = 0;
 };
 
 } // namespace chip

--- a/src/transport/tests/TestMessageHeader.cpp
+++ b/src/transport/tests/TestMessageHeader.cpp
@@ -40,6 +40,7 @@ void TestHeaderInitialState(nlTestSuite * inSuite, void * inContext)
     MessageHeader header;
 
     NL_TEST_ASSERT(inSuite, header.GetSecureMsgType() == 0);
+    NL_TEST_ASSERT(inSuite, header.GetProfileID() == 0);
     NL_TEST_ASSERT(inSuite, header.GetSecureSessionID() == 0);
     NL_TEST_ASSERT(inSuite, header.GetTag() == 0);
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 0);
@@ -102,6 +103,7 @@ void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
 
     header.SetMessageId(234).SetSourceNodeId(77).SetDestinationNodeId(88);
     header.SetSecureMsgType(1122).SetSessionID(2233).SetTag(12345);
+    header.SetProfileId(4);
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
 
     // change it to verify decoding
@@ -113,6 +115,7 @@ void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(88));
     NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77));
     NL_TEST_ASSERT(inSuite, header.GetSecureMsgType() == 1122);
+    NL_TEST_ASSERT(inSuite, header.GetProfileID() == 4);
     NL_TEST_ASSERT(inSuite, header.GetSecureSessionID() == 2233);
     NL_TEST_ASSERT(inSuite, header.GetTag() == 12345);
 }


### PR DESCRIPTION
We will be introducing something similar to weave profiles so adding the profile id to the message header.

Note from @pan-apple  : The profile ID will eventually be in the encrypted section of the message header. Right now it is being added in the non-encrypted part. That’s ok for time being, as we still need to finalize the message header format and encrypt relevant portions.

Follow up questions:
Should this be called a profile ID/ CHIP Profiles? "Profiles" are also a ZCL concept so should we change it to something different to avoid confusion.

fixes #1652 
