### PR TITLE
Remove static keys from the CHIPTool on iOS

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/CHIPViewControllerBase.h
+++ b/src/darwin/CHIPTool/CHIPTool/CHIPViewControllerBase.h
@@ -26,8 +26,6 @@ typedef void (^OnErrorBlock)(NSString * errorMsg);
 
 @interface CHIPViewControllerBase : UIViewController
 
-@property (readwrite) BOOL useIncorrectKey;
-@property (readwrite) BOOL useIncorrectKeyStateChanged;
 @property (readwrite) CHIPDeviceController * chipController;
 @property (weak, nonatomic) IBOutlet UILabel * resultLabel;
 @property (weak, nonatomic) IBOutlet UISwitch * encryptionKeySwitch;
@@ -39,7 +37,6 @@ typedef void (^OnErrorBlock)(NSString * errorMsg);
 - (void)reconnectIfNeeded;
 - (void)dismissKeyboard;
 - (void)postResult:(NSString *)result;
-- (IBAction)encryptionKey:(id)sender;
 
 @end
 

--- a/src/darwin/CHIPTool/CHIPTool/CHIPViewControllerBase.m
+++ b/src/darwin/CHIPTool/CHIPTool/CHIPViewControllerBase.m
@@ -74,8 +74,6 @@ static NSString * const ipKey = @"ipk";
     }
     [self.serverIPTextField setHidden:shouldHide];
     [self.IPLabel setHidden:shouldHide];
-    self.useIncorrectKey = NO;
-    self.useIncorrectKeyStateChanged = NO;
 }
 
 - (void)_appEnteredBackground:(NSNotification *)notification
@@ -99,47 +97,14 @@ static NSString * const ipKey = @"ipk";
 
     NSString * inputIPAddress = [[self _getScannedIP] length] > 0 ? [self _getScannedIP] : self.serverIPTextField.text;
 
-    const unsigned char local_key_bytes[] = { 0x00, 0xd1, 0x90, 0xd9, 0xb3, 0x95, 0x1c, 0x5f, 0xa4, 0xe7, 0x47, 0x92, 0x5b, 0x0a,
-        0xa9, 0xa7, 0xc1, 0x1c, 0xe7, 0x06, 0x10, 0xe2, 0xdd, 0x16, 0x41, 0x52, 0x55, 0xb7, 0xb8, 0x80, 0x8d, 0x87, 0xa1 };
-
-    const unsigned char peer_key_bytes[] = { 0x04, 0xe2, 0x07, 0x64, 0xff, 0x6f, 0x6a, 0x91, 0xd9, 0xc2, 0xc3, 0x0a, 0xc4, 0x3c,
-        0x56, 0x4b, 0x42, 0x8a, 0xf3, 0xb4, 0x49, 0x29, 0x39, 0x95, 0xa2, 0xf7, 0x02, 0x8c, 0xa5, 0xce, 0xf3, 0xc9, 0xca, 0x24,
-        0xc5, 0xd4, 0x5c, 0x60, 0x79, 0x48, 0x30, 0x3c, 0x53, 0x86, 0xd9, 0x23, 0xe6, 0x61, 0x1f, 0x5a, 0x3d, 0xdf, 0x9f, 0xdc,
-        0x35, 0xea, 0xd0, 0xde, 0x16, 0x7e, 0x64, 0xde, 0x7f, 0x3c, 0xa6 };
-
-    const unsigned char local_incorrect_key_bytes[] = { 0xc6, 0x1a, 0x2f, 0x89, 0x36, 0x67, 0x2b, 0x26, 0x12, 0x47, 0x4f, 0x11,
-        0x0e, 0x34, 0x15, 0x81, 0x81, 0x12, 0xfc, 0x36, 0xeb, 0x65, 0x61, 0x07, 0xaa, 0x63, 0xe8, 0xc5, 0x22, 0xac, 0x52, 0xa1 };
-
-    NSData * peer_key = [NSData dataWithBytes:peer_key_bytes length:sizeof(peer_key_bytes)];
-    NSData * local_key = NULL;
-    if (!self.useIncorrectKey) {
-        NSLog(@"Using correct key");
-        local_key = [NSData dataWithBytes:local_key_bytes length:sizeof(local_key_bytes)];
-    } else {
-        NSLog(@"Using incorrect key");
-        local_key = [NSData dataWithBytes:local_incorrect_key_bytes length:sizeof(local_incorrect_key_bytes)];
-    }
-
     if ([self.chipController isConnected]) {
         [self.chipController disconnect:nil];
     }
 
