### PR TITLE
Integrity protect unencrypted portion of message header

### DIFF
--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -133,7 +133,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR SecureSession::GetAAD(const MessageHeader & header, uint8_t * aad, size_t & len)
+CHIP_ERROR SecureSession::GetAdditionalAuthData(const MessageHeader & header, uint8_t * aad, size_t & len)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     size_t actualEncodedHeaderSize;
@@ -168,7 +168,7 @@ CHIP_ERROR SecureSession::Encrypt(const unsigned char * input, size_t input_leng
     error = GetIV(header, IV, sizeof(IV));
     SuccessOrExit(error);
 
-    error = GetAAD(header, AAD, aadLen);
+    error = GetAdditionalAuthData(header, AAD, aadLen);
     SuccessOrExit(error);
 
     error = AES_CCM_encrypt(input, input_length, AAD, aadLen, mKey, sizeof(mKey), (const unsigned char *) IV, sizeof(IV), output,
@@ -199,7 +199,7 @@ CHIP_ERROR SecureSession::Decrypt(const unsigned char * input, size_t input_leng
     error = GetIV(header, IV, sizeof(IV));
     SuccessOrExit(error);
 
-    error = GetAAD(header, AAD, aadLen);
+    error = GetAdditionalAuthData(header, AAD, aadLen);
     SuccessOrExit(error);
 
     error = AES_CCM_decrypt(input, input_length, AAD, aadLen, (const unsigned char *) tag, taglen, mKey, sizeof(mKey),

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -131,7 +131,10 @@ private:
 
     static CHIP_ERROR GetIV(const MessageHeader & header, uint8_t * iv, size_t len);
 
-    static CHIP_ERROR GetAAD(const MessageHeader & header, uint8_t * aad, size_t & len);
+    // Use unencrypted header as additional authenticated data (AAD) during encryption and decryption.
+    // The encryption operations includes AAD when message authentication tag is generated. This tag
+    // is used at the time of decryption to integrity check the received data.
+    static CHIP_ERROR GetAdditionalAuthData(const MessageHeader & header, uint8_t * aad, size_t & len);
 };
 
 } // namespace chip

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -130,6 +130,8 @@ private:
     uint8_t mKey[kAES_CCM128_Key_Length];
 
     static CHIP_ERROR GetIV(const MessageHeader & header, uint8_t * iv, size_t len);
+
+    static CHIP_ERROR GetAAD(const MessageHeader & header, uint8_t * aad, size_t & len);
 };
 
 } // namespace chip


### PR DESCRIPTION
 #### Problem
Unencrypted portion of message header is not integrity protected.

 #### Summary of Changes
Use unencrypted header as AAD (additional authenticated data) during encryption and decryption. The encryption operation includes AAD when MAC tag is generated. 