### PR TITLE
[linux] Add dbus gen for CHIP Linux device layer to talk to wpa_suppl…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2121,12 +2121,15 @@ fi
 # GIO
 #
 
+CHIP_WITH_GIO=no
+
 if test "${CHIP_DEVICE_LAYER_TARGET_LINUX}" = 1; then
     PKG_CHECK_MODULES([GIO], [gio-2.0])
 
     # Check for GIO library is available.
     AC_CHECK_LIB([gio-2.0], [g_bus_get_sync],
     [
+        CHIP_WITH_GIO=yes
         AC_DEFINE([CHIP_WITH_GIO], [1], [Define to 1 to build CHIP with GIO])
     ],
     [
@@ -2138,6 +2141,9 @@ if test "${CHIP_DEVICE_LAYER_TARGET_LINUX}" = 1; then
 
     AC_CHECK_PROG(GDBUSCODEGEN, gdbus-codegen, gdbus-codegen)
 fi
+
+AC_SUBST(CHIP_ENABLE_GIO)
+AM_CONDITIONAL([CHIP_ENABLE_GIO], [test "${CHIP_WITH_GIO}" == "yes"])
 
 #
 # Sockets

--- a/configure.ac
+++ b/configure.ac
@@ -2121,7 +2121,7 @@ fi
 # GIO
 #
 
-CHIP_WITH_GIO=no
+CHIP_ENABLE_GIO=0
 
 if test "${CHIP_DEVICE_LAYER_TARGET_LINUX}" = 1; then
     PKG_CHECK_MODULES([GIO], [gio-2.0])
@@ -2129,10 +2129,11 @@ if test "${CHIP_DEVICE_LAYER_TARGET_LINUX}" = 1; then
     # Check for GIO library is available.
     AC_CHECK_LIB([gio-2.0], [g_bus_get_sync],
     [
-        CHIP_WITH_GIO=yes
+        CHIP_ENABLE_GIO=1
         AC_DEFINE([CHIP_WITH_GIO], [1], [Define to 1 to build CHIP with GIO])
     ],
     [
+        CHIP_ENABLE_GIO=0
         AC_DEFINE([CHIP_WITH_GIO], [0], [Define to 0 to build CHIP without GIO])
     ]
     )
@@ -2142,8 +2143,33 @@ if test "${CHIP_DEVICE_LAYER_TARGET_LINUX}" = 1; then
     AC_CHECK_PROG(GDBUSCODEGEN, gdbus-codegen, gdbus-codegen)
 fi
 
-AC_SUBST(CHIP_ENABLE_GIO)
-AM_CONDITIONAL([CHIP_ENABLE_GIO], [test "${CHIP_WITH_GIO}" == "yes"])
+#
+#
+# WPA
+#
+
+CONFIG_WIFI_PLATFORM_WPA=0
+enable_chipwifi_wpa="no"
+
+# At this time, enable this only for linux, and only if the GIO package are installed. Currently, WiFi and Thread
+# are depending on the gdbus-internal configured by internal BLuez package. 
+# TODO: Refacrot BLuez to use common gdbus lib from GIO.
+
+if test "${with_device_layer}" = "linux" && test "${CHIP_ENABLE_GIO}" = 1 && test "${CONFIG_BLE_PLATFORM_BLUEZ}" = 1; then
+case "${target}" in
+    *linux*)
+        CONFIG_WIFI_PLATFORM_WPA=1
+        enable_chipwifi_wpa="yes"
+        ;;
+    *)
+        CONFIG_WIFI_PLATFORM_WPA=0
+        enable_chipwifi_wpa="no"
+        ;;
+    esac
+fi
+
+AM_CONDITIONAL([CONFIG_WIFI_PLATFORM_WPA], [test "${enable_chipwifi_wpa}" = "yes"])
+AC_DEFINE_UNQUOTED([CHIP_DEVICE_CONFIG_ENABLE_WPA],[${CONFIG_WIFI_PLATFORM_WPA}],[Define to 1 if you want to enable WPA support for wpa_supplicant.])
 
 #
 # Sockets

