### PR TITLE
Fix OpenSSL build of CHIPMessageLayer.h

### DIFF
--- a/src/crypto/BUILD.gn
+++ b/src/crypto/BUILD.gn
@@ -25,7 +25,10 @@ config("crypto_config") {
     defines += [ "CHIP_CRYPTO_MBEDTLS=0" ]
   }
   if (chip_crypto == "openssl") {
-    defines += [ "CHIP_CRYPTO_OPENSSL=1" ]
+    defines += [
+      "CHIP_CRYPTO_OPENSSL=1",
+      "CHIP_WITH_OPENSSL=1",
+    ]
   } else {
     defines += [ "CHIP_CRYPTO_OPENSSL=0" ]
   }
@@ -44,7 +47,10 @@ if (chip_crypto == "openssl") {
 static_library("crypto") {
   output_name = "libChipCrypto"
 
-  sources = [ "CHIPCryptoPAL.h", "CHIPCryptoPAL.cpp" ]
+  sources = [
+    "CHIPCryptoPAL.cpp",
+    "CHIPCryptoPAL.h",
+  ]
 
   public_deps = [
     "${chip_root}/src/lib/core",

--- a/src/lib/message/support/crypto/AESBlockCipher.h
+++ b/src/lib/message/support/crypto/AESBlockCipher.h
@@ -42,12 +42,7 @@
 
 #include "CHIPCrypto.h"
 
-#if CHIP_CONFIG_AES_IMPLEMENTATION_OPENSSL && !CHIP_WITH_OPENSSL
-#error                                                                                                                             \
-    "INVALID CHIP CONFIG: OpenSSL AES implementation enabled but OpenSSL not available (CHIP_CONFIG_AES_IMPLEMENTATION_OPENSSL == 1 && CHIP_WITH_OPENSSL == 0)."
-#endif
-
-#if CHIP_CONFIG_AES_IMPLEMENTATION_OPENSSL
+#if CHIP_CRYPTO_OPENSSL
 #include <openssl/aes.h>
 #endif
 
@@ -55,7 +50,7 @@
 #include <wmmintrin.h>
 #endif
 
-#if CHIP_CONFIG_AES_IMPLEMENTATION_MBEDTLS
+#if CHIP_CRYPTO_MBEDTLS
 #include <mbedtls/aes.h>
 #endif
 
@@ -84,11 +79,11 @@ protected:
     AES128BlockCipher(void);
     ~AES128BlockCipher(void);
 
-#if CHIP_CONFIG_AES_IMPLEMENTATION_OPENSSL
+#if CHIP_CRYPTO_OPENSSL
     AES_KEY mKey;
 #elif CHIP_CONFIG_AES_IMPLEMENTATION_AESNI
     __m128i mKey[kRoundCount + 1];
-#elif CHIP_CONFIG_AES_IMPLEMENTATION_MBEDTLS
+#elif CHIP_CRYPTO_MBEDTLS
     mbedtls_aes_context mCtx;
 #elif CHIP_CONFIG_AES_USE_EXPANDED_KEY
     uint8_t mKey[kBlockLength * (kRoundCount + 1)];
@@ -134,7 +129,7 @@ protected:
     AES_KEY mKey;
 #elif CHIP_CONFIG_AES_IMPLEMENTATION_AESNI
     __m128i mKey[kRoundCount + 1];
-#elif CHIP_CONFIG_AES_IMPLEMENTATION_MBEDTLS
+#elif CHIP_CRYPTO_MBEDTLS
     mbedtls_aes_context mCtx;
 #elif CHIP_CONFIG_AES_USE_EXPANDED_KEY
     uint8_t mKey[kBlockLength * (kRoundCount + 1)];


### PR DESCRIPTION
We're not taking the OpenSSL path in the OpenSSL build inside
AESBlockCipher.h in the OpenSSL build due to ifdef differences.

This happens to compile if you have mbedtls installed on the host
(/usr/include/mbedtls), which the docker container does.