### PR TITLE
Fix the darwin fwk compile

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/CHIPSetupPayload.mm
@@ -80,7 +80,7 @@
 - (NSArray<CHIPOptionalQRCodeInfo *> *)getAllOptionalVendorData:(NSError * __autoreleasing *)error
 {
     NSMutableArray<CHIPOptionalQRCodeInfo *> * allOptionalData = [NSMutableArray new];
-    vector<chip::OptionalQRCodeInfo> chipOptionalData = _chipSetupPayload.getAllOptionalVendorData();
+    std::vector<chip::OptionalQRCodeInfo> chipOptionalData = _chipSetupPayload.getAllOptionalVendorData();
     for (chip::OptionalQRCodeInfo chipInfo : chipOptionalData) {
         CHIPOptionalQRCodeInfo * info = [CHIPOptionalQRCodeInfo new];
         info.tag = [NSNumber numberWithUnsignedChar:chipInfo.tag];


### PR DESCRIPTION
 #### Problem
The Darwin CHIP.framework doesn't compile anymore. 

 #### Summary of Changes
Looks like #2273 (`cc2423adc79698f0a55350e0d53d0e32600a650e`) needed to also scope the `vector` usage in objc to `std::vector`.