### PR TITLE
Keep more warnings as fatal when building with GN

### DIFF
--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -332,7 +332,7 @@ void DoOnOff(DeviceController::ChipDeviceController * controller, Command comman
         dataLength = encodeToggleCommand(buffer->Start(), bufferSize, endpoint);
         break;
     default:
-        fprintf(stderr, "Unknown command: %d\n", command);
+        fprintf(stderr, "Unknown command: %d\n", int(command));
         return;
     }
     buffer->SetDataLength(dataLength);

--- a/examples/platform/nrf528xx/app/chipinit.cpp
+++ b/examples/platform/nrf528xx/app/chipinit.cpp
@@ -56,6 +56,7 @@ using namespace ::chip::DeviceLayer;
 
 DemoSessionManager sessions;
 
+#if CHIP_ENABLE_OPENTHREAD
 static void * ot_calloc(size_t n, size_t size)
 {
     void * p_ptr = NULL;
@@ -71,6 +72,7 @@ static void ot_free(void * p_ptr)
 {
     vPortFree(p_ptr);
 }
+#endif
 
 ret_code_t ChipInit()
 {

--- a/examples/shell/cmd_device.cpp
+++ b/examples/shell/cmd_device.cpp
@@ -417,8 +417,8 @@ exit:
 
 int cmd_device_get(int argc, char ** argv)
 {
-    CHIP_ERROR error  = CHIP_NO_ERROR;
-    streamer_t * sout = streamer_get();
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    streamer_get();
 
     if (argc == 0)
     {

--- a/gn/build/config/compiler/BUILD.gn
+++ b/gn/build/config/compiler/BUILD.gn
@@ -89,13 +89,6 @@ config("optimize_default") {
 
 config("disabled_warnings") {
   cflags = [
-    "-Wno-unused-parameter",
-    "-Wno-unused-function",
-    "-Wno-unused-variable",
-    "-Wno-format",
-    "-Wno-missing-field-initializers",
-    "-Wno-expansion-to-defined",
-    "-Wno-implicit-fallthrough",
     "-Wno-deprecated-declarations",
   ]
   cflags_cc = [

--- a/src/app/chip-zcl-zpro/command-encoder/encoder.c
+++ b/src/app/chip-zcl-zpro/command-encoder/encoder.c
@@ -16,6 +16,7 @@
  */
 
 #include "chip-zcl-zpro-codec.h"
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -96,7 +97,7 @@ uint32_t encodeApsFrame(uint8_t * buffer, uint32_t buf_length, uint16_t profileI
     nextOutByte += sizeof(uint8_t);
 
     buf_length = nextOutByte;
-    printf("Encoded %d bytes of aps frame\n", buf_length);
+    printf("Encoded %" PRIu32 " bytes of aps frame\n", buf_length);
     return buf_length;
 }
 
@@ -110,7 +111,7 @@ uint32_t _encodeOnOffCommand(uint8_t * buffer, uint32_t buf_length, int command,
     result = encodeApsFrame(buffer, buf_length, 65535, 6, 1, destination_endpoint, 0, 0, 0, 0);
     if (result == 0 || result > buf_length)
     {
-        printf("Error encoding aps frame result %d", result);
+        printf("Error encoding aps frame result %" PRIu32 "\n", result);
         result = 0;
         return result;
     }
@@ -124,7 +125,7 @@ uint32_t _encodeOnOffCommand(uint8_t * buffer, uint32_t buf_length, int command,
 
     if (indexToWrite >= buf_length)
     {
-        printf("indexToWrite %d\n", indexToWrite);
+        printf("indexToWrite %" PRIu32 "\n", indexToWrite);
         return 0;
     }
     // Transaction sequence number.  Just pick something.

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -1112,8 +1112,6 @@ static void TestSPAKE2P_spake2p_PointLoadWrite(nlTestSuite * inSuite, void * inC
 
 static void TestSPAKE2P_spake2p_PointIsValid(nlTestSuite * inSuite, void * inContext)
 {
-    unsigned char output[kMAX_Point_Length];
-
     int numOfTestVectors = ArraySize(point_valid_tvs);
     int numOfTestsRan    = 0;
     for (int vectorIndex = 0; vectorIndex < numOfTestVectors; vectorIndex++)

--- a/third_party/lwip/lwip.gni
+++ b/third_party/lwip/lwip.gni
@@ -85,7 +85,9 @@ template("lwip_target") {
   config("${lwip_target_name}_warnings") {
     cflags = [
       "-Wno-address",
+      "-Wno-format",
       "-Wno-type-limits",
+      "-Wno-unused-variable",
     ]
   }
 

--- a/third_party/nrf5_sdk/nrf5_sdk.gni
+++ b/third_party/nrf5_sdk/nrf5_sdk.gni
@@ -109,7 +109,11 @@ template("nrf5_sdk") {
     if (defined(invoker.defines)) {
       defines += invoker.defines
     }
-    cflags = [ "-Wno-array-bounds" ]
+
+    cflags = [
+      "-Wno-array-bounds",
+      "-Wno-unused-function",
+    ]
   }
 
   # TODO - Break up this monolith and make it configurable.


### PR DESCRIPTION
 #### Problem

While building with GN (which is support cool btw) I realised that some of the warnings I was used to see in some contexts where never shown there.
Instead of hiding them, this PR removes some of the rules that hides them with some smalls fixes for some of the cases where it bites us.

I wish getting more warnings as fatal will help landing less of them :)

 #### Summary of Changes
 * Remove some compiler rules that hides warnings
 * Do some small fixes