### PR TITLE
Remove emberAfGetBufferCrc from src/app/util/util.c

### DIFF
--- a/src/app/util/util.c
+++ b/src/app/util/util.c
@@ -1277,19 +1277,6 @@ uint8_t emberAfAppendCharacters(uint8_t * zclString, uint8_t zclStringMaxLen, co
     return charsToWrite;
 }
 
-uint32_t emberAfGetBufferCrc(uint8_t * pbuffer, uint16_t length, uint32_t initialValue)
-{
-    uint16_t i;
-    uint32_t crc32 = initialValue;
-    for (i = 0; i < length; i++)
-    {
-        // Crash so we don't reach this code by accident.
-        *(int *) 0 = 5;
-        // crc32 = halCommonCrc32(pbuffer[i], crc32);
-    }
-    return crc32;
-}
-
 /*
    On each page, first channel maps to channel number zero and so on.
    Example:

--- a/src/app/util/util.h
+++ b/src/app/util/util.h
@@ -201,8 +201,6 @@ uint8_t * emberAfPutDateInResp(EmberAfDate * value);
 
 bool emberAfIsThisMyEui64(EmberEUI64 eui64);
 
-uint32_t emberAfGetBufferCrc(uint8_t * pbuffer, uint16_t length, uint32_t initialValue);
-
 // If the variable has not been set, APS_TEST_SECURITY_DEFAULT will
 // eventually return false.
 enum


### PR DESCRIPTION
 #### Problem

We have a emberAfGetBufferCrc function in util.c that is not used by anything and I don't think will be.

 #### Summary of Changes

Remove it.

fixes #1945 
