### PR TITLE
Remove build flag CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING since RMP is …

### DIFF
--- a/src/lib/core/BUILD.gn
+++ b/src/lib/core/BUILD.gn
@@ -63,7 +63,6 @@ buildconfig_header("chip_buildconfig") {
     "HAVE_NEW=false",
     "CHIP_CONFIG_MEMORY_MGMT_SIMPLE=${chip_config_memory_management_simple}",
     "CHIP_CONFIG_MEMORY_MGMT_PLATFORM=${chip_config_memory_management_platform}",
-    "CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING=true",
     "CHIP_CONFIG_PROVIDE_OBSOLESCENT_INTERFACES=false",
   ]
 }

--- a/src/lib/message/CHIPBinding.cpp
+++ b/src/lib/message/CHIPBinding.cpp
@@ -444,8 +444,8 @@ void Binding::ResetConfig()
 
     mTransportOption            = kTransport_NotSpecified;
     mDefaultResponseTimeoutMsec = 0;
-    mDefaultRMPConfig = gDefaultRMPConfig;
-    mUDPPathMTU = CHIP_CONFIG_DEFAULT_UDP_MTU_SIZE;
+    mDefaultRMPConfig           = gDefaultRMPConfig;
+    mUDPPathMTU                 = CHIP_CONFIG_DEFAULT_UDP_MTU_SIZE;
 
     mSecurityOption = kSecurityOption_NotSpecified;
     mKeyId          = ChipKeyId::kNone;

--- a/src/lib/message/CHIPBinding.cpp
+++ b/src/lib/message/CHIPBinding.cpp
@@ -444,9 +444,7 @@ void Binding::ResetConfig()
 
     mTransportOption            = kTransport_NotSpecified;
     mDefaultResponseTimeoutMsec = 0;
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     mDefaultRMPConfig = gDefaultRMPConfig;
-#endif
     mUDPPathMTU = CHIP_CONFIG_DEFAULT_UDP_MTU_SIZE;
 
     mSecurityOption = kSecurityOption_NotSpecified;
