### PR TITLE
[nrf] Add CHIPoBLE Thread network provision in lock-app

### DIFF
--- a/examples/lock-app/nrf5/main/include/AppEvent.h
+++ b/examples/lock-app/nrf5/main/include/AppEvent.h
@@ -19,6 +19,8 @@
 #ifndef APP_EVENT_H
 #define APP_EVENT_H
 
+#include <stdint.h>
+
 struct AppEvent;
 typedef void (*EventHandler)(AppEvent *);
 

--- a/examples/lock-app/nrf5/main/include/AppTask.h
+++ b/examples/lock-app/nrf5/main/include/AppTask.h
@@ -29,6 +29,8 @@
 #include "AppEvent.h"
 #include "BoltLockManager.h"
 
+#include <ble/BLEEndPoint.h>
+
 class AppTask
 {
 public:
@@ -58,6 +60,10 @@ private:
     static void ButtonEventHandler(uint8_t pin_no, uint8_t button_action);
     static void TimerEventHandler(void * p_context);
 
+    static void HandleBLEConnectionOpened(chip::Ble::BLEEndPoint * endPoint);
+    static void HandleBLEConnectionClosed(chip::Ble::BLEEndPoint * endPoint, BLE_ERROR err);
+    static void HandleBLEMessageReceived(chip::Ble::BLEEndPoint * endPoint, chip::System::PacketBuffer * buffer);
+
     void StartTimer(uint32_t aTimeoutInMs);
 
     enum Function_t
@@ -71,6 +77,7 @@ private:
 
     Function_t mFunction;
     bool mFunctionTimerActive;
+    chip::Ble::BLEEndPoint * mBLEEndPoint;
 
     static AppTask sAppTask;
 };

--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -77,6 +77,8 @@ public:
     CHIP_ERROR GetPrimary802154MACAddress(uint8_t * buf);
 
     CHIP_ERROR JoinerStart(void);
+    CHIP_ERROR SetThreadProvision(const Internal::DeviceNetworkInfo & netInfo);
+    CHIP_ERROR SetThreadEnabled(bool val);
 
 private:
     // ===== Members for internal use by the following friends.
@@ -106,11 +108,9 @@ private:
 
     void OnPlatformEvent(const ChipDeviceEvent * event);
     bool IsThreadEnabled(void);
-    CHIP_ERROR SetThreadEnabled(bool val);
     bool IsThreadProvisioned(void);
     bool IsThreadAttached(void);
     CHIP_ERROR GetThreadProvision(Internal::DeviceNetworkInfo & netInfo, bool includeCredentials);
-    CHIP_ERROR SetThreadProvision(const Internal::DeviceNetworkInfo & netInfo);
     void ErasePersistentInfo(void);
     ConnectivityManager::ThreadDeviceType GetThreadDeviceType(void);
     CHIP_ERROR SetThreadDeviceType(ConnectivityManager::ThreadDeviceType threadRole);


### PR DESCRIPTION
 #### Problem
Network provision as in [ESP32 code](https://github.com/project-chip/connectedhomeip/blob/master/examples/wifi-echo/server/esp32/main/ServiceProvisioning.cpp) is currently missing in the nrf platform.

 #### Summary of Changes
This PR adds a prototype of Thread network provision over BLE in the lock app. 
