### PR TITLE
BleConnectionDelegate on Darwin crashes while initiating a scan

### DIFF
--- a/src/platform/Darwin/BleConnectionDelegateImpl.mm
+++ b/src/platform/Darwin/BleConnectionDelegateImpl.mm
@@ -74,10 +74,10 @@ namespace DeviceLayer {
 {
     self = [super init];
     if (self) {
+        self.shortServiceUUID = [BleConnection getShortestServiceUUID:&chip::Ble::CHIP_BLE_SVC_ID];
         _deviceDiscriminator = deviceDiscriminator;
         _workQueue = dispatch_queue_create("com.chip.ble.work_queue", DISPATCH_QUEUE_SERIAL);
         _centralManager = [CBCentralManager alloc];
-        _shortServiceUUID = [BleConnection getShortestServiceUUID:&chip::Ble::CHIP_BLE_SVC_ID];
         [_centralManager initWithDelegate:self queue:_workQueue];
     }
 


### PR DESCRIPTION
 #### Problem

BleConnectionDelegate crash on iOS.

 #### Summary of Changes
 * Use the shortServiceUUID setter to retain the object

fixes #2099 
