### PR TITLE
Spake2p implementation for mbedTLS

### DIFF
--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -641,11 +641,9 @@ struct Spake2p_Context
 #if CHIP_CRYPTO_OPENSSL
     EC_GROUP * curve;
     BN_CTX * bn_ctx;
-    EVP_MD_CTX * hash_ctx;
-    const EVP_MD * hash;
+    const EVP_MD * md_info;
 #elif CHIP_CRYPTO_MBEDTLS
     mbedtls_ecp_group curve;
-    mbedtls_md_context_t hash_ctxt;
     const mbedtls_md_info_t * md_info;
     mbedtls_ecp_point M;
     mbedtls_ecp_point N;

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -803,9 +803,9 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal(void)
     CHIP_ERROR error  = CHIP_ERROR_INTERNAL;
     int error_openssl = 0;
 
-    context.curve    = NULL;
-    context.bn_ctx   = NULL;
-    context.md_info  = NULL;
+    context.curve   = NULL;
+    context.bn_ctx  = NULL;
+    context.md_info = NULL;
 
     context.curve = EC_GROUP_new_by_curve_name(NID_X9_62_prime256v1);
     VerifyOrExit(context.curve != NULL, error = CHIP_ERROR_INTERNAL);

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -805,8 +805,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal(void)
 
     context.curve    = NULL;
     context.bn_ctx   = NULL;
-    context.hash_ctx = NULL;
-    context.hash     = NULL;
+    context.md_info  = NULL;
 
     context.curve = EC_GROUP_new_by_curve_name(NID_X9_62_prime256v1);
     VerifyOrExit(context.curve != NULL, error = CHIP_ERROR_INTERNAL);
@@ -817,13 +816,8 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal(void)
     context.bn_ctx = BN_CTX_secure_new();
     VerifyOrExit(context.bn_ctx != NULL, error = CHIP_ERROR_INTERNAL);
 
-    context.hash = EVP_sha256();
-    VerifyOrExit(context.hash != NULL, error = CHIP_ERROR_INTERNAL);
-
-    context.hash_ctx = EVP_MD_CTX_new();
-    VerifyOrExit(context.hash_ctx != NULL, error = CHIP_ERROR_INTERNAL);
-    error_openssl = EVP_DigestInit(context.hash_ctx, context.hash);
-    VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
+    context.md_info = EVP_sha256();
+    VerifyOrExit(context.md_info != NULL, error = CHIP_ERROR_INTERNAL);
 
     init_point(M);
     init_point(N);
@@ -850,7 +844,6 @@ void Spake2p_P256_SHA256_HKDF_HMAC::FreeImpl(void)
 {
     EC_GROUP_clear_free(context.curve);
     BN_CTX_free(context.bn_ctx);
-    EVP_MD_CTX_free(context.hash_ctx);
 
     free_point(M);
     free_point(N);
@@ -876,7 +869,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::Mac(const unsigned char * key, size_t 
     HMAC_CTX * mac_ctx = HMAC_CTX_new();
     VerifyOrExit(mac_ctx != NULL, error = CHIP_ERROR_INTERNAL);
 
-    error_openssl = HMAC_Init_ex(mac_ctx, key, key_len, context.hash, NULL);
+    error_openssl = HMAC_Init_ex(mac_ctx, key, key_len, context.md_info, NULL);
     VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
 
     error_openssl = HMAC_Update(mac_ctx, in, in_len);

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -785,18 +785,18 @@ void ClearSecretData(uint8_t * buf, uint32_t len)
     {                                                                                                                              \
         _point_ = EC_POINT_new(context.curve);                                                                                     \
         VerifyOrExit(_point_ != NULL, error = CHIP_ERROR_INTERNAL);                                                                \
-    } while (0);
+    } while (0)
 
 #define init_bn(_bn_)                                                                                                              \
     do                                                                                                                             \
     {                                                                                                                              \
         _bn_ = BN_new();                                                                                                           \
         VerifyOrExit(_bn_ != NULL, error = CHIP_ERROR_INTERNAL);                                                                   \
-    } while (0);
+    } while (0)
 
-#define free_point(_point_) EC_POINT_clear_free((EC_POINT *) _point_);
+#define free_point(_point_) EC_POINT_clear_free((EC_POINT *) _point_)
 
