### PR TITLE
Fixup nrf5 examples OpenThreadConfig.h

### DIFF
--- a/examples/platform/nrf528xx/app/project_include/OpenThreadConfig.h
+++ b/examples/platform/nrf528xx/app/project_include/OpenThreadConfig.h
@@ -45,6 +45,10 @@
 // Use smaller maximum interval to speed up reattaching.
 #define OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_MAXIMUM_INTERVAL (60 * 10 * 1000) // default 1200000 ms
 
+#define OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE 1
+#define OPENTHREAD_CONFIG_JOINER_ENABLE 1
+#define OPENTHREAD_CONFIG_NCP_UART_ENABLE 1
+
 // Use the Nordic-supplied default platform configuration for remainder
 // of OpenThread config options.
 //

--- a/examples/platform/nrf528xx/app/project_include/OpenThreadConfig.h
+++ b/examples/platform/nrf528xx/app/project_include/OpenThreadConfig.h
@@ -32,18 +32,18 @@
 
 // When operating in a less than ideal RF environment, having a more forgiving configuration
 // of OpenThread makes thread a great deal more reliable.
-#define OPENTHREAD_CONFIG_ADDRESS_QUERY_MAX_RETRY_DELAY 120 // default is 28800
-#define OPENTHREAD_CONFIG_MAC_MAX_FRAME_RETRIES_DIRECT 15   // default is 3
-#define OPENTHREAD_CONFIG_MAC_MAX_FRAME_RETRIES_INDIRECT 1  // default is 0
-#define OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_INDIRECT_POLLS 16 // default is 4
+#define OPENTHREAD_CONFIG_TMF_ADDRESS_QUERY_MAX_RETRY_DELAY 120    // default is 28800
+#define OPENTHREAD_CONFIG_MAC_DEFAULT_MAX_FRAME_RETRIES_DIRECT 15  // default is 3
+#define OPENTHREAD_CONFIG_MAC_DEFAULT_MAX_FRAME_RETRIES_INDIRECT 1 // default is 0
+#define OPENTHREAD_CONFIG_MAC_MAX_TX_ATTEMPTS_INDIRECT_POLLS 16    // default is 4
 
 // Enable periodic parent search to speed up finding a better parent.
-#define OPENTHREAD_CONFIG_ENABLE_PERIODIC_PARENT_SEARCH 1      // default is 0
+#define OPENTHREAD_CONFIG_PARENT_SEARCH_ENABLE 1               // default is 0
 #define OPENTHREAD_CONFIG_PARENT_SEARCH_RSS_THRESHOLD -45      // default is -65
-#define OPENTHREAD_CONFIG_INFORM_PREVIOUS_PARENT_ON_REATTACH 1 // default is 0
+#define OPENTHREAD_CONFIG_MLE_INFORM_PREVIOUS_PARENT_ON_REATTACH 1 // default is 0
 
 // Use smaller maximum interval to speed up reattaching.
-#define OPENTHREAD_CONFIG_ATTACH_BACKOFF_MAXIMUM_INTERVAL (60 * 10 * 1000) // default 1200000 ms
+#define OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_MAXIMUM_INTERVAL (60 * 10 * 1000) // default 1200000 ms
 
 // Use the Nordic-supplied default platform configuration for remainder
 // of OpenThread config options.

--- a/examples/platform/nrf528xx/app/project_include/OpenThreadConfig.h
+++ b/examples/platform/nrf528xx/app/project_include/OpenThreadConfig.h
@@ -38,8 +38,8 @@
 #define OPENTHREAD_CONFIG_MAC_MAX_TX_ATTEMPTS_INDIRECT_POLLS 16    // default is 4
 
 // Enable periodic parent search to speed up finding a better parent.
-#define OPENTHREAD_CONFIG_PARENT_SEARCH_ENABLE 1               // default is 0
-#define OPENTHREAD_CONFIG_PARENT_SEARCH_RSS_THRESHOLD -45      // default is -65
+#define OPENTHREAD_CONFIG_PARENT_SEARCH_ENABLE 1                   // default is 0
+#define OPENTHREAD_CONFIG_PARENT_SEARCH_RSS_THRESHOLD -45          // default is -65
 #define OPENTHREAD_CONFIG_MLE_INFORM_PREVIOUS_PARENT_ON_REATTACH 1 // default is 0
 
 // Use smaller maximum interval to speed up reattaching.


### PR DESCRIPTION
The example apps OpenThread config isn't currently being used, and doesn't
compile. Update the config so that the overrides the examples are intending
to make can work.