### PR TITLE
Get secure session expiry timer less verbose

### DIFF
--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -285,8 +285,6 @@ void SecureSessionMgrBase::HandleConnectionExpired(const Transport::PeerConnecti
 
 void SecureSessionMgrBase::ExpiryTimerCallback(System::Layer * layer, void * param, System::Error error)
 {
-    ChipLogProgress(Inet, "Checking for expired connections");
-
     SecureSessionMgrBase * mgr = reinterpret_cast<SecureSessionMgrBase *>(param);
     mgr->mPeerConnections.ExpireInactiveConnections(CHIP_PEER_CONNECTION_TIMEOUT_MS);
     mgr->ScheduleExpiryTimer(); // re-schedule the oneshot timer


### PR DESCRIPTION
 #### Problem

Periodically Secure session check if any session has expired. This is nice, and especially when there is an effective expiry. But otherwise it basically just tell you that it is checking and it happens quite often.

It would be better to just keep the effective session expiry logging. Pretty sure the other log is not really helpful in any way.

 #### Summary of Changes
 * The current PR just remove the chatty log
