### PR TITLE
fix build esp32 with gn

### DIFF
--- a/config/esp32/components/chip/component.mk
+++ b/config/esp32/components/chip/component.mk
@@ -221,8 +221,7 @@ install-chip-with-gn : $(OUTPUT_DIR)
 	echo esp32_cxx = \"$(CXX)\"              >> $(OUTPUT_DIR)/args.gn
 	echo esp32_cpu = \"esp32\"               >> $(OUTPUT_DIR)/args.gn
 	echo "Written file $(OUTPUT_DIR)/args.gn"
-#	MAKEFLAGS= make -C $(OUTPUT_DIR) --no-print-directory install
-	cd $(COMPONENT_PATH); gn gen $(OUTPUT_DIR)
+	cd $(CHIP_ROOT) && PW_ENVSETUP_QUIET=1 . scripts/activate.sh && cd $(COMPONENT_PATH) && gn gen $(OUTPUT_DIR)
 	cd $(COMPONENT_PATH); ninja -C $(OUTPUT_DIR) esp32
 
 install-chip-with-automake: configure-chip

--- a/config/esp32/components/chip/component.mk
+++ b/config/esp32/components/chip/component.mk
@@ -230,6 +230,7 @@ install-chip-with-automake: configure-chip
 
 ifeq ($(CHIP_BUILD_WITH_GN),y)
 install-chip: install-chip-with-gn
+SHELL=/bin/bash
 else
 install-chip: install-chip-with-automake
 endif


### PR DESCRIPTION
#### Problem
 pigweed and esp-idf fight over python library versions

 #### Summary of Changes
 limit pigweed's involvement in the build to where it has to be in the environment for 'gn gen'

 with these changes, this works:
 ```
 $ cd ~/dev/chip/examples/wifi-echo/server/esp32 && IDF_PATH=~/dev/esp-idf ./idf.sh make V=1 CHIP_BUILD_WITH_GN=y defconfig all
 ```