### PR TITLE
Add a second virtual LED to the M5Stack demo.

### DIFF
--- a/examples/wifi-echo/server/esp32/main/EchoDeviceCallbacks.cpp
+++ b/examples/wifi-echo/server/esp32/main/EchoDeviceCallbacks.cpp
@@ -44,7 +44,8 @@ using namespace ::chip::Inet;
 using namespace ::chip::DeviceLayer;
 
 // In wifi-echo.cpp
-extern LEDWidget statusLED;
+extern LEDWidget statusLED1;
+extern LEDWidget statusLED2;
 extern WiFiWidget wifiLED;
 extern RendezvousSession * rendezvousSession;
 
@@ -106,8 +107,20 @@ void EchoDeviceCallbacks::PostAttributeChangeCallback(uint8_t endpoint, EmberAfC
         ESP_LOGI(TAG, "Unknown attribute ID: %d", attributeId);
         return;
     }
-    ESP_LOGI(TAG, "Got the post attribute callback with value %d", *value);
+    ESP_LOGI(TAG, "Got the post attribute callback with value %d for endpoint %d", *value, endpoint);
     // At this point we can assume that value points to a bool value.
-    statusLED.Set(*value);
+    if (endpoint == 1)
+    {
+        statusLED1.Set(*value);
+    }
+    else if (endpoint == 2)
+    {
+        statusLED2.Set(*value);
+    }
+    else
+    {
+        ESP_LOGE(TAG, "Unexpected endpoint id: %d", endpoint);
+    }
+
     ESP_LOGI(TAG, "Current free heap: %d\n", heap_caps_get_free_size(MALLOC_CAP_8BIT));
 }

--- a/examples/wifi-echo/server/esp32/main/EchoServer.cpp
+++ b/examples/wifi-echo/server/esp32/main/EchoServer.cpp
@@ -56,7 +56,7 @@ using namespace ::chip::Inet;
 using namespace ::chip::Transport;
 
 extern const NodeId kLocalNodeId = 12344321;
-extern LEDWidget statusLED; // In wifi-echo.cpp
+extern LEDWidget statusLED1; // In wifi-echo.cpp
 
 namespace {
 
@@ -195,7 +195,7 @@ public:
     void OnReceiveError(CHIP_ERROR error, const Transport::PeerAddress & source, SecureSessionMgrBase * mgr) override
     {
         ESP_LOGE(TAG, "ERROR: %s\n Got UDP error", ErrorStr(error));
-        statusLED.BlinkOnError();
+        statusLED1.BlinkOnError();
     }
 
     void OnNewConnection(Transport::PeerConnectionState * state, SecureSessionMgrBase * mgr) override

--- a/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
@@ -98,7 +98,8 @@ extern void startClient(void);
 
 #endif // CONFIG_HAVE_DISPLAY
 
-LEDWidget statusLED;
+LEDWidget statusLED1;
+LEDWidget statusLED2;
 BluetoothWidget bluetoothLED;
 WiFiWidget wifiLED;
 
@@ -463,7 +464,10 @@ extern "C" void app_main()
 
     SetupPretendDevices();
 
-    statusLED.Init(STATUS_LED_GPIO_NUM);
+    statusLED1.Init(STATUS_LED_GPIO_NUM);
+    // Our second LED doesn't map to any physical LEDs so far, just to virtual
+    // "LED"s on devices with screens.
+    statusLED2.Init(GPIO_NUM_MAX);
     bluetoothLED.Init();
     wifiLED.Init();
 
@@ -549,7 +553,11 @@ extern "C" void app_main()
     {
         int vled1 = ScreenManager::AddVLED(TFT_GREEN);
         int vled2 = ScreenManager::AddVLED(TFT_RED);
-        statusLED.SetVLED(vled1, vled2);
+        statusLED1.SetVLED(vled1, vled2);
+
+        int vled3 = ScreenManager::AddVLED(TFT_CYAN);
+        int vled4 = ScreenManager::AddVLED(TFT_ORANGE);
+        statusLED2.SetVLED(vled3, vled4);
 
         bluetoothLED.SetVLED(ScreenManager::AddVLED(TFT_BLUE));
         wifiLED.SetVLED(ScreenManager::AddVLED(TFT_YELLOW));


### PR DESCRIPTION
 #### Problem
There is only one virtual LED, which doesn't let us test support for multiple endpoints.

 #### Summary of Changes
Add a second virtual LED, controlled by endpoint 2.

fixes https://github.com/project-chip/connectedhomeip/issues/1096