### PR TITLE
Fix buttons handling crash in nRF5 samples

### DIFF
--- a/examples/lighting-app/nrf5/main/AppTask.cpp
+++ b/examples/lighting-app/nrf5/main/AppTask.cpp
@@ -274,7 +274,7 @@ void AppTask::ButtonEventHandler(uint8_t pin_no, uint8_t button_action)
         return;
     }
 
-    AppEvent button_event;
+    AppEvent button_event           = {};
     button_event.Type               = AppEvent::kEventType_Button;
     button_event.ButtonEvent.PinNo  = pin_no;
     button_event.ButtonEvent.Action = button_action;
@@ -286,6 +286,10 @@ void AppTask::ButtonEventHandler(uint8_t pin_no, uint8_t button_action)
     else if (pin_no == FUNCTION_BUTTON)
     {
         button_event.Handler = FunctionHandler;
+    }
+    else
+    {
+        return;
     }
 
     sAppTask.PostEvent(&button_event);

--- a/examples/lock-app/nrf5/main/AppTask.cpp
+++ b/examples/lock-app/nrf5/main/AppTask.cpp
@@ -299,7 +299,7 @@ void AppTask::ButtonEventHandler(uint8_t pin_no, uint8_t button_action)
         return;
     }
 
-    AppEvent button_event;
+    AppEvent button_event           = {};
     button_event.Type               = AppEvent::kEventType_Button;
     button_event.ButtonEvent.PinNo  = pin_no;
     button_event.ButtonEvent.Action = button_action;
@@ -318,6 +318,10 @@ void AppTask::ButtonEventHandler(uint8_t pin_no, uint8_t button_action)
         button_event.Handler = JoinHandler;
     }
 #endif
+    else
+    {
+        return;
+    }
 
     sAppTask.PostEvent(&button_event);
 }


### PR DESCRIPTION
Best not to jump to an uninitialized address for unhandled buttons.