### PR TITLE
[BLE] set pairing status based on network provision status

### DIFF
--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -800,8 +800,15 @@ GenericConfigurationManagerImpl<ImplClass>::_GetBLEDeviceIdentificationInfo(Ble:
     SuccessOrExit(err);
     deviceIdInfo.SetDeviceDiscriminator(discriminator);
 
+    // TODO: Update when CHIP service/fabric provision is implemented
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    deviceIdInfo.PairingStatus = ThreadStackMgr().IsThreadAttached()
+        ? Ble::ChipBLEDeviceIdentificationInfo::kPairingStatus_Paired
+        : Ble::ChipBLEDeviceIdentificationInfo::kPairingStatus_Unpaired;
+#else
     deviceIdInfo.PairingStatus = Impl()->_IsPairedToAccount() ? Ble::ChipBLEDeviceIdentificationInfo::kPairingStatus_Paired
                                                               : Ble::ChipBLEDeviceIdentificationInfo::kPairingStatus_Unpaired;
+#endif
 
 exit:
     return err;


### PR DESCRIPTION
IsPairedToAccount is bound with Weave fabric and service which won't be
introduced in a short time. Set to use network status instead.