-#define free_bn(_bn_) BN_clear_free((BIGNUM *) _bn_);
+#define free_bn(_bn_) BN_clear_free((BIGNUM *) _bn_)
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal(void)
 {
@@ -825,9 +825,20 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal(void)
     error_openssl = EVP_DigestInit(context.hash_ctx, context.hash);
     VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
 
-    init_point(M) init_point(N) init_point(X) init_point(Y) init_point(L) init_point(V) init_point(Z) init_bn(w0) init_bn(w1)
-        init_bn(xy) init_bn(tempbn) init_bn(order) error_openssl =
-            EC_GROUP_get_order(context.curve, (BIGNUM *) order, context.bn_ctx);
+    init_point(M);
+    init_point(N);
+    init_point(X);
+    init_point(Y);
+    init_point(L);
+    init_point(V);
+    init_point(Z);
+    init_bn(w0);
+    init_bn(w1);
+    init_bn(xy);
+    init_bn(tempbn);
+    init_bn(order);
+
+    error_openssl = EC_GROUP_get_order(context.curve, (BIGNUM *) order, context.bn_ctx);
     VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
 
     error = CHIP_NO_ERROR;
@@ -841,8 +852,18 @@ void Spake2p_P256_SHA256_HKDF_HMAC::FreeImpl(void)
     BN_CTX_free(context.bn_ctx);
     EVP_MD_CTX_free(context.hash_ctx);
 
-    free_point(M) free_point(N) free_point(X) free_point(Y) free_point(L) free_point(V) free_point(Z) free_bn(w0) free_bn(w1)
-        free_bn(xy) free_bn(tempbn) free_bn(order)
+    free_point(M);
+    free_point(N);
+    free_point(X);
+    free_point(Y);
+    free_point(L);
+    free_point(V);
+    free_point(Z);
+    free_bn(w0);
+    free_bn(w1);
+    free_bn(xy);
+    free_bn(tempbn);
+    free_bn(order);
 }
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::Mac(const unsigned char * key, size_t key_len, const unsigned char * in, size_t in_len,

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -504,8 +504,8 @@ void ClearSecretData(uint8_t * buf, uint32_t len)
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal(void)
 {
-    CHIP_ERROR error  = CHIP_NO_ERROR;
-    int result        = 0;
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    int result       = 0;
 
     memset(&context, 0, sizeof(context));
     mbedtls_ecp_group_init(&context.curve);
@@ -598,13 +598,13 @@ exit:
     return error;
 }
 
-static inline int const_memcmp(const void *a, const void *b, size_t n)
+static inline int const_memcmp(const void * a, const void * b, size_t n)
 {
-    const unsigned char *A = (const unsigned char *) a;
-    const unsigned char *B = (const unsigned char *) b;
-    unsigned char diff = 0;
+    const unsigned char * A = (const unsigned char *) a;
+    const unsigned char * B = (const unsigned char *) b;
+    unsigned char diff      = 0;
 
-    for(size_t i = 0; i < n; i++)
+    for (size_t i = 0; i < n; i++)
     {
         diff |= (A[i] ^ B[i]);
     }

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -515,11 +515,6 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal(void)
     context.md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
     VerifyOrExit(context.md_info != NULL, error = CHIP_ERROR_INTERNAL);
 
-    mbedtls_md_init(&context.hash_ctxt);
-
-    result = mbedtls_md_setup(&context.hash_ctxt, context.md_info, 0);
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
-
     mbedtls_ecp_point_init(&context.M);
     mbedtls_ecp_point_init(&context.N);
     mbedtls_ecp_point_init(&context.X);
@@ -547,9 +542,6 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal(void)
     G     = &context.curve.G;
     order = &context.curve.N;
 
-    result = mbedtls_md_starts(&context.hash_ctxt);
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
-
     return error;
 
 exit:
@@ -573,8 +565,6 @@ void Spake2p_P256_SHA256_HKDF_HMAC::FreeImpl(void)
     mbedtls_mpi_free(&context.w1);
     mbedtls_mpi_free(&context.xy);
     mbedtls_mpi_free(&context.tempbn);
-
-    mbedtls_md_free(&context.hash_ctxt);
 
     mbedtls_ecp_group_free(&context.curve);
 }

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -598,7 +598,11 @@ exit:
     return error;
 }
 
