### PR TITLE
Update message header structure

### DIFF
--- a/src/transport/Base.h
+++ b/src/transport/Base.h
@@ -52,8 +52,7 @@ public:
      *
      */
     template <class T>
-    void SetMessageReceiveHandler(void (*handler)(const MessageHeader &, const PeerAddress &, System::PacketBuffer *, T *),
-                                  T * param)
+    void SetMessageReceiveHandler(void (*handler)(MessageHeader &, const PeerAddress &, System::PacketBuffer *, T *), T * param)
     {
         mMessageReceivedArgument = param;
         OnMessageReceived        = reinterpret_cast<MessageReceiveHandler>(handler);

--- a/src/transport/MessageHeader.cpp
+++ b/src/transport/MessageHeader.cpp
@@ -191,9 +191,9 @@ exit:
 
 CHIP_ERROR MessageHeader::DecodeMACTag(const uint8_t * data, size_t size, size_t * decode_len)
 {
-    CHIP_ERROR err    = CHIP_NO_ERROR;
-    const uint8_t * p = data;
-    const size_t taglen   = TagLenForEncryptionType(mEncryptionType);
+    CHIP_ERROR err      = CHIP_NO_ERROR;
+    const uint8_t * p   = data;
+    const size_t taglen = TagLenForEncryptionType(mEncryptionType);
 
     VerifyOrExit(taglen != 0, err = CHIP_ERROR_WRONG_ENCRYPTION_TYPE_FROM_PEER);
     VerifyOrExit(size >= taglen, err = CHIP_ERROR_INVALID_ARGUMENT);
@@ -266,8 +266,8 @@ exit:
 
 CHIP_ERROR MessageHeader::EncodeMACTag(uint8_t * data, size_t size, size_t * encode_size) const
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    uint8_t * p    = data;
+    CHIP_ERROR err      = CHIP_NO_ERROR;
+    uint8_t * p         = data;
     const size_t taglen = TagLenForEncryptionType(mEncryptionType);
 
     VerifyOrExit(taglen != 0, err = CHIP_ERROR_WRONG_ENCRYPTION_TYPE);

--- a/src/transport/MessageHeader.cpp
+++ b/src/transport/MessageHeader.cpp
@@ -39,7 +39,7 @@
  *  16 bit: | Payload Length                                                       |
  * -------- Encrypted header -------------------------------------------------------
  *  8 bit:  | Exchange Header                                                      |
- *  8 bit:  | Exchange Message Type                                                |
+ *  8 bit:  | Message Type                                                         |
  *  16 bit: | Exchange ID                                                          |
  * -------- Encrypted Application Data Start ---------------------------------------
  *  <var>:  | Encrypted Data                                                       |
@@ -176,9 +176,9 @@ CHIP_ERROR MessageHeader::DecodeEncryptedHeader(const uint8_t * data, size_t siz
 
     VerifyOrExit(size >= kEncryptedHeaderSizeBytes, err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    mExchangeHeader  = Read8(p);
-    mExchangeMsgType = Read8(p);
-    mExchangeID      = LittleEndian::Read16(p);
+    mExchangeHeader = Read8(p);
+    mMessageType    = Read8(p);
+    mExchangeID     = LittleEndian::Read16(p);
 
     size -= kEncryptedHeaderSizeBytes;
 
@@ -254,7 +254,7 @@ CHIP_ERROR MessageHeader::EncodeEncryptedHeader(uint8_t * data, size_t size, siz
     VerifyOrExit(size >= kEncryptedHeaderSizeBytes, err = CHIP_ERROR_INVALID_ARGUMENT);
 
     Write8(p, mExchangeHeader);
-    Write8(p, mExchangeMsgType);
+    Write8(p, mMessageType);
     LittleEndian::Write16(p, mExchangeID);
 
     // Written data size provided to caller on success

--- a/src/transport/MessageHeader.cpp
+++ b/src/transport/MessageHeader.cpp
@@ -30,13 +30,21 @@
 /**********************************************
  * Header format (little endian):
  *
- *  16 bit: | VERSION: 4 bit | FLAGS: 4 bit | RESERVED: 8 bit |
- *  16 bit: | Secure message type                             |
- *  32 bit: | MESSAGE_ID                                      |
- *  32 bit: | Secure Session ID                               |
- *  64 bit: | Message Authentication Tag                      |
- *  64 bit: | SOURCE_NODE_ID (iff source node flag is set)    |
- *  64 bit: | DEST_NODE_ID (iff destination node flag is set) |
+ * -------- Unencrypted header -----------------------------------------------------
+ *  16 bit: | VERSION: 4 bit | FLAGS: 4 bit | ENCRYPTTYPE: 4 bit | RESERVED: 4 bit |
+ *  32 bit: | MESSAGE_ID                                                           |
+ *  64 bit: | SOURCE_NODE_ID (iff source node flag is set)                         |
+ *  64 bit: | DEST_NODE_ID (iff destination node flag is set)                      |
+ *  16 bit: | Encryption Key ID                                                    |
+ *  16 bit: | Payload Length                                                       |
+ * -------- Encrypted header -------------------------------------------------------
+ *  8 bit:  | Exchange Header                                                      |
+ *  8 bit:  | Exchange Message Type                                                |
+ *  16 bit: | Exchange ID                                                          |
+ * -------- Encrypted Application Data Start ---------------------------------------
+ *  <var>:  | Encrypted Data                                                       |
+ * -------- Encrypted Application Data End -----------------------------------------
+ *  <var>:  | (Unencrypted) Message Authentication Tag                             |
  *
  **********************************************/
 
@@ -46,7 +54,10 @@ namespace {
 using namespace chip::Encoding;
 
 /// size of the fixed portion of the header
-constexpr size_t kFixedHeaderSizeBytes = 20;
+constexpr size_t kFixedUnencryptedHeaderSizeBytes = 10;
+
+/// size of the encrypted portion of the header
+constexpr size_t kEncryptedHeaderSizeBytes = 4;
 
 /// size of a serialized node id inside a header
 constexpr size_t kNodeIdSizeBytes = 8;
@@ -61,11 +72,16 @@ constexpr uint16_t kVersionMask = 0xF000;
 /// Shift to convert to/from a masked version 16bit value to a 4bit version.
 constexpr int kVersionShift = 12;
 
+/// Mask to extract just the encryption type part from a 16bit header prefix.
+constexpr uint16_t kEncryptionTypeMask = 0xF0;
+/// Shift to convert to/from a masked encryption type 16bit value to a 4bit encryption type.
+constexpr int kEncryptionTypeShift = 4;
+
 } // namespace
 
 size_t MessageHeader::EncodeSizeBytes() const
 {
-    size_t size = kFixedHeaderSizeBytes;
+    size_t size = kFixedUnencryptedHeaderSizeBytes;
 
     if (mSourceNodeId.HasValue())
     {
@@ -80,6 +96,29 @@ size_t MessageHeader::EncodeSizeBytes() const
     return size;
 }
 
+size_t MessageHeader::EncryptedHeaderSizeBytes() const
+{
+    return kEncryptedHeaderSizeBytes;
+}
+
+size_t MessageHeader::TagLenForEncryptionType(EncryptionType encType) const
+{
+    switch (encType)
+    {
+    case EncryptionType::kAESCCMTagLen8:
+        return 8;
+
+    case EncryptionType::kAESCCMTagLen12:
+        return 12;
+
+    case EncryptionType::kAESCCMTagLen16:
+        return 16;
+
+    default:
+        return 0;
+    }
+}
+
 CHIP_ERROR MessageHeader::Decode(const uint8_t * data, size_t size, size_t * decode_len)
 {
     CHIP_ERROR err    = CHIP_NO_ERROR;
@@ -87,19 +126,15 @@ CHIP_ERROR MessageHeader::Decode(const uint8_t * data, size_t size, size_t * dec
     uint16_t header;
     int version;
 
-    VerifyOrExit(size >= kFixedHeaderSizeBytes, err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(size >= kFixedUnencryptedHeaderSizeBytes, err = CHIP_ERROR_INVALID_ARGUMENT);
 
     header  = LittleEndian::Read16(p);
     version = ((header & kVersionMask) >> kVersionShift);
     VerifyOrExit(version == kHeaderVersion, err = CHIP_ERROR_VERSION_MISMATCH);
 
-    mSecureMsgType   = LittleEndian::Read16(p);
-    mMessageId       = LittleEndian::Read32(p);
-    mSecureSessionID = LittleEndian::Read32(p);
-    mTag             = LittleEndian::Read64(p);
+    mEncryptionType = (EncryptionType)((header & kEncryptionTypeMask) >> kEncryptionTypeShift);
 
-    assert(p - data == kFixedHeaderSizeBytes);
-    size -= kFixedHeaderSizeBytes;
+    mMessageId = LittleEndian::Read32(p);
 
     if (header & kFlagSourceNodeIdPresent)
     {
@@ -123,7 +158,49 @@ CHIP_ERROR MessageHeader::Decode(const uint8_t * data, size_t size, size_t * dec
         mDestinationNodeId.ClearValue();
     }
 
+    VerifyOrExit(size >= sizeof(uint16_t) * 2, err = CHIP_ERROR_INVALID_ARGUMENT);
+    mEncryptionKeyID = LittleEndian::Read16(p);
+    mPayloadLength   = LittleEndian::Read16(p);
+
     *decode_len = p - data;
+
+exit:
+
+    return err;
+}
+
+CHIP_ERROR MessageHeader::DecodeEncryptedHeader(const uint8_t * data, size_t size, size_t * decode_len)
+{
+    CHIP_ERROR err    = CHIP_NO_ERROR;
+    const uint8_t * p = data;
+
+    VerifyOrExit(size >= kEncryptedHeaderSizeBytes, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    mExchangeHeader  = Read8(p);
+    mExchangeMsgType = Read8(p);
+    mExchangeID      = LittleEndian::Read16(p);
+
+    size -= kEncryptedHeaderSizeBytes;
+
+    *decode_len = p - data;
+
+exit:
+
+    return err;
+}
+
+CHIP_ERROR MessageHeader::DecodeMACTag(const uint8_t * data, size_t size, size_t * decode_len)
+{
+    CHIP_ERROR err    = CHIP_NO_ERROR;
+    const uint8_t * p = data;
+    const size_t taglen   = TagLenForEncryptionType(mEncryptionType);
+
+    VerifyOrExit(taglen != 0, err = CHIP_ERROR_WRONG_ENCRYPTION_TYPE_FROM_PEER);
+    VerifyOrExit(size >= taglen, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    memcpy(&mTag[0], p, taglen);
+
+    *decode_len = taglen;
 
 exit:
 
@@ -147,11 +224,10 @@ CHIP_ERROR MessageHeader::Encode(uint8_t * data, size_t size, size_t * encode_si
         header |= kFlagDestinationNodeIdPresent;
     }
 
+    header |= (((uint16_t) mEncryptionType << kEncryptionTypeShift) & kEncryptionTypeMask);
+
     LittleEndian::Write16(p, header);
-    LittleEndian::Write16(p, mSecureMsgType);
     LittleEndian::Write32(p, mMessageId);
-    LittleEndian::Write32(p, mSecureSessionID);
-    LittleEndian::Write64(p, mTag);
     if (mSourceNodeId.HasValue())
     {
         LittleEndian::Write64(p, mSourceNodeId.Value());
@@ -161,8 +237,46 @@ CHIP_ERROR MessageHeader::Encode(uint8_t * data, size_t size, size_t * encode_si
         LittleEndian::Write64(p, mDestinationNodeId.Value());
     }
 
+    LittleEndian::Write16(p, mEncryptionKeyID);
+    LittleEndian::Write16(p, mPayloadLength);
+
     // Written data size provided to caller on success
     *encode_size = p - data;
+
+exit:
+    return err;
+}
+
+CHIP_ERROR MessageHeader::EncodeEncryptedHeader(uint8_t * data, size_t size, size_t * encode_size) const
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    uint8_t * p    = data;
+    VerifyOrExit(size >= kEncryptedHeaderSizeBytes, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    Write8(p, mExchangeHeader);
+    Write8(p, mExchangeMsgType);
+    LittleEndian::Write16(p, mExchangeID);
+
+    // Written data size provided to caller on success
+    *encode_size = p - data;
+
+exit:
+    return err;
+}
+
+CHIP_ERROR MessageHeader::EncodeMACTag(uint8_t * data, size_t size, size_t * encode_size) const
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    uint8_t * p    = data;
+    const size_t taglen = TagLenForEncryptionType(mEncryptionType);
+
+    VerifyOrExit(taglen != 0, err = CHIP_ERROR_WRONG_ENCRYPTION_TYPE);
+    VerifyOrExit(size >= taglen, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    memcpy(p, &mTag[0], taglen);
+
+    // Written data size provided to caller on success
+    *encode_size = taglen;
 
 exit:
     return err;

--- a/src/transport/MessageHeader.h
+++ b/src/transport/MessageHeader.h
@@ -63,6 +63,13 @@ public:
     const Optional<NodeId> & GetDestinationNodeId() const { return mDestinationNodeId; }
 
     /**
+     * Gets the vendor id in the current message.
+     *
+     * NOTE: the vendor id is optional and may be missing.
+     */
+    const Optional<uint16_t> & GetVendorId() const { return mVendorId; }
+
+    /**
      * Gets the message id set in the header.
      *
      * Message IDs are expecte to monotonically increase by one for each mesage
@@ -78,6 +85,9 @@ public:
 
     /** Get the Session ID from this header. */
     uint16_t GetExchangeID(void) const { return mExchangeID; }
+
+    /** Get the Protocol ID from this header. */
+    uint16_t GetProtocolID(void) const { return mProtocolID; }
 
     /** Get the MAC tag length. */
     size_t GetTagLength(void) const { return TagLenForEncryptionType(mEncryptionType); }
@@ -139,6 +149,30 @@ public:
         return *this;
     }
 
+    /** Set the vendor id for this header. */
+    MessageHeader & SetVendorId(uint16_t id)
+    {
+        mVendorId.SetValue(id);
+
+        return *this;
+    }
+
+    /** Set the vendor id for this header. */
+    MessageHeader & SetVendorId(Optional<uint16_t> id)
+    {
+        mVendorId = id;
+
+        return *this;
+    }
+
+    /** Clear the vendor id for this header. */
+    MessageHeader & ClearVendorId()
+    {
+        mVendorId.ClearValue();
+
+        return *this;
+    }
+
     /** Set the secure message type for this header. */
     MessageHeader & SetPayloadLength(uint16_t len)
     {
@@ -157,6 +191,13 @@ public:
     MessageHeader & SetExchangeID(uint16_t id)
     {
         mExchangeID = id;
+        return *this;
+    }
+
+    /** Set the Protocol ID for this header. */
+    MessageHeader & SetProtcolID(uint16_t id)
+    {
+        mProtocolID = id;
         return *this;
     }
 
@@ -313,8 +354,17 @@ private:
     /// Security session identifier
     uint16_t mExchangeID = 0;
 
+    /// Vendor identifier
+    Optional<uint16_t> mVendorId;
+
+    /// Protocol identifier
+    uint16_t mProtocolID = 0;
+
     /// Message authentication tag generated at encryption of the message.
     uint8_t mTag[kMaxTagLen];
+
+    /// Message header read from the message.
+    uint16_t mHeader = 0;
 };
 
 } // namespace chip

--- a/src/transport/MessageHeader.h
+++ b/src/transport/MessageHeader.h
@@ -74,7 +74,7 @@ public:
     uint16_t GetPayloadLength() const { return mPayloadLength; }
 
     /** Get the secure msg type from this header. */
-    uint8_t GetExchangeMsgType(void) const { return mExchangeMsgType; }
+    uint8_t GetMessageType(void) const { return mMessageType; }
 
     /** Get the Session ID from this header. */
     uint16_t GetExchangeID(void) const { return mExchangeID; }
@@ -147,9 +147,9 @@ public:
     }
 
     /** Set the secure message type for this header. */
-    MessageHeader & SetExchangeMsgType(uint8_t type)
+    MessageHeader & SetMessageType(uint8_t type)
     {
-        mExchangeMsgType = type;
+        mMessageType = type;
         return *this;
     }
 
@@ -308,7 +308,7 @@ private:
 
     /// Packet type (application data, security control packets, e.g. pairing,
     /// configuration, rekey etc)
-    uint8_t mExchangeMsgType = 0;
+    uint8_t mMessageType = 0;
 
     /// Security session identifier
     uint16_t mExchangeID = 0;

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -129,7 +129,7 @@ CHIP_ERROR SecureSessionMgrBase::SendMessage(NodeId peerNodeId, System::PacketBu
         const size_t headerSize = header.EncryptedHeaderSizeBytes();
         size_t actualEncodedHeaderSize;
         size_t totalLen = 0;
-        size_t taglen = 0;
+        size_t taglen   = 0;
 
         header
             .SetSourceNodeId(mLocalNodeId)              //
@@ -260,7 +260,7 @@ void SecureSessionMgrBase::HandleDataReceived(MessageHeader & header, const Peer
         uint16_t len            = msg->TotalLength();
         const size_t headerSize = header.EncryptedHeaderSizeBytes();
         size_t decodedSize      = 0;
-        size_t taglen = 0;
+        size_t taglen           = 0;
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
         /* This is a workaround for the case where PacketBuffer payload is not
            allocated as an inline buffer to PacketBuffer structure */
@@ -271,8 +271,7 @@ void SecureSessionMgrBase::HandleDataReceived(MessageHeader & header, const Peer
         plainText = msg->Start();
 
         err = header.DecodeMACTag(&data[header.GetPayloadLength()], kMaxTagLen, &taglen);
-        VerifyOrExit(err == CHIP_NO_ERROR,
-                     ChipLogProgress(Inet, "Secure transport failed to decode MAC Tag: err %d", err));
+        VerifyOrExit(err == CHIP_NO_ERROR, ChipLogProgress(Inet, "Secure transport failed to decode MAC Tag: err %d", err));
         len -= taglen;
         msg->SetDataLength(len, NULL);
 

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -124,16 +124,35 @@ CHIP_ERROR SecureSessionMgrBase::SendMessage(NodeId peerNodeId, System::PacketBu
     mPeerConnections.MarkConnectionActive(state);
 
     {
-        uint8_t * data = msgBuf->Start();
+        uint8_t * data = nullptr;
         MessageHeader header;
+        const size_t headerSize = header.EncryptedHeaderSizeBytes();
+        size_t actualEncodedHeaderSize;
+        size_t totalLen = 0;
+        size_t taglen = 0;
 
         header
-            .SetSourceNodeId(mLocalNodeId)    //
-            .SetDestinationNodeId(peerNodeId) //
-            .SetMessageId(state->GetSendMessageIndex());
+            .SetSourceNodeId(mLocalNodeId)              //
+            .SetDestinationNodeId(peerNodeId)           //
+            .SetMessageId(state->GetSendMessageIndex()) //
+            .SetPayloadLength(headerSize + msgBuf->TotalLength());
 
-        err = state->GetSecureSession().Encrypt(data, msgBuf->TotalLength(), data, header);
+        VerifyOrExit(msgBuf->EnsureReservedSize(headerSize), err = CHIP_ERROR_NO_MEMORY);
+
+        msgBuf->SetStart(msgBuf->Start() - headerSize);
+        data     = msgBuf->Start();
+        totalLen = msgBuf->TotalLength();
+
+        err = header.EncodeEncryptedHeader(data, totalLen, &actualEncodedHeaderSize);
         SuccessOrExit(err);
+
+        err = state->GetSecureSession().Encrypt(data, totalLen, data, header);
+        SuccessOrExit(err);
+
+        err = header.EncodeMACTag(&data[totalLen], kMaxTagLen, &taglen);
+        SuccessOrExit(err);
+
+        msgBuf->SetDataLength(totalLen + taglen, NULL);
 
         ChipLogProgress(Inet, "Secure transport transmitting msg %u after encryption", state->GetSendMessageIndex());
 
@@ -200,8 +219,8 @@ void SecureSessionMgrBase::CancelExpiryTimer(void)
     }
 }
 
-void SecureSessionMgrBase::HandleDataReceived(const MessageHeader & header, const PeerAddress & peerAddress,
-                                              System::PacketBuffer * msg, SecureSessionMgrBase * connection)
+void SecureSessionMgrBase::HandleDataReceived(MessageHeader & header, const PeerAddress & peerAddress, System::PacketBuffer * msg,
+                                              SecureSessionMgrBase * connection)
 
 {
     CHIP_ERROR err                 = CHIP_NO_ERROR;
@@ -236,20 +255,37 @@ void SecureSessionMgrBase::HandleDataReceived(const MessageHeader & header, cons
 
     // TODO this is where messages should be decoded
     {
-        uint8_t * data      = msg->Start();
-        uint8_t * plainText = nullptr;
-        uint16_t len        = msg->TotalLength();
+        uint8_t * data          = msg->Start();
+        uint8_t * plainText     = nullptr;
+        uint16_t len            = msg->TotalLength();
+        const size_t headerSize = header.EncryptedHeaderSizeBytes();
+        size_t decodedSize      = 0;
+        size_t taglen = 0;
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
-        /* This is a workaround for the case where PacketBuffer payload is not allocated
-           as an inline buffer to PacketBuffer structure */
+        /* This is a workaround for the case where PacketBuffer payload is not
+           allocated as an inline buffer to PacketBuffer structure */
         origMsg = msg;
         msg     = PacketBuffer::NewWithAvailableSize(len);
         msg->SetDataLength(len, msg);
 #endif
         plainText = msg->Start();
 
+        err = header.DecodeMACTag(&data[header.GetPayloadLength()], kMaxTagLen, &taglen);
+        VerifyOrExit(err == CHIP_NO_ERROR,
+                     ChipLogProgress(Inet, "Secure transport failed to decode MAC Tag: err %d", err));
+        len -= taglen;
+        msg->SetDataLength(len, NULL);
+
         err = state->GetSecureSession().Decrypt(data, len, plainText, header);
         VerifyOrExit(err == CHIP_NO_ERROR, ChipLogProgress(Inet, "Secure transport failed to decrypt msg: err %d", err));
+
+        err = header.DecodeEncryptedHeader(plainText, headerSize, &decodedSize);
+        VerifyOrExit(err == CHIP_NO_ERROR,
+                     ChipLogProgress(Inet, "Secure transport failed to decode encrypted header: err %d", err));
+        VerifyOrExit(headerSize == decodedSize,
+                     ChipLogProgress(Inet, "Secure transport decode encrypted header length mismatched"));
+
+        msg->ConsumeHead(headerSize);
 
         if (connection->mCB != nullptr)
         {

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -170,8 +170,8 @@ private:
     CHIP_ERROR AllocateNewConnection(const MessageHeader & header, const Transport::PeerAddress & address,
                                      Transport::PeerConnectionState ** state);
 
-    static void HandleDataReceived(const MessageHeader & header, const Transport::PeerAddress & source,
-                                   System::PacketBuffer * msgBuf, SecureSessionMgrBase * transport);
+    static void HandleDataReceived(MessageHeader & header, const Transport::PeerAddress & source, System::PacketBuffer * msgBuf,
+                                   SecureSessionMgrBase * transport);
 
     /**
      * Called when a specific connection expires.

--- a/src/transport/Tuple.h
+++ b/src/transport/Tuple.h
@@ -202,7 +202,7 @@ private:
      * Calls the underlying Base message receive handler whenever any of the underlying transports
      * receives a message.
      */
-    static void OnMessageReceive(const MessageHeader & header, const PeerAddress & source, System::PacketBuffer * msg, Tuple * t)
+    static void OnMessageReceive(MessageHeader & header, const PeerAddress & source, System::PacketBuffer * msg, Tuple * t)
     {
         t->HandleMessageReceived(header, source, msg);
     }

--- a/src/transport/tests/TestMessageHeader.cpp
+++ b/src/transport/tests/TestMessageHeader.cpp
@@ -42,8 +42,10 @@ void TestHeaderInitialState(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.GetMessageType() == 0);
     NL_TEST_ASSERT(inSuite, header.GetExchangeID() == 0);
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 0);
+    NL_TEST_ASSERT(inSuite, header.GetProtocolID() == 0);
     NL_TEST_ASSERT(inSuite, !header.GetDestinationNodeId().HasValue());
     NL_TEST_ASSERT(inSuite, !header.GetSourceNodeId().HasValue());
+    NL_TEST_ASSERT(inSuite, !header.GetVendorId().HasValue());
 }
 
 void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
@@ -64,6 +66,7 @@ void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 123);
     NL_TEST_ASSERT(inSuite, !header.GetDestinationNodeId().HasValue());
     NL_TEST_ASSERT(inSuite, !header.GetSourceNodeId().HasValue());
+    NL_TEST_ASSERT(inSuite, !header.GetVendorId().HasValue());
 
     header.SetSourceNodeId(55);
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
@@ -76,6 +79,7 @@ void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 123);
     NL_TEST_ASSERT(inSuite, !header.GetDestinationNodeId().HasValue());
     NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(55));
+    NL_TEST_ASSERT(inSuite, !header.GetVendorId().HasValue());
 
     header.ClearSourceNodeId().SetDestinationNodeId(11);
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
@@ -87,6 +91,7 @@ void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 123);
     NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(11));
     NL_TEST_ASSERT(inSuite, !header.GetSourceNodeId().HasValue());
+    NL_TEST_ASSERT(inSuite, !header.GetVendorId().HasValue());
 
     header.SetMessageId(234).SetSourceNodeId(77).SetDestinationNodeId(88);
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
@@ -98,6 +103,7 @@ void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 234);
     NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(88));
     NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77));
+    NL_TEST_ASSERT(inSuite, !header.GetVendorId().HasValue());
 
     header.SetMessageId(234).SetSourceNodeId(77).SetDestinationNodeId(88);
     header.SetMessageType(112).SetExchangeID(2233);
@@ -116,6 +122,50 @@ void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77));
     NL_TEST_ASSERT(inSuite, header.GetMessageType() == 112);
     NL_TEST_ASSERT(inSuite, header.GetExchangeID() == 2233);
+    NL_TEST_ASSERT(inSuite, !header.GetVendorId().HasValue());
+
+    header.SetMessageId(234).SetSourceNodeId(77).SetDestinationNodeId(88);
+    header.SetMessageType(112).SetExchangeID(2233).SetProtcolID(1221);
+    NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite,
+                   header.EncodeEncryptedHeader(&buffer[encodeLen], sizeof(buffer) - encodeLen, &encodeLen) == CHIP_NO_ERROR);
+
+    // change it to verify decoding
+    header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
+    header.SetMessageType(221).SetExchangeID(3322).SetProtcolID(4567);
+    NL_TEST_ASSERT(inSuite, header.Decode(buffer, sizeof(buffer), &decodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite,
+                   header.DecodeEncryptedHeader(&buffer[decodeLen], sizeof(buffer) - decodeLen, &decodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.GetMessageId() == 234);
+    NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(88));
+    NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77));
+    NL_TEST_ASSERT(inSuite, header.GetMessageType() == 112);
+    NL_TEST_ASSERT(inSuite, header.GetExchangeID() == 2233);
+    NL_TEST_ASSERT(inSuite, header.GetProtocolID() == 1221);
+    NL_TEST_ASSERT(inSuite, !header.GetVendorId().HasValue());
+
+    header.SetMessageId(234).SetSourceNodeId(77).SetDestinationNodeId(88);
+    header.SetMessageType(112).SetExchangeID(2233).SetProtcolID(1221);
+    header.SetVendorId(6789);
+    NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite,
+                   header.EncodeEncryptedHeader(&buffer[encodeLen], sizeof(buffer) - encodeLen, &encodeLen) == CHIP_NO_ERROR);
+
+    // change it to verify decoding
+    header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
+    header.SetMessageType(221).SetExchangeID(3322).SetProtcolID(4567);
+    header.SetVendorId(8976);
+    NL_TEST_ASSERT(inSuite, header.Decode(buffer, sizeof(buffer), &decodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite,
+                   header.DecodeEncryptedHeader(&buffer[decodeLen], sizeof(buffer) - decodeLen, &decodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.GetMessageId() == 234);
+    NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(88));
+    NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77));
+    NL_TEST_ASSERT(inSuite, header.GetMessageType() == 112);
+    NL_TEST_ASSERT(inSuite, header.GetExchangeID() == 2233);
+    NL_TEST_ASSERT(inSuite, header.GetProtocolID() == 1221);
+    NL_TEST_ASSERT(inSuite, header.GetVendorId().HasValue());
+    NL_TEST_ASSERT(inSuite, header.GetVendorId() == Optional<uint16_t>::Value(6789));
 }
 
 void TestHeaderEncodeDecodeBounds(nlTestSuite * inSuite, void * inContext)

