### PR TITLE
[nrf] fix build errors on nRF Connect SDK example

### DIFF
--- a/config/nrfconnect/nrfconnect-app.cmake
+++ b/config/nrfconnect/nrfconnect-app.cmake
@@ -75,6 +75,7 @@ set(CHIP_OUTPUT_LIBRARIES
     ${CHIP_OUTPUT_DIR}/lib/libSupportLayer.a
     ${CHIP_OUTPUT_DIR}/lib/libBleLayer.a
     ${CHIP_OUTPUT_DIR}/lib/libDeviceLayer.a
+    ${CHIP_OUTPUT_DIR}/lib/libCHIPDataModel.a
     )
 
 # ==================================================
@@ -95,8 +96,8 @@ get_zephyr_compilation_flags(CHIP_CFLAGS C)
 get_zephyr_compilation_flags(CHIP_CXXFLAGS CXX)
 list(FILTER CHIP_CXXFLAGS EXCLUDE REGEX -std.*) # CHIP adds gnu++11 anyway...
 
-set(CHIP_COMMON_FLAGS 
-    -D_SYS__PTHREADTYPES_H_ 
+set(CHIP_COMMON_FLAGS
+    -D_SYS__PTHREADTYPES_H_
     -isystem${ZEPHYR_BASE}/include/posix
     -DMBEDTLS_CONFIG_FILE=CONFIG_MBEDTLS_CFG_FILE
     -isystem${ZEPHYR_BASE}/../modules/crypto/mbedtls/configs)

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -30,11 +30,11 @@
 #endif
 // module header, comes first
 #include <controller/CHIPDeviceController.h>
+#include <platform/internal/CHIPDeviceLayerInternal.h>
 
 #include <core/CHIPCore.h>
 #include <core/CHIPEncoding.h>
 #include <platform/PlatformManager.h>
-#include <platform/internal/CHIPDeviceLayerInternal.h>
 #include <support/Base64.h>
 #include <support/CodeUtils.h>
 #include <support/ErrorStr.h>


### PR DESCRIPTION
 #### Problem
nRF Connect SDK example does not build after recent changes.

 #### Summary of Changes
This PR changed the order of include files and links the example with `libCHIPDataModel.a`.

fixes https://github.com/project-chip/connectedhomeip/issues/1676
