### PR TITLE
Augment the width of virtual leds on the M5Stack screen for demos

### DIFF
--- a/examples/common/screen-framework/ScreenManager.cpp
+++ b/examples/common/screen-framework/ScreenManager.cpp
@@ -43,7 +43,7 @@ namespace {
 constexpr int kMainFont   = DEJAVU24_FONT;
 constexpr int kButtonFont = DEJAVU18_FONT;
 
-constexpr int kVLEDWidth  = 8;
+constexpr int kVLEDWidth  = 16;
 constexpr int kVLEDHeight = 16;
 
 SemaphoreHandle_t mutex;


### PR DESCRIPTION
 #### Problem

The virtual leds of the ESP32 are a little bit tiny for demos. The current patch makes them a little bit larger.