### PR TITLE
[GN] make config header path gn arguments for external device layer

### DIFF
--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -54,6 +54,14 @@ if (chip_device_platform != "external") {
   chip_platform_config_include = ""
   chip_inet_platform_config_include = ""
   chip_system_platform_config_include = ""
+} else {
+  declare_args() {
+    chip_ble_platform_config_include = ""
+    chip_device_platform_config_include = ""
+    chip_platform_config_include = ""
+    chip_inet_platform_config_include = ""
+    chip_system_platform_config_include = ""
+  }
 }
 
 if (_chip_device_layer != "none" && chip_device_platform != "external") {


### PR DESCRIPTION
This PR allow users to path platform config header path in gn build arguments.