### PR TITLE
Add config options for overriding firmware build date & time

### DIFF
--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -978,4 +978,22 @@
  */
 #define CHIP_DEVICE_CONFIG_SWU_BDX_BLOCK_SIZE 1024
 
+/**
+ * CHIP_DEVICE_CONFIG_FIRWMARE_BUILD_DATE
+ *
+ * Specifies the date of the build. Useful for deterministic builds.
+ */
+#ifndef CHIP_DEVICE_CONFIG_FIRWMARE_BUILD_DATE
+#define CHIP_DEVICE_CONFIG_FIRWMARE_BUILD_DATE __DATE__
+#endif
+
+/**
+ * CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_TIME
+ *
+ * Specifies the date of the build. Useful for deterministic builds.
+ */
+#ifndef CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_TIME
+#define CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_TIME __TIME__
+#endif
+
 #endif // CHIP_DEVICE_CONFIG_H

--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -990,7 +990,7 @@
 /**
  * CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_TIME
  *
- * Specifies the date of the build. Useful for deterministic builds.
+ * Specifies the time of the build. Useful for deterministic builds.
  */
 #ifndef CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_TIME
 #define CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_TIME __TIME__

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -148,12 +148,10 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetFirmwareBuildTime(uin
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    // TODO: Allow build time to be overridden by compile-time config (e.g. CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_TIME).
-
-    err = ParseCompilerDateStr(__DATE__, year, month, dayOfMonth);
+    err = ParseCompilerDateStr(CHIP_DEVICE_CONFIG_FIRWMARE_BUILD_DATE, year, month, dayOfMonth);
     SuccessOrExit(err);
 
-    err = Parse24HourTimeStr(__TIME__, hour, minute, second);
+    err = Parse24HourTimeStr(CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_TIME, hour, minute, second);
     SuccessOrExit(err);
 
 exit:

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -25,6 +25,12 @@ if (device_platform != "none") {
   declare_args() {
     # Extra header to include in CHIPDeviceConfig.h for project.
     chip_device_project_config_include = ""
+
+    # Date the firmware was built.
+    chip_device_config_firwmare_build_date = ""
+
+    # Time the firmware was built.
+    chip_device_config_firwmare_build_time = ""
   }
 
   config("platform_config") {
@@ -37,6 +43,13 @@ if (device_platform != "none") {
     }
     if (chip_device_platform_config_include != "") {
       defines += [ "CHIP_DEVICE_PLATFORM_CONFIG_INCLUDE=${chip_device_platform_config_include}" ]
+    }
+
+    if (chip_device_config_firwmare_build_date != "") {
+      defines += [ "CHIP_DEVICE_CONFIG_FIRWMARE_BUILD_DATE=\"${chip_device_config_firwmare_build_date}\"" ]
+    }
+    if (chip_device_config_firwmare_build_time != "") {
+      defines += [ "CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_TIME=\"${chip_device_config_firwmare_build_time}\"" ]
     }
 
     if (device_platform == "darwin") {

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -27,10 +27,10 @@ if (device_platform != "none") {
     chip_device_project_config_include = ""
 
     # Date the firmware was built.
-    chip_device_config_firwmare_build_date = ""
+    chip_device_config_firmware_build_date = ""
 
     # Time the firmware was built.
-    chip_device_config_firwmare_build_time = ""
+    chip_device_config_firmware_build_time = ""
   }
 
   config("platform_config") {
@@ -45,10 +45,10 @@ if (device_platform != "none") {
       defines += [ "CHIP_DEVICE_PLATFORM_CONFIG_INCLUDE=${chip_device_platform_config_include}" ]
     }
 
-    if (chip_device_config_firwmare_build_date != "") {
+    if (chip_device_config_firmware_build_date != "") {
       defines += [ "CHIP_DEVICE_CONFIG_FIRWMARE_BUILD_DATE=\"${chip_device_config_firwmare_build_date}\"" ]
     }
-    if (chip_device_config_firwmare_build_time != "") {
+    if (chip_device_config_firmware_build_time != "") {
       defines += [ "CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_TIME=\"${chip_device_config_firwmare_build_time}\"" ]
     }
 


### PR DESCRIPTION
Using `__DATE__` & `__TIME__` breaks deterministic builds. Add a way to
avoid it.

fixes #1990

Change-Id: I4aceef1ef3b64e2b38ee2915731e7b307ddd756a