### PR TITLE
Create and lookup connection state using key ID and optional node ID

### DIFF
--- a/src/transport/PeerConnectionState.h
+++ b/src/transport/PeerConnectionState.h
@@ -64,11 +64,23 @@ public:
     uint32_t GetSendMessageIndex() const { return mSendMessageIndex; }
     void IncrementSendMessageIndex() { mSendMessageIndex++; }
 
+    uint32_t GetPeerKeyID() const { return mPeerKeyID; }
+    void SetPeerKeyID(uint32_t id) { mPeerKeyID = id; }
+
+    uint32_t GetLocalKeyID() const { return mLocalKeyID; }
+    void SetLocalKeyID(uint32_t id) { mLocalKeyID = id; }
+
     uint64_t GetLastActivityTimeMs() const { return mLastActityTimeMs; }
     void SetLastActivityTimeMs(uint64_t value) { mLastActityTimeMs = value; }
 
     SecureSession & GetSecureSession() { return mSecureSession; }
     const SecureSession & GetSecureSession() const { return mSecureSession; }
+
+    bool IsInitialized()
+    {
+        return (mPeerAddress.IsInitialized() || mPeerNodeId != kUndefinedNodeId || mPeerKeyID != UINT32_MAX ||
+                mLocalKeyID != UINT32_MAX);
+    }
 
     /**
      *  Reset the connection state to a completely uninitialized status.
@@ -86,6 +98,8 @@ private:
     PeerAddress mPeerAddress;
     NodeId mPeerNodeId         = kUndefinedNodeId;
     uint32_t mSendMessageIndex = 0;
+    uint32_t mPeerKeyID        = UINT32_MAX;
+    uint32_t mLocalKeyID       = UINT32_MAX;
     uint64_t mLastActityTimeMs = 0;
     SecureSession mSecureSession;
 };

--- a/src/transport/PeerConnections.h
+++ b/src/transport/PeerConnections.h
@@ -59,10 +59,61 @@ public:
 
         for (size_t i = 0; i < kMaxConnectionCount; i++)
         {
-            if (!mStates[i].GetPeerAddress().IsInitialized())
+            if (!mStates[i].IsInitialized())
             {
                 mStates[i] = PeerConnectionState(address);
                 mStates[i].SetLastActivityTimeMs(mTimeSource.GetCurrentMonotonicTimeMs());
+
+                if (state)
+                {
+                    *state = &mStates[i];
+                }
+
+                err = CHIP_NO_ERROR;
+                break;
+            }
+        }
+
+        return err;
+    }
+
+    /**
+     * Allocates a new peer connection state state object out of the internal resource pool.
+     *
+     * @param peerNode represents optional peer Node's ID
+     * @param peerKeyId represents the encryption key ID assigned by peer node
+     * @param localKeyId represents the encryption key ID assigned by local node
+     * @param state [out] will contain the connection state if one was available. May be null if no return value is desired.
+     *
+     * @note the newly created state will have an 'active' time set based on the current time source.
+     *
+     * @returns CHIP_NO_ERROR if state could be initialized. May fail if maximum connection count
+     *          has been reached (with CHIP_ERROR_NO_MEMORY).
+     */
+    CHECK_RETURN_VALUE
+    CHIP_ERROR CreateNewPeerConnectionState(const Optional<NodeId> & peerNode, uint16_t peerKeyId, uint16_t localKeyId,
+                                            PeerConnectionState ** state)
+    {
+        CHIP_ERROR err = CHIP_ERROR_NO_MEMORY;
+
+        if (state)
+        {
+            *state = nullptr;
+        }
+
+        for (size_t i = 0; i < kMaxConnectionCount; i++)
+        {
+            if (!mStates[i].IsInitialized())
+            {
+                mStates[i] = PeerConnectionState();
+                mStates[i].SetPeerKeyID(peerKeyId);
+                mStates[i].SetLocalKeyID(localKeyId);
+                mStates[i].SetLastActivityTimeMs(mTimeSource.GetCurrentMonotonicTimeMs());
+
+                if (peerNode.HasValue())
+                {
+                    mStates[i].SetPeerNodeId(peerNode.Value());
+                }
 
                 if (state)
                 {
@@ -115,7 +166,7 @@ public:
         *state = nullptr;
         for (size_t i = 0; i < kMaxConnectionCount; i++)
         {
-            if (!mStates[i].GetPeerAddress().IsInitialized())
+            if (!mStates[i].IsInitialized())
             {
                 continue;
             }
@@ -123,6 +174,70 @@ public:
             {
                 *state = &mStates[i];
                 break;
+            }
+        }
+        return *state != nullptr;
+    }
+
+    /**
+     * Get a peer connection state given a Node Id and Peer's Encryption Key Id.
+     *
+     * @param nodeId is the connection to find (based on nodeId). Note that initial connections
+     *        do not have a node id set. Use this if you know the node id should be set.
+     * @param peerKeyId Encryption key ID used by the peer node.
+     * @param state [out] the connection if found, null otherwise. MUST not be null.
+     *
+     * @return true if a corresponding state was found.
+     */
+    CHECK_RETURN_VALUE
+    bool FindPeerConnectionState(Optional<NodeId> nodeId, uint16_t peerKeyId, PeerConnectionState ** state)
+    {
+        *state = nullptr;
+        for (size_t i = 0; i < kMaxConnectionCount; i++)
+        {
+            if (!mStates[i].IsInitialized())
+            {
+                continue;
+            }
+            if (mStates[i].GetPeerKeyID() == peerKeyId)
+            {
+                if (!nodeId.HasValue() || mStates[i].GetPeerNodeId() == nodeId.Value())
+                {
+                    *state = &mStates[i];
+                    break;
+                }
+            }
+        }
+        return *state != nullptr;
+    }
+
+    /**
+     * Get a peer connection state given a Node Id and Peer's Encryption Key Id.
+     *
+     * @param nodeId is the connection to find (based on peer nodeId). Note that initial connections
+     *        do not have a node id set. Use this if you know the node id should be set.
+     * @param localKeyId Encryption key ID used by the local node.
+     * @param state [out] the connection if found, null otherwise. MUST not be null.
+     *
+     * @return true if a corresponding state was found.
+     */
+    CHECK_RETURN_VALUE
+    bool FindPeerConnectionStateByLocalKey(Optional<NodeId> nodeId, uint16_t localKeyId, PeerConnectionState ** state)
+    {
+        *state = nullptr;
+        for (size_t i = 0; i < kMaxConnectionCount; i++)
+        {
+            if (!mStates[i].IsInitialized())
+            {
+                continue;
+            }
+            if (mStates[i].GetLocalKeyID() == localKeyId)
+            {
+                if (!nodeId.HasValue() || mStates[i].GetPeerNodeId() == nodeId.Value())
+                {
+                    *state = &mStates[i];
+                    break;
+                }
             }
         }
         return *state != nullptr;

--- a/src/transport/tests/TestPeerConnections.cpp
+++ b/src/transport/tests/TestPeerConnections.cpp
@@ -80,17 +80,21 @@ void TestFindByAddress(nlTestSuite * inSuite, void * inContext)
     PeerConnectionState * statePtr;
     PeerConnections<2, Time::Source::kTest> connections;
 
-    err = connections.CreateNewPeerConnectionState(kPeer1Addr, nullptr);
+    PeerConnectionState * state1 = nullptr;
+    PeerConnectionState * state2 = nullptr;
+
+    err = connections.CreateNewPeerConnectionState(kPeer1Addr, &state1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = connections.CreateNewPeerConnectionState(kPeer2Addr, nullptr);
+    err = connections.CreateNewPeerConnectionState(kPeer2Addr, &state2);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, state1 != state2);
 
     NL_TEST_ASSERT(inSuite, connections.FindPeerConnectionState(kPeer1Addr, &statePtr));
     NL_TEST_ASSERT(inSuite, statePtr->GetPeerAddress() == kPeer1Addr);
     NL_TEST_ASSERT(inSuite, connections.FindPeerConnectionState(kPeer2Addr, &statePtr));
     NL_TEST_ASSERT(inSuite, statePtr->GetPeerAddress() == kPeer2Addr);
-
     NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer3Addr, &statePtr));
     NL_TEST_ASSERT(inSuite, statePtr == nullptr);
 }


### PR DESCRIPTION
 #### Problem
Missing functions to allocate and lookup secure session connections using encryption key ID.

 #### Summary of Changes
Use encryption key ID and optional node ID to allocate and lookup connections.
Added unit tests.