### PR TITLE
Use a delegate for client callbacks in the CHIP Darwin Framework

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/CHIPViewControllerBase.m
+++ b/src/darwin/CHIPTool/CHIPTool/CHIPViewControllerBase.m
@@ -234,11 +234,13 @@ static NSString * const ipKey = @"ipk";
 #pragma mark == CHIPDeviceControllerDelegate Methods ==
 #endif
 
-- (void)deviceControllerOnConnected {
+- (void)deviceControllerOnConnected
+{
     [self postConnected];
 }
 
-- (void)deviceControllerOnMessage:(NSData *)message {
+- (void)deviceControllerOnMessage:(NSData *)message
+{
     if ([CHIPDeviceController isDataModelCommand:message] == YES) {
         NSString * strMessage = [CHIPDeviceController commandToString:message];
         [self postResult:strMessage];
@@ -248,7 +250,8 @@ static NSString * const ipKey = @"ipk";
     }
 }
 
-- (void)deviceControllerOnError:(NSError *)error {
+- (void)deviceControllerOnError:(NSError *)error
+{
     [self postError:error.localizedDescription];
 }
 

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -81,7 +81,6 @@ typedef void (^ControllerOnErrorBlock)(NSError * error);
 
 @end
 
-
 /**
  * The protocol definition for the CHIPDeviceControllerDelegate
  *

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -27,6 +27,8 @@ typedef void (^ControllerOnConnectedBlock)(void);
 typedef void (^ControllerOnMessageBlock)(NSData * message);
 typedef void (^ControllerOnErrorBlock)(NSError * error);
 
+@protocol CHIPDeviceControllerDelegate;
+
 @interface AddressInfo : NSObject
 
 @property (readonly, copy) NSString * ip;
@@ -69,20 +71,43 @@ typedef void (^ControllerOnErrorBlock)(NSError * error);
 + (CHIPDeviceController *)sharedController;
 
 /**
- * Register callbacks for network activity.
+ * Set the Delegate for the Device Controller as well as the Queue on which the Delegate callbacks will be triggered
  *
- * @param[in] appCallbackQueue the queue that should be used to deliver the
- *                             message/error callbacks for this consumer.
+ * @param[in] delegate The delegate the Device Controller should use
  *
- * @param[in] onMessage the block to call when the controller gets a message
- *                      from the network.
- *
- * @param[in] onError the block to call when there is a network error.
+ * @param[in] queue The queue on which the Device Controller will deliver callbacks
  */
-- (void)registerCallbacks:(dispatch_queue_t)appCallbackQueue
-              onConnected:(ControllerOnConnectedBlock)onConnected
-                onMessage:(ControllerOnMessageBlock)onMessage
-                  onError:(ControllerOnErrorBlock)onError;
+- (void)setDelegate:(id<CHIPDeviceControllerDelegate>)delegate queue:(dispatch_queue_t)queue;
+
+@end
+
+
+/**
+ * The protocol definition for the CHIPDeviceControllerDelegate
+ *
+ * All delegate methods will be called on the supplied Delegate Queue.
+ */
+@protocol CHIPDeviceControllerDelegate <NSObject>
+
+/**
+ * Notify the delegate when a connection request succeeds
+ *
+ */
+- (void)deviceControllerOnConnected;
+
+/**
+ * Notify the delegate that a message was received
+ *
+ * @param[in] message The received message
+ */
+- (void)deviceControllerOnMessage:(NSData *)message;
+
+/**
+ * Notify the Delegate that an error occurred
+ *
+ * @param[in] error The error that occurred
+ */
+- (void)deviceControllerOnError:(NSError *)error;
 
 @end
 

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -157,8 +157,7 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
     CHIP_LOG_METHOD_ENTRY();
 
     id<CHIPDeviceControllerDelegate> strongDelegate = [self delegate];
-    if (strongDelegate && [self delegateQueue])
-    {
+    if (strongDelegate && [self delegateQueue]) {
         dispatch_async(self.delegateQueue, ^{
             [strongDelegate deviceControllerOnError:error];
         });
@@ -170,8 +169,7 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
     CHIP_LOG_METHOD_ENTRY();
 
     id<CHIPDeviceControllerDelegate> strongDelegate = [self delegate];
-    if (strongDelegate && [self delegateQueue])
-    {
+    if (strongDelegate && [self delegateQueue]) {
         dispatch_async(self.delegateQueue, ^{
             [strongDelegate deviceControllerOnMessage:data];
         });
@@ -183,8 +181,7 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
     CHIP_LOG_METHOD_ENTRY();
 
     id<CHIPDeviceControllerDelegate> strongDelegate = [self delegate];
-    if (strongDelegate && [self delegateQueue])
-    {
+    if (strongDelegate && [self delegateQueue]) {
         dispatch_async(self.delegateQueue, ^{
             [strongDelegate deviceControllerOnConnected];
         });
@@ -457,13 +454,10 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
 - (void)setDelegate:(id<CHIPDeviceControllerDelegate>)delegate queue:(dispatch_queue_t)queue
 {
     [self.lock lock];
-    if ( delegate && queue )
-    {
+    if (delegate && queue) {
         self->_delegate = delegate;
         self->_delegateQueue = queue;
-    }
-    else
-    {
+    } else {
         self->_delegate = nil;
         self->_delegateQueue = NULL;
     }


### PR DESCRIPTION
 #### Problem
The current API to register callbacks makes the client side code difficult to maintain. i.e, clients end up with inline dispatch blocks while registering the callbacks. 

A delegate protocol is much better suited to our needs
 #### Summary of Changes
Added a Delegate Protocol for the CHIPDeviceController and updated CHIPTool to use it. 