### PR TITLE
Fix crash in spake2p destructor

### DIFF
--- a/src/crypto/CHIPCryptoPAL.cpp
+++ b/src/crypto/CHIPCryptoPAL.cpp
@@ -65,6 +65,21 @@ Spake2p::Spake2p(size_t _fe_size, size_t _point_size, size_t _hash_size)
     Kcb = &Kcab[hash_size / 2];
     Ka  = &Kae[0];
     Ke  = &Kae[hash_size / 2];
+
+    M  = nullptr;
+    N  = nullptr;
+    G  = nullptr;
+    X  = nullptr;
+    Y  = nullptr;
+    L  = nullptr;
+    Z  = nullptr;
+    V  = nullptr;
+    w0 = nullptr;
+    w1 = nullptr;
+    xy = nullptr;
+
+    order  = nullptr;
+    tempbn = nullptr;
 }
 
 CHIP_ERROR Spake2p::Init(const unsigned char * context, size_t context_len)

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -25,6 +25,7 @@
 
 #include <core/CHIPError.h>
 #include <stddef.h>
+#include <string.h>
 
 #if CHIP_CRYPTO_OPENSSL
 #include <openssl/ec.h>
@@ -663,7 +664,11 @@ struct Spake2p_Context
 class Spake2p_P256_SHA256_HKDF_HMAC : public Spake2p
 {
 public:
-    Spake2p_P256_SHA256_HKDF_HMAC(void) : Spake2p(kP256_FE_Length, kP256_Point_Length, kSHA256_Hash_Length) {}
+    Spake2p_P256_SHA256_HKDF_HMAC(void) : Spake2p(kP256_FE_Length, kP256_Point_Length, kSHA256_Hash_Length)
+    {
+        memset(&context, 0, sizeof(context));
+    }
+
     virtual ~Spake2p_P256_SHA256_HKDF_HMAC(void) { FreeImpl(); }
 
     CHIP_ERROR Mac(const unsigned char * key, size_t key_len, const unsigned char * in, size_t in_len, unsigned char * out);

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -794,9 +794,23 @@ void ClearSecretData(uint8_t * buf, uint32_t len)
         VerifyOrExit(_bn_ != NULL, error = CHIP_ERROR_INTERNAL);                                                                   \
     } while (0)
 
-#define free_point(_point_) EC_POINT_clear_free((EC_POINT *) _point_)
+#define free_point(_point_)                                                                                                        \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        if (_point_ != nullptr)                                                                                                    \
+        {                                                                                                                          \
+            EC_POINT_clear_free((EC_POINT *) _point_);                                                                             \
+        }                                                                                                                          \
+    } while (0)
 
-#define free_bn(_bn_) BN_clear_free((BIGNUM *) _bn_)
+#define free_bn(_bn_)                                                                                                              \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        if (_bn_ != nullptr)                                                                                                       \
+        {                                                                                                                          \
+            BN_clear_free((BIGNUM *) _bn_);                                                                                        \
+        }                                                                                                                          \
+    } while (0)
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal(void)
 {
@@ -842,8 +856,15 @@ exit:
 
 void Spake2p_P256_SHA256_HKDF_HMAC::FreeImpl(void)
 {
-    EC_GROUP_clear_free(context.curve);
-    BN_CTX_free(context.bn_ctx);
+    if (context.curve != nullptr)
+    {
+        EC_GROUP_clear_free(context.curve);
+    }
+
+    if (context.bn_ctx != nullptr)
+    {
+        BN_CTX_free(context.bn_ctx);
+    }
 
     free_point(M);
     free_point(N);


### PR DESCRIPTION
 #### Problem
`SPAKE2P` destructor crashes if the object is freed before calling `Init`.

 #### Summary of Changes
Some member variables were not initialized to `nullptr`. If the destructor was called on an object that was not initialized, it tried to free these uninitialized variables.