### PR TITLE
[linux] Add ConnectivityManager generic implemenation for WiFi.

### DIFF
--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -249,6 +249,15 @@
 #define CHIP_DEVICE_CONFIG_LWIP_WIFI_STATION_IF_NAME "wl"
 #endif
 
+/**
+ * CHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME
+ *
+ * Name of the WiFi station interface
+ */
+#ifndef CHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME
+#define CHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME "wlan0"
+#endif
+
 // -------------------- WiFi AP Configuration --------------------
 
 /**

--- a/src/include/platform/internal/DeviceNetworkInfo.h
+++ b/src/include/platform/internal/DeviceNetworkInfo.h
@@ -57,20 +57,20 @@ enum
  */
 enum WiFiAuthSecurityType
 {
-    kWiFiSecurityType_NotSpecified              = -1,
+    kWiFiSecurityType_NotSpecified = -1,
 
-    kWiFiSecurityType_None                      = 1,
-    kWiFiSecurityType_WEP                       = 2,
-    kWiFiSecurityType_WPAPersonal               = 3,
-    kWiFiSecurityType_WPA2Personal              = 4,
-    kWiFiSecurityType_WPA2MixedPersonal         = 5,
-    kWiFiSecurityType_WPAEnterprise             = 6,
-    kWiFiSecurityType_WPA2Enterprise            = 7,
-    kWiFiSecurityType_WPA2MixedEnterprise       = 8,
-    kWiFiSecurityType_WPA3Personal              = 9,
-    kWiFiSecurityType_WPA3MixedPersonal         = 10,
-    kWiFiSecurityType_WPA3Enterprise            = 11,
-    kWiFiSecurityType_WPA3MixedEnterprise       = 12,
+    kWiFiSecurityType_None                = 1,
+    kWiFiSecurityType_WEP                 = 2,
+    kWiFiSecurityType_WPAPersonal         = 3,
+    kWiFiSecurityType_WPA2Personal        = 4,
+    kWiFiSecurityType_WPA2MixedPersonal   = 5,
+    kWiFiSecurityType_WPAEnterprise       = 6,
+    kWiFiSecurityType_WPA2Enterprise      = 7,
+    kWiFiSecurityType_WPA2MixedEnterprise = 8,
+    kWiFiSecurityType_WPA3Personal        = 9,
+    kWiFiSecurityType_WPA3MixedPersonal   = 10,
+    kWiFiSecurityType_WPA3Enterprise      = 11,
+    kWiFiSecurityType_WPA3MixedEnterprise = 12,
 };
 
 class DeviceNetworkInfo

--- a/src/include/platform/internal/DeviceNetworkInfo.h
+++ b/src/include/platform/internal/DeviceNetworkInfo.h
@@ -52,6 +52,27 @@ enum
     kWiFiStationNetworkId = 2,
 };
 
