### PR TITLE
whack boolean update BIT

### DIFF
--- a/examples/lighting-app/nrf5/main/gen/callback-stub.c
+++ b/examples/lighting-app/nrf5/main/gen/callback-stub.c
@@ -2474,4 +2474,4 @@ void halRadioPowerUpHandler(void) {}
  * @param enter        True if entering idle/sleep, False if exiting
  * @param sleepMode    Idle/sleep mode
  */
-void halSleepCallback(boolean enter, SleepModes sleepMode) {}
+void halSleepCallback(bool enter, SleepModes sleepMode) {}

--- a/examples/lighting-app/nrf5/main/gen/callback.h
+++ b/examples/lighting-app/nrf5/main/gen/callback.h
@@ -23770,7 +23770,7 @@ void halRadioPowerDownHandler(void);
  * @param enter        True if entering idle/sleep, False if exiting
  * @param sleepMode    Idle/sleep mode
  */
-void halSleepCallback(boolean enter, SleepModes sleepMode);
+void halSleepCallback(bool enter, SleepModes sleepMode);
 /** @} END HAL Library Plugin Callbacks */
 
 /** @} END addtogroup */

--- a/examples/lock-app/nrf5/main/gen/callback-stub.c
+++ b/examples/lock-app/nrf5/main/gen/callback-stub.c
@@ -2474,4 +2474,4 @@ void halRadioPowerUpHandler(void) {}
  * @param enter        True if entering idle/sleep, False if exiting
  * @param sleepMode    Idle/sleep mode
  */
-void halSleepCallback(boolean enter, SleepModes sleepMode) {}
+void halSleepCallback(bool enter, SleepModes sleepMode) {}

--- a/examples/lock-app/nrf5/main/gen/callback.h
+++ b/examples/lock-app/nrf5/main/gen/callback.h
@@ -23770,7 +23770,7 @@ void halRadioPowerDownHandler(void);
  * @param enter        True if entering idle/sleep, False if exiting
  * @param sleepMode    Idle/sleep mode
  */
-void halSleepCallback(boolean enter, SleepModes sleepMode);
+void halSleepCallback(bool enter, SleepModes sleepMode);
 /** @} END HAL Library Plugin Callbacks */
 
 /** @} END addtogroup */

--- a/examples/lock-app/nrfconnect/main/gen/callback-stub.c
+++ b/examples/lock-app/nrfconnect/main/gen/callback-stub.c
@@ -2474,4 +2474,4 @@ void halRadioPowerUpHandler(void) {}
  * @param enter        True if entering idle/sleep, False if exiting
  * @param sleepMode    Idle/sleep mode
  */
-void halSleepCallback(boolean enter, SleepModes sleepMode) {}
+void halSleepCallback(bool enter, SleepModes sleepMode) {}

--- a/examples/lock-app/nrfconnect/main/gen/callback.h
+++ b/examples/lock-app/nrfconnect/main/gen/callback.h
@@ -23770,7 +23770,7 @@ void halRadioPowerDownHandler(void);
  * @param enter        True if entering idle/sleep, False if exiting
  * @param sleepMode    Idle/sleep mode
  */
-void halSleepCallback(boolean enter, SleepModes sleepMode);
+void halSleepCallback(bool enter, SleepModes sleepMode);
 /** @} END HAL Library Plugin Callbacks */
 
 /** @} END addtogroup */

--- a/examples/wifi-echo/server/esp32/main/EchoDeviceCallbacks.cpp
+++ b/examples/wifi-echo/server/esp32/main/EchoDeviceCallbacks.cpp
@@ -107,7 +107,7 @@ void EchoDeviceCallbacks::PostAttributeChangeCallback(uint8_t endpoint, EmberAfC
         return;
     }
     ESP_LOGI(TAG, "Got the post attribute callback");
-    // At this point we can assume that value points to a boolean value.
+    // At this point we can assume that value points to a bool value.
     statusLED.Set(*value);
     ESP_LOGI(TAG, "Current free heap: %d\n", heap_caps_get_free_size(MALLOC_CAP_8BIT));
 }

--- a/examples/wifi-echo/server/esp32/main/gen/callback-stub.c
+++ b/examples/wifi-echo/server/esp32/main/gen/callback-stub.c
@@ -2474,4 +2474,4 @@ void halRadioPowerUpHandler(void) {}
  * @param enter        True if entering idle/sleep, False if exiting
  * @param sleepMode    Idle/sleep mode
  */
-void halSleepCallback(boolean enter, SleepModes sleepMode) {}
+void halSleepCallback(bool enter, SleepModes sleepMode) {}

--- a/examples/wifi-echo/server/esp32/main/gen/callback.h
+++ b/examples/wifi-echo/server/esp32/main/gen/callback.h
@@ -23770,7 +23770,7 @@ void halRadioPowerDownHandler(void);
  * @param enter        True if entering idle/sleep, False if exiting
  * @param sleepMode    Idle/sleep mode
  */
-void halSleepCallback(boolean enter, SleepModes sleepMode);
+void halSleepCallback(bool enter, SleepModes sleepMode);
 /** @} END HAL Library Plugin Callbacks */
 
 /** @} END addtogroup */

--- a/src/app/util/types_stub.h
+++ b/src/app/util/types_stub.h
@@ -1845,7 +1845,7 @@ typedef struct
 /**
  * @brief Useful to reference a single bit of a byte.
  */
-#define BIT(x) (1U << (x)) // Unsigned avoids compiler warnings re BIT(15)
+#define BIT(nr) (1UL << (nr)) // Unsigned avoids compiler warnings re BIT(15)
 
 /**
  * @brief Returns the low byte of the 16-bit value \c n as an \c uint8_t.
@@ -1905,9 +1905,6 @@ typedef struct
 // Stubs to just silence some compile errors
 
 #define emberAfPrintEnabled(...) false
-
-// Needed by callback.h and callback-stubs.c
-typedef bool boolean;
 
 #define emberAfPrintActiveArea EMBER_AF_PRINT_CORE
 #endif // TYPES_STUB_H


### PR DESCRIPTION
#### Problem
 boolean is a typedef we don't need
 BIT() is defined differently in types_stub.h than in esp32 platform, causes build warnings

 #### Summary of Changes
 * remove boolean and move consumers to bool
 * make BIT() the same in both places so compilers are happy

