### PR TITLE
Remove include dependency on underlying crypto libraries

### DIFF
--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -141,6 +141,11 @@ CHIP_ERROR Hash_SHA256(const unsigned char * data, const size_t data_length, uns
  * @brief A class that defines stream based implementation of SHA-256 hash
  **/
 
+struct HashSHA256OpaqueContext
+{
+    uint8_t mOpaque[kMAX_Hash_SHA256_Context_Size];
+};
+
 class Hash_SHA256_stream
 {
 public:
@@ -153,7 +158,7 @@ public:
     void Clear(void);
 
 private:
-    uint8_t mContext[kMAX_Hash_SHA256_Context_Size];
+    HashSHA256OpaqueContext mContext;
 };
 
 /**
@@ -629,10 +634,19 @@ protected:
     unsigned char * Ke;
 };
 
+struct Spake2pOpaqueContext
+{
+    uint8_t mOpaque[kMAX_Spake2p_Context_Size];
+};
+
 class Spake2p_P256_SHA256_HKDF_HMAC : public Spake2p
 {
 public:
-    Spake2p_P256_SHA256_HKDF_HMAC(void);
+    Spake2p_P256_SHA256_HKDF_HMAC(void) : Spake2p(kP256_FE_Length, kP256_Point_Length, kSHA256_Hash_Length)
+    {
+        memset(&mSpake2pContext, 0, sizeof(mSpake2pContext));
+    }
+
     virtual ~Spake2p_P256_SHA256_HKDF_HMAC(void) { FreeImpl(); }
 
     CHIP_ERROR Mac(const unsigned char * key, size_t key_len, const unsigned char * in, size_t in_len, unsigned char * out);
@@ -668,7 +682,7 @@ private:
     CHIP_ERROR InitInternal();
     Hash_SHA256_stream sha256_hash_ctx;
 
-    uint8_t mSpake2pContext[kMAX_Spake2p_Context_Size];
+    Spake2pOpaqueContext mSpake2pContext;
 };
 
 /** @brief Clears the first `len` bytes of memory area `buf`.

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -27,15 +27,6 @@
 #include <stddef.h>
 #include <string.h>
 
-#if CHIP_CRYPTO_OPENSSL
-#include <openssl/ec.h>
-#include <openssl/sha.h>
-#elif CHIP_CRYPTO_MBEDTLS
-#include <mbedtls/ecp.h>
-#include <mbedtls/md.h>
-#include <mbedtls/sha256.h>
-#endif
-
 namespace chip {
 namespace Crypto {
 
@@ -48,6 +39,13 @@ const size_t kMax_ECDSA_Signature_Length = 72;
 const size_t kMAX_FE_Length              = kP256_FE_Length;
 const size_t kMAX_Point_Length           = kP256_Point_Length;
 const size_t kMAX_Hash_Length            = kSHA256_Hash_Length;
+
+/* These sizes are hardcoded here to remove header dependency on underlying crypto library
+ * in a public interface file. The validity of these sizes is verified by static_assert in
+ * the implementation files.
+ */
+const size_t kMAX_Spake2p_Context_Size     = 1024;
+const size_t kMAX_Hash_SHA256_Context_Size = 128;
 
 /**
  * Spake2+ parameters for P256
@@ -155,13 +153,7 @@ public:
     void Clear(void);
 
 private:
-#if CHIP_CRYPTO_OPENSSL
-    SHA256_CTX context;
-#elif CHIP_CRYPTO_MBEDTLS
-    mbedtls_sha256_context context;
-#else
-    SHA256_CTX_PLATFORM context; // To be defined by the platform specific implementation of sha256.
-#endif
+    uint8_t mContext[kMAX_Hash_SHA256_Context_Size];
 };
 
 /**
@@ -637,36 +629,12 @@ protected:
     unsigned char * Ke;
 };
 
-struct Spake2p_Context
-{
-#if CHIP_CRYPTO_OPENSSL
-    EC_GROUP * curve;
-    BN_CTX * bn_ctx;
-    const EVP_MD * md_info;
-#elif CHIP_CRYPTO_MBEDTLS
-    mbedtls_ecp_group curve;
-    const mbedtls_md_info_t * md_info;
-    mbedtls_ecp_point M;
-    mbedtls_ecp_point N;
-    mbedtls_ecp_point X;
-    mbedtls_ecp_point Y;
-    mbedtls_ecp_point L;
-    mbedtls_ecp_point Z;
-    mbedtls_ecp_point V;
-
-    mbedtls_mpi w0;
-    mbedtls_mpi w1;
-    mbedtls_mpi xy;
-    mbedtls_mpi tempbn;
-#endif
-};
-
 class Spake2p_P256_SHA256_HKDF_HMAC : public Spake2p
 {
 public:
     Spake2p_P256_SHA256_HKDF_HMAC(void) : Spake2p(kP256_FE_Length, kP256_Point_Length, kSHA256_Hash_Length)
     {
-        memset(&context, 0, sizeof(context));
+        memset(&mSpake2pContext, 0, sizeof(mSpake2pContext));
     }
 
     virtual ~Spake2p_P256_SHA256_HKDF_HMAC(void) { FreeImpl(); }
@@ -702,9 +670,9 @@ private:
     void FreeImpl();
 
     CHIP_ERROR InitInternal();
-    class Hash_SHA256_stream sha256_hash_ctx;
+    Hash_SHA256_stream sha256_hash_ctx;
 
-    struct Spake2p_Context context;
+    uint8_t mSpake2pContext[kMAX_Spake2p_Context_Size];
 };
 
 /** @brief Clears the first `len` bytes of memory area `buf`.

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -45,7 +45,7 @@ const size_t kMAX_Hash_Length            = kSHA256_Hash_Length;
  * the implementation files.
  */
 const size_t kMAX_Spake2p_Context_Size     = 1024;
-const size_t kMAX_Hash_SHA256_Context_Size = 128;
+const size_t kMAX_Hash_SHA256_Context_Size = 256;
 
 /**
  * Spake2+ parameters for P256
@@ -632,11 +632,7 @@ protected:
 class Spake2p_P256_SHA256_HKDF_HMAC : public Spake2p
 {
 public:
-    Spake2p_P256_SHA256_HKDF_HMAC(void) : Spake2p(kP256_FE_Length, kP256_Point_Length, kSHA256_Hash_Length)
-    {
-        memset(&mSpake2pContext, 0, sizeof(mSpake2pContext));
-    }
-
+    Spake2p_P256_SHA256_HKDF_HMAC(void);
     virtual ~Spake2p_P256_SHA256_HKDF_HMAC(void) { FreeImpl(); }
 
     CHIP_ERROR Mac(const unsigned char * key, size_t key_len, const unsigned char * in, size_t in_len, unsigned char * out);

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -24,6 +24,7 @@
 
 #include <openssl/bn.h>
 #include <openssl/conf.h>
+#include <openssl/ec.h>
 #include <openssl/ecdsa.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
@@ -276,7 +277,10 @@ exit:
     return error;
 }
 
-Hash_SHA256_stream::Hash_SHA256_stream(void) {}
+Hash_SHA256_stream::Hash_SHA256_stream(void)
+{
+    static_assert(sizeof(mContext) >= sizeof(SHA256_CTX), "Need more memory to store SHA256 context");
+}
 
 Hash_SHA256_stream::~Hash_SHA256_stream(void) {}
 
@@ -285,7 +289,9 @@ CHIP_ERROR Hash_SHA256_stream::Begin(void)
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 1;
 
-    result = SHA256_Init(&context);
+    SHA256_CTX* context = (SHA256_CTX*)&mContext;
+
+    result = SHA256_Init(context);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
 exit:
@@ -297,7 +303,9 @@ CHIP_ERROR Hash_SHA256_stream::AddData(const unsigned char * data, const size_t 
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 1;
 
-    result = SHA256_Update(&context, data, data_length);
+    SHA256_CTX* context = (SHA256_CTX*)&mContext;
+
+    result = SHA256_Update(context, data, data_length);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
 exit:
@@ -309,7 +317,9 @@ CHIP_ERROR Hash_SHA256_stream::Finish(unsigned char * out_buffer)
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 1;
 
-    result = SHA256_Final(out_buffer, &context);
+    SHA256_CTX* context = (SHA256_CTX*)&mContext;
+
+    result = SHA256_Final(out_buffer, context);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
 exit:
@@ -783,7 +793,7 @@ void ClearSecretData(uint8_t * buf, uint32_t len)
 #define init_point(_point_)                                                                                                        \
     do                                                                                                                             \
     {                                                                                                                              \
-        _point_ = EC_POINT_new(context.curve);                                                                                     \
+        _point_ = EC_POINT_new(context->curve);                                                                                     \
         VerifyOrExit(_point_ != NULL, error = CHIP_ERROR_INTERNAL);                                                                \
     } while (0)
 
@@ -812,26 +822,36 @@ void ClearSecretData(uint8_t * buf, uint32_t len)
         }                                                                                                                          \
     } while (0)
 
+typedef struct Spake2p_Context
+{
+    EC_GROUP * curve;
+    BN_CTX * bn_ctx;
+    const EVP_MD * md_info;
+} Spake2p_Context;
+
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal(void)
 {
     CHIP_ERROR error  = CHIP_ERROR_INTERNAL;
     int error_openssl = 0;
 
-    context.curve   = NULL;
-    context.bn_ctx  = NULL;
-    context.md_info = NULL;
+    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
 
-    context.curve = EC_GROUP_new_by_curve_name(NID_X9_62_prime256v1);
-    VerifyOrExit(context.curve != NULL, error = CHIP_ERROR_INTERNAL);
+    context->curve   = NULL;
+    context->bn_ctx  = NULL;
+    context->md_info = NULL;
 
-    G = (void *) EC_GROUP_get0_generator(context.curve);
+    context->curve = EC_GROUP_new_by_curve_name(NID_X9_62_prime256v1);
+    VerifyOrExit(context->curve != NULL, error = CHIP_ERROR_INTERNAL);
+
+    G = (void *) EC_GROUP_get0_generator(context->curve);
     VerifyOrExit(G != NULL, error = CHIP_ERROR_INTERNAL);
 
-    context.bn_ctx = BN_CTX_secure_new();
-    VerifyOrExit(context.bn_ctx != NULL, error = CHIP_ERROR_INTERNAL);
+    context->bn_ctx = BN_CTX_secure_new();
+    VerifyOrExit(context->bn_ctx != NULL, error = CHIP_ERROR_INTERNAL);
 
-    context.md_info = EVP_sha256();
-    VerifyOrExit(context.md_info != NULL, error = CHIP_ERROR_INTERNAL);
+    context->md_info = EVP_sha256();
+    VerifyOrExit(context->md_info != NULL, error = CHIP_ERROR_INTERNAL);
 
     init_point(M);
     init_point(N);
@@ -846,7 +866,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal(void)
     init_bn(tempbn);
     init_bn(order);
 
-    error_openssl = EC_GROUP_get_order(context.curve, (BIGNUM *) order, context.bn_ctx);
+    error_openssl = EC_GROUP_get_order(context->curve, (BIGNUM *) order, context->bn_ctx);
     VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
 
     error = CHIP_NO_ERROR;
@@ -856,14 +876,17 @@ exit:
 
 void Spake2p_P256_SHA256_HKDF_HMAC::FreeImpl(void)
 {
-    if (context.curve != nullptr)
+    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
+
+    if (context->curve != nullptr)
     {
-        EC_GROUP_clear_free(context.curve);
+        EC_GROUP_clear_free(context->curve);
     }
 
-    if (context.bn_ctx != nullptr)
+    if (context->bn_ctx != nullptr)
     {
-        BN_CTX_free(context.bn_ctx);
+        BN_CTX_free(context->bn_ctx);
     }
 
     free_point(M);
@@ -887,10 +910,13 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::Mac(const unsigned char * key, size_t 
     int error_openssl        = 0;
     unsigned int mac_out_len = 0;
 
+    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
+
     HMAC_CTX * mac_ctx = HMAC_CTX_new();
     VerifyOrExit(mac_ctx != NULL, error = CHIP_ERROR_INTERNAL);
 
-    error_openssl = HMAC_Init_ex(mac_ctx, key, key_len, context.md_info, NULL);
+    error_openssl = HMAC_Init_ex(mac_ctx, key, key_len, context->md_info, NULL);
     VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
 
     error_openssl = HMAC_Update(mac_ctx, in, in_len);
@@ -929,8 +955,11 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::FELoad(const unsigned char * in, size_
     int error_openssl = 0;
     BIGNUM * bn_fe    = (BIGNUM *) fe;
 
+    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
+
     BN_bin2bn(in, in_len, bn_fe);
-    error_openssl = BN_mod(bn_fe, bn_fe, (BIGNUM *) order, context.bn_ctx);
+    error_openssl = BN_mod(bn_fe, bn_fe, (BIGNUM *) order, context->bn_ctx);
     VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
 
     error = CHIP_NO_ERROR;
@@ -968,7 +997,10 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::FEMul(void * fer, const void * fe1, co
     CHIP_ERROR error  = CHIP_ERROR_INTERNAL;
     int error_openssl = 0;
 
-    error_openssl = BN_mod_mul((BIGNUM *) fer, (BIGNUM *) fe1, (BIGNUM *) fe2, (BIGNUM *) order, context.bn_ctx);
+    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
+
+    error_openssl = BN_mod_mul((BIGNUM *) fer, (BIGNUM *) fe1, (BIGNUM *) fe2, (BIGNUM *) order, context->bn_ctx);
     VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
 
     error = CHIP_NO_ERROR;
@@ -981,7 +1013,10 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointLoad(const unsigned char * in, si
     CHIP_ERROR error  = CHIP_ERROR_INTERNAL;
     int error_openssl = 0;
 
-    error_openssl = EC_POINT_oct2point(context.curve, (EC_POINT *) R, in, in_len, context.bn_ctx);
+    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
+
+    error_openssl = EC_POINT_oct2point(context->curve, (EC_POINT *) R, in, in_len, context->bn_ctx);
     VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
 
     error = CHIP_NO_ERROR;
@@ -992,8 +1027,11 @@ exit:
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointWrite(const void * R, unsigned char * out, size_t out_len)
 {
     CHIP_ERROR error = CHIP_ERROR_INTERNAL;
+    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
+
     size_t ec_out_len =
-        EC_POINT_point2oct(context.curve, (EC_POINT *) R, POINT_CONVERSION_UNCOMPRESSED, out, out_len, context.bn_ctx);
+        EC_POINT_point2oct(context->curve, (EC_POINT *) R, POINT_CONVERSION_UNCOMPRESSED, out, out_len, context->bn_ctx);
     VerifyOrExit(ec_out_len == out_len, error = CHIP_ERROR_INTERNAL);
 
     error = CHIP_NO_ERROR;
@@ -1006,7 +1044,10 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointMul(void * R, const void * P1, co
     CHIP_ERROR error  = CHIP_ERROR_INTERNAL;
     int error_openssl = 0;
 
-    error_openssl = EC_POINT_mul(context.curve, (EC_POINT *) R, NULL, (EC_POINT *) P1, (BIGNUM *) fe1, context.bn_ctx);
+    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
+
+    error_openssl = EC_POINT_mul(context->curve, (EC_POINT *) R, NULL, (EC_POINT *) P1, (BIGNUM *) fe1, context->bn_ctx);
     VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
 
     error = CHIP_NO_ERROR;
@@ -1021,7 +1062,10 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointAddMul(void * R, const void * P1,
     int error_openssl  = 0;
     EC_POINT * scratch = NULL;
 
-    scratch = EC_POINT_new(context.curve);
+    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
+
+    scratch = EC_POINT_new(context->curve);
     VerifyOrExit(scratch != NULL, error = CHIP_ERROR_INTERNAL);
 
     error = PointMul(scratch, P1, fe1);
@@ -1030,7 +1074,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointAddMul(void * R, const void * P1,
     error = PointMul(R, P2, fe2);
     VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
 
-    error_openssl = EC_POINT_add(context.curve, (EC_POINT *) R, (EC_POINT *) R, (const EC_POINT *) scratch, context.bn_ctx);
+    error_openssl = EC_POINT_add(context->curve, (EC_POINT *) R, (EC_POINT *) R, (const EC_POINT *) scratch, context->bn_ctx);
     VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
 
     error = CHIP_NO_ERROR;
@@ -1044,7 +1088,10 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointInvert(void * R)
     CHIP_ERROR error  = CHIP_ERROR_INTERNAL;
     int error_openssl = 0;
 
-    error_openssl = EC_POINT_invert(context.curve, (EC_POINT *) R, context.bn_ctx);
+    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
+
+    error_openssl = EC_POINT_invert(context->curve, (EC_POINT *) R, context->bn_ctx);
     VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
 
     error = CHIP_NO_ERROR;
@@ -1066,20 +1113,23 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(unsigned char * Lout, size_t 
     BIGNUM * w1_bn        = NULL;
     EC_POINT * Lout_point = NULL;
 
+    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
+
     w1_bn = BN_new();
     VerifyOrExit(w1_bn != NULL, error = CHIP_ERROR_INTERNAL);
 
-    Lout_point = EC_POINT_new(context.curve);
+    Lout_point = EC_POINT_new(context->curve);
     VerifyOrExit(Lout_point != NULL, error = CHIP_ERROR_INTERNAL);
 
     BN_bin2bn(w1in, w1in_len, w1_bn);
-    error_openssl = BN_mod(w1_bn, w1_bn, (BIGNUM *) order, context.bn_ctx);
+    error_openssl = BN_mod(w1_bn, w1_bn, (BIGNUM *) order, context->bn_ctx);
     VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
 
-    error_openssl = EC_POINT_mul(context.curve, Lout_point, w1_bn, NULL, NULL, context.bn_ctx);
+    error_openssl = EC_POINT_mul(context->curve, Lout_point, w1_bn, NULL, NULL, context->bn_ctx);
     VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
 
-    *L_len = EC_POINT_point2oct(context.curve, Lout_point, POINT_CONVERSION_UNCOMPRESSED, Lout, *L_len, context.bn_ctx);
+    *L_len = EC_POINT_point2oct(context->curve, Lout_point, POINT_CONVERSION_UNCOMPRESSED, Lout, *L_len, context->bn_ctx);
     VerifyOrExit(*L_len != 0, error = CHIP_ERROR_INTERNAL);
 
     error = CHIP_NO_ERROR;
@@ -1095,7 +1145,10 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointIsValid(void * R)
     CHIP_ERROR error  = CHIP_ERROR_INTERNAL;
     int error_openssl = 0;
 
-    error_openssl = EC_POINT_is_on_curve(context.curve, (EC_POINT *) R, context.bn_ctx);
+    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
+
+    error_openssl = EC_POINT_is_on_curve(context->curve, (EC_POINT *) R, context->bn_ctx);
     VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
 
     error = CHIP_NO_ERROR;

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -289,7 +289,7 @@ CHIP_ERROR Hash_SHA256_stream::Begin(void)
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 1;
 
-    SHA256_CTX* context = (SHA256_CTX*)&mContext;
+    SHA256_CTX * context = (SHA256_CTX *) &mContext;
 
     result = SHA256_Init(context);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
@@ -303,7 +303,7 @@ CHIP_ERROR Hash_SHA256_stream::AddData(const unsigned char * data, const size_t 
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 1;
 
-    SHA256_CTX* context = (SHA256_CTX*)&mContext;
+    SHA256_CTX * context = (SHA256_CTX *) &mContext;
 
     result = SHA256_Update(context, data, data_length);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
@@ -317,7 +317,7 @@ CHIP_ERROR Hash_SHA256_stream::Finish(unsigned char * out_buffer)
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 1;
 
-    SHA256_CTX* context = (SHA256_CTX*)&mContext;
+    SHA256_CTX * context = (SHA256_CTX *) &mContext;
 
     result = SHA256_Final(out_buffer, context);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
@@ -793,7 +793,7 @@ void ClearSecretData(uint8_t * buf, uint32_t len)
 #define init_point(_point_)                                                                                                        \
     do                                                                                                                             \
     {                                                                                                                              \
-        _point_ = EC_POINT_new(context->curve);                                                                                     \
+        _point_ = EC_POINT_new(context->curve);                                                                                    \
         VerifyOrExit(_point_ != NULL, error = CHIP_ERROR_INTERNAL);                                                                \
     } while (0)
 
@@ -834,7 +834,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal(void)
     CHIP_ERROR error  = CHIP_ERROR_INTERNAL;
     int error_openssl = 0;
 
-    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    Spake2p_Context * context = (Spake2p_Context *) &mSpake2pContext;
     static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
 
     context->curve   = NULL;
@@ -876,7 +876,7 @@ exit:
 
 void Spake2p_P256_SHA256_HKDF_HMAC::FreeImpl(void)
 {
-    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    Spake2p_Context * context = (Spake2p_Context *) &mSpake2pContext;
     static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
 
     if (context->curve != nullptr)
@@ -910,7 +910,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::Mac(const unsigned char * key, size_t 
     int error_openssl        = 0;
     unsigned int mac_out_len = 0;
 
-    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    Spake2p_Context * context = (Spake2p_Context *) &mSpake2pContext;
     static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
 
     HMAC_CTX * mac_ctx = HMAC_CTX_new();
@@ -955,7 +955,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::FELoad(const unsigned char * in, size_
     int error_openssl = 0;
     BIGNUM * bn_fe    = (BIGNUM *) fe;
 
-    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    Spake2p_Context * context = (Spake2p_Context *) &mSpake2pContext;
     static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
 
     BN_bin2bn(in, in_len, bn_fe);
@@ -997,7 +997,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::FEMul(void * fer, const void * fe1, co
     CHIP_ERROR error  = CHIP_ERROR_INTERNAL;
     int error_openssl = 0;
 
-    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    Spake2p_Context * context = (Spake2p_Context *) &mSpake2pContext;
     static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
 
     error_openssl = BN_mod_mul((BIGNUM *) fer, (BIGNUM *) fe1, (BIGNUM *) fe2, (BIGNUM *) order, context->bn_ctx);
@@ -1013,7 +1013,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointLoad(const unsigned char * in, si
     CHIP_ERROR error  = CHIP_ERROR_INTERNAL;
     int error_openssl = 0;
 
-    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    Spake2p_Context * context = (Spake2p_Context *) &mSpake2pContext;
     static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
 
     error_openssl = EC_POINT_oct2point(context->curve, (EC_POINT *) R, in, in_len, context->bn_ctx);
@@ -1026,8 +1026,8 @@ exit:
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointWrite(const void * R, unsigned char * out, size_t out_len)
 {
-    CHIP_ERROR error = CHIP_ERROR_INTERNAL;
-    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    CHIP_ERROR error          = CHIP_ERROR_INTERNAL;
+    Spake2p_Context * context = (Spake2p_Context *) &mSpake2pContext;
     static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
 
     size_t ec_out_len =
@@ -1044,7 +1044,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointMul(void * R, const void * P1, co
     CHIP_ERROR error  = CHIP_ERROR_INTERNAL;
     int error_openssl = 0;
 
-    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    Spake2p_Context * context = (Spake2p_Context *) &mSpake2pContext;
     static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
 
     error_openssl = EC_POINT_mul(context->curve, (EC_POINT *) R, NULL, (EC_POINT *) P1, (BIGNUM *) fe1, context->bn_ctx);
@@ -1062,7 +1062,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointAddMul(void * R, const void * P1,
     int error_openssl  = 0;
     EC_POINT * scratch = NULL;
 
-    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    Spake2p_Context * context = (Spake2p_Context *) &mSpake2pContext;
     static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
 
     scratch = EC_POINT_new(context->curve);
@@ -1088,7 +1088,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointInvert(void * R)
     CHIP_ERROR error  = CHIP_ERROR_INTERNAL;
     int error_openssl = 0;
 
-    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    Spake2p_Context * context = (Spake2p_Context *) &mSpake2pContext;
     static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
 
     error_openssl = EC_POINT_invert(context->curve, (EC_POINT *) R, context->bn_ctx);
@@ -1113,7 +1113,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(unsigned char * Lout, size_t 
     BIGNUM * w1_bn        = NULL;
     EC_POINT * Lout_point = NULL;
 
-    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    Spake2p_Context * context = (Spake2p_Context *) &mSpake2pContext;
     static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
 
     w1_bn = BN_new();
@@ -1145,7 +1145,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointIsValid(void * R)
     CHIP_ERROR error  = CHIP_ERROR_INTERNAL;
     int error_openssl = 0;
 
-    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    Spake2p_Context * context = (Spake2p_Context *) &mSpake2pContext;
     static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
 
     error_openssl = EC_POINT_is_on_curve(context->curve, (EC_POINT *) R, context->bn_ctx);

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -829,7 +829,8 @@ typedef struct Spake2p_Context
     const EVP_MD * md_info;
 } Spake2p_Context;
 
-Spake2p_P256_SHA256_HKDF_HMAC::Spake2p_P256_SHA256_HKDF_HMAC(void) : Spake2p(kP256_FE_Length, kP256_Point_Length, kSHA256_Hash_Length)
+Spake2p_P256_SHA256_HKDF_HMAC::Spake2p_P256_SHA256_HKDF_HMAC(void) :
+    Spake2p(kP256_FE_Length, kP256_Point_Length, kSHA256_Hash_Length)
 {
     memset(mSpake2pContext, 0, sizeof(mSpake2pContext));
     nlSTATIC_ASSERT_PRINT(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -281,7 +281,7 @@ Hash_SHA256_stream::Hash_SHA256_stream(void) {}
 
 Hash_SHA256_stream::~Hash_SHA256_stream(void) {}
 
-static inline SHA256_CTX* to_inner_hash_sha256_context(HashSHA256OpaqueContext* context)
+static inline SHA256_CTX * to_inner_hash_sha256_context(HashSHA256OpaqueContext * context)
 {
     nlSTATIC_ASSERT_PRINT(sizeof(HashSHA256OpaqueContext) >= sizeof(SHA256_CTX), "Need more memory for SHA256 Context");
     return reinterpret_cast<SHA256_CTX *>(context->mOpaque);
@@ -832,7 +832,7 @@ typedef struct Spake2p_Context
     const EVP_MD * md_info;
 } Spake2p_Context;
 
-static inline Spake2p_Context* to_inner_spake2p_context(Spake2pOpaqueContext* context)
+static inline Spake2p_Context * to_inner_spake2p_context(Spake2pOpaqueContext * context)
 {
     nlSTATIC_ASSERT_PRINT(sizeof(Spake2pOpaqueContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
     return reinterpret_cast<Spake2p_Context *>(context->mOpaque);

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -189,7 +189,7 @@ CHIP_ERROR Hash_SHA256_stream::Begin(void)
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
 
-    mbedtls_sha256_context* context = (mbedtls_sha256_context*) &mContext;
+    mbedtls_sha256_context * context = (mbedtls_sha256_context *) &mContext;
 
     result = mbedtls_sha256_starts_ret(context, 0);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
@@ -203,7 +203,7 @@ CHIP_ERROR Hash_SHA256_stream::AddData(const unsigned char * data, const size_t 
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
 
-    mbedtls_sha256_context* context = (mbedtls_sha256_context*) &mContext;
+    mbedtls_sha256_context * context = (mbedtls_sha256_context *) &mContext;
 
     result = mbedtls_sha256_update_ret(context, data, data_length);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
@@ -217,7 +217,7 @@ CHIP_ERROR Hash_SHA256_stream::Finish(unsigned char * out_buffer)
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
 
-    mbedtls_sha256_context* context = (mbedtls_sha256_context*) &mContext;
+    mbedtls_sha256_context * context = (mbedtls_sha256_context *) &mContext;
 
     result = mbedtls_sha256_finish_ret(context, out_buffer);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
@@ -549,7 +549,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal(void)
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
 
-    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    Spake2p_Context * context = (Spake2p_Context *) &mSpake2pContext;
     static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
 
     memset(context, 0, sizeof(Spake2p_Context));
@@ -598,7 +598,7 @@ exit:
 
 void Spake2p_P256_SHA256_HKDF_HMAC::FreeImpl(void)
 {
-    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    Spake2p_Context * context = (Spake2p_Context *) &mSpake2pContext;
     static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
 
     mbedtls_ecp_point_free(&context->M);
@@ -626,7 +626,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::Mac(const unsigned char * key, size_t 
     mbedtls_md_context_t hmac_ctx;
     mbedtls_md_init(&hmac_ctx);
 
-    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    Spake2p_Context * context = (Spake2p_Context *) &mSpake2pContext;
     static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
 
     result = mbedtls_md_setup(&hmac_ctx, context->md_info, 1);
@@ -719,7 +719,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::FEGenerate(void * fe)
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
 
-    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    Spake2p_Context * context = (Spake2p_Context *) &mSpake2pContext;
     static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
 
     result = mbedtls_ecp_gen_privkey(&context->curve, (mbedtls_mpi *) fe, ECDSA_sign_rng, nullptr);
@@ -748,7 +748,7 @@ exit:
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointLoad(const unsigned char * in, size_t in_len, void * R)
 {
-    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    Spake2p_Context * context = (Spake2p_Context *) &mSpake2pContext;
     static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
 
     if (mbedtls_ecp_point_read_binary(&context->curve, (mbedtls_ecp_point *) R, in, in_len) != 0)
@@ -764,11 +764,11 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointWrite(const void * R, unsigned ch
     memset(out, 0, out_len);
     size_t mbedtls_out_len = out_len;
 
-    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    Spake2p_Context * context = (Spake2p_Context *) &mSpake2pContext;
     static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
 
-    if (mbedtls_ecp_point_write_binary(&context->curve, (const mbedtls_ecp_point *) R, MBEDTLS_ECP_PF_UNCOMPRESSED, &mbedtls_out_len,
-                                       out, out_len) != 0)
+    if (mbedtls_ecp_point_write_binary(&context->curve, (const mbedtls_ecp_point *) R, MBEDTLS_ECP_PF_UNCOMPRESSED,
+                                       &mbedtls_out_len, out, out_len) != 0)
     {
         return CHIP_ERROR_INTERNAL;
     }
@@ -778,7 +778,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointWrite(const void * R, unsigned ch
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointMul(void * R, const void * P1, const void * fe1)
 {
-    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    Spake2p_Context * context = (Spake2p_Context *) &mSpake2pContext;
     static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
 
     if (mbedtls_ecp_mul(&context->curve, (mbedtls_ecp_point *) R, (const mbedtls_mpi *) fe1, (const mbedtls_ecp_point *) P1,
@@ -793,7 +793,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointMul(void * R, const void * P1, co
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointAddMul(void * R, const void * P1, const void * fe1, const void * P2,
                                                       const void * fe2)
 {
-    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    Spake2p_Context * context = (Spake2p_Context *) &mSpake2pContext;
     static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
 
     if (mbedtls_ecp_muladd(&context->curve, (mbedtls_ecp_point *) R, (const mbedtls_mpi *) fe1, (const mbedtls_ecp_point *) P1,
@@ -807,8 +807,8 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointAddMul(void * R, const void * P1,
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointInvert(void * R)
 {
-    mbedtls_ecp_point * Rp = (mbedtls_ecp_point *) R;
-    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    mbedtls_ecp_point * Rp    = (mbedtls_ecp_point *) R;
+    Spake2p_Context * context = (Spake2p_Context *) &mSpake2pContext;
     static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
 
     if (mbedtls_mpi_sub_mpi(&Rp->Y, &context->curve.P, &Rp->Y) != 0)
@@ -866,7 +866,7 @@ exit:
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointIsValid(void * R)
 {
-    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    Spake2p_Context * context = (Spake2p_Context *) &mSpake2pContext;
     static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
 
     if (mbedtls_ecp_check_pubkey(&context->curve, (mbedtls_ecp_point *) R) != 0)

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -27,6 +27,7 @@
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/ecdh.h>
 #include <mbedtls/ecdsa.h>
+#include <mbedtls/ecp.h>
 #include <mbedtls/entropy.h>
 #include <mbedtls/error.h>
 #include <mbedtls/hkdf.h>
@@ -176,7 +177,10 @@ exit:
     return error;
 }
 
-Hash_SHA256_stream::Hash_SHA256_stream(void) {}
+Hash_SHA256_stream::Hash_SHA256_stream(void)
+{
+    static_assert(sizeof(mContext) >= sizeof(mbedtls_sha256_context), "Need more memory to store SHA256 context");
+}
 
 Hash_SHA256_stream::~Hash_SHA256_stream(void) {}
 
@@ -185,7 +189,9 @@ CHIP_ERROR Hash_SHA256_stream::Begin(void)
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
 
-    result = mbedtls_sha256_starts_ret(&context, 0);
+    mbedtls_sha256_context* context = (mbedtls_sha256_context*) &mContext;
+
+    result = mbedtls_sha256_starts_ret(context, 0);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
 exit:
@@ -197,7 +203,9 @@ CHIP_ERROR Hash_SHA256_stream::AddData(const unsigned char * data, const size_t 
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
 
-    result = mbedtls_sha256_update_ret(&context, data, data_length);
+    mbedtls_sha256_context* context = (mbedtls_sha256_context*) &mContext;
+
+    result = mbedtls_sha256_update_ret(context, data, data_length);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
 exit:
@@ -209,7 +217,9 @@ CHIP_ERROR Hash_SHA256_stream::Finish(unsigned char * out_buffer)
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
 
-    result = mbedtls_sha256_finish_ret(&context, out_buffer);
+    mbedtls_sha256_context* context = (mbedtls_sha256_context*) &mContext;
+
+    result = mbedtls_sha256_finish_ret(context, out_buffer);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
 exit:
@@ -516,45 +526,66 @@ void ClearSecretData(uint8_t * buf, uint32_t len)
     memset(buf, 0, len);
 }
 
+typedef struct Spake2p_Context
+{
+    mbedtls_ecp_group curve;
+    const mbedtls_md_info_t * md_info;
+    mbedtls_ecp_point M;
+    mbedtls_ecp_point N;
+    mbedtls_ecp_point X;
+    mbedtls_ecp_point Y;
+    mbedtls_ecp_point L;
+    mbedtls_ecp_point Z;
+    mbedtls_ecp_point V;
+
+    mbedtls_mpi w0;
+    mbedtls_mpi w1;
+    mbedtls_mpi xy;
+    mbedtls_mpi tempbn;
+} Spake2p_Context;
+
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal(void)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
 
-    memset(&context, 0, sizeof(context));
-    mbedtls_ecp_group_init(&context.curve);
-    result = mbedtls_ecp_group_load(&context.curve, MBEDTLS_ECP_DP_SECP256R1);
+    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
+
+    memset(context, 0, sizeof(Spake2p_Context));
+    mbedtls_ecp_group_init(&context->curve);
+    result = mbedtls_ecp_group_load(&context->curve, MBEDTLS_ECP_DP_SECP256R1);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
-    context.md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
-    VerifyOrExit(context.md_info != NULL, error = CHIP_ERROR_INTERNAL);
+    context->md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+    VerifyOrExit(context->md_info != NULL, error = CHIP_ERROR_INTERNAL);
 
-    mbedtls_ecp_point_init(&context.M);
-    mbedtls_ecp_point_init(&context.N);
-    mbedtls_ecp_point_init(&context.X);
-    mbedtls_ecp_point_init(&context.Y);
-    mbedtls_ecp_point_init(&context.L);
-    mbedtls_ecp_point_init(&context.V);
-    mbedtls_ecp_point_init(&context.Z);
-    M = &context.M;
-    N = &context.N;
-    X = &context.X;
-    Y = &context.Y;
-    L = &context.L;
-    V = &context.V;
-    Z = &context.Z;
+    mbedtls_ecp_point_init(&context->M);
+    mbedtls_ecp_point_init(&context->N);
+    mbedtls_ecp_point_init(&context->X);
+    mbedtls_ecp_point_init(&context->Y);
+    mbedtls_ecp_point_init(&context->L);
+    mbedtls_ecp_point_init(&context->V);
+    mbedtls_ecp_point_init(&context->Z);
+    M = &context->M;
+    N = &context->N;
+    X = &context->X;
+    Y = &context->Y;
+    L = &context->L;
+    V = &context->V;
+    Z = &context->Z;
 
-    mbedtls_mpi_init(&context.w0);
-    mbedtls_mpi_init(&context.w1);
-    mbedtls_mpi_init(&context.xy);
-    mbedtls_mpi_init(&context.tempbn);
-    w0     = &context.w0;
-    w1     = &context.w1;
-    xy     = &context.xy;
-    tempbn = &context.tempbn;
+    mbedtls_mpi_init(&context->w0);
+    mbedtls_mpi_init(&context->w1);
+    mbedtls_mpi_init(&context->xy);
+    mbedtls_mpi_init(&context->tempbn);
+    w0     = &context->w0;
+    w1     = &context->w1;
+    xy     = &context->xy;
+    tempbn = &context->tempbn;
 
-    G     = &context.curve.G;
-    order = &context.curve.N;
+    G     = &context->curve.G;
+    order = &context->curve.N;
 
     return error;
 
@@ -567,20 +598,23 @@ exit:
 
 void Spake2p_P256_SHA256_HKDF_HMAC::FreeImpl(void)
 {
-    mbedtls_ecp_point_free(&context.M);
-    mbedtls_ecp_point_free(&context.N);
-    mbedtls_ecp_point_free(&context.X);
-    mbedtls_ecp_point_free(&context.Y);
-    mbedtls_ecp_point_free(&context.L);
-    mbedtls_ecp_point_free(&context.Z);
-    mbedtls_ecp_point_free(&context.V);
+    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
 
-    mbedtls_mpi_free(&context.w0);
-    mbedtls_mpi_free(&context.w1);
-    mbedtls_mpi_free(&context.xy);
-    mbedtls_mpi_free(&context.tempbn);
+    mbedtls_ecp_point_free(&context->M);
+    mbedtls_ecp_point_free(&context->N);
+    mbedtls_ecp_point_free(&context->X);
+    mbedtls_ecp_point_free(&context->Y);
+    mbedtls_ecp_point_free(&context->L);
+    mbedtls_ecp_point_free(&context->Z);
+    mbedtls_ecp_point_free(&context->V);
 
-    mbedtls_ecp_group_free(&context.curve);
+    mbedtls_mpi_free(&context->w0);
+    mbedtls_mpi_free(&context->w1);
+    mbedtls_mpi_free(&context->xy);
+    mbedtls_mpi_free(&context->tempbn);
+
+    mbedtls_ecp_group_free(&context->curve);
 }
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::Mac(const unsigned char * key, size_t key_len, const unsigned char * in, size_t in_len,
@@ -591,7 +625,11 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::Mac(const unsigned char * key, size_t 
 
     mbedtls_md_context_t hmac_ctx;
     mbedtls_md_init(&hmac_ctx);
-    result = mbedtls_md_setup(&hmac_ctx, context.md_info, 1);
+
+    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
+
+    result = mbedtls_md_setup(&hmac_ctx, context->md_info, 1);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
     result = mbedtls_md_hmac_starts(&hmac_ctx, key, key_len);
@@ -681,7 +719,10 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::FEGenerate(void * fe)
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
 
-    result = mbedtls_ecp_gen_privkey(&context.curve, (mbedtls_mpi *) fe, ECDSA_sign_rng, nullptr);
+    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
+
+    result = mbedtls_ecp_gen_privkey(&context->curve, (mbedtls_mpi *) fe, ECDSA_sign_rng, nullptr);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
 exit:
@@ -707,7 +748,10 @@ exit:
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointLoad(const unsigned char * in, size_t in_len, void * R)
 {
-    if (mbedtls_ecp_point_read_binary(&context.curve, (mbedtls_ecp_point *) R, in, in_len) != 0)
+    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
+
+    if (mbedtls_ecp_point_read_binary(&context->curve, (mbedtls_ecp_point *) R, in, in_len) != 0)
     {
         return CHIP_ERROR_INTERNAL;
     }
@@ -720,7 +764,10 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointWrite(const void * R, unsigned ch
     memset(out, 0, out_len);
     size_t mbedtls_out_len = out_len;
 
-    if (mbedtls_ecp_point_write_binary(&context.curve, (const mbedtls_ecp_point *) R, MBEDTLS_ECP_PF_UNCOMPRESSED, &mbedtls_out_len,
+    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
+
+    if (mbedtls_ecp_point_write_binary(&context->curve, (const mbedtls_ecp_point *) R, MBEDTLS_ECP_PF_UNCOMPRESSED, &mbedtls_out_len,
                                        out, out_len) != 0)
     {
         return CHIP_ERROR_INTERNAL;
@@ -731,7 +778,10 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointWrite(const void * R, unsigned ch
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointMul(void * R, const void * P1, const void * fe1)
 {
-    if (mbedtls_ecp_mul(&context.curve, (mbedtls_ecp_point *) R, (const mbedtls_mpi *) fe1, (const mbedtls_ecp_point *) P1,
+    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
+
+    if (mbedtls_ecp_mul(&context->curve, (mbedtls_ecp_point *) R, (const mbedtls_mpi *) fe1, (const mbedtls_ecp_point *) P1,
                         ECDSA_sign_rng, nullptr) != 0)
     {
         return CHIP_ERROR_INTERNAL;
@@ -743,8 +793,10 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointMul(void * R, const void * P1, co
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointAddMul(void * R, const void * P1, const void * fe1, const void * P2,
                                                       const void * fe2)
 {
+    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
 
-    if (mbedtls_ecp_muladd(&context.curve, (mbedtls_ecp_point *) R, (const mbedtls_mpi *) fe1, (const mbedtls_ecp_point *) P1,
+    if (mbedtls_ecp_muladd(&context->curve, (mbedtls_ecp_point *) R, (const mbedtls_mpi *) fe1, (const mbedtls_ecp_point *) P1,
                            (const mbedtls_mpi *) fe2, (const mbedtls_ecp_point *) P2) != 0)
     {
         return CHIP_ERROR_INTERNAL;
@@ -756,7 +808,10 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointAddMul(void * R, const void * P1,
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointInvert(void * R)
 {
     mbedtls_ecp_point * Rp = (mbedtls_ecp_point *) R;
-    if (mbedtls_mpi_sub_mpi(&Rp->Y, &context.curve.P, &Rp->Y) != 0)
+    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
+
+    if (mbedtls_mpi_sub_mpi(&Rp->Y, &context->curve.P, &Rp->Y) != 0)
     {
         return CHIP_ERROR_INTERNAL;
     }
@@ -811,7 +866,10 @@ exit:
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointIsValid(void * R)
 {
-    if (mbedtls_ecp_check_pubkey(&context.curve, (mbedtls_ecp_point *) R) != 0)
+    Spake2p_Context* context = (Spake2p_Context*) &mSpake2pContext;
+    static_assert(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
+
+    if (mbedtls_ecp_check_pubkey(&context->curve, (mbedtls_ecp_point *) R) != 0)
     {
         return CHIP_ERROR_INTERNAL;
     }

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -177,19 +177,22 @@ exit:
     return error;
 }
 
-Hash_SHA256_stream::Hash_SHA256_stream(void)
-{
-    nlSTATIC_ASSERT_PRINT(sizeof(mContext) >= sizeof(mbedtls_sha256_context), "Need more memory to store SHA256 context");
-}
+Hash_SHA256_stream::Hash_SHA256_stream(void) {}
 
 Hash_SHA256_stream::~Hash_SHA256_stream(void) {}
+
+static inline mbedtls_sha256_context* to_inner_hash_sha256_context(HashSHA256OpaqueContext* context)
+{
+    nlSTATIC_ASSERT_PRINT(sizeof(context->mOpaque) >= sizeof(mbedtls_sha256_context), "Need more memory for SHA256 Context");
+    return reinterpret_cast<mbedtls_sha256_context *>(context->mOpaque);
+}
 
 CHIP_ERROR Hash_SHA256_stream::Begin(void)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
 
-    mbedtls_sha256_context * context = reinterpret_cast<mbedtls_sha256_context *>(mContext);
+    mbedtls_sha256_context * context = to_inner_hash_sha256_context(&mContext);
 
     result = mbedtls_sha256_starts_ret(context, 0);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
@@ -203,7 +206,7 @@ CHIP_ERROR Hash_SHA256_stream::AddData(const unsigned char * data, const size_t 
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
 
-    mbedtls_sha256_context * context = reinterpret_cast<mbedtls_sha256_context *>(mContext);
+    mbedtls_sha256_context * context = to_inner_hash_sha256_context(&mContext);
 
     result = mbedtls_sha256_update_ret(context, data, data_length);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
@@ -217,7 +220,7 @@ CHIP_ERROR Hash_SHA256_stream::Finish(unsigned char * out_buffer)
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
 
-    mbedtls_sha256_context * context = reinterpret_cast<mbedtls_sha256_context *>(mContext);
+    mbedtls_sha256_context * context = to_inner_hash_sha256_context(&mContext);
 
     result = mbedtls_sha256_finish_ret(context, out_buffer);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
@@ -544,11 +547,10 @@ typedef struct Spake2p_Context
     mbedtls_mpi tempbn;
 } Spake2p_Context;
 
-Spake2p_P256_SHA256_HKDF_HMAC::Spake2p_P256_SHA256_HKDF_HMAC(void) :
-    Spake2p(kP256_FE_Length, kP256_Point_Length, kSHA256_Hash_Length)
+static inline Spake2p_Context* to_inner_spake2p_context(Spake2pOpaqueContext* context)
 {
-    memset(mSpake2pContext, 0, sizeof(mSpake2pContext));
-    nlSTATIC_ASSERT_PRINT(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
+    nlSTATIC_ASSERT_PRINT(sizeof(context->mOpaque) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
+    return reinterpret_cast<Spake2p_Context *>(context->mOpaque);
 }
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal(void)
@@ -556,7 +558,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal(void)
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
 
-    Spake2p_Context * context = reinterpret_cast<Spake2p_Context *>(mSpake2pContext);
+    Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
     memset(context, 0, sizeof(Spake2p_Context));
     mbedtls_ecp_group_init(&context->curve);
@@ -604,7 +606,7 @@ exit:
 
 void Spake2p_P256_SHA256_HKDF_HMAC::FreeImpl(void)
 {
-    Spake2p_Context * context = reinterpret_cast<Spake2p_Context *>(mSpake2pContext);
+    Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
     mbedtls_ecp_point_free(&context->M);
     mbedtls_ecp_point_free(&context->N);
@@ -631,7 +633,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::Mac(const unsigned char * key, size_t 
     mbedtls_md_context_t hmac_ctx;
     mbedtls_md_init(&hmac_ctx);
 
-    Spake2p_Context * context = reinterpret_cast<Spake2p_Context *>(mSpake2pContext);
+    Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
     result = mbedtls_md_setup(&hmac_ctx, context->md_info, 1);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
@@ -723,7 +725,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::FEGenerate(void * fe)
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
 
-    Spake2p_Context * context = reinterpret_cast<Spake2p_Context *>(mSpake2pContext);
+    Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
     result = mbedtls_ecp_gen_privkey(&context->curve, (mbedtls_mpi *) fe, ECDSA_sign_rng, nullptr);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
@@ -751,7 +753,7 @@ exit:
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointLoad(const unsigned char * in, size_t in_len, void * R)
 {
-    Spake2p_Context * context = reinterpret_cast<Spake2p_Context *>(mSpake2pContext);
+    Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
     if (mbedtls_ecp_point_read_binary(&context->curve, (mbedtls_ecp_point *) R, in, in_len) != 0)
     {
@@ -766,7 +768,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointWrite(const void * R, unsigned ch
     memset(out, 0, out_len);
     size_t mbedtls_out_len = out_len;
 
-    Spake2p_Context * context = reinterpret_cast<Spake2p_Context *>(mSpake2pContext);
+    Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
     if (mbedtls_ecp_point_write_binary(&context->curve, (const mbedtls_ecp_point *) R, MBEDTLS_ECP_PF_UNCOMPRESSED,
                                        &mbedtls_out_len, out, out_len) != 0)
@@ -779,7 +781,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointWrite(const void * R, unsigned ch
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointMul(void * R, const void * P1, const void * fe1)
 {
-    Spake2p_Context * context = reinterpret_cast<Spake2p_Context *>(mSpake2pContext);
+    Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
     if (mbedtls_ecp_mul(&context->curve, (mbedtls_ecp_point *) R, (const mbedtls_mpi *) fe1, (const mbedtls_ecp_point *) P1,
                         ECDSA_sign_rng, nullptr) != 0)
@@ -793,7 +795,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointMul(void * R, const void * P1, co
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointAddMul(void * R, const void * P1, const void * fe1, const void * P2,
                                                       const void * fe2)
 {
-    Spake2p_Context * context = reinterpret_cast<Spake2p_Context *>(mSpake2pContext);
+    Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
     if (mbedtls_ecp_muladd(&context->curve, (mbedtls_ecp_point *) R, (const mbedtls_mpi *) fe1, (const mbedtls_ecp_point *) P1,
                            (const mbedtls_mpi *) fe2, (const mbedtls_ecp_point *) P2) != 0)
@@ -807,7 +809,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointAddMul(void * R, const void * P1,
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointInvert(void * R)
 {
     mbedtls_ecp_point * Rp    = (mbedtls_ecp_point *) R;
-    Spake2p_Context * context = reinterpret_cast<Spake2p_Context *>(mSpake2pContext);
+    Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
     if (mbedtls_mpi_sub_mpi(&Rp->Y, &context->curve.P, &Rp->Y) != 0)
     {
@@ -864,7 +866,7 @@ exit:
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointIsValid(void * R)
 {
-    Spake2p_Context * context = reinterpret_cast<Spake2p_Context *>(mSpake2pContext);
+    Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
     if (mbedtls_ecp_check_pubkey(&context->curve, (mbedtls_ecp_point *) R) != 0)
     {

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -544,7 +544,8 @@ typedef struct Spake2p_Context
     mbedtls_mpi tempbn;
 } Spake2p_Context;
 
-Spake2p_P256_SHA256_HKDF_HMAC::Spake2p_P256_SHA256_HKDF_HMAC(void) : Spake2p(kP256_FE_Length, kP256_Point_Length, kSHA256_Hash_Length)
+Spake2p_P256_SHA256_HKDF_HMAC::Spake2p_P256_SHA256_HKDF_HMAC(void) :
+    Spake2p(kP256_FE_Length, kP256_Point_Length, kSHA256_Hash_Length)
 {
     memset(mSpake2pContext, 0, sizeof(mSpake2pContext));
     nlSTATIC_ASSERT_PRINT(sizeof(mSpake2pContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -181,7 +181,7 @@ Hash_SHA256_stream::Hash_SHA256_stream(void) {}
 
 Hash_SHA256_stream::~Hash_SHA256_stream(void) {}
 
-static inline mbedtls_sha256_context* to_inner_hash_sha256_context(HashSHA256OpaqueContext* context)
+static inline mbedtls_sha256_context * to_inner_hash_sha256_context(HashSHA256OpaqueContext * context)
 {
     nlSTATIC_ASSERT_PRINT(sizeof(context->mOpaque) >= sizeof(mbedtls_sha256_context), "Need more memory for SHA256 Context");
     return reinterpret_cast<mbedtls_sha256_context *>(context->mOpaque);
@@ -547,7 +547,7 @@ typedef struct Spake2p_Context
     mbedtls_mpi tempbn;
 } Spake2p_Context;
 
-static inline Spake2p_Context* to_inner_spake2p_context(Spake2pOpaqueContext* context)
+static inline Spake2p_Context * to_inner_spake2p_context(Spake2pOpaqueContext * context)
 {
     nlSTATIC_ASSERT_PRINT(sizeof(context->mOpaque) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
     return reinterpret_cast<Spake2p_Context *>(context->mOpaque);

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -1177,10 +1177,10 @@ static void TestSPAKE2P_RFC(nlTestSuite * inSuite, void * inContext)
 
     int numOfTestVectors = ArraySize(rfc_tvs);
     int numOfTestsRan    = 0;
-    //static_assert(sizeof(Spake2p_Context) < 1024, "Allocate more bytes for Spake2p Context");
-    //printf("Sizeof spake2pcontext %lu\n", sizeof(Spake2p_Context));
-    //printf("Sizeof mbedtls_sha256_context %lu\n", sizeof(mbedtls_sha256_context));
-    //printf("Sizeof SHA256_CTX %lu\n", sizeof(SHA256_CTX));
+    // static_assert(sizeof(Spake2p_Context) < 1024, "Allocate more bytes for Spake2p Context");
+    // printf("Sizeof spake2pcontext %lu\n", sizeof(Spake2p_Context));
+    // printf("Sizeof mbedtls_sha256_context %lu\n", sizeof(mbedtls_sha256_context));
+    // printf("Sizeof SHA256_CTX %lu\n", sizeof(SHA256_CTX));
     for (int vectorIndex = 0; vectorIndex < numOfTestVectors; vectorIndex++)
     {
         const struct spake2p_rfc_tv * vector = rfc_tvs[vectorIndex];

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -1157,7 +1157,7 @@ private:
 
 static void TestSPAKE2P_RFC(nlTestSuite * inSuite, void * inContext)
 {
-    CHIP_ERROR error;
+    CHIP_ERROR error = CHIP_NO_ERROR;
     unsigned char L[kMAX_Point_Length];
     size_t L_len = sizeof(L);
     unsigned char Z[kMAX_Point_Length];
@@ -1177,6 +1177,10 @@ static void TestSPAKE2P_RFC(nlTestSuite * inSuite, void * inContext)
 
     int numOfTestVectors = ArraySize(rfc_tvs);
     int numOfTestsRan    = 0;
+    //static_assert(sizeof(Spake2p_Context) < 1024, "Allocate more bytes for Spake2p Context");
+    //printf("Sizeof spake2pcontext %lu\n", sizeof(Spake2p_Context));
+    //printf("Sizeof mbedtls_sha256_context %lu\n", sizeof(mbedtls_sha256_context));
+    //printf("Sizeof SHA256_CTX %lu\n", sizeof(SHA256_CTX));
     for (int vectorIndex = 0; vectorIndex < numOfTestVectors; vectorIndex++)
     {
         const struct spake2p_rfc_tv * vector = rfc_tvs[vectorIndex];

--- a/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
@@ -454,7 +454,6 @@
 					"CHIP_DEVICE_LAYER_TARGET_LINUX=0",
 					"CHIP_DEVICE_LAYER_TARGET_NRF5=0",
 					"CHIP_DEVICE_LAYER_TARGET_EFR32=0",
-					CHIP_CRYPTO_MBEDTLS,
 					"CHIP_SYSTEM_CONFIG_USE_SOCKETS=1",
 					"$(inherited)",
 				);
@@ -464,7 +463,6 @@
 					"$(CHIP_ROOT)/src/lib",
 					"$(CHIP_ROOT)/config/standalone",
 					"$(CHIP_ROOT)/third_party/nlassert/repo/include",
-					"$(CHIP_ROOT)/third_party/mbedtls/repo/include",
 				);
 				INFOPLIST_FILE = CHIP/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -513,7 +511,6 @@
 					"CHIP_DEVICE_LAYER_TARGET_LINUX=0",
 					"CHIP_DEVICE_LAYER_TARGET_NRF5=0",
 					"CHIP_DEVICE_LAYER_TARGET_EFR32=0",
-					CHIP_CRYPTO_MBEDTLS,
 					"CHIP_SYSTEM_CONFIG_USE_SOCKETS=1",
 					"$(inherited)",
 				);
@@ -524,7 +521,6 @@
 					"$(CHIP_ROOT)/src/app",
 					"$(CHIP_ROOT)/config/standalone",
 					"$(CHIP_ROOT)/third_party/nlassert/repo/include",
-					"$(CHIP_ROOT)/third_party/mbedtls/repo/include",
 				);
 				INFOPLIST_FILE = CHIP/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -669,7 +665,6 @@
 					"CHIP_DEVICE_LAYER_TARGET_LINUX=0",
 					"CHIP_DEVICE_LAYER_TARGET_NRF5=0",
 					"CHIP_DEVICE_LAYER_TARGET_EFR32=0",
-					CHIP_CRYPTO_MBEDTLS,
 					"CHIP_SYSTEM_CONFIG_USE_SOCKETS=1",
 					"$(inherited)",
 				);
@@ -680,7 +675,6 @@
 					"$(CHIP_ROOT)/src/app",
 					"$(CHIP_ROOT)/config/ios",
 					"$(CHIP_ROOT)/third_party/nlassert/repo/include",
-					"$(CHIP_ROOT)/third_party/mbedtls/repo/include",
 				);
 				INFOPLIST_FILE = CHIP/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -806,7 +800,6 @@
 					"CHIP_DEVICE_LAYER_TARGET_LINUX=0",
 					"CHIP_DEVICE_LAYER_TARGET_NRF5=0",
 					"CHIP_DEVICE_LAYER_TARGET_EFR32=0",
-					CHIP_CRYPTO_MBEDTLS,
 					"CHIP_SYSTEM_CONFIG_USE_SOCKETS=1",
 					"$(inherited)",
 				);
@@ -817,7 +810,6 @@
 					"$(CHIP_ROOT)/src/app",
 					"$(CHIP_ROOT)/config/ios",
 					"$(CHIP_ROOT)/third_party/nlassert/repo/include",
-					"$(CHIP_ROOT)/third_party/mbedtls/repo/include",
 				);
 				INFOPLIST_FILE = CHIP/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";


### PR DESCRIPTION
 #### Problem
CHIPCryptoPal.h includes headers from underlying implementations (OpenSSL, mbedTLS). This requires the code at upper layers to be aware of which crypto implementation is being used, and requires it to specify include paths (e.g. iOS framework project file has to point to mbedTLS header file location).

 #### Summary of Changes
Move implementation specific code to individual implementation source code. The interface has opaque types for the context, and the size of context is checked via `static_assert` in each implementation file.

fixes #2284 