--- a/src/platform/Linux/dbus/wpa.xml
+++ b/src/platform/Linux/dbus/wpa.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" ?>
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "https://raw.githubusercontent.com/freedesktop/dbus/master/doc/introspect.dtd">
+<node>
+    <interface name="fi.w1.wpa_supplicant1">
+        <method name="CreateInterface">
+            <arg name="args" type="a{sv}" direction="in" />
+            <arg name="path" type="o" direction="out" />
+        </method>
+        <method name="RemoveInterface">
+            <arg name="path" type="o" direction="in" />
+        </method>
+        <method name="GetInterface">
+            <arg name="ifname" type="s" direction="in" />
+            <arg name="path" type="o" direction="out" />
+        </method>
+        <method name="ExpectDisconnect" />
+        <signal name="InterfaceAdded">
+            <arg name="path" type="o" />
+            <arg name="properties" type="a{sv}" />
+        </signal>
+        <signal name="InterfaceRemoved">
+            <arg name="path" type="o" />
+        </signal>
+        <signal name="PropertiesChanged">
+            <arg name="properties" type="a{sv}" />
+        </signal>
+        <property name="DebugLevel" type="s" access="readwrite" />
+        <property name="DebugTimestamp" type="b" access="readwrite" />
+        <property name="DebugShowKeys" type="b" access="readwrite" />
+        <property name="Interfaces" type="ao" access="read" />
+        <property name="EapMethods" type="as" access="read" />
+        <property name="Capabilities" type="as" access="read" />
+        <property name="WFDIEs" type="ay" access="readwrite" />
+    </interface>
+    <node name="Interfaces" />
+</node>

