### PR TITLE
Replace extractMessage with output from extractApsFrame #1980

### DIFF
--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -100,18 +100,14 @@ static bool ContentMayBeADataModelMessage(System::PacketBuffer * buffer)
 static void HandleDataModelMessage(System::PacketBuffer * buffer)
 {
     EmberApsFrame frame;
-    bool ok = extractApsFrame(buffer->Start(), buffer->DataLength(), &frame) > 0 ? true : false;
-    if (ok)
-    {
-        printf("APS frame processing success!\n");
-    }
-    else
+    if (extractApsFrame(buffer->Start(), buffer->DataLength(), &frame) == 0)
     {
         printf("APS frame processing failure!\n");
         System::PacketBuffer::Free(buffer);
         return;
     }
 
+    printf("APS frame processing success!\n");
     uint8_t * message;
     uint16_t messageLen = extractMessage(buffer->Start(), buffer->DataLength(), &message);
 

--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -100,7 +100,7 @@ static bool ContentMayBeADataModelMessage(System::PacketBuffer * buffer)
 static void HandleDataModelMessage(System::PacketBuffer * buffer)
 {
     EmberApsFrame frame;
-    bool ok = extractApsFrame(buffer->Start(), buffer->DataLength(), &frame);
+    bool ok = extractApsFrame(buffer->Start(), buffer->DataLength(), &frame) > 0 ? true : false;
     if (ok)
     {
         printf("APS frame processing success!\n");

--- a/examples/lock-app/nrfconnect/main/Server.cpp
+++ b/examples/lock-app/nrfconnect/main/Server.cpp
@@ -115,7 +115,7 @@ private:
     void HandleDataModelMessage(const MessageHeader & header, System::PacketBuffer * buffer, SecureSessionMgrBase * mgr)
     {
         EmberApsFrame frame;
-        bool ok = extractApsFrame(buffer->Start(), buffer->DataLength(), &frame) > 0 ? true : false;
+        bool ok = extractApsFrame(buffer->Start(), buffer->DataLength(), &frame) > 0;
         if (ok)
         {
             LOG_INF("APS frame processing success!");

--- a/examples/lock-app/nrfconnect/main/Server.cpp
+++ b/examples/lock-app/nrfconnect/main/Server.cpp
@@ -115,7 +115,7 @@ private:
     void HandleDataModelMessage(const MessageHeader & header, System::PacketBuffer * buffer, SecureSessionMgrBase * mgr)
     {
         EmberApsFrame frame;
-        bool ok = extractApsFrame(buffer->Start(), buffer->DataLength(), &frame);
+        bool ok = extractApsFrame(buffer->Start(), buffer->DataLength(), &frame) > 0 ? true : false;
         if (ok)
         {
             LOG_INF("APS frame processing success!");

--- a/examples/platform/nrf528xx/app/Server.cpp
+++ b/examples/platform/nrf528xx/app/Server.cpp
@@ -120,7 +120,7 @@ private:
     void HandleDataModelMessage(const MessageHeader & header, System::PacketBuffer * buffer, SecureSessionMgrBase * mgr)
     {
         EmberApsFrame frame;
-        bool ok = extractApsFrame(buffer->Start(), buffer->DataLength(), &frame);
+        bool ok = extractApsFrame(buffer->Start(), buffer->DataLength(), &frame) > 0 ? true : false;
         if (ok)
         {
             NRF_LOG_INFO("APS frame processing success!");

--- a/examples/platform/nrf528xx/app/Server.cpp
+++ b/examples/platform/nrf528xx/app/Server.cpp
@@ -120,7 +120,7 @@ private:
     void HandleDataModelMessage(const MessageHeader & header, System::PacketBuffer * buffer, SecureSessionMgrBase * mgr)
     {
         EmberApsFrame frame;
-        bool ok = extractApsFrame(buffer->Start(), buffer->DataLength(), &frame) > 0 ? true : false;
+        bool ok = extractApsFrame(buffer->Start(), buffer->DataLength(), &frame) > 0;
         if (ok)
         {
             NRF_LOG_INFO("APS frame processing success!");

--- a/examples/wifi-echo/server/esp32/main/DataModelHandler.cpp
+++ b/examples/wifi-echo/server/esp32/main/DataModelHandler.cpp
@@ -47,7 +47,7 @@ void InitDataModelHandler()
 void HandleDataModelMessage(const MessageHeader & header, System::PacketBuffer * buffer, SecureSessionMgrBase * mgr)
 {
     EmberApsFrame frame;
-    bool ok = extractApsFrame(buffer->Start(), buffer->DataLength(), &frame) > 0 ? true : false;
+    bool ok = extractApsFrame(buffer->Start(), buffer->DataLength(), &frame) > 0;
     if (ok)
     {
         ESP_LOGI(TAG, "APS frame processing success!");

--- a/examples/wifi-echo/server/esp32/main/DataModelHandler.cpp
+++ b/examples/wifi-echo/server/esp32/main/DataModelHandler.cpp
@@ -47,7 +47,7 @@ void InitDataModelHandler()
 void HandleDataModelMessage(const MessageHeader & header, System::PacketBuffer * buffer, SecureSessionMgrBase * mgr)
 {
     EmberApsFrame frame;
-    bool ok = extractApsFrame(buffer->Start(), buffer->DataLength(), &frame);
+    bool ok = extractApsFrame(buffer->Start(), buffer->DataLength(), &frame) > 0 ? true : false;
     if (ok)
     {
         ESP_LOGI(TAG, "APS frame processing success!");

--- a/src/app/chip-zcl-zpro/command-encoder/chip-zcl-zpro-codec.h
+++ b/src/app/chip-zcl-zpro/command-encoder/chip-zcl-zpro-codec.h
@@ -77,8 +77,12 @@ uint16_t encodeReadAttributesCommand(uint8_t * buffer, uint16_t buf_length, uint
 uint16_t encodeReadOnOffCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
 
 /** @brief Extracts an aps frame from buffer into outApsFrame
+ * @param buffer Buffer to read from
+ * @param buf_length Length of buffer
+ * @param outApsFrame Pointer to EmberApsFrame struct to read into
+ * @return returns the number of bytes that were consumed to read out the EmberApsFrame. 0 means an error was encountered
  */
-bool extractApsFrame(uint8_t * buffer, uint32_t buf_length, EmberApsFrame * outApsFrame);
+uint16_t extractApsFrame(void * buffer, uint32_t buf_length, EmberApsFrame * outApsFrame);
 
 /** @brief Populates msg with address of the zcl message within buffer.
  * @return Returns the length of msg buffer. Returns 0 on error e.g. if buffer is too short.

--- a/src/app/chip-zcl-zpro/command-encoder/decoder.c
+++ b/src/app/chip-zcl-zpro/command-encoder/decoder.c
@@ -111,7 +111,6 @@ uint16_t extractMessage(uint8_t * buffer, uint16_t buffer_length, uint8_t ** msg
     uint16_t apsFrameSize = extractApsFrame(buffer, buffer_length, &frame);
     if (msg && apsFrameSize > 0 && buffer_length > apsFrameSize)
     {
-        // These are hard coded for now.
         *msg   = buffer + apsFrameSize;
         result = buffer_length - apsFrameSize;
     }

--- a/src/app/chip-zcl-zpro/command-encoder/decoder.c
+++ b/src/app/chip-zcl-zpro/command-encoder/decoder.c
@@ -26,73 +26,73 @@
 #include <stdio.h>
 #include <string.h>
 
-// TODO: Make this return a CHIP_ERROR
-bool extractApsFrame(uint8_t * buffer, uint32_t buf_length, EmberApsFrame * outApsFrame)
+uint16_t extractApsFrame(void * buffer, uint32_t buf_length, EmberApsFrame * outApsFrame)
 {
+
     if (buffer == NULL || buf_length == 0 || outApsFrame == NULL)
     {
-        return false;
+        return 0;
     }
     // Skip first byte, because that's the always-0 frame control.
     uint8_t nextByteToRead = 1;
 
     if (nextByteToRead >= buf_length)
     {
-        return false;
+        return 0;
     }
     memcpy(&outApsFrame->profileId, buffer + nextByteToRead, sizeof(outApsFrame->profileId));
     nextByteToRead += sizeof(outApsFrame->profileId);
 
     if (nextByteToRead >= buf_length)
     {
-        return false;
+        return 0;
     }
     memcpy(&outApsFrame->clusterId, buffer + nextByteToRead, sizeof(outApsFrame->clusterId));
     nextByteToRead += sizeof(outApsFrame->clusterId);
 
     if (nextByteToRead >= buf_length)
     {
-        return false;
+        return 0;
     }
     memcpy(&outApsFrame->sourceEndpoint, buffer + nextByteToRead, sizeof(outApsFrame->sourceEndpoint));
     nextByteToRead += sizeof(outApsFrame->sourceEndpoint);
 
     if (nextByteToRead >= buf_length)
     {
-        return false;
+        return 0;
     }
     memcpy(&outApsFrame->destinationEndpoint, buffer + nextByteToRead, sizeof(outApsFrame->destinationEndpoint));
     nextByteToRead += sizeof(outApsFrame->destinationEndpoint);
 
     if (nextByteToRead >= buf_length)
     {
-        return false;
+        return 0;
     }
     memcpy(&outApsFrame->options, buffer + nextByteToRead, sizeof(outApsFrame->options));
     nextByteToRead += sizeof(outApsFrame->options);
 
     if (nextByteToRead >= buf_length)
     {
-        return false;
+        return 0;
     }
     memcpy(&outApsFrame->groupId, buffer + nextByteToRead, sizeof(outApsFrame->groupId));
     nextByteToRead += sizeof(outApsFrame->groupId);
 
     if (nextByteToRead >= buf_length)
     {
-        return false;
+        return 0;
     }
     memcpy(&outApsFrame->sequence, buffer + nextByteToRead, sizeof(outApsFrame->sequence));
     nextByteToRead += sizeof(outApsFrame->sequence);
 
     if (nextByteToRead >= buf_length)
     {
-        return false;
+        return 0;
     }
     memcpy(&outApsFrame->radius, buffer + nextByteToRead, sizeof(outApsFrame->radius));
     nextByteToRead += sizeof(outApsFrame->radius);
 
-    return true;
+    return nextByteToRead;
 }
 
 void printApsFrame(EmberApsFrame * frame)
@@ -103,18 +103,17 @@ void printApsFrame(EmberApsFrame * frame)
            frame->groupId, frame->sequence, frame->radius);
 }
 
-// Size of an encoded EmberApsFrame.
-static const size_t kEmberApsFrameSize = 13;
-
 uint16_t extractMessage(uint8_t * buffer, uint16_t buffer_length, uint8_t ** msg)
 {
     // The message starts after the EmberApsFrame.
     uint16_t result = 0;
-    if (msg && buffer_length > kEmberApsFrameSize)
+    EmberApsFrame frame;
+    uint16_t apsFrameSize = extractApsFrame(buffer, buffer_length, &frame);
+    if (msg && apsFrameSize > 0 && buffer_length > apsFrameSize)
     {
         // These are hard coded for now.
-        *msg   = buffer + kEmberApsFrameSize;
-        result = buffer_length - kEmberApsFrameSize;
+        *msg   = buffer + apsFrameSize;
+        result = buffer_length - apsFrameSize;
     }
     else if (msg)
     {

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -394,7 +394,7 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
     uint8_t * bytes = (uint8_t *) response.bytes;
 
     EmberApsFrame frame;
-    if (!extractApsFrame(bytes, response.length, &frame)) {
+    if (extractApsFrame(bytes, response.length, &frame) == 0) {
         return @"Response is not an APS frame";
     }
 


### PR DESCRIPTION
 #### Problem
Replace extractMessage with output from extractApsFrame #1980

 #### Summary of Changes
`extractApsFrame` now returns the number of bytes that was used by the aps header. This lets us remove the hard coded size.

fixes #1980
