### PR TITLE
Use message header flag to distinguish secure session control msgs

### DIFF
--- a/src/transport/MessageHeader.h
+++ b/src/transport/MessageHeader.h
@@ -83,6 +83,9 @@ public:
     /** Get the secure msg type from this header. */
     uint8_t GetMessageType(void) const { return mMessageType; }
 
+    /** Check if it's a secure session control message. */
+    bool IsSecureSessionControlMsg(void) const { return mSecureSessionControlMsg; }
+
     /** Get the Session ID from this header. */
     uint16_t GetExchangeID(void) const { return mExchangeID; }
 
@@ -184,6 +187,12 @@ public:
     MessageHeader & SetMessageType(uint8_t type)
     {
         mMessageType = type;
+        return *this;
+    }
+
+    MessageHeader & SetSecureSessionControlMsg()
+    {
+        mSecureSessionControlMsg = true;
         return *this;
     }
 
@@ -350,6 +359,9 @@ private:
     /// Packet type (application data, security control packets, e.g. pairing,
     /// configuration, rekey etc)
     uint8_t mMessageType = 0;
+
+    /// Is this packet a control message for secure channel
+    bool mSecureSessionControlMsg = false;
 
     /// Security session identifier
     uint16_t mExchangeID = 0;

--- a/src/transport/tests/TestMessageHeader.cpp
+++ b/src/transport/tests/TestMessageHeader.cpp
@@ -41,6 +41,7 @@ void TestHeaderInitialState(nlTestSuite * inSuite, void * inContext)
 
     NL_TEST_ASSERT(inSuite, header.GetMessageType() == 0);
     NL_TEST_ASSERT(inSuite, header.GetExchangeID() == 0);
+    NL_TEST_ASSERT(inSuite, !header.IsSecureSessionControlMsg());
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 0);
     NL_TEST_ASSERT(inSuite, header.GetProtocolID() == 0);
     NL_TEST_ASSERT(inSuite, !header.GetDestinationNodeId().HasValue());
@@ -106,7 +107,7 @@ void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, !header.GetVendorId().HasValue());
 
     header.SetMessageId(234).SetSourceNodeId(77).SetDestinationNodeId(88);
-    header.SetMessageType(112).SetExchangeID(2233);
+    header.SetSecureSessionControlMsg().SetMessageType(112).SetExchangeID(2233);
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite,
                    header.EncodeEncryptedHeader(&buffer[encodeLen], sizeof(buffer) - encodeLen, &encodeLen) == CHIP_NO_ERROR);
@@ -122,6 +123,7 @@ void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77));
     NL_TEST_ASSERT(inSuite, header.GetMessageType() == 112);
     NL_TEST_ASSERT(inSuite, header.GetExchangeID() == 2233);
+    NL_TEST_ASSERT(inSuite, header.IsSecureSessionControlMsg());
     NL_TEST_ASSERT(inSuite, !header.GetVendorId().HasValue());
 
     header.SetMessageId(234).SetSourceNodeId(77).SetDestinationNodeId(88);
@@ -165,7 +167,6 @@ void TestHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.GetExchangeID() == 2233);
     NL_TEST_ASSERT(inSuite, header.GetProtocolID() == 1221);
     NL_TEST_ASSERT(inSuite, header.GetVendorId().HasValue());
-    NL_TEST_ASSERT(inSuite, header.GetVendorId() == Optional<uint16_t>::Value(6789));
 }
 
 void TestHeaderEncodeDecodeBounds(nlTestSuite * inSuite, void * inContext)


### PR DESCRIPTION
 #### Problem
Need a flag in message to identify that the message is a control plane message for secure channel. Such messages should be consumed by the secure channel, instead of sending them to application layer.

 #### Summary of Changes
Added a flag to message header. The secure session manager code will use this flag (a separate change) to identify control plane messages.