-    BOOL didConnect = [self.chipController connect:inputIPAddress local_key:local_key peer_key:peer_key error:&error];
+    BOOL didConnect = [self.chipController connect:inputIPAddress error:&error];
     if (!didConnect) {
         [self postResult:[@"Error: " stringByAppendingString:error.localizedDescription]];
     }
-}
-
-- (IBAction)encryptionKey:(id)sender
-{
-    if ([self.encryptionKeySwitch isOn]) {
-        self.useIncorrectKey = YES;
-        [self postResult:@"App will use incorrect key"];
-    } else {
-        self.useIncorrectKey = NO;
-        [self postResult:@"App will use correct key"];
-    }
-    self.useIncorrectKeyStateChanged = YES;
 }
 
 - (void)dismissKeyboard
@@ -170,9 +135,8 @@ static NSString * const ipKey = @"ipk";
         }
     }
 
-    if (!addrInfo || needsReconnect || self.useIncorrectKeyStateChanged) {
+    if (!addrInfo || needsReconnect) {
         [self _connect];
-        self.useIncorrectKeyStateChanged = NO;
     }
 }
 

--- a/src/darwin/CHIPTool/CHIPTool/UI/Base.lproj/Main.storyboard
+++ b/src/darwin/CHIPTool/CHIPTool/UI/Base.lproj/Main.storyboard
@@ -381,28 +381,12 @@
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Use Incorrect Encryption Keys" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="778-me-ArK">
-                                <rect key="frame" x="16" y="273" width="231" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="dN9-8p-BcA">
-                                <rect key="frame" x="349" y="268" width="51" height="31"/>
-                                <connections>
-                                    <action selector="encryptionKey:" destination="NR6-8N-IDd" eventType="valueChanged" id="Ggg-GX-tuM"/>
-                                </connections>
-                            </switch>
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="cfO-gM-sug" firstAttribute="top" secondItem="dN9-8p-BcA" secondAttribute="bottom" constant="24" id="A9R-9q-bzG"/>
                             <constraint firstItem="7aI-Vo-UyO" firstAttribute="top" secondItem="UPn-Qe-uvu" secondAttribute="top" constant="40" id="B9Y-y5-JFG"/>
                             <constraint firstItem="tC3-Jk-Opv" firstAttribute="centerY" secondItem="Tzm-Xh-QOZ" secondAttribute="centerY" id="Egc-2k-Dph"/>
                             <constraint firstItem="UPn-Qe-uvu" firstAttribute="trailing" secondItem="tC3-Jk-Opv" secondAttribute="trailing" constant="16" id="JXz-FF-C88"/>
-                            <constraint firstItem="dN9-8p-BcA" firstAttribute="top" secondItem="tC3-Jk-Opv" secondAttribute="bottom" constant="26" id="KUK-yd-Sge"/>
-                            <constraint firstItem="778-me-ArK" firstAttribute="leading" secondItem="UPn-Qe-uvu" secondAttribute="leading" constant="16" id="QGc-aq-sk9"/>
-                            <constraint firstItem="UPn-Qe-uvu" firstAttribute="trailing" secondItem="dN9-8p-BcA" secondAttribute="trailing" constant="16" id="REb-3f-Z1g"/>
                             <constraint firstItem="UPn-Qe-uvu" firstAttribute="trailing" secondItem="cfO-gM-sug" secondAttribute="trailing" constant="16" id="SN2-ii-WwN"/>
                             <constraint firstItem="6Z1-j3-AvT" firstAttribute="top" secondItem="cfO-gM-sug" secondAttribute="bottom" constant="40" id="SQh-l6-Flp"/>
                             <constraint firstItem="7aI-Vo-UyO" firstAttribute="centerX" secondItem="UPn-Qe-uvu" secondAttribute="centerX" id="VC8-BO-IEv"/>
@@ -415,7 +399,6 @@
                             <constraint firstItem="6Z1-j3-AvT" firstAttribute="leading" secondItem="UPn-Qe-uvu" secondAttribute="leading" constant="16" id="fdf-Mv-mqP"/>
                             <constraint firstItem="6Z1-j3-AvT" firstAttribute="top" secondItem="lvN-Eg-W6F" secondAttribute="bottom" constant="40" id="keR-8B-8EU"/>
                             <constraint firstItem="Tzm-Xh-QOZ" firstAttribute="leading" secondItem="UPn-Qe-uvu" secondAttribute="leading" constant="16" id="oFI-15-MgQ"/>
-                            <constraint firstItem="778-me-ArK" firstAttribute="centerY" secondItem="dN9-8p-BcA" secondAttribute="centerY" id="vRO-8x-KDG"/>
                             <constraint firstItem="tC3-Jk-Opv" firstAttribute="top" secondItem="7aI-Vo-UyO" secondAttribute="bottom" constant="8" id="xkI-6e-Plp"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="UPn-Qe-uvu"/>
