### PR TITLE
Fix Android NDK build on Mac

### DIFF
--- a/gn/build/toolchain/android/android_toolchain.gni
+++ b/gn/build/toolchain/android/android_toolchain.gni
@@ -41,10 +41,23 @@ template("android_clang_toolchain") {
 
   _ndk_prefix = ""
   if (android_ndk_root != "") {
-    if (host_os == "linux" && host_cpu == "x64") {
-      _ndk_prefix =
-          "${android_ndk_root}/toolchains/llvm/prebuilt/linux-x86_64/bin/"
+    _ndk_host_os = ""
+    if (host_os == "linux") {
+      _ndk_host_os = "linux"
+    } else if (host_os == "mac") {
+      _ndk_host_os = "darwin"
+    } else if (host_os == "win") {
+      _ndk_host_os = "windows"
     }
+
+    _ndk_host_cpu = ""
+    if (host_cpu == "x64") {
+      _ndk_host_cpu = "-x86_64"
+    }
+
+    _ndk_host = _ndk_host_os + _ndk_host_cpu
+    _ndk_prefix =
+        "${android_ndk_root}/toolchains/llvm/prebuilt/${_ndk_host}/bin/"
   }
 
   gcc_toolchain(target_name) {

--- a/gn/chip/java/javac_runner.py
+++ b/gn/chip/java/javac_runner.py
@@ -99,6 +99,8 @@ def main():
       'rest', metavar='JAVAC_ARGS', nargs='*', help='Argumets to pass to javac')
 
   args = parser.parse_args()
+  if not os.path.isdir(args.classdir):
+    os.makedirs(args.classdir)
   retcode = subprocess.check_call([java_path] + args.rest)
   if retcode != EXIT_SUCCESS:
     return retcode

--- a/gn_build.sh
+++ b/gn_build.sh
@@ -74,7 +74,7 @@ extra_args=""
 # Android NDK setup
 android_ndk_args=""
 
-if [[ -d "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" ]]; then
+if [[ -d "${ANDROID_NDK_HOME}/toolchains" ]]; then
     android_ndk_args+="android_ndk_root=\"$ANDROID_NDK_HOME\""
     extra_args+=" $android_ndk_args enable_android_builds=true"
 else


### PR DESCRIPTION
Don't hardcode linux paths in the toolchain. Use the right paths based
on host OS.