### PR TITLE
Cleanup trickle and message id reuse

### DIFF
--- a/src/lib/message/CHIPExchangeMgr.h
+++ b/src/lib/message/CHIPExchangeMgr.h
@@ -46,26 +46,6 @@ class ChipConnection;
 class Binding;
 
 /**
- *  @def CHIP_TRICKLE_DEFAULT_PERIOD
- *
- *  @brief
- *    Defines Trickle algorithm's default period (in milliseconds) for periodic
- *    transmissions.
- *
- */
-#define CHIP_TRICKLE_DEFAULT_PERIOD 1000
-
-/**
- *  @def CHIP_TRICKLE_DEFAULT_THRESHOLD
- *
- *  @brief
- *    Defines Trickle algorithm's default value for the maximum number of received
- *    duplicate messages to wait before retransmission.
- *
- */
-#define CHIP_TRICKLE_DEFAULT_THRESHOLD 2
-
-/**
  *  @class ChipExchangeHeader
  *
  *  @brief
@@ -143,11 +123,9 @@ public:
 #endif
     enum
     {
-        kSendFlag_AutoRetrans           = 0x0001, /**< Used to indicate that automatic retransmission is enabled. */
-        kSendFlag_ExpectResponse        = 0x0002, /**< Used to indicate that a response is expected within a specified timeout. */
-        kSendFlag_RetransmissionTrickle = 0x0004, /**< Used to indicate the requirement of retransmissions for Trickle. */
+        kSendFlag_AutoRetrans    = 0x0001, /**< Used to indicate that automatic retransmission is enabled. */
+        kSendFlag_ExpectResponse = 0x0002, /**< Used to indicate that a response is expected within a specified timeout. */
         kSendFlag_DelaySend      = 0x0008, /**< Used to indicate that the sending of the current message needs to be delayed. */
-        kSendFlag_ReuseMessageId = 0x0010, /**< Used to indicate that the message ID in the message header can be reused. */
         kSendFlag_ReuseSourceId  = 0x0020, /**< Used to indicate that the source node ID in the message header can be reused. */
         kSendFlag_RetainBuffer   = 0x0040, /**< Used to indicate that the message buffer should not be freed after sending. */
         kSendFlag_AlreadyEncoded = 0x0080, /**< Used to indicate that the message is already encoded. */
@@ -197,9 +175,6 @@ public:
     CHIP_ERROR SendCommonNullMessage(void);
     CHIP_ERROR EncodeExchHeader(ChipExchangeHeader * exchangeHeader, uint32_t profileId, uint8_t msgType, PacketBuffer * msgBuf,
                                 uint16_t sendFlags);
