### PR TITLE
Use WiFi credentials from Rendezvous BLE message

### DIFF
--- a/examples/wifi-echo/server/esp32/main/RendezvousSession.cpp
+++ b/examples/wifi-echo/server/esp32/main/RendezvousSession.cpp
@@ -23,6 +23,8 @@
 
 using namespace ::chip;
 
+extern CHIP_ERROR SetWiFiStationProvisioning(char * ssid, char * key);
+
 BluetoothWidget * RendezvousSession::mVirtualLed;
 
 Ble::BLEEndPoint * RendezvousSession::mEndPoint = nullptr;
@@ -79,5 +81,8 @@ void RendezvousSession::HandleMessageReceived(Ble::BLEEndPoint * endPoint, Packe
 
     ChipLogProgress(Ble, "RendezvousSession: Receive message: %s", msg);
 
-    mEndPoint->Send(buffer);
+    char * ssid = strtok(msg, ":");
+    char * key  = strtok(NULL, ":");
+    ChipLogProgress(Ble, "RendezvousSession: SSID: %s, key: %s", ssid, key);
+    SetWiFiStationProvisioning(ssid, key);
 }


### PR DESCRIPTION
For this first draft, SSID and key are separated by ‘:’.
This will need to change since any character including ‘:’
can appear in an SSID or password.
