### PR TITLE
Disable security test mode to silence the build

### DIFF
--- a/config/standalone/CHIPProjectConfig.h
+++ b/config/standalone/CHIPProjectConfig.h
@@ -43,7 +43,7 @@
 // properly when CHIP_CONFIG_RNG_IMPLEMENTATION_CHIPDRBG is enabled.
 #define CHIP_CONFIG_DEV_RANDOM_DRBG_SEED 1
 
-#define CHIP_CONFIG_SECURITY_TEST_MODE 1
+#define CHIP_CONFIG_SECURITY_TEST_MODE 0
 
 // Increase session idle timeout in stand-alone builds for the convenience of developers.
 #define CHIP_CONFIG_DEFAULT_SECURITY_SESSION_IDLE_TIMEOUT 120000

--- a/examples/lock-app/efr32/include/CHIPProjectConfig.h
+++ b/examples/lock-app/efr32/include/CHIPProjectConfig.h
@@ -49,7 +49,7 @@
 //    WARNING: These options make it possible to circumvent basic Chip security functionality,
 //    including message encryption. Because of this they MUST NEVER BE ENABLED IN PRODUCTION BUILDS.
 //
-#define CHIP_CONFIG_SECURITY_TEST_MODE 1
+#define CHIP_CONFIG_SECURITY_TEST_MODE 0
 #define CHIP_CONFIG_REQUIRE_AUTH 0
 
 /**

--- a/examples/platform/nrf528xx/app/project_include/CHIPProjectConfig.h
+++ b/examples/platform/nrf528xx/app/project_include/CHIPProjectConfig.h
@@ -41,7 +41,7 @@
 // authentication in various protocols.
 // WARNING: These options make it possible to circumvent basic CHIP security functionality,
 // including message encryption. Because of this they MUST NEVER BE ENABLED IN PRODUCTION BUILDS.
-#define CHIP_CONFIG_SECURITY_TEST_MODE 1
+#define CHIP_CONFIG_SECURITY_TEST_MODE 0
 #define CHIP_CONFIG_REQUIRE_AUTH 0
 
 /**


### PR DESCRIPTION
This creates a large amount of spam:

```
[171/1555] c++ linux_x64_clang/obj/src/lib/message/libChipMessage.CHIPFabricState.cpp.o
../../src/lib/message/CHIPFabricState.cpp:79:9: warning:                   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!                  !!!!    WARNING - SECURITY_TEST_MODE IS ENABLED    !!!!                  !!!! BASIC CHIP SECURITY / ENCRYPTION IS CRIPPLED !!!!                  !!!!        DEVELOPMENT ONLY -- DO NOT SHIP        !!!!                  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!                   [-W#pragma-messages]
        ^
1 warning generated.
[448/1555] c++ linux_x64_gcc/obj/src/lib/message/libChipMessage.CHIPFabricState.cpp.o
../../src/lib/message/CHIPFabricState.cpp:79:17: note: #pragma message:
                  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                  !!!!    WARNING - SECURITY_TEST_MODE IS ENABLED    !!!!
                  !!!! BASIC CHIP SECURITY / ENCRYPTION IS CRIPPLED !!!!
                  !!!!        DEVELOPMENT ONLY -- DO NOT SHIP        !!!!
                  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

   79 | #pragma message "\n \
      |                 ^~~~~
   80 |                  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n \
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   81 |                  !!!!    WARNING - SECURITY_TEST_MODE IS ENABLED    !!!!\n \
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   82 |                  !!!! BASIC CHIP SECURITY / ENCRYPTION IS CRIPPLED !!!!\n \
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   83 |                  !!!!        DEVELOPMENT ONLY -- DO NOT SHIP        !!!!\n \
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   84 |                  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n \
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   85 |                  "
      |                  ~
[753/1555] c++ linux_x64_gcc_embedded/obj/src/lib/message/libChipMessage.CHIPFabricState.cpp.o
../../src/lib/message/CHIPFabricState.cpp:79:17: note: #pragma message:
                  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                  !!!!    WARNING - SECURITY_TEST_MODE IS ENABLED    !!!!
                  !!!! BASIC CHIP SECURITY / ENCRYPTION IS CRIPPLED !!!!
                  !!!!        DEVELOPMENT ONLY -- DO NOT SHIP        !!!!
                  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

   79 | #pragma message "\n \
      |                 ^~~~~
   80 |                  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n \
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   81 |                  !!!!    WARNING - SECURITY_TEST_MODE IS ENABLED    !!!!\n \
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   82 |                  !!!! BASIC CHIP SECURITY / ENCRYPTION IS CRIPPLED !!!!\n \
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   83 |                  !!!!        DEVELOPMENT ONLY -- DO NOT SHIP        !!!!\n \
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   84 |                  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n \
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   85 |                  "
      |                  ~
[1031/1555] c++ linux_x64_gcc_mbedtls/obj/src/lib/message/libChipMessage.CHIPFabricState.cpp.o
../../src/lib/message/CHIPFabricState.cpp:79:17: note: #pragma message:
                  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                  !!!!    WARNING - SECURITY_TEST_MODE IS ENABLED    !!!!
                  !!!! BASIC CHIP SECURITY / ENCRYPTION IS CRIPPLED !!!!
                  !!!!        DEVELOPMENT ONLY -- DO NOT SHIP        !!!!
                  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

   79 | #pragma message "\n \
      |                 ^~~~~
   80 |                  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n \
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   81 |                  !!!!    WARNING - SECURITY_TEST_MODE IS ENABLED    !!!!\n \
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   82 |                  !!!! BASIC CHIP SECURITY / ENCRYPTION IS CRIPPLED !!!!\n \
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   83 |                  !!!!        DEVELOPMENT ONLY -- DO NOT SHIP        !!!!\n \
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   84 |                  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n \
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   85 |                  "
      |                  ~

```