### PR TITLE
Fix a typo in rename_submodules.sh helper

### DIFF
--- a/scripts/helpers/rename_submodules.sh
+++ b/scripts/helpers/rename_submodules.sh
@@ -34,7 +34,7 @@ fi
 
 # Remove renamed submodules from config
 git -C "$CHIP_ROOT" config --get-regexp "$OLD_SUBMODULE_KEYS" | while read key value; do
-    git -C "$CHP_ROOT" config --unset "$key"
+    git -C "$CHIP_ROOT" config --unset "$key"
 done
 
 # Re-init with new submodule names.


### PR DESCRIPTION
 #### Problem

I guess CHP_ROOT is supposed to be CHIP_ROOT in this context