### PR TITLE
[nrf5-demo] Add simple service discovery code for nrf5 example app

### DIFF
--- a/examples/lighting-app/nrf5/main/AppTask.cpp
+++ b/examples/lighting-app/nrf5/main/AppTask.cpp
@@ -242,7 +242,7 @@ void AppTask::AppTaskMain(void * pvParameter)
 
         if (nowUS > nextChangeTimeUS)
         {
-            SendUDPBroadCast();
+            PublishService();
             mLastChangeTimeUS = nowUS;
         }
     }

--- a/examples/lighting-app/nrf5/main/AppTask.cpp
+++ b/examples/lighting-app/nrf5/main/AppTask.cpp
@@ -34,6 +34,15 @@
 #include "FreeRTOS.h"
 
 #include <platform/CHIPDeviceLayer.h>
+#include <platform/OpenThread/OpenThreadUtils.h>
+#include <platform/ThreadStackManager.h>
+#include <platform/internal/DeviceNetworkInfo.h>
+#include <platform/nRF5/ThreadStackManagerImpl.h>
+#include <support/ErrorStr.h>
+#include <system/SystemClock.h>
+
+#include <openthread/message.h>
+#include <openthread/udp.h>
 
 APP_TIMER_DEF(sFunctionTimer);
 
@@ -152,10 +161,58 @@ int AppTask::Init()
     return ret;
 }
 
+void SendUDPBroadCast()
+{
+    // TODO: change to CHIP inet layer
+    const char * domainName = "LightingDemo._chip._udp.local.";
+    chip::Inet::IPAddress addr;
+    if (!ConnectivityMgrImpl().IsThreadAttached())
+    {
+        return;
+    }
+    ThreadStackMgrImpl().LockThreadStack();
+    otError error = OT_ERROR_NONE;
+    otMessageInfo messageInfo;
+    otUdpSocket mSocket;
+    otMessage * message = nullptr;
+
+    memset(&mSocket, 0, sizeof(mSocket));
+    memset(&messageInfo, 0, sizeof(messageInfo));
+
+    // Select a address to send
+    const otNetifAddress * otAddrs = otIp6GetUnicastAddresses(ThreadStackMgrImpl().OTInstance());
+    for (const otNetifAddress * otAddr = otAddrs; otAddr != NULL; otAddr = otAddr->mNext)
+    {
+        addr = chip::DeviceLayer::Internal::ToIPAddress(otAddr->mAddress);
+        if (otAddr->mValid && !otAddr->mRloc &&
+            (!addr.IsIPv6ULA() ||
+             ::chip::DeviceLayer::Internal::IsOpenThreadMeshLocalAddress(ThreadStackMgrImpl().OTInstance(), addr)))
+        {
+            memcpy(&messageInfo.mSockAddr, &(otAddr->mAddress), sizeof(otAddr->mAddress));
+            break;
+        }
+    }
+
+    message = otUdpNewMessage(ThreadStackMgrImpl().OTInstance(), nullptr);
+    otIp6AddressFromString("ff03::1", &messageInfo.mPeerAddr);
+    messageInfo.mPeerPort = 23367;
+    otMessageAppend(message, domainName, static_cast<uint16_t>(strlen(domainName)));
+
+    error = otUdpSend(ThreadStackMgrImpl().OTInstance(), &mSocket, message, &messageInfo);
+
+    if (error != OT_ERROR_NONE && message != nullptr)
+    {
+        otMessageFree(message);
+        NRF_LOG_INFO("Failed to otUdpSend: %d", error);
+    }
+    ThreadStackMgrImpl().UnlockThreadStack();
+}
+
 void AppTask::AppTaskMain(void * pvParameter)
 {
     ret_code_t ret;
     AppEvent event;
+    uint64_t mLastChangeTimeUS = 0;
 
     ret = sAppTask.Init();
     if (ret != NRF_SUCCESS)
@@ -227,6 +284,15 @@ void AppTask::AppTaskMain(void * pvParameter)
         sStatusLED.Animate();
         sUnusedLED.Animate();
         sUnusedLED_1.Animate();
+
+        uint64_t nowUS            = chip::System::Platform::Layer::GetClock_Monotonic();
+        uint64_t nextChangeTimeUS = mLastChangeTimeUS + 5 * 1000 * 1000UL;
+
+        if (nowUS > nextChangeTimeUS)
+        {
+            SendUDPBroadCast();
+            mLastChangeTimeUS = nowUS;
+        }
     }
 }
 

