### PR TITLE
Fix warning for build argument has not effect

### DIFF
--- a/config/standalone/args.gni
+++ b/config/standalone/args.gni
@@ -15,6 +15,5 @@
 # Options from standalone-chip.mk that differ from configure defaults. These
 # options are used from examples/.
 chip_build_tests = false
-chip_inet_config_enable_tun_endpoint = false
 chip_inet_config_enable_raw_endpoint = false
 chip_inet_config_enable_dns_resolver = false

--- a/src/lib/message/CHIPRMPConfig.h
+++ b/src/lib/message/CHIPRMPConfig.h
@@ -23,8 +23,8 @@
  *      for the CHIP Reliable Messaging Protocol.
  *
  */
-#ifndef CHIP_RM_CONFIG_H_
-#define CHIP_RM_CONFIG_H_
+#ifndef CHIP_RMP_CONFIG_H_
+#define CHIP_RMP_CONFIG_H_
 
 namespace chip {
 
@@ -134,4 +134,4 @@ const RMPConfig gDefaultRMPConfig = { CHIP_CONFIG_RMP_DEFAULT_INITIAL_RETRANS_TI
 
 } // namespace chip
 
-#endif // CHIP_RM_CONFIG_H_
+#endif // CHIP_RMP_CONFIG_H_


### PR DESCRIPTION
Problem
WARNING at //config/standalone/args.gni:18:40: Build argument has no effect.
chip_inet_config_enable_tun_endpoint = false

Summary of Changes
remove unused gn variable definition.


