### PR TITLE
Fix building of iOS CHIPTool app

### DIFF
--- a/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
@@ -451,9 +451,10 @@
 					"CHIP_LOGGING_STYLE_EXTERNAL=1",
 					"CHIP_DEVICE_LAYER_TARGET=Darwin",
 					"CHIP_DEVICE_LAYER_TARGET_DARWIN=1",
-                                        "CHIP_DEVICE_LAYER_TARGET_LINUX=0",
-                                        "CHIP_DEVICE_LAYER_TARGET_NRF5=0",
-                                        "CHIP_DEVICE_LAYER_TARGET_EFR32=0",
+					"CHIP_DEVICE_LAYER_TARGET_LINUX=0",
+					"CHIP_DEVICE_LAYER_TARGET_NRF5=0",
+					"CHIP_DEVICE_LAYER_TARGET_EFR32=0",
+					CHIP_CRYPTO_MBEDTLS,
 					"CHIP_SYSTEM_CONFIG_USE_SOCKETS=1",
 					"$(inherited)",
 				);
@@ -463,6 +464,7 @@
 					"$(CHIP_ROOT)/src/lib",
 					"$(CHIP_ROOT)/config/standalone",
 					"$(CHIP_ROOT)/third_party/nlassert/repo/include",
+					"$(CHIP_ROOT)/third_party/mbedtls/repo/include",
 				);
 				INFOPLIST_FILE = CHIP/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -508,9 +510,10 @@
 					"CHIP_LOGGING_STYLE_EXTERNAL=1",
 					"CHIP_DEVICE_LAYER_TARGET=Darwin",
 					"CHIP_DEVICE_LAYER_TARGET_DARWIN=1",
-                                        "CHIP_DEVICE_LAYER_TARGET_LINUX=0",
-                                        "CHIP_DEVICE_LAYER_TARGET_NRF5=0",
-                                        "CHIP_DEVICE_LAYER_TARGET_EFR32=0",
+					"CHIP_DEVICE_LAYER_TARGET_LINUX=0",
+					"CHIP_DEVICE_LAYER_TARGET_NRF5=0",
+					"CHIP_DEVICE_LAYER_TARGET_EFR32=0",
+					CHIP_CRYPTO_MBEDTLS,
 					"CHIP_SYSTEM_CONFIG_USE_SOCKETS=1",
 					"$(inherited)",
 				);
@@ -521,6 +524,7 @@
 					"$(CHIP_ROOT)/src/app",
 					"$(CHIP_ROOT)/config/standalone",
 					"$(CHIP_ROOT)/third_party/nlassert/repo/include",
+					"$(CHIP_ROOT)/third_party/mbedtls/repo/include",
 				);
 				INFOPLIST_FILE = CHIP/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -662,9 +666,10 @@
 					"CHIP_LOGGING_STYLE_EXTERNAL=1",
 					"CHIP_DEVICE_LAYER_TARGET=Darwin",
 					"CHIP_DEVICE_LAYER_TARGET_DARWIN=1",
-                                        "CHIP_DEVICE_LAYER_TARGET_LINUX=0",
-                                        "CHIP_DEVICE_LAYER_TARGET_NRF5=0",
-                                        "CHIP_DEVICE_LAYER_TARGET_EFR32=0",
+					"CHIP_DEVICE_LAYER_TARGET_LINUX=0",
+					"CHIP_DEVICE_LAYER_TARGET_NRF5=0",
+					"CHIP_DEVICE_LAYER_TARGET_EFR32=0",
+					CHIP_CRYPTO_MBEDTLS,
 					"CHIP_SYSTEM_CONFIG_USE_SOCKETS=1",
 					"$(inherited)",
 				);
@@ -675,6 +680,7 @@
 					"$(CHIP_ROOT)/src/app",
 					"$(CHIP_ROOT)/config/ios",
 					"$(CHIP_ROOT)/third_party/nlassert/repo/include",
+					"$(CHIP_ROOT)/third_party/mbedtls/repo/include",
 				);
 				INFOPLIST_FILE = CHIP/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -797,9 +803,10 @@
 					"CHIP_LOGGING_STYLE_EXTERNAL=1",
 					"CHIP_DEVICE_LAYER_TARGET=Darwin",
 					"CHIP_DEVICE_LAYER_TARGET_DARWIN=1",
-                                        "CHIP_DEVICE_LAYER_TARGET_LINUX=0",
-                                        "CHIP_DEVICE_LAYER_TARGET_NRF5=0",
-                                        "CHIP_DEVICE_LAYER_TARGET_EFR32=0",
+					"CHIP_DEVICE_LAYER_TARGET_LINUX=0",
+					"CHIP_DEVICE_LAYER_TARGET_NRF5=0",
+					"CHIP_DEVICE_LAYER_TARGET_EFR32=0",
+					CHIP_CRYPTO_MBEDTLS,
 					"CHIP_SYSTEM_CONFIG_USE_SOCKETS=1",
 					"$(inherited)",
 				);
@@ -810,6 +817,7 @@
 					"$(CHIP_ROOT)/src/app",
 					"$(CHIP_ROOT)/config/ios",
 					"$(CHIP_ROOT)/third_party/nlassert/repo/include",
+					"$(CHIP_ROOT)/third_party/mbedtls/repo/include",
 				);
 				INFOPLIST_FILE = CHIP/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";

--- a/src/darwin/Framework/chip_xcode_build_connector.sh
+++ b/src/darwin/Framework/chip_xcode_build_connector.sh
@@ -62,6 +62,9 @@ for define in "${DEFINES[@]}"; do
         CONFIG_NETWORK_LAYER*)
             continue
             ;;
+        CHIP_CRYPTO_*)
+            continue
+            ;;
     esac
     target_defines+=,\"${define//\"/\\\"}\"
 done


### PR DESCRIPTION
 #### Problem
CHIPTool iOS app doesn't build.

 #### Summary of Changes
The build is failing due to missing `mbedtls` header include path. Updated the project file.