### PR TITLE
Remove spam from CHIP_CONFIG_REQUIRE_AUTH == 0

### DIFF
--- a/config/standalone/CHIPProjectConfig.h
+++ b/config/standalone/CHIPProjectConfig.h
@@ -43,7 +43,14 @@
 // properly when CHIP_CONFIG_RNG_IMPLEMENTATION_CHIPDRBG is enabled.
 #define CHIP_CONFIG_DEV_RANDOM_DRBG_SEED 1
 
+// For convenience, Chip Security Test Mode can be enabled and the
+// requirement for authentication in various protocols can be disabled.
+//
+//    WARNING: These options make it possible to circumvent basic Chip security functionality,
+//    including message encryption. Because of this they MUST NEVER BE ENABLED IN PRODUCTION BUILDS.
+//
 #define CHIP_CONFIG_SECURITY_TEST_MODE 0
+#define CHIP_CONFIG_REQUIRE_AUTH 1
 
 // Increase session idle timeout in stand-alone builds for the convenience of developers.
 #define CHIP_CONFIG_DEFAULT_SECURITY_SESSION_IDLE_TIMEOUT 120000

--- a/examples/lock-app/efr32/include/CHIPProjectConfig.h
+++ b/examples/lock-app/efr32/include/CHIPProjectConfig.h
@@ -43,14 +43,14 @@
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 12345678
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR 0xF00
 
-// For convenience, enable Chip Security Test Mode and disable the requirement for
-// authentication in various protocols.
+// For convenience, Chip Security Test Mode can be enabled and the
+// requirement for authentication in various protocols can be disabled.
 //
 //    WARNING: These options make it possible to circumvent basic Chip security functionality,
 //    including message encryption. Because of this they MUST NEVER BE ENABLED IN PRODUCTION BUILDS.
 //
 #define CHIP_CONFIG_SECURITY_TEST_MODE 0
-#define CHIP_CONFIG_REQUIRE_AUTH 0
+#define CHIP_CONFIG_REQUIRE_AUTH 1
 
 /**
  * CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID

--- a/examples/platform/nrf528xx/app/project_include/CHIPProjectConfig.h
+++ b/examples/platform/nrf528xx/app/project_include/CHIPProjectConfig.h
@@ -28,21 +28,16 @@
 #ifndef CHIP_PROJECT_CONFIG_H
 #define CHIP_PROJECT_CONFIG_H
 
-#if BUILD_RELEASE // release build
+#if !BUILD_RELEASE // development build
 
-// Security and Authentication enabled for release build.
+// For convenience, Chip Security Test Mode can be enabled and the
+// requirement for authentication in various protocols can be disabled.
+//
+//    WARNING: These options make it possible to circumvent basic Chip security functionality,
+//    including message encryption. Because of this they MUST NEVER BE ENABLED IN PRODUCTION BUILDS.
+//
 #define CHIP_CONFIG_SECURITY_TEST_MODE 0
 #define CHIP_CONFIG_REQUIRE_AUTH 1
-
-#else // development build
-
-// Security and Authentication disabled for development build.
-// For convenience, enable CHIP Security Test Mode and disable the requirement for
-// authentication in various protocols.
-// WARNING: These options make it possible to circumvent basic CHIP security functionality,
-// including message encryption. Because of this they MUST NEVER BE ENABLED IN PRODUCTION BUILDS.
-#define CHIP_CONFIG_SECURITY_TEST_MODE 0
-#define CHIP_CONFIG_REQUIRE_AUTH 0
 
 /**
  * CHIP_DEVICE_CONFIG_ENABLE_TEST_DEVICE_IDENTITY


### PR DESCRIPTION
This spams the build when message layer is built with the corresponding
project configs:

```
../../src/lib/message/CHIPFabricState.cpp:89:17: note: #pragma message:
                  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                  !!!!  WARNING - REQUIRE_AUTH IS DISABLED   !!!!
                  !!!! CLIENT AUTHENTICATION IS NOT REQUIRED !!!!
                  !!!!    DEVELOPMENT ONLY -- DO NOT SHIP    !!!!
                  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

   89 | #pragma message "\n \
      |                 ^~~~~
   90 |                  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n \
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   91 |                  !!!!  WARNING - REQUIRE_AUTH IS DISABLED   !!!!\n \
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   92 |                  !!!! CLIENT AUTHENTICATION IS NOT REQUIRED !!!!\n \
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   93 |                  !!!!    DEVELOPMENT ONLY -- DO NOT SHIP    !!!!\n \
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   94 |                  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n \
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   95 |                  "
      |                  ~

```
Change-Id: Ie6709bac051a9ac78b211473fa7ae38fcf805cc3