### PR TITLE
Remove allow_circular_includes_from from src/controller/BUILD.gn

### DIFF
--- a/src/controller/BUILD.gn
+++ b/src/controller/BUILD.gn
@@ -33,6 +33,5 @@ static_library("controller") {
     "${chip_root}/src/transport",
   ]
 
-  allow_circular_includes_from = [ "${chip_root}/src/transport" ]
   configs += [ ":controller_wno_deprecate" ]
 }

--- a/src/transport/BLE.cpp
+++ b/src/transport/BLE.cpp
@@ -24,7 +24,6 @@
 
 #include <transport/BLE.h>
 
-#include <controller/CHIPDeviceController.h>
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
 #include <transport/MessageHeader.h>


### PR DESCRIPTION
 #### Problem

The allow_circular_includes_from rule was needed in src/transport since BLE was accessing directly CHIPDeviceController.
Since #2020 remove the coupling it is not needed anymore.

 #### Summary of Changes
 * Remove the allow_circular_includes_from rule
 * Remove leftover #include <controller/CHIPDeviceController.h>
