### PR TITLE
whack some macros

### DIFF
--- a/examples/wifi-echo/server/esp32/main/gen/callback-stub.c
+++ b/examples/wifi-echo/server/esp32/main/gen/callback-stub.c
@@ -1191,7 +1191,7 @@ void emberAfOtaClientVersionInfoCallback(EmberAfOtaImageId * currentImageInfo, u
     /* This is commented out since the #defines below are not defined.
 
       if (currentImageInfo != NULL) {
-        MEMSET(currentImageInfo, 0, sizeof(EmberAfOtaImageId));
+        memset(currentImageInfo, 0, sizeof(EmberAfOtaImageId));
         currentImageInfo->manufacturerId  = EMBER_AF_MANUFACTURER_CODE;
         currentImageInfo->imageTypeId     = EMBER_AF_IMAGE_TYPE_ID;
         currentImageInfo->firmwareVersion = EMBER_AF_CUSTOM_FIRMWARE_VERSION;

--- a/src/app/util/attribute-storage.c
+++ b/src/app/util/attribute-storage.c
@@ -391,11 +391,11 @@ static EmberAfStatus typeSensitiveMemCopy(uint8_t * dest, uint8_t * src, EmberAf
         }
         if (src == NULL)
         {
-            MEMSET(dest, 0, size);
+            memset(dest, 0, size);
         }
         else
         {
-            MEMMOVE(dest, src, size);
+            memmove(dest, src, size);
         }
     }
     return EMBER_ZCL_STATUS_SUCCESS;

--- a/src/app/util/attribute-table.c
+++ b/src/app/util/attribute-table.c
@@ -394,10 +394,10 @@ void emberAfRetrieveAttributeAndCraftResponse(uint8_t endpoint, EmberAfClusterId
         }
         else
         {
-            MEMMOVE(&(appResponseData[appResponseLength]), data, dataLen);
+            memmove(&(appResponseData[appResponseLength]), data, dataLen);
         }
 #else  //(BIGENDIAN_CPU)
-        MEMMOVE(&(appResponseData[appResponseLength]), data, dataLen);
+        memmove(&(appResponseData[appResponseLength]), data, dataLen);
 #endif //(BIGENDIAN_CPU)
         appResponseLength += dataLen;
     }
@@ -443,10 +443,10 @@ EmberAfStatus emberAfAppendAttributeReportFields(uint8_t endpoint, EmberAfCluste
     }
     else
     {
-        MEMMOVE(buffer + *bufIndex, data, size);
+        memmove(buffer + *bufIndex, data, size);
     }
 #else
-    MEMMOVE(buffer + *bufIndex, data, size);
+    memmove(buffer + *bufIndex, data, size);
 #endif
     *bufIndex += size;
 

--- a/src/app/util/client-api.c
+++ b/src/app/util/client-api.c
@@ -207,7 +207,7 @@ static uint16_t vFillBuffer(uint8_t * buffer, uint16_t bufferLen, uint8_t frameC
         // Finally, if there is data, add it to the destination buffer as is.  If
         // the data length is zero, data may actually be NULL.  Even if the length
         // argument is zero, passing NULL as either the source or destination to
-        // MEMCOPY is invalid and the behavior is undefined.  We avoid that with an
+        // memcpy is invalid and the behavior is undefined.  We avoid that with an
         // explicit check.
         if (dataLen != 0)
         {
@@ -216,7 +216,7 @@ static uint16_t vFillBuffer(uint8_t * buffer, uint16_t bufferLen, uint8_t frameC
                 emberAfDebugPrintln("ERR: Missing data for %d bytes for format '%c'", dataLen, cmd);
                 return 0;
             }
-            MEMCOPY(buffer + bytes, data, dataLen);
+            memcpy(buffer + bytes, data, dataLen);
             bytes += dataLen;
         }
     }

--- a/src/app/util/message.c
+++ b/src/app/util/message.c
@@ -71,9 +71,9 @@ void emberAfClearResponseData(void)
     // To prevent accidentally sending to someone else,
     // set the destination to ourselves.
     emberAfResponseDestination = 0 /* emberAfGetNodeId() */;
-    MEMSET(appResponseData, 0, EMBER_AF_RESPONSE_BUFFER_LEN);
+    memset(appResponseData, 0, EMBER_AF_RESPONSE_BUFFER_LEN);
     appResponseLength = 0;
-    MEMSET(&emberAfResponseApsFrame, 0, sizeof(EmberApsFrame));
+    memset(&emberAfResponseApsFrame, 0, sizeof(EmberApsFrame));
 }
 
 uint8_t * emberAfPutInt8uInResp(uint8_t value)