@@ -424,7 +407,6 @@
                     <navigationItem key="navigationItem" id="gdO-P7-Ere"/>
                     <connections>
                         <outlet property="IPLabel" destination="Tzm-Xh-QOZ" id="lYU-0W-rNa"/>
-                        <outlet property="encryptionKeySwitch" destination="dN9-8p-BcA" id="geC-Ed-VOi"/>
                         <outlet property="messageTextField" destination="lvN-Eg-W6F" id="I9L-eN-4b6"/>
                         <outlet property="resultLabel" destination="6Z1-j3-AvT" id="mMP-KW-l7u"/>
                         <outlet property="sendButton" destination="cfO-gM-sug" id="jSr-fh-7Y0"/>
@@ -565,7 +547,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="192.168.1.1" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="WTA-xG-Iyv">
-                                <rect key="frame" x="145" y="187" width="253" height="34.666666666666657"/>
+                                <rect key="frame" x="145" y="187" width="253" height="34"/>
                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <textInputTraits key="textInputTraits" keyboardType="decimalPad"/>
@@ -626,41 +608,24 @@
                                     <action selector="offButtonTapped:" destination="UgW-Ob-0KX" eventType="touchUpInside" id="JJt-5D-6pb"/>
                                 </connections>
                             </button>
-                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="kmC-Kl-vj2">
-                                <rect key="frame" x="349" y="255.66666666666663" width="51" height="31"/>
-                                <connections>
-                                    <action selector="encryptionKey:" destination="UgW-Ob-0KX" eventType="valueChanged" id="WaE-yH-elT"/>
-                                </connections>
-                            </switch>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Use Incorrect Encryption Keys" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HeR-1a-hjt">
-                                <rect key="frame" x="16" y="260.66666666666669" width="231" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="cwX-vi-vgG" firstAttribute="width" secondItem="1XM-cR-Y6o" secondAttribute="width" id="582-Pj-QoZ"/>
                             <constraint firstItem="XIj-Oo-qmz" firstAttribute="leading" secondItem="kG5-yT-GzM" secondAttribute="leading" constant="16" id="6o4-kh-TOw"/>
-                            <constraint firstItem="HeR-1a-hjt" firstAttribute="leading" secondItem="kG5-yT-GzM" secondAttribute="leading" constant="16" id="9XA-y5-9Om"/>
                             <constraint firstItem="jhI-Pt-QaG" firstAttribute="top" secondItem="XIj-Oo-qmz" secondAttribute="bottom" constant="95" id="A5I-Ui-JsH"/>
                             <constraint firstItem="cwX-vi-vgG" firstAttribute="height" secondItem="1XM-cR-Y6o" secondAttribute="height" id="ARb-ea-aSV"/>
                             <constraint firstItem="eg3-7c-7WS" firstAttribute="top" secondItem="kG5-yT-GzM" secondAttribute="top" constant="19" id="Eu0-fd-IpC"/>
                             <constraint firstItem="XIj-Oo-qmz" firstAttribute="leading" secondItem="c45-FF-oLb" secondAttribute="leadingMargin" id="KLq-hK-kli"/>
                             <constraint firstItem="ERS-fv-Yhs" firstAttribute="leading" secondItem="kG5-yT-GzM" secondAttribute="leading" constant="16" id="LVO-tn-vpG"/>
                             <constraint firstItem="eg3-7c-7WS" firstAttribute="leading" secondItem="kG5-yT-GzM" secondAttribute="leading" constant="77" id="LyU-T1-mwz"/>
-                            <constraint firstItem="kG5-yT-GzM" firstAttribute="trailing" secondItem="kmC-Kl-vj2" secondAttribute="trailing" constant="16" id="O1w-nm-0Or"/>
-                            <constraint firstItem="1XM-cR-Y6o" firstAttribute="top" secondItem="kmC-Kl-vj2" secondAttribute="bottom" constant="23" id="OOf-aG-laS"/>
                             <constraint firstItem="1XM-cR-Y6o" firstAttribute="centerY" secondItem="cwX-vi-vgG" secondAttribute="centerY" id="PIV-cB-jxE"/>
                             <constraint firstItem="ERS-fv-Yhs" firstAttribute="top" secondItem="jhI-Pt-QaG" secondAttribute="bottom" constant="30" id="SfK-C8-ojg"/>
                             <constraint firstItem="kG5-yT-GzM" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="1XM-cR-Y6o" secondAttribute="trailing" constant="200" id="Ssx-2M-iya"/>
                             <constraint firstItem="cwX-vi-vgG" firstAttribute="leading" secondItem="jhI-Pt-QaG" secondAttribute="trailing" constant="10" id="Urx-pk-Pkt"/>
