### PR TITLE
groom logging

### DIFF
--- a/src/lib/support/logging/CHIPLogging.cpp
+++ b/src/lib/support/logging/CHIPLogging.cpp
@@ -148,12 +148,6 @@ exit:
 #endif // CHIP_LOGGING_STYLE_STDIO_WITH_TIMESTAMPS
 }
 
-#if CHIP_LOG_FILTERING
-
-uint8_t gLogFilter = kLogCategory_Max;
-
-#endif // CHIP_LOG_FILTERING
-
 /**
  * Log, to the platform-specified mechanism, the specified log
  * message, @a msg, for the specified module, @a module, in the
@@ -187,21 +181,41 @@ DLL_EXPORT void Log(uint8_t module, uint8_t category, const char * msg, ...)
     va_end(v);
 }
 
+#if CHIP_LOG_FILTERING
+uint8_t gLogFilter = kLogCategory_Max;
+DLL_EXPORT bool IsCategoryEnabled(uint8_t category)
+{
+    return (category <= gLogFilter);
+}
+
 DLL_EXPORT uint8_t GetLogFilter()
 {
-#if CHIP_LOG_FILTERING
     return gLogFilter;
-#else
-    return kLogCategory_Max;
-#endif
 }
 
 DLL_EXPORT void SetLogFilter(uint8_t category)
 {
-#if CHIP_LOG_FILTERING
     gLogFilter = category;
-#endif
 }
+
+#else  // CHIP_LOG_FILTERING
+
+DLL_EXPORT bool IsCategoryEnabled(uint8_t category)
+{
+    (void) category;
+    return true;
+}
+
+DLL_EXPORT uint8_t GetLogFilter()
+{
+    return kLogCategory_Max;
+}
+
+DLL_EXPORT void SetLogFilter(uint8_t category)
+{
+    (void) category;
+}
+#endif // CHIP_LOG_FILTERING
 
 #endif /* _CHIP_USE_LOGGING */
 

--- a/src/lib/support/logging/CHIPLogging.h
+++ b/src/lib/support/logging/CHIPLogging.h
@@ -306,7 +306,7 @@ extern void SetLogFilter(uint8_t category);
 
 extern void GetMessageWithPrefix(char * buf, uint8_t bufSize, uint8_t module, const char * msg);
 extern void GetModuleName(char * buf, uint8_t module);
-void PrintMessagePrefix(uint8_t module);
+extern void PrintMessagePrefix(uint8_t module);
 
 #else
 
@@ -322,23 +322,7 @@ static inline void GetModuleName(char * buf, uint8_t module)
 
 #endif // _CHIP_USE_LOGGING
 
-#if CHIP_LOG_FILTERING
-
-extern uint8_t gLogFilter;
-
-static inline bool IsCategoryEnabled(uint8_t CAT)
-{
-    return (CAT <= gLogFilter);
-}
-
-#else // CHIP_LOG_FILTERING
-
-static inline bool IsCategoryEnabled(uint8_t CAT)
-{
-    return true;
-}
-
-#endif // CHIP_LOG_FILTERING
+extern bool IsCategoryEnabled(uint8_t CAT);
 
 /**
  *  @def ChipLogIfFalse(aCondition)


### PR DESCRIPTION
#### Problem
 CHIPLogging.h has a lot of fiddly bits governed by config.h that would be
  better fiddled with in CHIPLogging.cpp, e.g. CHIP_LOG_FILTERING is
  in a platform device config header, and so needs to be set the same
  by CHIP when being built *and* by a CHIP customer.

 #### Summary of Changes
 move that code to CHIPLogging.cpp to reduce the possible failure modes