--- a/src/platform/Linux/dbus/wpa_interface.xml
+++ b/src/platform/Linux/dbus/wpa_interface.xml
@@ -1,0 +1,478 @@
+<?xml version="1.0" ?>
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "https://raw.githubusercontent.com/freedesktop/dbus/master/doc/introspect.dtd">
+<node>
+    <interface name="fi.w1.wpa_supplicant1.Interface">
+        <method name="Scan">
+            <arg name="args" type="a{sv}" direction="in" />
+        </method>
+        <method name="SignalPoll">
+            <arg name="args" type="a{sv}" direction="out" />
+        </method>
+        <method name="Disconnect" />
+        <method name="AddNetwork">
+            <arg name="args" type="a{sv}" direction="in" />
+            <arg name="path" type="o" direction="out" />
+        </method>
+        <method name="Reassociate" />
+        <method name="Reattach" />
+        <method name="Reconnect" />
+        <method name="RemoveNetwork">
+            <arg name="path" type="o" direction="in" />
+        </method>
+        <method name="RemoveAllNetworks" />
+        <method name="SelectNetwork">
+            <arg name="path" type="o" direction="in" />
+        </method>
+        <method name="NetworkReply">
+            <arg name="path" type="o" direction="in" />
+            <arg name="field" type="s" direction="in" />
+            <arg name="value" type="s" direction="in" />
+        </method>
+        <method name="AddBlob">
+            <arg name="name" type="s" direction="in" />
+            <arg name="data" type="ay" direction="in" />
+        </method>
+        <method name="GetBlob">
+            <arg name="name" type="s" direction="in" />
+            <arg name="data" type="ay" direction="out" />
+        </method>
+        <method name="RemoveBlob">
+            <arg name="name" type="s" direction="in" />
+        </method>
+        <method name="SetPKCS11EngineAndModulePath">
+            <arg name="pkcs11_engine_path" type="s" direction="in" />
+            <arg name="pkcs11_module_path" type="s" direction="in" />
+        </method>
+        <method name="FlushBSS">
+            <arg name="age" type="u" direction="in" />
+        </method>
+        <method name="SubscribeProbeReq" />
+        <method name="UnsubscribeProbeReq" />
+        <method name="EAPLogoff" />
+        <method name="EAPLogon" />
+        <method name="AutoScan">
+            <arg name="arg" type="s" direction="in" />
+        </method>
+        <method name="TDLSDiscover">
+            <arg name="peer_address" type="s" direction="in" />
+        </method>
+        <method name="TDLSSetup">
+            <arg name="peer_address" type="s" direction="in" />
+        </method>
+        <method name="TDLSStatus">
+            <arg name="peer_address" type="s" direction="in" />
+            <arg name="status" type="s" direction="out" />
+        </method>
+        <method name="TDLSTeardown">
+            <arg name="peer_address" type="s" direction="in" />
+        </method>
+        <method name="TDLSChannelSwitch">
+            <arg name="args" type="a{sv}" direction="in" />
+        </method>
+        <method name="TDLSCancelChannelSwitch">
+            <arg name="peer_address" type="s" direction="in" />
+        </method>
+        <method name="VendorElemAdd">
+            <arg name="frame_id" type="i" direction="in" />
+            <arg name="ielems" type="ay" direction="in" />
+        </method>
+        <method name="VendorElemGet">
+            <arg name="frame_id" type="i" direction="in" />
+            <arg name="ielems" type="ay" direction="out" />
+        </method>
+        <method name="VendorElemRem">
+            <arg name="frame_id" type="i" direction="in" />
+            <arg name="ielems" type="ay" direction="in" />
+        </method>
+        <method name="SaveConfig" />
+        <method name="AbortScan" />
+        <signal name="ScanDone">
+            <arg name="success" type="b" />
+        </signal>
+        <signal name="BSSAdded">
+            <arg name="path" type="o" />
+            <arg name="properties" type="a{sv}" />
+        </signal>
+        <signal name="BSSRemoved">
+            <arg name="path" type="o" />
+        </signal>
+        <signal name="BlobAdded">
+            <arg name="name" type="s" />
+        </signal>
+        <signal name="BlobRemoved">
+            <arg name="name" type="s" />
+        </signal>
+        <signal name="NetworkAdded">
+            <arg name="path" type="o" />
+            <arg name="properties" type="a{sv}" />
+        </signal>
+        <signal name="NetworkRemoved">
+            <arg name="path" type="o" />
+        </signal>
+        <signal name="NetworkSelected">
+            <arg name="path" type="o" />
+        </signal>
+        <signal name="PropertiesChanged">
+            <arg name="properties" type="a{sv}" />
+        </signal>
+        <signal name="ProbeRequest">
+            <arg name="args" type="a{sv}" />
+        </signal>
+        <signal name="Certification">
+            <arg name="certification" type="a{sv}" />
+        </signal>
+        <signal name="EAP">
+            <arg name="status" type="s" />
+            <arg name="parameter" type="s" />
+        </signal>
+        <signal name="StaAuthorized">
+            <arg name="name" type="s" />
+        </signal>
+        <signal name="StaDeauthorized">
+            <arg name="name" type="s" />
+        </signal>
+        <signal name="StationAdded">
+            <arg name="path" type="o" />
+            <arg name="properties" type="a{sv}" />
+        </signal>
+        <signal name="StationRemoved">
+            <arg name="path" type="o" />
+        </signal>
+        <signal name="NetworkRequest">
+            <arg name="path" type="o" />
+            <arg name="field" type="s" />
+            <arg name="text" type="s" />
+        </signal>
+        <property name="Capabilities" type="a{sv}" access="read" />
+        <property name="State" type="s" access="read" />
+        <property name="Scanning" type="b" access="read" />
+        <property name="ApScan" type="u" access="readwrite" />
+        <property name="BSSExpireAge" type="u" access="readwrite" />
+        <property name="BSSExpireCount" type="u" access="readwrite" />
+        <property name="Country" type="s" access="readwrite" />
+        <property name="Ifname" type="s" access="read" />
+        <property name="Driver" type="s" access="read" />
+        <property name="BridgeIfname" type="s" access="read" />
+        <property name="ConfigFile" type="s" access="read" />
+        <property name="CurrentBSS" type="o" access="read" />
+        <property name="CurrentNetwork" type="o" access="read" />
+        <property name="CurrentAuthMode" type="s" access="read" />
+        <property name="Blobs" type="a{say}" access="read" />
+        <property name="BSSs" type="ao" access="read" />
+        <property name="Networks" type="ao" access="read" />
+        <property name="FastReauth" type="b" access="readwrite" />
+        <property name="ScanInterval" type="i" access="readwrite" />
+        <property name="PKCS11EnginePath" type="s" access="read" />
+        <property name="PKCS11ModulePath" type="s" access="read" />
+        <property name="DisconnectReason" type="i" access="read" />
+        <property name="AuthStatusCode" type="i" access="read" />
+        <property name="AssocStatusCode" type="i" access="read" />
+        <property name="RoamTime" type="u" access="read" />
+        <property name="RoamComplete" type="b" access="read" />
+        <property name="SessionLength" type="u" access="read" />
+        <property name="BSSTMStatus" type="u" access="read" />
+        <property name="Stations" type="ao" access="read" />
+        <property name="MACAddressRandomizationMask" type="a{say}" access="readwrite" />
+        <property name="CtrlInterface" type="s" access="readwrite" />
+        <property name="CtrlInterfaceGroup" type="s" access="readwrite" />
+        <property name="EapolVersion" type="s" access="readwrite" />
+        <property name="Bgscan" type="s" access="readwrite" />
+        <property name="DisableScanOffload" type="s" access="readwrite" />
+        <property name="OpenscEnginePath" type="s" access="readwrite" />
+        <property name="OpensslCiphers" type="s" access="readwrite" />
+        <property name="PcscReader" type="s" access="readwrite" />
+        <property name="PcscPin" type="s" access="readwrite" />
+        <property name="ExternalSim" type="s" access="readwrite" />
+        <property name="DriverParam" type="s" access="readwrite" />
+        <property name="Dot11RSNAConfigPMKLifetime" type="s" access="readwrite" />
+        <property name="Dot11RSNAConfigPMKReauthThreshold" type="s" access="readwrite" />
+        <property name="Dot11RSNAConfigSATimeout" type="s" access="readwrite" />
+        <property name="UpdateConfig" type="s" access="readwrite" />
+        <property name="Uuid" type="s" access="readwrite" />
+        <property name="AutoUuid" type="s" access="readwrite" />
+        <property name="DeviceName" type="s" access="readwrite" />
+        <property name="Manufacturer" type="s" access="readwrite" />
+        <property name="ModelName" type="s" access="readwrite" />
+        <property name="ModelNumber" type="s" access="readwrite" />
+        <property name="SerialNumber" type="s" access="readwrite" />
+        <property name="DeviceType" type="s" access="readwrite" />
+        <property name="OsVersion" type="s" access="readwrite" />
+        <property name="ConfigMethods" type="s" access="readwrite" />
+        <property name="WpsCredProcessing" type="s" access="readwrite" />
+        <property name="WpsCredAddSae" type="s" access="readwrite" />
+        <property name="WpsVendorExtM1" type="s" access="readwrite" />
+        <property name="SecDeviceType" type="s" access="readwrite" />
+        <property name="P2pListenRegClass" type="s" access="readwrite" />
+        <property name="P2pListenChannel" type="s" access="readwrite" />
+        <property name="P2pOperRegClass" type="s" access="readwrite" />
+        <property name="P2pOperChannel" type="s" access="readwrite" />
+        <property name="P2pGoIntent" type="s" access="readwrite" />
+        <property name="P2pSsidPostfix" type="s" access="readwrite" />
+        <property name="PersistentReconnect" type="s" access="readwrite" />
+        <property name="P2pIntraBss" type="s" access="readwrite" />
+        <property name="P2pGroupIdle" type="s" access="readwrite" />
+        <property name="P2pGoFreqChangePolicy" type="s" access="readwrite" />
+        <property name="P2pPassphraseLen" type="s" access="readwrite" />
+        <property name="P2pPrefChan" type="s" access="readwrite" />
+        <property name="P2pNoGoFreq" type="s" access="readwrite" />
+        <property name="P2pAddCliChan" type="s" access="readwrite" />
+        <property name="P2pOptimizeListenChan" type="s" access="readwrite" />
+        <property name="P2pGoHt40" type="s" access="readwrite" />
+        <property name="P2pGoVht" type="s" access="readwrite" />
+        <property name="P2pGoHe" type="s" access="readwrite" />
+        <property name="P2pGoEdmg" type="s" access="readwrite" />
+        <property name="P2pDisabled" type="s" access="readwrite" />
+        <property name="P2pGoCtwindow" type="s" access="readwrite" />
+        <property name="P2pNoGroupIface" type="s" access="readwrite" />
+        <property name="P2pIgnoreSharedFreq" type="s" access="readwrite" />
+        <property name="IpAddrGo" type="s" access="readwrite" />
+        <property name="IpAddrMask" type="s" access="readwrite" />
+        <property name="IpAddrStart" type="s" access="readwrite" />
+        <property name="IpAddrEnd" type="s" access="readwrite" />
+        <property name="P2pCliProbe" type="s" access="readwrite" />
+        <property name="P2pDeviceRandomMacAddr" type="s" access="readwrite" />
+        <property name="P2pDevicePersistentMacAddr" type="s" access="readwrite" />
+        <property name="P2pInterfaceRandomMacAddr" type="s" access="readwrite" />
+        <property name="BssMaxCount" type="s" access="readwrite" />
+        <property name="FilterSsids" type="s" access="readwrite" />
+        <property name="FilterRssi" type="s" access="readwrite" />
+        <property name="MaxNumSta" type="s" access="readwrite" />
+        <property name="ApIsolate" type="s" access="readwrite" />
+        <property name="DisassocLowAck" type="s" access="readwrite" />
+        <property name="Hs20" type="s" access="readwrite" />
+        <property name="Interworking" type="s" access="readwrite" />
+        <property name="Hessid" type="s" access="readwrite" />
+        <property name="AccessNetworkType" type="s" access="readwrite" />
+        <property name="GoInterworking" type="s" access="readwrite" />
+        <property name="GoAccessNetworkType" type="s" access="readwrite" />
+        <property name="GoInternet" type="s" access="readwrite" />
+        <property name="GoVenueGroup" type="s" access="readwrite" />
+        <property name="GoVenueType" type="s" access="readwrite" />
+        <property name="PbcInM1" type="s" access="readwrite" />
+        <property name="Autoscan" type="s" access="readwrite" />
+        <property name="WpsNfcDevPwId" type="s" access="readwrite" />
+        <property name="WpsNfcDhPubkey" type="s" access="readwrite" />
+        <property name="WpsNfcDhPrivkey" type="s" access="readwrite" />
+        <property name="WpsNfcDevPw" type="s" access="readwrite" />
+        <property name="ExtPasswordBackend" type="s" access="readwrite" />
+        <property name="P2pGoMaxInactivity" type="s" access="readwrite" />
+        <property name="AutoInterworking" type="s" access="readwrite" />
+        <property name="Okc" type="s" access="readwrite" />
+        <property name="Pmf" type="s" access="readwrite" />
+        <property name="SaeGroups" type="s" access="readwrite" />
+        <property name="SaePwe" type="s" access="readwrite" />
+        <property name="SaePmkidInAssoc" type="s" access="readwrite" />
+        <property name="DtimPeriod" type="s" access="readwrite" />
+        <property name="BeaconInt" type="s" access="readwrite" />
+        <property name="ApVendorElements" type="s" access="readwrite" />
+        <property name="IgnoreOldScanRes" type="s" access="readwrite" />
+        <property name="FreqList" type="s" access="readwrite" />
+        <property name="ScanCurFreq" type="s" access="readwrite" />
+        <property name="SchedScanInterval" type="s" access="readwrite" />
+        <property name="SchedScanStartDelay" type="s" access="readwrite" />
+        <property name="TdlsExternalControl" type="s" access="readwrite" />
+        <property name="OsuDir" type="s" access="readwrite" />
+        <property name="WowlanTriggers" type="s" access="readwrite" />
+        <property name="P2pSearchDelay" type="s" access="readwrite" />
+        <property name="MacAddr" type="s" access="readwrite" />
+        <property name="RandAddrLifetime" type="s" access="readwrite" />
+        <property name="PreassocMacAddr" type="s" access="readwrite" />
+        <property name="KeyMgmtOffload" type="s" access="readwrite" />
+        <property name="PassiveScan" type="s" access="readwrite" />
+        <property name="ReassocSameBssOptim" type="s" access="readwrite" />
+        <property name="WpsPriority" type="s" access="readwrite" />
+        <property name="FstGroupId" type="s" access="readwrite" />
+        <property name="FstPriority" type="s" access="readwrite" />
+        <property name="FstLlt" type="s" access="readwrite" />
+        <property name="CertInCb" type="s" access="readwrite" />
+        <property name="WpaRscRelaxation" type="s" access="readwrite" />
+        <property name="SchedScanPlans" type="s" access="readwrite" />
+        <property name="GasAddress3" type="s" access="readwrite" />
+        <property name="FtmResponder" type="s" access="readwrite" />
+        <property name="FtmInitiator" type="s" access="readwrite" />
+        <property name="GasRandAddrLifetime" type="s" access="readwrite" />
+        <property name="GasRandMacAddr" type="s" access="readwrite" />
+        <property name="DppConfigProcessing" type="s" access="readwrite" />
+        <property name="DppName" type="s" access="readwrite" />
+        <property name="DppMudUrl" type="s" access="readwrite" />
+        <property name="ColocIntfReporting" type="s" access="readwrite" />
+    </interface>
+    <interface name="fi.w1.wpa_supplicant1.Interface.WPS">
+        <method name="Start">
+            <arg name="args" type="a{sv}" direction="in" />
+            <arg name="output" type="a{sv}" direction="out" />
+        </method>
+        <method name="Cancel" />
+        <signal name="Event">
+            <arg name="name" type="s" />
+            <arg name="args" type="a{sv}" />
+        </signal>
+        <signal name="Credentials">
+            <arg name="credentials" type="a{sv}" />
+        </signal>
+        <signal name="PropertiesChanged">
+            <arg name="properties" type="a{sv}" />
+        </signal>
+        <property name="ProcessCredentials" type="b" access="readwrite" />
+        <property name="ConfigMethods" type="s" access="readwrite" />
+        <property name="DeviceName" type="s" access="readwrite" />
+        <property name="Manufacturer" type="s" access="readwrite" />
+        <property name="ModelName" type="s" access="readwrite" />
+        <property name="ModelNumber" type="s" access="readwrite" />
+        <property name="SerialNumber" type="s" access="readwrite" />
+        <property name="DeviceType" type="ay" access="readwrite" />
+    </interface>
+    <interface name="fi.w1.wpa_supplicant1.Interface.P2PDevice">
+        <method name="Find">
+            <arg name="args" type="a{sv}" direction="in" />
+        </method>
+        <method name="StopFind" />
+        <method name="Listen">
+            <arg name="timeout" type="i" direction="in" />
+        </method>
+        <method name="ExtendedListen">
+            <arg name="args" type="a{sv}" direction="in" />
+        </method>
+        <method name="PresenceRequest">
+            <arg name="args" type="a{sv}" direction="in" />
+        </method>
+        <method name="ProvisionDiscoveryRequest">
+            <arg name="peer" type="o" direction="in" />
+            <arg name="config_method" type="s" direction="in" />
+        </method>
+        <method name="Connect">
+            <arg name="args" type="a{sv}" direction="in" />
+            <arg name="generated_pin" type="s" direction="out" />
+        </method>
+        <method name="GroupAdd">
+            <arg name="args" type="a{sv}" direction="in" />
+        </method>
+        <method name="Cancel" />
+        <method name="Invite">
+            <arg name="args" type="a{sv}" direction="in" />
+        </method>
+        <method name="Disconnect" />
+        <method name="RejectPeer">
+            <arg name="peer" type="o" direction="in" />
+        </method>
+        <method name="RemoveClient">
+            <arg name="args" type="a{sv}" direction="in" />
+        </method>
+        <method name="Flush" />
+        <method name="AddService">
+            <arg name="args" type="a{sv}" direction="in" />
+        </method>
+        <method name="DeleteService">
+            <arg name="args" type="a{sv}" direction="in" />
+        </method>
+        <method name="FlushService" />
+        <method name="ServiceDiscoveryRequest">
+            <arg name="args" type="a{sv}" direction="in" />
+            <arg name="ref" type="t" direction="out" />
+        </method>
+        <method name="ServiceDiscoveryResponse">
+            <arg name="args" type="a{sv}" direction="in" />
+        </method>
+        <method name="ServiceDiscoveryCancelRequest">
+            <arg name="args" type="t" direction="in" />
+        </method>
+        <method name="ServiceUpdate" />
+        <method name="ServiceDiscoveryExternal">
+            <arg name="arg" type="i" direction="in" />
+        </method>
+        <method name="AddPersistentGroup">
+            <arg name="args" type="a{sv}" direction="in" />
+            <arg name="path" type="o" direction="out" />
+        </method>
+        <method name="RemovePersistentGroup">
+            <arg name="path" type="o" direction="in" />
+        </method>
+        <method name="RemoveAllPersistentGroups" />
+        <signal name="DeviceFound">
+            <arg name="path" type="o" />
+        </signal>
+        <signal name="DeviceFoundProperties">
+            <arg name="path" type="o" />
+            <arg name="properties" type="a{sv}" />
+        </signal>
+        <signal name="DeviceLost">
+            <arg name="path" type="o" />
+        </signal>
+        <signal name="FindStopped" />
+        <signal name="ProvisionDiscoveryRequestDisplayPin">
+            <arg name="peer_object" type="o" />
+            <arg name="pin" type="s" />
+        </signal>
+        <signal name="ProvisionDiscoveryResponseDisplayPin">
+            <arg name="peer_object" type="o" />
+            <arg name="pin" type="s" />
+        </signal>
+        <signal name="ProvisionDiscoveryRequestEnterPin">
+            <arg name="peer_object" type="o" />
+        </signal>
+        <signal name="ProvisionDiscoveryResponseEnterPin">
+            <arg name="peer_object" type="o" />
+        </signal>
+        <signal name="ProvisionDiscoveryPBCRequest">
+            <arg name="peer_object" type="o" />
+        </signal>
+        <signal name="ProvisionDiscoveryPBCResponse">
+            <arg name="peer_object" type="o" />
+        </signal>
+        <signal name="ProvisionDiscoveryFailure">
+            <arg name="peer_object" type="o" />
+            <arg name="status" type="i" />
+        </signal>
+        <signal name="GroupStarted">
+            <arg name="properties" type="a{sv}" />
+        </signal>
+        <signal name="GroupFormationFailure">
+            <arg name="reason" type="s" />
+        </signal>
+        <signal name="GONegotiationSuccess">
+            <arg name="properties" type="a{sv}" />
+        </signal>
+        <signal name="GONegotiationFailure">
+            <arg name="properties" type="a{sv}" />
+        </signal>
+        <signal name="GONegotiationRequest">
+            <arg name="path" type="o" />
+            <arg name="dev_passwd_id" type="q" />
+            <arg name="device_go_intent" type="y" />
+        </signal>
+        <signal name="InvitationResult">
+            <arg name="invite_result" type="a{sv}" />
+        </signal>
+        <signal name="GroupFinished">
+            <arg name="properties" type="a{sv}" />
+        </signal>
+        <signal name="ServiceDiscoveryRequest">
+            <arg name="sd_request" type="a{sv}" />
+        </signal>
+        <signal name="ServiceDiscoveryResponse">
+            <arg name="sd_response" type="a{sv}" />
+        </signal>
+        <signal name="PersistentGroupAdded">
+            <arg name="path" type="o" />
+            <arg name="properties" type="a{sv}" />
+        </signal>
+        <signal name="PersistentGroupRemoved">
+            <arg name="path" type="o" />
+        </signal>
+        <signal name="WpsFailed">
+            <arg name="name" type="s" />
+            <arg name="args" type="a{sv}" />
+        </signal>
+        <signal name="InvitationReceived">
+            <arg name="properties" type="a{sv}" />
+        </signal>
+        <property name="P2PDeviceConfig" type="a{sv}" access="readwrite" />
+        <property name="Peers" type="ao" access="read" />
+        <property name="Role" type="s" access="read" />
+        <property name="Group" type="o" access="read" />
+        <property name="PeerGO" type="o" access="read" />
+        <property name="PersistentGroups" type="ao" access="read" />
+    </interface>
+    <node name="BSSs" />
+    <node name="Networks" />
+</node>