--- a/examples/lock-app/nrf5/BUILD.gn
+++ b/examples/lock-app/nrf5/BUILD.gn
@@ -103,6 +103,8 @@ executable("lock_app") {
   ldscript = "${nrf5_platform_dir}/app/ldscripts/chip-nrf52840-example.ld"
 
   ldflags = [ "-T" + rebase_path(ldscript, root_build_dir) ]
+
+  defines = [ "CHIP_ENABLE_OPENTHREAD=1" ]
 }
 
 group("nrf5") {

--- a/examples/lock-app/nrf5/main/AppTask.cpp
+++ b/examples/lock-app/nrf5/main/AppTask.cpp
@@ -233,6 +233,7 @@ void AppTask::HandleBLEMessageReceived(chip::Ble::BLEEndPoint * endPoint, chip::
 
 void SendUDPBroadCast()
 {
+#if CHIP_ENABLE_OPENTHREAD
     // TODO: change to CHIP inet layer
     const char * domainName = "LockDemo._chip._udp.local.";
     chip::Inet::IPAddress addr;
@@ -276,6 +277,9 @@ void SendUDPBroadCast()
         NRF_LOG_INFO("Failed to otUdpSend: %d", error);
     }
     ThreadStackMgrImpl().UnlockThreadStack();
+#else
+    NRF_LOG_INFO("OpenThread disabled, not sending UDP broadcasts");
+#endif
 }
 
 void AppTask::AppTaskMain(void * pvParameter)

--- a/examples/lock-app/nrf5/main/AppTask.cpp
+++ b/examples/lock-app/nrf5/main/AppTask.cpp
@@ -318,7 +318,7 @@ void AppTask::AppTaskMain(void * pvParameter)
 
         if (nowUS > nextChangeTimeUS)
         {
-            SendUDPBroadCast();
+            PublishService();
             mLastChangeTimeUS = nowUS;
         }
     }

--- a/examples/lock-app/nrf5/main/include/app_config.h
+++ b/examples/lock-app/nrf5/main/include/app_config.h
@@ -126,6 +126,7 @@
 
 #define SYSTEM_STATE_LED BSP_LED_0
 #define LOCK_STATE_LED BSP_LED_1
+#define LOCK_STATE_LED_GPIO 3
 
 // Time it takes in ms for the simulated actuator to move from one
 // state to another.

--- a/examples/platform/nrf528xx/app/Server.cpp
+++ b/examples/platform/nrf528xx/app/Server.cpp
@@ -15,6 +15,8 @@
  *    limitations under the License.
  */
 
+#include "Server.h"
+
 #include "FreeRTOS.h"
 #include "nrf_log.h"
 #include "task.h"
@@ -36,7 +38,14 @@
 #include <transport/SecureSessionMgr.h>
 #include <transport/UDP.h>
 
-#include "Server.h"
+#if CHIP_ENABLE_OPENTHREAD
+#include <openthread/message.h>
+#include <openthread/udp.h>
+#include <platform/OpenThread/OpenThreadUtils.h>
+#include <platform/ThreadStackManager.h>
+#include <platform/internal/DeviceNetworkInfo.h>
+#include <platform/nRF5/ThreadStackManagerImpl.h>
+#endif
 
 #include "attribute-storage.h"
 #include "chip-zcl/chip-zcl-zpro-codec.h"
@@ -46,6 +55,7 @@
 using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::Transport;
