### PR TITLE
[android] android app supports Thread Commissioning

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -64,3 +64,6 @@
 	branch = master
 	ignore = dirty
 	commit = 18e137db73e2ae6d307e62ac8430f7326efdb0c3
+[submodule "third_party/ot-commissioner/repo"]
+	path = third_party/ot-commissioner/repo
+	url = https://github.com/openthread/ot-commissioner

--- a/src/android/CHIPTool/README.md
+++ b/src/android/CHIPTool/README.md
@@ -96,12 +96,9 @@ jniLibs/arm64-v8a
     tweaking of the Android automake build rules. Include it in the interim to
     be able to build the Android app).
 
-11. Before running `gradle sync`, setup ot-commissioner
+11. Build OT Commissioner
 
     ```shell
-    cd third_party/ot-commissioner/repo/
-    ./script/bootstrap.sh
-
-    ## Install SWIG 4.0
-    brew install swig@4
+    ./third_party/ot-commissioner/build-android-libs.sh
+    ## JAR and .so libraries will be copy to target directories.
     ```

--- a/src/android/CHIPTool/README.md
+++ b/src/android/CHIPTool/README.md
@@ -99,6 +99,7 @@ jniLibs/arm64-v8a
 11. Build OT Commissioner
 
     ```shell
+    git submodule update --init --recursive third_party/ot-commissioner/repo
     ./third_party/ot-commissioner/build-android-libs.sh
     ## JAR and .so libraries will be copy to target directories.
     ```

--- a/src/android/CHIPTool/README.md
+++ b/src/android/CHIPTool/README.md
@@ -96,7 +96,7 @@ jniLibs/arm64-v8a
     tweaking of the Android automake build rules. Include it in the interim to
     be able to build the Android app).
 
