### PR TITLE
Deduplicate args.gni for nRF5 examples

### DIFF
--- a/examples/build_overrides/nrf5_sdk.gni
+++ b/examples/build_overrides/nrf5_sdk.gni
@@ -16,3 +16,8 @@ declare_args() {
   # Root directory for nRF5 SDK.
   nrf5_sdk_build_root = "//third_party/connectedhomeip/third_party/nrf5_sdk"
 }
+
+declare_args() {
+  # Location of the nRF5 SDK.
+  nrf5_sdk_root = ""
+}

--- a/examples/lighting-app/nrf5/BUILD.gn
+++ b/examples/lighting-app/nrf5/BUILD.gn
@@ -52,11 +52,6 @@ nrf5_sdk("sdk") {
 executable("lighting_app") {
   output_name = "chip-nrf52840-lighting-example"
 
-  public_deps = [
-    ":sdk",
-    "${chip_root}/src/lib",
-  ]
-
   sources = [
     "${nrf5_platform_dir}/app/Server.cpp",
     "${nrf5_platform_dir}/app/chipinit.cpp",
@@ -75,6 +70,11 @@ executable("lighting_app") {
     "main/include/DataModelHandler.h",
     "main/include/LightingManager.h",
     "main/main.cpp",
+  ]
+
+  deps = [
+    ":sdk",
+    "${chip_root}/src/lib",
   ]
 
   output_dir = root_out_dir

--- a/examples/lock-app/nrf5/BUILD.gn
+++ b/examples/lock-app/nrf5/BUILD.gn
@@ -52,11 +52,6 @@ nrf5_sdk("sdk") {
 executable("lock_app") {
   output_name = "chip-nrf52840-lock-example"
 
-  public_deps = [
-    ":sdk",
-    "${chip_root}/src/lib",
-  ]
-
   sources = [
     "${nrf5_platform_dir}/app/Server.cpp",
     "${nrf5_platform_dir}/app/chipinit.cpp",
@@ -75,6 +70,11 @@ executable("lock_app") {
     "main/include/BoltLockManager.h",
     "main/include/DataModelHandler.h",
     "main/main.cpp",
+  ]
+
+  deps = [
+    ":sdk",
+    "${chip_root}/src/lib",
   ]
 
   output_dir = root_out_dir

--- a/examples/lock-app/nrf5/args.gni
+++ b/examples/lock-app/nrf5/args.gni
@@ -14,18 +14,7 @@
 
 import("//build_overrides/chip.gni")
 
-import("${chip_root}/src/platform/nRF5/args.gni")
+import("${chip_root}/examples/platform/nrf528xx/args.gni")
 
 # SDK target. This is overriden to add our SDK app_config.h & defines.
 nrf5_sdk_target = get_label_info(":sdk", "label_no_toolchain")
-
-arm_arch = "armv7e-m"
-arm_float_abi = "hard"
-arm_cpu = "cortex-m4"
-arm_fpu = "fpv4-sp-d16"
-
-chip_ble_project_config_include = "<CHIPProjectConfig.h>"
-chip_device_project_config_include = "<CHIPProjectConfig.h>"
-chip_project_config_include = "<CHIPProjectConfig.h>"
-chip_inet_project_config_include = "<CHIPProjectConfig.h>"
-chip_system_project_config_include = "<CHIPProjectConfig.h>"

--- a/examples/platform/nrf528xx/args.gni
+++ b/examples/platform/nrf528xx/args.gni
@@ -14,7 +14,20 @@
 
 import("//build_overrides/chip.gni")
 
-import("${chip_root}/examples/platform/nrf528xx/args.gni")
+import("${chip_root}/src/platform/nRF5/args.gni")
 
-# SDK target. This is overriden to add our SDK app_config.h & defines.
-nrf5_sdk_target = get_label_info(":sdk", "label_no_toolchain")
+arm_arch = "armv7e-m"
+arm_float_abi = "hard"
+arm_cpu = "cortex-m4"
+arm_fpu = "fpv4-sp-d16"
+
+chip_ble_project_config_include = "<CHIPProjectConfig.h>"
+chip_device_project_config_include = "<CHIPProjectConfig.h>"
+chip_project_config_include = "<CHIPProjectConfig.h>"
+chip_inet_project_config_include = "<CHIPProjectConfig.h>"
+chip_system_project_config_include = "<CHIPProjectConfig.h>"
+
+chip_config_enable_arg_parser = false
+chip_system_config_provide_statistics = false
+chip_inet_config_enable_raw_endpoint = false
+chip_with_nlfaultinjection = true

--- a/gn/build_overrides/nrf5_sdk.gni
+++ b/gn/build_overrides/nrf5_sdk.gni
@@ -16,3 +16,8 @@ declare_args() {
   # Root directory for nRF5 SDK build files.
   nrf5_sdk_build_root = "//third_party/nrf5_sdk"
 }
+
+declare_args() {
+  # Location of the nRF5 SDK.
+  nrf5_sdk_root = ""
+}

--- a/src/inet/BUILD.gn
+++ b/src/inet/BUILD.gn
@@ -116,12 +116,6 @@ static_library("inet") {
     "InetLayerBasis.h",
     "InetLayerEvents.h",
     "InetUtils.cpp",
-    "RawEndPoint.cpp",
-    "RawEndPoint.h",
-    "TCPEndPoint.cpp",
-    "TCPEndPoint.h",
-    "UDPEndPoint.cpp",
-    "UDPEndPoint.h",
     "arpa-inet-compatibility.h",
   ]
 
@@ -131,6 +125,27 @@ static_library("inet") {
     "${chip_root}/src/system",
     "${nlio_root}:nlio",
   ]
+
+  if (chip_inet_config_enable_raw_endpoint) {
+    sources += [
+      "RawEndPoint.cpp",
+      "RawEndPoint.h",
+    ]
+  }
+
+  if (chip_inet_config_enable_tcp_endpoint) {
+    sources += [
+      "TCPEndPoint.cpp",
+      "TCPEndPoint.h",
+    ]
+  }
+
+  if (chip_inet_config_enable_udp_endpoint) {
+    sources += [
+      "UDPEndPoint.cpp",
+      "UDPEndPoint.h",
+    ]
+  }
 
   if (chip_inet_config_enable_dns_resolver) {
     sources += [

--- a/third_party/nrf5_sdk/nrf5_sdk.gni
+++ b/third_party/nrf5_sdk/nrf5_sdk.gni
@@ -14,11 +14,6 @@
 
 import("//build_overrides/nrf5_sdk.gni")
 
-declare_args() {
-  # Location of the nRF5 SDK.
-  nrf5_sdk_root = ""
-}
-
 if (nrf5_sdk_root == "") {
   nrf5_sdk_root = getenv("NRF5_SDK_ROOT")
 }
@@ -29,7 +24,7 @@ assert(nrf5_sdk_root != "", "nrf5_sdk_root must be specified")
 #
 # Parameters:
 #   nrf5_sdk_root - The location of the nRF SDK.
-#   sources - The sources files to build.
+#   sources - Extra source files to build.
 template("nrf5_sdk") {
   if (defined(invoker.nrf5_sdk_root)) {
     nrf5_sdk_root = invoker.nrf5_sdk_root


### PR DESCRIPTION
Move common args between lock-app and lighting-app to
examples/platform/nrf528xx/args.gni.
    
Also make some minor build file cleanups and add some settings that the
automake build is using such as disabling the raw endpoint.
    
Depends on #2036
