### PR TITLE
[K32W] Enable Thread Joining

### DIFF
--- a/config/k32w/k32w061-chip.mk
+++ b/config/k32w/k32w061-chip.mk
@@ -77,7 +77,7 @@ CHIP_CXXFLAGS = $(STD_CXXFLAGS) $(CXXFLAGS)
 CHIP_CONFIGURE_OPTIONS = \
     -C AR="$(AR)" AS="$(AS)" CC="$(CCACHE) $(CC)" CXX="$(CCACHE) $(CXX)" \
     LD="$(LD)" OBJCOPY="$(OBJCOPY)" RANLIB="$(RANLIB)" INSTALL="$(INSTALL) $(INSTALLFLAGS)" \
-    CPPFLAGS="$(CHIP_CPPFLAGS)" \
+    CPPFLAGS="$(CHIP_CPPFLAGS) -imacros $(CHIP_ROOT)/third_party/openthread/repo/examples/platforms/k32w/k32w061/k32w061-sdk-config.h" \
     CXXFLAGS="$(CHIP_CXXFLAGS)" \
     --prefix=$(CHIP_OUTPUT_DIR) \
     --exec-prefix=$(CHIP_OUTPUT_DIR) \

--- a/configure.ac
+++ b/configure.ac
@@ -1846,6 +1846,8 @@ NL_WITH_OPTIONAL_INTERNAL_PACKAGE(
                 -DJENNIC_CHIP_FAMILY_NAME=_JN518x \
                 -DSDK_DEBUGCONSOLE=0 \
                 -DUSE_RTOS=1 \
+                -DFSL_RTOS_FREE_RTOS=1 \
+                -DMBEDTLS_FREESCALE_FREERTOS_CALLOC_ALT=1  \
                 -DOPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE=1 \
                 -DOPENTHREAD_CONFIG_HEAP_INTERNAL_SIZE=16 \
                 -DOPENTHREAD_CONFIG_JOINER_ENABLE=1 \
@@ -1857,7 +1859,7 @@ NL_WITH_OPTIONAL_INTERNAL_PACKAGE(
 
             (mkdir -p ${ac_pwd}/third_party/openthread \
              && cd ${ac_pwd}/third_party/openthread \
-             && CPPFLAGS="${ot_cppflags}" CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" ${chip_srcdir}/third_party/openthread/repo/configure \
+             && CPPFLAGS="${ot_cppflags}" CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS} -Og -g" ${chip_srcdir}/third_party/openthread/repo/configure \
              --disable-docs \
              --disable-executable \
              --disable-tools \

--- a/examples/lock-app/k32w/README.md
+++ b/examples/lock-app/k32w/README.md
@@ -7,9 +7,12 @@ board.
 <hr>
 
 -   [CHIP K32W Lock Example Application](#chip-k32w-lock-example-application) -
-    [Introduction](#introduction) - [Device UI](#device-ui) -
-    [Building](#building) - [Flashing and debugging](#flashdebug)
-    <hr>
+-   [Introduction](#introduction)
+-   [Device UI](#device-ui) -
+-   [Building](#building)
+- [Flashing and debugging](#flashdebug)
+
+<hr>
 
 <a name="intro"></a>
 
@@ -129,6 +132,8 @@ pycryptodome           3.9.8
 
 The resulting elf file can be found in the build directory and it's named
 chip-k32w061-lock-example.elf.
+
+<a name="flashdebug"></a>
 
 ## Flashing and debugging
 

--- a/examples/lock-app/k32w/README.md
+++ b/examples/lock-app/k32w/README.md
@@ -10,7 +10,7 @@ board.
 -   [Introduction](#introduction)
 -   [Device UI](#device-ui) -
 -   [Building](#building)
-- [Flashing and debugging](#flashdebug)
+-   [Flashing and debugging](#flashdebug)
 
 <hr>
 

--- a/examples/lock-app/k32w/main/AppTask.cpp
+++ b/examples/lock-app/k32w/main/AppTask.cpp
@@ -20,8 +20,10 @@
 #include "AppTask.h"
 #include "AppEvent.h"
 #include "LEDWidget.h"
+#include "support/ErrorStr.h"
 
 #include <platform/CHIPDeviceLayer.h>
+#include <platform/internal/DeviceNetworkInfo.h>
 
 #include "Keyboard.h"
 #include "LED.h"
@@ -214,7 +216,8 @@ void AppTask::AppTaskMain(void * pvParameter)
 
 void AppTask::ButtonEventHandler(uint8_t pin_no, uint8_t button_action)
 {
-    if ((pin_no != RESET_BUTTON) && (pin_no != LOCK_BUTTON) && (pin_no != OTA_BUTTON))
+    if ((pin_no != RESET_BUTTON) && (pin_no != LOCK_BUTTON) &&
+       (pin_no != JOIN_BUTTON))
     {
         return;
     }
@@ -232,9 +235,9 @@ void AppTask::ButtonEventHandler(uint8_t pin_no, uint8_t button_action)
     {
         button_event.Handler = LockActionEventHandler;
     }
-    else if (pin_no == OTA_BUTTON)
+    else if (pin_no == JOIN_BUTTON)
     {
-        button_event.Handler = OtaHandler;
+        button_event.Handler = JoinHandler;
     }
 
     sAppTask.PostEvent(&button_event);
@@ -271,7 +274,7 @@ void AppTask::HandleKeyboard(void)
             ButtonEventHandler(LOCK_BUTTON, LOCK_BUTTON_PUSH);
             break;
         case gKBD_EventPB3_c:
-            ButtonEventHandler(OTA_BUTTON, OTA_BUTTON_PUSH);
+            ButtonEventHandler(JOIN_BUTTON, JOIN_BUTTON_PUSH);
             break;
         default:
             break;
@@ -398,18 +401,68 @@ void AppTask::LockActionEventHandler(AppEvent * aEvent)
     }
 }
 
-void AppTask::OtaHandler(AppEvent * aEvent)
+void AppTask::ThreadStart()
 {
-    if (aEvent->ButtonEvent.PinNo != OTA_BUTTON)
+    chip::DeviceLayer::Internal::DeviceNetworkInfo networkInfo;
+
+    memset(networkInfo.ThreadNetworkName, 0, chip::DeviceLayer::Internal::kMaxThreadNetworkNameLength + 1);
+    memcpy(networkInfo.ThreadNetworkName, "OpenThread", 10);
+
+    networkInfo.ThreadExtendedPANId[0] = 0xde;
+    networkInfo.ThreadExtendedPANId[1] = 0xad;
+    networkInfo.ThreadExtendedPANId[2] = 0x00;
+    networkInfo.ThreadExtendedPANId[3] = 0xbe;
+    networkInfo.ThreadExtendedPANId[4] = 0xef;
+    networkInfo.ThreadExtendedPANId[5] = 0x00;
+    networkInfo.ThreadExtendedPANId[6] = 0xca;
+    networkInfo.ThreadExtendedPANId[7] = 0xfe;
+
+    networkInfo.ThreadNetworkKey[0]  = 0x00;
+    networkInfo.ThreadNetworkKey[1]  = 0x11;
+    networkInfo.ThreadNetworkKey[2]  = 0x22;
+    networkInfo.ThreadNetworkKey[3]  = 0x33;
+    networkInfo.ThreadNetworkKey[4]  = 0x44;
+    networkInfo.ThreadNetworkKey[5]  = 0x55;
+    networkInfo.ThreadNetworkKey[6]  = 0x66;
+    networkInfo.ThreadNetworkKey[7]  = 0x77;
+    networkInfo.ThreadNetworkKey[8]  = 0x88;
+    networkInfo.ThreadNetworkKey[9]  = 0x99;
+    networkInfo.ThreadNetworkKey[10] = 0xAA;
+    networkInfo.ThreadNetworkKey[11] = 0xBB;
+    networkInfo.ThreadNetworkKey[12] = 0xCC;
+    networkInfo.ThreadNetworkKey[13] = 0xDD;
+    networkInfo.ThreadNetworkKey[14] = 0xEE;
+    networkInfo.ThreadNetworkKey[15] = 0xFF;
+
+    networkInfo.ThreadPANId = 0xabcd;
+    networkInfo.ThreadChannel = 15;
+
+    networkInfo.FieldPresent.ThreadExtendedPANId = true;
+    networkInfo.FieldPresent.ThreadMeshPrefix = false;
+    networkInfo.FieldPresent.ThreadPSKc = false;
+    networkInfo.NetworkId              = 0;
+    networkInfo.FieldPresent.NetworkId = true;
+
+    ThreadStackMgr().SetThreadEnabled(false);
+    ThreadStackMgr().SetThreadProvision(networkInfo);
+    ThreadStackMgr().SetThreadEnabled(true);
+}
+
+void AppTask::JoinHandler(AppEvent * aEvent)
+{
+    if (aEvent->ButtonEvent.PinNo != JOIN_BUTTON)
         return;
 
     if (sAppTask.mFunction != kFunction_NoneSelected)
     {
-        K32W_LOG("Another function is scheduled. Could not initiate Software Update!");
+        K32W_LOG("Another function is scheduled. Could not initiate Thread Join!");
         return;
     }
 
-    // TODO: Add OTA support
+    /* hard-code Thread Commissioning Parameters for the moment.
+     * In a future PR, these parameters will be sent via BLE.
+     */
+    ThreadStart();
 }
 
 void AppTask::CancelTimer()

--- a/examples/lock-app/k32w/main/AppTask.cpp
+++ b/examples/lock-app/k32w/main/AppTask.cpp
@@ -216,8 +216,7 @@ void AppTask::AppTaskMain(void * pvParameter)
 
 void AppTask::ButtonEventHandler(uint8_t pin_no, uint8_t button_action)
 {
-    if ((pin_no != RESET_BUTTON) && (pin_no != LOCK_BUTTON) &&
-       (pin_no != JOIN_BUTTON))
+    if ((pin_no != RESET_BUTTON) && (pin_no != LOCK_BUTTON) && (pin_no != JOIN_BUTTON))
     {
         return;
     }
@@ -434,14 +433,14 @@ void AppTask::ThreadStart()
     networkInfo.ThreadNetworkKey[14] = 0xEE;
     networkInfo.ThreadNetworkKey[15] = 0xFF;
 
-    networkInfo.ThreadPANId = 0xabcd;
+    networkInfo.ThreadPANId   = 0xabcd;
     networkInfo.ThreadChannel = 15;
 
     networkInfo.FieldPresent.ThreadExtendedPANId = true;
-    networkInfo.FieldPresent.ThreadMeshPrefix = false;
-    networkInfo.FieldPresent.ThreadPSKc = false;
-    networkInfo.NetworkId              = 0;
-    networkInfo.FieldPresent.NetworkId = true;
+    networkInfo.FieldPresent.ThreadMeshPrefix    = false;
+    networkInfo.FieldPresent.ThreadPSKc          = false;
+    networkInfo.NetworkId                        = 0;
+    networkInfo.FieldPresent.NetworkId           = true;
 
     ThreadStackMgr().SetThreadEnabled(false);
     ThreadStackMgr().SetThreadProvision(networkInfo);

--- a/examples/lock-app/k32w/main/include/AppTask.h
+++ b/examples/lock-app/k32w/main/include/AppTask.h
@@ -54,7 +54,7 @@ private:
     static void FunctionTimerEventHandler(AppEvent * aEvent);
     static void KBD_Callback(uint8_t events);
     static void HandleKeyboard(void);
-    static void OtaHandler(AppEvent * aEvent);
+    static void JoinHandler(AppEvent * aEvent);
     static void LockActionEventHandler(AppEvent * aEvent);
     static void ResetActionEventHandler(AppEvent * aEvent);
     static void InstallEventHandler(AppEvent * aEvent);
@@ -62,6 +62,7 @@ private:
     static void ButtonEventHandler(uint8_t pin_no, uint8_t button_action);
     static void TimerEventHandler(TimerHandle_t xTimer);
 
+    static void ThreadStart();
     void StartTimer(uint32_t aTimeoutInMs);
 
     enum Function_t

--- a/examples/lock-app/k32w/main/include/app_config.h
+++ b/examples/lock-app/k32w/main/include/app_config.h
@@ -24,12 +24,12 @@
 // ---- Lock Example App Config ----
 
 #define RESET_BUTTON 1
-#define LOCK_BUTTON 2
-#define OTA_BUTTON 3
+#define LOCK_BUTTON  2
+#define JOIN_BUTTON  3
 
 #define RESET_BUTTON_PUSH 1
-#define LOCK_BUTTON_PUSH 2
-#define OTA_BUTTON_PUSH 3
+#define LOCK_BUTTON_PUSH  2
+#define JOIN_BUTTON_PUSH  3
 
 #define APP_BUTTON_PUSH 1
 

--- a/examples/lock-app/k32w/main/include/app_config.h
+++ b/examples/lock-app/k32w/main/include/app_config.h
@@ -24,12 +24,12 @@
 // ---- Lock Example App Config ----
 
 #define RESET_BUTTON 1
-#define LOCK_BUTTON  2
-#define JOIN_BUTTON  3
+#define LOCK_BUTTON 2
+#define JOIN_BUTTON 3
 
 #define RESET_BUTTON_PUSH 1
-#define LOCK_BUTTON_PUSH  2
-#define JOIN_BUTTON_PUSH  3
+#define LOCK_BUTTON_PUSH 2
+#define JOIN_BUTTON_PUSH 3
 
 #define APP_BUTTON_PUSH 1
 

--- a/examples/lock-app/k32w/main/main.cpp
+++ b/examples/lock-app/k32w/main/main.cpp
@@ -40,7 +40,7 @@ using namespace ::chip::Inet;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::Logging;
 
-extern "C" void *pvPortCalloc(size_t num, size_t size);
+extern "C" void * pvPortCalloc(size_t num, size_t size);
 
 #include <AppTask.h>
 

--- a/examples/lock-app/k32w/main/main.cpp
+++ b/examples/lock-app/k32w/main/main.cpp
@@ -40,6 +40,8 @@ using namespace ::chip::Inet;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::Logging;
 
+extern "C" void *pvPortCalloc(size_t num, size_t size);
+
 #include <AppTask.h>
 
 void k32wLog(const char * aFormat, ...)
@@ -78,7 +80,7 @@ extern "C" void main_task(void const * argument)
 
     /* Using OT Heap is deprecated so use instead the FreeRTOS
      * allocation system - which is also thread-safe */
-    otHeapSetCAllocFree(calloc, free);
+    otHeapSetCAllocFree(pvPortCalloc, vPortFree);
 
     /* Mbedtls Threading support is needed because both
      * Thread and Weave tasks are using it */

--- a/src/platform/K32W/ConnectivityManagerImpl.h
+++ b/src/platform/K32W/ConnectivityManagerImpl.h
@@ -35,12 +35,6 @@
 #include <platform/internal/GenericConnectivityManagerImpl_NoWiFi.h>
 #include <support/FlagUtils.hpp>
 
-namespace nl {
-namespace Inet {
-class IPAddress;
-} // namespace Inet
-} // namespace nl
-
 namespace chip {
 namespace DeviceLayer {
 

--- a/src/platform/K32W/Logging.cpp
+++ b/src/platform/K32W/Logging.cpp
@@ -166,7 +166,7 @@ void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
     // Let the application know that a log message has been emitted.
     DeviceLayer::OnLogOutput();
 
-#endif // NRF_LOG_ENABLED
+#endif // K32W_LOG_ENABLED
 }
 
 } // namespace Logging
@@ -203,7 +203,7 @@ extern "C" void LwIPLog(const char * msg, ...)
     // Let the application know that a log message has been emitted.
     DeviceLayer::OnLogOutput();
 
-#endif // NRF_LOG_ENABLED
+#endif // K32W_LOG_ENABLED
 
     va_end(v);
 }
@@ -240,7 +240,7 @@ extern "C" void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const ch
 
     // Let the application know that a log message has been emitted.
     DeviceLayer::OnLogOutput();
-#endif // NRF_LOG_ENABLED
+#endif // K32W_LOG_ENABLED
 
     va_end(v);
 }


### PR DESCRIPTION
    [K32W] Enable Thread Joining
    
    Using the SW4 button on the Expansion board, the user can initiate a
    Thread session to a Border Router. Thread Commissioning parameters are
    hard-coded for the moment but in a future PR these parameters will be
    sent via BLE.
   

    [K32W] Code refactor
    
    * remove invalid reference to IPAddress;
    * fix typos.