### PR TITLE
Fix the non-gn build of chip-tool on Mac.

### DIFF
--- a/config/standalone/standalone-chip.mk
+++ b/config/standalone/standalone-chip.mk
@@ -98,7 +98,6 @@ CHIP_CONFIGURE_OPTIONS = \
     --with-network-layer=all \
     --with-target-network=sockets \
     --with-inet-endpoint="tcp udp" \
-    --with-device-layer=linux \
     --disable-tests \
     --disable-tools \
     --disable-docs \


### PR DESCRIPTION
Forcing the Linux device layer on Mac makes no sense, and causes
chip-tool to not compile due to the resulting dbus, glib, etc
dependencies.

 #### Problem
Can't compile chip-tool on Mac

 #### Summary of Changes
Stop forcing Linux device layer on Mac

fixes https://github.com/project-chip/connectedhomeip/issues/2301
