### PR TITLE
ESP32 - Retrieve discriminator and setupPINCode from the Configuratio…

### DIFF
--- a/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
@@ -86,10 +86,6 @@ extern void startClient(void);
 #define EXAMPLE_VENDOR_ID 2447
 // Spells ESP32 on a dialer
 #define EXAMPLE_PRODUCT_ID 37732
-// Used to have an initial shared secret
-#define EXAMPLE_SETUP_CODE 123456789
-// Used to discriminate the device
-#define EXAMPLE_DISCRIMINATOR 0X0F00
 // Used to indicate that an IP address has been added to the QRCode
 #define EXAMPLE_VENDOR_TAG_IP 1
 
@@ -361,16 +357,33 @@ bool isRendezvousBLE()
 
 std::string createSetupPayload()
 {
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    string result;
+
+    uint32_t discriminator;
+    err = ConfigurationMgr().GetSetupDiscriminator(discriminator);
+    if (err != CHIP_NO_ERROR)
+    {
+        ESP_LOGE(TAG, "Couldn't get discriminator: %d", err);
+        return result;
+    }
+
+    uint32_t setupPINCode;
+    err = ConfigurationMgr().GetSetupPinCode(setupPINCode);
+    if (err != CHIP_NO_ERROR)
+    {
+        ESP_LOGE(TAG, "Couldn't get setupPINCode: %d", err);
+        return result;
+    }
+
     SetupPayload payload;
     payload.version               = 1;
-    payload.discriminator         = EXAMPLE_DISCRIMINATOR;
-    payload.setUpPINCode          = EXAMPLE_SETUP_CODE;
+    payload.discriminator         = discriminator;
+    payload.setUpPINCode          = setupPINCode;
     payload.rendezvousInformation = static_cast<RendezvousInformationFlags>(CONFIG_RENDEZVOUS_MODE);
     payload.vendorID              = EXAMPLE_VENDOR_ID;
     payload.productID             = EXAMPLE_PRODUCT_ID;
 
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    string result;
     if (!isRendezvousBLE())
     {
         char gw_ip[INET6_ADDRSTRLEN];

--- a/src/include/platform/internal/GenericPlatformManagerImpl.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.ipp
@@ -32,8 +32,8 @@
 #include <platform/internal/EventLogging.h>
 #include <platform/internal/GenericPlatformManagerImpl.h>
 
-#include <support/CodeUtils.h>
 #include <support/CHIPMem.h>
+#include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
 
 namespace chip {
@@ -54,7 +54,12 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack(void)
 
     // TODO Initialize the source used by CHIP to get secure random data.
 
-    // TODO Initialize the Configuration Manager object.
+    err = ConfigurationMgr().Init();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Configuration Manager initialization failed: %s", ErrorStr(err));
+    }
+    SuccessOrExit(err);
 
     // Initialize the CHIP system layer.
     new (&SystemLayer) System::Layer();

--- a/src/platform/ESP32/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/BLEManagerImpl.cpp
@@ -629,10 +629,10 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     uint8_t index                        = 0;
 
     // If a custom device name has not been specified, generate a CHIP-standard name based on the
-    // bottom digits of the Chip device id.
+    // discriminator value
+    uint32_t discriminator;
+    SuccessOrExit(err = ConfigurationMgr().GetSetupDiscriminator(discriminator));
 
-    // TODO Pull this from the configuration manager
-    const uint16_t discriminator = 0x0F00;
     if (!GetFlag(mFlags, kFlag_UseCustomDeviceName))
     {
         snprintf(mDeviceName, sizeof(mDeviceName), "%s%04u", CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, discriminator);

--- a/src/platform/ESP32/ConnectivityManagerImpl.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl.cpp
@@ -908,8 +908,8 @@ CHIP_ERROR ConnectivityManagerImpl::ConfigureWiFiAP()
 
     memset(&wifiConfig, 0, sizeof(wifiConfig));
 
-    // TODO Pull this from the configuration manager
-    const uint16_t discriminator = 0x0F00;
+    uint32_t discriminator;
+    SuccessOrExit(err = ConfigurationMgr().GetSetupDiscriminator(discriminator));
 
     snprintf((char *) wifiConfig.ap.ssid, sizeof(wifiConfig.ap.ssid), "%s%04u", CHIP_DEVICE_CONFIG_WIFI_AP_SSID_PREFIX,
              discriminator);

--- a/src/platform/ESP32/ESP32Config.cpp
+++ b/src/platform/ESP32/ESP32Config.cpp
@@ -58,6 +58,7 @@ const ESP32Config::Key ESP32Config::kConfigKey_SetupPinCode        = { kConfigNa
 const ESP32Config::Key ESP32Config::kConfigKey_SetupDiscriminator  = { kConfigNamespace_ChipFactory, "discriminator" };
 
 // Keys stored in the chip-config namespace
+const ESP32Config::Key ESP32Config::kConfigKey_FabricId                    = { kConfigNamespace_ChipConfig, "fabric-id" };
 const ESP32Config::Key ESP32Config::kConfigKey_ServiceConfig               = { kConfigNamespace_ChipConfig, "service-config" };
 const ESP32Config::Key ESP32Config::kConfigKey_PairedAccountId             = { kConfigNamespace_ChipConfig, "account-id" };
 const ESP32Config::Key ESP32Config::kConfigKey_ServiceId                   = { kConfigNamespace_ChipConfig, "service-id" };


### PR DESCRIPTION
…nManager

 #### Problem

Currently the discriminator and the setupPINCode are hardcoded.

 #### Summary of Changes
 * Activate ConfigurationManager for all FREERTOS
 * Use the configuration manager to retrieve the setupPINCode and the discriminator

At the moment the discriminator and the setupPINCode are values pulled from the Kconfig file. It can be customised via menuconfig.
