### PR TITLE
Add explicit BLE parameters to Device controller connectivity.

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -53,6 +53,13 @@ namespace DeviceController {
 
 using namespace chip::Encoding;
 
+BLEDeviceConnectionParameters::BLEDeviceConnectionParameters()
+{
+#if CONFIG_DEVICE_LAYER
+    SetBleLayer(DeviceLayer::ConnectivityMgr().GetBleLayer());
+#endif
+}
+
 static constexpr uint32_t kSpake2p_Iteration_Count = 50000;
 static const char * kSpake2pKeyExchangeSalt        = "SPAKE2P Key Exchange Salt";
 
@@ -134,7 +141,6 @@ CHIP_ERROR ChipDeviceController::Shutdown()
     if (mUnsecuredTransport != NULL)
     {
         mUnsecuredTransport->Release();
-        delete mUnsecuredTransport;
         mUnsecuredTransport = NULL;
     }
 
@@ -215,45 +221,45 @@ exit:
     return;
 }
 
-CHIP_ERROR ChipDeviceController::ConnectDevice(NodeId remoteDeviceId, const uint16_t discriminator, const uint32_t setupPINCode,
-                                               void * appReqState, NewConnectionHandler onConnected,
-                                               MessageReceiveHandler onMessageReceived, ErrorHandler onError)
+CHIP_ERROR ChipDeviceController::ConnectDevice(const BLEDeviceConnectionParameters & params)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-#if CONFIG_DEVICE_LAYER && CONFIG_NETWORK_LAYER_BLE
+#if CONFIG_NETWORK_LAYER_BLE
     Transport::BLE * transport;
 
     ChipLogProgress(Controller, "Received new pairing request");
     ChipLogProgress(Controller, "mState %d. mConState %d", mState, mConState);
     VerifyOrExit(mState == kState_Initialized && mConState == kConnectionState_NotConnected, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(params.GetBleLayer() != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
 
     if (mPairingInProgress)
     {
         ChipLogError(Controller, "Pairing was already is progress. This will restart pairing.");
     }
 
-    mRemoteDeviceId  = Optional<NodeId>::Value(remoteDeviceId);
-    mAppReqState     = appReqState;
-    mPairingComplete = onConnected;
+    mRemoteDeviceId  = Optional<NodeId>::Value(params.GetRemoteDeviceId());
+    mAppReqState     = params.GetAppReqState();
+    mPairingComplete = params.GetOnConnected();
     mOnNewConnection = BLEConnectionHandler;
-    mAppMsgHandler   = onMessageReceived;
+    mAppMsgHandler   = params.GetOnMessageReceived();
 
-    mSetupPINCode = setupPINCode;
+    mSetupPINCode = params.GetSetupPINCode();
 
     transport = new Transport::BLE();
-    err       = transport->Init(Transport::BleConnectionParameters(this, DeviceLayer::ConnectivityMgr().GetBleLayer())
-                              .SetDiscriminator(discriminator)
-                              .SetSetupPINCode(setupPINCode));
+    err       = transport->Init(Transport::BleConnectionParameters(this, params.GetBleLayer())
+                              .SetDiscriminator(params.GetDiscriminator())
+                              .SetSetupPINCode(params.GetSetupPINCode()));
     SuccessOrExit(err);
 
     mUnsecuredTransport = transport->Retain();
+    transport->Release();
 
     // connected state before 'OnConnect'
     mConState = kConnectionState_Connected;
 
     mOnComplete.Response = PairingMessageHandler;
-    mOnError             = onError;
+    mOnError             = params.GetOnError();
 
     if (err != CHIP_NO_ERROR)
     {
@@ -386,7 +392,6 @@ CHIP_ERROR ChipDeviceController::DisconnectDevice()
     if (mUnsecuredTransport != NULL)
     {
         mUnsecuredTransport->Release();
-        delete mUnsecuredTransport;
         mUnsecuredTransport = NULL;
     }
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -51,6 +51,78 @@ typedef void (*ErrorHandler)(ChipDeviceController * deviceController, void * app
 typedef void (*MessageReceiveHandler)(ChipDeviceController * deviceController, void * appReqState, System::PacketBuffer * payload);
 };
 
+class BLEDeviceConnectionParameters
+{
+public:
+    BLEDeviceConnectionParameters();
+
+    NodeId GetRemoteDeviceId() const { return remoteDeviceId; }
+    BLEDeviceConnectionParameters & SetRemoteDeviceId(NodeId id)
+    {
+        remoteDeviceId = id;
+        return *this;
+    }
+
+    uint16_t GetDiscriminator() const { return discriminator; }
+    BLEDeviceConnectionParameters & SetDiscriminator(uint16_t value)
+    {
+        discriminator = value;
+        return *this;
+    }
+
+    uint32_t GetSetupPINCode() const { return setupPINCode; }
+    BLEDeviceConnectionParameters & SetSetupPINCode(uint32_t value)
+    {
+        setupPINCode = value;
+        return *this;
+    }
+
+    void * GetAppReqState() const { return appReqState; }
+    BLEDeviceConnectionParameters & SetAppReqState(void * value)
+    {
+        appReqState = value;
+        return *this;
+    }
+
+    NewConnectionHandler GetOnConnected() const { return onConnected; }
+    BLEDeviceConnectionParameters & SetOnConnected(NewConnectionHandler value)
+    {
+        onConnected = value;
+        return *this;
+    }
+
+    MessageReceiveHandler GetOnMessageReceived() const { return onMessageReceived; }
+    BLEDeviceConnectionParameters & SetOnMessageReceived(MessageReceiveHandler value)
+    {
+        onMessageReceived = value;
+        return *this;
+    }
+
+    ErrorHandler GetOnError() const { return onError; }
+    BLEDeviceConnectionParameters & SetOnError(ErrorHandler value)
+    {
+        onError = value;
+        return *this;
+    }
+
+    BleLayer * GetBleLayer() const { return bleLayer; }
+    BLEDeviceConnectionParameters & SetBleLayer(BleLayer * value)
+    {
+        bleLayer = value;
+        return *this;
+    }
+
+private:
+    NodeId remoteDeviceId                   = 0;
+    uint16_t discriminator                  = 0;
+    uint32_t setupPINCode                   = 0;
+    void * appReqState                      = nullptr;
+    NewConnectionHandler onConnected        = nullptr;
+    MessageReceiveHandler onMessageReceived = nullptr;
+    ErrorHandler onError                    = nullptr;
+    BleLayer * bleLayer                     = nullptr;
+};
+
 class DLL_EXPORT ChipDeviceController : public SecureSessionMgrCallback,
                                         public SecurePairingSessionDelegate,
                                         public Transport::BLECallbackHandler
@@ -88,7 +160,25 @@ public:
      * @return CHIP_ERROR               The connection status
      */
     CHIP_ERROR ConnectDevice(NodeId remoteDeviceId, const uint16_t discriminator, const uint32_t setupPINCode, void * appReqState,
-                             NewConnectionHandler onConnected, MessageReceiveHandler onMessageReceived, ErrorHandler onError);
+                             NewConnectionHandler onConnected, MessageReceiveHandler onMessageReceived, ErrorHandler onError)
+    {
+        return ConnectDevice(BLEDeviceConnectionParameters()
+                                 .SetRemoteDeviceId(remoteDeviceId)
+                                 .SetDiscriminator(discriminator)
+                                 .SetSetupPINCode(setupPINCode)
+                                 .SetAppReqState(appReqState)
+                                 .SetOnConnected(onConnected)
+                                 .SetOnMessageReceived(onMessageReceived)
+                                 .SetOnError(onError));
+    }
+
+    /**
+     * @brief
+     *   Connect to a CHIP device with the provided BLE connection parameters
+     *
+     * @return CHIP_ERROR               The connection status
+     */
+    CHIP_ERROR ConnectDevice(const BLEDeviceConnectionParameters & params);
 
     /**
      * @brief


### PR DESCRIPTION
Device layer is not used by android and BLE only requires a 'ble layer'
accessible. Add the ability to explicitly specity the BLE layer for the
chip controller.

Also updated the retain/release logic for the unsecured transport.