### PR TITLE
Crash when sending messages over wifi

### DIFF
--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -76,7 +76,7 @@ static void OnConnect(DeviceController::ChipDeviceController * controller, Trans
 {
     isDeviceConnected = true;
 
-    if (state && appReqState)
+    if (state != NULL)
     {
         CHIP_ERROR err = controller->ManualKeyExchange(state, remote_public_key, sizeof(remote_public_key), local_private_key,
                                                        sizeof(local_private_key));
@@ -149,6 +149,11 @@ bool EqualsLiteral(const char * str, const char (&literal)[N])
 
 bool DetermineCommand(int argc, char * argv[], Command * command)
 {
+    if (argc <= 1)
+    {
+        return false;
+    }
+
     if (EqualsLiteral(argv[1], "off"))
     {
         *command = Command::Off;
@@ -183,7 +188,7 @@ bool DetermineCommand(int argc, char * argv[], Command * command)
     return false;
 }
 
-union CommandArgs
+struct CommandArgs
 {
     IPAddress hostAddr;
     uint16_t port;
@@ -262,6 +267,7 @@ bool DetermineCommandArgs(char * argv[], Command command, CommandArgs * commandA
 // Handle the echo case, where we just send a string and expect to get it back.
 void DoEcho(DeviceController::ChipDeviceController * controller, const char * identifier)
 {
+    CHIP_ERROR err     = CHIP_NO_ERROR;
     size_t payload_len = strlen(PAYLOAD);
 
     // Run the client
@@ -275,8 +281,8 @@ void DoEcho(DeviceController::ChipDeviceController * controller, const char * id
             memcpy(buffer->Start(), PAYLOAD, payload_len);
             buffer->SetDataLength(payload_len);
 
-            controller->SendMessage(NULL, buffer);
-            printf("Msg sent to server %s\n", identifier);
+            err = controller->SendMessage(NULL, buffer);
+            printf("Msg sent to server %s\n", err != CHIP_NO_ERROR ? ErrorStr(err) : identifier);
         }
 
         sleep(SEND_DELAY);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -285,7 +285,7 @@ CHIP_ERROR ChipDeviceController::SendMessage(void * appReqState, PacketBuffer * 
 
     mAppReqState = appReqState;
 
-    if (mUnsecuredTransport)
+    if (mUnsecuredTransport != NULL)
     {
         VerifyOrExit(IsConnected(), err = CHIP_ERROR_INCORRECT_STATE);
         // Unsecured transport does not use a MessageHeader, but the Transport::Base API expects one, so

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -195,7 +195,7 @@ private:
     };
 
     SecureSessionMgr<Transport::UDP> * mSessionManager;
-    Transport::Base * mUnsecuredTransport;
+    Transport::Base * mUnsecuredTransport = NULL;
 
     ConnectionState mConState;
     void * mAppReqState;


### PR DESCRIPTION
 #### Problem

While doing #1660 I did a mistake in the last commit that broke the wifi part of the chip-tool. This PR fix that so it does not crash anymore while sending Wifi messages via the device controller.