### PR TITLE
Suppress warnings -Wno-unused-but-set-variable

### DIFF
--- a/third_party/openthread/platforms/nrf528xx/BUILD.gn
+++ b/third_party/openthread/platforms/nrf528xx/BUILD.gn
@@ -59,6 +59,7 @@ static_library("libopenthread-nrf52840-softdevice-sdk") {
     "..:libopenthread-platform",
     "..:libopenthread-platform-utils",
   ]
+  cflags = [ "-Wno-unused-but-set-variable" ]
 }
 
 config("libopenthread-nrf52840-transport_config") {


### PR DESCRIPTION
OpenThread triggers this in release builds due to using assert() for
error checking:

../../third_party/openthread/repo/examples/platforms/nrf528xx/src/flash.c: In function 'otPlatFlashWrite':
../../third_party/openthread/repo/examples/platforms/nrf528xx/src/flash.c:134:13: error: variable 'error' set but not used [-Werror=unused-but-set-variable]
  134 |     otError error;
      |             ^~~~~
../../third_party/openthread

Change-Id: I80f873b41cd9dc0bfd0ddce058536e5f7e56eef5