@@ -1217,8 +1215,6 @@ CHIP_ERROR Binding::NewExchangeContext(chip::ExchangeContext *& appExchangeConte
     appExchangeContext = mExchangeManager->NewContext(mPeerNodeId, mPeerAddress, mPeerPort, mInterfaceId, NULL);
     VerifyOrExit(NULL != appExchangeContext, err = CHIP_ERROR_NO_MEMORY);
 
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
-
     // Set the default RMP configuration in the new exchange.
     appExchangeContext->mRMPConfig = mDefaultRMPConfig;
 
@@ -1229,8 +1225,6 @@ CHIP_ERROR Binding::NewExchangeContext(chip::ExchangeContext *& appExchangeConte
         // include a request for acknowledgment.
         appExchangeContext->SetAutoRequestAck(true);
     }
-
-#endif // CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
 
     // If using a connection-oriented transport...
     if (mTransportOption == kTransport_TCP || mTransportOption == kTransport_ExistingConnection)
@@ -1531,11 +1525,7 @@ Binding::Configuration & Binding::Configuration::Transport_UDP()
  */
 Binding::Configuration & Binding::Configuration::Transport_UDP_RMP()
 {
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     mBinding.mTransportOption = kTransport_UDP_RMP;
-#else  // CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
-    mError = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     return *this;
 }
 
@@ -1562,12 +1552,7 @@ Binding::Configuration & Binding::Configuration::Transport_UDP_PathMTU(uint32_t 
  */
 Binding::Configuration & Binding::Configuration::Transport_DefaultRMPConfig(const chip::RMPConfig & aRMPConfig)
 {
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     mBinding.mDefaultRMPConfig = aRMPConfig;
-#else  // CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
-    IgnoreUnusedVariable(aRMPConfig);
-    mError = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     return *this;
 }
 
@@ -1840,11 +1825,7 @@ Binding::Configuration & Binding::Configuration::ConfigureFromMessage(const chip
     {
         if (aMsgInfo->Flags & kChipMessageFlag_PeerRequestedAck)
         {
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
             Transport_UDP_RMP();
-#else
-            mError = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // #if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
         }
         else
         {

--- a/src/lib/message/CHIPBinding.h
+++ b/src/lib/message/CHIPBinding.h
@@ -189,10 +189,8 @@ public:
     uint8_t GetEncryptionType(void) const;
     uint32_t GetDefaultResponseTimeout() const;
     void SetDefaultResponseTimeout(uint32_t msec);
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     const RMPConfig & GetDefaultRMPConfig(void) const;
     void SetDefaultRMPConfig(const RMPConfig & RMPConfig);
-#endif // #if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     EventCallback GetEventCallback() const;
     void SetEventCallback(EventCallback aEventCallback);
     ChipConnection * GetConnection() const;
@@ -294,9 +292,7 @@ private:
     ChipConnection * mCon;
     uint32_t mDefaultResponseTimeoutMsec;
     uint32_t mUDPPathMTU;
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     RMPConfig mDefaultRMPConfig;
-#endif
     uint8_t mHostNameLen;
 
     // Security-specific configuration
@@ -520,8 +516,6 @@ inline void Binding::SetDefaultResponseTimeout(uint32_t timeout)
     mDefaultResponseTimeoutMsec = timeout;
 }
 
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
-
 inline const RMPConfig & Binding::GetDefaultRMPConfig(void) const
 {
     return mDefaultRMPConfig;
@@ -531,8 +525,6 @@ inline void Binding::SetDefaultRMPConfig(const RMPConfig & aRMPConfig)
 {
     mDefaultRMPConfig = aRMPConfig;
 }
-
-#endif // #if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
 
 inline Binding::EventCallback Binding::GetEventCallback() const
 {

--- a/src/lib/message/CHIPExchangeMgr.cpp
+++ b/src/lib/message/CHIPExchangeMgr.cpp
@@ -102,8 +102,6 @@ CHIP_ERROR ChipExchangeManager::Init(ChipMessageLayer * msgLayer)
     msgLayer->ExchangeMgr       = this;
     msgLayer->OnMessageReceived = HandleMessageReceived;
     msgLayer->OnAcceptError     = HandleAcceptError;
-
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     mRMPTimerInterval = CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD; // CRMP Timer tick period
 
     memset(RetransTable, 0, sizeof(RetransTable));
@@ -111,7 +109,6 @@ CHIP_ERROR ChipExchangeManager::Init(ChipMessageLayer * msgLayer)
     mRMPTimeStampBase = System::Timer::GetCurrentEpoch();
 
     mRMPCurrentTimerExpiry = 0;
-#endif
 
     State = kState_Initialized;
 
@@ -141,7 +138,7 @@ CHIP_ERROR ChipExchangeManager::Shutdown()
             MessageLayer->OnMessageReceived = NULL;
             MessageLayer->OnAcceptError     = NULL;
         }
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
+
         RMPStopTimer();
 
         // Clear the retransmit table
@@ -149,7 +146,7 @@ CHIP_ERROR ChipExchangeManager::Shutdown()
         {
             ClearRetransmitTable(RetransTable[i]);
         }
-#endif
+
         MessageLayer = NULL;
     }
 
@@ -230,7 +227,6 @@ ExchangeContext * ChipExchangeManager::NewContext(const uint64_t & peerNodeId, c
         ec->SetInitiator(true);
         // Initialize RMP variables
         ec->mMsgProtocolVersion = 0;
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
         // No need to set RMP timer, this will be done when we add to retrans table
         ec->mRMPNextAckTime = 0;
         ec->SetAckPending(false);
@@ -244,7 +240,6 @@ ExchangeContext * ChipExchangeManager::NewContext(const uint64_t & peerNodeId, c
         ec->OnDDRcvd       = NULL;
         ec->OnAckRcvd      = NULL;
         ec->OnSendError    = NULL;
-#endif
 #if CHIP_CONFIG_ENABLE_EPHEMERAL_UDP_PORT
         ec->SetUseEphemeralUDPPort(MessageLayer->EphemeralUDPPortEnabled());
 #endif // CHIP_CONFIG_ENABLE_EPHEMERAL_UDP_PORT
@@ -581,7 +576,6 @@ ExchangeContext * ChipExchangeManager::AllocContext()
     return NULL;
 }
 
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
 void ChipExchangeManager::RMPProcessDDMessage(uint32_t PauseTimeMillis, uint64_t DelayedNodeId)
 {
     // Expire any virtual ticks that have expired so all wakeup sources reflect the current time
@@ -617,7 +611,6 @@ void ChipExchangeManager::RMPProcessDDMessage(uint32_t PauseTimeMillis, uint64_t
     // Schedule next physical wakeup
     RMPStartTimer();
 }
-#endif // CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
 
 static void DefaultOnMessageReceived(ExchangeContext * ec, const IPPacketInfo * pktInfo, const ChipMessageInfo * msgInfo,
                                      uint32_t profileId, uint8_t msgType, PacketBuffer * payload)
@@ -635,14 +628,12 @@ void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffe
     UnsolicitedMessageHandler * matchingUMH = NULL;
     ExchangeContext * ec                    = NULL;
     ChipConnection * msgCon                 = NULL;
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     const uint8_t * p        = NULL;
     uint32_t PauseTimeMillis = 0;
     uint64_t DelayedNodeId   = 0;
     bool dupMsg;
     bool msgNeedsAck;
     bool sendAckAndCloseExchange;
-#endif
 #if CHIP_CONFIG_USE_APP_GROUP_KEYS_FOR_MSG_ENC
     bool isMsgCounterSyncResp;
     bool peerGroupMsgIdNotSynchronized;
@@ -688,10 +679,8 @@ void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffe
     {
         MessageLayer->SecurityMgr->SendMsgCounterSyncResp(msgInfo, msgInfo->InPacketInfo);
 
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
         // Retransmit all pending messages that were encrypted with application group key.
         RetransPendingAppGroupMsgs(msgInfo->SourceNodeId);
-#endif
     }
     // Otherwise, if received message is not MsgCounterSyncResp and peer's message counter synchronization is needed.
     else if (!isMsgCounterSyncResp && peerGroupMsgIdNotSynchronized)
@@ -706,7 +695,6 @@ void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffe
     }
 #endif // CHIP_CONFIG_USE_APP_GROUP_KEYS_FOR_MSG_ENC
 
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     // Received Delayed Delivery Message: Extend time for pending retrans objects
     if (exchangeHeader.ProfileId == chip::Protocols::kChipProtocol_Common &&
         exchangeHeader.MessageType == chip::Protocols::Common::kMsgType_RMP_Delayed_Delivery)
@@ -725,7 +713,6 @@ void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffe
         // Return after processing Delayed Delivery message
         ExitNow(err = CHIP_NO_ERROR);
     } // If delayed delivery Msg
-#endif
 
     // Search for an existing exchange that the message applies to. If a match is found...
     ec = (ExchangeContext *) ContextPool;
@@ -733,14 +720,12 @@ void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffe
     {
         if (ec->ExchangeMgr != NULL && ec->MatchExchange(msgCon, msgInfo, &exchangeHeader))
         {
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
             // Found a matching exchange. Set flag for correct subsequent RMP
             // retransmission timeout selection.
             if (!ec->HasRcvdMsgFromPeer())
             {
                 ec->SetMsgRcvdFromPeer(true);
             }
-#endif
 
             // Matched ExchangeContext; send to message handler.
             ec->HandleMessage(msgInfo, &exchangeHeader, msgBuf);
@@ -751,11 +736,9 @@ void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffe
         }
     }
 
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     // Is message a duplicate that needs ack.
     msgNeedsAck = exchangeHeader.Flags & kChipExchangeFlag_NeedsAck;
     dupMsg      = (msgInfo->Flags & kChipMessageFlag_DuplicateMessage);
-#endif
 
     // Search for an unsolicited message handler if it marked as being sent by an initiator. Since we didn't
     // find an existing exchange that matches the message, it must be an unsolicited message. However all
@@ -786,9 +769,7 @@ void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffe
     // that needs to send ack to the peer.
     else
     {
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
         if (!msgNeedsAck)
-#endif
             ExitNow(err = CHIP_ERROR_UNSOLICITED_MSG_NO_ORIGINATOR);
     }
 
@@ -803,8 +784,6 @@ void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffe
     //       Y      |     N    |    -    |     N     | Create EC, ec->HandleMessage() sends Dup ack; Close EC.
     //       N      |     Y    |    -    |     -     | Create EC, ec->HandleMessage() sends ack (if needed) and App callback.
     //       N      |     N    |    -    |     -     | Do nothing.
-
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     // Create new exchange to send ack for a duplicate message and then close this exchange.
     sendAckAndCloseExchange = msgNeedsAck && (matchingUMH == NULL || (dupMsg && !matchingUMH->AllowDuplicateMsgs));
 
@@ -813,14 +792,9 @@ void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffe
     if (peerGroupMsgIdNotSynchronized)
         sendAckAndCloseExchange = false;
 #endif
-#endif
 
     // If we found a handler or we need to open a new exchange to send ack for a duplicate message.
-    if (matchingUMH != NULL
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
-        || sendAckAndCloseExchange
-#endif
-    )
+    if (matchingUMH != NULL || sendAckAndCloseExchange)
     {
         ExchangeContext::MessageReceiveFunct umhandler = NULL;
 
@@ -850,7 +824,6 @@ void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffe
         }
         ec->EncryptionType = msgInfo->EncryptionType;
         ec->KeyId          = msgInfo->KeyId;
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
         // No need to set RMP timer, this will be done when we add to retrans table
         ec->mRMPNextAckTime = 0;
         ec->SetAckPending(false);
@@ -859,15 +832,12 @@ void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffe
         ec->mRMPThrottleTimeout = 0;
         // Internal and for Debug Only; When set, Exchange Layer does not send Ack.
         ec->SetDropAck(false);
-#endif
 
         // Set the ExchangeContext version from the Message header version
         ec->mMsgProtocolVersion = msgInfo->MessageVersion;
 
         // If UMH was found and the exchange is created not just for sending ack.
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
         if (!sendAckAndCloseExchange)
-#endif
         {
             umhandler = matchingUMH->Handler;
 
@@ -878,7 +848,6 @@ void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffe
 
             ChipLogProgress(ExchangeManager, "ec id: %d, AppState: 0x%x", EXCHANGE_CONTEXT_ID(ec - ContextPool), ec->AppState);
         }
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
         // If the exchange is created only to send ack.
         else
         {
@@ -886,7 +855,6 @@ void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffe
             // If rcvd msg is not from initiator then this exchange is created as Initiator (argument to SetInitiator() is true).
             ec->SetInitiator((exchangeHeader.Flags & kChipExchangeFlag_Initiator) == 0);
         }
-#endif
 
         // If support for ephemeral UDP ports is enabled, arrange to send outbound messages on this exchange from the
         // local ephemeral UDP port IF the inbound message that initiated the exchange was sent TO the local ephemeral port.
@@ -903,11 +871,9 @@ void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffe
         ec->HandleMessage(msgInfo, &exchangeHeader, msgBuf, umhandler);
         msgBuf = NULL;
 
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
         // Close exchange if it was created only to send ack for a duplicate message.
         if (sendAckAndCloseExchange)
             ec->Close();
-#endif
     }
 
 exit:
@@ -998,13 +964,11 @@ CHIP_ERROR ChipExchangeManager::PrependHeader(ChipExchangeHeader * exchangeHeade
     if (exchangeHeader->Version != kChipExchangeVersion_V1)
         ExitNow(err = CHIP_ERROR_UNSUPPORTED_EXCHANGE_VERSION);
 
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     // Compute the Header Len
     if (exchangeHeader->Flags & kChipExchangeFlag_AckId)
     {
         headLen += 4;
     }
-#endif
 
     p = buf->Start();
 
@@ -1020,12 +984,10 @@ CHIP_ERROR ChipExchangeManager::PrependHeader(ChipExchangeHeader * exchangeHeade
     LittleEndian::Write16(p, exchangeHeader->ExchangeId);
     LittleEndian::Write32(p, exchangeHeader->ProfileId);
 
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     if (exchangeHeader->Flags & kChipExchangeFlag_AckId)
     {
         LittleEndian::Write32(p, exchangeHeader->AckMsgId);
     }
-#endif
 
     CHIP_FAULT_INJECT_MAX_ARG(
         FaultInjection::kFault_FuzzExchangeHeaderTx,
@@ -1054,10 +1016,8 @@ CHIP_ERROR ChipExchangeManager::DecodeHeader(ChipExchangeHeader * exchangeHeader
 
     uint8_t * p = NULL;
     uint8_t versionFlags;
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     uint16_t msgLen  = buf->DataLength();
     uint8_t * msgEnd = buf->Start() + msgLen;
-#endif
 
     if (buf->DataLength() < 8)
         ExitNow(err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
@@ -1077,14 +1037,12 @@ CHIP_ERROR ChipExchangeManager::DecodeHeader(ChipExchangeHeader * exchangeHeader
 
     exchangeHeader->ProfileId = LittleEndian::Read32(p);
 
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     if ((exchangeHeader->Flags & kChipExchangeFlag_AckId))
     {
         if ((p + 4) > msgEnd)
             ExitNow(err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
         exchangeHeader->AckMsgId = LittleEndian::Read32(p);
     }
-#endif
 
     buf->SetStart(p);
 
@@ -1124,22 +1082,18 @@ void ChipExchangeManager::NotifyKeyFailed(uint64_t peerNodeId, uint16_t keyId, C
     {
         if (ec->ExchangeMgr != NULL && ec->KeyId == keyId && ec->PeerNodeId == peerNodeId)
         {
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
             // Ensure the exchange context stays around until we're done with it.
             ec->AddRef();
 
             // Fail entries matching ec.
             FailRetransmitTableEntries(ec, keyErr);
-#endif
 
             // Application callback function in key error case.
             if (ec->OnKeyError)
                 ec->OnKeyError(ec, keyErr);
 
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
             // Release reference to the exchange context.
             ec->Release();
-#endif
         }
     }
 
@@ -1164,7 +1118,6 @@ void ChipExchangeManager::NotifySecurityManagerAvailable()
     }
 }
 
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
 /**
  *  Clear MsgCounterSyncReq flag for all pending messages to that peer.
  *
@@ -1803,7 +1756,6 @@ void ChipExchangeManager::RMPStopTimer()
 {
     MessageLayer->SystemLayer->CancelTimer(RMPTimeout, this);
 }
-#endif // CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
 
 /**
  *  Initialize the shared pool of Bindings.

--- a/src/lib/message/CHIPExchangeMgr.cpp
+++ b/src/lib/message/CHIPExchangeMgr.cpp
@@ -102,7 +102,7 @@ CHIP_ERROR ChipExchangeManager::Init(ChipMessageLayer * msgLayer)
     msgLayer->ExchangeMgr       = this;
     msgLayer->OnMessageReceived = HandleMessageReceived;
     msgLayer->OnAcceptError     = HandleAcceptError;
-    mRMPTimerInterval = CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD; // CRMP Timer tick period
+    mRMPTimerInterval           = CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD; // CRMP Timer tick period
 
     memset(RetransTable, 0, sizeof(RetransTable));
 
@@ -628,9 +628,9 @@ void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffe
     UnsolicitedMessageHandler * matchingUMH = NULL;
     ExchangeContext * ec                    = NULL;
     ChipConnection * msgCon                 = NULL;
-    const uint8_t * p        = NULL;
-    uint32_t PauseTimeMillis = 0;
-    uint64_t DelayedNodeId   = 0;
+    const uint8_t * p                       = NULL;
+    uint32_t PauseTimeMillis                = 0;
+    uint64_t DelayedNodeId                  = 0;
     bool dupMsg;
     bool msgNeedsAck;
     bool sendAckAndCloseExchange;

--- a/src/lib/message/CHIPExchangeMgr.h
+++ b/src/lib/message/CHIPExchangeMgr.h
@@ -60,10 +60,8 @@ public:
     uint16_t ExchangeId; /**< The Exchange identifier for the ExchangeContext */
     uint32_t ProfileId;  /**< The Profile identifier of the CHIP message */
     uint8_t MessageType; /**< The Message type for the specified CHIP profile */
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     uint32_t AckMsgId; /**< Optional; Message identifier being acknowledged.
                             Specified when requiring acknowledgments. */
-#endif
 };
 
 /**
@@ -118,9 +116,7 @@ public:
     uint16_t KeyId;           /**< Encryption key to use when sending a message. */
     uint32_t RetransInterval; /**< Time between retransmissions (in milliseconds); 0 disables retransmissions. */
     Timeout ResponseTimeout;  /**< Maximum time to wait for response (in milliseconds); 0 disables response timeout. */
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     RMPConfig mRMPConfig; /**< RMP configuration. */
-#endif
     enum
     {
         kSendFlag_AutoRetrans    = 0x0001, /**< Used to indicate that automatic retransmission is enabled. */
@@ -144,7 +140,6 @@ public:
     bool IsResponseExpected(void) const;
     void SetInitiator(bool inInitiator);
     void SetConnectionClosed(bool inConnectionClosed);
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     bool ShouldDropAck(void) const;
     bool IsAckPending(void) const;
     void SetDropAck(bool inDropAck);
@@ -155,7 +150,6 @@ public:
     void SetMsgRcvdFromPeer(bool inMsgRcvdFromPeer);
     CHIP_ERROR RMPFlushAcks(void);
     uint32_t GetCurrentRetransmitTimeout(void);
-#endif
     void SetResponseExpected(bool inResponseExpected);
     bool AutoRequestAck() const;
     void SetAutoRequestAck(bool autoReqAck);
@@ -248,7 +242,6 @@ public:
 
     void CancelRetrans(void);
 
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     CHIP_ERROR RMPSendThrottleFlow(uint32_t PauseTimeMillis);
     CHIP_ERROR RMPSendDelayedDelivery(uint32_t PauseTimeMillis, uint64_t DelayedNodeId);
 
@@ -296,7 +289,6 @@ public:
     RMPPauseRcvdFunct OnDDRcvd;       /**< Application callback for received Delayed Delivery message. */
     RMPSendErrorFunct OnSendError;    /**< Application callback for error while sending. */
     RMPAckRcvdFunct OnAckRcvd;        /**< Application callback for received acknowledgment. */
-#endif                                // CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
 
     /*
      * in order to use reference counting (see refCount below)
@@ -332,22 +324,18 @@ private:
     static void HandleResponseTimeout(System::Layer * aSystemLayer, void * aAppState, System::Error aError);
 
     uint32_t mPendingPeerAckId;
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     uint16_t mRMPNextAckTime;     // Next time for triggering Solo Ack
     uint16_t mRMPThrottleTimeout; // Timeout until when Throttle is On when RMPThrottleEnabled is set
-#endif
     void DoClose(bool clearRetransTable);
     CHIP_ERROR HandleMessage(ChipMessageInfo * msgInfo, const ChipExchangeHeader * exchHeader, PacketBuffer * msgBuf);
     CHIP_ERROR HandleMessage(ChipMessageInfo * msgInfo, const ChipExchangeHeader * exchHeader, PacketBuffer * msgBuf,
                              ExchangeContext::MessageReceiveFunct umhandler);
     void HandleConnectionClosed(CHIP_ERROR conErr);
 
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     bool RMPCheckAndRemRetransTable(uint32_t msgId, void ** rCtxt);
     CHIP_ERROR RMPHandleRcvdAck(const ChipExchangeHeader * exchHeader, const ChipMessageInfo * msgInfo);
     CHIP_ERROR RMPHandleNeedsAck(const ChipMessageInfo * msgInfo);
     CHIP_ERROR HandleThrottleFlow(uint32_t PauseTimeMillis);
-#endif
 
     uint8_t mRefCount;
 };
@@ -418,14 +406,10 @@ public:
     CHIP_ERROR UnregisterUnsolicitedMessageHandler(uint32_t profileId, uint8_t msgType, ChipConnection * con);
 
     void AllowUnsolicitedMessages(ChipConnection * con);
-
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     void ClearMsgCounterSyncReq(uint64_t peerNodeId);
-#endif
 
 private:
     uint16_t NextExchangeId;
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     uint64_t mRMPTimeStampBase;                  // RMP timer base value to add offsets to evaluate timeouts
     System::Timer::Epoch mRMPCurrentTimerExpiry; // Tracks when the RMP timer will next expire
     uint16_t mRMPTimerInterval;                  // RMP Timer tick period
@@ -470,7 +454,6 @@ private:
 
     // RMP Global tables for timer context
     RetransTableEntry RetransTable[CHIP_CONFIG_RMP_RETRANS_TABLE_SIZE];
-#endif // CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
 
     class UnsolicitedMessageHandler
     {

--- a/src/lib/message/CHIPExchangeMgr.h
+++ b/src/lib/message/CHIPExchangeMgr.h
@@ -60,8 +60,8 @@ public:
     uint16_t ExchangeId; /**< The Exchange identifier for the ExchangeContext */
     uint32_t ProfileId;  /**< The Profile identifier of the CHIP message */
     uint8_t MessageType; /**< The Message type for the specified CHIP profile */
-    uint32_t AckMsgId; /**< Optional; Message identifier being acknowledged.
-                            Specified when requiring acknowledgments. */
+    uint32_t AckMsgId;   /**< Optional; Message identifier being acknowledged.
+                              Specified when requiring acknowledgments. */
 };
 
 /**
@@ -116,7 +116,7 @@ public:
     uint16_t KeyId;           /**< Encryption key to use when sending a message. */
     uint32_t RetransInterval; /**< Time between retransmissions (in milliseconds); 0 disables retransmissions. */
     Timeout ResponseTimeout;  /**< Maximum time to wait for response (in milliseconds); 0 disables response timeout. */
-    RMPConfig mRMPConfig; /**< RMP configuration. */
+    RMPConfig mRMPConfig;     /**< RMP configuration. */
     enum
     {
         kSendFlag_AutoRetrans    = 0x0001, /**< Used to indicate that automatic retransmission is enabled. */

--- a/src/lib/message/CHIPFabricState.cpp
+++ b/src/lib/message/CHIPFabricState.cpp
@@ -1067,10 +1067,8 @@ void ChipFabricState::OnMsgCounterSyncRespRcvd(uint64_t peerNodeId, uint32_t pee
             PeerStates.GroupKeyRcvFlags[peerIndex]     = ChipSessionState::kReceiveFlags_MessageIdSynchronized;
             PeerStates.MaxGroupKeyMsgIdRcvd[peerIndex] = peerMsgId;
 
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
             // Clear MsgCounterSyncReq flag for all pending messages to that peer.
             MessageLayer->ExchangeMgr->ClearMsgCounterSyncReq(peerNodeId);
-#endif
         }
     }
 

--- a/src/lib/message/CHIPRMPConfig.h
+++ b/src/lib/message/CHIPRMPConfig.h
@@ -31,18 +31,6 @@ namespace chip {
 // clang-format off
 
 /**
- *  @def CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
- *
- *  @brief
- *    If set to (1), use of the RMP implementation is
- *    enabled. Default value is (1) or enabled.
- *
- */
-#ifndef CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
-#define CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING              1
-#endif // CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
-
-/**
  *  @def CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD
  *
  *  @brief

--- a/src/lib/message/CHIPSecurityMgr.cpp
+++ b/src/lib/message/CHIPSecurityMgr.cpp
@@ -151,9 +151,7 @@ void ChipSecurityManager::HandleUnsolicitedMessage(ExchangeContext * ec, const I
         ExitNow(err = CHIP_ERROR_SECURITY_MANAGER_BUSY);
     });
 
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     if (!ec->HasPeerRequestedAck())
-#endif
     {
         // Reject the request if it did not arrive over a connection.
         VerifyOrExit(ec->Con != NULL, err = CHIP_ERROR_INVALID_ARGUMENT);
@@ -433,7 +431,6 @@ CHIP_ERROR ChipSecurityManager::NewSessionExchange(uint64_t peerNodeId, IPAddres
     }
     else
     {
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
         VerifyOrExit(peerNodeId != kNodeIdNotSpecified && peerNodeId != kAnyNodeId, err = CHIP_ERROR_INVALID_ARGUMENT);
 
         mEC = ExchangeManager->NewContext(peerNodeId, peerAddr, peerPort, INET_NULL_INTERFACEID, this);
@@ -441,10 +438,6 @@ CHIP_ERROR ChipSecurityManager::NewSessionExchange(uint64_t peerNodeId, IPAddres
 
         mEC->OnAckRcvd   = RMPHandleAckRcvd;
         mEC->OnSendError = RMPHandleSendError;
-#else
-        // Reject the request if no connection has been specified.
-        ExitNow(err = CHIP_ERROR_INVALID_ARGUMENT);
-#endif
     }
 
 exit:
@@ -741,11 +734,7 @@ CHIP_ERROR ChipSecurityManager::SendStatusReport(CHIP_ERROR localErr, ExchangeCo
     }
     else
     {
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
         sendFlags = ExchangeContext::kSendFlag_RequestAck;
-#else
-        ExitNow(err = CHIP_ERROR_INVALID_ARGUMENT);
-#endif
     }
 
     // TODO: map CASE errors
@@ -925,8 +914,6 @@ void ChipSecurityManager::HandleIdleSessionTimeout(System::Layer * aLayer, void 
     }
 }
 
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
-
 void ChipSecurityManager::RMPHandleAckRcvd(ExchangeContext * ec, void * msgCtxt)
 {
     ChipLogProgress(SecurityManager, "%s", __FUNCTION__);
@@ -939,8 +926,6 @@ void ChipSecurityManager::RMPHandleSendError(ExchangeContext * ec, CHIP_ERROR er
 
     secMgr->HandleSessionError(err, NULL);
 }
-
-#endif // CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
 
 void ChipSecurityManager::AsyncNotifySecurityManagerAvailable()
 {

--- a/src/lib/message/CHIPSecurityMgr.h
+++ b/src/lib/message/CHIPSecurityMgr.h
@@ -209,11 +209,8 @@ private:
     void HandleSessionError(CHIP_ERROR err, PacketBuffer * statusReportMsgBuf);
     static void HandleConnectionClosed(ExchangeContext * ec, ChipConnection * con, CHIP_ERROR conErr);
     static CHIP_ERROR SendStatusReport(CHIP_ERROR localError, ExchangeContext * ec);
-
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     static void RMPHandleAckRcvd(ExchangeContext * ec, void * msgCtxt);
     static void RMPHandleSendError(ExchangeContext * ec, CHIP_ERROR err, void * msgCtxt);
-#endif // CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
 
     void Reset(void);
 

--- a/src/lib/message/ExchangeContext.cpp
+++ b/src/lib/message/ExchangeContext.cpp
@@ -421,8 +421,8 @@ CHIP_ERROR ExchangeContext::SendMessage(uint32_t profileId, uint8_t msgType, Pac
 CHIP_ERROR ExchangeContext::SendMessage(uint32_t profileId, uint8_t msgType, PacketBuffer * msgBuf, uint16_t sendFlags,
                                         ChipMessageInfo * msgInfo, void * msgCtxt)
 {
-    CHIP_ERROR err  = CHIP_NO_ERROR;
-    bool sendCalled = false;
+    CHIP_ERROR err                                 = CHIP_NO_ERROR;
+    bool sendCalled                                = false;
     ChipExchangeManager::RetransTableEntry * entry = NULL;
 
 #if CHIP_RETAIN_LOGGING
@@ -1284,7 +1284,7 @@ CHIP_ERROR ExchangeContext::HandleMessage(ChipMessageInfo * msgInfo, const ChipE
 CHIP_ERROR ExchangeContext::HandleMessage(ChipMessageInfo * msgInfo, const ChipExchangeHeader * exchHeader, PacketBuffer * msgBuf,
                                           ExchangeContext::MessageReceiveFunct umhandler)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    CHIP_ERROR err           = CHIP_NO_ERROR;
     const uint8_t * p        = NULL;
     uint32_t PauseTimeMillis = 0;
 

--- a/src/lib/message/ExchangeContext.cpp
+++ b/src/lib/message/ExchangeContext.cpp
@@ -134,7 +134,6 @@ void ExchangeContext::SetConnectionClosed(bool inConnectionClosed)
     SetFlag(mFlags, static_cast<uint16_t>(kFlagConnectionClosed), inConnectionClosed);
 }
 
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
 /**
  *  Determine whether there is already an acknowledgment pending to be sent
  *  to the peer on this exchange.
@@ -242,7 +241,6 @@ static inline bool IsRMPControlMessage(uint32_t profileId, uint8_t msgType)
             (msgType == chip::Protocols::Common::kMsgType_RMP_Throttle_Flow ||
              msgType == chip::Protocols::Common::kMsgType_RMP_Delayed_Delivery));
 }
-#endif // CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
 
 /**
  *  Set whether a response is expected on this exchange.
@@ -425,9 +423,7 @@ CHIP_ERROR ExchangeContext::SendMessage(uint32_t profileId, uint8_t msgType, Pac
 {
     CHIP_ERROR err  = CHIP_NO_ERROR;
     bool sendCalled = false;
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     ChipExchangeManager::RetransTableEntry * entry = NULL;
-#endif
 
 #if CHIP_RETAIN_LOGGING
     uint16_t payloadLen = msgBuf->DataLength();
@@ -440,8 +436,6 @@ CHIP_ERROR ExchangeContext::SendMessage(uint32_t profileId, uint8_t msgType, Pac
     // originally generated it tries to close it as a result of
     // an error arising below. at the end, we have to close it.
     AddRef();
-
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
 
     // If sending via UDP and the auto-request ACK feature is enabled, automatically
     // request an acknowledgment, UNLESS the NoAutoRequestAck send flag has been specified.
@@ -458,17 +452,6 @@ CHIP_ERROR ExchangeContext::SendMessage(uint32_t profileId, uint8_t msgType, Pac
 
     // Abort early if Throttle is already set;
     VerifyOrExit(mRMPThrottleTimeout == 0, err = CHIP_ERROR_SEND_THROTTLED);
-
-#else // CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
-
-    // If CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING == 0, then
-    // kSendFlag_RequestAck should not be set.
-    if (sendFlags & kSendFlag_RequestAck)
-    {
-        ExitNow(err = CHIP_ERROR_INVALID_ARGUMENT);
-    }
-
-#endif // CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
 
     // Set the Message Protocol Version
     if (kChipMessageVersion_Unspecified == mMsgProtocolVersion)
@@ -540,8 +523,6 @@ CHIP_ERROR ExchangeContext::SendMessage(uint32_t profileId, uint8_t msgType, Pac
     }
     else
     {
-
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
         if (sendFlags & kSendFlag_RequestAck)
         {
             err = ExchangeMgr->MessageLayer->SelectDestNodeIdAndAddress(msgInfo->DestNodeId, PeerAddr);
@@ -564,7 +545,6 @@ CHIP_ERROR ExchangeContext::SendMessage(uint32_t profileId, uint8_t msgType, Pac
             CHIP_FAULT_INJECT(FaultInjection::kFault_RMPDoubleTx, entry->nextRetransTime = 0; ExchangeMgr->RMPStartTimer());
         }
         else
-#endif // CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
         {
             err        = ExchangeMgr->MessageLayer->SendMessage(PeerAddr, PeerPort, PeerIntf, msgInfo, msgBuf);
             msgBuf     = NULL;
@@ -678,7 +658,6 @@ CHIP_ERROR ExchangeContext::EncodeExchHeader(ChipExchangeHeader * exchangeHeader
     exchangeHeader->Flags = (IsInitiator() || (sendFlags & kSendFlag_FromInitiator)) ? kChipExchangeFlag_Initiator : 0;
 
     // RMP PreProcess Checks and Flag setting
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     // If there is a pending acknowledgment piggyback it on this message.
     // If there is no pending acknowledgment piggyback the last Ack that was sent.
     //   - HasPeerRequestedAck() is used to verify that AckId field is valid
@@ -707,7 +686,6 @@ CHIP_ERROR ExchangeContext::EncodeExchHeader(ChipExchangeHeader * exchangeHeader
     {
         exchangeHeader->Flags |= kChipExchangeFlag_NeedsAck;
     }
-#endif // CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
 
     err = ChipExchangeManager::PrependHeader(exchangeHeader, msgBuf);
 
@@ -736,7 +714,6 @@ void ExchangeContext::DoClose(bool clearRetransTable)
     OnConnectionClosed      = NULL;
     OnKeyError              = NULL;
 
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     // Expire any virtual ticks that have expired so all wakeup sources reflect the current time
     ExchangeMgr->RMPExpireTicks();
 
@@ -756,7 +733,6 @@ void ExchangeContext::DoClose(bool clearRetransTable)
 
     // Schedule next physical wakeup
     ExchangeMgr->RMPStartTimer();
-#endif
 
     // Cancel the response timer.
     CancelResponseTimer();
@@ -940,7 +916,6 @@ void ExchangeContext::HandleResponseTimeout(System::Layer * aSystemLayer, void *
         ec->OnResponseTimeout(ec);
 }
 
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
 bool ExchangeContext::RMPCheckAndRemRetransTable(uint32_t ackMsgId, void ** rCtxt)
 {
     bool res = false;
@@ -1277,7 +1252,6 @@ CHIP_ERROR ExchangeContext::HandleThrottleFlow(uint32_t PauseTimeMillis)
     ExchangeMgr->RMPStartTimer();
     return CHIP_NO_ERROR;
 }
-#endif // CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
 
 /**
  * @overload
@@ -1311,10 +1285,8 @@ CHIP_ERROR ExchangeContext::HandleMessage(ChipMessageInfo * msgInfo, const ChipE
                                           ExchangeContext::MessageReceiveFunct umhandler)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     const uint8_t * p        = NULL;
     uint32_t PauseTimeMillis = 0;
-#endif
 
     // We hold a reference to the ExchangeContext here to
     // guard against Close() calls(decrementing the reference
@@ -1322,7 +1294,6 @@ CHIP_ERROR ExchangeContext::HandleMessage(ChipMessageInfo * msgInfo, const ChipE
     // layer has completed its work on the ExchangeContext.
     AddRef();
 
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     if (exchHeader->Flags & kChipExchangeFlag_AckId)
     {
         err = RMPHandleRcvdAck(exchHeader, msgInfo);
@@ -1340,7 +1311,6 @@ CHIP_ERROR ExchangeContext::HandleMessage(ChipMessageInfo * msgInfo, const ChipE
             err = RMPHandleNeedsAck(msgInfo);
         }
     }
-#endif
 
     // If the message is a duplicate and duplicates are not allowed for this exchange.
     if ((msgInfo->Flags & kChipMessageFlag_DuplicateMessage) && !AllowDuplicateMsgs)
@@ -1352,13 +1322,11 @@ CHIP_ERROR ExchangeContext::HandleMessage(ChipMessageInfo * msgInfo, const ChipE
     if (exchHeader->ProfileId == chip::Protocols::kChipProtocol_Common &&
         exchHeader->MessageType == chip::Protocols::Common::kMsgType_RMP_Throttle_Flow)
     {
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
         // Extract PauseTimeMillis from msgBuf
         p               = msgBuf->Start();
         PauseTimeMillis = LittleEndian::Read32(p);
         HandleThrottleFlow(PauseTimeMillis);
         ExitNow(err = CHIP_NO_ERROR);
-#endif
     }
     // Return and not pass this to Application if Common::Null Msg Type
     else if ((exchHeader->ProfileId == chip::Protocols::kChipProtocol_Common) &&

--- a/src/lib/support/CHIPFaultInjection.cpp
+++ b/src/lib/support/CHIPFaultInjection.cpp
@@ -38,9 +38,8 @@ static class nl::FaultInjection::Manager sChipFaultInMgr;
 static const nl::FaultInjection::Name sManagerName  = "chip";
 static const nl::FaultInjection::Name sFaultNames[] = {
     "AllocExchangeContext", "DropIncomingUDPMsg",   "DropOutgoingUDPMsg", "AllocBinding", "SendAlarm",
-    "HandleAlarm",          "FuzzExchangeHeaderTx",
-    "RMPDoubleTx",          "RMPSendError",
-    "BDXBadBlockCounter",   "BDXAllocTransfer",     "CASEKeyConfirm",     "SecMgrBusy",
+    "HandleAlarm",          "FuzzExchangeHeaderTx", "RMPDoubleTx",        "RMPSendError", "BDXBadBlockCounter",
+    "BDXAllocTransfer",     "CASEKeyConfirm",       "SecMgrBusy",
 #if CONFIG_NETWORK_LAYER_BLE
     "CHIPOBLESend",
 #endif // CONFIG_NETWORK_LAYER_BLE

--- a/src/lib/support/CHIPFaultInjection.cpp
+++ b/src/lib/support/CHIPFaultInjection.cpp
@@ -39,9 +39,7 @@ static const nl::FaultInjection::Name sManagerName  = "chip";
 static const nl::FaultInjection::Name sFaultNames[] = {
     "AllocExchangeContext", "DropIncomingUDPMsg",   "DropOutgoingUDPMsg", "AllocBinding", "SendAlarm",
     "HandleAlarm",          "FuzzExchangeHeaderTx",
-#if WEAVE_CONFIG_ENABLE_RELIABLE_MESSAGING
-    "WRMDoubleTx",          "WRMSendError",
-#endif // WEAVE_CONFIG_ENABLE_RELIABLE_MESSAGING
+    "RMPDoubleTx",          "RMPSendError",
     "BDXBadBlockCounter",   "BDXAllocTransfer",     "CASEKeyConfirm",     "SecMgrBusy",
 #if CONFIG_NETWORK_LAYER_BLE
     "CHIPOBLESend",

--- a/src/lib/support/CHIPFaultInjection.h
+++ b/src/lib/support/CHIPFaultInjection.h
@@ -55,11 +55,11 @@ typedef enum
     kFault_FuzzExchangeHeaderTx, /**< Fuzz a chip Exchange Header after it has been encoded into the packet buffer;
                                       when the fault is enabled, it expects an integer argument, which is an index into
                                       a table of modifications that can be applied to the header. @see FuzzExchangeHeader */
-    kFault_RMPDoubleTx,        /**< Force RMP to transmit the outgoing message twice */
-    kFault_RMPSendError,       /**< Fail a transmission in RMP as if the max number of retransmission has been exceeded */
-    kFault_BDXBadBlockCounter, /**< Corrupt the BDX Block Counter in the BDX BlockSend or BlockEOF message about to be sent */
-    kFault_BDXAllocTransfer,   /**< Fail the allocation of a BDXTransfer object */
-    kFault_SecMgrBusy,         /**< Trigger a WEAVE_ERROR_SECURITY_MANAGER_BUSY when starting an authentication session */
+    kFault_RMPDoubleTx,          /**< Force RMP to transmit the outgoing message twice */
+    kFault_RMPSendError,         /**< Fail a transmission in RMP as if the max number of retransmission has been exceeded */
+    kFault_BDXBadBlockCounter,   /**< Corrupt the BDX Block Counter in the BDX BlockSend or BlockEOF message about to be sent */
+    kFault_BDXAllocTransfer,     /**< Fail the allocation of a BDXTransfer object */
+    kFault_SecMgrBusy,           /**< Trigger a WEAVE_ERROR_SECURITY_MANAGER_BUSY when starting an authentication session */
 #if CONFIG_NETWORK_LAYER_BLE
     kFault_CHIPOBLESend, /**< Inject a GATT error when sending the first fragment of a chip message over BLE */
 #endif                   // CONFIG_NETWORK_LAYER_BLE

--- a/src/lib/support/CHIPFaultInjection.h
+++ b/src/lib/support/CHIPFaultInjection.h
@@ -55,10 +55,8 @@ typedef enum
     kFault_FuzzExchangeHeaderTx, /**< Fuzz a chip Exchange Header after it has been encoded into the packet buffer;
                                       when the fault is enabled, it expects an integer argument, which is an index into
                                       a table of modifications that can be applied to the header. @see FuzzExchangeHeader */
-#if CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING
     kFault_RMPDoubleTx,        /**< Force RMP to transmit the outgoing message twice */
     kFault_RMPSendError,       /**< Fail a transmission in RMP as if the max number of retransmission has been exceeded */
-#endif                         // WEAVE_CONFIG_ENABLE_RELIABLE_MESSAGING
     kFault_BDXBadBlockCounter, /**< Corrupt the BDX Block Counter in the BDX BlockSend or BlockEOF message about to be sent */
     kFault_BDXAllocTransfer,   /**< Fail the allocation of a BDXTransfer object */
     kFault_SecMgrBusy,         /**< Trigger a WEAVE_ERROR_SECURITY_MANAGER_BUSY when starting an authentication session */


### PR DESCRIPTION
Problem
The decision whether to use RMP or UDP is made at the Binding level, when Binding is created there will be a setting whether RMP should be used for this protocol, the CHIP device does not have to always use RMP, so we can always build with this feature enabled.

Summary of Changes
Remove build flag CHIP_CONFIG_ENABLE_RELIABLE_MESSAGING

fixes #2215
