### PR TITLE
Add support for a more general attribute-reading command to chip-tool

### DIFF
--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -219,7 +219,9 @@ void ShowUsage(const char * executable)
             "    off device-ip-address device-port endpoint-id\n"
             "    on device-ip-address device-port endpoint-id\n"
             "    toggle device-ip-address device-port endpoint-id\n"
-            "    read-onoff device-ip-address device-port endpoint-id\n",
+            "    read device-ip-address device-port endpoint-id attr-name\n"
+            "  Supported attribute names for the 'read' command:\n"
+            "    onoff -- OnOff attribute from the On/Off cluster\n",
             executable);
 }
 
@@ -228,7 +230,7 @@ enum class Command
     Off,
     On,
     Toggle,
-    ReadOnOff,
+    Read,
     Echo,
     EchoBle,
 };
@@ -264,10 +266,10 @@ bool DetermineCommand(int argc, char * argv[], Command * command)
         return argc == 5;
     }
 
-    if (EqualsLiteral(argv[1], "read-onoff"))
+    if (EqualsLiteral(argv[1], "read"))
     {
-        *command = Command::ReadOnOff;
-        return argc == 5;
+        *command = Command::Read;
+        return argc == 6;
     }
 
     if (EqualsLiteral(argv[1], "echo"))
@@ -293,6 +295,8 @@ struct CommandArgs
     uint16_t discriminator;
     uint32_t setupPINCode;
     uint8_t endpointId;
+    // attrName is only used for Read commands.
+    const char * attrName;
 };
 
 bool DetermineArgsBle(char * argv[], CommandArgs * commandArgs)
@@ -360,8 +364,17 @@ bool DetermineCommandArgs(char * argv[], Command command, CommandArgs * commandA
     case Command::On:
     case Command::Off:
     case Command::Toggle:
-    case Command::ReadOnOff:
-        return DetermineArgsOnOff(argv, commandArgs);
+    case Command::Read: {
+        if (!DetermineArgsOnOff(argv, commandArgs))
+        {
+            return false;
+        }
+        if (command == Command::Read)
+        {
+            commandArgs->attrName = argv[5];
+        }
+        return true;
+    }
     }
 
     fprintf(stderr, "Need to define arg handling for command '%d'\n", int(command));
@@ -412,8 +425,10 @@ void DoEchoIP(DeviceController::ChipDeviceController * controller, const IPAddre
 
 // Handle the on/off/toggle case, where we are sending a ZCL command and not
 // expecting a response at all.
-void DoOnOff(DeviceController::ChipDeviceController * controller, Command command, uint8_t endpoint)
+void DoOnOff(DeviceController::ChipDeviceController * controller, Command command, const CommandArgs & commandArgs)
 {
+    const uint8_t endpoint = commandArgs.endpointId;
+
     // Make sure our buffer is big enough, but this will need a better setup!
     static const size_t bufferSize = 1024;
     auto * buffer                  = System::PacketBuffer::NewWithAvailableSize(bufferSize);
@@ -430,7 +445,12 @@ void DoOnOff(DeviceController::ChipDeviceController * controller, Command comman
     case Command::Toggle:
         dataLength = encodeToggleCommand(buffer->Start(), bufferSize, endpoint);
         break;
-    case Command::ReadOnOff:
+    case Command::Read:
+        if (!EqualsLiteral(commandArgs.attrName, "onoff"))
+        {
+            fprintf(stderr, "Don't know how to read '%s' attribute\n", commandArgs.attrName);
+            return;
+        }
         dataLength = encodeReadOnOffCommand(buffer->Start(), bufferSize, endpoint);
         break;
     default:
@@ -483,7 +503,7 @@ CHIP_ERROR ExecuteCommand(DeviceController::ChipDeviceController * controller, C
         err =
             controller->ConnectDevice(kRemoteDeviceId, commandArgs.hostAddr, NULL, OnConnect, OnMessage, OnError, commandArgs.port);
         VerifyOrExit(err == CHIP_NO_ERROR, fprintf(stderr, "Failed to connect to the device"));
-        DoOnOff(controller, command, commandArgs.endpointId);
+        DoOnOff(controller, command, commandArgs);
         controller->ServiceEventSignal();
         break;
     }


### PR DESCRIPTION
 #### Problem
Right now we really only support reading the OnOff attribute of the On/Off cluster, via the "read-onoff" command, in chip-tool.

 #### Summary of Changes
Introduce a "read" command which takes a separate arg for which attr to read.  For now, only "onoff" is supported.

fixes https://github.com/project-chip/connectedhomeip/issues/1985
