### PR TITLE
Add android toolchain to GN build system

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -40,7 +40,6 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
       "${chip_root}/src/inet",
       "${chip_root}/src/lib",
       "${chip_root}/src/lib/core",
-      "${chip_root}/src/lib/message",
       "${chip_root}/src/lib/shell",
       "${chip_root}/src/lib/support",
       "${chip_root}/src/lwip:all",
@@ -51,6 +50,11 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
       "${nlio_root}:nlio",
       "${nlunit_test_root}:nlunit-test",
     ]
+
+    # Temporary until RNG issue sorted out
+    if (current_os != "android") {
+       deps += [ "${chip_root}/src/lib/message" ]
+    }
 
     if (chip_build_tests) {
       deps += [ ":tests" ]
@@ -89,6 +93,7 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
     }
   }
 } else {
+
   # This is the unified build. Configure various real toolchains.
   import("${chip_root}/gn/chip/chip_build.gni")
   declare_args() {

--- a/gn/build/config/BUILDCONFIG.gn
+++ b/gn/build/config/BUILDCONFIG.gn
@@ -69,6 +69,15 @@ if (_chip_defaults.custom_toolchain != "") {
   } else {
     assert(false, "Unsupported target_cpu: ${target_cpu}")
   }
+} else if (target_os == "android") {
+  # TODO: Add x86, arm64
+  if (current_cpu == "arm") {
+    _default_toolchain = "//build/toolchain/android:armv7_clang"
+  } else if (current_cpu == "x86_64") {
+    _default_toolchain = "//build/toolchain/android:x86_64_clang"
+  } else {
+    assert(false, "Unsupported target_cpu: ${current_cpu}")
+  }
 } else {
   assert(false, "No toolchain specified, please specify custom_toolchain")
 }

--- a/gn/build/config/compiler/BUILD.gn
+++ b/gn/build/config/compiler/BUILD.gn
@@ -23,8 +23,10 @@ declare_args() {
   treat_warnings_as_errors = true
 }
 
-if (current_cpu == "arm") {
+if (current_cpu == "arm" || current_cpu == "arm64") {
   import("//build/config/arm.gni")
+} else if (current_cpu == "x86" || current_cpu == "x86_64") {
+  import("//build/config/x86.gni")
 }
 
 config("release") {
@@ -39,7 +41,7 @@ config("debug_default") {
 
 config("abi_default") {
   cflags = []
-  if (current_cpu == "arm") {
+  if (current_cpu == "arm" || current_cpu == "arm64") {
     if (arm_arch != "") {
       cflags += [ "-march=${arm_arch}" ]
     }
@@ -60,6 +62,22 @@ config("abi_default") {
     }
     if (arm_use_thumb) {
       cflags += [ "-mthumb" ]
+    }
+  } else if (current_cpu == "x86" || current_cpu == "x86_64") {
+    if (x86_arch != "") {
+      cflags += [ "-march=${x86_arch}" ]
+    }
+    if (x86_cpu != "") {
+      cflags += [ "-mcpu=${x86_cpu}" ]
+    }
+    if (x86_tune != "") {
+      cflags += [ "-mtune=${x86_tune}" ]
+    }
+
+    if (current_cpu == "x86_64") {
+      cflags += [ "-msse4.2", "-mpopcnt", "-m64" ]
+    } else if (current_cpu == "x86") {
+      cflags += [ "-mssse3", "-mfpmath=sse", "-m32" ]
     }
   }
   ldflags = cflags

--- a/gn/build/config/custom_toolchain.gni
+++ b/gn/build/config/custom_toolchain.gni
@@ -15,6 +15,6 @@
 import("//build_overrides/chip.gni")
 
 declare_args() {
-  # Toolchain to use for taget.
+  # Toolchain to use for target.
   custom_toolchain = ""
 }

--- a/gn/build/config/x86.gni
+++ b/gn/build/config/x86.gni
@@ -1,0 +1,54 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if (current_cpu == "x86" || current_cpu == "x86_64") {
+  declare_args() {
+    # Build file to import for X86 defaults.
+    x86_platform_config = ""
+  }
+
+  # Allow platforms to override how ARM architecture flags are chosen by
+  # providing a file to import.
+  if (x86_platform_config != "") {
+    _platform_defaults = {
+      import(x86_platform_config)
+    }
+  }
+
+  _defaults = {
+    x86_arch = ""
+    x86_cpu = ""
+    x86_tune = ""
+    x86_sysroot = ""
+
+    # Update defaults with platform values, if any.
+    if (x86_platform_config != "") {
+      forward_variables_from(_platform_defaults, "*")
+    }
+  }
+
+  declare_args() {
+    # ARM architecture (value for -march flag).
+    x86_arch = _defaults.x86_arch
+
+    # ARM CPU (value for -mcpu flag).
+    x86_cpu = _defaults.x86_cpu
+
+    # ARM tuning (value for -mtune flag).
+    x86_tune = _defaults.x86_tune
+
+    # ARM sysroot (value for --sysroot flag).
+    x86_sysroot = _defaults.x86_sysroot
+  }
+}

--- a/gn/build/toolchain/android/BUILD.gn
+++ b/gn/build/toolchain/android/BUILD.gn
@@ -1,3 +1,4 @@
+# Copyright 2020 The Pigweed Authors
 # Copyright (c) 2020 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,22 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-declare_args() {
-  # Use clang to build.
-  is_clang = current_os == "android"
+import("android_toolchain.gni")
 
-  # Optimize for size by default.
-  optimize_for_size = true
-
-  # Optimize debug builds with -Og.
-  optimize_debug = current_os == "freertos"
-
-  # Symbol level for debugging.
-  symbol_level = 2
-
-  # Enable position independent code (-fPIC).
-  enable_pic = current_os == "linux" || current_os == "mac"
-
-  # Enable position independent executables (-pie).
-  enable_pie = current_os == "linux"
+if (current_cpu == "arm") {
+  android_arm_toolchain("armv7_clang") {
+    toolchain_args = {
+       is_clang = true
+    }
+  }
+} else if (current_cpu == "x86_64") {
+  android_x86_64_toolchain("x86_64_clang") {
+    toolchain_args = {
+       is_clang = true
+    }
+  }
+} else {
+  assert(false, "Unknown target cpu ${current_cpu}")
 }

--- a/gn/build/toolchain/android/android_toolchain.gni
+++ b/gn/build/toolchain/android/android_toolchain.gni
@@ -1,0 +1,58 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build/toolchain/gcc_toolchain.gni")
+
+template("android_arm_toolchain") {
+  gcc_toolchain(target_name) {
+    # TODO : arm64
+    # TODO: Drop API level to 21 after getifaddrs issue fixed
+    _tool_name_root = "armv7a-linux-androideabi24-"
+
+    toolchain_args = {
+      current_cpu = "arm"
+      arm_arch = "armv7-a"
+      arm_fpu = "vfpv3-d16"
+      arm_float_abi = "softfp"
+      current_os = "android"
+      is_clang = true
+
+      forward_variables_from(invoker.toolchain_args, "*")
+    }
+    ar = "llvm-ar"
+    cc = _tool_name_root + "clang"
+    cxx = _tool_name_root + "clang++"
+  }
+}
+
+template("android_x86_64_toolchain") {
+  gcc_toolchain(target_name) {
+    # TODO : x86
+    # TODO: Drop API level to 21 after getifaddrs issue fixed
+    _tool_name_root = "x86_64-linux-android24-"
+
+    toolchain_args = {
+      current_cpu = "x86_64"
+      x86_arch = "x86-64"
+      x86_tune = "intel"
+      current_os = "android"
+      is_clang = true
+
+      forward_variables_from(invoker.toolchain_args, "*")
+    }
+    ar = "llvm-ar"
+    cc = _tool_name_root + "clang"
+    cxx = _tool_name_root + "clang++"
+  }
+}

--- a/gn/chip/chip_test.gni
+++ b/gn/chip/chip_test.gni
@@ -33,16 +33,23 @@ template("chip_test") {
     output_dir = _test_output_dir
   }
 
-  pw_python_script(_test_name + "_run") {
-    deps = [ ":${_test_name}" ]
-    inputs = [ pw_unit_test_AUTOMATIC_RUNNER ]
-    script = "$dir_pw_unit_test/py/pw_unit_test/test_runner.py"
-    args = [
-      "--runner",
-      rebase_path(pw_unit_test_AUTOMATIC_RUNNER, root_build_dir),
-      "--test",
-      rebase_path("$_test_output_dir/$_test_name", root_build_dir),
-    ]
-    stamp = true
+  # Only execute tests when current_os == host_os
+  if (current_os != host_os) {
+    # NOOP dummy group
+    group(_test_name + "_run") {
+    }
+  } else {
+    pw_python_script(_test_name + "_run") {
+      deps = [ ":${_test_name}" ]
+      inputs = [ pw_unit_test_AUTOMATIC_RUNNER ]
+      script = "$dir_pw_unit_test/py/pw_unit_test/test_runner.py"
+      args = [
+        "--runner",
+        rebase_path(pw_unit_test_AUTOMATIC_RUNNER, root_build_dir),
+        "--test",
+        rebase_path("$_test_output_dir/$_test_name", root_build_dir),
+      ]
+      stamp = true
+    }
   }
 }

--- a/src/crypto/BUILD.gn
+++ b/src/crypto/BUILD.gn
@@ -30,7 +30,9 @@ config("crypto_config") {
       "CHIP_WITH_OPENSSL=1",
     ]
   } else {
-    defines += [ "CHIP_CRYPTO_OPENSSL=0" ]
+    defines += [
+      "CHIP_CRYPTO_OPENSSL=0",
+      "CHIP_WITH_OPENSSL=0" ]
   }
 }
 

--- a/src/crypto/crypto.gni
+++ b/src/crypto/crypto.gni
@@ -18,7 +18,7 @@ declare_args() {
 }
 
 if (chip_crypto == "") {
-  if (current_os == "freertos") {
+  if (current_os == "android" || current_os == "freertos") {
     chip_crypto = "mbedtls"
   } else {
     chip_crypto = "openssl"

--- a/src/inet/BUILD.gn
+++ b/src/inet/BUILD.gn
@@ -160,4 +160,12 @@ static_library("inet") {
     sources += [ "InetFaultInjection.cpp" ]
     public_deps += [ "${nlfaultinjection_root}:nlfaultinjection" ]
   }
+
+  include_dirs = [ ]
+  if (current_os == "android") {
+    include_dirs += [
+       "${chip_root}/third_party/android/platform-libcore/android-platform-libcore/luni/src/main/native",
+       "${chip_root}/third_party/android/platform-libcore/android-platform-libcore/include"
+    ]
+  }
 }

--- a/src/lwip/BUILD.gn
+++ b/src/lwip/BUILD.gn
@@ -53,6 +53,10 @@ config("lwip_config") {
     "HAVE_LWIP_UDP_BIND_NETIF=1",
   ]
 
+  if (current_os == "android") {
+     defines += [ "LWIP_NO_STDINT_H=1" ]
+  }
+
   include_dirs = [ lwip_platform ]
 
   if (lwip_platform != "standalone") {


### PR DESCRIPTION
 #### Problem
Android toolchain needed for GN build

 #### Summary of Changes
Adding an android toolchain for arm and x86_64 target
cpus.  Subsequent CLs may add target arch to select
armv6, armv7, arm64 and x86 targets if required.

Added a check to only attempt to run tests when
current_os == host_os, otherwise cross compiled tests
attempt to execute on the wrong architecture and fail.

Need to temporarily omit lib/messages from android build
due to RNG dependency on openssl.

fixes #2242
