### PR TITLE
Disable session expiry until rekeying is supported

### DIFF
--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -302,7 +302,9 @@ void SecureSessionMgrBase::HandleConnectionExpired(const Transport::PeerConnecti
 void SecureSessionMgrBase::ExpiryTimerCallback(System::Layer * layer, void * param, System::Error error)
 {
     SecureSessionMgrBase * mgr = reinterpret_cast<SecureSessionMgrBase *>(param);
+#if CHIP_CONFIG_SESSION_REKEYING
     mgr->mPeerConnections.ExpireInactiveConnections(CHIP_PEER_CONNECTION_TIMEOUT_MS);
+#endif
     mgr->ScheduleExpiryTimer(); // re-schedule the oneshot timer
 }
 


### PR DESCRIPTION
 #### Problem
The connectivity between controller and device is lost after 2 minutes of inactivity.

 #### Summary of Changes
The secure sessions are being expired after 2 minutes of inactivity. Since we added secure pairing, the session cannot be reestablished without device operation credentials, or rekeying (or re-pairing the device).

Disabling the session expiry until session re-keying or operational credentials are supported.