### PR TITLE
Add an entry in the Setup view of the ESP32 to reset WiFi provisioning

### DIFF
--- a/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
@@ -266,6 +266,30 @@ public:
     }
 };
 
+class SetupListModel : public ListScreen::Model
+{
+public:
+    SetupListModel()
+    {
+        std::string resetWiFi = "Reset WiFi";
+        options.emplace_back(resetWiFi);
+    }
+    virtual std::string GetTitle() { return "Setup"; }
+    virtual int GetItemCount() { return options.size(); }
+    virtual std::string GetItemText(int i) { return options.at(i); }
+    virtual void ItemAction(int i)
+    {
+        ESP_LOGI(TAG, "Opening options %d: %s", i, GetItemText(i).c_str());
+        if (i == 0)
+        {
+            ConnectivityMgr().ClearWiFiStationProvision();
+        }
+    }
+
+private:
+    std::vector<std::string> options;
+};
+
 class CustomScreen : public Screen
 {
 public:
@@ -461,7 +485,11 @@ extern "C" void app_main()
                                                             ESP_LOGI(TAG, "Opening QR code screen");
                                                             ScreenManager::PushScreen(new QRCodeScreen(qrCodeText));
                                                         })
-                                                 ->Item("Setup")
+                                                 ->Item("Setup",
+                                                        [=]() {
+                                                            ESP_LOGI(TAG, "Opening Setup list");
+                                                            ScreenManager::PushScreen(new ListScreen(new SetupListModel()));
+                                                        })
                                                  ->Item("More")
                                                  ->Item("Items")
                                                  ->Item("For")


### PR DESCRIPTION
 #### Problem

If the WiFi has already been provisioned on the ESP32 there is no way to change it right now without altering the code. This PR add an menu entry to clear it.