### PR TITLE
Move thread configuration after platform configuration

### DIFF
--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -17,9 +17,6 @@ import("//build_overrides/chip.gni")
 declare_args() {
   # Device platform layer: freertos, nrf5, none.
   device_platform = "auto"
-
-  # Enable openthread support.
-  chip_enable_openthread = false
 }
 
 if (device_platform == "auto") {
@@ -28,10 +25,14 @@ if (device_platform == "auto") {
   } else if (current_os == "linux") {
     # FIXME: enable openthread on nrf5 gn build
     device_platform = "linux"
-    chip_enable_openthread = true
   } else {
     device_platform = "none"
   }
+}
+
+declare_args() {
+  # Enable openthread support.
+  chip_enable_openthread = (device_platform == "linux")
 }
 
 device_layer = "none"


### PR DESCRIPTION
This keeps thread configurable on Linux instead of forcing it to on.