+/**
+ * WiFi Security Modes.
+ */
+enum WiFiAuthSecurityType
+{
+    kWiFiSecurityType_NotSpecified              = -1,
+
+    kWiFiSecurityType_None                      = 1,
+    kWiFiSecurityType_WEP                       = 2,
+    kWiFiSecurityType_WPAPersonal               = 3,
+    kWiFiSecurityType_WPA2Personal              = 4,
+    kWiFiSecurityType_WPA2MixedPersonal         = 5,
+    kWiFiSecurityType_WPAEnterprise             = 6,
+    kWiFiSecurityType_WPA2Enterprise            = 7,
+    kWiFiSecurityType_WPA2MixedEnterprise       = 8,
+    kWiFiSecurityType_WPA3Personal              = 9,
+    kWiFiSecurityType_WPA3MixedPersonal         = 10,
+    kWiFiSecurityType_WPA3Enterprise            = 11,
+    kWiFiSecurityType_WPA3MixedEnterprise       = 12,
+};
+
 class DeviceNetworkInfo
 {
 public:
@@ -61,6 +82,7 @@ public:
     char WiFiSSID[kMaxWiFiSSIDLength + 1]; /**< The WiFi SSID as a NULL-terminated string. */
     uint8_t WiFiKey[kMaxWiFiKeyLength];    /**< The WiFi key (NOT NULL-terminated). */
     uint8_t WiFiKeyLen;                    /**< The length in bytes of the WiFi key. */
+    WiFiAuthSecurityType WiFiSecurityType; /**< The WiFi security type. */
 
     // ---- Thread-specific Fields ----
     char ThreadNetworkName[kMaxThreadNetworkNameLength + 1];

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
@@ -101,7 +101,7 @@ private:
 template <class ImplClass>
 inline ConnectivityManager::WiFiStationMode GenericConnectivityManagerImpl_WiFi<ImplClass>::_GetWiFiStationMode(void)
 {
-    return mWiFiStationMode;;
+    return mWiFiStationMode;
 }
 
 template <class ImplClass>

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
@@ -57,13 +57,13 @@ public:
     // ===== Methods that implement the ConnectivityManager abstract interface.
 
     ConnectivityManager::WiFiStationMode _GetWiFiStationMode(void);
+    CHIP_ERROR _SetWiFiStationMode(ConnectivityManager::WiFiStationMode val);
     bool _IsWiFiStationEnabled(void);
     bool _IsWiFiStationApplicationControlled(void);
-    bool _HaveIPv4InternetConnectivity(void);
-    bool _HaveIPv6InternetConnectivity(void);
     uint32_t _GetWiFiStationReconnectIntervalMS(void);
     CHIP_ERROR _SetWiFiStationReconnectIntervalMS(uint32_t val);
     bool _IsWiFiStationProvisioned(void);
+    void _ClearWiFiStationProvision(void);
     ConnectivityManager::WiFiAPMode _GetWiFiAPMode(void);
     CHIP_ERROR _SetWiFiAPMode(ConnectivityManager::WiFiAPMode val);
     bool _IsWiFiAPActive(void);
@@ -90,9 +90,8 @@ protected:
 
     DeviceNetworkInfo mWiFiNetworkInfo;
     ConnectivityManager::WiFiStationMode mWiFiStationMode;
-    uint16_t mFlags;
-    bool mWiFiProvisioned = false;
-    bool mWiFiScanPending = false;
+    bool mWiFiProvisioned;
+    bool mWiFiScanPending;
 
 private:
     ImplClass * Impl() { return static_cast<ImplClass *>(this); }
@@ -111,18 +110,6 @@ inline bool GenericConnectivityManagerImpl_WiFi<ImplClass>::_IsWiFiStationApplic
 }
 
 template <class ImplClass>
-inline bool GenericConnectivityManagerImpl_WiFi<ImplClass>::_HaveIPv4InternetConnectivity(void)
-{
-    return (mFlags & kFlag_HaveIPv4InternetConnectivity) != 0;
-}
-
-template <class ImplClass>
-inline bool GenericConnectivityManagerImpl_WiFi<ImplClass>::_HaveIPv6InternetConnectivity(void)
-{
-    return (mFlags & kFlag_HaveIPv6InternetConnectivity) != 0;
-}
-
-template <class ImplClass>
 inline uint32_t GenericConnectivityManagerImpl_WiFi<ImplClass>::_GetWiFiStationReconnectIntervalMS(void)
 {
     return 0;
@@ -138,6 +125,12 @@ template <class ImplClass>
 inline bool GenericConnectivityManagerImpl_WiFi<ImplClass>::_IsWiFiStationProvisioned(void)
 {
     return mWiFiProvisioned;
+}
+
+template <class ImplClass>
+inline void GenericConnectivityManagerImpl_WiFi<ImplClass>::_ClearWiFiStationProvision(void)
+{
+    mWiFiProvisioned = false;
 }
 
 template <class ImplClass>

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.ipp
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.ipp
@@ -60,6 +60,24 @@ bool GenericConnectivityManagerImpl_WiFi<ImplClass>::_IsWiFiStationEnabled(void)
     return Impl()->GetWiFiStationMode() == ConnectivityManager::kWiFiStationMode_Enabled;
 }
 
