### PR TITLE
Disabled bluez in VSCode main build task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -88,7 +88,7 @@
         {
             "label": "Bootstrap",
             "type": "shell",
-            "command": "scripts/build/bootstrap.sh",
+            "command": "scripts/build/bootstrap.sh --with-bluez=no",
             "group": "none",
             "problemMatcher": ["$gcc"]
         },


### PR DESCRIPTION
 #### Problem
VSCode devcontainer build tasks are failing.

 #### Summary of Changes
Disable `bluez` in VSCode build task

Ref: #1668 