### PR TITLE
Fix ConnectivityManagerImpl.cpp in order to let the ESP32 connect to …

### DIFF
--- a/examples/wifi-echo/server/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/wifi-echo/server/esp32/main/CHIPDeviceManager.cpp
@@ -60,7 +60,6 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     {
     case RendezvousInformationFlags::kBLE:
         ConnectivityMgr().SetBLEAdvertisingEnabled(ConnectivityManager::kCHIPoBLEServiceMode_Enabled);
-        ConnectivityMgr().SetWiFiAPMode(ConnectivityManager::kWiFiAPMode_Disabled);
         break;
 
     case RendezvousInformationFlags::kWiFi:

--- a/src/platform/ESP32/ConnectivityManagerImpl.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl.cpp
@@ -58,7 +58,8 @@ ConnectivityManager::WiFiStationMode ConnectivityManagerImpl::_GetWiFiStationMod
     if (mWiFiStationMode != kWiFiStationMode_ApplicationControlled)
     {
         wifi_mode_t curWiFiMode;
-        mWiFiStationMode = (esp_wifi_get_mode(&curWiFiMode) == ESP_OK && curWiFiMode == WIFI_MODE_APSTA)
+        mWiFiStationMode =
+            (esp_wifi_get_mode(&curWiFiMode) == ESP_OK && (curWiFiMode == WIFI_MODE_APSTA || curWiFiMode == WIFI_MODE_STA))
             ? kWiFiStationMode_Enabled
             : kWiFiStationMode_Disabled;
     }

--- a/src/platform/ESP32/ESP32Utils.cpp
+++ b/src/platform/ESP32/ESP32Utils.cpp
@@ -152,7 +152,7 @@ CHIP_ERROR ESP32Utils::SetAPMode(bool enabled)
 
     // If station mode is not already enabled (implying the current mode is WIFI_MODE_AP), change
     // the mode to WIFI_MODE_APSTA.
-    if (true /* curWiFiMode != targetWiFiMode */)
+    if (curWiFiMode != targetWiFiMode)
     {
         ChipLogProgress(DeviceLayer, "Changing ESP WiFi mode: %s -> %s", WiFiModeToStr(curWiFiMode), WiFiModeToStr(targetWiFiMode));
 


### PR DESCRIPTION
…WiFi while STA mode is enabled but AP mode is disabled

 #### Problem
 Currently when the AP mode is disabled on the device. For example when one does not expect Rendezvous over WiFi, the ESP32 station mode does not work since the expected mode is APSTA while the current mode is only STA in this case.
