### PR TITLE
configure --with-device-layer=none is broken

### DIFF
--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -194,6 +194,9 @@ private:
         kConnectionState_SecureConnected = 2,
     };
 
+    System::Layer * mSystemLayer;
+    Inet::InetLayer * mInetLayer;
+
     SecureSessionMgr<Transport::UDP> * mSessionManager;
     Transport::Base * mUnsecuredTransport = NULL;
 


### PR DESCRIPTION
 #### Problem
The device layer used to be optional, but this is broken as of recent changes.

In file included from /Users/spang/connectedhomeip/src/lib/../../src/controller/CHIPDeviceController.cpp:33:
In file included from /Users/spang/connectedhomeip/src/include/platform/internal/CHIPDeviceLayerInternal.h:23:
In file included from /Users/spang/connectedhomeip/src/include/platform/CHIPDeviceLayer.h:27:
/Users/spang/connectedhomeip/src/include/platform/ConfigurationManager.h:199:10: fatal error:
'platform/NONE/ConfigurationManagerImpl.h' file not found
#include CONFIGURATIONMANAGERIMPL_HEADER
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/spang/connectedhomeip/src/include/platform/ConfigurationManager.h:198:41: note: expanded from macro
'CONFIGURATIONMANAGERIMPL_HEADER'
#define CONFIGURATIONMANAGERIMPL_HEADER <platform/CHIP_DEVICE_LAYER_TARGET/ConfigurationManagerImpl.h>
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
:294:1: note: expanded from here
<platform/NONE/ConfigurationManagerImpl.h>

 #### Summary of Changes
* Do not include the device layer if there is no platform associated with the build

fixes #1703 
