### PR TITLE
Fix typo in src/platform/BUILD.gn

### DIFF
--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -46,10 +46,10 @@ if (device_platform != "none") {
     }
 
     if (chip_device_config_firmware_build_date != "") {
-      defines += [ "CHIP_DEVICE_CONFIG_FIRWMARE_BUILD_DATE=\"${chip_device_config_firwmare_build_date}\"" ]
+      defines += [ "CHIP_DEVICE_CONFIG_FIRWMARE_BUILD_DATE=\"${chip_device_config_firmware_build_date}\"" ]
     }
     if (chip_device_config_firmware_build_time != "") {
-      defines += [ "CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_TIME=\"${chip_device_config_firwmare_build_time}\"" ]
+      defines += [ "CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_TIME=\"${chip_device_config_firmware_build_time}\"" ]
     }
 
     if (device_platform == "darwin") {


### PR DESCRIPTION
This typo was corrected in the declaration in GitHub's editor, but not
at the usage site.