--- a/src/platform/Linux/dbus/wpa_network.xml
+++ b/src/platform/Linux/dbus/wpa_network.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "https://raw.githubusercontent.com/freedesktop/dbus/master/doc/introspect.dtd">
+<node>
+    <interface name="fi.w1.wpa_supplicant1.Network">
+        <signal name="PropertiesChanged">
+            <arg name="properties" type="a{sv}" />
+        </signal>
+        <property name="Properties" type="a{sv}" access="readwrite" />
+        <property name="Enabled" type="b" access="readwrite" />
+    </interface>
+</node>

--- a/src/platform/Makefile.am
+++ b/src/platform/Makefile.am
@@ -233,43 +233,43 @@ libDeviceLayer_a_SOURCES               += \
 
 endif #CONFIG_BLE_PLATFORM_BLUEZ
 
-if CHIP_ENABLE_GIO
+if CONFIG_WIFI_PLATFORM_WPA
 BUILT_SOURCES                          += \
-    gen/DBusWpa.h                         \
-    gen/DBusWpaInterface.h                \
-    gen/DBusWpaNetwork.h                  \
-    gen/DBusWpa.c                         \
-    gen/DBusWpaInterface.c                \
-    gen/DBusWpaNetwork.c                  \
+    Linux/gen/DBusWpa.h                   \
+    Linux/gen/DBusWpaInterface.h          \
+    Linux/gen/DBusWpaNetwork.h            \
+    Linux/gen/DBusWpa.c                   \
+    Linux/gen/DBusWpaInterface.c          \
+    Linux/gen/DBusWpaNetwork.c            \
     $(NULL)
 