+using namespace ::chip::DeviceLayer;
 
 // Transport Callbacks
 namespace {
@@ -54,6 +64,9 @@ namespace {
 // "nRF5"
 #define EXAMPLE_SERVER_NODEID 0x3546526e
 #endif // EXAMPLE_SERVER_NODEID
+
+char deviceName[128];
+constexpr uint16_t kUDPBroadcastPort = 23367;
 
 const uint8_t local_private_key[] = { 0xc6, 0x1a, 0x2f, 0x89, 0x36, 0x67, 0x2b, 0x26, 0x12, 0x47, 0x4f,
                                       0x11, 0x0e, 0x34, 0x15, 0x81, 0x81, 0x12, 0xfc, 0x36, 0xeb, 0x65,
@@ -157,6 +170,56 @@ private:
 static ServerCallback gCallbacks;
 
 } // namespace
+
+void SetDeviceName(const char * newDeviceName)
+{
+    strncpy(deviceName, newDeviceName, sizeof(deviceName) - 1);
+}
+
+void SendUDPBroadCast()
+{
+    chip::Inet::IPAddress addr;
+    if (!ConnectivityMgrImpl().IsThreadAttached())
+    {
+        return;
+    }
+    ThreadStackMgrImpl().LockThreadStack();
+    otError error = OT_ERROR_NONE;
+    otMessageInfo messageInfo;
+    otUdpSocket mSocket;
+    otMessage * message = nullptr;
+
+    memset(&mSocket, 0, sizeof(mSocket));
+    memset(&messageInfo, 0, sizeof(messageInfo));
+
+    // Select a address to send
+    const otNetifAddress * otAddrs = otIp6GetUnicastAddresses(ThreadStackMgrImpl().OTInstance());
+    for (const otNetifAddress * otAddr = otAddrs; otAddr != NULL; otAddr = otAddr->mNext)
+    {
+        addr = chip::DeviceLayer::Internal::ToIPAddress(otAddr->mAddress);
+        if (otAddr->mValid && !otAddr->mRloc &&
+            (!addr.IsIPv6ULA() ||
+             ::chip::DeviceLayer::Internal::IsOpenThreadMeshLocalAddress(ThreadStackMgrImpl().OTInstance(), addr)))
+        {
+            memcpy(&messageInfo.mSockAddr, &(otAddr->mAddress), sizeof(otAddr->mAddress));
+            break;
+        }
+    }
+
+    message = otUdpNewMessage(ThreadStackMgrImpl().OTInstance(), nullptr);
+    otIp6AddressFromString("ff03::1", &messageInfo.mPeerAddr);
+    messageInfo.mPeerPort = kUDPBroadcastPort;
+    otMessageAppend(message, deviceName, static_cast<uint16_t>(strlen(deviceName)));
+
+    error = otUdpSend(ThreadStackMgrImpl().OTInstance(), &mSocket, message, &messageInfo);
+
+    if (error != OT_ERROR_NONE && message != nullptr)
+    {
+        otMessageFree(message);
+        NRF_LOG_INFO("Failed to otUdpSend: %d", error);
+    }
+    ThreadStackMgrImpl().UnlockThreadStack();
+}
 
 void InitDataModelHandler()
 {

--- a/examples/platform/nrf528xx/app/Server.cpp
+++ b/examples/platform/nrf528xx/app/Server.cpp
@@ -176,7 +176,7 @@ void SetDeviceName(const char * newDeviceName)
     strncpy(deviceName, newDeviceName, sizeof(deviceName) - 1);
 }
 
-void SendUDPBroadCast()
+void PublishService()
 {
     chip::Inet::IPAddress addr;
     if (!ConnectivityMgrImpl().IsThreadAttached())

--- a/examples/platform/nrf528xx/app/include/Server.h
+++ b/examples/platform/nrf528xx/app/include/Server.h
@@ -28,5 +28,7 @@ using DemoSessionManager = chip::SecureSessionMgr<chip::Transport::UDP>;
 
 void StartServer(DemoSessionManager * sessions);
 void InitDataModelHandler();
+void SetDeviceName(const char * newDeviceName);
+void SendUDPBroadCast();
 
 #endif // NRF5_COMMON_SERVER_H

--- a/examples/platform/nrf528xx/app/include/Server.h
+++ b/examples/platform/nrf528xx/app/include/Server.h
@@ -29,6 +29,6 @@ using DemoSessionManager = chip::SecureSessionMgr<chip::Transport::UDP>;
 void StartServer(DemoSessionManager * sessions);
 void InitDataModelHandler();
 void SetDeviceName(const char * newDeviceName);
-void SendUDPBroadCast();
+void PublishService();
 
 #endif // NRF5_COMMON_SERVER_H


### PR DESCRIPTION
This PR adds a temporary solution for device discovery by sending UDP broadcasts to port 23367 (just a random port) via thread.