-    void TeardownTrickleRetransmit(void);
-    CHIP_ERROR SetupTrickleRetransmit(uint32_t retransInterval = CHIP_TRICKLE_DEFAULT_PERIOD,
-                                      uint8_t threshold = CHIP_TRICKLE_DEFAULT_THRESHOLD, uint32_t timeout = 0);
 
     /**
      * This function is the application callback for handling a received CHIP message.
@@ -272,7 +247,6 @@ public:
     KeyErrorFunct OnKeyError;
 
     void CancelRetrans(void);
-    void HandleTrickleMessage(const IPPacketInfo * pktInfo, const ChipMessageInfo * msgInfo);
 
 #if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     CHIP_ERROR RMPSendThrottleFlow(uint32_t PauseTimeMillis);
@@ -334,7 +308,6 @@ public:
     void Close(void);
     void Abort(void);
     void Release(void);
-    CHIP_ERROR StartTimerT(void);
 
     enum
     {
@@ -347,19 +320,12 @@ public:
 
 private:
     PacketBuffer * msg; // If we are re-transmitting, then this is the pointer to the message being retransmitted
-    // Trickle-controlled retransmissions:
-    uint32_t backoff; // backoff for sampling the numner of messages
-    uint32_t currentBcastMsgID;
-    uint8_t msgsReceived;         // number of messages heard during the backoff period
-    uint8_t rebroadcastThreshold; // re-broadcast threshold
 
     uint16_t mFlags; // Internal state flags
 
     CHIP_ERROR ResendMessage(void);
     bool MatchExchange(ChipConnection * msgCon, const ChipMessageInfo * msgInfo, const ChipExchangeHeader * exchangeHeader);
-    static void TimerTau(System::Layer * aSystemLayer, void * aAppState, System::Error aError);
     static void CancelRetransmissionTimer(System::Layer * aSystemLayer, void * aAppState, System::Error aError);
-    static void TimerT(System::Layer * aSystemLayer, void * aAppState, System::Error aError);
 
     CHIP_ERROR StartResponseTimer(void);
     void CancelResponseTimer(void);

--- a/src/lib/message/CHIPMessageLayer.cpp
+++ b/src/lib/message/CHIPMessageLayer.cpp
@@ -1235,8 +1235,7 @@ CHIP_ERROR ChipMessageLayer::EncodeMessage(ChipMessageInfo * msgInfo, PacketBuff
     uint8_t * p = payloadStart - headLen;
 
     // Allocate a new message identifier and write the message identifier field.
-    if ((msgInfo->Flags & kChipMessageFlag_ReuseMessageId) == 0)
-        msgInfo->MessageId = sessionState.NewMessageId();
+    msgInfo->MessageId = sessionState.NewMessageId();
 
 #if CHIP_CONFIG_USE_APP_GROUP_KEYS_FOR_MSG_ENC
     // Request message counter synchronization if peer group key counter is not synchronized.

--- a/src/lib/message/CHIPMessageLayer.h
+++ b/src/lib/message/CHIPMessageLayer.h
@@ -119,7 +119,6 @@ typedef struct ChipMessageInfo ChipMessageHeader;
  */
 typedef enum ChipMessageFlags
 {
-    kChipMessageFlag_ReuseMessageId = 0x00000010, /**< Indicates that the existing message identifier must be reused. */
     kChipMessageFlag_ReuseSourceId  = 0x00000020, /**< Indicates that the existing source node identifier must be reused. */
     kChipMessageFlag_DelaySend      = 0x00000040, /**< Indicates that the sending of the message needs to be delayed. */
     kChipMessageFlag_RetainBuffer   = 0x00000080, /**< Indicates that the message buffer should not be freed after sending. */

--- a/src/lib/message/ExchangeContext.cpp
+++ b/src/lib/message/ExchangeContext.cpp
@@ -499,30 +499,6 @@ CHIP_ERROR ExchangeContext::SendMessage(uint32_t profileId, uint8_t msgType, Pac
 
     // TODO: implement support for retransmissions.
 
-    // flag validation
-    if (sendFlags & kSendFlag_RetransmissionTrickle)
-    {
-        // We do not allow RMP to be used when Trickle retransmission is requested
-        if (sendFlags & kSendFlag_RequestAck)
-        {
-            ExitNow(err = CHIP_ERROR_INVALID_ARGUMENT);
-        }
-
-        // We do not support trickle retrasnmissions over
-        // connection-oriented exchanges
-        VerifyOrExit(Con == NULL, err = CHIP_ERROR_INVALID_ARGUMENT);
-
-        if (0 == RetransInterval)
-        { // we're not retransmitting, do not hold onto the buffer
-            sendFlags &= ~kSendFlag_RetainBuffer;
-        }
-        else
-        {
-            sendFlags |= kSendFlag_RetainBuffer;
-            msg = msgBuf;
-        }
-    }
-
     // Add the exchange header to the message buffer.
     ChipExchangeHeader exchangeHeader;
     memset(&exchangeHeader, 0, sizeof(exchangeHeader));
@@ -554,8 +530,6 @@ CHIP_ERROR ExchangeContext::SendMessage(uint32_t profileId, uint8_t msgType, Pac
         msgInfo->Flags |= kChipMessageFlag_RetainBuffer;
     if (sendFlags & kSendFlag_AlreadyEncoded)
         msgInfo->Flags |= kChipMessageFlag_MessageEncoded;
-    if (sendFlags & kSendFlag_ReuseMessageId)
-        msgInfo->Flags |= kChipMessageFlag_ReuseMessageId;
     if (sendFlags & kSendFlag_ReuseSourceId)
         msgInfo->Flags |= kChipMessageFlag_ReuseSourceId;
     if (sendFlags & kSendFlag_DefaultMulticastSourceAddress)
@@ -610,18 +584,6 @@ CHIP_ERROR ExchangeContext::SendMessage(uint32_t profileId, uint8_t msgType, Pac
             msgBuf     = NULL;
             sendCalled = true;
             SuccessOrExit(err);
-        }
-
-        if (sendFlags & kSendFlag_RetransmissionTrickle)
-        {
-            currentBcastMsgID = msgInfo->MessageId;
-            if (RetransInterval != 0)
-            {
-                if (StartTimerT() != CHIP_NO_ERROR)
-                {
-                    nlLogError("EC: cant start T\n");
-                }
-            }
         }
     }
 
@@ -770,16 +732,6 @@ CHIP_ERROR ExchangeContext::EncodeExchHeader(ChipExchangeHeader * exchangeHeader
 }
 
 /**
- *  Cancel the Trickle retransmission mechanism.
- *
- */
-void ExchangeContext::CancelRetrans()
-{
-    // NOTE: modify for other retransmission schemes
-    TeardownTrickleRetransmit();
-}
-
-/**
  *  Increment the reference counter for the exchange context by one.
  *
  */
@@ -823,8 +775,6 @@ void ExchangeContext::DoClose(bool clearRetransTable)
     ExchangeMgr->RMPStartTimer();
 #endif
 
-    // Cancel the trickle retransmission timer.
-    CancelRetrans();
     // Cancel the response timer.
     CancelResponseTimer();
 }
@@ -942,71 +892,9 @@ CHIP_ERROR ExchangeContext::ResendMessage()
     if (res != CHIP_NO_ERROR)
         return CHIP_ERROR_INCORRECT_STATE;
 
-    msgInfo.Flags |= kChipMessageFlag_RetainBuffer | kChipMessageFlag_MessageEncoded | kChipMessageFlag_ReuseMessageId |
-        kChipMessageFlag_ReuseSourceId;
+    msgInfo.Flags |= kChipMessageFlag_RetainBuffer | kChipMessageFlag_MessageEncoded | kChipMessageFlag_ReuseSourceId;
 
     return ExchangeMgr->MessageLayer->ResendMessage(PeerAddr, PeerPort, PeerIntf, &msgInfo, msg);
-}
-
-/**
- *  Start the Trickle rebroadcast algorithm's periodic retransmission timer mechanism.
- *
- *  @return  #CHIP_NO_ERROR if successful, else an INET_ERROR mapped into a CHIP_ERROR.
- *
- */
-CHIP_ERROR ExchangeContext::StartTimerT()
-{
-    if (RetransInterval == 0)
-    {
-        return CHIP_NO_ERROR;
-    }
-
-    // range from 1 to RetransInterval
-    backoff      = 1 + (GetRandU32() % (RetransInterval - 1));
-    msgsReceived = 0;
-    ChipLogDetail(ExchangeManager, "Trickle new interval");
-    return ExchangeMgr->MessageLayer->SystemLayer->StartTimer(backoff, TimerTau, this);
-}
-
-void ExchangeContext::TimerT(System::Layer * aSystemLayer, void * aAppState, System::Error aError)
-{
-    ExchangeContext * client = reinterpret_cast<ExchangeContext *>(aAppState);
-
-    if ((aSystemLayer == NULL) || (aAppState == NULL) || (aError != CHIP_SYSTEM_NO_ERROR))
-    {
-        return;
-    }
-    if (client->StartTimerT() != CHIP_NO_ERROR)
-    {
-        nlLogError("EC: cant start T\n");
-    }
-}
-
-void ExchangeContext::TimerTau(System::Layer * aSystemLayer, void * aAppState, System::Error aError)
-{
-    ExchangeContext * ec = reinterpret_cast<ExchangeContext *>(aAppState);
-
-    if ((aSystemLayer == NULL) || (aAppState == NULL) || (aError != CHIP_SYSTEM_NO_ERROR))
-    {
-        return;
-    }
-    if (ec->msgsReceived < ec->rebroadcastThreshold)
-    {
-        ChipLogDetail(ExchangeManager, "Trickle re-send with duplicate message counter: %u", ec->msgsReceived);
-        ec->ResendMessage();
-    }
-    else
-    {
-        ChipLogDetail(ExchangeManager, "Trickle skipping this interval");
-    }
-    if ((ec->RetransInterval == 0) || (ec->RetransInterval <= ec->backoff))
-    {
-        return;
-    }
-    if (aSystemLayer->StartTimer(ec->RetransInterval - ec->backoff, TimerT, ec) != CHIP_NO_ERROR)
-    {
-        nlLogError("EC: cant start Tau\n");
-    }
 }
 
 bool ExchangeContext::MatchExchange(ChipConnection * msgCon, const ChipMessageInfo * msgInfo,
@@ -1032,90 +920,6 @@ bool ExchangeContext::MatchExchange(ChipConnection * msgCon, const ChipMessageIn
         //    case, the initiator is ill defined)
 
         && (((exchangeHeader->Flags & kChipExchangeFlag_Initiator) != 0) != IsInitiator());
-}
-
-/**
- *  Handle trickle message within the exchange context.
- *
- *  @param[in]    pktInfo    A pointer to the IPPacketInfo object.
- *
- *  @param[in]    msgInfo    A pointer to the CHIP message info structure.
- *
- */
-void ExchangeContext::HandleTrickleMessage(const IPPacketInfo * pktInfo, const ChipMessageInfo * msgInfo)
-{
-    // check if we're at all interested in this message
-    const bool isMessageIdMatching = currentBcastMsgID == msgInfo->MessageId;
-    const bool isNodeIdMatching    = (PeerNodeId == kAnyNodeId) || (PeerNodeId == msgInfo->SourceNodeId);
-    if (isMessageIdMatching && isNodeIdMatching)
-    {
-        msgsReceived++;
-        ChipLogDetail(ExchangeManager, "Increasing trickle duplicate message counter: %u", msgsReceived);
-    }
-    else
-    {
-        ChipLogDetail(ExchangeManager, "Not counted as duplicate message, for MsgId:%08" PRIX32 " NodeId:%d", isMessageIdMatching,
-                      isNodeIdMatching);
-    }
-}
-
-/**
- *  Setup the trickle retransmission mechanism by setting the corresponding retransmission interval
- *  and rebroadcast threshold.
- *
- *  @param[in]    retransInterval    The retransmit interval of the Trickle rebroadcast algorithm.
- *
- *  @param[in]    threshold          The maximum number of times a message is rebroadcast.
- *
- *  @param[in]    timeout            The maximum time to wait before canceling the Trickle retransmission timer.
- *
- *  @return  #CHIP_NO_ERROR if Trickle setup was successful, else an INET_ERROR mapped into a CHIP_ERROR.
- *
- */
-CHIP_ERROR ExchangeContext::SetupTrickleRetransmit(uint32_t retransInterval, uint8_t threshold, uint32_t timeout)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    CancelRetrans();
-    RetransInterval      = retransInterval;
-    rebroadcastThreshold = threshold;
-    if (timeout != 0)
-    {
-        err = ExchangeMgr->MessageLayer->SystemLayer->StartTimer(timeout, CancelRetransmissionTimer, this);
-        if (err != CHIP_NO_ERROR)
-        {
-            nlLogError("EC: cant setup timeout\n");
-            return err;
-        }
-    }
-    ChipLogDetail(ExchangeManager, "Trickle interval %u ms, threshold %u, timeout %u ms", retransInterval, threshold, timeout);
-    return CHIP_NO_ERROR;
-}
-
-/**
- *  Tear down the Trickle retransmission mechanism by canceling the periodic timers
- *  within Trickle and freeing the message buffer holding the CHIP
- *  message.
- *
- */
-void ExchangeContext::TeardownTrickleRetransmit()
-{
-    System::Layer * lSystemLayer = ExchangeMgr->MessageLayer->SystemLayer;
-    if (lSystemLayer == NULL)
-    {
-        // this is an assertion error, which shall never happen
-        return;
-    }
-    lSystemLayer->CancelTimer(TimerT, this);
-    lSystemLayer->CancelTimer(TimerTau, this);
-    lSystemLayer->CancelTimer(CancelRetransmissionTimer, this);
-    if (msg != NULL)
-    {
-        PacketBuffer::Free(msg);
-    }
-
-    msg             = NULL;
-    backoff         = 0;
-    RetransInterval = 0;
 }
 
 void ExchangeContext::CancelRetransmissionTimer(System::Layer * aSystemLayer, void * aAppState, System::Error aError)


### PR DESCRIPTION
 #### Problem
Vestigial WML functionality was included in the WML baseline copy.

 #### Summary of Changes
Removes flag for 'message id reuse'
Removes 'Trickle' flags and methods

fixes #2247 
