### PR TITLE
Fix error logging for unknown commands in chip-tool

### DIFF
--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -231,7 +231,7 @@ bool DetermineCommand(int argc, char * argv[], Command * command)
         return argc == 4;
     }
 
-    fprintf(stderr, "Unknown command: %s\n", argv[3]);
+    fprintf(stderr, "Unknown command: %s\n", argv[1]);
     return false;
 }
 


### PR DESCRIPTION
 #### Problem
The "unknown command" logging in chip-tool uses the wrong index into argv, because the order of arguments got changed without updating the log line.

 #### Summary of Changes
Fix the index to point to the command argument.