+template <class ImplClass>
+CHIP_ERROR GenericConnectivityManagerImpl_WiFi<ImplClass>::_SetWiFiStationMode(ConnectivityManager::WiFiStationMode val)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    VerifyOrExit(val != ConnectivityManager::kWiFiStationMode_NotSupported, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    if (mWiFiStationMode != val)
+    {
+        ChipLogProgress(DeviceLayer, "WiFi station mode change: %s -> %s", Impl()->WiFiStationModeToStr(mWiFiStationMode),
+                        Impl()->WiFiStationModeToStr(val));
+    }
+
+    mWiFiStationMode = val;
+exit:
+    return err;
+}
+
 } // namespace Internal
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.ipp
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.ipp
@@ -1,0 +1,67 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Provides an generic implementation of ConnectivityManager features
+ *          for use on platforms that support WiFi.
+ */
+
+#ifndef GENERIC_CONNECTIVITY_MANAGER_IMPL_WIFI_IPP
+#define GENERIC_CONNECTIVITY_MANAGER_IMPL_WIFI_IPP
+
+#include <platform/internal/CHIPDeviceLayerInternal.h>
+#include <platform/internal/GenericConnectivityManagerImpl_WiFi.h>
+#include <support/CodeUtils.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+// Fully instantiate the generic implementation class in whatever compilation unit includes this file.
+template class GenericConnectivityManagerImpl_WiFi<ConnectivityManagerImpl>;
+
+template <class ImplClass>
+const char *
+GenericConnectivityManagerImpl_WiFi<ImplClass>::_WiFiStationModeToStr(ConnectivityManager::WiFiStationMode mode)
+{
+    switch (mode)
+    {
+    case ConnectivityManager::kWiFiStationMode_NotSupported:
+        return "NotSupported";
+    case ConnectivityManager::kWiFiStationMode_ApplicationControlled:
+        return "AppControlled";
+    case ConnectivityManager::kWiFiStationMode_Enabled:
+        return "Enabled";
+    case ConnectivityManager::kWiFiStationMode_Disabled:
+        return "Disabled";
+    default:
+        return "(unknown)";
+    }
+}
+
+template <class ImplClass>
+bool GenericConnectivityManagerImpl_WiFi<ImplClass>::_IsWiFiStationEnabled(void)
+{
+    return Impl()->GetWiFiStationMode() == ConnectivityManager::kWiFiStationMode_Enabled;
+}
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip
+
+#endif // GENERIC_CONNECTIVITY_MANAGER_IMPL_WIFI_IPP

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -83,16 +83,6 @@ private:
     static ConnectivityManagerImpl sInstance;
 };
 
-inline bool ConnectivityManagerImpl::_HaveIPv4InternetConnectivity(void)
-{
-    return false;
-}
-
-inline bool ConnectivityManagerImpl::_HaveIPv6InternetConnectivity(void)
-{
-    return false;
-}
-
 inline bool ConnectivityManagerImpl::_HaveServiceConnectivity(void)
 {
     return _HaveServiceConnectivityViaThread();

--- a/src/platform/Makefile.am
+++ b/src/platform/Makefile.am
@@ -62,6 +62,8 @@ noinst_HEADERS                          = \
     @top_srcdir@/src/include/platform/internal/GenericConnectivityManagerImpl_NoWiFi.h \
     @top_srcdir@/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.h \
     @top_srcdir@/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.ipp \
+    @top_srcdir@/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h \
+    @top_srcdir@/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.ipp \
     @top_srcdir@/src/include/platform/internal/GenericPlatformManagerImpl.h \
     @top_srcdir@/src/include/platform/internal/GenericPlatformManagerImpl.ipp \
     @top_srcdir@/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h \


### PR DESCRIPTION
Problem
The Linux device layer needs a ConnectivityMgr that handles a single, primary WiFi interface.

Summary of Changes
* Provides an generic implementation of ConnectivityManager for WiFi interface.

fixes #<739>