### PR TITLE
Use '= delete' to mark forbidden copy constructors and = in WML classes.

### DIFF
--- a/src/lib/message/CHIPExchangeMgr.h
+++ b/src/lib/message/CHIPExchangeMgr.h
@@ -412,6 +412,8 @@ public:
     };
 
     ChipExchangeManager(void);
+    ChipExchangeManager(const ChipExchangeManager &) = delete;
+    ChipExchangeManager operator=(const ChipExchangeManager &) = delete;
 
     ChipMessageLayer * MessageLayer; /**< [READ ONLY] The associated ChipMessageLayer object. */
     ChipFabricState * FabricState;   /**< [READ ONLY] The associated FabricState object. */
@@ -546,8 +548,6 @@ private:
 
     void NotifySecurityManagerAvailable();
     void NotifyKeyFailed(uint64_t peerNodeId, uint16_t keyId, CHIP_ERROR keyErr);
-
-    ChipExchangeManager(const ChipExchangeManager &); // not defined
 };
 
 #if !CHIP_CONFIG_ENABLE_EPHEMERAL_UDP_PORT

--- a/src/lib/message/CHIPMessageLayer.h
+++ b/src/lib/message/CHIPMessageLayer.h
@@ -492,6 +492,8 @@ public:
     };
 
     ChipMessageLayer(void);
+    ChipMessageLayer(const ChipMessageLayer &) = delete;
+    ChipMessageLayer & operator=(const ChipMessageLayer &) = delete;
 
     System::Layer * SystemLayer;       /*** [READ ONLY] The associated SystemLayer object. */
     InetLayer * Inet;                  /**< [READ ONLY] The associated InetLayer object. */
@@ -717,8 +719,6 @@ private:
     static bool IsIgnoredMulticastSendError(CHIP_ERROR err);
 
     static bool IsSendErrorNonCritical(CHIP_ERROR err);
-
-    ChipMessageLayer(const ChipMessageLayer &); // not defined
 
 #if CONFIG_NETWORK_LAYER_BLE
 public:

--- a/src/lib/message/CHIPServerBase.h
+++ b/src/lib/message/CHIPServerBase.h
@@ -63,12 +63,11 @@ public:
 
 protected:
     ChipServerBase(void) {}
+    ChipServerBase(const ChipServerBase &) = delete;
+    ChipServerBase & operator=(const ChipServerBase &) = delete;
 
     bool EnforceAccessControl(ExchangeContext * ec, uint32_t msgProfileId, uint8_t msgType, const ChipMessageInfo * msgInfo,
                               ChipServerDelegateBase * delegate);
-
-private:
-    ChipServerBase(const ChipServerBase &); // not defined
 };
 
 /**

--- a/src/lib/message/Profiles/fabric-provisioning/FabricProvisioning.h
+++ b/src/lib/message/Profiles/fabric-provisioning/FabricProvisioning.h
@@ -180,6 +180,8 @@ class DLL_EXPORT FabricProvisioningServer : public ChipServerBase
 {
 public:
     FabricProvisioningServer(void);
+    FabricProvisioningServer(const FabricProvisioningServer &) = delete;
+    FabricProvisioningServer & operator=(const FabricProvisioningServer &) = delete;
 
     CHIP_ERROR Init(ChipExchangeManager * exchangeMgr);
     CHIP_ERROR Shutdown(void);
@@ -218,8 +220,6 @@ private:
     FabricConfigAccessSession mFabricConfigAccessSession;
 
     chip::ChipFabricState::SessionEndCbCtxt mSessionEndCbCtxt;
-
-    FabricProvisioningServer(const FabricProvisioningServer &); // not defined
 };
 
 } // namespace FabricProvisioning


### PR DESCRIPTION
Previously the copy constructor was defined and commented as 'not
defined'. Using explicit '= delete' seems better.

