### PR TITLE
[chip-demo] Print commit ID in builds

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -29,6 +29,9 @@ executable("chip-standalone-demo") {
 
   public_deps = [ "${chip_root}/src/lib" ]
 
+  commit_id = exec_script("${chip_root}/scripts/examples/print_git_commit_id.py", [], "trim string", [])
+  defines += [ "COMMIT_ID=\"${commit_id}\"" ]
+
   output_dir = root_out_dir
 }
 

--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -29,7 +29,11 @@ executable("chip-standalone-demo") {
 
   public_deps = [ "${chip_root}/src/lib" ]
 
-  commit_id = exec_script("${chip_root}/scripts/examples/print_git_commit_id.py", [], "trim string", [])
+  commit_id =
+      exec_script("${chip_root}/scripts/examples/print_git_commit_id.py",
+                  [],
+                  "trim string",
+                  [])
   defines += [ "COMMIT_ID=\"${commit_id}\"" ]
 
   output_dir = root_out_dir

--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -505,6 +505,10 @@ int main(int argc, char * argv[])
     Command command;
     CommandArgs commandArgs;
 
+#ifdef COMMIT_ID
+    fprintf(stderr, "Commit ID: %s\n", COMMIT_ID);
+#endif
+
     if (!DetermineCommand(argc, argv, &command) || !DetermineCommandArgs(argv, command, &commandArgs))
     {
         ShowUsage(argv[0]);

--- a/examples/lighting-app/nrf5/BUILD.gn
+++ b/examples/lighting-app/nrf5/BUILD.gn
@@ -103,7 +103,11 @@ executable("lighting_app") {
 
   ldscript = "${nrf5_platform_dir}/app/ldscripts/chip-nrf52840-example.ld"
 
-  commit_id = exec_script("${chip_root}/scripts/examples/print_git_commit_id.py", [], "trim string", [])
+  commit_id =
+      exec_script("${chip_root}/scripts/examples/print_git_commit_id.py",
+                  [],
+                  "trim string",
+                  [])
 
   ldflags = [ "-T" + rebase_path(ldscript, root_build_dir) ]
   defines = [ "COMMIT_ID=\"${commit_id}\"" ]

--- a/examples/lighting-app/nrf5/BUILD.gn
+++ b/examples/lighting-app/nrf5/BUILD.gn
@@ -103,7 +103,10 @@ executable("lighting_app") {
 
   ldscript = "${nrf5_platform_dir}/app/ldscripts/chip-nrf52840-example.ld"
 
+  commit_id = exec_script("${chip_root}/scripts/examples/print_git_commit_id.py", [], "trim string", [])
+
   ldflags = [ "-T" + rebase_path(ldscript, root_build_dir) ]
+  defines = [ "COMMIT_ID=\"${commit_id}\"" ]
 }
 
 group("nrf5") {

--- a/examples/lighting-app/nrf5/main/main.cpp
+++ b/examples/lighting-app/nrf5/main/main.cpp
@@ -156,6 +156,9 @@ int main(void)
 #else
     NRF_LOG_INFO("*** DEVELOPMENT BUILD ***");
 #endif
+#ifdef COMMIT_ID
+    NRF_LOG_INFO("*** COMMIT ID: %s ***", COMMIT_ID);
+#endif
     NRF_LOG_INFO("==================================================");
     NRF_LOG_FLUSH();
 

--- a/examples/lock-app/nrf5/BUILD.gn
+++ b/examples/lock-app/nrf5/BUILD.gn
@@ -100,13 +100,15 @@ executable("lock_app") {
     "${openthread_root}:libopenthread-ftd",
   ]
 
+  commit_id = exec_script("${chip_root}/scripts/examples/print_git_commit_id.py", [], "trim string", [])
+
   output_dir = root_out_dir
 
   ldscript = "${nrf5_platform_dir}/app/ldscripts/chip-nrf52840-example.ld"
 
   ldflags = [ "-T" + rebase_path(ldscript, root_build_dir) ]
 
-  defines = [ "CHIP_ENABLE_OPENTHREAD=1" ]
+  defines = [ "CHIP_ENABLE_OPENTHREAD=1", "COMMIT_ID=\"${commit_id}\"" ]
 }
 
 group("nrf5") {

--- a/examples/lock-app/nrf5/BUILD.gn
+++ b/examples/lock-app/nrf5/BUILD.gn
@@ -100,7 +100,11 @@ executable("lock_app") {
     "${openthread_root}:libopenthread-ftd",
   ]
 
-  commit_id = exec_script("${chip_root}/scripts/examples/print_git_commit_id.py", [], "trim string", [])
+  commit_id =
+      exec_script("${chip_root}/scripts/examples/print_git_commit_id.py",
+                  [],
+                  "trim string",
+                  [])
 
   output_dir = root_out_dir
 
@@ -108,7 +112,10 @@ executable("lock_app") {
 
   ldflags = [ "-T" + rebase_path(ldscript, root_build_dir) ]
 
-  defines = [ "CHIP_ENABLE_OPENTHREAD=1", "COMMIT_ID=\"${commit_id}\"" ]
+  defines = [
+    "CHIP_ENABLE_OPENTHREAD=1",
+    "COMMIT_ID=\"${commit_id}\"",
+  ]
 }
 
 group("nrf5") {

--- a/examples/lock-app/nrf5/main/main.cpp
+++ b/examples/lock-app/nrf5/main/main.cpp
@@ -156,6 +156,9 @@ int main(void)
 #else
     NRF_LOG_INFO("*** DEVELOPMENT BUILD ***");
 #endif
+#ifdef COMMIT_ID
+    NRF_LOG_INFO("*** COMMIT ID: %s ***", COMMIT_ID);
+#endif
     NRF_LOG_INFO("==================================================");
     NRF_LOG_FLUSH();
 

--- a/scripts/examples/print_git_commit_id.py
+++ b/scripts/examples/print_git_commit_id.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# This script just executes git from command line and prints the commit ID
+
+import subprocess
+
+try:
+    output = subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True)
+    print(output.stdout.decode("utf-8").strip())
+except:
+    # any error will results in unknown
+    print("unknown")


### PR DESCRIPTION
#### Problem
We are building and testing on several branches with several dev boards, it will be more convenient if we can identify which image is running on the board.

#### Summary of Changes
Write a python script (because gn uses it when using exec_script) to get the commit id and introduced a `COMMIT_ID` macro for commit id.

chip-tool will print commit id on start, and nrf examples will write commit id to jlink log output on boot.