### PR TITLE
[android] fix android build

### DIFF
--- a/src/app/README.md
+++ b/src/app/README.md
@@ -4,5 +4,4 @@
 
 The purpose of this folder is to contain CHIP clusters and associated utilities.
 The cluster implementations live under the clusters/ directory. Utility files
-live in the util/ and chip-zcl-zpro/ directory: the former contains most of the
-utilities while the latter contains encoder/decoder utility functions.
+live in the util/.

--- a/src/controller/java/Makefile.am
+++ b/src/controller/java/Makefile.am
@@ -34,7 +34,6 @@ lib_LTLIBRARIES                              = libCHIPController.la
 
 libCHIPController_la_CPPFLAGS                              = \
     -I$(top_srcdir)/src                                      \
-    -I$(top_srcdir)/src/app/util/command-encoder             \
     -I$(top_srcdir)/src/lib                                  \
     -I$(top_srcdir)/src/lib/core                             \
     -I$(top_srcdir)/src/controller                           \

--- a/src/setup_payload/java/SetupPayloadParser-JNI.cpp
+++ b/src/setup_payload/java/SetupPayloadParser-JNI.cpp
@@ -1,6 +1,8 @@
 #include "ManualSetupPayloadParser.h"
 #include "QRCodeSetupPayloadParser.h"
 
+#include <vector>
+
 #include <jni.h>
 
 using namespace chip;
@@ -62,7 +64,7 @@ jobject TransformSetupPayload(JNIEnv * env, SetupPayload & payload)
     jmethodID addOptionalInfoMid =
         env->GetMethodID(setupPayloadClass, "addOptionalQRCodeInfo", "(Lchip/setuppayload/OptionalQRCodeInfo;)V");
 
-    vector<OptionalQRCodeInfo> optional_info = payload.getAllOptionalVendorData();
+    std::vector<OptionalQRCodeInfo> optional_info = payload.getAllOptionalVendorData();
     for (OptionalQRCodeInfo & info : optional_info)
     {
 


### PR DESCRIPTION
 #### Problem
This PR fixes android build error: `vector` not declared.

 #### Summary of Changes
Fix `std::vector` inclusion, `app/util` headers inclusion and documentation.
