### PR TITLE
[shell] Add commands to control device layer thread management APIs.

### DIFF
--- a/examples/shell/cmd_device.cpp
+++ b/examples/shell/cmd_device.cpp
@@ -24,6 +24,9 @@
 #include <support/CHIPArgParser.hpp>
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
+#if CHIP_ENABLE_OPENTHREAD
+#include <platform/ThreadStackManager.h>
+#endif
 
 using namespace chip;
 using namespace chip::Shell;
@@ -418,7 +421,6 @@ exit:
 int cmd_device_get(int argc, char ** argv)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
-    streamer_get();
 
     if (argc == 0)
     {
@@ -490,6 +492,101 @@ exit:
     return error;
 }
 
+int cmd_device_thread(int argc, char ** argv)
+{
+    streamer_t * sout = streamer_get();
+
+    CHIP_ERROR error = CHIP_NO_ERROR;
+
+    VerifyOrExit(argc > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+
+    VerifyOrExit(PlatformMgr().TryLockChipStack(), error = CHIP_ERROR_INVALID_ARGUMENT);
+
+    if (strcmp(argv[0], "mac") == 0)
+    {
+        uint64_t mac;
+        SuccessOrExit(error = ThreadStackMgr().GetPrimary802154MACAddress(reinterpret_cast<uint8_t *>(&mac)));
+        streamer_printf(sout, "%" PRIu64 " (0x%" PRIX64 ")", mac, mac);
+    }
+    else if (strcmp(argv[0], "start") == 0)
+    {
+        SuccessOrExit(error = ThreadStackMgr().StartThreadTask());
+    }
+    else if (strcmp(argv[0], "role") == 0)
+    {
+        const char * typeStr = u8"Unknown";
+        ConnectivityManager::ThreadDeviceType type;
+        type = ConnectivityMgr().GetThreadDeviceType();
+        switch (type)
+        {
+        case ConnectivityManager::kThreadDeviceType_NotSupported:
+            typeStr = u8"NotSupported";
+            break;
+        case ConnectivityManager::kThreadDeviceType_Router:
+            typeStr = u8"Router";
+            break;
+        case ConnectivityManager::kThreadDeviceType_FullEndDevice:
+            typeStr = u8"FullEndDevice";
+            break;
+        case ConnectivityManager::kThreadDeviceType_MinimalEndDevice:
+            typeStr = u8"MinimalEndDevice";
+            break;
+        case ConnectivityManager::kThreadDeviceType_SleepyEndDevice:
+            typeStr = u8"SleepyEndDevice";
+            break;
+        }
+        streamer_printf(sout, "%d: %s\r\n", static_cast<int>(type), typeStr);
+    }
+    else if (strcmp(argv[0], "enabled") == 0)
+    {
+        bool isState = ConnectivityMgr().IsThreadEnabled();
+        streamer_printf(sout, "%s\r\n", (isState) ? "true" : "false");
+    }
+    else if (strcmp(argv[0], "attached") == 0)
+    {
+        bool isState = ConnectivityMgr().IsThreadAttached();
+        streamer_printf(sout, "%s\r\n", (isState) ? "true" : "false");
+    }
+    else if (strcmp(argv[0], "provisioned") == 0)
+    {
+        bool isState = ConnectivityMgr().IsThreadProvisioned();
+        streamer_printf(sout, "%s\r\n", (isState) ? "true" : "false");
+    }
+    else if (strcmp(argv[0], "controlled") == 0)
+    {
+        bool isState = ConnectivityMgr().IsThreadApplicationControlled();
+        streamer_printf(sout, "%s\r\n", (isState) ? "true" : "false");
+    }
+    else if (strcmp(argv[0], "connected") == 0)
+    {
+        bool isState = ConnectivityMgr().HaveServiceConnectivityViaThread();
+        streamer_printf(sout, "%s\r\n", (isState) ? "true" : "false");
+    }
+    else if (strcmp(argv[0], "erase") == 0)
+    {
+        ConnectivityMgr().ErasePersistentInfo();
+        streamer_printf(sout, "Thread Factory Reset\r\n");
+    }
+    else if (strcmp(argv[0], "stats") == 0)
+    {
+        SuccessOrExit(error = ThreadStackMgr().GetAndLogThreadStatsCounters());
+        streamer_printf(sout, "Thread statistics written to log\r\n");
+    }
+    else if (strcmp(argv[0], "topology") == 0)
+    {
+        SuccessOrExit(error = ThreadStackMgr().GetAndLogThreadTopologyFull());
+        streamer_printf(sout, "Thread topology written to log\r\n");
+    }
+    else
+    {
+        ExitNow(error = CHIP_ERROR_INVALID_ARGUMENT);
+    }
+
+exit:
+    PlatformMgr().UnlockChipStack();
+    return error;
+}
+
 int cmd_device_dispatch(int argc, char ** argv)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
@@ -509,7 +606,10 @@ static const shell_command_t cmds_device[] = {
     { &cmd_device_help, "help", "Usage: device <subcommand>" },
     { &cmd_device_start, "start", "Start the device layer. Usage: device start" },
     { &cmd_device_get, "get", "Get configuration value. Usage: device get <param_name>" },
-    { &cmd_device_config, "config", "Dump entire configuration of device. Usage: device dump" },
+    { &cmd_device_config, "config", "Dump entire configuration of device. Usage: device config" },
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    { &cmd_device_thread, "thread", "Control the Thread interface. Usage: device thread <param_name>" },
+#endif
 };
 
 #endif // CONFIG_DEVICE_LAYER
@@ -532,6 +632,15 @@ void cmd_device_init(void)
 
     if (error != CHIP_NO_ERROR)
         streamer_printf(sout, "Failed to init CHIP Stack with error: %s\r\n", ErrorStr(error));
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    streamer_printf(sout, "Init Thread stack\r\n");
+    error = ThreadStackMgr().InitThreadStack();
+    if (error != CHIP_NO_ERROR)
+    {
+        streamer_printf(sout, "ThreadStackMgr().InitThreadStack() failed\r\n");
+    }
+#endif
 
 #endif // CONFIG_DEVICE_LAYER
 }

--- a/examples/shell/cmd_device.cpp
+++ b/examples/shell/cmd_device.cpp
@@ -492,6 +492,7 @@ exit:
     return error;
 }
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 int cmd_device_thread(int argc, char ** argv)
 {
     streamer_t * sout = streamer_get();
@@ -586,6 +587,7 @@ exit:
     PlatformMgr().UnlockChipStack();
     return error;
 }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 
 int cmd_device_dispatch(int argc, char ** argv)
 {

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -416,12 +416,12 @@ CHIP_ERROR ThreadStackManagerImpl::_JoinerStart(void)
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
-extern ThreadStackManager & ThreadStackMgr(void)
+ThreadStackManager & ThreadStackMgr(void)
 {
     return chip::DeviceLayer::ThreadStackManagerImpl::sInstance;
 }
 
-extern ThreadStackManagerImpl & ThreadStackMgrImpl(void)
+ThreadStackManagerImpl & ThreadStackMgrImpl(void)
 {
     return chip::DeviceLayer::ThreadStackManagerImpl::sInstance;
 }


### PR DESCRIPTION
 #### Problem
Shell doesn't have anyway to manage the Thread interface yet.

 #### Summary of Changes
Add commands to expose most of the ThreadStackManager and ConnectivityManager APIs for controlling the Thread interface.