### PR TITLE
[nrf5-example] Fix LEDWidget animate

### DIFF
--- a/examples/platform/nrf528xx/util/LEDWidget.cpp
+++ b/examples/platform/nrf528xx/util/LEDWidget.cpp
@@ -21,6 +21,8 @@
 
 #include "LEDWidget.h"
 
+#include <system/SystemClock.h>
+
 void LEDWidget::Init(uint32_t gpioNum)
 {
     mLastChangeTimeUS = 0;
@@ -60,7 +62,7 @@ void LEDWidget::Animate()
 {
     if (mBlinkOnTimeMS != 0 && mBlinkOffTimeMS != 0)
     {
-        int64_t nowUS            = 0;
+        int64_t nowUS            = chip::System::Platform::Layer::GetClock_Monotonic();
         int64_t stateDurUS       = ((mState) ? mBlinkOnTimeMS : mBlinkOffTimeMS) * 1000LL;
         int64_t nextChangeTimeUS = mLastChangeTimeUS + stateDurUS;
 


### PR DESCRIPTION
#### Problem
The LEDWidget cannot blinking before since Animate() does not get current system time and always return 0.

#### Summary of Changes
This PR fixes it by adding GetClock_Monotonic() to that function.
