### PR TITLE
Fix warnings -Werror=memset-elt-size

### DIFF
--- a/src/lib/message/CHIPMessageLayer.cpp
+++ b/src/lib/message/CHIPMessageLayer.cpp
@@ -146,8 +146,12 @@ CHIP_ERROR ChipMessageLayer::Init(InitContext * context)
     OnUnsecuredConnectionCallbacksRemoved = NULL;
     OnAcceptError                         = NULL;
     OnMessageLayerActivityChange          = NULL;
+#if CHIP_CONFIG_MAX_CONNECTIONS
     memset(mConPool, 0, sizeof(mConPool));
+#endif
+#if CHIP_CONFIG_MAX_TUNNELS
     memset(mTunnelPool, 0, sizeof(mTunnelPool));
+#endif
     AppState               = NULL;
     ExchangeMgr            = NULL;
     SecurityMgr            = NULL;
@@ -245,8 +249,12 @@ CHIP_ERROR ChipMessageLayer::Shutdown()
     OnConnectionReceived          = NULL;
     OnAcceptError                 = NULL;
     OnMessageLayerActivityChange  = NULL;
+#if CHIP_CONFIG_MAX_CONNECTIONS
     memset(mConPool, 0, sizeof(mConPool));
+#endif
+#if CHIP_CONFIG_MAX_TUNNELS
     memset(mTunnelPool, 0, sizeof(mTunnelPool));
+#endif
     ExchangeMgr = NULL;
     AppState    = NULL;
     mFlags      = 0;


### PR DESCRIPTION
This warning happens if we try to compile CHIPMessageLayer with
CHIP_CONFIG_MAX_TUNNELS == 0 or CHIP_CONFIG_MAX_CONNECTIONS == 0.

These warnings seems incorrect for a zero sized array, but the warning might catch more
interesting cases so solve the problem with #ifdefs.

Change-Id: Ic038519707e3f38c11bc216835eb733631c4ad15