### PR TITLE
Set the BLE uncomissioned advertising interval (200ms) closer to the …

### DIFF
--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -367,10 +367,10 @@
  * The interval (in units of 0.625ms) at which the device will send BLE advertisements while
  * in fast advertising mode.
  *
- * Defaults to 800 (500ms).
+ * Defaults to 320 (200ms).
  */
 #ifndef CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_INTERVAL
-#define CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_INTERVAL 800
+#define CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_INTERVAL 320
 #endif
 
 /**


### PR DESCRIPTION
…spec (between 100ms and 250ms)

 #### Problem

In order to reduce the discovery time the spec expect an advertising interval between 100ms and 250ms. Set it to 200ms (from 500ms).
