### PR TITLE
GN: make ot-br-posix path configurable

### DIFF
--- a/examples/build_overrides/ot_br_posix.gni
+++ b/examples/build_overrides/ot_br_posix.gni
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+declare_args() {
+  ot_br_posix_root = "//third_party/connectedhomeip/third_party/ot-br-posix"
+}

--- a/gn/build_overrides/ot_br_posix.gni
+++ b/gn/build_overrides/ot_br_posix.gni
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+declare_args() {
+  ot_br_posix_root = "//third_party/ot-br-posix"
+}

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -20,6 +20,7 @@ import("device.gni")
 
 if (chip_enable_openthread) {
   import("//build_overrides/openthread.gni")
+  import("//build_overrides/ot_br_posix.gni")
 }
 
 if (chip_device_platform == "nrf5") {
@@ -219,7 +220,7 @@ if (chip_device_platform != "none") {
           "Linux/ThreadStackManagerImpl.cpp",
           "Linux/ThreadStackManagerImpl.h",
         ]
-        public_deps += [ "${chip_root}/third_party/ot-br-posix:ot_br_client" ]
+        public_deps += [ "${ot_br_posix_root}:ot_br_client" ]
       }
 
       if (chip_enable_wifi) {


### PR DESCRIPTION
This allows building CHIP with linux device layer as a submodule.
