### PR TITLE
ESP32 - Update advertising data to be closer to the spec

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -511,7 +511,7 @@ menu "CHIP Device Layer"
 
         config BLE_FAST_ADVERTISING_INTERVAL
             int "Fast Advertising Interval"
-            default 800
+            default 320
             depends on ENABLE_CHIPOBLE
             help
                 The interval (in units of 0.625ms) at which the device will send BLE advertisements while

--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -192,13 +192,14 @@ struct CommandArgs
 {
     IPAddress hostAddr;
     uint16_t port;
-    char * name;
+    uint16_t discriminator;
     uint8_t endpointId;
 };
 
 bool DetermineArgsBle(char * argv[], CommandArgs * commandArgs)
 {
-    commandArgs->name = argv[2];
+    std::string discriminator_str(argv[2]);
+    commandArgs->discriminator = std::stoi(discriminator_str);
     return true;
 }
 
@@ -289,9 +290,11 @@ void DoEcho(DeviceController::ChipDeviceController * controller, const char * id
     }
 }
 
-void DoEchoBle(DeviceController::ChipDeviceController * controller, const std::string & name)
+void DoEchoBle(DeviceController::ChipDeviceController * controller, const uint16_t discriminator)
 {
-    DoEcho(controller, name.c_str());
+    char name[4];
+    snprintf(name, sizeof(name), "%u", discriminator);
+    DoEcho(controller, "");
 }
 
 void DoEchoIP(DeviceController::ChipDeviceController * controller, const IPAddress & hostAddr, uint16_t port)
@@ -350,9 +353,9 @@ CHIP_ERROR ExecuteCommand(DeviceController::ChipDeviceController * controller, C
     switch (command)
     {
     case Command::EchoBle:
-        err = controller->ConnectDevice(kRemoteDeviceId, commandArgs.name, NULL, OnConnect, OnMessage, OnError);
+        err = controller->ConnectDevice(kRemoteDeviceId, commandArgs.discriminator, NULL, OnConnect, OnMessage, OnError);
         VerifyOrExit(err == CHIP_NO_ERROR, fprintf(stderr, "Failed to connect to the device"));
-        DoEchoBle(controller, commandArgs.name);
+        DoEchoBle(controller, commandArgs.discriminator);
         break;
 
     case Command::Echo:

--- a/src/ble/BleConnectionDelegate.h
+++ b/src/ble/BleConnectionDelegate.h
@@ -50,8 +50,8 @@ public:
     OnConnectionErrorFunct OnConnectionError;
 
     // Call this function to delegate the connection steps required to get a BLE_CONNECTION_OBJECT
-    // out of a peripheral name.
-    virtual void NewConnection(BleLayer * bleLayer, void * appState, const char * connName) = 0;
+    // out of a peripheral discriminator.
+    virtual void NewConnection(BleLayer * bleLayer, void * appState, const uint16_t connDiscriminator) = 0;
 };
 
 } /* namespace Ble */

--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -369,19 +369,19 @@ BLE_ERROR BleLayer::Shutdown()
     return BLE_NO_ERROR;
 }
 
