### PR TITLE
Pass the setupPINCode from the application layer down to Transport::BLE

### DIFF
--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -124,7 +124,7 @@ void ShowUsage(const char * executable)
             "Usage: \n"
             "  %s command [params]\n"
             "  Supported commands and their parameters:\n"
-            "    echo-ble device-ble-name\n"
+            "    echo-ble discriminator setupPINCode\n"
             "    echo device-ip-address device-port\n"
             "    off device-ip-address device-port endpoint-id\n"
             "    on device-ip-address device-port endpoint-id\n"
@@ -181,7 +181,7 @@ bool DetermineCommand(int argc, char * argv[], Command * command)
     if (EqualsLiteral(argv[1], "echo-ble"))
     {
         *command = Command::EchoBle;
-        return argc == 3;
+        return argc == 4;
     }
 
     fprintf(stderr, "Unknown command: %s\n", argv[3]);
@@ -193,6 +193,7 @@ struct CommandArgs
     IPAddress hostAddr;
     uint16_t port;
     uint16_t discriminator;
+    uint32_t setupPINCode;
     uint8_t endpointId;
 };
 
@@ -200,6 +201,9 @@ bool DetermineArgsBle(char * argv[], CommandArgs * commandArgs)
 {
     std::string discriminator_str(argv[2]);
     commandArgs->discriminator = std::stoi(discriminator_str);
+
+    std::string setup_pin_code_str(argv[3]);
+    commandArgs->setupPINCode = std::stoi(setup_pin_code_str);
     return true;
 }
 