-gen/DBusWpa.h: Linux/dbus/wpa.xml
+Linux/gen/DBusWpa.h: Linux/dbus/wpa.xml
 	gdbus-codegen --header --output $@ --c-namespace Wpa $<
 
-gen/DBusWpaInterface.h: Linux/dbus/wpa_interface.xml
+Linux/gen/DBusWpaInterface.h: Linux/dbus/wpa_interface.xml
 	gdbus-codegen --header --output $@ --c-namespace Wpa $<
 
-gen/DBusWpaNetwork.h: Linux/dbus/wpa_network.xml
+Linux/gen/DBusWpaNetwork.h: Linux/dbus/wpa_network.xml
 	gdbus-codegen --header --output $@ --c-namespace Wpa $<
 
-gen/DBusWpa.c: Linux/dbus/wpa.xml
+Linux/gen/DBusWpa.c: Linux/dbus/wpa.xml
 	gdbus-codegen --body --output $@ --c-namespace Wpa $<
 	sed -i 's/config\.h/BuildConfig.h/g' $@
 
-gen/DBusWpaInterface.c: Linux/dbus/wpa_interface.xml
+Linux/gen/DBusWpaInterface.c: Linux/dbus/wpa_interface.xml
 	gdbus-codegen --body --output $@ --c-namespace Wpa $<
 	sed -i 's/config\.h/BuildConfig.h/g' $@
 
