### PR TITLE
Fix namespace conflict if using NRF5_SDK_ROOT environment variable

### DIFF
--- a/examples/build_overrides/nrf5_sdk.gni
+++ b/examples/build_overrides/nrf5_sdk.gni
@@ -16,8 +16,3 @@ declare_args() {
   # Root directory for nRF5 SDK.
   nrf5_sdk_build_root = "//third_party/connectedhomeip/third_party/nrf5_sdk"
 }
-
-declare_args() {
-  # Location of the nRF5 SDK.
-  nrf5_sdk_root = ""
-}

--- a/gn/build_overrides/nrf5_sdk.gni
+++ b/gn/build_overrides/nrf5_sdk.gni
@@ -16,8 +16,3 @@ declare_args() {
   # Root directory for nRF5 SDK build files.
   nrf5_sdk_build_root = "//third_party/nrf5_sdk"
 }
-
-declare_args() {
-  # Location of the nRF5 SDK.
-  nrf5_sdk_root = ""
-}

--- a/third_party/nrf5_sdk/nrf5_sdk.gni
+++ b/third_party/nrf5_sdk/nrf5_sdk.gni
@@ -15,7 +15,8 @@
 import("//build_overrides/nrf5_sdk.gni")
 import("//build_overrides/openthread.gni")
 
-if (nrf5_sdk_root == "") {
+declare_args() {
+  # Location of the nRF5 SDK.
   nrf5_sdk_root = getenv("NRF5_SDK_ROOT")
 }
 

--- a/third_party/openthread/platforms/nrf528xx/BUILD.gn
+++ b/third_party/openthread/platforms/nrf528xx/BUILD.gn
@@ -15,6 +15,8 @@
 import("//build_overrides/nrf5_sdk.gni")
 import("//build_overrides/openthread.gni")
 
+import("${nrf5_sdk_build_root}/nrf5_sdk.gni")
+
 # TODO(spang): Clean this up. We're mixing the vanilla Nordic SDK with forked
 # SDK code from OpenThread. See use_openthread_radio_driver below.
 


### PR DESCRIPTION
The nrf5_sdk_root argument was recently moved to build_overrides,
but this has broken setting it via the environment:

```
ERROR at //BUILD.gn:19:1: Value collision.
import("${nrf5_sdk_build_root}/nrf5_sdk.gni")
^-------------------------------------------
This import contains "nrf5_sdk_root"
See //third_party/connectedhomeip/third_party/nrf5_sdk/nrf5_sdk.gni:19:19: defined here.
  nrf5_sdk_root = getenv("NRF5_SDK_ROOT")
                  ^---------------------
Which would clobber the one in your current scope
See //build_overrides/nrf5_sdk.gni:22:19: defined here.
  nrf5_sdk_root = ""
                  ^-
Executing import should not conflict with anything in the current
scope unless the values are identical.
```
Solve the issue by move nrf5_sdk_root back to nrf5_sdk.gni and just import that
file from the openthread platform build file.