### PR TITLE
Don't build libopenthread-{mtd,radio} by default in examples

### DIFF
--- a/examples/lighting-app/nrf5/BUILD.gn
+++ b/examples/lighting-app/nrf5/BUILD.gn
@@ -111,5 +111,5 @@ group("nrf5") {
 }
 
 group("default") {
-  deps = [":nrf5"]
+  deps = [ ":nrf5" ]
 }

--- a/examples/lighting-app/nrf5/BUILD.gn
+++ b/examples/lighting-app/nrf5/BUILD.gn
@@ -109,3 +109,7 @@ executable("lighting_app") {
 group("nrf5") {
   deps = [ ":lighting_app" ]
 }
+
+group("default") {
+  deps = [":nrf5"]
+}

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -105,3 +105,7 @@ executable("lock_app") {
 group("efr32") {
   deps = [ ":lock_app" ]
 }
+
+group("default") {
+  deps = [":efr32"]
+}

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -107,5 +107,5 @@ group("efr32") {
 }
 
 group("default") {
-  deps = [":efr32"]
+  deps = [ ":efr32" ]
 }

--- a/examples/lock-app/nrf5/BUILD.gn
+++ b/examples/lock-app/nrf5/BUILD.gn
@@ -114,5 +114,5 @@ group("nrf5") {
 }
 
 group("default") {
-  deps = [":nrf5"]
+  deps = [ ":nrf5" ]
 }

--- a/examples/lock-app/nrf5/BUILD.gn
+++ b/examples/lock-app/nrf5/BUILD.gn
@@ -112,3 +112,7 @@ executable("lock_app") {
 group("nrf5") {
   deps = [ ":lock_app" ]
 }
+
+group("default") {
+  deps = [":nrf5"]
+}


### PR DESCRIPTION
OpenThread defines 3 variants of its core library: ftd, mtd, radio.
Currently building examples builds all 3 variants, because without a
"default" target, GN builds everything that's defined.

Add a "default" target to examples that builds only the example. If you
want to build all defined targets you can still explicitly build "all".