-static inline int const_memcmp(const void * a, const void * b, size_t n)
+/**
+ * This function implements constant time memcmp. It's good practice
+ * to use constant time functions for cryptographic functions.
+ */
+static inline int constant_time_memcmp(const void * a, const void * b, size_t n)
 {
     const unsigned char * A = (const unsigned char *) a;
     const unsigned char * B = (const unsigned char *) b;
@@ -625,7 +629,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::MacVerify(const unsigned char * key, s
     error = Mac(key, key_len, in, in_len, computed_mac);
     SuccessOrExit(error);
 
-    VerifyOrExit(const_memcmp(mac, computed_mac, kSHA256_Hash_Length) == 0, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(constant_time_memcmp(mac, computed_mac, kSHA256_Hash_Length) == 0, error = CHIP_ERROR_INTERNAL);
 
 exit:
     _log_mbedTLS_error(result);
@@ -762,11 +766,11 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(unsigned char * Lout, size_t 
     mbedtls_ecp_point Ltemp;
 
     mbedtls_ecp_group_init(&curve);
-    result = mbedtls_ecp_group_load(&curve, MBEDTLS_ECP_DP_SECP256R1);
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
-
     mbedtls_mpi_init(&w1_bn);
     mbedtls_ecp_point_init(&Ltemp);
+
+    result = mbedtls_ecp_group_load(&curve, MBEDTLS_ECP_DP_SECP256R1);
+    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
     result = mbedtls_mpi_read_binary(&w1_bn, w1in, w1in_len);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -24,7 +24,6 @@
 #include "Hash_SHA256_test_vectors.h"
 #include "PBKDF2_SHA256_test_vectors.h"
 
-#if CHIP_CRYPTO_OPENSSL
 #include "SPAKE2P_FE_MUL_test_vectors.h"
 #include "SPAKE2P_FE_RW_test_vectors.h"
 #include "SPAKE2P_HMAC_test_vectors.h"
@@ -33,7 +32,6 @@
 #include "SPAKE2P_POINT_RW_test_vectors.h"
 #include "SPAKE2P_POINT_VALID_test_vectors.h"
 #include "SPAKE2P_RFC_test_vectors.h"
-#endif
 
 #include <crypto/CHIPCryptoPAL.h>
 
@@ -913,7 +911,6 @@ static void TestPBKDF2_SHA256_TestVectors(nlTestSuite * inSuite, void * inContex
     NL_TEST_ASSERT(inSuite, numOfTestsRan > 0);
 }
 
-#if CHIP_CRYPTO_OPENSSL
 static void TestSPAKE2P_spake2p_FEMul(nlTestSuite * inSuite, void * inContext)
 {
     unsigned char fe_out[kMAX_FE_Length];
@@ -1286,7 +1283,7 @@ static void TestSPAKE2P_RFC(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, numOfTestsRan > 0);
     NL_TEST_ASSERT(inSuite, numOfTestsRan == numOfTestVectors);
 }
-#endif
+
 namespace chip {
 namespace Logging {
 void LogV(uint8_t module, uint8_t category, const char * format, va_list argptr)
@@ -1337,7 +1334,6 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("Test ECDH sample vectors", TestECDH_SampleInputVectors),
     NL_TEST_DEF("Test adding entropy sources", TestAddEntropySources),
     NL_TEST_DEF("Test PBKDF2 SHA256", TestPBKDF2_SHA256_TestVectors),
-#if CHIP_CRYPTO_OPENSSL
     NL_TEST_DEF("Test Spake2p_spake2p FEMul", TestSPAKE2P_spake2p_FEMul),
     NL_TEST_DEF("Test Spake2p_spake2p FELoad/FEWrite", TestSPAKE2P_spake2p_FELoadWrite),
     NL_TEST_DEF("Test Spake2p_spake2p Mac", TestSPAKE2P_spake2p_Mac),
@@ -1346,7 +1342,6 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("Test Spake2p_spake2p PointLoad/PointWrite", TestSPAKE2P_spake2p_PointLoadWrite),
     NL_TEST_DEF("Test Spake2p_spake2p PointIsValid", TestSPAKE2P_spake2p_PointIsValid),
     NL_TEST_DEF("Test Spake2+ against RFC test vectors", TestSPAKE2P_RFC),
-#endif
     NL_TEST_SENTINEL()
 };
 


### PR DESCRIPTION
 #### Problem
Missing spake2p implementation for `mbedTLS`

 #### Summary of Changes
Added the missing APIs to CHIP's `mbedTLS` wrapper. 

fixes #266