### PR TITLE
Fix chip-tool build with device layer "none"

### DIFF
--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -32,7 +32,6 @@
 #include <core/CHIPError.h>
 #include <inet/InetLayer.h>
 #include <inet/UDPEndPoint.h>
-#include <platform/ConnectivityManager.h>
 #include <support/CHIPLogging.h>
 #include <support/CodeUtils.h>
 #include <support/ErrorStr.h>


### PR DESCRIPTION
Remove an unused include to fix the build. This config is currently
untested, see #1713.