### PR TITLE
Fix logic error in FreeRTOSNewlibLockSupport_test.c

### DIFF
--- a/examples/platform/nrf528xx/app/support/FreeRTOSNewlibLockSupport_test.c
+++ b/examples/platform/nrf528xx/app/support/FreeRTOSNewlibLockSupport_test.c
@@ -75,7 +75,7 @@ void freertos_newlib_lock_test()
     __lock_acquire_recursive(dynamic_lock_recursive);
     acquired = __lock_try_acquire_recursive(dynamic_lock_recursive);
     ASSERT(acquired);
-    __lock_release_recursive(dynamic_lock);
+    __lock_release_recursive(dynamic_lock_recursive);
     acquired = __lock_try_acquire_recursive(dynamic_lock_recursive);
     ASSERT(acquired);
     __lock_release_recursive(dynamic_lock_recursive);


### PR DESCRIPTION
This tries to release a freed lock due to a typo. It seems the updated
firmware image didn't get flashed when validating the previous change :(