### PR TITLE
Derive MAC tag length from encryption type

### DIFF
--- a/src/transport/MessageHeader.h
+++ b/src/transport/MessageHeader.h
@@ -339,14 +339,14 @@ public:
      */
     CHIP_ERROR EncodeMACTag(uint8_t * data, size_t size, size_t * encode_size) const;
 
-private:
     size_t TagLenForEncryptionType(EncryptionType encType) const;
 
+private:
     /// Represents the current encode/decode header version
     static constexpr int kHeaderVersion = 2;
 
     /// Represents encryption type used for encrypting current packet
-    EncryptionType mEncryptionType = EncryptionType::kAESCCMTagLen8;
+    EncryptionType mEncryptionType = EncryptionType::kAESCCMTagLen16;
 
     /// Value expected to be incremented for each message sent.
     uint32_t mMessageId = 0;


### PR DESCRIPTION
 #### Problem
Current `SecureSession` code always uses 8 bytes MAC tag. The use of `uint64_t` is also confusing. It implies a need for byte order check, whereas the MAC tag should be treated as a buffer of bytes (without changing byte order).

 #### Summary of Changes
Change the code to derive tag length from the encryption type. The tag is generated in a uint8_t buffer. Also use 16 bytes tag by default, as recommended by Secure Channel TT.
