### PR TITLE
Fix broken image link in lightning-app README

### DIFF
--- a/examples/lighting-app/nrf5/README.md
+++ b/examples/lighting-app/nrf5/README.md
@@ -21,7 +21,7 @@ An example application showing the use
 
 ## Introduction
 
-![nrf52840 DK](doc/images/nrf52840-dk.jpg)
+![nrf52840 DK](images/nrf52840-dk.jpg)
 
 The nRF52840 lighting example application provides a working demonstration of a
 connected lighting device, built using CHIP, and the Nordic nRF5 SDK. The


### PR DESCRIPTION
#### Problem
The image link in the introduction of the [lighting-app README](https://github.com/project-chip/connectedhomeip/tree/master/examples/lighting-app/nrf5#introduction) is broken

#### Summary of Changes

Fix the image path


