### PR TITLE
Stop using void* in our command decoder.

### DIFF
--- a/src/app/chip-zcl-zpro/command-encoder/chip-zcl-zpro-codec.h
+++ b/src/app/chip-zcl-zpro/command-encoder/chip-zcl-zpro-codec.h
@@ -78,7 +78,7 @@ uint16_t encodeReadOnOffCommand(uint8_t * buffer, uint16_t buf_length, uint8_t d
 
 /** @brief Extracts an aps frame from buffer into outApsFrame
  */
-bool extractApsFrame(void * buffer, uint32_t buf_length, EmberApsFrame * outApsFrame);
+bool extractApsFrame(uint8_t * buffer, uint32_t buf_length, EmberApsFrame * outApsFrame);
 
 /** @brief Populates msg with address of the zcl message within buffer.
  * @return Returns the length of msg buffer. Returns 0 on error e.g. if buffer is too short.

--- a/src/app/chip-zcl-zpro/command-encoder/decoder.c
+++ b/src/app/chip-zcl-zpro/command-encoder/decoder.c
@@ -27,7 +27,7 @@
 #include <string.h>
 
 // TODO: Make this return a CHIP_ERROR
-bool extractApsFrame(void * buffer, uint32_t buf_length, EmberApsFrame * outApsFrame)
+bool extractApsFrame(uint8_t * buffer, uint32_t buf_length, EmberApsFrame * outApsFrame)
 {
     if (buffer == NULL || buf_length == 0 || outApsFrame == NULL)
     {


### PR DESCRIPTION
 #### Problem
`extractApsFrame` uses `void*` for the buffer and does pointer arithmetic with it.  This is technically not valid C (though some compilers allow it), and is definitely not supported in C+++, and we'd like to be able to switch this code to C++.

 #### Summary of Changes
Using `uint8_t*` instead.

fixes https://github.com/project-chip/connectedhomeip/issues/1629
