### PR TITLE
Refactor NRF5 flashing scripts

### DIFF
--- a/third_party/nrf5_sdk/gen_flashing_script.py
+++ b/third_party/nrf5_sdk/gen_flashing_script.py
@@ -11,91 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.!/usr/bin/env python
-
 """Generate script to flash or erase an NRF5 device."""
 
-import argparse
-import os
-import stat
 import sys
-
-# Script to generate. This is a minimal wrapper around nrf_firmware_utils.
-# The substitutions are:
-#   scripts_dir - The location of nrf5_firmware_utils.
-#   defaults    - Options passed to nrf5_firmware_utils, including
-#                 in particular the image file to flash.
-
-SCRIPT = """#!/usr/bin/env python
-
-import sys
-
-SCRIPTS_DIR = '{scripts_dir}'
-DEFAULTS = {{
-{defaults}
-}}
-
-sys.path.append(SCRIPTS_DIR)
 import nrf5_firmware_utils
 
 if __name__ == '__main__':
-    sys.exit(nrf5_firmware_utils.flash_command(sys.argv[1:], DEFAULTS))
-"""
-
-
-# Generate flashing script.
-
-def main(argv):
-    """Generate script to flash or erase an NRF5 device."""
-    parser = argparse.ArgumentParser(description='Generate a flashing script')
-    parser.add_argument(
-        '--output',
-        metavar='FILENAME',
-        required=True,
-        help='flashing script name')
-    parser.add_argument(
-        '--scripts-dir',
-        metavar='DIR',
-        required=True,
-        help='nrf5 script utilities directory')
-    parser.add_argument(
-        '--nrfjprog',
-        metavar='FILENAME',
-        help='nrfjprog command')
-    parser.add_argument(
-        '--family',
-        metavar='FAMILY',
-        help='device family')
-    parser.add_argument(
-        '--softdevice',
-        metavar='GLOB',
-        help='softdevice file pattern')
-    parser.add_argument(
-        '--application',
-        metavar='FILENAME',
-        help='program to flash')
-
-    args = parser.parse_args(argv)
-    options = vars(args)
-
-    defaults = []
-    for key in ['nrfjprog', 'family', 'softdevice', 'application']:
-        if options.get(key):
-            defaults.append('  {}: {},'.format(repr(key), repr(options[key])))
-
-    script = SCRIPT.format(
-        scripts_dir=args.scripts_dir, defaults='\n'.join(defaults))
-    try:
-        with open(args.output, 'w') as script_file:
-            script_file.write(script)
-        os.chmod(args.output, (stat.S_IXUSR | stat.S_IRUSR | stat.S_IWUSR
-                             | stat.S_IXGRP | stat.S_IRGRP
-                             | stat.S_IXOTH | stat.S_IROTH))
-    except OSError as exception:
-        print(exception, sys.stderr)
-        return 1
-
-    return 0
-
-
-if __name__ == '__main__':
-    sys.exit(main(sys.argv[1:]))
+    sys.exit(nrf5_firmware_utils.NRF5Flasher().make_wrapper(sys.argv[1:]))


### PR DESCRIPTION
This change modifies nrf5_firmware_utils to isolate platform-independent
parts, and moves flashing-script generation into that module so that
relevant properties are not unnecessarily duplicated between two files.

After this change, large parts of nrf5_firmware_utils.py and
efr32_firmware_utils.py are identical. The intent is to move those parts
into a separate module shared between platforms.

issue #1520 - GN build parity - flashing
