### PR TITLE
[OpenThread] Add missing SetThreadProvision implementation on RTOS

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.ipp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.ipp
@@ -38,6 +38,7 @@
 #include <platform/OpenThread/OpenThreadUtils.h>
 #include <platform/ThreadStackManager.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
+#include <platform/internal/DeviceNetworkInfo.h>
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
 
@@ -190,6 +191,57 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_SetThreadEnable
     }
 
 exit:
+    Impl()->UnlockThreadStack();
+
+    return MapOpenThreadError(otErr);
+}
+
+template <class ImplClass>
+CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_SetThreadProvision(const DeviceNetworkInfo & netInfo)
+{
+    otError otErr = OT_ERROR_FAILED;
+    otOperationalDataset newDataset;
+
+    // Form a Thread operational dataset from the given network parameters.
+    memset(&newDataset, 0, sizeof(newDataset));
+    newDataset.mComponents.mIsActiveTimestampPresent  = true;
+    newDataset.mComponents.mIsPendingTimestampPresent = true;
+    if (netInfo.ThreadNetworkName[0] != 0)
+    {
+        strncpy((char *) newDataset.mNetworkName.m8, netInfo.ThreadNetworkName, sizeof(newDataset.mNetworkName.m8));
+        newDataset.mComponents.mIsNetworkNamePresent = true;
+    }
+    if (netInfo.FieldPresent.ThreadExtendedPANId)
+    {
+        memcpy(newDataset.mExtendedPanId.m8, netInfo.ThreadExtendedPANId, sizeof(newDataset.mExtendedPanId.m8));
+        newDataset.mComponents.mIsExtendedPanIdPresent = true;
+    }
+    if (netInfo.FieldPresent.ThreadMeshPrefix)
+    {
+        memcpy(newDataset.mMeshLocalPrefix.m8, netInfo.ThreadMeshPrefix, sizeof(newDataset.mMeshLocalPrefix.m8));
+        newDataset.mComponents.mIsMeshLocalPrefixPresent = true;
+    }
+    memcpy(newDataset.mMasterKey.m8, netInfo.ThreadNetworkKey, sizeof(newDataset.mMasterKey.m8));
+    newDataset.mComponents.mIsMasterKeyPresent = true;
+    if (netInfo.FieldPresent.ThreadPSKc)
+    {
+        memcpy(newDataset.mPskc.m8, netInfo.ThreadPSKc, sizeof(newDataset.mPskc.m8));
+        newDataset.mComponents.mIsPskcPresent = true;
+    }
+    if (netInfo.ThreadPANId != kThreadPANId_NotSpecified)
+    {
+        newDataset.mPanId                      = netInfo.ThreadPANId;
+        newDataset.mComponents.mIsPanIdPresent = true;
+    }
+    if (netInfo.ThreadChannel != kThreadChannel_NotSpecified)
+    {
+        newDataset.mChannel                      = netInfo.ThreadChannel;
+        newDataset.mComponents.mIsChannelPresent = true;
+    }
+
+    // Set the dataset as the active dataset for the node.
+    Impl()->LockThreadStack();
+    otErr = otDatasetSetActive(mOTInst, &newDataset);
     Impl()->UnlockThreadStack();
 
     return MapOpenThreadError(otErr);


### PR DESCRIPTION
 #### Problem

`SetThreadProvision` is undefined for RTOS devices currently.

 #### Summary of Changes

Add the definition of this method.