### PR TITLE
Split platform specifics out into separate directories

### DIFF
--- a/src/lib/core/BUILD.gn
+++ b/src/lib/core/BUILD.gn
@@ -154,7 +154,6 @@ static_library("core") {
   ]
 
   public_deps = [
-    chip_platform_target,
     ":chip_config_header",
     "${chip_root}/src/ble",
     "${chip_root}/src/inet",
@@ -162,6 +161,7 @@ static_library("core") {
     "${chip_root}/src/platform",
     "${chip_root}/src/system",
     "${nlio_root}:nlio",
+    chip_platform_target,
   ]
 
   allow_circular_includes_from = [

--- a/src/lib/core/BUILD.gn
+++ b/src/lib/core/BUILD.gn
@@ -17,6 +17,7 @@ import("//build_overrides/nlio.gni")
 
 import("${chip_root}/gn/chip/tests.gni")
 import("${chip_root}/src/inet/inet.gni")
+import("${chip_root}/src/platform/device.gni")
 import("core.gni")
 
 config("chip_config") {
@@ -153,6 +154,7 @@ static_library("core") {
   ]
 
   public_deps = [
+    chip_platform_target,
     ":chip_config_header",
     "${chip_root}/src/ble",
     "${chip_root}/src/inet",
@@ -163,6 +165,7 @@ static_library("core") {
   ]
 
   allow_circular_includes_from = [
+    chip_platform_target,
     "${chip_root}/src/ble",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/inet",

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -12,22 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import("//build/config/linux/pkg_config.gni")
 import("//build_overrides/chip.gni")
 import("//build_overrides/nlio.gni")
 
 import("device.gni")
 
-if (chip_enable_openthread) {
-  import("//build_overrides/openthread.gni")
-  import("//build_overrides/ot_br_posix.gni")
-}
-
-if (chip_device_platform == "nrf5") {
-  import("//build_overrides/nrf5_sdk.gni")
-}
-
-if (chip_device_platform != "none" && chip_device_platform != "external") {
+if (chip_device_platform != "none") {
   declare_args() {
     # Extra header to include in CHIPDeviceConfig.h for project.
     chip_device_project_config_include = ""
@@ -42,8 +32,8 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
   config("platform_config") {
     configs = [ "${chip_root}/src:includes" ]
 
-    defines = []
-    libs = []
+    defines = [ "CONFIG_DEVICE_LAYER=1" ]
+
     if (chip_device_project_config_include != "") {
       defines += [ "CHIP_DEVICE_PROJECT_CONFIG_INCLUDE=${chip_device_project_config_include}" ]
     }
@@ -58,58 +48,28 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
       defines += [ "CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_TIME=\"${chip_device_config_firmware_build_time}\"" ]
     }
 
-    if (chip_device_platform == "darwin") {
-      frameworks = [
-        "CoreFoundation.framework",
-        "CoreBluetooth.framework",
-        "Foundation.framework",
-      ]
-      defines += [
-        "CONFIG_DEVICE_LAYER=1",
-        "CHIP_DEVICE_LAYER_TARGET_DARWIN=1",
-        "CHIP_DEVICE_LAYER_TARGET=Darwin",
-      ]
-    } else {
-      defines += [ "CHIP_DEVICE_LAYER_TARGET_DARWIN=0" ]
-    }
-    if (chip_device_platform == "linux") {
-      defines += [
-        "CONFIG_DEVICE_LAYER=1",
-        "CHIP_DEVICE_LAYER_TARGET_LINUX=1",
-        "CHIP_DEVICE_LAYER_TARGET=Linux",
-      ]
-    } else {
-      defines += [ "CHIP_DEVICE_LAYER_TARGET_LINUX=0" ]
-    }
-    if (chip_device_platform == "nrf5") {
-      defines += [
-        "CONFIG_DEVICE_LAYER=1",
-        "CHIP_DEVICE_LAYER_TARGET_NRF5=1",
-        "CHIP_DEVICE_LAYER_TARGET=nRF5",
-      ]
-    } else {
-      defines += [ "CHIP_DEVICE_LAYER_TARGET_NRF5=0" ]
-    }
     if (chip_enable_openthread) {
       defines += [
         "CHIP_DEVICE_CONFIG_ENABLE_THREAD=1",
         "CHIP_ENABLE_OPENTHREAD=1",
       ]
     }
-    if (chip_enable_wifi) {
-      defines += [ "CHIP_DEVICE_CONFIG_ENABLE_WPA=1" ]
-    }
-    if (chip_device_platform == "efr32") {
-      defines += [
-        "CONFIG_DEVICE_LAYER=1",
-        "CHIP_DEVICE_LAYER_TARGET_EFR32=1",
-        "CHIP_DEVICE_LAYER_TARGET=EFR32",
-      ]
-    } else {
-      defines += [ "CHIP_DEVICE_LAYER_TARGET_EFR32=0" ]
-    }
   }
 
+  group("platform_base") {
+    public_deps = [
+      "${chip_root}/src/ble",
+      "${chip_root}/src/inet",
+      "${chip_root}/src/lib/core:chip_config_header",
+      "${chip_root}/src/lib/support",
+      "${nlio_root}:nlio",
+    ]
+
+    public_configs = [ ":platform_config" ]
+  }
+}
+
+if (chip_device_platform != "none") {
   static_library("platform") {
     output_name = "libDeviceLayer"
 
@@ -155,152 +115,15 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
     ]
 
     public_deps = [
-      "${chip_root}/src/ble",
-      "${chip_root}/src/inet",
-      "${chip_root}/src/lib/core:chip_config_header",
+      ":platform_base",
       "${chip_root}/src/lib/support",
-      "${nlio_root}:nlio",
+      chip_platform_target,
     ]
 
-    public_configs = [ ":platform_config" ]
-
-    if (chip_device_platform == "darwin") {
-      sources += [
-        "Darwin/BLEManagerImpl.cpp",
-        "Darwin/BLEManagerImpl.h",
-        "Darwin/BleApplicationDelegate.h",
-        "Darwin/BleApplicationDelegateImpl.mm",
-        "Darwin/BleConnectionDelegate.h",
-        "Darwin/BleConnectionDelegateImpl.mm",
-        "Darwin/BlePlatformConfig.h",
-        "Darwin/BlePlatformDelegate.h",
-        "Darwin/BlePlatformDelegateImpl.mm",
-        "Darwin/CHIPDevicePlatformConfig.h",
-        "Darwin/CHIPDevicePlatformEvent.h",
-        "Darwin/CHIPPlatformConfig.h",
-        "Darwin/ConfigurationManagerImpl.cpp",
-        "Darwin/ConfigurationManagerImpl.h",
-        "Darwin/ConnectivityManagerImpl.cpp",
-        "Darwin/ConnectivityManagerImpl.h",
-        "Darwin/InetPlatformConfig.h",
-        "Darwin/PlatformManagerImpl.cpp",
-        "Darwin/PlatformManagerImpl.h",
-        "Darwin/PosixConfig.cpp",
-        "Darwin/PosixConfig.h",
-        "Darwin/SystemPlatformConfig.h",
-      ]
-    } else if (chip_device_platform == "linux") {
-      sources += [
-        "Linux/BLEManagerImpl.cpp",
-        "Linux/BLEManagerImpl.h",
-        "Linux/BlePlatformConfig.h",
-        "Linux/CHIPDevicePlatformConfig.h",
-        "Linux/CHIPDevicePlatformEvent.h",
-        "Linux/CHIPLinuxStorage.cpp",
-        "Linux/CHIPLinuxStorage.h",
-        "Linux/CHIPLinuxStorageIni.cpp",
-        "Linux/CHIPLinuxStorageIni.h",
-        "Linux/CHIPPlatformConfig.h",
-        "Linux/ConfigurationManagerImpl.cpp",
-        "Linux/ConfigurationManagerImpl.h",
-        "Linux/ConnectivityManagerImpl.cpp",
-        "Linux/ConnectivityManagerImpl.h",
-        "Linux/InetPlatformConfig.h",
-        "Linux/Logging.cpp",
-        "Linux/PlatformManagerImpl.cpp",
-        "Linux/PlatformManagerImpl.h",
-        "Linux/PosixConfig.cpp",
-        "Linux/PosixConfig.h",
-        "Linux/SystemPlatformConfig.h",
-        "Linux/SystemTimeSupport.cpp",
-      ]
-
-      if (chip_enable_openthread) {
-        sources += [
-          "Linux/ThreadStackManagerImpl.cpp",
-          "Linux/ThreadStackManagerImpl.h",
-        ]
-        public_deps += [ "${ot_br_posix_root}:ot_br_client" ]
-      }
-
-      if (chip_enable_wifi) {
-        public_deps += [ "Linux/dbus" ]
-      }
-
-      public_deps += [ "${chip_root}/third_party/inipp" ]
-    } else if (chip_device_platform == "nrf5") {
-      sources += [
-        "FreeRTOS/SystemTimeSupport.cpp",
-        "nRF5/BLEManagerImpl.cpp",
-        "nRF5/BLEManagerImpl.h",
-        "nRF5/BlePlatformConfig.h",
-        "nRF5/CHIPDevicePlatformConfig.h",
-        "nRF5/CHIPDevicePlatformEvent.h",
-        "nRF5/CHIPPlatformConfig.h",
-        "nRF5/ConfigurationManagerImpl.cpp",
-        "nRF5/ConfigurationManagerImpl.h",
-        "nRF5/ConnectivityManagerImpl.cpp",
-        "nRF5/ConnectivityManagerImpl.h",
-        "nRF5/InetPlatformConfig.h",
-        "nRF5/Logging.cpp",
-        "nRF5/PlatformManagerImpl.cpp",
-        "nRF5/PlatformManagerImpl.h",
-        "nRF5/SystemPlatformConfig.h",
-        "nRF5/nRF5Config.cpp",
-        "nRF5/nRF5Config.h",
-        "nRF5/nRF5Utils.cpp",
-        "nRF5/nRF5Utils.h",
-      ]
-
-      public_deps += [ "${nrf5_sdk_build_root}:nrf5_sdk" ]
-
-      if (chip_enable_openthread) {
-        public_deps += [ "${openthread_root}:libopenthread-ftd" ]
-
-        sources += [
-          "OpenThread/OpenThreadUtils.cpp",
-          "nRF5/ThreadStackManagerImpl.cpp",
-          "nRF5/ThreadStackManagerImpl.h",
-        ]
-      }
-    } else if (chip_device_platform == "efr32") {
-      sources += [
-        "EFR32/BLEManagerImpl.cpp",
-        "EFR32/BLEManagerImpl.h",
-        "EFR32/BlePlatformConfig.h",
-        "EFR32/CHIPDevicePlatformConfig.h",
-        "EFR32/CHIPDevicePlatformEvent.h",
-        "EFR32/CHIPPlatformConfig.h",
-        "EFR32/ConfigurationManagerImpl.cpp",
-        "EFR32/ConfigurationManagerImpl.h",
-        "EFR32/ConnectivityManagerImpl.cpp",
-        "EFR32/ConnectivityManagerImpl.h",
-        "EFR32/EFR32Config.cpp",
-        "EFR32/EFR32Config.h",
-        "EFR32/InetPlatformConfig.h",
-        "EFR32/Logging.cpp",
-        "EFR32/PlatformManagerImpl.cpp",
-        "EFR32/PlatformManagerImpl.h",
-        "EFR32/SystemPlatformConfig.h",
-        "EFR32/freertos_bluetooth.c",
-        "EFR32/freertos_bluetooth.h",
-        "EFR32/gatt_db.c",
-        "EFR32/gatt_db.h",
-        "FreeRTOS/SystemTimeSupport.cpp",
-      ]
-      if (chip_enable_openthread) {
-        sources += [
-          "EFR32/ThreadStackManagerImpl.cpp",
-          "EFR32/ThreadStackManagerImpl.h",
-        ]
-      }
-    }
-
-    allow_circular_includes_from = [ "${chip_root}/src/lib/support" ]
-  }
-} else if (chip_device_platform == "external") {
-  group("platform") {
-    public_deps = [ "${chip_platform_target}" ]
+    allow_circular_includes_from = [
+      chip_platform_target,
+      "${chip_root}/src/lib/support",
+    ]
   }
 } else {
   group("platform") {

--- a/src/platform/Darwin/BUILD.gn
+++ b/src/platform/Darwin/BUILD.gn
@@ -1,0 +1,64 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+import("${chip_root}/src/platform/device.gni")
+
+assert(chip_device_platform == "darwin")
+
+config("darwin_config") {
+  frameworks = [
+    "CoreFoundation.framework",
+    "CoreBluetooth.framework",
+    "Foundation.framework",
+  ]
+  defines = [
+    "CHIP_DEVICE_LAYER_TARGET_DARWIN=1",
+    "CHIP_DEVICE_LAYER_TARGET=Darwin",
+  ]
+}
+
+static_library("Darwin") {
+  output_name = "libDeviceLayerDarwin"
+
+  sources = [
+    "BLEManagerImpl.cpp",
+    "BLEManagerImpl.h",
+    "BleApplicationDelegate.h",
+    "BleApplicationDelegateImpl.mm",
+    "BleConnectionDelegate.h",
+    "BleConnectionDelegateImpl.mm",
+    "BlePlatformConfig.h",
+    "BlePlatformDelegate.h",
+    "BlePlatformDelegateImpl.mm",
+    "CHIPDevicePlatformConfig.h",
+    "CHIPDevicePlatformEvent.h",
+    "CHIPPlatformConfig.h",
+    "ConfigurationManagerImpl.cpp",
+    "ConfigurationManagerImpl.h",
+    "ConnectivityManagerImpl.cpp",
+    "ConnectivityManagerImpl.h",
+    "InetPlatformConfig.h",
+    "PlatformManagerImpl.cpp",
+    "PlatformManagerImpl.h",
+    "PosixConfig.cpp",
+    "PosixConfig.h",
+    "SystemPlatformConfig.h",
+  ]
+
+  public_deps = [ "${chip_root}/src/platform:platform_base" ]
+
+  public_configs = [ ":darwin_config" ]
+}

--- a/src/platform/EFR32/BUILD.gn
+++ b/src/platform/EFR32/BUILD.gn
@@ -1,0 +1,66 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+import("${chip_root}/src/platform/device.gni")
+
+assert(chip_device_platform == "efr32")
+
+config("efr32_config") {
+  defines = [
+    "CHIP_DEVICE_LAYER_TARGET_EFR32=1",
+    "CHIP_DEVICE_LAYER_TARGET=EFR32",
+  ]
+}
+
+static_library("EFR32") {
+  output_name = "libDeviceLayerEFR32"
+
+  sources = [
+    "../FreeRTOS/SystemTimeSupport.cpp",
+    "BLEManagerImpl.cpp",
+    "BLEManagerImpl.h",
+    "BlePlatformConfig.h",
+    "CHIPDevicePlatformConfig.h",
+    "CHIPDevicePlatformEvent.h",
+    "CHIPPlatformConfig.h",
+    "ConfigurationManagerImpl.cpp",
+    "ConfigurationManagerImpl.h",
+    "ConnectivityManagerImpl.cpp",
+    "ConnectivityManagerImpl.h",
+    "EFR32Config.cpp",
+    "EFR32Config.h",
+    "InetPlatformConfig.h",
+    "Logging.cpp",
+    "PlatformManagerImpl.cpp",
+    "PlatformManagerImpl.h",
+    "SystemPlatformConfig.h",
+    "freertos_bluetooth.c",
+    "freertos_bluetooth.h",
+    "gatt_db.c",
+    "gatt_db.h",
+  ]
+
+  public_deps = [ "${chip_root}/src/platform:platform_base" ]
+
+  public_configs = [ ":efr32_config" ]
+
+  if (chip_enable_openthread) {
+    sources += [
+      "ThreadStackManagerImpl.cpp",
+      "ThreadStackManagerImpl.h",
+    ]
+  }
+}

--- a/src/platform/Linux/BUILD.gn
+++ b/src/platform/Linux/BUILD.gn
@@ -1,0 +1,84 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build/config/linux/pkg_config.gni")
+import("//build_overrides/chip.gni")
+
+import("${chip_root}/src/platform/device.gni")
+
+assert(chip_device_platform == "linux")
+
+if (chip_enable_openthread) {
+  import("//build_overrides/openthread.gni")
+  import("//build_overrides/ot_br_posix.gni")
+}
+
+config("linux_config") {
+  defines = [
+    "CHIP_DEVICE_LAYER_TARGET_LINUX=1",
+    "CHIP_DEVICE_LAYER_TARGET=Linux",
+  ]
+
+  if (chip_enable_wifi) {
+    defines += [ "CHIP_DEVICE_CONFIG_ENABLE_WPA=1" ]
+  }
+}
+
+static_library("Linux") {
+  output_name = "libDeviceLayerLinux"
+
+  sources = [
+    "BLEManagerImpl.cpp",
+    "BLEManagerImpl.h",
+    "BlePlatformConfig.h",
+    "CHIPDevicePlatformConfig.h",
+    "CHIPDevicePlatformEvent.h",
+    "CHIPLinuxStorage.cpp",
+    "CHIPLinuxStorage.h",
+    "CHIPLinuxStorageIni.cpp",
+    "CHIPLinuxStorageIni.h",
+    "CHIPPlatformConfig.h",
+    "ConfigurationManagerImpl.cpp",
+    "ConfigurationManagerImpl.h",
+    "ConnectivityManagerImpl.cpp",
+    "ConnectivityManagerImpl.h",
+    "InetPlatformConfig.h",
+    "Logging.cpp",
+    "PlatformManagerImpl.cpp",
+    "PlatformManagerImpl.h",
+    "PosixConfig.cpp",
+    "PosixConfig.h",
+    "SystemPlatformConfig.h",
+    "SystemTimeSupport.cpp",
+  ]
+
+  public_deps = [
+    "${chip_root}/src/platform:platform_base",
+    "${chip_root}/third_party/inipp",
+  ]
+
+  if (chip_enable_openthread) {
+    sources += [
+      "ThreadStackManagerImpl.cpp",
+      "ThreadStackManagerImpl.h",
+    ]
+    public_deps += [ "${ot_br_posix_root}:ot_br_client" ]
+  }
+
+  if (chip_enable_wifi) {
+    public_deps += [ "dbus" ]
+  }
+
+  public_configs = [ ":linux_config" ]
+}

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -97,6 +97,7 @@ if (chip_device_platform == "external") {
       get_label_info(_chip_device_layer, "label_no_toolchain")
 }
 
-assert(chip_device_platform == "darwin" || chip_device_platform == "nrf5" || chip_device_platform == "efr32" || chip_device_platform == "linux" ||
+assert(chip_device_platform == "darwin" || chip_device_platform == "nrf5" ||
+           chip_device_platform == "efr32" || chip_device_platform == "linux" ||
            chip_device_platform == "external" || chip_device_platform == "none",
        "Please select a valid value for chip_device_platform")

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -17,7 +17,6 @@ import("//build_overrides/chip.gni")
 declare_args() {
   # Device platform layer: darwin, linux, freertos, nrf5, efr32, external, none.
   chip_device_platform = "auto"
-  chip_platform_target = ""
 }
 
 if (chip_device_platform == "auto") {
@@ -46,39 +45,58 @@ if (chip_device_platform == "darwin") {
   _chip_device_layer = "Linux"
 } else if (chip_device_platform == "nrf5") {
   _chip_device_layer = "nRF5"
+} else if (chip_device_platform == "efr32") {
+  _chip_device_layer = "EFR32"
 }
 
-if (chip_device_platform != "external") {
-  chip_ble_platform_config_include = ""
-  chip_device_platform_config_include = ""
-  chip_platform_config_include = ""
-  chip_inet_platform_config_include = ""
-  chip_system_platform_config_include = ""
-} else {
+_chip_ble_platform_config_include = ""
+_chip_device_platform_config_include = ""
+_chip_platform_config_include = ""
+_chip_inet_platform_config_include = ""
+_chip_system_platform_config_include = ""
+
+if (chip_device_platform != "none") {
+  if (chip_device_platform != "external") {
+    _chip_ble_platform_config_include =
+        "<platform/" + _chip_device_layer + "/BlePlatformConfig.h>"
+    _chip_device_platform_config_include =
+        "<platform/" + _chip_device_layer + "/CHIPDevicePlatformConfig.h>"
+    _chip_platform_config_include =
+        "<platform/" + _chip_device_layer + "/CHIPPlatformConfig.h>"
+    _chip_inet_platform_config_include =
+        "<platform/" + _chip_device_layer + "/InetPlatformConfig.h>"
+    _chip_system_platform_config_include =
+        "<platform/" + _chip_device_layer + "/SystemPlatformConfig.h>"
+  }
+
   declare_args() {
-    chip_ble_platform_config_include = ""
-    chip_device_platform_config_include = ""
-    chip_platform_config_include = ""
-    chip_inet_platform_config_include = ""
-    chip_system_platform_config_include = ""
+    # Platform configuration header for BLE.
+    chip_ble_platform_config_include = _chip_ble_platform_config_include
+
+    # Platform configuration header for device layer.
+    chip_device_platform_config_include = _chip_device_platform_config_include
+
+    # Platform configuration header for CHIP core.
+    chip_platform_config_include = _chip_platform_config_include
+
+    # Platform configuration header for inet layer.
+    chip_inet_platform_config_include = _chip_inet_platform_config_include
+
+    # Platform configuration header for system layer.
+    chip_system_platform_config_include = _chip_system_platform_config_include
   }
 }
 
-if (_chip_device_layer != "none" && chip_device_platform != "external") {
-  chip_ble_platform_config_include =
-      "<platform/" + _chip_device_layer + "/BlePlatformConfig.h>"
-  chip_device_platform_config_include =
-      "<platform/" + _chip_device_layer + "/CHIPDevicePlatformConfig.h>"
-  chip_platform_config_include =
-      "<platform/" + _chip_device_layer + "/CHIPPlatformConfig.h>"
-  chip_inet_platform_config_include =
-      "<platform/" + _chip_device_layer + "/InetPlatformConfig.h>"
-  chip_system_platform_config_include =
-      "<platform/" + _chip_device_layer + "/SystemPlatformConfig.h>"
+if (chip_device_platform == "external") {
+  declare_args() {
+    # Target for external platform.
+    chip_platform_target = ""
+  }
+} else if (chip_device_platform != "none") {
+  chip_platform_target =
+      get_label_info(_chip_device_layer, "label_no_toolchain")
 }
 
-assert(
-    (current_os != "freertos" && chip_device_platform == "none") ||
-        chip_device_platform == "darwin" || chip_device_platform == "nrf5" ||
-        chip_device_platform == "linux" || chip_device_platform == "external",
-    "Please select a valid value for chip_device_platform")
+assert(chip_device_platform == "darwin" || chip_device_platform == "nrf5" || chip_device_platform == "efr32" || chip_device_platform == "linux" ||
+           chip_device_platform == "external" || chip_device_platform == "none",
+       "Please select a valid value for chip_device_platform")

--- a/src/platform/nRF5/BUILD.gn
+++ b/src/platform/nRF5/BUILD.gn
@@ -1,0 +1,78 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+import("//build_overrides/nrf5_sdk.gni")
+
+import("${chip_root}/src/platform/device.gni")
+
+assert(chip_device_platform == "nrf5")
+
+if (chip_enable_openthread) {
+  import("//build_overrides/openthread.gni")
+}
+
+config("nrf5_config") {
+  defines = [
+    "CHIP_DEVICE_LAYER_TARGET_NRF5=1",
+    "CHIP_DEVICE_LAYER_TARGET=nRF5",
+  ]
+}
+
+static_library("nRF5") {
+  output_name = "libDeviceLayerNRF5"
+
+  sources = [
+    "../FreeRTOS/SystemTimeSupport.cpp",
+    "BLEManagerImpl.cpp",
+    "BLEManagerImpl.h",
+    "BlePlatformConfig.h",
+    "CHIPDevicePlatformConfig.h",
+    "CHIPDevicePlatformEvent.h",
+    "CHIPPlatformConfig.h",
+    "ConfigurationManagerImpl.cpp",
+    "ConfigurationManagerImpl.h",
+    "ConnectivityManagerImpl.cpp",
+    "ConnectivityManagerImpl.h",
+    "InetPlatformConfig.h",
+    "Logging.cpp",
+    "PlatformManagerImpl.cpp",
+    "PlatformManagerImpl.h",
+    "SystemPlatformConfig.h",
+    "nRF5Config.cpp",
+    "nRF5Config.h",
+    "nRF5Utils.cpp",
+    "nRF5Utils.h",
+  ]
+
+  public_deps = [
+    "${chip_root}/src/platform:platform_base",
+    "${nrf5_sdk_build_root}:nrf5_sdk",
+  ]
+
+  if (chip_enable_openthread) {
+    public_deps += [
+      "${openthread_root}:libopenthread-cli-ftd",
+      "${openthread_root}:libopenthread-ftd",
+    ]
+
+    sources += [
+      "../OpenThread/OpenThreadUtils.cpp",
+      "ThreadStackManagerImpl.cpp",
+      "ThreadStackManagerImpl.h",
+    ]
+  }
+
+  public_configs = [ ":nrf5_config" ]
+}


### PR DESCRIPTION
Break up the giant build file src/platform/BUILD.gn. This is a bit
trickier than expected due to the circular dependencies between platform
code and src/lib/{support,core}, but adding some extra dependencies and
use of allow_circular_includes_from makes it work.