-BLE_ERROR BleLayer::NewBleConnection(void * appState, const char * connName,
+BLE_ERROR BleLayer::NewBleConnection(void * appState, const uint16_t connDiscriminator,
                                      BleConnectionDelegate::OnConnectionCompleteFunct onConnectionComplete,
                                      BleConnectionDelegate::OnConnectionErrorFunct onConnectionError)
 {
     BLE_ERROR err = BLE_NO_ERROR;
 
     VerifyOrExit(mState == kState_Initialized, err = BLE_ERROR_INCORRECT_STATE);
-    VerifyOrExit(connName != nullptr, err = BLE_ERROR_BAD_ARGS);
+    VerifyOrExit(connDiscriminator != 0, err = BLE_ERROR_BAD_ARGS);
     VerifyOrExit(mConnectionDelegate != nullptr, err = BLE_ERROR_INCORRECT_STATE);
 
     mConnectionDelegate->OnConnectionComplete = onConnectionComplete;
     mConnectionDelegate->OnConnectionError    = onConnectionError;
-    mConnectionDelegate->NewConnection(this, appState, connName);
+    mConnectionDelegate->NewConnection(this, appState, connDiscriminator);
 
 exit:
     return err;

--- a/src/ble/BleLayer.h
+++ b/src/ble/BleLayer.h
@@ -253,7 +253,7 @@ public:
                    BleApplicationDelegate * appDelegate, chip::System::Layer * systemLayer);
     BLE_ERROR Shutdown(void);
 
-    BLE_ERROR NewBleConnection(void * appState, const char * connName,
+    BLE_ERROR NewBleConnection(void * appState, const uint16_t connDiscriminator,
                                BleConnectionDelegate::OnConnectionCompleteFunct onConnectionComplete,
                                BleConnectionDelegate::OnConnectionErrorFunct onConnectionError);
     BLE_ERROR NewBleEndPoint(BLEEndPoint ** retEndPoint, BLE_CONNECTION_OBJECT connObj, BleRole role, bool autoClose);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -145,7 +145,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR ChipDeviceController::ConnectDevice(NodeId remoteDeviceId, const char * deviceName, void * appReqState,
+CHIP_ERROR ChipDeviceController::ConnectDevice(NodeId remoteDeviceId, const uint16_t deviceDiscriminator, void * appReqState,
                                                NewConnectionHandler onConnected, MessageReceiveHandler onMessageReceived,
                                                ErrorHandler onError)
 {
@@ -161,8 +161,8 @@ CHIP_ERROR ChipDeviceController::ConnectDevice(NodeId remoteDeviceId, const char
     mOnNewConnection = onConnected;
 
     transport = new Transport::BLE();
-    err       = transport->Init(
-        Transport::BleConnectionParameters(this, DeviceLayer::ConnectivityMgr().GetBleLayer()).SetConnectionName(deviceName));
+    err       = transport->Init(Transport::BleConnectionParameters(this, DeviceLayer::ConnectivityMgr().GetBleLayer())
+                              .SetConnectionDiscriminator(deviceDiscriminator));
     SuccessOrExit(err);
     mUnsecuredTransport = transport->Retain();
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -68,15 +68,15 @@ public:
      *   Connect to a CHIP device with a given name for Rendezvous
      *
      * @param[in] remoteDeviceId        The remote device Id.
-     * @param[in] deviceName            The name of the requested Device
+     * @param[in] deviceDiscriminator   The discriminator of the requested Device
      * @param[in] appReqState           Application specific context to be passed back when a message is received or on error
      * @param[in] onConnected           Callback for when the connection is established
      * @param[in] onMessageReceived     Callback for when a message is received
      * @param[in] onError               Callback for when an error occurs
      * @return CHIP_ERROR               The connection status
      */
-    CHIP_ERROR ConnectDevice(NodeId remoteDeviceId, const char * deviceName, void * appReqState, NewConnectionHandler onConnected,
-                             MessageReceiveHandler onMessageReceived, ErrorHandler onError);
+    CHIP_ERROR ConnectDevice(NodeId remoteDeviceId, const uint16_t deviceDiscriminator, void * appReqState,
+                             NewConnectionHandler onConnected, MessageReceiveHandler onMessageReceived, ErrorHandler onError);
 
     /**
      * @brief

--- a/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
@@ -340,22 +340,22 @@ static NSString * const ipKey = @"ipk";
         break;
     case kRendezvousInformationBLE:
         NSLog(@"Rendezvous BLE");
-        [self handleRendezVousBLE:[self getNetworkName:payload.discriminator]];
+        [self handleRendezVousBLE:payload.discriminator.unsignedShortValue];
         break;
     }
 }
 
 - (NSString *)getNetworkName:(NSNumber *)discriminator
 {
-    NSString * peripheralDiscriminator = [NSString stringWithFormat:@"%hX", discriminator.unsignedShortValue];
+    NSString * peripheralDiscriminator = [NSString stringWithFormat:@"%04u", discriminator.unsignedShortValue];
     NSString * peripheralFullName = [NSString stringWithFormat:@"%@%@", NETWORK_CHIP_PREFIX, peripheralDiscriminator];
     return peripheralFullName;
 }
 
-- (void)handleRendezVousBLE:(NSString *)name
+- (void)handleRendezVousBLE:(uint16_t)discriminator
 {
     NSError * error;
-    [self.chipController connect:name error:&error];
+    [self.chipController connect:discriminator error:&error];
 }
 
 - (void)handleRendezVousWiFi:(NSString *)name

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -40,7 +40,7 @@ typedef void (^ControllerOnErrorBlock)(NSError * error);
       local_key:(NSData *)local_key
        peer_key:(NSData *)peer_key
           error:(NSError * __autoreleasing *)error;
-- (BOOL)connect:(NSString *)deviceName error:(NSError * __autoreleasing *)error;
+- (BOOL)connect:(uint16_t)deviceDiscriminator error:(NSError * __autoreleasing *)error;
 - (nullable AddressInfo *)getAddressInfo;
 - (BOOL)sendMessage:(NSData *)message error:(NSError * __autoreleasing *)error;
 - (BOOL)sendOnCommand;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -229,13 +229,13 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
     return YES;
 }
 
-- (BOOL)connect:(NSString *)deviceName error:(NSError * __autoreleasing *)error
+- (BOOL)connect:(uint16_t)deviceDiscriminator error:(NSError * __autoreleasing *)error
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     [self.lock lock];
     err = self.cppController->ConnectDevice(
-        kRemoteDeviceId, [deviceName UTF8String], (__bridge void *) self, onConnected, onMessageReceived, onInternalError);
+        kRemoteDeviceId, deviceDiscriminator, (__bridge void *) self, onConnected, onMessageReceived, onInternalError);
     [self.lock unlock];
 
     if (err != CHIP_NO_ERROR) {

--- a/src/platform/Darwin/BleConnectionDelegate.h
+++ b/src/platform/Darwin/BleConnectionDelegate.h
@@ -29,7 +29,7 @@ namespace Internal {
 class BleConnectionDelegateImpl : public BleConnectionDelegate
 {
 public:
-    virtual void NewConnection(Ble::BleLayer * bleLayer, void * appState, const char * connName);
+    virtual void NewConnection(Ble::BleLayer * bleLayer, void * appState, const uint16_t connDiscriminator);
 };
 
 } // namespace Internal

--- a/src/platform/ESP32/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/BLEManagerImpl.cpp
@@ -41,6 +41,13 @@
 
 #include <new>
 
+#define MAX_ADV_DATA_LEN 31
+#define CHIP_ADV_DATA_TYPE_FLAGS 0x01
+#define CHIP_ADV_DATA_FLAGS 0x06
+#define CHIP_ADV_DATA_TYPE_SERVICE_DATA 0x16
+#define CHIP_BLE_OPCODE 0x00
+#define CHIP_ADV_VERSION 0x00
+
 using namespace ::chip;
 using namespace ::chip::Ble;
 
@@ -617,8 +624,9 @@ exit:
 CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
 {
     CHIP_ERROR err;
-    esp_ble_adv_data_t advertData;
-    ESP32ChipServiceData chipServiceData;
+    uint8_t advData[MAX_ADV_DATA_LEN];
+    uint16_t advDataVersionDiscriminator = 0;
+    uint8_t index                        = 0;
 
     // If a custom device name has not been specified, generate a CHIP-standard name based on the
     // bottom digits of the Chip device id.
@@ -627,7 +635,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     const uint16_t discriminator = 0x0F00;
     if (!GetFlag(mFlags, kFlag_UseCustomDeviceName))
     {
-        snprintf(mDeviceName, sizeof(mDeviceName), "%s%03" PRIX16, CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, discriminator);
+        snprintf(mDeviceName, sizeof(mDeviceName), "%s%04u", CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, discriminator);
         mDeviceName[kMaxDeviceNameLength] = 0;
     }
 
@@ -639,53 +647,25 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
         ExitNow();
     }
 
-    // Configure the contents of the advertising packet.
-    memset(&advertData, 0, sizeof(advertData));
-    advertData.set_scan_rsp        = false;
-    advertData.include_name        = true;
-    advertData.include_txpower     = false;
-    advertData.min_interval        = 0;
-    advertData.max_interval        = 0;
-    advertData.appearance          = 0;
-    advertData.manufacturer_len    = 0;
-    advertData.p_manufacturer_data = NULL;
-    advertData.service_data_len    = 0;
-    advertData.p_service_data      = NULL;
-    advertData.service_uuid_len    = sizeof(UUID_CHIPoBLEService);
-    advertData.p_service_uuid      = (uint8_t *) UUID_CHIPoBLEService;
-    advertData.flag                = ESP_BLE_ADV_FLAG_GEN_DISC | ESP_BLE_ADV_FLAG_BREDR_NOT_SPT;
-    err                            = esp_ble_gap_config_adv_data(&advertData);
+    advDataVersionDiscriminator = (discriminator | (CHIP_ADV_VERSION << 12));
+
+    memset(advData, 0, sizeof(advData));
+    advData[index++] = 0x02;                             // length
+    advData[index++] = CHIP_ADV_DATA_TYPE_FLAGS;         // AD type : flags
+    advData[index++] = CHIP_ADV_DATA_FLAGS;              // AD value
+    advData[index++] = 0x06;                             // length
+    advData[index++] = CHIP_ADV_DATA_TYPE_SERVICE_DATA;  // AD type: (Service Data - 16-bit UUID)
+    advData[index++] = ShortUUID_CHIPoBLEService[0];     // AD value
+    advData[index++] = ShortUUID_CHIPoBLEService[1];     // AD value
+    advData[index++] = CHIP_BLE_OPCODE;                  // Used to differentiate from operational CHIP Ble adv
+    advData[index++] = advDataVersionDiscriminator >> 8; // Bits[15:12] == version - Bits[11:0] Discriminator
+    advData[index++] = advDataVersionDiscriminator & 0x00FF;
+
+    // Construct the Chip BLE Service Data to be sent in the scan response packet.
+    err = esp_ble_gap_config_adv_data_raw(advData, sizeof(advData));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "esp_ble_gap_config_adv_data(<advertising data>) failed: %s", ErrorStr(err));
-        ExitNow();
-    }
-
-    // Construct the Chip BLE Service Data to be sent in the scan response packet.  On the ESP32,
-    // the buffer given to esp_ble_gap_config_adv_data() must begin with the Chip BLE service UUID.
-    memcpy(chipServiceData.ServiceUUID, ShortUUID_CHIPoBLEService, sizeof(chipServiceData.ServiceUUID));
-    err = ConfigurationMgr().GetBLEDeviceIdentificationInfo(chipServiceData.DeviceIdInfo);
-    SuccessOrExit(err);
-
-    // Configure the contents of the scan response packet.
-    memset(&advertData, 0, sizeof(advertData));
-    advertData.set_scan_rsp        = true;
-    advertData.include_name        = false;
-    advertData.include_txpower     = true;
-    advertData.min_interval        = 0;
-    advertData.max_interval        = 0;
-    advertData.appearance          = 0;
-    advertData.manufacturer_len    = 0;
-    advertData.p_manufacturer_data = NULL;
-    advertData.service_data_len    = sizeof(chipServiceData);
-    advertData.p_service_data      = (uint8_t *) &chipServiceData;
-    advertData.service_uuid_len    = 0;
-    advertData.p_service_uuid      = NULL;
-    advertData.flag                = 0;
-    err                            = esp_ble_gap_config_adv_data(&advertData);
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(DeviceLayer, "esp_ble_gap_config_adv_data(<scan response>) failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "esp_ble_gap_config_adv_data_raw(<raw_data>) failed: %s", ErrorStr(err));
         ExitNow();
     }
 
@@ -1215,7 +1195,7 @@ void BLEManagerImpl::HandleGAPEvent(esp_gap_ble_cb_event_t event, esp_ble_gap_cb
 
     switch (event)
     {
-    case ESP_GAP_BLE_ADV_DATA_SET_COMPLETE_EVT:
+    case ESP_GAP_BLE_ADV_DATA_RAW_SET_COMPLETE_EVT:
 
         if (param->adv_data_cmpl.status != ESP_BT_STATUS_SUCCESS)
         {

--- a/src/platform/ESP32/ConnectivityManagerImpl.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl.cpp
@@ -911,7 +911,7 @@ CHIP_ERROR ConnectivityManagerImpl::ConfigureWiFiAP()
     // TODO Pull this from the configuration manager
     const uint16_t discriminator = 0x0F00;
 
-    snprintf((char *) wifiConfig.ap.ssid, sizeof(wifiConfig.ap.ssid), "%s%03" PRIX16, CHIP_DEVICE_CONFIG_WIFI_AP_SSID_PREFIX,
+    snprintf((char *) wifiConfig.ap.ssid, sizeof(wifiConfig.ap.ssid), "%s%04u", CHIP_DEVICE_CONFIG_WIFI_AP_SSID_PREFIX,
              discriminator);
     wifiConfig.ap.channel         = CHIP_DEVICE_CONFIG_WIFI_AP_CHANNEL;
     wifiConfig.ap.authmode        = WIFI_AUTH_OPEN;

--- a/src/transport/BLE.cpp
+++ b/src/transport/BLE.cpp
@@ -54,7 +54,7 @@ CHIP_ERROR BLE::Init(BleConnectionParameters & params)
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     VerifyOrExit(mState == State::kNotReady, err = CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrExit(params.HasConnectionObject() || params.HasConnectionName(), err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(params.HasConnectionObject() || params.HasConnectionDiscriminator(), err = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(params.GetDeviceController(), err = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(params.GetBleLayer(), err = CHIP_ERROR_INVALID_ARGUMENT);
 
@@ -64,7 +64,7 @@ CHIP_ERROR BLE::Init(BleConnectionParameters & params)
     }
     else
     {
-        err = InitInternal(params.GetBleLayer(), params.GetConnectionName());
+        err = DelegateConnection(params.GetBleLayer(), params.GetConnectionDiscriminator());
     }
     SuccessOrExit(err);
 
@@ -107,11 +107,12 @@ exit:
     return err;
 }
 
-CHIP_ERROR BLE::InitInternal(Ble::BleLayer * bleLayer, const char * connName)
+CHIP_ERROR BLE::DelegateConnection(Ble::BleLayer * bleLayer, const uint16_t connDiscriminator)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    err = bleLayer->NewBleConnection(reinterpret_cast<void *>(this), connName, OnBleConnectionComplete, OnBleConnectionError);
+    err = bleLayer->NewBleConnection(reinterpret_cast<void *>(this), connDiscriminator, OnBleConnectionComplete,
+                                     OnBleConnectionError);
     SuccessOrExit(err);
 
 exit:

--- a/src/transport/BLE.h
+++ b/src/transport/BLE.h
@@ -74,11 +74,11 @@ public:
         return *this;
     }
 
-    bool HasConnectionName() const { return mConnectionName != nullptr; };
-    const char * GetConnectionName() const { return mConnectionName; };
-    BleConnectionParameters & SetConnectionName(const char * connName)
+    bool HasConnectionDiscriminator() const { return mConnectionDiscriminator != 0; };
+    uint16_t GetConnectionDiscriminator() const { return mConnectionDiscriminator; };
+    BleConnectionParameters & SetConnectionDiscriminator(const uint16_t connDiscriminator)
     {
-        mConnectionName = connName;
+        mConnectionDiscriminator = connDiscriminator;
 
         return *this;
     }
@@ -87,7 +87,7 @@ private:
     DeviceController::ChipDeviceController * mDeviceController = nullptr; ///< Associated device controller
     Ble::BleLayer * mLayer                                     = nullptr; ///< Associated ble layer
     BLE_CONNECTION_OBJECT mConnectionObj                       = 0;       ///< the target peripheral BLE_CONNECTION_OBJECT
-    const char * mConnectionName                               = nullptr; ///< the target peripheral name
+    uint16_t mConnectionDiscriminator                          = 0;       ///< the target peripheral discriminator
 };
 
 /** Implements a transport using BLE. */
@@ -123,7 +123,7 @@ public:
 
 private:
     CHIP_ERROR InitInternal(Ble::BleLayer * bleLayer, BLE_CONNECTION_OBJECT connObj);
-    CHIP_ERROR InitInternal(Ble::BleLayer * bleLayer, const char * connName);
+    CHIP_ERROR DelegateConnection(Ble::BleLayer * bleLayer, const uint16_t connDiscriminator);
 
     // Those functions are BLEConnectionDelegate callbacks used when the connection
     // parameters used a name instead of a BLE_CONNECTION_OBJECT.


### PR DESCRIPTION
 #### Problem

This PR update the ble advertising data to get it closer to the spec.

 #### Summary of Changes
 * Update the advertising data on the esp32
 * Change the connection delegate to use the content of the advertising data instead of the connection name to connect to the peripheral
 * Change the code in examples/chip-tool/ to pass the discriminator instead of a name
 * Change the code in src/darwin to pass the discriminator instead of a name