--- a/src/transport/tests/TestMessageHeader.cpp
+++ b/src/transport/tests/TestMessageHeader.cpp
@@ -39,7 +39,7 @@ void TestHeaderInitialState(nlTestSuite * inSuite, void * inContext)
 {
     MessageHeader header;
 
-    NL_TEST_ASSERT(inSuite, header.GetExchangeMsgType() == 0);
+    NL_TEST_ASSERT(inSuite, header.GetMessageType() == 0);
     NL_TEST_ASSERT(inSuite, header.GetExchangeID() == 0);
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 0);
     NL_TEST_ASSERT(inSuite, !header.GetDestinationNodeId().HasValue());
@@ -114,7 +114,7 @@ void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 234);
     NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(88));
     NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77));
-    NL_TEST_ASSERT(inSuite, header.GetExchangeMsgType() == 112);
+    NL_TEST_ASSERT(inSuite, header.GetMessageType() == 112);
     NL_TEST_ASSERT(inSuite, header.GetExchangeID() == 2233);
 }
 

--- a/src/transport/tests/TestMessageHeader.cpp
+++ b/src/transport/tests/TestMessageHeader.cpp
@@ -100,14 +100,14 @@ void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77));
 
     header.SetMessageId(234).SetSourceNodeId(77).SetDestinationNodeId(88);
