### PR TITLE
Add a helper to setup wifi on the esp32

### DIFF
--- a/examples/wifi-echo/server/esp32/main/ServiceProvisioning.cpp
+++ b/examples/wifi-echo/server/esp32/main/ServiceProvisioning.cpp
@@ -1,0 +1,53 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <platform/CHIPDeviceLayer.h>
+#include <support/CodeUtils.h>
+#include <support/logging/CHIPLogging.h>
+
+#include "esp_wifi.h"
+
+using namespace ::chip::DeviceLayer;
+
+CHIP_ERROR SetWiFiStationProvisioning(char * ssid, char * key)
+{
+    ConnectivityMgr().SetWiFiStationMode(ConnectivityManager::kWiFiStationMode_Disabled);
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    wifi_config_t wifiConfig;
+
+    // Set the wifi configuration
+    memset(&wifiConfig, 0, sizeof(wifiConfig));
+    memcpy(wifiConfig.sta.ssid, ssid, strlen(ssid) + 1);
+    memcpy(wifiConfig.sta.password, key, strlen(key) + 1);
+    wifiConfig.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
+    wifiConfig.sta.sort_method = WIFI_CONNECT_AP_BY_SIGNAL;
+
+    // Configure the ESP WiFi interface.
+    err = esp_wifi_set_config(ESP_IF_WIFI_STA, &wifiConfig);
+    if (err != ESP_OK)
+    {
+        ChipLogError(DeviceLayer, "esp_wifi_set_config() failed: %s", chip::ErrorStr(err));
+    }
+    SuccessOrExit(err);
+
+    ConnectivityMgr().SetWiFiStationMode(ConnectivityManager::kWiFiStationMode_Disabled);
+    ConnectivityMgr().SetWiFiStationMode(ConnectivityManager::kWiFiStationMode_Enabled);
+
+exit:
+    return err;
+}


### PR DESCRIPTION
 #### Problem

This PR is similar to #1600 except that it copies some code up in the stack so it is available from the application layer.
I have kept it in a separated file since this code will likely go away at some point if we turn on the code in https://github.com/project-chip/connectedhomeip/blob/e0aa5e5102d12150c0e17868579ddf43aec59884/src/include/platform/internal/NetworkProvisioningServer.h

 #### Summary of Changes
 * Add a little helper in a separate file to configure WiFi from the esp32 example code
