### PR TITLE
[thread] enable Thread SLAAC by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1757,6 +1757,7 @@ NL_WITH_OPTIONAL_INTERNAL_PACKAGE(
                 -DOPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE=1 \
                 -DOPENTHREAD_CONFIG_JOINER_ENABLE=1 \
                 -DOPENTHREAD_CONFIG_NCP_UART_ENABLE=1 \
+                -DOPENTHREAD_CONFIG_IP6_SLAAC_ENABLE=1 \
                 -DUART_AS_SERIAL_TRANSPORT=1"
 
             (mkdir -p ${ac_pwd}/third_party/openthread \

--- a/examples/platform/nrf528xx/app/project_include/OpenThreadConfig.h
+++ b/examples/platform/nrf528xx/app/project_include/OpenThreadConfig.h
@@ -48,6 +48,7 @@
 #define OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE 1
 #define OPENTHREAD_CONFIG_JOINER_ENABLE 1
 #define OPENTHREAD_CONFIG_NCP_UART_ENABLE 1
+#define OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE 1
 
 // Use the Nordic-supplied default platform configuration for remainder
 // of OpenThread config options.

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.ipp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.ipp
@@ -806,9 +806,9 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::DoInit(otInstanc
         VerifyOrExit(otErr == OT_ERROR_NONE, err = MapOpenThreadError(otErr));
     }
 
-    // Disable automatic assignment of Thread advertised addresses.
-#if OPENTHREAD_CONFIG_ENABLE_SLAAC
-    otIp6SetSlaacEnabled(otInst, false);
+    // Enable automatic assignment of Thread advertised addresses.
+#if OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
+    otIp6SetSlaacEnabled(otInst, true);
 #endif
 
     // If the Thread stack has been provisioned, but is not currently enabled, enable it now.


### PR DESCRIPTION
 #### Problem
The Thread device should have SLAAC feature enabled but it is not.

 #### Summary of Changes
This PR enables SLAAC for Thread devices.

fixes https://github.com/project-chip/connectedhomeip/issues/2154