### PR TITLE
[chip-tool] Rename executable to chip-tool and improve quick start instructions.

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -118,7 +118,7 @@ jobs:
                       ${{ env.BUILD_TYPE }}-example-build-${{
                       steps.outsuffix.outputs.value }}
                   path: |
-                      out/chip_tool_debug/chip-standalone-demo
+                      out/chip_tool_debug/chip-tool
                       out/shell_debug/chip-shell
     efr32:
         name: EFR32

--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -66,4 +66,3 @@ executable("chip-tool-server") {
 
   output_dir = root_out_dir
 }
-

--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -18,7 +18,7 @@ import("${chip_root}/gn/chip/tools.gni")
 
 assert(chip_build_tools)
 
-executable("chip-standalone-demo") {
+executable("chip-tool") {
   sources = [ "main.cpp" ]
 
   if (is_debug) {
@@ -32,7 +32,7 @@ executable("chip-standalone-demo") {
   output_dir = root_out_dir
 }
 
-executable("chip-standalone-server") {
+executable("chip-tool-server") {
   sources = [
     "${chip_root}/src/app/clusters/on-off-server/on-off.c",
     "${chip_root}/src/app/util/attribute-size.c",
@@ -67,6 +67,3 @@ executable("chip-standalone-server") {
   output_dir = root_out_dir
 }
 
-group("chip-tool") {
-  deps = [ ":chip-standalone-demo" ]
-}

--- a/examples/chip-tool/Dockerfile.server
+++ b/examples/chip-tool/Dockerfile.server
@@ -17,8 +17,8 @@
 
 from generic_node_image
 
-COPY out/debug/chip-standalone-demo /usr/bin/
-COPY out/debug/chip-standalone-server /usr/bin/
+COPY out/debug/chip-tool /usr/bin/
+COPY out/debug/chip-tool-server /usr/bin/
 COPY entrypoint.sh /
 
 ENTRYPOINT ["/entrypoint.sh", "server"]

--- a/examples/chip-tool/Dockerfile.tool
+++ b/examples/chip-tool/Dockerfile.tool
@@ -17,8 +17,8 @@
 
 from generic_node_image
 
-COPY out/debug/chip-standalone-demo /usr/bin/
-COPY out/debug/chip-standalone-server /usr/bin/
+COPY out/debug/chip-tool /usr/bin/
+COPY out/debug/chip-tool-server /usr/bin/
 COPY entrypoint.sh /
 
 ENTRYPOINT ["/entrypoint.sh", "tool"]

--- a/examples/chip-tool/Makefile
+++ b/examples/chip-tool/Makefile
@@ -30,7 +30,7 @@ BUILD_SUPPORT_DIR = $(CHIP_ROOT)/config/standalone
 include $(BUILD_SUPPORT_DIR)/standalone-app.mk
 include $(BUILD_SUPPORT_DIR)/standalone-chip.mk
 
-APP = chip-standalone-demo
+APP = chip-tool
 
 SRCS = \
     $(PROJECT_ROOT)/main.cpp       \

--- a/examples/chip-tool/README.md
+++ b/examples/chip-tool/README.md
@@ -14,20 +14,48 @@ An example application that uses CHIP to send messages to a CHIP server.
 
 Building the example application is quite straightforward.
 
+### gn
+
+- From the top-level of the chip repo, run `./gn_build.sh`
+
+          $ ./gn_build.sh
+
+- Or from the `examples/chip-tool` directory:
+
+```
+source third_party/connectedhomeip/scripts/activate.sh
+gn gen out/debug
+ninja -C out/debug
+```
+
+- After the application is built, it can be found in the build directory as
+  `out/debug/standalone/chip-tool`
+
+### autotools
+
 -   In the root of the example directory, run `make`.
 
           $ make
           $ make -f server.mk
 
--   After the application is built, it can be found in the build directory as
-    `chip-standalone-demo.out`
+-   After the application is built, it can be found in the build directory as `chip-tool`.
 
 ## Using the Client to Request an Echo
+
+### Ping a device over BLE
+
+To initiate a client echo request to a BLE device, run the built executable
+and pass it the discriminator and pairing code of the remote device. The command
+below uses the default values hard-coded into the debug versions of the ESP32 wifi-echo app:
+
+          $ chip-tool echo-ble 3840 12345678
+
+### Ping a device over IP
 
 To start the Client in echo mode, run the built executable and pass it the IP
 address and port of the server to talk to, as well as the command "echo".
 
-          $ ./build/chip-standalone-demo.out 192.168.0.30 8000 echo
+          $ chip-tool 192.168.0.30 8000 echo
 
 If valid values are supplied, it will begin to periodically send messages to the
 server address provided.
@@ -45,6 +73,6 @@ send, as well as an enpoint id. Right now the "off", "on", and "toggle" commands
 are supported, from the On/Off cluster. The endpoint id must be between 1
 and 240.
 
-          $ ./build/chip-standalone-demo.out 192.168.0.30 8000 on 1
+          $ chip-tool 192.168.0.30 8000 on 1
 
 The client will send a single command packet and then exit.

--- a/examples/chip-tool/README.md
+++ b/examples/chip-tool/README.md
@@ -16,11 +16,11 @@ Building the example application is quite straightforward.
 
 ### gn
 
-- From the top-level of the chip repo, run `./gn_build.sh`
+-   From the top-level of the chip repo, run `./gn_build.sh`
 
-          $ ./gn_build.sh
+            $ ./gn_build.sh
 
-- Or from the `examples/chip-tool` directory:
+-   Or from the `examples/chip-tool` directory:
 
 ```
 source third_party/connectedhomeip/scripts/activate.sh
@@ -28,8 +28,8 @@ gn gen out/debug
 ninja -C out/debug
 ```
 
-- After the application is built, it can be found in the build directory as
-  `out/debug/standalone/chip-tool`
+-   After the application is built, it can be found in the build directory as
+    `out/debug/standalone/chip-tool`
 
 ### autotools
 
@@ -38,15 +38,17 @@ ninja -C out/debug
           $ make
           $ make -f server.mk
 
--   After the application is built, it can be found in the build directory as `chip-tool`.
+-   After the application is built, it can be found in the build directory as
+    `chip-tool`.
 
 ## Using the Client to Request an Echo
 
 ### Ping a device over BLE
 
-To initiate a client echo request to a BLE device, run the built executable
-and pass it the discriminator and pairing code of the remote device. The command
-below uses the default values hard-coded into the debug versions of the ESP32 wifi-echo app:
+To initiate a client echo request to a BLE device, run the built executable and
+pass it the discriminator and pairing code of the remote device. The command
+below uses the default values hard-coded into the debug versions of the ESP32
+wifi-echo app:
 
           $ chip-tool echo-ble 3840 12345678
 

--- a/examples/chip-tool/entrypoint.sh
+++ b/examples/chip-tool/entrypoint.sh
@@ -9,7 +9,7 @@ ot-ctl ifconfig up
 ot-ctl thread start
 
 if [ "$1" == "server" ]; then
-    chip-standalone-server
+    chip-tool-server
 elif [ "$1" == "tool" ]; then
     sleep infinity
 fi

--- a/examples/chip-tool/server.mk
+++ b/examples/chip-tool/server.mk
@@ -30,7 +30,7 @@ BUILD_SUPPORT_DIR = $(CHIP_ROOT)/config/standalone
 include $(BUILD_SUPPORT_DIR)/standalone-app.mk
 include $(BUILD_SUPPORT_DIR)/standalone-chip.mk
 
-APP = chip-standalone-server
+APP = chip-tool-server
 
 SRCS = \
     $(PROJECT_ROOT)/server.cpp \

--- a/src/test_driver/linux-cirque/test-on-off-cluster.py
+++ b/src/test_driver/linux-cirque/test-on-off-cluster.py
@@ -79,13 +79,13 @@ class TestOnOffCluster(CHIPVirtualHome):
 
         for ip in server_ip_address:
             output = self.execute_device_cmd(
-                tool_device_id, "chip-standalone-demo on {} {} 1".format(ip, CHIP_PORT))
+                tool_device_id, "chip-tool on {} {} 1".format(ip, CHIP_PORT))
             self.assertFalse(self.sequenceMatch(
                 output['output'], ["No response from device."]))
         time.sleep(1)
         for ip in server_ip_address:
             output = self.execute_device_cmd(
-                tool_device_id, "chip-standalone-demo off {} {} 1".format(ip, CHIP_PORT))
+                tool_device_id, "chip-tool off {} {} 1".format(ip, CHIP_PORT))
             self.assertFalse(self.sequenceMatch(
                 output['output'], ["No response from device."]))
 


### PR DESCRIPTION
 #### Problem
The chip-tool code outputs an executable named `chip-standalone-demo`.

 #### Summary of Changes
Rename the executable to simply `chip-tool`.
