### PR TITLE
Separate Rendezvous message handling from BLE session

### DIFF
--- a/examples/wifi-echo/server/esp32/main/RendezvousMessageHandler.cpp
+++ b/examples/wifi-echo/server/esp32/main/RendezvousMessageHandler.cpp
@@ -1,0 +1,55 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "RendezvousMessageHandler.h"
+#include <support/CodeUtils.h>
+#include <support/logging/CHIPLogging.h>
+#include <system/SystemPacketBuffer.h>
+
+using namespace ::chip;
+
+extern CHIP_ERROR SetWiFiStationProvisioning(char * ssid, char * key);
+
+CHIP_ERROR RendezvousMessageHandler::HandleMessageReceived(System::PacketBuffer * buffer)
+{
+    CHIP_ERROR err         = CHIP_NO_ERROR;
+    const size_t bufferLen = buffer->DataLength();
+    char * key             = nullptr;
+    char * ssid            = nullptr;
+    char msg[bufferLen];
+
+    msg[bufferLen] = 0;
+    memcpy(msg, buffer->Start(), bufferLen);
+    ChipLogProgress(NetworkProvisioning, "RendezvousMessageHandler: Receive message: %s", msg);
+
+    // Pending definition of an actual message format, WiFi credentials have the form
+    // ‘::SSID:password:’, where ‘:’ can be any single ASCII character.
+    bool isWiFiCredentials = ((bufferLen > 3) && (msg[0] == msg[1]) && (msg[0] == msg[bufferLen - 1]));
+    VerifyOrExit(isWiFiCredentials, err = CHIP_ERROR_INVALID_MESSAGE_TYPE);
+
+    msg[1] = 0;
+    ssid   = strtok(&msg[2], msg);
+    key    = strtok(NULL, msg);
+    VerifyOrExit(ssid && key, err = CHIP_ERROR_INVALID_MESSAGE_TYPE);
+
+    ChipLogProgress(NetworkProvisioning, "RendezvousMessageHandler: SSID: %s, key: %s", ssid, key);
+    err = SetWiFiStationProvisioning(ssid, key);
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}

--- a/examples/wifi-echo/server/esp32/main/RendezvousSession.cpp
+++ b/examples/wifi-echo/server/esp32/main/RendezvousSession.cpp
@@ -15,8 +15,8 @@
  *    limitations under the License.
  */
 
-#include "RendezvousMessageHandler.h"
 #include "RendezvousSession.h"
+#include "RendezvousMessageHandler.h"
 #include <support/CodeUtils.h>
 #include <support/ErrorStr.h>
 #include <support/logging/CHIPLogging.h>

--- a/examples/wifi-echo/server/esp32/main/include/RendezvousMessageHandler.h
+++ b/examples/wifi-echo/server/esp32/main/include/RendezvousMessageHandler.h
@@ -1,0 +1,36 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef _RENDEZVOUS_MESSAGE_HANDLER_H
+#define _RENDEZVOUS_MESSAGE_HANDLER_H
+
+#include <core/CHIPError.h>
+#include <platform/CHIPDeviceLayer.h>
+
+using namespace ::chip;
+
+class RendezvousMessageHandler
+{
+public:
+    // Handle a rendezvous message. Returns:
+    // - CHIP_NO_ERROR if the message was handled successfully.
+    // - CHIP_ERROR_INVALID_MESSAGE_TYPE if the message was not recognized.
+    // - Some other error encountered processing a specific message type.
+    static CHIP_ERROR HandleMessageReceived(System::PacketBuffer * buffer);
+};
+
+#endif // _RENDEZVOUS_MESSAGE_HANDLER_H


### PR DESCRIPTION
With this change, BLE handling remains in RendezvousSession and
message processing independent of BLE moves to RendervousMessageHandler.
