### PR TITLE
Bring up the SoftAP on M5Stack when using the Bypass rendezvous mode.

### DIFF
--- a/examples/wifi-echo/server/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/wifi-echo/server/esp32/main/CHIPDeviceManager.cpp
@@ -67,6 +67,12 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
         ConnectivityMgr().SetWiFiAPMode(ConnectivityManager::kWiFiAPMode_Enabled);
         break;
 
+    case RendezvousInformationFlags::kNone:
+        // If rendezvous is bypassed, enable SoftAP so that the device can still
+        // be communicated with via its SoftAP as needed.
+        ConnectivityMgr().SetWiFiAPMode(ConnectivityManager::kWiFiAPMode_Enabled);
+        break;
+
     default:
         break;
     }


### PR DESCRIPTION
This allows communication with the device without placing it on an
existing wifi network.

 #### Problem
When using the "Bypass" rendezvous mode, can't connect to M5Stack via SoftAP.

 #### Summary of Changes
Bring up SoftAP in "Bypass" mode.