-                            <constraint firstItem="HeR-1a-hjt" firstAttribute="centerY" secondItem="kmC-Kl-vj2" secondAttribute="centerY" id="V0E-8b-aCB"/>
                             <constraint firstItem="jhI-Pt-QaG" firstAttribute="height" secondItem="cwX-vi-vgG" secondAttribute="height" id="ZQb-0R-izb"/>
                             <constraint firstItem="jhI-Pt-QaG" firstAttribute="leading" secondItem="kG5-yT-GzM" secondAttribute="leading" constant="16" id="cec-Qo-hyK"/>
                             <constraint firstItem="XIj-Oo-qmz" firstAttribute="top" secondItem="eg3-7c-7WS" secondAttribute="bottom" constant="14.666666666666657" id="eBh-cR-lX1"/>
-                            <constraint firstItem="kmC-Kl-vj2" firstAttribute="top" secondItem="WTA-xG-Iyv" secondAttribute="bottom" constant="34" id="eCg-dt-JkC"/>
                             <constraint firstItem="kG5-yT-GzM" firstAttribute="trailing" secondItem="ERS-fv-Yhs" secondAttribute="trailing" constant="16" id="gij-Jw-J5R"/>
                             <constraint firstItem="1XM-cR-Y6o" firstAttribute="leading" secondItem="cwX-vi-vgG" secondAttribute="trailing" constant="10" id="kCe-dG-Nbo"/>
                             <constraint firstItem="cwX-vi-vgG" firstAttribute="centerY" secondItem="jhI-Pt-QaG" secondAttribute="centerY" id="lGp-co-aTI"/>
@@ -674,7 +639,6 @@
                     <navigationItem key="navigationItem" id="X3a-IB-ct7"/>
                     <connections>
                         <outlet property="IPLabel" destination="XIj-Oo-qmz" id="MW7-GN-hns"/>
-                        <outlet property="encryptionKeySwitch" destination="kmC-Kl-vj2" id="vlU-GK-77e"/>
                         <outlet property="offButton" destination="cwX-vi-vgG" id="ctm-j9-5Vj"/>
                         <outlet property="onButton" destination="jhI-Pt-QaG" id="qUw-MV-lYT"/>
                         <outlet property="resultLabel" destination="ERS-fv-Yhs" id="Jgg-GZ-RIs"/>

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -38,10 +38,7 @@ typedef void (^ControllerOnErrorBlock)(NSError * error);
 
 @interface CHIPDeviceController : NSObject
 
-- (BOOL)connect:(NSString *)ipAddress
-      local_key:(NSData *)local_key
-       peer_key:(NSData *)peer_key
-          error:(NSError * __autoreleasing *)error;
+- (BOOL)connect:(NSString *)ipAddress error:(NSError * __autoreleasing *)error;
 - (BOOL)connect:(uint16_t)discriminator setupPINCode:(uint32_t)setupPINCode error:(NSError * __autoreleasing *)error;
 - (nullable AddressInfo *)getAddressInfo;
 - (BOOL)sendMessage:(NSData *)message error:(NSError * __autoreleasing *)error;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -179,8 +179,7 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
     }
 }
 
-- (BOOL)connect:(NSString *)ipAddress
-          error:(NSError * __autoreleasing *)error
+- (BOOL)connect:(NSString *)ipAddress error:(NSError * __autoreleasing *)error
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -63,8 +63,6 @@ constexpr chip::NodeId kRemoteDeviceId = 12344321;
  */
 @property (readonly, nonatomic) dispatch_queue_t delegateQueue;
 @property (readonly) chip::DeviceController::ChipDeviceController * cppController;
-@property (readwrite) NSData * localKey;
-@property (readwrite) NSData * peerKey;
 
 @end
 
@@ -182,15 +180,9 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
 }
 
 - (BOOL)connect:(NSString *)ipAddress
-      local_key:(NSData *)local_key
-       peer_key:(NSData *)peer_key
           error:(NSError * __autoreleasing *)error
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-
-    // cache the keys before calling connect (because connect invokes the manual key exchange)
-    self.localKey = local_key.copy;
-    self.peerKey = peer_key.copy;
 
     [self.lock lock];
     chip::Inet::IPAddress addr;


### PR DESCRIPTION
 #### Problem
1. The static keys in CHIPTool are completely unused. 
2. The switch to "use incorrect encryption key" is no longer supported since secure pairing handles the key exchange internally

 #### Summary of Changes
Remove the unused static keys and UI bits