### PR TITLE
Fix command-line chip-tool toggle command.

### DIFF
--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -169,7 +169,7 @@ bool DetermineCommand(int argc, char * argv[], Command * command)
     if (EqualsLiteral(argv[1], "toggle"))
     {
         *command = Command::Toggle;
-        return argc == 4;
+        return argc == 5;
     }
 
     if (EqualsLiteral(argv[1], "echo"))


### PR DESCRIPTION
The toggle command takes 5 args (executable, "toggle", ip, port,
endpoint), not 4.

 #### Problem
chip-tool toggle command does not work

 #### Summary of Changes
Fix condition to make it work

fixes https://github.com/project-chip/connectedhomeip/issues/1699
