### PR TITLE
Add basic support for Read Attributes Response in chip-tool

### DIFF
--- a/src/app/chip-zcl-zpro/command-encoder/chip-zcl-zpro-codec.h
+++ b/src/app/chip-zcl-zpro/command-encoder/chip-zcl-zpro-codec.h
@@ -63,6 +63,19 @@ uint32_t encodeOffCommand(uint8_t * buffer, uint32_t buf_length, uint8_t destina
 
 uint32_t encodeToggleCommand(uint8_t * buffer, uint32_t buf_length, uint8_t destination_endpoint);
 
+/**
+ * @brief Encode a Read Attributes command for the given cluster and the given
+ * list of attributes.
+ */
+uint16_t encodeReadAttributesCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint8_t cluster_id,
+                                     uint16_t * attr_ids, uint16_t attr_id_count);
+
+/**
+ * @brief Encode a command to read the OnOff attribute from the on/off
+ * cluster.
+ */
+uint16_t encodeReadOnOffCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+
 /** @brief Extracts an aps frame from buffer into outApsFrame
  */
 bool extractApsFrame(void * buffer, uint32_t buf_length, EmberApsFrame * outApsFrame);


### PR DESCRIPTION
 #### Problem
Can't issue Read Attributes commands via chip-tool and get responses.

 #### Summary of Changes
Add some encoder APIs for encoding Read Attributes commands and implement some very basic processing of the Read Attributes Response command in chip-tool

fixes https://github.com/project-chip/connectedhomeip/issues/1055 sort of...
