### PR TITLE
Allow chip-tool echo-ble to work along with credential passing

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/QRCode/QRCodeViewController.m
@@ -260,7 +260,7 @@ static NSString * const ipKey = @"ipk";
 
 - (void)sendWifiCredentialsWithSSID:(NSString *)ssid password:(NSString *)password
 {
-    NSString * msg = [NSString stringWithFormat:@"%@:%@", ssid, password];
+    NSString * msg = [NSString stringWithFormat:@"::%@:%@:", ssid, password];
     NSError * error;
     BOOL didSend = [self.chipController sendMessage:[msg dataUsingEncoding:NSUTF8StringEncoding] error:&error];
     if (!didSend) {


### PR DESCRIPTION
Prior to #1898, received bluetooth messages were echoed back
to the sender, and this facility is used by the command-line
`chip-tool echo-ble`. To restore that, this change adopts a
stricter format for WiFi credentials and treats anything else
as an echo request. (This too is temporary code, pending an
actual rendezvous implementation.)