@@ -142,7 +142,7 @@ uint8_t * emberAfPutBlockInResp(const uint8_t * data, uint16_t length)
 {
     if ((appResponseLength + length) < EMBER_AF_RESPONSE_BUFFER_LEN)
     {
-        MEMMOVE(appResponseData + appResponseLength, data, length);
+        memmove(appResponseData + appResponseLength, data, length);
         appResponseLength += length;
         return &appResponseData[appResponseLength - length];
     }

--- a/src/app/util/process-global-message.c
+++ b/src/app/util/process-global-message.c
@@ -340,7 +340,7 @@ bool emAfProcessGlobalCommand(EmberAfClusterCommand * cmd)
                 // readable format. These should not be flipped.
                 if (emberAfIsThisDataTypeAStringType(dataType))
                 {
-                    MEMMOVE(writeData, message + msgIndex + 3, dataSize);
+                    memmove(writeData, message + msgIndex + 3, dataSize);
                 }
                 else
                 {

--- a/src/app/util/types_stub.h
+++ b/src/app/util/types_stub.h
@@ -1843,16 +1843,6 @@ typedef struct
 #define EMBER_BROADCAST_ENDPOINT 0xFF
 
 /**
- * @brief Friendly convenience macro pointing to the C Stdlib functions.
- */
-#define MEMSET(d, v, l) memset(d, v, l)
-#define MEMCOPY(d, s, l) memcpy(d, s, l)
-#define MEMMOVE(d, s, l) memmove(d, s, l)
-#define MEMPGMCOPY(d, s, l) memcpy(d, s, l)
-#define MEMCOMPARE(s0, s1, l) memcmp(s0, s1, l)
-#define MEMPGMCOMPARE(s0, s1, l) memcmp(s0, s1, l)
-
-/**
  * @brief Useful to reference a single bit of a byte.
  */
 #define BIT(x) (1U << (x)) // Unsigned avoids compiler warnings re BIT(15)

--- a/src/app/util/util.c
+++ b/src/app/util/util.c
@@ -1272,7 +1272,7 @@ uint8_t emberAfAppendCharacters(uint8_t * zclString, uint8_t zclStringMaxLen, co
     charsToWrite = (freeChars > appendingCharsLen) ? appendingCharsLen : freeChars;
 
     memcpy(&zclString[1 + curLen], // 1 is to account for zcl's length byte
-            appendingChars, charsToWrite);
+           appendingChars, charsToWrite);
     zclString[0] = curLen + charsToWrite;
     return charsToWrite;
 }

--- a/src/app/util/util.c
+++ b/src/app/util/util.c
@@ -234,7 +234,7 @@ static void prepareForResponse(const EmberAfClusterCommand * cmd)
     else
     {
         emberAfResponseType |= ZCL_UTIL_RESP_INTERPAN;
-        MEMMOVE(&interpanResponseHeader, cmd->interPanHeader, sizeof(EmberAfInterpanHeader));
+        memmove(&interpanResponseHeader, cmd->interPanHeader, sizeof(EmberAfInterpanHeader));
         // Always send responses as unicast
         interpanResponseHeader.messageType = EMBER_AF_INTER_PAN_UNICAST;
     }
@@ -258,7 +258,7 @@ void emberAfInit(void)
         // emberAfPopNetworkIndex();
     }
 
-    MEMSET(afDeviceEnabled, true, emberAfEndpointCount());
+    memset(afDeviceEnabled, true, emberAfEndpointCount());
 
     // Set up client API buffer.
     emberAfSetExternalBuffer(appResponseData, EMBER_AF_RESPONSE_BUFFER_LEN, &appResponseLength, &emberAfResponseApsFrame);
@@ -593,7 +593,7 @@ bool emberAfProcessMessage(EmberApsFrame * apsFrame, EmberIncomingMessageType ty
 
 kickout:
     emberAfClearResponseData();
-    MEMSET(&interpanResponseHeader, 0, sizeof(EmberAfInterpanHeader));
+    memset(&interpanResponseHeader, 0, sizeof(EmberAfInterpanHeader));
     emAfCurrentCommand = NULL;
     return msgHandled;
 }
@@ -1041,7 +1041,7 @@ void emberAfCopyString(uint8_t * dest, uint8_t * src, uint8_t size)
         {
             length = size;
         }
-        MEMMOVE(dest + 1, src + 1, length);
+        memmove(dest + 1, src + 1, length);
         dest[0] = length;
     }
 }
@@ -1064,7 +1064,7 @@ void emberAfCopyLongString(uint8_t * dest, uint8_t * src, uint16_t size)
         {
             length = size;
         }
-        MEMMOVE(dest + 2, src + 2, length);
+        memmove(dest + 2, src + 2, length);
         dest[0] = LOW_BYTE(length);
         dest[1] = HIGH_BYTE(length);
     }
@@ -1246,7 +1246,7 @@ bool emberAfIsThisMyEui64(EmberEUI64 eui64)
 {
     EmberEUI64 myEui64;
     emberAfGetEui64(myEui64);
-    return (0 == MEMCOMPARE(eui64, myEui64, EUI64_SIZE) ? true : false);
+    return (0 == memcmp(eui64, myEui64, EUI64_SIZE) ? true : false);
 }
 
 uint8_t emberAfAppendCharacters(uint8_t * zclString, uint8_t zclStringMaxLen, const uint8_t * appendingChars,
@@ -1271,7 +1271,7 @@ uint8_t emberAfAppendCharacters(uint8_t * zclString, uint8_t zclStringMaxLen, co
     freeChars    = zclStringMaxLen - curLen;
     charsToWrite = (freeChars > appendingCharsLen) ? appendingCharsLen : freeChars;
 
-    MEMCOPY(&zclString[1 + curLen], // 1 is to account for zcl's length byte
+    memcpy(&zclString[1 + curLen], // 1 is to account for zcl's length byte
             appendingChars, charsToWrite);
     zclString[0] = curLen + charsToWrite;
     return charsToWrite;


### PR DESCRIPTION
#### Problem
 trivial macros that have redefinitions can cause compiler warnings

 #### Summary of Changes
 remove trivial definitions, use C std library names