### PR TITLE
Remove unused chip_inet_config_enable_tcp_endpoint overrides

### DIFF
--- a/config/standalone/args.gni
+++ b/config/standalone/args.gni
@@ -15,6 +15,5 @@
 # Options from standalone-chip.mk that differ from configure defaults. These
 # options are used from examples/.
 chip_build_tests = false
-chip_inet_config_enable_tun_endpoint = false
 chip_inet_config_enable_raw_endpoint = false
 chip_inet_config_enable_dns_resolver = false


### PR DESCRIPTION
This option was removed and so now causes an unused argument warning:

WARNING at //config/standalone/args.gni:18:40: Build argument has no effect.
chip_inet_config_enable_tun_endpoint = false
                                       ^----
Did you mean "chip_inet_config_enable_tcp_endpoint"?

Change-Id: Iec935e9c17de4bc76d382539879b7faf88ddfad0