-11. Before running `gradle sync`, seetup ot-commissioner
+11. Before running `gradle sync`, setup ot-commissioner
 
     ```shell
     cd third_party/ot-commissioner/repo/

--- a/src/android/CHIPTool/README.md
+++ b/src/android/CHIPTool/README.md
@@ -88,10 +88,16 @@ jniLibs/arm64-v8a
 
 'Gradle sync' the Android project and run.
 
-10. You will also need the "libc++\_shared.so" file in the jniLibs folder. This
-    file comes packaged with Android NDK and can be found under
-    $ANDROID_NDK_HOME/sources/cxx-stl/llvm-libc++/libs/$TARGET
+10. You will also need the "libc++\_shared.so" file in the jniLibs folder. This file comes packaged with Android NDK and can be found under `$ANDROID_NDK_HOME/sources/cxx-stl/llvm-libc++/libs/$TARGET`.
 
-(Eventually hoping to not have to include this .so, but that needs some more
-tweaking of the Android automake build rules. Include it in the interim to be
-able to build the Android app).
+    (Eventually hoping to not have to include this .so, but that needs some more tweaking of the Android automake build rules. Include it in the interim to be able to build the Android app).
+
+11. Before running `gradle sync`, seetup ot-commissioner
+
+    ```shell
+    cd third_party/ot-commissioner/repo/
+    ./script/bootstrap.sh
+
+    ## Install SWIG 4.0
+    brew install swig@4
+    ```

--- a/src/android/CHIPTool/README.md
+++ b/src/android/CHIPTool/README.md
@@ -88,9 +88,13 @@ jniLibs/arm64-v8a
 
 'Gradle sync' the Android project and run.
 
-10. You will also need the "libc++\_shared.so" file in the jniLibs folder. This file comes packaged with Android NDK and can be found under `$ANDROID_NDK_HOME/sources/cxx-stl/llvm-libc++/libs/$TARGET`.
+10. You will also need the "libc++\_shared.so" file in the jniLibs folder. This
+    file comes packaged with Android NDK and can be found under
+    `$ANDROID_NDK_HOME/sources/cxx-stl/llvm-libc++/libs/$TARGET`.
 
-    (Eventually hoping to not have to include this .so, but that needs some more tweaking of the Android automake build rules. Include it in the interim to be able to build the Android app).
+    (Eventually hoping to not have to include this .so, but that needs some more
+    tweaking of the Android automake build rules. Include it in the interim to
+    be able to build the Android app).
 
 11. Before running `gradle sync`, seetup ot-commissioner
 

--- a/src/android/CHIPTool/app/build.gradle
+++ b/src/android/CHIPTool/app/build.gradle
@@ -18,23 +18,6 @@ android {
         // NOTE: This build assumes CHIP was configured and built for armeabi-v7a. Deal with
         // other archs later when build is sane.
         //  ndk {abiFilters 'armeabi-v7a'}
-
-        externalNativeBuild {
-            // For ndk-build, instead use the ndkBuild block.
-            cmake {
-                arguments "-DBUILD_SHARED_LIBS=ON",
-                          "-DOT_COMM_ANDROID=ON",
-                          "-DOT_COMM_JAVA_BINDING=ON",
-                          "-DOT_COMM_APP=OFF",
-                          "-DOT_COMM_CCM=OFF",
-                          "-DOT_COMM_COVERAGE=OFF",
-                          "-DOT_COMM_TEST=OFF",
-                          "-DOT_COMM_JAVA_BINDING_OUTDIR=$projectDir/src/main/java"
-                // Specifies the library and executable targets from your CMake project
-                // that Gradle should build.
-                targets "commissioner-java", "event_core_shared", "event_pthreads_shared"
-            }
-        }
     }
 
     buildTypes {
@@ -54,16 +37,6 @@ android {
             }
         }
     }
-
-    externalNativeBuild {
-        cmake {
-            path "../../../../third_party/ot-commissioner/repo/CMakeLists.txt"
-        }
-    }
-}
-
-project.afterEvaluate {
-    javaPreCompileDebug.dependsOn externalNativeBuildDebug
 }
 
 dependencies {

--- a/src/android/CHIPTool/app/build.gradle
+++ b/src/android/CHIPTool/app/build.gradle
@@ -18,6 +18,23 @@ android {
         // NOTE: This build assumes CHIP was configured and built for armeabi-v7a. Deal with
         // other archs later when build is sane.
         //  ndk {abiFilters 'armeabi-v7a'}
+
+        externalNativeBuild {
+            // For ndk-build, instead use the ndkBuild block.
+            cmake {
+                arguments "-DBUILD_SHARED_LIBS=ON",
+                          "-DOT_COMM_ANDROID=ON",
+                          "-DOT_COMM_JAVA_BINDING=ON",
+                          "-DOT_COMM_APP=OFF",
+                          "-DOT_COMM_CCM=OFF",
+                          "-DOT_COMM_COVERAGE=OFF",
+                          "-DOT_COMM_TEST=OFF",
+                          "-DOT_COMM_JAVA_BINDING_OUTDIR=$projectDir/src/main/java"
+                // Specifies the library and executable targets from your CMake project
+                // that Gradle should build.
+                targets "commissioner-java", "event_core_shared", "event_pthreads_shared"
+            }
+        }
     }
 
     buildTypes {
@@ -37,6 +54,16 @@ android {
             }
         }
     }
+
+    externalNativeBuild {
+        cmake {
+            path "../../../../third_party/ot-commissioner/repo/CMakeLists.txt"
+        }
+    }
+}
+
+project.afterEvaluate {
+    javaPreCompileDebug.dependsOn externalNativeBuildDebug
 }
 
 dependencies {
@@ -45,11 +72,16 @@ dependencies {
     implementation 'androidx.preference:preference:1.1.1'
     implementation "com.google.android.gms:play-services-vision:20.1.0"
     implementation "androidx.annotation:annotation:1.1.0"
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.3.0'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.3.0'
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     implementation "androidx.core:core-ktx:1.3.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "androidx.work:work-runtime:2.3.3"
+    implementation 'com.google.code.gson:gson:2.8.5'
 }
 repositories {
     mavenCentral()

--- a/src/android/CHIPTool/app/src/main/AndroidManifest.xml
+++ b/src/android/CHIPTool/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.google.chip.chiptool">
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -22,6 +23,15 @@
             android:name=".OnOffActivity"
             android:exported="false"
             android:screenOrientation="portrait"/>
+
+        <activity
+            android:name="com.google.chip.chiptool.commissioner.CommissionerActivity"
+            android:label="@string/commissioner_name">
+            <intent-filter>
+                <action android:name="com.google.chip.chiptool.commissioner.COMMISSION" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/src/android/CHIPTool/app/src/main/AndroidManifest.xml
+++ b/src/android/CHIPTool/app/src/main/AndroidManifest.xml
@@ -27,10 +27,6 @@
         <activity
             android:name="com.google.chip.chiptool.commissioner.CommissionerActivity"
             android:label="@string/commissioner_name">
-            <intent-filter>
-                <action android:name="com.google.chip.chiptool.commissioner.COMMISSION" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
     </application>
 

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -17,9 +17,11 @@
  */
 package com.google.chip.chiptool
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import com.google.chip.chiptool.commissioner.CommissionerActivity
 import com.google.chip.chiptool.echoclient.EchoClientFragment
 import com.google.chip.chiptool.clusterclient.OnOffClientFragment
 import com.google.chip.chiptool.setuppayloadscanner.BarcodeFragment
@@ -52,6 +54,12 @@ class CHIPToolActivity :
     showFragment(BarcodeFragment.newInstance())
   }
 
+  override fun handleCommissioningClicked() {
+    var intent = Intent(ACTION_COMMISSIONING)
+    intent.setClass(this, CommissionerActivity::class.java)
+    startActivityForResult(intent, REQUEST_CODE_COMMISSIONING)
+  }
+
   override fun handleEchoClientClicked() {
     showFragment(EchoClientFragment.newInstance())
   }
@@ -60,11 +68,25 @@ class CHIPToolActivity :
     showFragment(OnOffClientFragment.newInstance())
   }
 
+  override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+    super.onActivityResult(requestCode, resultCode, data)
+
+    // Simply ignore the commissioning result.
+
+    // TODO: tracking commissioned devices.
+  }
+
   private fun showFragment(fragment: Fragment) {
     supportFragmentManager
         .beginTransaction()
         .replace(R.id.fragment_container, fragment, fragment.javaClass.simpleName)
         .addToBackStack(null)
         .commit()
+  }
+
+  companion object{
+
+    val ACTION_COMMISSIONING = "com.google.chip.chiptool.commissioner.COMMISSION"
+    var REQUEST_CODE_COMMISSIONING = 0xB003
   }
 }

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -83,7 +83,7 @@ class CHIPToolActivity :
         .commit()
   }
 
-  companion object{
+  companion object {
     var REQUEST_CODE_COMMISSIONING = 0xB003
   }
 }

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -55,8 +55,7 @@ class CHIPToolActivity :
   }
 
   override fun handleCommissioningClicked() {
-    var intent = Intent(ACTION_COMMISSIONING)
-    intent.setClass(this, CommissionerActivity::class.java)
+    var intent = Intent(this, CommissionerActivity::class.java)
     startActivityForResult(intent, REQUEST_CODE_COMMISSIONING)
   }
 
@@ -85,8 +84,6 @@ class CHIPToolActivity :
   }
 
   companion object{
-
-    val ACTION_COMMISSIONING = "com.google.chip.chiptool.commissioner.COMMISSION"
     var REQUEST_CODE_COMMISSIONING = 0xB003
   }
 }

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/SelectActionFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/SelectActionFragment.kt
@@ -35,6 +35,7 @@ class SelectActionFragment : Fragment() {
   ): View {
     return inflater.inflate(R.layout.select_action_fragment, container, false).apply {
       scanQrBtn.setOnClickListener { getCallback()?.handleScanQrCodeClicked() }
+      commissioningBtn.setOnClickListener { getCallback()?.handleCommissioningClicked() }
       echoClientBtn.setOnClickListener { getCallback()?.handleEchoClientClicked() }
       onOffClusterBtn.setOnClickListener { getCallback()?.handleOnOffClicked() }
     }
@@ -46,6 +47,8 @@ class SelectActionFragment : Fragment() {
   interface Callback {
     /** Notifies listener of Scan QR code button click. */
     fun handleScanQrCodeClicked()
+    /** Notifies listener of Commissioning button click. */
+    fun handleCommissioningClicked()
     /** Notifies listener of Echo client button click. */
     fun handleEchoClientClicked()
     /** Notifies listener of send command button click. */

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/BorderAgentDiscoverer.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/BorderAgentDiscoverer.java
@@ -1,0 +1,143 @@
+/*
+ *   Copyright (c) 2020 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package com.google.chip.chiptool.commissioner;
+
+import android.Manifest;
+import android.Manifest.permission;
+import android.content.Context;
+import android.net.nsd.NsdManager;
+import android.net.nsd.NsdServiceInfo;
+import android.net.wifi.WifiManager;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+import androidx.annotation.RequiresPermission;
+import java.util.Map;
+
+public class BorderAgentDiscoverer implements NsdManager.DiscoveryListener  {
+
+  private static final String TAG = BorderAgentDiscoverer.class.getSimpleName();
+
+  private static final String SERVICE_TYPE = "_meshcop._udp";
+  private static final String KEY_DISCRIMINATOR = "discriminator";
+  private static final String KEY_NETWORK_NAME = "nn";
+  private static final String KEY_EXTENDED_PAN_ID = "xp";
+
+  private static final byte[] PSKC = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+
+  private WifiManager.MulticastLock wifiMulticastLock;
+  private NsdManager nsdManager;
+  private NetworkAdapter networkAdapter;
+
+  @RequiresPermission(permission.INTERNET)
+  public BorderAgentDiscoverer(Context context, NetworkAdapter networkAdapter) {
+    WifiManager wifi = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
+    wifiMulticastLock = wifi.createMulticastLock("multicastLock");
+
+    nsdManager = (NsdManager)context.getSystemService(Context.NSD_SERVICE);
+
+    this.networkAdapter = networkAdapter;
+  }
+
+  public void start() {
+    wifiMulticastLock.setReferenceCounted(true);
+    wifiMulticastLock.acquire();
+
+    nsdManager.discoverServices(BorderAgentDiscoverer.SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, this);
+  }
+
+  public void stop() {
+    nsdManager.stopServiceDiscovery(this);
+
+    if (wifiMulticastLock != null) {
+      wifiMulticastLock.release();
+      wifiMulticastLock = null;
+    }
+  }
+
+  @Override
+  public void onDiscoveryStarted(String serviceType) {
+    Log.d(TAG, "start discovering Border Agent");
+  }
+
+  @Override
+  public void onDiscoveryStopped(String serviceType) {
+    Log.d(TAG, "stop discovering Border Agent");
+  }
+
+  @Override
+  public void onServiceFound(NsdServiceInfo nsdServiceInfo) {
+    Log.d(TAG, "a Border Agent service found");
+
+    nsdManager.resolveService(nsdServiceInfo, new NsdManager.ResolveListener() {
+      @Override
+      public void onResolveFailed(NsdServiceInfo serviceInfo, int errorCode) {
+        Log.e(TAG, String.format("failed to resolve service %s, error: %d", serviceInfo.toString(), errorCode));
+      }
+
+      @Override
+      public void onServiceResolved(NsdServiceInfo serviceInfo) {
+        Log.d(TAG, "successfully resolved service " + serviceInfo.toString());
+
+        Map<String, byte[]> attrs = serviceInfo.getAttributes();
+
+        String discriminator = "CC11BB22";
+
+        try {
+          if (attrs.containsKey(KEY_DISCRIMINATOR)) {
+            discriminator = new String(attrs.get(KEY_DISCRIMINATOR));
+          }
+          final BorderAgentInfo borderAgent = new BorderAgentInfo(
+                  discriminator,
+                  new String(attrs.get(KEY_NETWORK_NAME)),
+                  attrs.get(KEY_EXTENDED_PAN_ID),
+                  serviceInfo.getHost(),
+                  serviceInfo.getPort(),
+                  PSKC);
+
+          Handler handler = new Handler(Looper.getMainLooper());
+          handler.post(new Runnable() {
+            @RequiresPermission(Manifest.permission.CAMERA)
+            @Override
+            public void run () {
+              networkAdapter.addNetwork(new NetworkInfo(borderAgent));
+            }
+          });
+        } catch (Exception e) {
+          Log.e(TAG, "invalid Border Agent service: " + e.toString());
+        }
+      }
+    });
+  }
+
+  @Override
+  public void onServiceLost(NsdServiceInfo nsdServiceInfo) {
+    Log.d(TAG, "a Border Agent service is gone");
+  }
+
+  @Override
+  public void onStartDiscoveryFailed(String serviceType, int errorCode) {
+    Log.d(TAG, "start discovering Border Agent failed: " + errorCode);
+  }
+
+  @Override
+  public void onStopDiscoveryFailed(String serviceType, int errorCode) {
+    Log.d(TAG, "stop discovering Border Agent failed: " + errorCode);
+  }
+}

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/BorderAgentInfo.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/BorderAgentInfo.java
@@ -1,0 +1,82 @@
+/*
+ *   Copyright (c) 2020 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package com.google.chip.chiptool.commissioner;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import androidx.annotation.NonNull;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+public class BorderAgentInfo implements Parcelable {
+    public String discriminator;
+    public String networkName;
+    public byte[] extendedPanId;
+    public InetAddress host;
+    public int port;
+    public byte[] pskc;
+
+    public BorderAgentInfo(@NonNull String discriminator, @NonNull String networkName, @NonNull byte[] extendedPanId, @NonNull InetAddress host, @NonNull int port, @NonNull byte[] pskc) {
+        this.discriminator = discriminator;
+        this.networkName = networkName;
+        this.extendedPanId = extendedPanId;
+        this.host = host;
+        this.port = port;
+        this.pskc = pskc;
+    }
+
+    protected BorderAgentInfo(Parcel in) {
+        discriminator = in.readString();
+        networkName = in.readString();
+        extendedPanId = in.createByteArray();
+        try {
+            host = InetAddress.getByAddress(in.createByteArray());
+        } catch (UnknownHostException e) {
+        }
+        port = in.readInt();
+        pskc = in.createByteArray();
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(discriminator);
+        dest.writeString(networkName);
+        dest.writeByteArray(extendedPanId);
+        dest.writeByteArray(host.getAddress());
+        dest.writeInt(port);
+        dest.writeByteArray(pskc);
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public static final Creator<BorderAgentInfo> CREATOR = new Creator<BorderAgentInfo>() {
+        @Override
+        public BorderAgentInfo createFromParcel(Parcel in) {
+            return new BorderAgentInfo(in);
+        }
+
+        @Override
+        public BorderAgentInfo[] newArray(int size) {
+            return new BorderAgentInfo[size];
+        }
+    };
+}

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/BorderAgentInfo.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/BorderAgentInfo.java
@@ -25,58 +25,65 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 
 public class BorderAgentInfo implements Parcelable {
-    public String discriminator;
-    public String networkName;
-    public byte[] extendedPanId;
-    public InetAddress host;
-    public int port;
-    public byte[] pskc;
+  public String discriminator;
+  public String networkName;
+  public byte[] extendedPanId;
+  public InetAddress host;
+  public int port;
+  public byte[] pskc;
 
-    public BorderAgentInfo(@NonNull String discriminator, @NonNull String networkName, @NonNull byte[] extendedPanId, @NonNull InetAddress host, @NonNull int port, @NonNull byte[] pskc) {
-        this.discriminator = discriminator;
-        this.networkName = networkName;
-        this.extendedPanId = extendedPanId;
-        this.host = host;
-        this.port = port;
-        this.pskc = pskc;
+  public BorderAgentInfo(
+      @NonNull String discriminator,
+      @NonNull String networkName,
+      @NonNull byte[] extendedPanId,
+      @NonNull InetAddress host,
+      @NonNull int port,
+      @NonNull byte[] pskc) {
+    this.discriminator = discriminator;
+    this.networkName = networkName;
+    this.extendedPanId = extendedPanId;
+    this.host = host;
+    this.port = port;
+    this.pskc = pskc;
+  }
+
+  protected BorderAgentInfo(Parcel in) {
+    discriminator = in.readString();
+    networkName = in.readString();
+    extendedPanId = in.createByteArray();
+    try {
+      host = InetAddress.getByAddress(in.createByteArray());
+    } catch (UnknownHostException e) {
     }
+    port = in.readInt();
+    pskc = in.createByteArray();
+  }
 
-    protected BorderAgentInfo(Parcel in) {
-        discriminator = in.readString();
-        networkName = in.readString();
-        extendedPanId = in.createByteArray();
-        try {
-            host = InetAddress.getByAddress(in.createByteArray());
-        } catch (UnknownHostException e) {
-        }
-        port = in.readInt();
-        pskc = in.createByteArray();
-    }
+  @Override
+  public void writeToParcel(Parcel dest, int flags) {
+    dest.writeString(discriminator);
+    dest.writeString(networkName);
+    dest.writeByteArray(extendedPanId);
+    dest.writeByteArray(host.getAddress());
+    dest.writeInt(port);
+    dest.writeByteArray(pskc);
+  }
 
-    @Override
-    public void writeToParcel(Parcel dest, int flags) {
-        dest.writeString(discriminator);
-        dest.writeString(networkName);
-        dest.writeByteArray(extendedPanId);
-        dest.writeByteArray(host.getAddress());
-        dest.writeInt(port);
-        dest.writeByteArray(pskc);
-    }
+  @Override
+  public int describeContents() {
+    return 0;
+  }
 
-    @Override
-    public int describeContents() {
-        return 0;
-    }
-
-    public static final Creator<BorderAgentInfo> CREATOR = new Creator<BorderAgentInfo>() {
+  public static final Creator<BorderAgentInfo> CREATOR =
+      new Creator<BorderAgentInfo>() {
         @Override
         public BorderAgentInfo createFromParcel(Parcel in) {
-            return new BorderAgentInfo(in);
+          return new BorderAgentInfo(in);
         }
 
         @Override
         public BorderAgentInfo[] newArray(int size) {
-            return new BorderAgentInfo[size];
+          return new BorderAgentInfo[size];
         }
-    };
+      };
 }

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/CommissionerActivity.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/CommissionerActivity.java
@@ -1,0 +1,56 @@
+/*
+ *   Copyright (c) 2020 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package com.google.chip.chiptool.commissioner;
+
+import android.content.Intent;
+import android.os.Bundle;
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.navigation.NavController;
+import androidx.navigation.Navigation;
+import androidx.navigation.fragment.NavHostFragment;
+import com.google.chip.chiptool.CHIPToolActivity;
+import com.google.chip.chiptool.R;
+import com.google.chip.chiptool.setuppayloadscanner.BarcodeFragment;
+import com.google.chip.chiptool.setuppayloadscanner.CHIPDeviceInfo;
+
+public class CommissionerActivity extends AppCompatActivity implements BarcodeFragment.Callback {
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.commissioner_activity);
+  }
+
+  public void onCHIPDeviceInfoReceived(@NonNull CHIPDeviceInfo deviceInfo) {
+    NavController controller = Navigation.findNavController(this, R.id.nav_host_fragment);
+
+    if (controller.getCurrentDestination().getId() == R.id.commissioner_scan_qr_code_fragment) {
+      Bundle bundle = new Bundle();
+      bundle.putParcelable(Constants.KEY_DEVICE_INFO, deviceInfo);
+      controller.navigate(R.id.action_scan_qr_code_to_select_network, bundle);
+    }
+  }
+
+  public void finishCommissioning(int resultCode) {
+    Intent resultIntent = new Intent();
+    setResult(resultCode, resultIntent);
+    finish();
+  }
+}

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/CommissionerActivity.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/CommissionerActivity.java
@@ -24,8 +24,6 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.navigation.NavController;
 import androidx.navigation.Navigation;
-import androidx.navigation.fragment.NavHostFragment;
-import com.google.chip.chiptool.CHIPToolActivity;
 import com.google.chip.chiptool.R;
 import com.google.chip.chiptool.setuppayloadscanner.BarcodeFragment;
 import com.google.chip.chiptool.setuppayloadscanner.CHIPDeviceInfo;

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/CommissionerWorker.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/CommissionerWorker.java
@@ -1,0 +1,241 @@
+/*
+ *   Copyright (c) 2020 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package com.google.chip.chiptool.commissioner;
+
+import android.content.Context;
+import android.util.Log;
+import androidx.annotation.NonNull;
+import androidx.work.Data;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+
+import com.google.chip.chiptool.setuppayloadscanner.CHIPDeviceInfo;
+
+import com.google.gson.Gson;
+import io.openthread.commissioner.Commissioner;
+import io.openthread.commissioner.CommissionerDataset;
+import io.openthread.commissioner.Config;
+import io.openthread.commissioner.Error;
+import io.openthread.commissioner.ByteArray;
+import io.openthread.commissioner.ChannelMask;
+import io.openthread.commissioner.CommissionerHandler;
+import io.openthread.commissioner.ErrorCode;
+import io.openthread.commissioner.Logger;
+import io.openthread.commissioner.LogLevel;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+class NativeCommissionerLogger extends Logger {
+    private static final String TAG = "NativeCommissioner";
+
+    @Override
+    public void log(LogLevel level, String region, String msg) {
+        Log.d(TAG, String.format("[ %s ]: %s", region, msg));
+    }
+}
+
+class NativeCommissionerHandler extends CommissionerHandler {
+    private static final String TAG = "NativeCommissioner";
+
+    private CommissionerWorker commissionerWorker;
+
+    NativeCommissionerHandler(CommissionerWorker commissionerWorker) {
+        this.commissionerWorker = commissionerWorker;
+    }
+
+    @Override
+    public String onJoinerRequest(ByteArray joinerId) {
+        Log.d(TAG, "A joiner is requesting commissioning");
+        return commissionerWorker.getPskd();
+    }
+
+    @Override
+    public void onJoinerConnected(ByteArray joinerId, Error error) {
+        Log.d(TAG, "A joiner is connected");
+    }
+
+    @Override
+    public boolean onJoinerFinalize(ByteArray joinerId, String vendorName, String vendorModel, String vendorSwVersion, ByteArray vendorStackVersion, String provisioningUrl, ByteArray vendorData) {
+        Log.d(TAG, "A joiner is finalizing");
+        commissionerWorker.onJoinerFinalize(joinerId);
+        return true;
+    }
+
+    @Override
+    public void onKeepAliveResponse(Error error) {
+        Log.d(TAG, "received keep-alive response: " + error.toString());
+    }
+
+    @Override
+    public void onPanIdConflict(String peerAddr, ChannelMask channelMask, int panId) {
+        Log.d(TAG, "received PAN ID CONFLICT report");
+    }
+
+    @Override
+    public void onEnergyReport(String aPeerAddr, ChannelMask aChannelMask, ByteArray aEnergyList) {
+        Log.d(TAG, "received ENERGY SCAN report");
+    }
+
+    @Override
+    public void onDatasetChanged() {
+        Log.d(TAG, "Thread Network Dataset chanaged");
+    }
+}
+
+public class CommissionerWorker extends Worker {
+
+    private static final String TAG = CommissionerWorker.class.getSimpleName();
+
+    private CHIPDeviceInfo deviceInfo;
+    private NetworkInfo networkInfo;
+
+    private AtomicBoolean curJoinerCommissioned = new AtomicBoolean(false);
+
+    private static Commissioner nativeCommissioner;
+
+    public CommissionerWorker(@NonNull Context context, @NonNull WorkerParameters workerParams) {
+        super(context, workerParams);
+
+        deviceInfo = new Gson().fromJson(getInputData().getString(Constants.KEY_DEVICE_INFO), CHIPDeviceInfo.class);
+        networkInfo = new Gson().fromJson(getInputData().getString(Constants.KEY_DEVICE_INFO), NetworkInfo.class);
+
+        nativeCommissioner = Commissioner.create(new NativeCommissionerHandler(this));
+
+        ByteArray pskc = new ByteArray(new short[]{0x3a, 0xa5, 0x5f, 0x91, 0xca, 0x47, 0xd1, 0xe4, 0xe7, 0x1a, 0x08, 0xcb, 0x35, 0xe9, 0x15, 0x91});
+        Config config = new Config();
+        config.setId("TestComm");
+        config.setDomainName("TestDomain");
+        config.setEnableCcm(false);
+        config.setPSKc(pskc);
+        config.setLogger(new NativeCommissionerLogger());
+
+        nativeCommissioner.init(config);
+    }
+
+    String getPskd() {
+        final int pskdLength = 27 / 5 + 1;
+        StringBuilder str = new StringBuilder();
+
+        for (int i = 0; i < pskdLength; ++i) {
+            str.append("0123456789ABCDEFGHJKLMNPRSTUVWXY".charAt(((int)deviceInfo.getSetupPinCode() >> (i * 5)) & ((1 << 5) - 1)));
+        }
+
+        return str.toString();
+    }
+
+    private ByteArray getJoinerId() {
+        int productId = deviceInfo.getProductId();
+        return new ByteArray(new short[] {0x00, 0x00, 0x00, 0x00,
+            (short)(productId >> 24),
+            (short)(productId >> 16),
+            (short)(productId >> 8),
+            (short)(productId & 0xff)
+            });
+    }
+
+    @NonNull
+    @Override
+    public Result doWork() {
+        setProgressAsync(StateToData("commissioning..."));
+
+        if (nativeCommissioner != null) {
+            nativeCommissioner.resign();
+        }
+
+        //Error error = nativeCommissioner.init(config);
+        //if (error.getCode() != ErrorCode.kNone) {
+        //    return errorToResult(error);
+        //}
+
+        String[] existingCommissionerId = new String[1];
+        Error error = nativeCommissioner.petition(existingCommissionerId, networkInfo.getHost().getHostAddress(), networkInfo.getPort());
+        if (error.getCode() != ErrorCode.kNone) {
+            return errorToResult(error);
+        }
+
+        setProgressAsync(StateToData("commissioner connected"));
+
+        curJoinerCommissioned.set(false);
+
+        ByteArray steeringData = new ByteArray(new short[] {0xFF});
+        //Commissioner.addJoiner(steeringData, getJoinerId());
+        CommissionerDataset commDataset = new CommissionerDataset();
+        commDataset.setSteeringData(steeringData);
+        commDataset.setPresentFlags(commDataset.getPresentFlags() | CommissionerDataset.kSteeringDataBit);
+
+        error = nativeCommissioner.setCommissionerDataset(commDataset);
+        if (error.getCode() != ErrorCode.kNone) {
+            nativeCommissioner.resign();
+            return errorToResult(error);
+        }
+
+        setProgressAsync(StateToData("waiting for new device...\nPSKD: " + getPskd()));
+
+        // Wait 200 seconds for a joiner.
+        for (int i = 0; i < 200; ++i) {
+            if (curJoinerCommissioned.get()) {
+                break;
+            }
+
+            try {
+                TimeUnit.SECONDS.sleep(1);
+            } catch (InterruptedException e) {
+                Log.d(TAG, "interrupted exception");
+            }
+        }
+
+        if (!curJoinerCommissioned.get()) {
+            nativeCommissioner.resign();
+            return errorToResult(new Error(ErrorCode.kTimeout, "No joiner is pairing"));
+        }
+
+        nativeCommissioner.resign();
+
+        return errorToResult(new Error(ErrorCode.kNone, ""));
+    }
+
+    @Override
+    public void onStopped() {
+        if (nativeCommissioner != null) {
+            nativeCommissioner.resign();
+        }
+    }
+
+    private Result errorToResult(Error error) {
+        Data.Builder dataBuilder = new Data.Builder();
+
+        if (error.getCode() == ErrorCode.kNone) {
+            dataBuilder.putString(Constants.KEY_COMMISSIONING_STATUS, "commission device success!");
+            dataBuilder.putBoolean(Constants.KEY_SUCCESS, true);
+            return Result.success(dataBuilder.build());
+        } else {
+            dataBuilder.putString(Constants.KEY_COMMISSIONING_STATUS, error.toString());
+            dataBuilder.putBoolean(Constants.KEY_SUCCESS, false);
+            return Result.failure(StateToData(error.toString()));
+        }
+    }
+
+    private Data StateToData(String state) {
+        return new Data.Builder().putString(Constants.KEY_COMMISSIONING_STATUS, state).build();
+    }
+
+    public void onJoinerFinalize(ByteArray joinerId) {
+        curJoinerCommissioned.set(true);
+    }
+}

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/CommissionerWorker.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/CommissionerWorker.java
@@ -121,7 +121,8 @@ public class CommissionerWorker extends Worker {
         new Gson()
             .fromJson(getInputData().getString(Constants.KEY_DEVICE_INFO), CHIPDeviceInfo.class);
     networkInfo =
-        new Gson().fromJson(getInputData().getString(Constants.KEY_NETWORK_INFO), NetworkInfo.class);
+        new Gson()
+            .fromJson(getInputData().getString(Constants.KEY_NETWORK_INFO), NetworkInfo.class);
 
     nativeCommissioner = Commissioner.create(new NativeCommissionerHandler(this));
 

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/CommissionerWorker.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/CommissionerWorker.java
@@ -24,218 +24,241 @@ import androidx.annotation.NonNull;
 import androidx.work.Data;
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
-
 import com.google.chip.chiptool.setuppayloadscanner.CHIPDeviceInfo;
-
 import com.google.gson.Gson;
-import io.openthread.commissioner.Commissioner;
-import io.openthread.commissioner.CommissionerDataset;
-import io.openthread.commissioner.Config;
-import io.openthread.commissioner.Error;
 import io.openthread.commissioner.ByteArray;
 import io.openthread.commissioner.ChannelMask;
+import io.openthread.commissioner.Commissioner;
+import io.openthread.commissioner.CommissionerDataset;
 import io.openthread.commissioner.CommissionerHandler;
+import io.openthread.commissioner.Config;
+import io.openthread.commissioner.Error;
 import io.openthread.commissioner.ErrorCode;
-import io.openthread.commissioner.Logger;
 import io.openthread.commissioner.LogLevel;
+import io.openthread.commissioner.Logger;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 class NativeCommissionerLogger extends Logger {
-    private static final String TAG = "NativeCommissioner";
+  private static final String TAG = "NativeCommissioner";
 
-    @Override
-    public void log(LogLevel level, String region, String msg) {
-        Log.d(TAG, String.format("[ %s ]: %s", region, msg));
-    }
+  @Override
+  public void log(LogLevel level, String region, String msg) {
+    Log.d(TAG, String.format("[ %s ]: %s", region, msg));
+  }
 }
 
 class NativeCommissionerHandler extends CommissionerHandler {
-    private static final String TAG = "NativeCommissioner";
+  private static final String TAG = "NativeCommissioner";
 
-    private CommissionerWorker commissionerWorker;
+  private CommissionerWorker commissionerWorker;
 
-    NativeCommissionerHandler(CommissionerWorker commissionerWorker) {
-        this.commissionerWorker = commissionerWorker;
-    }
+  NativeCommissionerHandler(CommissionerWorker commissionerWorker) {
+    this.commissionerWorker = commissionerWorker;
+  }
 
-    @Override
-    public String onJoinerRequest(ByteArray joinerId) {
-        Log.d(TAG, "A joiner is requesting commissioning");
-        return commissionerWorker.getPskd();
-    }
+  @Override
+  public String onJoinerRequest(ByteArray joinerId) {
+    Log.d(TAG, "A joiner is requesting commissioning");
+    return commissionerWorker.getPskd();
+  }
 
-    @Override
-    public void onJoinerConnected(ByteArray joinerId, Error error) {
-        Log.d(TAG, "A joiner is connected");
-    }
+  @Override
+  public void onJoinerConnected(ByteArray joinerId, Error error) {
+    Log.d(TAG, "A joiner is connected");
+  }
 
-    @Override
-    public boolean onJoinerFinalize(ByteArray joinerId, String vendorName, String vendorModel, String vendorSwVersion, ByteArray vendorStackVersion, String provisioningUrl, ByteArray vendorData) {
-        Log.d(TAG, "A joiner is finalizing");
-        commissionerWorker.onJoinerFinalize(joinerId);
-        return true;
-    }
+  @Override
+  public boolean onJoinerFinalize(
+      ByteArray joinerId,
+      String vendorName,
+      String vendorModel,
+      String vendorSwVersion,
+      ByteArray vendorStackVersion,
+      String provisioningUrl,
+      ByteArray vendorData) {
+    Log.d(TAG, "A joiner is finalizing");
+    commissionerWorker.onJoinerFinalize(joinerId);
+    return true;
+  }
 
-    @Override
-    public void onKeepAliveResponse(Error error) {
-        Log.d(TAG, "received keep-alive response: " + error.toString());
-    }
+  @Override
+  public void onKeepAliveResponse(Error error) {
+    Log.d(TAG, "received keep-alive response: " + error.toString());
+  }
 
-    @Override
-    public void onPanIdConflict(String peerAddr, ChannelMask channelMask, int panId) {
-        Log.d(TAG, "received PAN ID CONFLICT report");
-    }
+  @Override
+  public void onPanIdConflict(String peerAddr, ChannelMask channelMask, int panId) {
+    Log.d(TAG, "received PAN ID CONFLICT report");
+  }
 
-    @Override
-    public void onEnergyReport(String aPeerAddr, ChannelMask aChannelMask, ByteArray aEnergyList) {
-        Log.d(TAG, "received ENERGY SCAN report");
-    }
+  @Override
+  public void onEnergyReport(String aPeerAddr, ChannelMask aChannelMask, ByteArray aEnergyList) {
+    Log.d(TAG, "received ENERGY SCAN report");
+  }
 
-    @Override
-    public void onDatasetChanged() {
-        Log.d(TAG, "Thread Network Dataset chanaged");
-    }
+  @Override
+  public void onDatasetChanged() {
+    Log.d(TAG, "Thread Network Dataset chanaged");
+  }
 }
 
 public class CommissionerWorker extends Worker {
 
-    private static final String TAG = CommissionerWorker.class.getSimpleName();
+  private static final String TAG = CommissionerWorker.class.getSimpleName();
 
-    private CHIPDeviceInfo deviceInfo;
-    private NetworkInfo networkInfo;
+  private CHIPDeviceInfo deviceInfo;
+  private NetworkInfo networkInfo;
 
-    private AtomicBoolean curJoinerCommissioned = new AtomicBoolean(false);
+  private AtomicBoolean curJoinerCommissioned = new AtomicBoolean(false);
 
-    private static Commissioner nativeCommissioner;
+  private static Commissioner nativeCommissioner;
 
-    public CommissionerWorker(@NonNull Context context, @NonNull WorkerParameters workerParams) {
-        super(context, workerParams);
+  public CommissionerWorker(@NonNull Context context, @NonNull WorkerParameters workerParams) {
+    super(context, workerParams);
 
-        deviceInfo = new Gson().fromJson(getInputData().getString(Constants.KEY_DEVICE_INFO), CHIPDeviceInfo.class);
-        networkInfo = new Gson().fromJson(getInputData().getString(Constants.KEY_DEVICE_INFO), NetworkInfo.class);
+    deviceInfo =
+        new Gson()
+            .fromJson(getInputData().getString(Constants.KEY_DEVICE_INFO), CHIPDeviceInfo.class);
+    networkInfo =
+        new Gson().fromJson(getInputData().getString(Constants.KEY_DEVICE_INFO), NetworkInfo.class);
 
-        nativeCommissioner = Commissioner.create(new NativeCommissionerHandler(this));
+    nativeCommissioner = Commissioner.create(new NativeCommissionerHandler(this));
 
-        ByteArray pskc = new ByteArray(new short[]{0x3a, 0xa5, 0x5f, 0x91, 0xca, 0x47, 0xd1, 0xe4, 0xe7, 0x1a, 0x08, 0xcb, 0x35, 0xe9, 0x15, 0x91});
-        Config config = new Config();
-        config.setId("TestComm");
-        config.setDomainName("TestDomain");
-        config.setEnableCcm(false);
-        config.setPSKc(pskc);
-        config.setLogger(new NativeCommissionerLogger());
-
-        nativeCommissioner.init(config);
-    }
-
-    String getPskd() {
-        final int pskdLength = 27 / 5 + 1;
-        StringBuilder str = new StringBuilder();
-
-        for (int i = 0; i < pskdLength; ++i) {
-            str.append("0123456789ABCDEFGHJKLMNPRSTUVWXY".charAt(((int)deviceInfo.getSetupPinCode() >> (i * 5)) & ((1 << 5) - 1)));
-        }
-
-        return str.toString();
-    }
-
-    private ByteArray getJoinerId() {
-        int productId = deviceInfo.getProductId();
-        return new ByteArray(new short[] {0x00, 0x00, 0x00, 0x00,
-            (short)(productId >> 24),
-            (short)(productId >> 16),
-            (short)(productId >> 8),
-            (short)(productId & 0xff)
+    ByteArray pskc =
+        new ByteArray(
+            new short[] {
+              0x3a, 0xa5, 0x5f, 0x91, 0xca, 0x47, 0xd1, 0xe4, 0xe7, 0x1a, 0x08, 0xcb, 0x35, 0xe9,
+              0x15, 0x91
             });
+    Config config = new Config();
+    config.setId("TestComm");
+    config.setDomainName("TestDomain");
+    config.setEnableCcm(false);
+    config.setPSKc(pskc);
+    config.setLogger(new NativeCommissionerLogger());
+
+    nativeCommissioner.init(config);
+  }
+
+  String getPskd() {
+    final int pskdLength = 27 / 5 + 1;
+    StringBuilder str = new StringBuilder();
+
+    for (int i = 0; i < pskdLength; ++i) {
+      str.append(
+          "0123456789ABCDEFGHJKLMNPRSTUVWXY"
+              .charAt(((int) deviceInfo.getSetupPinCode() >> (i * 5)) & ((1 << 5) - 1)));
     }
 
-    @NonNull
-    @Override
-    public Result doWork() {
-        setProgressAsync(StateToData("commissioning..."));
+    return str.toString();
+  }
 
-        if (nativeCommissioner != null) {
-            nativeCommissioner.resign();
-        }
+  private ByteArray getJoinerId() {
+    int productId = deviceInfo.getProductId();
+    return new ByteArray(
+        new short[] {
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          (short) (productId >> 24),
+          (short) (productId >> 16),
+          (short) (productId >> 8),
+          (short) (productId & 0xff)
+        });
+  }
 
-        //Error error = nativeCommissioner.init(config);
-        //if (error.getCode() != ErrorCode.kNone) {
-        //    return errorToResult(error);
-        //}
+  @NonNull
+  @Override
+  public Result doWork() {
+    setProgressAsync(StateToData("commissioning..."));
 
-        String[] existingCommissionerId = new String[1];
-        Error error = nativeCommissioner.petition(existingCommissionerId, networkInfo.getHost().getHostAddress(), networkInfo.getPort());
-        if (error.getCode() != ErrorCode.kNone) {
-            return errorToResult(error);
-        }
-
-        setProgressAsync(StateToData("commissioner connected"));
-
-        curJoinerCommissioned.set(false);
-
-        ByteArray steeringData = new ByteArray(new short[] {0xFF});
-        //Commissioner.addJoiner(steeringData, getJoinerId());
-        CommissionerDataset commDataset = new CommissionerDataset();
-        commDataset.setSteeringData(steeringData);
-        commDataset.setPresentFlags(commDataset.getPresentFlags() | CommissionerDataset.kSteeringDataBit);
-
-        error = nativeCommissioner.setCommissionerDataset(commDataset);
-        if (error.getCode() != ErrorCode.kNone) {
-            nativeCommissioner.resign();
-            return errorToResult(error);
-        }
-
-        setProgressAsync(StateToData("waiting for new device...\nPSKD: " + getPskd()));
-
-        // Wait 200 seconds for a joiner.
-        for (int i = 0; i < 200; ++i) {
-            if (curJoinerCommissioned.get()) {
-                break;
-            }
-
-            try {
-                TimeUnit.SECONDS.sleep(1);
-            } catch (InterruptedException e) {
-                Log.d(TAG, "interrupted exception");
-            }
-        }
-
-        if (!curJoinerCommissioned.get()) {
-            nativeCommissioner.resign();
-            return errorToResult(new Error(ErrorCode.kTimeout, "No joiner is pairing"));
-        }
-
-        nativeCommissioner.resign();
-
-        return errorToResult(new Error(ErrorCode.kNone, ""));
+    if (nativeCommissioner != null) {
+      nativeCommissioner.resign();
     }
 
-    @Override
-    public void onStopped() {
-        if (nativeCommissioner != null) {
-            nativeCommissioner.resign();
-        }
+    // Error error = nativeCommissioner.init(config);
+    // if (error.getCode() != ErrorCode.kNone) {
+    //    return errorToResult(error);
+    // }
+
+    String[] existingCommissionerId = new String[1];
+    Error error =
+        nativeCommissioner.petition(
+            existingCommissionerId, networkInfo.getHost().getHostAddress(), networkInfo.getPort());
+    if (error.getCode() != ErrorCode.kNone) {
+      return errorToResult(error);
     }
 
-    private Result errorToResult(Error error) {
-        Data.Builder dataBuilder = new Data.Builder();
+    setProgressAsync(StateToData("commissioner connected"));
 
-        if (error.getCode() == ErrorCode.kNone) {
-            dataBuilder.putString(Constants.KEY_COMMISSIONING_STATUS, "commission device success!");
-            dataBuilder.putBoolean(Constants.KEY_SUCCESS, true);
-            return Result.success(dataBuilder.build());
-        } else {
-            dataBuilder.putString(Constants.KEY_COMMISSIONING_STATUS, error.toString());
-            dataBuilder.putBoolean(Constants.KEY_SUCCESS, false);
-            return Result.failure(StateToData(error.toString()));
-        }
+    curJoinerCommissioned.set(false);
+
+    ByteArray steeringData = new ByteArray(new short[] {0xFF});
+    // Commissioner.addJoiner(steeringData, getJoinerId());
+    CommissionerDataset commDataset = new CommissionerDataset();
+    commDataset.setSteeringData(steeringData);
+    commDataset.setPresentFlags(
+        commDataset.getPresentFlags() | CommissionerDataset.kSteeringDataBit);
+
+    error = nativeCommissioner.setCommissionerDataset(commDataset);
+    if (error.getCode() != ErrorCode.kNone) {
+      nativeCommissioner.resign();
+      return errorToResult(error);
     }
 
-    private Data StateToData(String state) {
-        return new Data.Builder().putString(Constants.KEY_COMMISSIONING_STATUS, state).build();
+    setProgressAsync(StateToData("waiting for new device...\nPSKD: " + getPskd()));
+
+    // Wait 200 seconds for a joiner.
+    for (int i = 0; i < 200; ++i) {
+      if (curJoinerCommissioned.get()) {
+        break;
+      }
+
+      try {
+        TimeUnit.SECONDS.sleep(1);
+      } catch (InterruptedException e) {
+        Log.d(TAG, "interrupted exception");
+      }
     }
 
-    public void onJoinerFinalize(ByteArray joinerId) {
-        curJoinerCommissioned.set(true);
+    if (!curJoinerCommissioned.get()) {
+      nativeCommissioner.resign();
+      return errorToResult(new Error(ErrorCode.kTimeout, "No joiner is pairing"));
     }
+
+    nativeCommissioner.resign();
+
+    return errorToResult(new Error(ErrorCode.kNone, ""));
+  }
+
+  @Override
+  public void onStopped() {
+    if (nativeCommissioner != null) {
+      nativeCommissioner.resign();
+    }
+  }
+
+  private Result errorToResult(Error error) {
+    Data.Builder dataBuilder = new Data.Builder();
+
+    if (error.getCode() == ErrorCode.kNone) {
+      dataBuilder.putString(Constants.KEY_COMMISSIONING_STATUS, "commission device success!");
+      dataBuilder.putBoolean(Constants.KEY_SUCCESS, true);
+      return Result.success(dataBuilder.build());
+    } else {
+      dataBuilder.putString(Constants.KEY_COMMISSIONING_STATUS, error.toString());
+      dataBuilder.putBoolean(Constants.KEY_SUCCESS, false);
+      return Result.failure(StateToData(error.toString()));
+    }
+  }
+
+  private Data StateToData(String state) {
+    return new Data.Builder().putString(Constants.KEY_COMMISSIONING_STATUS, state).build();
+  }
+
+  public void onJoinerFinalize(ByteArray joinerId) {
+    curJoinerCommissioned.set(true);
+  }
 }

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/CommissionerWorker.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/CommissionerWorker.java
@@ -121,7 +121,7 @@ public class CommissionerWorker extends Worker {
         new Gson()
             .fromJson(getInputData().getString(Constants.KEY_DEVICE_INFO), CHIPDeviceInfo.class);
     networkInfo =
-        new Gson().fromJson(getInputData().getString(Constants.KEY_DEVICE_INFO), NetworkInfo.class);
+        new Gson().fromJson(getInputData().getString(Constants.KEY_NETWORK_INFO), NetworkInfo.class);
 
     nativeCommissioner = Commissioner.create(new NativeCommissionerHandler(this));
 

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/CommissioningFragment.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/CommissioningFragment.java
@@ -1,0 +1,163 @@
+/*
+ *   Copyright (c) 2020 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package com.google.chip.chiptool.commissioner;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.Observer;
+import androidx.work.Data;
+import androidx.work.OneTimeWorkRequest;
+import androidx.work.WorkInfo;
+import androidx.work.WorkManager;
+import androidx.work.WorkRequest;
+import com.google.chip.chiptool.R;
+import com.google.chip.chiptool.setuppayloadscanner.CHIPDeviceInfo;
+import com.google.gson.Gson;
+
+public class CommissioningFragment extends Fragment implements Observer<WorkInfo> {
+
+  private static final String TAG = CommissioningFragment.class.getSimpleName();
+
+  private CHIPDeviceInfo deviceInfo;
+  private NetworkInfo networkInfo;
+
+  WorkRequest commssionerWorkRequest;
+
+  @Override
+  public View onCreateView(
+      LayoutInflater inflater, ViewGroup container,
+      Bundle savedInstanceState
+  ) {
+    // Inflate the layout for this fragment
+    return inflater.inflate(R.layout.commissioner_commissioning_fragment, container, false);
+  }
+
+  public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
+
+    ProgressBar progressBar = getActivity().findViewById(R.id.commissioning_progress);
+    progressBar.setMin(0);
+    progressBar.setMax(100);
+
+    deviceInfo = getArguments().getParcelable(Constants.KEY_DEVICE_INFO);
+    networkInfo = getArguments().getParcelable(Constants.KEY_NETWORK_INFO);
+
+    Data arguments = new Data.Builder()
+            .putString(Constants.KEY_DEVICE_INFO, new Gson().toJson(deviceInfo))
+            .putString(Constants.KEY_DEVICE_INFO, new Gson().toJson(networkInfo))
+            .build();
+    commssionerWorkRequest = new OneTimeWorkRequest.Builder(CommissionerWorker.class).setInputData(arguments).build();
+
+    WorkManager.getInstance(getActivity()).enqueue(commssionerWorkRequest);
+
+    WorkManager.getInstance(getActivity()).getWorkInfoByIdLiveData(commssionerWorkRequest.getId())
+            .observe(getViewLifecycleOwner(), this);
+
+    view.findViewById(R.id.cancel_button).setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View view) {
+        WorkManager.getInstance(getActivity()).cancelWorkById(commssionerWorkRequest.getId());
+
+        CommissionerActivity commissionerActivity = (CommissionerActivity)getActivity();
+        commissionerActivity.finishCommissioning(Activity.RESULT_CANCELED);
+      }
+    });
+
+    view.findViewById(R.id.done_button).setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View view) {
+        CommissionerActivity commissionerActivity = (CommissionerActivity)getActivity();
+        commissionerActivity.finishCommissioning(Activity.RESULT_OK);
+      }
+    });
+  }
+
+  @Override
+  public void onChanged(@Nullable WorkInfo workInfo) {
+    TextView statusText = getActivity().findViewById(R.id.status_text);
+    ProgressBar progressBar = getActivity().findViewById(R.id.commissioning_progress);
+
+    if (workInfo != null) {
+      if (workInfo.getState().isFinished()) {
+
+        showCommissionDone(workInfo.getOutputData().getBoolean(Constants.KEY_SUCCESS, false), workInfo.getOutputData().getString(Constants.KEY_COMMISSIONING_STATUS));
+      } else {
+        showInProgress(workInfo.getProgress().getString(Constants.KEY_COMMISSIONING_STATUS));
+      }
+    }
+  }
+
+  private void showInProgress(String status) {
+    TextView statusText = getActivity().findViewById(R.id.status_text);
+    if (status != null) {
+      statusText.setText(status);
+    }
+
+    ProgressBar progressBar = getActivity().findViewById(R.id.commissioning_progress);
+    progressBar.setVisibility(View.VISIBLE);
+
+    Button cancelButton = getActivity().findViewById(R.id.cancel_button);
+    cancelButton.setVisibility(View.VISIBLE);
+
+    ImageView doneImage = getActivity().findViewById(R.id.done_image);
+    doneImage.setVisibility(View.GONE);
+
+    ImageView errorImage = getActivity().findViewById(R.id.error_image);
+    errorImage.setVisibility(View.GONE);
+
+    Button doneButton = getActivity().findViewById(R.id.done_button);
+    doneButton.setVisibility(View.GONE);
+  }
+
+  private void showCommissionDone(Boolean success, String status) {
+    TextView statusText = getActivity().findViewById(R.id.status_text);
+    if (status != null) {
+      statusText.setText(status);
+    }
+
+    ProgressBar progressBar = getActivity().findViewById(R.id.commissioning_progress);
+    progressBar.setVisibility(View.GONE);
+
+    Button cancelButton = getActivity().findViewById(R.id.cancel_button);
+    cancelButton.setVisibility(View.GONE);
+
+    if (success) {
+      ImageView doneImage = getActivity().findViewById(R.id.done_image);
+      doneImage.setVisibility(View.VISIBLE);
+    } else {
+      ImageView errorImage = getActivity().findViewById(R.id.error_image);
+      errorImage.setVisibility(View.VISIBLE);
+    }
+
+    Button doneButton = getActivity().findViewById(R.id.done_button);
+    doneButton.setVisibility(View.VISIBLE);
+  }
+}

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/CommissioningFragment.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/CommissioningFragment.java
@@ -66,12 +66,12 @@ public class CommissioningFragment extends Fragment implements Observer<WorkInfo
   public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
 
-    cancelButton = getActivity().findViewById(R.id.cancel_button);
-    doneButton = getActivity().findViewById(R.id.done_button);
-    doneImage = getActivity().findViewById(R.id.done_image);
-    errorImage = getActivity().findViewById(R.id.error_image);
-    statusText = getActivity().findViewById(R.id.status_text);
-    progressBar = getActivity().findViewById(R.id.commissioning_progress);
+    cancelButton = view.findViewById(R.id.cancel_button);
+    doneButton = view.findViewById(R.id.done_button);
+    doneImage = view.findViewById(R.id.done_image);
+    errorImage = view.findViewById(R.id.error_image);
+    statusText = view.findViewById(R.id.status_text);
+    progressBar = view.findViewById(R.id.commissioning_progress);
     progressBar.setMin(0);
     progressBar.setMax(100);
 
@@ -118,8 +118,6 @@ public class CommissioningFragment extends Fragment implements Observer<WorkInfo
 
   @Override
   public void onChanged(@Nullable WorkInfo workInfo) {
-    progressBar = getActivity().findViewById(R.id.commissioning_progress);
-
     if (workInfo != null) {
       if (workInfo.getState().isFinished()) {
 
@@ -133,12 +131,10 @@ public class CommissioningFragment extends Fragment implements Observer<WorkInfo
   }
 
   private void showInProgress(String status) {
-    statusText = getActivity().findViewById(R.id.status_text);
     if (status != null) {
       statusText.setText(status);
     }
 
-    progressBar = getActivity().findViewById(R.id.commissioning_progress);
     progressBar.setVisibility(View.VISIBLE);
 
     cancelButton.setVisibility(View.VISIBLE);

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/CommissioningFragment.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/CommissioningFragment.java
@@ -49,6 +49,13 @@ public class CommissioningFragment extends Fragment implements Observer<WorkInfo
 
   WorkRequest commssionerWorkRequest;
 
+  TextView statusText;
+  ProgressBar progressBar;
+  Button cancelButton;
+  Button doneButton;
+  ImageView doneImage;
+  ImageView errorImage;
+
   @Override
   public View onCreateView(
       LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -59,7 +66,12 @@ public class CommissioningFragment extends Fragment implements Observer<WorkInfo
   public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
 
-    ProgressBar progressBar = getActivity().findViewById(R.id.commissioning_progress);
+    cancelButton = getActivity().findViewById(R.id.cancel_button);
+    doneButton = getActivity().findViewById(R.id.done_button);
+    doneImage = getActivity().findViewById(R.id.done_image);
+    errorImage = getActivity().findViewById(R.id.error_image);
+    statusText = getActivity().findViewById(R.id.status_text);
+    progressBar = getActivity().findViewById(R.id.commissioning_progress);
     progressBar.setMin(0);
     progressBar.setMax(100);
 
@@ -106,8 +118,7 @@ public class CommissioningFragment extends Fragment implements Observer<WorkInfo
 
   @Override
   public void onChanged(@Nullable WorkInfo workInfo) {
-    TextView statusText = getActivity().findViewById(R.id.status_text);
-    ProgressBar progressBar = getActivity().findViewById(R.id.commissioning_progress);
+    progressBar = getActivity().findViewById(R.id.commissioning_progress);
 
     if (workInfo != null) {
       if (workInfo.getState().isFinished()) {
@@ -122,48 +133,35 @@ public class CommissioningFragment extends Fragment implements Observer<WorkInfo
   }
 
   private void showInProgress(String status) {
-    TextView statusText = getActivity().findViewById(R.id.status_text);
+    statusText = getActivity().findViewById(R.id.status_text);
     if (status != null) {
       statusText.setText(status);
     }
 
-    ProgressBar progressBar = getActivity().findViewById(R.id.commissioning_progress);
+    progressBar = getActivity().findViewById(R.id.commissioning_progress);
     progressBar.setVisibility(View.VISIBLE);
 
-    Button cancelButton = getActivity().findViewById(R.id.cancel_button);
     cancelButton.setVisibility(View.VISIBLE);
-
-    ImageView doneImage = getActivity().findViewById(R.id.done_image);
     doneImage.setVisibility(View.GONE);
-
-    ImageView errorImage = getActivity().findViewById(R.id.error_image);
     errorImage.setVisibility(View.GONE);
-
-    Button doneButton = getActivity().findViewById(R.id.done_button);
     doneButton.setVisibility(View.GONE);
   }
 
   private void showCommissionDone(Boolean success, String status) {
-    TextView statusText = getActivity().findViewById(R.id.status_text);
     if (status != null) {
       statusText.setText(status);
     }
 
-    ProgressBar progressBar = getActivity().findViewById(R.id.commissioning_progress);
     progressBar.setVisibility(View.GONE);
-
-    Button cancelButton = getActivity().findViewById(R.id.cancel_button);
     cancelButton.setVisibility(View.GONE);
+    doneButton.setVisibility(View.VISIBLE);
 
     if (success) {
-      ImageView doneImage = getActivity().findViewById(R.id.done_image);
       doneImage.setVisibility(View.VISIBLE);
+      errorImage.setVisibility(View.GONE);
     } else {
-      ImageView errorImage = getActivity().findViewById(R.id.error_image);
+      doneImage.setVisibility(View.GONE);
       errorImage.setVisibility(View.VISIBLE);
     }
-
-    Button doneButton = getActivity().findViewById(R.id.done_button);
-    doneButton.setVisibility(View.VISIBLE);
   }
 }

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/CommissioningFragment.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/CommissioningFragment.java
@@ -81,7 +81,7 @@ public class CommissioningFragment extends Fragment implements Observer<WorkInfo
     Data arguments =
         new Data.Builder()
             .putString(Constants.KEY_DEVICE_INFO, new Gson().toJson(deviceInfo))
-            .putString(Constants.KEY_DEVICE_INFO, new Gson().toJson(networkInfo))
+            .putString(Constants.KEY_NETWORK_INFO, new Gson().toJson(networkInfo))
             .build();
     commssionerWorkRequest =
         new OneTimeWorkRequest.Builder(CommissionerWorker.class).setInputData(arguments).build();

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/CommissioningFragment.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/CommissioningFragment.java
@@ -20,8 +20,6 @@ package com.google.chip.chiptool.commissioner;
 
 import android.app.Activity;
 import android.os.Bundle;
-import android.os.Parcel;
-import android.os.Parcelable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -53,9 +51,7 @@ public class CommissioningFragment extends Fragment implements Observer<WorkInfo
 
   @Override
   public View onCreateView(
-      LayoutInflater inflater, ViewGroup container,
-      Bundle savedInstanceState
-  ) {
+      LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     // Inflate the layout for this fragment
     return inflater.inflate(R.layout.commissioner_commissioning_fragment, container, false);
   }
@@ -70,34 +66,42 @@ public class CommissioningFragment extends Fragment implements Observer<WorkInfo
     deviceInfo = getArguments().getParcelable(Constants.KEY_DEVICE_INFO);
     networkInfo = getArguments().getParcelable(Constants.KEY_NETWORK_INFO);
 
-    Data arguments = new Data.Builder()
+    Data arguments =
+        new Data.Builder()
             .putString(Constants.KEY_DEVICE_INFO, new Gson().toJson(deviceInfo))
             .putString(Constants.KEY_DEVICE_INFO, new Gson().toJson(networkInfo))
             .build();
-    commssionerWorkRequest = new OneTimeWorkRequest.Builder(CommissionerWorker.class).setInputData(arguments).build();
+    commssionerWorkRequest =
+        new OneTimeWorkRequest.Builder(CommissionerWorker.class).setInputData(arguments).build();
 
     WorkManager.getInstance(getActivity()).enqueue(commssionerWorkRequest);
 
-    WorkManager.getInstance(getActivity()).getWorkInfoByIdLiveData(commssionerWorkRequest.getId())
-            .observe(getViewLifecycleOwner(), this);
+    WorkManager.getInstance(getActivity())
+        .getWorkInfoByIdLiveData(commssionerWorkRequest.getId())
+        .observe(getViewLifecycleOwner(), this);
 
-    view.findViewById(R.id.cancel_button).setOnClickListener(new View.OnClickListener() {
-      @Override
-      public void onClick(View view) {
-        WorkManager.getInstance(getActivity()).cancelWorkById(commssionerWorkRequest.getId());
+    view.findViewById(R.id.cancel_button)
+        .setOnClickListener(
+            new View.OnClickListener() {
+              @Override
+              public void onClick(View view) {
+                WorkManager.getInstance(getActivity())
+                    .cancelWorkById(commssionerWorkRequest.getId());
 
-        CommissionerActivity commissionerActivity = (CommissionerActivity)getActivity();
-        commissionerActivity.finishCommissioning(Activity.RESULT_CANCELED);
-      }
-    });
+                CommissionerActivity commissionerActivity = (CommissionerActivity) getActivity();
+                commissionerActivity.finishCommissioning(Activity.RESULT_CANCELED);
+              }
+            });
 
-    view.findViewById(R.id.done_button).setOnClickListener(new View.OnClickListener() {
-      @Override
-      public void onClick(View view) {
-        CommissionerActivity commissionerActivity = (CommissionerActivity)getActivity();
-        commissionerActivity.finishCommissioning(Activity.RESULT_OK);
-      }
-    });
+    view.findViewById(R.id.done_button)
+        .setOnClickListener(
+            new View.OnClickListener() {
+              @Override
+              public void onClick(View view) {
+                CommissionerActivity commissionerActivity = (CommissionerActivity) getActivity();
+                commissionerActivity.finishCommissioning(Activity.RESULT_OK);
+              }
+            });
   }
 
   @Override
@@ -108,7 +112,9 @@ public class CommissioningFragment extends Fragment implements Observer<WorkInfo
     if (workInfo != null) {
       if (workInfo.getState().isFinished()) {
 
-        showCommissionDone(workInfo.getOutputData().getBoolean(Constants.KEY_SUCCESS, false), workInfo.getOutputData().getString(Constants.KEY_COMMISSIONING_STATUS));
+        showCommissionDone(
+            workInfo.getOutputData().getBoolean(Constants.KEY_SUCCESS, false),
+            workInfo.getOutputData().getString(Constants.KEY_COMMISSIONING_STATUS));
       } else {
         showInProgress(workInfo.getProgress().getString(Constants.KEY_COMMISSIONING_STATUS));
       }

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/Constants.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/Constants.java
@@ -1,0 +1,29 @@
+/*
+ *   Copyright (c) 2020 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package com.google.chip.chiptool.commissioner;
+
+public class Constants {
+    public static final String KEY_DEVICE_INFO = "deviceinfo";
+
+    public static final String KEY_NETWORK_INFO = "networkinfo";
+
+    public static final String KEY_COMMISSIONING_STATUS = "commissioning_status";
+
+    public static final String KEY_SUCCESS = "success";
+}

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/Constants.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/Constants.java
@@ -19,11 +19,11 @@
 package com.google.chip.chiptool.commissioner;
 
 public class Constants {
-    public static final String KEY_DEVICE_INFO = "deviceinfo";
+  public static final String KEY_DEVICE_INFO = "deviceinfo";
 
-    public static final String KEY_NETWORK_INFO = "networkinfo";
+  public static final String KEY_NETWORK_INFO = "networkinfo";
 
-    public static final String KEY_COMMISSIONING_STATUS = "commissioning_status";
+  public static final String KEY_COMMISSIONING_STATUS = "commissioning_status";
 
-    public static final String KEY_SUCCESS = "success";
+  public static final String KEY_SUCCESS = "success";
 }

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/NetworkAdapter.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/NetworkAdapter.java
@@ -1,0 +1,79 @@
+/*
+ *   Copyright (c) 2020 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package com.google.chip.chiptool.commissioner;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.TextView;
+import com.google.chip.chiptool.R;
+import java.util.Arrays;
+import java.util.Vector;
+
+public class NetworkAdapter extends BaseAdapter {
+  private Vector<NetworkInfo> networks;
+
+  private LayoutInflater inflater;
+
+  NetworkAdapter(Context context) {
+    inflater = (LayoutInflater)context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+    networks = new Vector<>();
+  }
+
+  public boolean addNetwork(NetworkInfo newNetwork) {
+    for (NetworkInfo network : networks) {
+      if (network.getNetworkName().equals(newNetwork.getNetworkName()) &&
+              Arrays.equals(network.getExtendedPanId(), newNetwork.getExtendedPanId())) {
+        network.merge(newNetwork);
+        return false;
+      }
+    }
+
+    networks.add(newNetwork);
+    notifyDataSetChanged();
+    return true;
+  }
+
+  @Override
+  public int getCount() {
+    return networks.size();
+  }
+
+  @Override
+  public Object getItem(int position) {
+    return networks.get(position);
+  }
+
+  @Override
+  public long getItemId(int position) {
+    return position;
+  }
+
+  @Override
+  public View getView(int position, View convertView, ViewGroup container) {
+    if (convertView == null) {
+      convertView = inflater.inflate(R.layout.commissioner_network_list_item, container, false);
+    }
+    TextView networkNameText = convertView.findViewById(R.id.network_name);
+    networkNameText.setText(networks.get(position).getNetworkName());
+    return convertView;
+  }
+}

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/NetworkAdapter.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/NetworkAdapter.java
@@ -34,14 +34,14 @@ public class NetworkAdapter extends BaseAdapter {
   private LayoutInflater inflater;
 
   NetworkAdapter(Context context) {
-    inflater = (LayoutInflater)context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+    inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
     networks = new Vector<>();
   }
 
   public boolean addNetwork(NetworkInfo newNetwork) {
     for (NetworkInfo network : networks) {
-      if (network.getNetworkName().equals(newNetwork.getNetworkName()) &&
-              Arrays.equals(network.getExtendedPanId(), newNetwork.getExtendedPanId())) {
+      if (network.getNetworkName().equals(newNetwork.getNetworkName())
+          && Arrays.equals(network.getExtendedPanId(), newNetwork.getExtendedPanId())) {
         network.merge(newNetwork);
         return false;
       }

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/NetworkInfo.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/NetworkInfo.java
@@ -1,0 +1,81 @@
+/*
+ *   Copyright (c) 2020 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package com.google.chip.chiptool.commissioner;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import java.net.InetAddress;
+import java.util.ArrayList;
+
+public class NetworkInfo implements Parcelable {
+
+  private ArrayList<BorderAgentInfo> borderAgents;
+
+  public NetworkInfo(BorderAgentInfo borderAgent) {
+    borderAgents = new ArrayList<>();
+    borderAgents.add(borderAgent);
+  }
+
+  public InetAddress getHost() { return borderAgents.get(0).host; }
+
+  public int getPort() { return borderAgents.get(0).port; }
+
+  public String getNetworkName() {
+    return borderAgents.get(0).networkName;
+  }
+
+  public byte[] getExtendedPanId() {
+    return borderAgents.get(0).extendedPanId;
+  }
+
+  public void merge(NetworkInfo networkInfo) {
+    borderAgents.addAll(networkInfo.borderAgents);
+  }
+
+  public void addBorderAgent(BorderAgentInfo borderAgent) {
+    // TODO(wgtdkp): verify that the network name and extended PAN ID match.
+    borderAgents.add(borderAgent);
+  }
+
+  protected NetworkInfo(Parcel in) {
+    borderAgents = in.readArrayList(BorderAgentInfo.class.getClassLoader());
+  }
+
+  public static final Creator<NetworkInfo> CREATOR = new Creator<NetworkInfo>() {
+    @Override
+    public NetworkInfo createFromParcel(Parcel in) {
+      return new NetworkInfo(in);
+    }
+
+    @Override
+    public NetworkInfo[] newArray(int size) {
+      return new NetworkInfo[size];
+    }
+  };
+
+  @Override
+  public int describeContents() {
+    return 0;
+  }
+
+  @Override
+  public void writeToParcel(Parcel parcel, int flags) {
+    parcel.writeList(borderAgents);
+  }
+}

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/NetworkInfo.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/NetworkInfo.java
@@ -32,9 +32,13 @@ public class NetworkInfo implements Parcelable {
     borderAgents.add(borderAgent);
   }
 
-  public InetAddress getHost() { return borderAgents.get(0).host; }
+  public InetAddress getHost() {
+    return borderAgents.get(0).host;
+  }
 
-  public int getPort() { return borderAgents.get(0).port; }
+  public int getPort() {
+    return borderAgents.get(0).port;
+  }
 
   public String getNetworkName() {
     return borderAgents.get(0).networkName;
@@ -57,17 +61,18 @@ public class NetworkInfo implements Parcelable {
     borderAgents = in.readArrayList(BorderAgentInfo.class.getClassLoader());
   }
 
-  public static final Creator<NetworkInfo> CREATOR = new Creator<NetworkInfo>() {
-    @Override
-    public NetworkInfo createFromParcel(Parcel in) {
-      return new NetworkInfo(in);
-    }
+  public static final Creator<NetworkInfo> CREATOR =
+      new Creator<NetworkInfo>() {
+        @Override
+        public NetworkInfo createFromParcel(Parcel in) {
+          return new NetworkInfo(in);
+        }
 
-    @Override
-    public NetworkInfo[] newArray(int size) {
-      return new NetworkInfo[size];
-    }
-  };
+        @Override
+        public NetworkInfo[] newArray(int size) {
+          return new NetworkInfo[size];
+        }
+      };
 
   @Override
   public int describeContents() {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/SelectNetworkFragment.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/SelectNetworkFragment.java
@@ -1,0 +1,122 @@
+/*
+ *   Copyright (c) 2020 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package com.google.chip.chiptool.commissioner;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.Button;
+import android.widget.ListView;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+import androidx.navigation.NavController;
+import androidx.navigation.fragment.NavHostFragment;
+import com.google.chip.chiptool.R;
+import com.google.chip.chiptool.setuppayloadscanner.CHIPDeviceInfo;
+
+public class SelectNetworkFragment extends Fragment {
+
+  private CHIPDeviceInfo deviceInfo;
+
+  private NetworkAdapter networksAdapter;
+
+  private NetworkInfo selectedNetwork;
+  private Button addDeviceButton;
+
+
+  private BorderAgentDiscoverer borderAgentDiscoverer;
+
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    networksAdapter = new NetworkAdapter(getContext());
+    borderAgentDiscoverer = new BorderAgentDiscoverer(getContext(), networksAdapter);
+    borderAgentDiscoverer.start();
+  }
+
+  @Override
+  public void onDestroy() {
+    super.onDestroy();
+
+    borderAgentDiscoverer.stop();
+  }
+
+  @Override
+  public View onCreateView(
+      LayoutInflater inflater, ViewGroup container,
+      Bundle savedInstanceState
+  ) {
+    // Inflate the layout for this fragment
+    return inflater.inflate(R.layout.commissioner_select_network_fragment, container, false);
+  }
+
+  public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
+
+    // Hide the button
+    addDeviceButton = view.findViewById(R.id.add_device_button);
+    addDeviceButton.setVisibility(View.GONE);
+
+    deviceInfo = getArguments().getParcelable(Constants.KEY_DEVICE_INFO);
+
+    String deviceInfoString = String.format("version: %d\nvendorId: %d\nproductId: %d\nsetupPinCode: %d",
+            deviceInfo.getVersion(), deviceInfo.getVendorId(), deviceInfo.getProductId(), deviceInfo.getSetupPinCode());
+    TextView deviceInfoView = view.findViewById(R.id.device_info);
+    deviceInfoView.setText(deviceInfoString);
+
+    final ListView networkListView = view.findViewById(R.id.networks);
+    networkListView.setAdapter(networksAdapter);
+
+    networkListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+      @Override
+      public void onItemClick(AdapterView<?> adapterView, View view, int position, long id) {
+        selectedNetwork = (NetworkInfo)adapterView.getItemAtPosition(position);
+        addDeviceButton.setVisibility(View.VISIBLE);
+      }
+    });
+
+    view.findViewById(R.id.add_device_button).setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View view) {
+        NavController controller = NavHostFragment.findNavController(SelectNetworkFragment.this);
+
+        if (controller.getCurrentDestination().getId() == R.id.commissioner_select_network_fragment) {
+          Bundle bundle = new Bundle();
+
+          assert(deviceInfo != null);
+          assert(selectedNetwork != null);
+          bundle.putParcelable(Constants.KEY_DEVICE_INFO, deviceInfo);
+          bundle.putParcelable(Constants.KEY_NETWORK_INFO, selectedNetwork);
+
+          controller.navigate(R.id.action_select_network_to_commissioning, bundle);
+        }
+      }
+    });
+  }
+
+  // TODO: may add network if it is new.
+  private void onFoundBorderAgent() {
+
+  }
+}

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/SelectNetworkFragment.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/SelectNetworkFragment.java
@@ -19,6 +19,7 @@
 package com.google.chip.chiptool.commissioner;
 
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -34,6 +35,8 @@ import com.google.chip.chiptool.R;
 import com.google.chip.chiptool.setuppayloadscanner.CHIPDeviceInfo;
 
 public class SelectNetworkFragment extends Fragment {
+
+  private static final String TAG = CommissioningFragment.class.getSimpleName();
 
   private CHIPDeviceInfo deviceInfo;
 
@@ -110,8 +113,14 @@ public class SelectNetworkFragment extends Fragment {
                     == R.id.commissioner_select_network_fragment) {
                   Bundle bundle = new Bundle();
 
-                  assert (deviceInfo != null);
-                  assert (selectedNetwork != null);
+                  if (deviceInfo == null) {
+                    Log.e(TAG, "no device info provided");
+                    return;
+                  }
+                  if (selectedNetwork == null) {
+                    Log.e(TAG, "no selected network");
+                    return;
+                  }
                   bundle.putParcelable(Constants.KEY_DEVICE_INFO, deviceInfo);
                   bundle.putParcelable(Constants.KEY_NETWORK_INFO, selectedNetwork);
 
@@ -120,7 +129,4 @@ public class SelectNetworkFragment extends Fragment {
               }
             });
   }
-
-  // TODO: may add network if it is new.
-  private void onFoundBorderAgent() {}
 }

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/SelectNetworkFragment.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/SelectNetworkFragment.java
@@ -42,9 +42,7 @@ public class SelectNetworkFragment extends Fragment {
   private NetworkInfo selectedNetwork;
   private Button addDeviceButton;
 
-
   private BorderAgentDiscoverer borderAgentDiscoverer;
-
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
@@ -64,9 +62,7 @@ public class SelectNetworkFragment extends Fragment {
 
   @Override
   public View onCreateView(
-      LayoutInflater inflater, ViewGroup container,
-      Bundle savedInstanceState
-  ) {
+      LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     // Inflate the layout for this fragment
     return inflater.inflate(R.layout.commissioner_select_network_fragment, container, false);
   }
@@ -80,43 +76,51 @@ public class SelectNetworkFragment extends Fragment {
 
     deviceInfo = getArguments().getParcelable(Constants.KEY_DEVICE_INFO);
 
-    String deviceInfoString = String.format("version: %d\nvendorId: %d\nproductId: %d\nsetupPinCode: %d",
-            deviceInfo.getVersion(), deviceInfo.getVendorId(), deviceInfo.getProductId(), deviceInfo.getSetupPinCode());
+    String deviceInfoString =
+        String.format(
+            "version: %d\nvendorId: %d\nproductId: %d\nsetupPinCode: %d",
+            deviceInfo.getVersion(),
+            deviceInfo.getVendorId(),
+            deviceInfo.getProductId(),
+            deviceInfo.getSetupPinCode());
     TextView deviceInfoView = view.findViewById(R.id.device_info);
     deviceInfoView.setText(deviceInfoString);
 
     final ListView networkListView = view.findViewById(R.id.networks);
     networkListView.setAdapter(networksAdapter);
 
-    networkListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
-      @Override
-      public void onItemClick(AdapterView<?> adapterView, View view, int position, long id) {
-        selectedNetwork = (NetworkInfo)adapterView.getItemAtPosition(position);
-        addDeviceButton.setVisibility(View.VISIBLE);
-      }
-    });
+    networkListView.setOnItemClickListener(
+        new AdapterView.OnItemClickListener() {
+          @Override
+          public void onItemClick(AdapterView<?> adapterView, View view, int position, long id) {
+            selectedNetwork = (NetworkInfo) adapterView.getItemAtPosition(position);
+            addDeviceButton.setVisibility(View.VISIBLE);
+          }
+        });
 
-    view.findViewById(R.id.add_device_button).setOnClickListener(new View.OnClickListener() {
-      @Override
-      public void onClick(View view) {
-        NavController controller = NavHostFragment.findNavController(SelectNetworkFragment.this);
+    view.findViewById(R.id.add_device_button)
+        .setOnClickListener(
+            new View.OnClickListener() {
+              @Override
+              public void onClick(View view) {
+                NavController controller =
+                    NavHostFragment.findNavController(SelectNetworkFragment.this);
 
-        if (controller.getCurrentDestination().getId() == R.id.commissioner_select_network_fragment) {
-          Bundle bundle = new Bundle();
+                if (controller.getCurrentDestination().getId()
+                    == R.id.commissioner_select_network_fragment) {
+                  Bundle bundle = new Bundle();
 
-          assert(deviceInfo != null);
-          assert(selectedNetwork != null);
-          bundle.putParcelable(Constants.KEY_DEVICE_INFO, deviceInfo);
-          bundle.putParcelable(Constants.KEY_NETWORK_INFO, selectedNetwork);
+                  assert (deviceInfo != null);
+                  assert (selectedNetwork != null);
+                  bundle.putParcelable(Constants.KEY_DEVICE_INFO, deviceInfo);
+                  bundle.putParcelable(Constants.KEY_NETWORK_INFO, selectedNetwork);
 
-          controller.navigate(R.id.action_select_network_to_commissioning, bundle);
-        }
-      }
-    });
+                  controller.navigate(R.id.action_select_network_to_commissioning, bundle);
+                }
+              }
+            });
   }
 
   // TODO: may add network if it is new.
-  private void onFoundBorderAgent() {
-
-  }
+  private void onFoundBorderAgent() {}
 }

--- a/src/android/CHIPTool/app/src/main/res/drawable/ic_done_icon.xml
+++ b/src/android/CHIPTool/app/src/main/res/drawable/ic_done_icon.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M9,16.2L4.8,12l-1.4,1.4L9,19 21,7l-1.4,-1.4L9,16.2z"
+      android:fillColor="#000000"/>
+</vector>

--- a/src/android/CHIPTool/app/src/main/res/drawable/ic_error_icon.xml
+++ b/src/android/CHIPTool/app/src/main/res/drawable/ic_error_icon.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M11,15h2v2h-2zM11,7h2v6h-2zM11.99,2C6.47,2 2,6.48 2,12s4.47,10 9.99,10C17.52,22 22,17.52 22,12S17.52,2 11.99,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z"
+      android:fillColor="#000000"/>
+</vector>

--- a/src/android/CHIPTool/app/src/main/res/drawable/ic_network_selected_icon.xml
+++ b/src/android/CHIPTool/app/src/main/res/drawable/ic_network_selected_icon.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z"
+      android:fillColor="#000000"/>
+</vector>

--- a/src/android/CHIPTool/app/src/main/res/drawable/ic_wireless_network_icon.xml
+++ b/src/android/CHIPTool/app/src/main/res/drawable/ic_wireless_network_icon.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M1,9l2,2c4.97,-4.97 13.03,-4.97 18,0l2,-2C16.93,2.93 7.08,2.93 1,9zM9,17l3,3 3,-3c-1.65,-1.66 -4.34,-1.66 -6,0zM5,13l2,2c2.76,-2.76 7.24,-2.76 10,0l2,-2C15.14,9.14 8.87,9.14 5,13z"
+      android:fillColor="#000000"/>
+</vector>

--- a/src/android/CHIPTool/app/src/main/res/layout/commissioner_activity.xml
+++ b/src/android/CHIPTool/app/src/main/res/layout/commissioner_activity.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/commissioner_service_activity"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+  <fragment
+      android:id="@+id/nav_host_fragment"
+      android:name="androidx.navigation.fragment.NavHostFragment"
+      android:layout_width="0dp"
+      android:layout_height="0dp"
+      app:defaultNavHost="true"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintLeft_toLeftOf="parent"
+      app:layout_constraintRight_toRightOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
+      app:navGraph="@navigation/commissioner_nav_graph" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/src/android/CHIPTool/app/src/main/res/layout/commissioner_commissioning_fragment.xml
+++ b/src/android/CHIPTool/app/src/main/res/layout/commissioner_commissioning_fragment.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".CommissioningFragment">
+
+  <ProgressBar
+      android:id="@+id/commissioning_progress"
+      style="?android:attr/progressBarStyle"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:indeterminateBehavior="repeat"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent" />
+
+  <Button
+      android:id="@+id/cancel_button"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginBottom="32dp"
+      android:text="@string/commissioner_cancel"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent" />
+  <TextView
+      android:id="@+id/status_text"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      style="@style/info_text"
+      app:layout_constraintBottom_toTopOf="@+id/cancel_button"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@+id/commissioning_progress" />
+
+  <ImageView
+      android:id="@+id/done_image"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:scaleType="center"
+      android:scaleX="1.5"
+      android:scaleY="1.5"
+      android:src="@drawable/ic_done_icon"
+      android:visibility="gone"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent" />
+
+  <ImageView
+      android:id="@+id/error_image"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:scaleType="center"
+      android:scaleX="1.5"
+      android:scaleY="1.5"
+      android:src="@drawable/ic_error_icon"
+      android:visibility="gone"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent" />
+
+  <Button
+      android:id="@+id/done_button"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginBottom="32dp"
+      android:text="@string/commissioner_done"
+      android:visibility="gone"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/src/android/CHIPTool/app/src/main/res/layout/commissioner_network_list_item.xml
+++ b/src/android/CHIPTool/app/src/main/res/layout/commissioner_network_list_item.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/network_list_item"
+    android:layout_width="match_parent"
+    android:layout_height="50dp">
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/network_icon"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_marginStart="5dp"
+        app:layout_constraintEnd_toStartOf="@+id/network_name"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_wireless_network_icon"></androidx.appcompat.widget.AppCompatImageView>
+
+    <TextView
+        android:id="@+id/network_name"
+        style="@style/info_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="20dp"
+        app:layout_constraintBottom_toBottomOf="@+id/network_icon"
+        app:layout_constraintStart_toEndOf="@+id/network_icon"
+        app:layout_constraintTop_toTopOf="@+id/network_icon"></TextView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/src/android/CHIPTool/app/src/main/res/layout/commissioner_select_network_fragment.xml
+++ b/src/android/CHIPTool/app/src/main/res/layout/commissioner_select_network_fragment.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".SelectNetworkFragment">
+
+  <Button
+      android:id="@+id/add_device_button"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginBottom="32dp"
+      android:text="@string/commissioner_commission_device"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent" />
+
+  <ListView
+      android:id="@+id/networks"
+      style="@style/Widget.AppCompat.Light.ListView.DropDown"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:orientation="vertical"
+      android:choiceMode="singleChoice"
+      android:listSelector="#bbbbbb"
+      app:layout_constrainedHeight="true"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintHeight_max="240dp"
+      app:layout_constraintHeight_min="120dp"
+      app:layout_constraintHorizontal_bias="0.0"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@+id/network_scan_bar"></ListView>
+
+  <TextView
+      android:id="@+id/device_info"
+      style="@style/info_text"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="16dp"
+      app:layout_constraintStart_toStartOf="@+id/your_device"
+      app:layout_constraintTop_toBottomOf="@+id/your_device" />
+
+  <TextView
+      android:id="@+id/select_network"
+      style="@style/title_text"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="24dp"
+      android:text="@string/commissioner_select_network"
+      app:layout_constraintStart_toStartOf="@+id/your_device"
+      app:layout_constraintTop_toBottomOf="@+id/device_info" />
+
+  <TextView
+      android:id="@+id/your_device"
+      style="@style/title_text"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="2dp"
+      android:layout_marginTop="24dp"
+      android:text="@string/commissioner_your_device"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent" />
+
+  <ProgressBar
+      android:id="@+id/network_scan_bar"
+      style="?android:attr/progressBarStyleHorizontal"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:indeterminate="true"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@+id/select_network" />
+
+  <View
+      android:id="@+id/networks_bottom_separator"
+      android:layout_width="0dp"
+      android:layout_height="1dp"
+      android:layout_marginTop="2dp"
+      android:background="@android:color/darker_gray"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@+id/networks" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/src/android/CHIPTool/app/src/main/res/layout/root_fragment.xml
+++ b/src/android/CHIPTool/app/src/main/res/layout/root_fragment.xml
@@ -12,6 +12,12 @@
         android:text="Scan QR Code" />
 
     <Button
+        android:id="@+id/commissioning_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:text="Commissioning" />
+    <Button
         android:id="@+id/echo_client_button"
         android:layout_height="wrap_content"
         android:layout_width="wrap_content"

--- a/src/android/CHIPTool/app/src/main/res/layout/select_action_fragment.xml
+++ b/src/android/CHIPTool/app/src/main/res/layout/select_action_fragment.xml
@@ -12,6 +12,14 @@
         android:text="@string/scan_qr_code_btn_text" />
 
     <Button
+        android:id="@+id/commissioningBtn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/commissioner_commissioning" />
+
+    <Button
         android:id="@+id/echoClientBtn"
         android:layout_height="wrap_content"
         android:layout_width="wrap_content"

--- a/src/android/CHIPTool/app/src/main/res/navigation/commissioner_nav_graph.xml
+++ b/src/android/CHIPTool/app/src/main/res/navigation/commissioner_nav_graph.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nav_graph"
+    app:startDestination="@id/commissioner_scan_qr_code_fragment">
+
+  <fragment
+      android:id="@+id/commissioner_scan_qr_code_fragment"
+      android:name="com.google.chip.chiptool.setuppayloadscanner.BarcodeFragment"
+      tools:layout="@layout/barcode_fragment">
+
+    <action
+        android:id="@+id/action_scan_qr_code_to_select_network"
+        app:destination="@id/commissioner_select_network_fragment" />
+  </fragment>
+
+  <fragment
+      android:id="@+id/commissioner_select_network_fragment"
+      android:name="com.google.chip.chiptool.commissioner.SelectNetworkFragment"
+      android:label="@string/commissioner_select_network_fragment_label"
+      tools:layout="@layout/commissioner_select_network_fragment">
+
+    <action
+        android:id="@+id/action_select_network_to_commissioning"
+        app:destination="@id/commissioner_commissioning_fragment" />
+  </fragment>
+
+  <fragment
+      android:id="@+id/commissioner_commissioning_fragment"
+      android:name="com.google.chip.chiptool.commissioner.CommissioningFragment"
+      android:label="@string/commissioner_commissioning_fragment_label"
+      tools:layout="@layout/commissioner_commissioning_fragment">
+
+    <action
+        android:id="@+id/action_commissioning_to_select_network"
+        app:destination="@id/commissioner_select_network_fragment" />
+  </fragment>
+
+</navigation>

--- a/src/android/CHIPTool/app/src/main/res/values/strings.xml
+++ b/src/android/CHIPTool/app/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="camera_unavailable_alert_title">Camera unavailable</string>
     <string name="camera_unavailable_alert_subtitle">Error launching camera to scan the QR code.</string>
     <string name="camera_unavailable_alert_exit">Exit</string>
+
     <string name="send_echo_btn_text">Send echo</string>
     <string name="echo_status_connecting">Connecting…</string>
     <string name="echo_status_sending_message">Sending message…</string>
@@ -23,7 +24,21 @@
     <string name="on_off_btn_text">Light On/Off Cluster</string>
     <string name="enter_ip_address_hint_text">Enter IP Address (eg. 192.168.10.2)</string>
     <string name="echo_input_hint_text">Enter message for device</string>
+
     <string name="send_command_on_btn_text">On</string>
     <string name="send_command_off_btn_text">Off</string>
     <string name="send_command_toggle_btn_text">Toggle</string>
+
+    <string name="commissioner_commissioning">Commissioning</string>
+    <string name="commissioner_name">Commissioner</string>
+    <string name="commissioner_scan_device">Scan Device</string>
+    <string name="commissioner_cancel">Cancel</string>
+    <string name="commissioner_done">Done</string>
+    <string name="commissioner_scan_instruction">Please scan the QR code on the device</string>
+    <string name="commissioner_your_device">Your Device</string>
+    <string name="commissioner_select_network">Select Network</string>
+    <string name="commissioner_commission_device">Commission Device</string>
+    <string name="commissioner_scan_qrcode_fragment_label">Scan QR Code</string>
+    <string name="commissioner_select_network_fragment_label">Select Network</string>
+    <string name="commissioner_commissioning_fragment_label">Commissioning</string>
 </resources>

--- a/src/android/CHIPTool/app/src/main/res/values/styles.xml
+++ b/src/android/CHIPTool/app/src/main/res/values/styles.xml
@@ -6,4 +6,7 @@
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
     </style>
+
+    <style name="title_text" parent="TextAppearance.AppCompat.Title" />
+    <style name="info_text" parent="TextAppearance.AppCompat.Medium" />
 </resources>

--- a/third_party/ot-commissioner/build-android-libs.sh
+++ b/third_party/ot-commissioner/build-android-libs.sh
@@ -58,6 +58,7 @@ cd ../../../
 
 ## Copy shared native libraries
 for lib in $(find ./build -name "*.so"); do
+    ## Avoid copying symblink files.
     [ ! -L "$lib" ] && cp "$lib" libs
 done
 

--- a/third_party/ot-commissioner/build-android-libs.sh
+++ b/third_party/ot-commissioner/build-android-libs.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -e
+
+case "${TARGET}" in
+    armv7a-linux-androideabi)
+        ABI="armeabi-v7a"
+        ;;
+    aarch64-linux-android)
+        ABI="arm64-v8a "
+        ;;
+    i686-linux-android)
+        ABI="x86"
+        ;;
+    x86_64-linux-android)
+        ABI="x86-64"
+        ;;
+    *)
+        echo "invalid TARGET value: ${TARGET}"
+        exit 1
+esac
+
+## Install dependencies.
+#[ ! -d build/ ] && ./repo/script/bootstrap.sh
+
+mkdir -p build && cd build
+cmake -GNinja                                                                               \
+    -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK_HOME}"/build/cmake/android.toolchain.cmake \
+    -DANDROID_ABI="${ABI}"                                                                  \
+    -DANDROID_ARM_NEON=ON                                                                   \
+    -DANDROID_NATIVE_API_LEVEL="${API}"                                                     \
+    -DBUILD_SHARED_LIBS=ON                                                                  \
+    -DCMAKE_CXX_STANDARD=11                                                                 \
+    -DCMAKE_CXX_STANDARD_REQUIRED=ON                                                        \
+    -DCMAKE_BUILD_TYPE=Release                                                              \
+    -DOT_COMM_ANDROID=ON                                                                    \
+    -DOT_COMM_JAVA_BINDING=ON                                                               \
+    -DOT_COMM_APP=OFF                                                                       \
+    -DOT_COMM_TEST=OFF                                                                      \
+    -DOT_COMM_CCM=OFF                                                                \
+    ../repo
+
+ninja
+cd ../
+
+rm -rf libs && mkdir -p libs
+
+## Create JAR library
+javac -source 8 -target 8 build/src/java/io/openthread/commissioner/*.java
+
+cd build/src/java
+find ./io/openthread/commissioner -name "*.class" | xargs jar cvf ../../../libs/libotcommissioner.jar
+cd ../../../
+
+## Copy shared native libraries
+for lib in $(find ./build -name "*.so"); do
+    [ ! -L "$lib" ] && cp "$lib" libs
+done

--- a/third_party/ot-commissioner/build-android-libs.sh
+++ b/third_party/ot-commissioner/build-android-libs.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+readonly CUR_DIR=$(dirname "$(realpath -s $0)")
+
 set -e
 
 case "${TARGET}" in
@@ -7,7 +9,7 @@ case "${TARGET}" in
         ABI="armeabi-v7a"
         ;;
     aarch64-linux-android)
-        ABI="arm64-v8a "
+        ABI="arm64-v8a"
         ;;
     i686-linux-android)
         ABI="x86"
@@ -20,8 +22,10 @@ case "${TARGET}" in
         exit 1
 esac
 
+cd "${CUR_DIR}"
+
 ## Install dependencies.
-#[ ! -d build/ ] && ./repo/script/bootstrap.sh
+[ ! -d build/ ] && ./repo/script/bootstrap.sh
 
 mkdir -p build && cd build
 cmake -GNinja                                                                               \
@@ -56,3 +60,6 @@ cd ../../../
 for lib in $(find ./build -name "*.so"); do
     [ ! -L "$lib" ] && cp "$lib" libs
 done
+
+cp libs/libotcommissioner.jar ../../src/android/CHIPTool/app/libs
+cp libs/*.so ../../src/android/CHIPTool/app/src/main/jniLibs/"$ABI"


### PR DESCRIPTION
This PR adds Thread Commissioner to the Android demo App to support commissioning.

The Commissioner Activity scans CHIP QR code to extract device information and scans local Thread Network to join. After connecting to the selected Thread Network, the Thread Commissioner waits a while for a new device to pair. See the demo vedio: https://www.youtube.com/watch?v=nU0aj9_lBKU.

The Thread Commissioner depends on [ot-commissioner](https://github.com/openthread/ot-commissioner) so it is added as a 3rd party. Instructions to setup ot-commissioner has been updated in `src/android/CHIPTool/README.md`.

Addresses https://github.com/project-chip/connectedhomeip/issues/1979.