### PR TITLE
Fix chip-tool build on Mac not finding openssl headers

### DIFF
--- a/examples/chip-tool/Makefile
+++ b/examples/chip-tool/Makefile
@@ -53,6 +53,11 @@ DEFINES = \
 
 CXXFLAGS += -std=c++11
 
+# Until https://github.com/project-chip/connectedhomeip/issues/2284 is
+# fixed, CHIPDeviceController.h pulls in openssl headers, so we need
+# to make sure our include path contains those.
+CFLAGS += $(shell pkg-config --cflags openssl)
+
 ifdef BUILD_RELEASE
     DEFINES += BUILD_RELEASE=1
 else


### PR DESCRIPTION
 #### Problem
Compiling chip-tool on Mac (not using gn) does not work because it does not find the openssl headers.  This is an issue ever since ade4ad689ada096efd9fe1374dd75328ef7be9e3 started including those in `CHIPDeviceController.h`.

 #### Summary of Changes
Ensure that we pass the right `-I` bits to our compiler.