-gen/DBusWpaNetwork.c: Linux/dbus/wpa_network.xml
+Linux/gen/DBusWpaNetwork.c: Linux/dbus/wpa_network.xml
 	gdbus-codegen --body --output $@ --c-namespace Wpa $<
 	sed -i 's/config\.h/BuildConfig.h/g' $@
 
 libDeviceLayer_a_SOURCES               += \
-    gen/DBusWpa.c                         \
-    gen/DBusWpaInterface.c                \
-    gen/DBusWpaNetwork.c                  \
+    Linux/gen/DBusWpa.c                   \
+    Linux/gen/DBusWpaInterface.c          \
+    Linux/gen/DBusWpaNetwork.c            \
     $(NULL)
-endif #CHIP_ENABLE_GIO
+endif # CONFIG_WIFI_PLATFORM_WPA
 
 libDeviceLayer_a_SOURCES               += \
     Linux/BLEManagerImpl.cpp              \

--- a/src/platform/Makefile.am
+++ b/src/platform/Makefile.am
@@ -233,6 +233,44 @@ libDeviceLayer_a_SOURCES               += \
 
 endif #CONFIG_BLE_PLATFORM_BLUEZ
 
+if CHIP_ENABLE_GIO
+BUILT_SOURCES                          += \
+    gen/DBusWpa.h                         \
+    gen/DBusWpaInterface.h                \
+    gen/DBusWpaNetwork.h                  \
+    gen/DBusWpa.c                         \
+    gen/DBusWpaInterface.c                \
+    gen/DBusWpaNetwork.c                  \
+    $(NULL)
+
+gen/DBusWpa.h: Linux/dbus/wpa.xml
+	gdbus-codegen --header --output $@ --c-namespace Wpa $<
+
+gen/DBusWpaInterface.h: Linux/dbus/wpa_interface.xml
+	gdbus-codegen --header --output $@ --c-namespace Wpa $<
+
+gen/DBusWpaNetwork.h: Linux/dbus/wpa_network.xml
+	gdbus-codegen --header --output $@ --c-namespace Wpa $<
+
+gen/DBusWpa.c: Linux/dbus/wpa.xml
+	gdbus-codegen --body --output $@ --c-namespace Wpa $<
+	sed -i 's/config\.h/BuildConfig.h/g' $@
+
+gen/DBusWpaInterface.c: Linux/dbus/wpa_interface.xml
+	gdbus-codegen --body --output $@ --c-namespace Wpa $<
+	sed -i 's/config\.h/BuildConfig.h/g' $@
+
+gen/DBusWpaNetwork.c: Linux/dbus/wpa_network.xml
+	gdbus-codegen --body --output $@ --c-namespace Wpa $<
+	sed -i 's/config\.h/BuildConfig.h/g' $@
+
+libDeviceLayer_a_SOURCES               += \
+    gen/DBusWpa.c                         \
+    gen/DBusWpaInterface.c                \
+    gen/DBusWpaNetwork.c                  \
+    $(NULL)
+endif #CHIP_ENABLE_GIO
+
 libDeviceLayer_a_SOURCES               += \
     Linux/BLEManagerImpl.cpp              \
     Linux/ConfigurationManagerImpl.cpp    \

