### PR TITLE
[build] fix -Wdeprecated build errors in CHIPDeviceController

### DIFF
--- a/src/controller/BUILD.gn
+++ b/src/controller/BUILD.gn
@@ -14,6 +14,11 @@
 
 import("//build_overrides/chip.gni")
 
+# FIXME: remove after actual key exchange is implemented
+config("controller_wno_deprecate") {
+  cflags = ["-Wno-deprecated-declarations"]
+}
+
 static_library("controller") {
   output_name = "libChipController"
 
@@ -29,4 +34,5 @@ static_library("controller") {
   ]
 
   allow_circular_includes_from = [ "${chip_root}/src/transport" ]
+  configs += [ ":controller_wno_deprecate" ]
 }


### PR DESCRIPTION
Using TemporaryManualKeyExchange is the extended behavior before the actual key exchange mechanism is landed.