### PR TITLE
Get Linux/ThreadStackManagerImpl.h functions prototypes to match plat…

### DIFF
--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -111,10 +111,7 @@ void ThreadStackManagerImpl::_ThreadDevcieRoleChangedHandler(DeviceRole role)
     PlatformMgr().PostEvent(&event);
 }
 
-CHIP_ERROR ThreadStackManagerImpl::_ProcessThreadActivity()
-{
-    return CHIP_NO_ERROR;
-}
+void ThreadStackManagerImpl::_ProcessThreadActivity() {}
 
 static bool RouteMatch(const otbr::DBus::Ip6Prefix & prefix, const Inet::IPAddress & addr)
 {

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -35,12 +35,12 @@ public:
     ThreadStackManagerImpl();
 
     CHIP_ERROR _InitThreadStack();
-    CHIP_ERROR _ProcessThreadActivity();
+    void _ProcessThreadActivity();
 
-    CHIP_ERROR _StartThreadTask() { return CHIP_NO_ERROR; }    // Intentionally left blank
-    CHIP_ERROR _LockThreadStack() { return CHIP_NO_ERROR; }    // Intentionally left blank
-    CHIP_ERROR _TryLockThreadStack() { return CHIP_NO_ERROR; } // Intentionally left blank
-    CHIP_ERROR _UnlockThreadStack() { return CHIP_NO_ERROR; }  // Intentionally left blank
+    CHIP_ERROR _StartThreadTask() { return CHIP_NO_ERROR; } // Intentionally left blank
+    void _LockThreadStack() {}                              // Intentionally left blank
+    bool _TryLockThreadStack() { return false; }            // Intentionally left blank
+    void _UnlockThreadStack() {}                            // Intentionally left blank
 
     bool _HaveRouteToAddress(const Inet::IPAddress & destAddr);
 


### PR DESCRIPTION
…form/ThreadStackManager.h functions prototypes

 #### Problem

The functions prototypes from platform/ThreadStackManager.h and Linux/ThreadStackManagerImpl.h are differents.

 #### Summary of Changes
* Changes the prototypes so they match.