--- a/src/platform/tests/Makefile.am
+++ b/src/platform/tests/Makefile.am
@@ -58,6 +58,7 @@ dist_libPlatformTests_a_HEADERS                = \
 # objects in this makefile.
 
 AM_CPPFLAGS                                    = \
+    -I$(builddir)/../gen                         \
     -I$(top_srcdir)/src/                         \
     -I$(top_srcdir)/src/lib                      \
     -I$(top_srcdir)/src/system                   \
@@ -71,6 +72,7 @@ AM_CPPFLAGS                                    = \
 if CHIP_DEVICE_LAYER_TARGET_LINUX
 AM_CPPFLAGS                                   += \
     $(GIO_CFLAGS)                                \
+    $(GIO_UNIX_CFLAGS)                           \
     $(NULL)
 
 if CHIP_WITH_OT_BR_POSIX
@@ -103,6 +105,7 @@ COMMON_LDADD                                          = \
     libPlatformTests.a                                  \
     $(CHIP_LDADD)                                       \
     $(GIO_CFLAGS) $(GIO_LIBS)                           \
+    $(GIO_UNIX_CFLAGS) $(GIO_UNIX_LIBS)                 \
     $(NLFAULTINJECTION_LDFLAGS) $(NLFAULTINJECTION_LIBS)\
     $(NLUNIT_TEST_LDFLAGS) $(NLUNIT_TEST_LIBS)          \
     $(LWIP_LDFLAGS) $(LWIP_LIBS)                        \

--- a/src/platform/tests/Makefile.am
+++ b/src/platform/tests/Makefile.am
@@ -58,7 +58,7 @@ dist_libPlatformTests_a_HEADERS                = \
 # objects in this makefile.
 
 AM_CPPFLAGS                                    = \
-    -I$(builddir)/../gen                         \
+    -I$(builddir)/../Linux/gen                   \
     -I$(top_srcdir)/src/                         \
     -I$(top_srcdir)/src/lib                      \
     -I$(top_srcdir)/src/system                   \


### PR DESCRIPTION
Problem
The Linux device layer needs a ConnectivityMgr that handles a single, primary WiFi interface.

Summary of Changes
* Generate wpa_supplicant GDBus interface for ConnectivityMgr.

fixes #<739>

