### PR TITLE
Add the API to bypass Rendezvous in the CHIP.framework

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -40,6 +40,7 @@ typedef void (^ControllerOnErrorBlock)(NSError * error);
 
 - (BOOL)connect:(NSString *)ipAddress error:(NSError * __autoreleasing *)error;
 - (BOOL)connect:(uint16_t)discriminator setupPINCode:(uint32_t)setupPINCode error:(NSError * __autoreleasing *)error;
+- (BOOL)connectWithoutSecurePairing:(NSString *)ipAddress error:(NSError * __autoreleasing *)error __attribute__ ((deprecated("Available until Rendezvous is fully integrated")));
 - (nullable AddressInfo *)getAddressInfo;
 - (BOOL)sendMessage:(NSData *)message error:(NSError * __autoreleasing *)error;
 - (BOOL)sendOnCommand;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -40,7 +40,9 @@ typedef void (^ControllerOnErrorBlock)(NSError * error);
 
 - (BOOL)connect:(NSString *)ipAddress error:(NSError * __autoreleasing *)error;
 - (BOOL)connect:(uint16_t)discriminator setupPINCode:(uint32_t)setupPINCode error:(NSError * __autoreleasing *)error;
-- (BOOL)connectWithoutSecurePairing:(NSString *)ipAddress error:(NSError * __autoreleasing *)error __attribute__ ((deprecated("Available until Rendezvous is fully integrated")));
+- (BOOL)connectWithoutSecurePairing:(NSString *)ipAddress
+                              error:(NSError * __autoreleasing *)error
+    __attribute__((deprecated("Available until Rendezvous is fully integrated")));
 - (nullable AddressInfo *)getAddressInfo;
 - (BOOL)sendMessage:(NSData *)message error:(NSError * __autoreleasing *)error;
 - (BOOL)sendOnCommand;


### PR DESCRIPTION
 #### Problem
Rendezvous isn't fully integrated yet and the client is expected to perform it manually. 
 
#### Summary of Changes
To avoid code duplication for the time being, I exposed the cpp controller's API to bypass Rendezvous in the CHIP.framework layer as well. 

This will be removed once Rendezvous is more directly integrated with CHIP.