### PR TITLE
process-global-message.c:297:27: warning: this statement may fall thr…

### DIFF
--- a/examples/wifi-echo/server/esp32/main/process-global-message.c
+++ b/examples/wifi-echo/server/esp32/main/process-global-message.c
@@ -295,6 +295,7 @@ bool emAfProcessGlobalCommand(EmberAfClusterCommand * cmd)
         // Reset message back to start
         msgIndex          = cmd->payloadStartIndex;
         appResponseLength = (cmd->mfgSpecific ? 4 : 2);
+        /* fall through */
     // DO NOT BREAK from this case
 
     // the format of the write attributes cmd is:


### PR DESCRIPTION
…ough [-Wimplicit-fallthrough=]

It looks like an intentional fall through but the compiler is a bit zealous about warnings. So the proposed patch uses a marker to shut down the warning.