### PR TITLE
Fix warnings -Wformat-truncation

### DIFF
--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -343,7 +343,7 @@ void DoEcho(DeviceController::ChipDeviceController * controller, const char * id
 
 void DoEchoBle(DeviceController::ChipDeviceController * controller, const uint16_t discriminator)
 {
-    char name[4];
+    char name[6];
     snprintf(name, sizeof(name), "%u", discriminator);
     DoEcho(controller, "");
 }

--- a/gn/build/config/compiler/BUILD.gn
+++ b/gn/build/config/compiler/BUILD.gn
@@ -17,6 +17,12 @@ import("//build_overrides/pigweed.gni")
 
 import("//build/config/compiler/compiler.gni")
 
+declare_args() {
+  # Enable -Werror. This can be disabled if using a different compiler
+  # with unfixed or unsupported wanings.
+  treat_warnings_as_errors = true
+}
+
 if (current_cpu == "arm") {
   import("//build/config/arm.gni")
 }
@@ -104,10 +110,14 @@ config("disabled_warnings") {
 }
 
 config("strict_warnings") {
-  cflags = [
-    "-Wall",
-    "-Werror",
-  ]
+  cflags = [ "-Wall" ]
+
+  ldflags = []
+
+  if (treat_warnings_as_errors) {
+    cflags += [ "-Werror" ]
+    ldflags += [ "-Werror" ]
+  }
 
   if (is_clang) {
     cflags += [ "-Wimplicit-fallthrough" ]

--- a/gn/build/config/compiler/BUILD.gn
+++ b/gn/build/config/compiler/BUILD.gn
@@ -92,13 +92,13 @@ config("disabled_warnings") {
   cflags_cc = [
     "-Wno-non-virtual-dtor",
     "-Wno-deprecated-copy",
+    "-Wno-unknown-warning-option",
   ]
   if (!is_clang) {
     cflags += [
       "-Wno-psabi",
       "-Wno-cast-function-type",
       "-Wno-maybe-uninitialized",
-      "-Wno-unknown-warning-option",
     ]
   }
 }


### PR DESCRIPTION
This warning only occurs in optimized builds which we aren't testing at
the moment.

../../examples/chip-tool/main.cpp: In function ‘void DoEchoBle(chip::DeviceController::ChipDeviceController*, uint16_t)’:
../../examples/chip-tool/main.cpp:347:37: error: ‘snprintf’ output may be truncated before the last format character [-Werror=format-truncation=]
  347 |     snprintf(name, sizeof(name), "%u", discriminator);
      |                                     ^
../../examples/chip-tool/main.cpp:347:13: note: ‘snprintf’ output between 2 and 6 bytes into a destination of size 5
  347 |     snprintf(name, sizeof(name), "%u", discriminator);
      |     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~