### PR TITLE
Fix circular dependency issue when linking message layer

### DIFF
--- a/examples/shell/BUILD.gn
+++ b/examples/shell/BUILD.gn
@@ -27,7 +27,10 @@ executable("chip-shell") {
     "main.cpp",
   ]
 
-  public_deps = [ "${chip_root}/src/lib/shell" ]
+  public_deps = [
+    "${chip_root}/src/lib/shell",
+    "${chip_root}/src/platform",
+  ]
 
   if (is_debug) {
     defines = [ "BUILD_RELEASE=0" ]

--- a/src/controller/BUILD.gn
+++ b/src/controller/BUILD.gn
@@ -30,6 +30,7 @@ static_library("controller") {
   public_deps = [
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
+    "${chip_root}/src/platform",
     "${chip_root}/src/transport",
   ]
 

--- a/src/lib/core/BUILD.gn
+++ b/src/lib/core/BUILD.gn
@@ -115,7 +115,6 @@ static_library("core") {
     "${chip_root}/src/ble",
     "${chip_root}/src/inet",
     "${chip_root}/src/lib/support",
-    "${chip_root}/src/platform",
     "${chip_root}/src/system",
     "${nlio_root}:nlio",
   ]
@@ -124,7 +123,6 @@ static_library("core") {
     "${chip_root}/src/ble",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/inet",
-    "${chip_root}/src/platform",
     "${chip_root}/src/system",
     "${chip_root}/src/app",
   ]

--- a/src/lib/support/tests/BUILD.gn
+++ b/src/lib/support/tests/BUILD.gn
@@ -35,6 +35,7 @@ chip_test_suite("tests") {
 
   public_deps = [
     "${chip_root}/src/lib/core",
+    "${chip_root}/src/platform",
     "${nlunit_test_root}:nlunit-test",
   ]
 

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -162,6 +162,7 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
       ":platform_buildconfig",
       "${chip_root}/src/ble",
       "${chip_root}/src/inet",
+      "${chip_root}/src/lib/core",
       "${chip_root}/src/lib/core:chip_config_header",
       "${chip_root}/src/lib/support",
       "${nlio_root}:nlio",

--- a/third_party/nrf5_sdk/nrf5_sdk.gni
+++ b/third_party/nrf5_sdk/nrf5_sdk.gni
@@ -412,7 +412,7 @@ template("nrf5_sdk") {
     ]
 
     public_deps = [
-      "${openthread_root}/src/core:libopenthread_core_headers",
+      "${openthread_root}/include/openthread:openthread_config",
       "${segger_rtt_root}:segger_rtt",
       "${segger_rtt_root}:segger_rtt_printf",
       "${segger_rtt_root}:segger_rtt_syscalls",

--- a/third_party/nrf5_sdk/nrf5_sdk.gni
+++ b/third_party/nrf5_sdk/nrf5_sdk.gni
@@ -412,6 +412,7 @@ template("nrf5_sdk") {
     ]
 
     public_deps = [
+      "${openthread_root}/src/core:libopenthread_core_headers",
       "${segger_rtt_root}:segger_rtt",
       "${segger_rtt_root}:segger_rtt_printf",
       "${segger_rtt_root}:segger_rtt_syscalls",


### PR DESCRIPTION
Problem
PlatformLayer is responsible for initilizing the CHIP stack, it should depend on the libcore which is the dependent of most of CHIP Core stack components. 

Summary of Changes
We should remove platform from libcore as the dependent to make message layer link.

