### PR TITLE
[nRF Connect] Add github workflow to verify build of the lock example

### DIFF
--- a/.github/workflows/bloat_check.yaml
+++ b/.github/workflows/bloat_check.yaml
@@ -24,7 +24,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build:0.4.0
+            image: connectedhomeip/chip-build:0.4.1
 
         steps:
             - name: Checkout

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build:0.4.0
+            image: connectedhomeip/chip-build:0.4.1
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -28,7 +28,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build-esp32:0.4.0
+            image: connectedhomeip/chip-build-esp32:0.4.1
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
                 - "/tmp/output_binaries:/tmp/output_binaries"
@@ -74,7 +74,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build-nrf-platform:0.4.0
+            image: connectedhomeip/chip-build-nrf-platform:0.4.1
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
                 - "/tmp/output_binaries:/tmp/output_binaries"
@@ -120,7 +120,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build-nrf-platform:0.4.0
+            image: connectedhomeip/chip-build-nrf-platform:0.4.1
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
                 - "/tmp/output_binaries:/tmp/output_binaries"
@@ -166,7 +166,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build:0.4.0
+            image: connectedhomeip/chip-build:0.4.1
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
                 - "/tmp/output_binaries:/tmp/output_binaries"

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -111,6 +111,52 @@ jobs:
                       steps.outsuffix.outputs.value }}
                   path: /tmp/output_binaries/${{ env.BUILD_TYPE }}-build
 
+    nrfconnect:
+        name: nRF Connect SDK
+
+        env:
+            BUILD_TYPE: nrfconnect
+
+        runs-on: ubuntu-latest
+
+        container:
+            image: connectedhomeip/chip-build-nrf-platform:0.4.0
+            volumes:
+                - "/tmp/bloat_reports:/tmp/bloat_reports"
+                - "/tmp/output_binaries:/tmp/output_binaries"
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              # Fetch depth 0 to get all history and be able to check mergepoint for bloat report
+              with:
+                  fetch-depth: 0
+                  submodules: true
+            - name: Build example nRF Connect SDK Lock App
+              run: scripts/examples/nrfconnect_lock_app.sh
+            - name: Copy aside build products
+              run: |
+                  mkdir -p example_binaries/$BUILD_TYPE-build
+                  cp examples/lock-app/nrfconnect/build/zephyr/zephyr.elf       \
+                     example_binaries/$BUILD_TYPE-build/chip-nrf52840-lock-example.elf
+            - name: Binary artifact suffix
+              id: outsuffix
+              uses: haya14busa/action-cond@v1.0.0
+              with:
+                  cond: ${{ github.event.pull_request.number == '' }}
+                  if_true: "${{ github.sha }}"
+                  if_false: "pull-${{ github.event.pull_request.number }}"
+            - name: Copy aside bloat report & binaries
+              run: |
+                  cp -r example_binaries/$BUILD_TYPE-build /tmp/output_binaries/
+            - name: Uploading Binaries
+              uses: actions/upload-artifact@v1
+              with:
+                  name:
+                      ${{ env.BUILD_TYPE }}-example-build-${{
+                      steps.outsuffix.outputs.value }}
+                  path: /tmp/output_binaries/${{ env.BUILD_TYPE }}-build
+        
     linux-standalone:
         name: Linux Standalone
 

--- a/.github/workflows/gn_build.yaml
+++ b/.github/workflows/gn_build.yaml
@@ -34,7 +34,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build:0.4.0
+            image: connectedhomeip/chip-build:0.4.1
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/.github/workflows/gn_examples.yaml
+++ b/.github/workflows/gn_examples.yaml
@@ -31,7 +31,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build-nrf-platform:0.4.0
+            image: connectedhomeip/chip-build-nrf-platform:0.4.1
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
                 - "/tmp/output_binaries:/tmp/output_binaries"
@@ -82,7 +82,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build:0.4.0
+            image: connectedhomeip/chip-build:0.4.1
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
                 - "/tmp/output_binaries:/tmp/output_binaries"

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -28,7 +28,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build-esp32-qemu:0.4.0
+            image: connectedhomeip/chip-build-esp32-qemu:0.4.1
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/scripts/examples/nrfconnect_lock_app.sh
+++ b/scripts/examples/nrfconnect_lock_app.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+set -x
+[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh"
+env
+
+./bootstrap
+west build -b nrf52840dk_nrf52840 -d examples/lock-app/nrfconnect/build examples/lock-app/nrfconnect


### PR DESCRIPTION
 #### Problem
Build status of the nRF Connect SDK platform layer along with the door-lock example is not verified in CI

 #### Summary of Changes
* Add github workflow to build the door-lock app for nRF Connect SDK platform
* Fix existing build errors (commit shared with #1678)

fixes #1893