-    header.SetExchangeMsgType(112).SetExchangeID(2233);
+    header.SetMessageType(112).SetExchangeID(2233);
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite,
                    header.EncodeEncryptedHeader(&buffer[encodeLen], sizeof(buffer) - encodeLen, &encodeLen) == CHIP_NO_ERROR);
 
     // change it to verify decoding
     header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
-    header.SetExchangeMsgType(221).SetExchangeID(3322);
+    header.SetMessageType(221).SetExchangeID(3322);
     NL_TEST_ASSERT(inSuite, header.Decode(buffer, sizeof(buffer), &decodeLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite,
                    header.DecodeEncryptedHeader(&buffer[decodeLen], sizeof(buffer) - decodeLen, &decodeLen) == CHIP_NO_ERROR);

--- a/src/transport/tests/TestUDP.cpp
+++ b/src/transport/tests/TestUDP.cpp
@@ -51,7 +51,7 @@ TestContext sContext;
 const char PAYLOAD[]        = "Hello!";
 int ReceiveHandlerCallCount = 0;
 
-void MessageReceiveHandler(const MessageHeader & header, const Transport::PeerAddress & source, System::PacketBuffer * msgBuf,
+void MessageReceiveHandler(MessageHeader & header, const Transport::PeerAddress & source, System::PacketBuffer * msgBuf,
                            nlTestSuite * inSuite)
 {
     NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<NodeId>::Value(kSourceNodeId));


### PR DESCRIPTION
 #### Problem
The message header structure wire format is missing some fields. And, some fields are at incorrect offsets.

 #### Summary of Changes
Update the message header structure to follow agreed upon format. Also, a part of structure is expected to be encrypted. Added support for the encrypted header fields.

fixes #1692 
