### PR TITLE
Disconnect bluetooth once the commissioner app receive an IP

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
@@ -100,6 +100,8 @@ static NSString * const ipKey = @"ipk";
 - (void)onMessage:(NSString *)message
 {
     [[NSUserDefaults standardUserDefaults] setObject:message forKey:ipKey];
+    NSError * error;
+    [self.chipController disconnect:&error];
 }
 
 - (void)onError:(NSString *)error


### PR DESCRIPTION
 #### Problem

When the commissioner app receive an IP from the device (#1887) the communication should switch to a secure WiFi connection.

 #### Summary of Changes
 * Close the BLE connection once the device receive an IP