@@ -353,7 +357,8 @@ CHIP_ERROR ExecuteCommand(DeviceController::ChipDeviceController * controller, C
     switch (command)
     {
     case Command::EchoBle:
-        err = controller->ConnectDevice(kRemoteDeviceId, commandArgs.discriminator, NULL, OnConnect, OnMessage, OnError);
+        err = controller->ConnectDevice(kRemoteDeviceId, commandArgs.discriminator, commandArgs.setupPINCode, NULL, OnConnect,
+                                        OnMessage, OnError);
         VerifyOrExit(err == CHIP_NO_ERROR, fprintf(stderr, "Failed to connect to the device"));
         DoEchoBle(controller, commandArgs.discriminator);
         break;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -146,9 +146,9 @@ exit:
     return err;
 }
 
-CHIP_ERROR ChipDeviceController::ConnectDevice(NodeId remoteDeviceId, const uint16_t deviceDiscriminator, void * appReqState,
-                                               NewConnectionHandler onConnected, MessageReceiveHandler onMessageReceived,
-                                               ErrorHandler onError)
+CHIP_ERROR ChipDeviceController::ConnectDevice(NodeId remoteDeviceId, const uint16_t discriminator, const uint32_t setupPINCode,
+                                               void * appReqState, NewConnectionHandler onConnected,
+                                               MessageReceiveHandler onMessageReceived, ErrorHandler onError)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -163,7 +163,8 @@ CHIP_ERROR ChipDeviceController::ConnectDevice(NodeId remoteDeviceId, const uint
 
     transport = new Transport::BLE();
     err       = transport->Init(Transport::BleConnectionParameters(this, DeviceLayer::ConnectivityMgr().GetBleLayer())
-                              .SetConnectionDiscriminator(deviceDiscriminator));
+                              .SetDiscriminator(discriminator)
+                              .SetSetupPINCode(setupPINCode));
     SuccessOrExit(err);
     mUnsecuredTransport = transport->Retain();
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -76,14 +76,15 @@ public:
      *   Connect to a CHIP device with a given name for Rendezvous
      *
      * @param[in] remoteDeviceId        The remote device Id.
-     * @param[in] deviceDiscriminator   The discriminator of the requested Device
+     * @param[in] discriminator         The discriminator of the requested Device
+     * @param[in] setupPINCode          The setup PIN code of the requested Device
      * @param[in] appReqState           Application specific context to be passed back when a message is received or on error
      * @param[in] onConnected           Callback for when the connection is established
      * @param[in] onMessageReceived     Callback for when a message is received
      * @param[in] onError               Callback for when an error occurs
      * @return CHIP_ERROR               The connection status
      */
-    CHIP_ERROR ConnectDevice(NodeId remoteDeviceId, const uint16_t deviceDiscriminator, void * appReqState,
+    CHIP_ERROR ConnectDevice(NodeId remoteDeviceId, const uint16_t discriminator, const uint32_t setupPINCode, void * appReqState,
                              NewConnectionHandler onConnected, MessageReceiveHandler onMessageReceived, ErrorHandler onError);
 
     /**

--- a/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
@@ -345,7 +345,7 @@ static NSString * const ipKey = @"ipk";
         break;
     case kRendezvousInformationBLE:
         NSLog(@"Rendezvous BLE");
-        [self handleRendezVousBLE:payload.discriminator.unsignedShortValue];
+        [self handleRendezVousBLE:payload.discriminator.unsignedShortValue setupPINCode:payload.setUpPINCode.unsignedIntValue];
         break;
     }
 }
@@ -357,10 +357,10 @@ static NSString * const ipKey = @"ipk";
     return peripheralFullName;
 }
 
-- (void)handleRendezVousBLE:(uint16_t)discriminator
+- (void)handleRendezVousBLE:(uint16_t)discriminator setupPINCode:(uint32_t)setupPINCode
 {
     NSError * error;
-    [self.chipController connect:discriminator error:&error];
+    [self.chipController connect:discriminator setupPINCode:setupPINCode error:&error];
 }
 
 - (void)handleRendezVousWiFi:(NSString *)name

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -40,7 +40,7 @@ typedef void (^ControllerOnErrorBlock)(NSError * error);
       local_key:(NSData *)local_key
        peer_key:(NSData *)peer_key
           error:(NSError * __autoreleasing *)error;
-- (BOOL)connect:(uint16_t)deviceDiscriminator error:(NSError * __autoreleasing *)error;
+- (BOOL)connect:(uint16_t)discriminator setupPINCode:(uint32_t)setupPINCode error:(NSError * __autoreleasing *)error;
 - (nullable AddressInfo *)getAddressInfo;
 - (BOOL)sendMessage:(NSData *)message error:(NSError * __autoreleasing *)error;
 - (BOOL)sendOnCommand;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -229,13 +229,13 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
     return YES;
 }
 
-- (BOOL)connect:(uint16_t)deviceDiscriminator error:(NSError * __autoreleasing *)error
+- (BOOL)connect:(uint16_t)discriminator setupPINCode:(uint32_t)setupPINCode error:(NSError * __autoreleasing *)error
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     [self.lock lock];
     err = self.cppController->ConnectDevice(
-        kRemoteDeviceId, deviceDiscriminator, (__bridge void *) self, onConnected, onMessageReceived, onInternalError);
+        kRemoteDeviceId, discriminator, setupPINCode, (__bridge void *) self, onConnected, onMessageReceived, onInternalError);
     [self.lock unlock];
 
     if (err != CHIP_NO_ERROR) {

--- a/src/transport/BLE.cpp
+++ b/src/transport/BLE.cpp
@@ -54,7 +54,7 @@ CHIP_ERROR BLE::Init(BleConnectionParameters & params)
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     VerifyOrExit(mState == State::kNotReady, err = CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrExit(params.HasConnectionObject() || params.HasConnectionDiscriminator(), err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(params.HasConnectionObject() || params.HasDiscriminator(), err = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(params.GetDeviceController(), err = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(params.GetBleLayer(), err = CHIP_ERROR_INVALID_ARGUMENT);
 
@@ -64,7 +64,7 @@ CHIP_ERROR BLE::Init(BleConnectionParameters & params)
     }
     else
     {
-        err = DelegateConnection(params.GetBleLayer(), params.GetConnectionDiscriminator());
+        err = DelegateConnection(params.GetBleLayer(), params.GetDiscriminator());
     }
     SuccessOrExit(err);
 

--- a/src/transport/BLE.h
+++ b/src/transport/BLE.h
@@ -74,11 +74,20 @@ public:
         return *this;
     }
 
-    bool HasConnectionDiscriminator() const { return mConnectionDiscriminator != 0; };
-    uint16_t GetConnectionDiscriminator() const { return mConnectionDiscriminator; };
-    BleConnectionParameters & SetConnectionDiscriminator(const uint16_t connDiscriminator)
+    bool HasDiscriminator() const { return mDiscriminator != 0; };
+    uint16_t GetDiscriminator() const { return mDiscriminator; };
+    BleConnectionParameters & SetDiscriminator(const uint16_t discriminator)
     {
-        mConnectionDiscriminator = connDiscriminator;
+        mDiscriminator = discriminator;
+
+        return *this;
+    }
+
+    bool HasSetupPINCode() const { return mSetupPINCode != 0; };
+    uint32_t GetSetupPINCode() const { return mSetupPINCode; };
+    BleConnectionParameters & SetSetupPINCode(const uint32_t setupPINCode)
+    {
+        mSetupPINCode = setupPINCode;
 
         return *this;
     }
@@ -87,7 +96,8 @@ private:
     DeviceController::ChipDeviceController * mDeviceController = nullptr; ///< Associated device controller
     Ble::BleLayer * mLayer                                     = nullptr; ///< Associated ble layer
     BLE_CONNECTION_OBJECT mConnectionObj                       = 0;       ///< the target peripheral BLE_CONNECTION_OBJECT
-    uint16_t mConnectionDiscriminator                          = 0;       ///< the target peripheral discriminator
+    uint16_t mDiscriminator                                    = 0;       ///< the target peripheral discriminator
+    uint32_t mSetupPINCode                                     = 0;       ///< the target peripheral setup PIN Code
 };
 
 /** Implements a transport using BLE. */


### PR DESCRIPTION
 #### Problem

The setup PIN code is only exposed to the application layer. At some point we will need it down into the stack to setup a secure channel.

 #### Summary of Changes
 * Pass the setupPINCode from the QRCode down to Transport::BLE
