### PR TITLE
add Framework to CHIP Tool App iOS.xscheme

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool.xcodeproj/xcshareddata/xcschemes/CHIP Tool App iOS.xcscheme
+++ b/src/darwin/CHIPTool/CHIPTool.xcodeproj/xcshareddata/xcschemes/CHIP Tool App iOS.xcscheme
@@ -3,9 +3,23 @@
    LastUpgradeVersion = "1150"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
+      parallelizeBuildables = "NO"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B202528C2459E34F00F97062"
+               BuildableName = "CHIP.framework"
+               BlueprintName = "CHIP"
+               ReferencedContainer = "container:../Framework/CHIP.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"


### PR DESCRIPTION
#### Problem
 CHIP Tool App iOS scheme doesn't include CHIP, so CHIPTool won't build unless you build Framework first

 #### Summary of Changes
 add CHIP to the scheme