### PR TITLE
Implement ECP256 keygen crypto API

### DIFF
--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -301,12 +301,12 @@ CHIP_ERROR add_entropy_source(entropy_source fn_source, void * p_source, size_t 
 CHIP_ERROR pbkdf2_sha256(const uint8_t * password, size_t plen, const uint8_t * salt, size_t slen, unsigned int iteration_count,
                          uint32_t key_length, uint8_t * output);
 
-/** @brief Generate a new keypair for ECP256 curve.
+/** @brief Generate a new ECP keypair.
  * @param pubkey Generated public key
  * @param privkey Generated private key
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  **/
-CHIP_ERROR GenECPKeypair(ECPKey & pubkey, ECPKey & privkey);
+CHIP_ERROR NewECPKeypair(ECPKey & pubkey, ECPKey & privkey);
 
 /**
  * The below class implements the draft 01 version of the Spake2+ protocol as

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -44,6 +44,9 @@ const size_t kMAX_FE_Length              = kP256_FE_Length;
 const size_t kMAX_Point_Length           = kP256_Point_Length;
 const size_t kMAX_Hash_Length            = kSHA256_Hash_Length;
 
+const size_t kP256_PrivateKey_Length = 32;
+const size_t kP256_PublicKey_Length  = 65;
+
 /* These sizes are hardcoded here to remove header dependency on underlying crypto library
  * in a public interface file. The validity of these sizes is verified by static_assert in
  * the implementation files.
@@ -89,6 +92,16 @@ enum class CHIP_SPAKE2P_ROLE : uint8_t
     VERIFIER = 0, // Accessory
     PROVER   = 1, // Commissioner
 };
+
+typedef struct P256PrivateKey
+{
+    uint8_t bytes[kP256_PrivateKey_Length];
+} P256PrivateKey;
+
+typedef struct P256PublicKey
+{
+    uint8_t bytes[kP256_PublicKey_Length];
+} P256PublicKey;
 
 /**
  * @brief A function that implements AES-CCM encryption
@@ -265,12 +278,10 @@ CHIP_ERROR pbkdf2_sha256(const uint8_t * password, size_t plen, const uint8_t * 
 
 /** @brief Generate a new keypair for ECP256 curve.
  * @param pubkey Generated public key
- * @param pklen length of pubkey buffer
  * @param privkey Generated private key
- * @param pklen length of privkey buffer
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  **/
-CHIP_ERROR GenP256Keypair(uint8_t * pubkey, size_t * pklen, uint8_t * privkey, size_t * pvlen);
+CHIP_ERROR GenP256Keypair(P256PublicKey * pubkey, P256PrivateKey * privkey);
 
 /**
  * The below class implements the draft 01 version of the Spake2+ protocol as

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -102,8 +102,8 @@ class ECPKey
 {
 public:
     virtual SupportedECPKeyTypes Type() = 0;
-    virtual size_t Length() = 0;
-    virtual uint8_t * Value() = 0;
+    virtual size_t Length()             = 0;
+    virtual uint8_t * Value()           = 0;
 };
 
 class P256PrivateKey : public ECPKey

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -103,7 +103,7 @@ class ECPKey
 public:
     virtual SupportedECPKeyTypes Type() = 0;
     virtual size_t Length()             = 0;
-    virtual operator uint8_t*()         = 0;
+    virtual operator uint8_t *()        = 0;
 };
 
 class P256PrivateKey : public ECPKey
@@ -111,7 +111,7 @@ class P256PrivateKey : public ECPKey
 public:
     SupportedECPKeyTypes Type() override { return SupportedECPKeyTypes::ECP256R1; }
     size_t Length() override { return kP256_PrivateKey_Length; }
-    operator uint8_t*() override { return bytes; }
+    operator uint8_t *() override { return bytes; }
 
 private:
     uint8_t bytes[kP256_PrivateKey_Length];
@@ -122,7 +122,7 @@ class P256PublicKey : public ECPKey
 public:
     SupportedECPKeyTypes Type() override { return SupportedECPKeyTypes::ECP256R1; }
     size_t Length() override { return kP256_PublicKey_Length; }
-    operator uint8_t*() override { return bytes; }
+    operator uint8_t *() override { return bytes; }
 
 private:
     uint8_t bytes[kP256_PublicKey_Length];

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -262,6 +262,16 @@ CHIP_ERROR add_entropy_source(entropy_source fn_source, void * p_source, size_t 
  **/
 CHIP_ERROR pbkdf2_sha256(const uint8_t * password, size_t plen, const uint8_t * salt, size_t slen, unsigned int iteration_count,
                          uint32_t key_length, uint8_t * output);
+
+/** @brief Generate a new keypair for ECP256 curve.
+ * @param pubkey Generated public key
+ * @param pklen length of pubkey buffer
+ * @param privkey Generated private key
+ * @param pklen length of privkey buffer
+ * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+ **/
+CHIP_ERROR GenP256Keypair(uint8_t * pubkey, size_t * pklen, uint8_t * privkey, size_t * pvlen);
+
 /**
  * The below class implements the draft 01 version of the Spake2+ protocol as
  * defined in https://www.ietf.org/id/draft-bar-cfrg-spake2plus-01.html.

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -103,7 +103,7 @@ class ECPKey
 public:
     virtual SupportedECPKeyTypes Type() = 0;
     virtual size_t Length()             = 0;
-    virtual uint8_t * Value()           = 0;
+    virtual operator uint8_t*()         = 0;
 };
 
 class P256PrivateKey : public ECPKey
@@ -111,7 +111,7 @@ class P256PrivateKey : public ECPKey
 public:
     SupportedECPKeyTypes Type() override { return SupportedECPKeyTypes::ECP256R1; }
     size_t Length() override { return kP256_PrivateKey_Length; }
-    uint8_t * Value() override { return bytes; }
+    operator uint8_t*() override { return bytes; }
 
 private:
     uint8_t bytes[kP256_PrivateKey_Length];
@@ -122,7 +122,7 @@ class P256PublicKey : public ECPKey
 public:
     SupportedECPKeyTypes Type() override { return SupportedECPKeyTypes::ECP256R1; }
     size_t Length() override { return kP256_PublicKey_Length; }
-    uint8_t * Value() override { return bytes; }
+    operator uint8_t*() override { return bytes; }
 
 private:
     uint8_t bytes[kP256_PublicKey_Length];

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -93,15 +93,40 @@ enum class CHIP_SPAKE2P_ROLE : uint8_t
     PROVER   = 1, // Commissioner
 };
 
-typedef struct P256PrivateKey
+enum class SupportedECPKeyTypes : uint8_t
 {
-    uint8_t bytes[kP256_PrivateKey_Length];
-} P256PrivateKey;
+    ECP256R1 = 0,
+};
 
-typedef struct P256PublicKey
+class ECPKey
 {
+public:
+    virtual SupportedECPKeyTypes Type() = 0;
+    virtual size_t Length() = 0;
+    virtual uint8_t * Value() = 0;
+};
+
+class P256PrivateKey : public ECPKey
+{
+public:
+    SupportedECPKeyTypes Type() override { return SupportedECPKeyTypes::ECP256R1; }
+    size_t Length() override { return kP256_PrivateKey_Length; }
+    uint8_t * Value() override { return bytes; }
+
+private:
+    uint8_t bytes[kP256_PrivateKey_Length];
+};
+
+class P256PublicKey : public ECPKey
+{
+public:
+    SupportedECPKeyTypes Type() override { return SupportedECPKeyTypes::ECP256R1; }
+    size_t Length() override { return kP256_PublicKey_Length; }
+    uint8_t * Value() override { return bytes; }
+
+private:
     uint8_t bytes[kP256_PublicKey_Length];
-} P256PublicKey;
+};
 
 /**
  * @brief A function that implements AES-CCM encryption
@@ -281,7 +306,7 @@ CHIP_ERROR pbkdf2_sha256(const uint8_t * password, size_t plen, const uint8_t * 
  * @param privkey Generated private key
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  **/
-CHIP_ERROR GenP256Keypair(P256PublicKey & pubkey, P256PrivateKey & privkey);
+CHIP_ERROR GenECPKeypair(ECPKey & pubkey, ECPKey & privkey);
 
 /**
  * The below class implements the draft 01 version of the Spake2+ protocol as

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -281,7 +281,7 @@ CHIP_ERROR pbkdf2_sha256(const uint8_t * password, size_t plen, const uint8_t * 
  * @param privkey Generated private key
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  **/
-CHIP_ERROR GenP256Keypair(P256PublicKey * pubkey, P256PrivateKey * privkey);
+CHIP_ERROR GenP256Keypair(P256PublicKey & pubkey, P256PrivateKey & privkey);
 
 /**
  * The below class implements the draft 01 version of the Spake2+ protocol as

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -838,9 +838,9 @@ CHIP_ERROR GenECPKeypair(ECPKey & pubkey, ECPKey & privkey)
         const EC_POINT * pubkey_ecp = EC_KEY_get0_public_key(ec_key);
         VerifyOrExit(pubkey_ecp != nullptr, error = CHIP_ERROR_INTERNAL);
 
-        pubkey_size = EC_POINT_point2oct(group, pubkey_ecp, POINT_CONVERSION_UNCOMPRESSED, Uint8::to_uchar(pubkey),
-                                         pubkey.Length(), nullptr);
-        pubkey_ecp  = nullptr;
+        pubkey_size =
+            EC_POINT_point2oct(group, pubkey_ecp, POINT_CONVERSION_UNCOMPRESSED, Uint8::to_uchar(pubkey), pubkey.Length(), nullptr);
+        pubkey_ecp = nullptr;
 
         VerifyOrExit(pubkey_size == pubkey.Length(), error = CHIP_ERROR_INTERNAL);
     }

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -809,7 +809,7 @@ ECName MapECName(SupportedECPKeyTypes keyType)
     }
 }
 
-CHIP_ERROR GenECPKeypair(ECPKey & pubkey, ECPKey & privkey)
+CHIP_ERROR NewECPKeypair(ECPKey & pubkey, ECPKey & privkey)
 {
     ERR_clear_error();
     CHIP_ERROR error = CHIP_NO_ERROR;

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -826,9 +826,9 @@ CHIP_ERROR GenP256Keypair(P256PublicKey * pubkey, P256PrivateKey * privkey)
         const EC_POINT * pubkey_ecp = EC_KEY_get0_public_key(ec_key);
         VerifyOrExit(pubkey_ecp != nullptr, error = CHIP_ERROR_INTERNAL);
 
-        pubkey_size =
-            EC_POINT_point2oct(group, pubkey_ecp, POINT_CONVERSION_UNCOMPRESSED, Uint8::to_uchar(pubkey->bytes), sizeof(pubkey->bytes), nullptr);
-        pubkey_ecp = nullptr;
+        pubkey_size = EC_POINT_point2oct(group, pubkey_ecp, POINT_CONVERSION_UNCOMPRESSED, Uint8::to_uchar(pubkey->bytes),
+                                         sizeof(pubkey->bytes), nullptr);
+        pubkey_ecp  = nullptr;
 
         VerifyOrExit(pubkey_size == sizeof(pubkey->bytes), error = CHIP_ERROR_INTERNAL);
     }

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -838,7 +838,7 @@ CHIP_ERROR GenECPKeypair(ECPKey & pubkey, ECPKey & privkey)
         const EC_POINT * pubkey_ecp = EC_KEY_get0_public_key(ec_key);
         VerifyOrExit(pubkey_ecp != nullptr, error = CHIP_ERROR_INTERNAL);
 
-        pubkey_size = EC_POINT_point2oct(group, pubkey_ecp, POINT_CONVERSION_UNCOMPRESSED, Uint8::to_uchar(pubkey.Value()),
+        pubkey_size = EC_POINT_point2oct(group, pubkey_ecp, POINT_CONVERSION_UNCOMPRESSED, Uint8::to_uchar(pubkey),
                                          pubkey.Length(), nullptr);
         pubkey_ecp  = nullptr;
 
@@ -850,7 +850,7 @@ CHIP_ERROR GenECPKeypair(ECPKey & pubkey, ECPKey & privkey)
         const BIGNUM * privkey_bn = EC_KEY_get0_private_key(ec_key);
         VerifyOrExit(privkey_bn != nullptr, error = CHIP_ERROR_INTERNAL);
 
-        privkey_size = BN_bn2binpad(privkey_bn, Uint8::to_uchar(privkey.Value()), privkey.Length());
+        privkey_size = BN_bn2binpad(privkey_bn, Uint8::to_uchar(privkey), privkey.Length());
         privkey_bn   = nullptr;
 
         VerifyOrExit(privkey_size > 0, error = CHIP_ERROR_INTERNAL);

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -853,7 +853,8 @@ CHIP_ERROR GenECPKeypair(ECPKey & pubkey, ECPKey & privkey)
         privkey_size = BN_bn2binpad(privkey_bn, Uint8::to_uchar(privkey.Value()), privkey.Length());
         privkey_bn   = nullptr;
 
-        VerifyOrExit(privkey_size == privkey.Length(), error = CHIP_ERROR_INTERNAL);
+        VerifyOrExit(privkey_size > 0, error = CHIP_ERROR_INTERNAL);
+        VerifyOrExit((size_t)privkey_size == privkey.Length(), error = CHIP_ERROR_INTERNAL);
     }
 
 exit:

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -797,7 +797,7 @@ void ClearSecretData(uint8_t * buf, uint32_t len)
     memset(buf, 0, len);
 }
 
-CHIP_ERROR GenP256Keypair(P256PublicKey * pubkey, P256PrivateKey * privkey)
+CHIP_ERROR GenP256Keypair(P256PublicKey & pubkey, P256PrivateKey & privkey)
 {
     ERR_clear_error();
     CHIP_ERROR error = CHIP_NO_ERROR;
@@ -805,9 +805,6 @@ CHIP_ERROR GenP256Keypair(P256PublicKey * pubkey, P256PrivateKey * privkey)
     int nid          = NID_undef;
     EC_KEY * ec_key  = nullptr;
     EC_GROUP * group = nullptr;
-
-    VerifyOrExit(pubkey != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(privkey != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     nid = _nidForCurve(ECName::P256v1);
     VerifyOrExit(nid != NID_undef, error = CHIP_ERROR_INVALID_ARGUMENT);
@@ -826,11 +823,11 @@ CHIP_ERROR GenP256Keypair(P256PublicKey * pubkey, P256PrivateKey * privkey)
         const EC_POINT * pubkey_ecp = EC_KEY_get0_public_key(ec_key);
         VerifyOrExit(pubkey_ecp != nullptr, error = CHIP_ERROR_INTERNAL);
 
-        pubkey_size = EC_POINT_point2oct(group, pubkey_ecp, POINT_CONVERSION_UNCOMPRESSED, Uint8::to_uchar(pubkey->bytes),
-                                         sizeof(pubkey->bytes), nullptr);
+        pubkey_size = EC_POINT_point2oct(group, pubkey_ecp, POINT_CONVERSION_UNCOMPRESSED, Uint8::to_uchar(pubkey.bytes),
+                                         sizeof(pubkey.bytes), nullptr);
         pubkey_ecp  = nullptr;
 
-        VerifyOrExit(pubkey_size == sizeof(pubkey->bytes), error = CHIP_ERROR_INTERNAL);
+        VerifyOrExit(pubkey_size == sizeof(pubkey.bytes), error = CHIP_ERROR_INTERNAL);
     }
 
     {
@@ -838,10 +835,10 @@ CHIP_ERROR GenP256Keypair(P256PublicKey * pubkey, P256PrivateKey * privkey)
         const BIGNUM * privkey_bn = EC_KEY_get0_private_key(ec_key);
         VerifyOrExit(privkey_bn != nullptr, error = CHIP_ERROR_INTERNAL);
 
-        privkey_size = BN_bn2binpad(privkey_bn, Uint8::to_uchar(privkey->bytes), sizeof(privkey->bytes));
+        privkey_size = BN_bn2binpad(privkey_bn, Uint8::to_uchar(privkey.bytes), sizeof(privkey.bytes));
         privkey_bn   = nullptr;
 
-        VerifyOrExit(privkey_size == sizeof(privkey->bytes), error = CHIP_ERROR_INTERNAL);
+        VerifyOrExit(privkey_size == sizeof(privkey.bytes), error = CHIP_ERROR_INTERNAL);
     }
 
 exit:

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -797,6 +797,77 @@ void ClearSecretData(uint8_t * buf, uint32_t len)
     memset(buf, 0, len);
 }
 
+CHIP_ERROR GenP256Keypair(uint8_t * pubkey, size_t * pklen, uint8_t * privkey, size_t * pvlen)
+{
+    ERR_clear_error();
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    int result       = 0;
+    int nid          = NID_undef;
+    EC_KEY * ec_key  = nullptr;
+    EC_GROUP * group = nullptr;
+
+    VerifyOrExit(pubkey != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(pklen != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(*pklen > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(privkey != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(pvlen != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(*pvlen > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+
+    nid = _nidForCurve(ECName::P256v1);
+    VerifyOrExit(nid != NID_undef, error = CHIP_ERROR_INVALID_ARGUMENT);
+
+    ec_key = EC_KEY_new_by_curve_name(nid);
+    VerifyOrExit(ec_key != nullptr, error = CHIP_ERROR_INTERNAL);
+
+    group = EC_GROUP_new_by_curve_name(nid);
+    VerifyOrExit(group != nullptr, error = CHIP_ERROR_INTERNAL);
+
+    result = EC_KEY_generate_key(ec_key);
+    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
+
+    {
+        size_t pubkey_size = 0;
+        const EC_POINT * pubkey_ecp = EC_KEY_get0_public_key(ec_key);
+        VerifyOrExit(pubkey_ecp != nullptr, error = CHIP_ERROR_INTERNAL);
+
+        pubkey_size = EC_POINT_point2oct(group, pubkey_ecp, POINT_CONVERSION_UNCOMPRESSED, Uint8::to_uchar(pubkey),
+                                         *pklen, nullptr);
+        pubkey_ecp = nullptr;
+
+        VerifyOrExit(pubkey_size <= *pklen, error = CHIP_ERROR_INTERNAL);
+        *pklen = pubkey_size;
+    }
+
+    {
+        int privkey_size = 0;
+        const BIGNUM * privkey_bn = EC_KEY_get0_private_key(ec_key);
+        VerifyOrExit(privkey_bn != nullptr, error = CHIP_ERROR_INTERNAL);
+
+        privkey_size = BN_bn2binpad(privkey_bn, Uint8::to_uchar(privkey), *pvlen);
+        privkey_bn = nullptr;
+
+        VerifyOrExit(privkey_size > 0, error = CHIP_ERROR_INTERNAL);
+        VerifyOrExit(privkey_size <= *pvlen, error = CHIP_ERROR_INTERNAL);
+        *pvlen = privkey_size;
+    }
+
+exit:
+    if (ec_key != nullptr)
+    {
+        EC_KEY_free(ec_key);
+        ec_key = nullptr;
+    }
+
+    if (group != nullptr)
+    {
+        EC_GROUP_free(group);
+        group = nullptr;
+    }
+
+    _logSSLError();
+    return error;
+}
+
 #define init_point(_point_)                                                                                                        \
     do                                                                                                                             \
     {                                                                                                                              \

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -52,7 +52,7 @@ enum class DigestType
 
 enum class ECName
 {
-    None = 0,
+    None   = 0,
     P256v1 = 1,
 };
 
@@ -802,10 +802,10 @@ ECName MapECName(SupportedECPKeyTypes keyType)
 {
     switch (keyType)
     {
-        case SupportedECPKeyTypes::ECP256R1:
-            return ECName::P256v1;
-        default:
-            return ECName::None;
+    case SupportedECPKeyTypes::ECP256R1:
+        return ECName::P256v1;
+    default:
+        return ECName::None;
     }
 }
 

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -847,7 +847,6 @@ CHIP_ERROR GenP256Keypair(uint8_t * pubkey, size_t * pklen, uint8_t * privkey, s
         privkey_bn   = nullptr;
 
         VerifyOrExit(privkey_size > 0, error = CHIP_ERROR_INTERNAL);
-        VerifyOrExit(privkey_size <= *pvlen, error = CHIP_ERROR_INTERNAL);
         *pvlen = privkey_size;
     }
 

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -854,7 +854,7 @@ CHIP_ERROR GenECPKeypair(ECPKey & pubkey, ECPKey & privkey)
         privkey_bn   = nullptr;
 
         VerifyOrExit(privkey_size > 0, error = CHIP_ERROR_INTERNAL);
-        VerifyOrExit((size_t)privkey_size == privkey.Length(), error = CHIP_ERROR_INTERNAL);
+        VerifyOrExit((size_t) privkey_size == privkey.Length(), error = CHIP_ERROR_INTERNAL);
     }
 
 exit:

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -826,12 +826,12 @@ CHIP_ERROR GenP256Keypair(uint8_t * pubkey, size_t * pklen, uint8_t * privkey, s
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
     {
-        size_t pubkey_size = 0;
+        size_t pubkey_size          = 0;
         const EC_POINT * pubkey_ecp = EC_KEY_get0_public_key(ec_key);
         VerifyOrExit(pubkey_ecp != nullptr, error = CHIP_ERROR_INTERNAL);
 
-        pubkey_size = EC_POINT_point2oct(group, pubkey_ecp, POINT_CONVERSION_UNCOMPRESSED, Uint8::to_uchar(pubkey),
-                                         *pklen, nullptr);
+        pubkey_size =
+            EC_POINT_point2oct(group, pubkey_ecp, POINT_CONVERSION_UNCOMPRESSED, Uint8::to_uchar(pubkey), *pklen, nullptr);
         pubkey_ecp = nullptr;
 
         VerifyOrExit(pubkey_size <= *pklen, error = CHIP_ERROR_INTERNAL);
@@ -839,12 +839,12 @@ CHIP_ERROR GenP256Keypair(uint8_t * pubkey, size_t * pklen, uint8_t * privkey, s
     }
 
     {
-        int privkey_size = 0;
+        int privkey_size          = 0;
         const BIGNUM * privkey_bn = EC_KEY_get0_private_key(ec_key);
         VerifyOrExit(privkey_bn != nullptr, error = CHIP_ERROR_INTERNAL);
 
         privkey_size = BN_bn2binpad(privkey_bn, Uint8::to_uchar(privkey), *pvlen);
-        privkey_bn = nullptr;
+        privkey_bn   = nullptr;
 
         VerifyOrExit(privkey_size > 0, error = CHIP_ERROR_INTERNAL);
         VerifyOrExit(privkey_size <= *pvlen, error = CHIP_ERROR_INTERNAL);

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -533,7 +533,7 @@ void ClearSecretData(uint8_t * buf, uint32_t len)
     memset(buf, 0, len);
 }
 
-CHIP_ERROR GenP256Keypair(P256PublicKey * pubkey, P256PrivateKey * privkey)
+CHIP_ERROR GenP256Keypair(P256PublicKey & pubkey, P256PrivateKey & privkey)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
@@ -543,20 +543,17 @@ CHIP_ERROR GenP256Keypair(P256PublicKey * pubkey, P256PrivateKey * privkey)
     mbedtls_ecp_keypair keypair;
     mbedtls_ecp_keypair_init(&keypair);
 
-    VerifyOrExit(pubkey != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(privkey != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-
     result = mbedtls_ecp_gen_key(MBEDTLS_ECP_DP_SECP256R1, &keypair, CryptoRNG, nullptr);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
     result = mbedtls_ecp_point_write_binary(&keypair.grp, &keypair.Q, MBEDTLS_ECP_PF_UNCOMPRESSED, &pubkey_size,
-                                            Uint8::to_uchar(pubkey->bytes), sizeof(pubkey->bytes));
+                                            Uint8::to_uchar(pubkey.bytes), sizeof(pubkey.bytes));
     VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(pubkey_size == sizeof(pubkey->bytes), error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(pubkey_size == sizeof(pubkey.bytes), error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    VerifyOrExit(mbedtls_mpi_size(&keypair.d) == sizeof(privkey->bytes), error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(mbedtls_mpi_size(&keypair.d) == sizeof(privkey.bytes), error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    result = mbedtls_mpi_write_binary(&keypair.d, Uint8::to_uchar(privkey->bytes), sizeof(privkey->bytes));
+    result = mbedtls_mpi_write_binary(&keypair.d, Uint8::to_uchar(privkey.bytes), sizeof(privkey.bytes));
     VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
 
 exit:

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -562,13 +562,13 @@ CHIP_ERROR GenECPKeypair(ECPKey & pubkey, ECPKey & privkey)
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
     result = mbedtls_ecp_point_write_binary(&keypair.grp, &keypair.Q, MBEDTLS_ECP_PF_UNCOMPRESSED, &pubkey_size,
-                                            Uint8::to_uchar(pubkey.Value()), pubkey.Length());
+                                            Uint8::to_uchar(pubkey), pubkey.Length());
     VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(pubkey_size == pubkey.Length(), error = CHIP_ERROR_INVALID_ARGUMENT);
 
     VerifyOrExit(mbedtls_mpi_size(&keypair.d) == privkey.Length(), error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    result = mbedtls_mpi_write_binary(&keypair.d, Uint8::to_uchar(privkey.Value()), privkey.Length());
+    result = mbedtls_mpi_write_binary(&keypair.d, Uint8::to_uchar(privkey), privkey.Length());
     VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
 
 exit:

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -549,8 +549,8 @@ CHIP_ERROR GenP256Keypair(P256PublicKey * pubkey, P256PrivateKey * privkey)
     result = mbedtls_ecp_gen_key(MBEDTLS_ECP_DP_SECP256R1, &keypair, ECDSA_sign_rng, nullptr);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
-    result = mbedtls_ecp_point_write_binary(&keypair.grp, &keypair.Q, MBEDTLS_ECP_PF_UNCOMPRESSED, &pubkey_size, Uint8::to_uchar(pubkey->bytes),
-                                            sizeof(pubkey->bytes));
+    result = mbedtls_ecp_point_write_binary(&keypair.grp, &keypair.Q, MBEDTLS_ECP_PF_UNCOMPRESSED, &pubkey_size,
+                                            Uint8::to_uchar(pubkey->bytes), sizeof(pubkey->bytes));
     VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(pubkey_size == sizeof(pubkey->bytes), error = CHIP_ERROR_INVALID_ARGUMENT);
 

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -544,7 +544,7 @@ mbedtls_ecp_group_id MapECPGroupId(SupportedECPKeyTypes keyType)
     }
 }
 
-CHIP_ERROR GenECPKeypair(ECPKey & pubkey, ECPKey & privkey)
+CHIP_ERROR NewECPKeypair(ECPKey & pubkey, ECPKey & privkey)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -537,7 +537,8 @@ CHIP_ERROR GenP256Keypair(uint8_t * pubkey, size_t * pklen, uint8_t * privkey, s
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
-    int privkey_size = 0;
+
+    size_t privkey_size = 0;
 
     mbedtls_ecp_keypair keypair;
     mbedtls_ecp_keypair_init(&keypair);

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -537,10 +537,10 @@ mbedtls_ecp_group_id MapECPGroupId(SupportedECPKeyTypes keyType)
 {
     switch (keyType)
     {
-        case SupportedECPKeyTypes::ECP256R1:
-            return MBEDTLS_ECP_DP_SECP256R1;
-        default:
-            return MBEDTLS_ECP_DP_NONE;
+    case SupportedECPKeyTypes::ECP256R1:
+        return MBEDTLS_ECP_DP_SECP256R1;
+    default:
+        return MBEDTLS_ECP_DP_NONE;
     }
 }
 

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -552,7 +552,8 @@ CHIP_ERROR GenP256Keypair(uint8_t * pubkey, size_t * pklen, uint8_t * privkey, s
     result = mbedtls_ecp_gen_key(MBEDTLS_ECP_DP_SECP256R1, &keypair, ECDSA_sign_rng, nullptr);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
-    result = mbedtls_ecp_point_write_binary(&keypair.grp, &keypair.Q, MBEDTLS_ECP_PF_UNCOMPRESSED, pklen, Uint8::to_uchar(pubkey), *pklen);
+    result = mbedtls_ecp_point_write_binary(&keypair.grp, &keypair.Q, MBEDTLS_ECP_PF_UNCOMPRESSED, pklen, Uint8::to_uchar(pubkey),
+                                            *pklen);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     privkey_size = mbedtls_mpi_size(&keypair.d);

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -533,37 +533,31 @@ void ClearSecretData(uint8_t * buf, uint32_t len)
     memset(buf, 0, len);
 }
 
-CHIP_ERROR GenP256Keypair(uint8_t * pubkey, size_t * pklen, uint8_t * privkey, size_t * pvlen)
+CHIP_ERROR GenP256Keypair(P256PublicKey * pubkey, P256PrivateKey * privkey)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
 
-    size_t privkey_size = 0;
+    size_t pubkey_size = 0;
 
     mbedtls_ecp_keypair keypair;
     mbedtls_ecp_keypair_init(&keypair);
 
     VerifyOrExit(pubkey != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(pklen != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(*pklen > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(privkey != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(pvlen != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(*pvlen > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     result = mbedtls_ecp_gen_key(MBEDTLS_ECP_DP_SECP256R1, &keypair, ECDSA_sign_rng, nullptr);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
-    result = mbedtls_ecp_point_write_binary(&keypair.grp, &keypair.Q, MBEDTLS_ECP_PF_UNCOMPRESSED, pklen, Uint8::to_uchar(pubkey),
-                                            *pklen);
+    result = mbedtls_ecp_point_write_binary(&keypair.grp, &keypair.Q, MBEDTLS_ECP_PF_UNCOMPRESSED, &pubkey_size, Uint8::to_uchar(pubkey->bytes),
+                                            sizeof(pubkey->bytes));
     VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(pubkey_size == sizeof(pubkey->bytes), error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    privkey_size = mbedtls_mpi_size(&keypair.d);
-    VerifyOrExit(privkey_size <= *pvlen, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(mbedtls_mpi_size(&keypair.d) == sizeof(privkey->bytes), error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    result = mbedtls_mpi_write_binary(&keypair.d, Uint8::to_uchar(privkey), privkey_size);
+    result = mbedtls_mpi_write_binary(&keypair.d, Uint8::to_uchar(privkey->bytes), sizeof(privkey->bytes));
     VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-
-    *pvlen = privkey_size;
 
 exit:
     mbedtls_ecp_keypair_free(&keypair);

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -383,7 +383,7 @@ exit:
     return error;
 }
 
-static int ECDSA_sign_rng(void * ctxt, uint8_t * out_buffer, size_t out_length)
+static int CryptoRNG(void * ctxt, uint8_t * out_buffer, size_t out_length)
 {
     return (chip::Crypto::DRBG_get_bytes(out_buffer, out_length) == CHIP_NO_ERROR) ? 0 : 1;
 }
@@ -421,7 +421,7 @@ CHIP_ERROR ECDSA_sign_msg(const uint8_t * msg, const size_t msg_length, const ui
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
     result = mbedtls_ecdsa_write_signature(&ecdsa_ctxt, MBEDTLS_MD_SHA256, hash, sizeof(hash), Uint8::to_uchar(out_signature),
-                                           &out_signature_length, ECDSA_sign_rng, NULL);
+                                           &out_signature_length, CryptoRNG, NULL);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
 exit:
@@ -512,7 +512,7 @@ CHIP_ERROR ECDH_derive_secret(const uint8_t * remote_public_key, const size_t re
         mbedtls_ecp_point_read_binary(&ecp_grp, &ecp_pubkey, Uint8::to_const_uchar(remote_public_key), remote_public_key_length);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    result = mbedtls_ecdh_compute_shared(&ecp_grp, &mpi_secret, &ecp_pubkey, &mpi_privkey, ECDSA_sign_rng, NULL);
+    result = mbedtls_ecdh_compute_shared(&ecp_grp, &mpi_secret, &ecp_pubkey, &mpi_privkey, CryptoRNG, NULL);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
     result = mbedtls_mpi_write_binary(&mpi_secret, Uint8::to_uchar(out_secret), out_secret_length);
@@ -546,7 +546,7 @@ CHIP_ERROR GenP256Keypair(P256PublicKey * pubkey, P256PrivateKey * privkey)
     VerifyOrExit(pubkey != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(privkey != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    result = mbedtls_ecp_gen_key(MBEDTLS_ECP_DP_SECP256R1, &keypair, ECDSA_sign_rng, nullptr);
+    result = mbedtls_ecp_gen_key(MBEDTLS_ECP_DP_SECP256R1, &keypair, CryptoRNG, nullptr);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
     result = mbedtls_ecp_point_write_binary(&keypair.grp, &keypair.Q, MBEDTLS_ECP_PF_UNCOMPRESSED, &pubkey_size,
@@ -762,7 +762,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::FEGenerate(void * fe)
 
     Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
-    result = mbedtls_ecp_gen_privkey(&context->curve, (mbedtls_mpi *) fe, ECDSA_sign_rng, nullptr);
+    result = mbedtls_ecp_gen_privkey(&context->curve, (mbedtls_mpi *) fe, CryptoRNG, nullptr);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
 exit:
@@ -819,7 +819,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointMul(void * R, const void * P1, co
     Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
     if (mbedtls_ecp_mul(&context->curve, (mbedtls_ecp_point *) R, (const mbedtls_mpi *) fe1, (const mbedtls_ecp_point *) P1,
-                        ECDSA_sign_rng, nullptr) != 0)
+                        CryptoRNG, nullptr) != 0)
     {
         return CHIP_ERROR_INTERNAL;
     }
@@ -881,7 +881,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_le
     result = mbedtls_mpi_mod_mpi(&w1_bn, &w1_bn, &curve.N);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
-    result = mbedtls_ecp_mul(&curve, &Ltemp, &w1_bn, &curve.G, ECDSA_sign_rng, nullptr);
+    result = mbedtls_ecp_mul(&curve, &Ltemp, &w1_bn, &curve.G, CryptoRNG, nullptr);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
     memset(Lout, 0, *L_len);

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -907,7 +907,7 @@ static void TestP256_Keygen(nlTestSuite * inSuite, void * inContext)
     P256PublicKey pubkey;
     P256PrivateKey privkey;
 
-    NL_TEST_ASSERT(inSuite, GenP256Keypair(pubkey, privkey) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, GenECPKeypair(pubkey, privkey) == CHIP_NO_ERROR);
 
     const char * msg         = "Test Message for Keygen";
     const uint8_t * test_msg = Uint8::from_const_char(msg);
@@ -916,10 +916,10 @@ static void TestP256_Keygen(nlTestSuite * inSuite, void * inContext)
     size_t siglen = sizeof(test_sig);
 
     NL_TEST_ASSERT(inSuite,
-                   ECDSA_sign_msg(test_msg, msglen, privkey.bytes, sizeof(privkey.bytes), test_sig, siglen) == CHIP_NO_ERROR);
+                   ECDSA_sign_msg(test_msg, msglen, privkey.Value(), privkey.Length(), test_sig, siglen) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
-                   ECDSA_validate_msg_signature(test_msg, msglen, pubkey.bytes, sizeof(pubkey.bytes), test_sig, siglen) ==
+                   ECDSA_validate_msg_signature(test_msg, msglen, pubkey.Value(), pubkey.Length(), test_sig, siglen) ==
                        CHIP_NO_ERROR);
 }
 

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -907,7 +907,7 @@ static void TestP256_Keygen(nlTestSuite * inSuite, void * inContext)
     P256PublicKey pubkey;
     P256PrivateKey privkey;
 
-    NL_TEST_ASSERT(inSuite, GenECPKeypair(pubkey, privkey) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, NewECPKeypair(pubkey, privkey) == CHIP_NO_ERROR);
 
     const char * msg         = "Test Message for Keygen";
     const uint8_t * test_msg = Uint8::from_const_char(msg);

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -918,8 +918,7 @@ static void TestP256_Keygen(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, ECDSA_sign_msg(test_msg, msglen, privkey, privkey.Length(), test_sig, siglen) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
-                   ECDSA_validate_msg_signature(test_msg, msglen, pubkey, pubkey.Length(), test_sig, siglen) ==
-                       CHIP_NO_ERROR);
+                   ECDSA_validate_msg_signature(test_msg, msglen, pubkey, pubkey.Length(), test_sig, siglen) == CHIP_NO_ERROR);
 }
 
 static void TestSPAKE2P_spake2p_FEMul(nlTestSuite * inSuite, void * inContext)

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -915,8 +915,7 @@ static void TestP256_Keygen(nlTestSuite * inSuite, void * inContext)
     uint8_t test_sig[kMax_ECDSA_Signature_Length];
     size_t siglen = sizeof(test_sig);
 
-    NL_TEST_ASSERT(inSuite,
-                   ECDSA_sign_msg(test_msg, msglen, privkey.Value(), privkey.Length(), test_sig, siglen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, ECDSA_sign_msg(test_msg, msglen, privkey.Value(), privkey.Length(), test_sig, siglen) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
                    ECDSA_validate_msg_signature(test_msg, msglen, pubkey.Value(), pubkey.Length(), test_sig, siglen) ==

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -905,7 +905,7 @@ static void TestPBKDF2_SHA256_TestVectors(nlTestSuite * inSuite, void * inContex
 static void TestP256_Keygen(nlTestSuite * inSuite, void * inContext)
 {
     uint8_t pubkey[65], privkey[32];
-    size_t pubkey_len = sizeof(pubkey);
+    size_t pubkey_len  = sizeof(pubkey);
     size_t privkey_len = sizeof(privkey);
 
     NL_TEST_ASSERT(inSuite, GenP256Keypair(nullptr, &pubkey_len, nullptr, &privkey_len) == CHIP_ERROR_INVALID_ARGUMENT);
@@ -920,23 +920,22 @@ static void TestP256_Keygen(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, GenP256Keypair(pubkey, &pubkey_len, privkey, &privkey_len) != CHIP_NO_ERROR);
 
     privkey_len = sizeof(privkey);
-    pubkey_len = 0;
+    pubkey_len  = 0;
     NL_TEST_ASSERT(inSuite, GenP256Keypair(pubkey, &pubkey_len, privkey, &privkey_len) == CHIP_ERROR_INVALID_ARGUMENT);
 
-    pubkey_len = sizeof(pubkey);
+    pubkey_len  = sizeof(pubkey);
     privkey_len = sizeof(privkey);
     NL_TEST_ASSERT(inSuite, GenP256Keypair(pubkey, &pubkey_len, privkey, &privkey_len) == CHIP_NO_ERROR);
 
-    const char * msg = "Test Message for Keygen";
+    const char * msg         = "Test Message for Keygen";
     const uint8_t * test_msg = Uint8::from_const_char(msg);
-    size_t msglen = strlen(msg);
+    size_t msglen            = strlen(msg);
     uint8_t test_sig[kMax_ECDSA_Signature_Length];
     size_t siglen = sizeof(test_sig);
 
     NL_TEST_ASSERT(inSuite, ECDSA_sign_msg(test_msg, msglen, privkey, privkey_len, test_sig, siglen) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, ECDSA_validate_msg_signature(test_msg, msglen, pubkey, pubkey_len, test_sig, siglen) == CHIP_NO_ERROR);
-
 }
 
 static void TestSPAKE2P_spake2p_FEMul(nlTestSuite * inSuite, void * inContext)

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -907,11 +907,7 @@ static void TestP256_Keygen(nlTestSuite * inSuite, void * inContext)
     P256PublicKey pubkey;
     P256PrivateKey privkey;
 
-    NL_TEST_ASSERT(inSuite, GenP256Keypair(nullptr, nullptr) == CHIP_ERROR_INVALID_ARGUMENT);
-    NL_TEST_ASSERT(inSuite, GenP256Keypair(&pubkey, nullptr) == CHIP_ERROR_INVALID_ARGUMENT);
-    NL_TEST_ASSERT(inSuite, GenP256Keypair(nullptr, &privkey) == CHIP_ERROR_INVALID_ARGUMENT);
-
-    NL_TEST_ASSERT(inSuite, GenP256Keypair(&pubkey, &privkey) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, GenP256Keypair(pubkey, privkey) == CHIP_NO_ERROR);
 
     const char * msg         = "Test Message for Keygen";
     const uint8_t * test_msg = Uint8::from_const_char(msg);

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -919,9 +919,12 @@ static void TestP256_Keygen(nlTestSuite * inSuite, void * inContext)
     uint8_t test_sig[kMax_ECDSA_Signature_Length];
     size_t siglen = sizeof(test_sig);
 
-    NL_TEST_ASSERT(inSuite, ECDSA_sign_msg(test_msg, msglen, privkey.bytes, sizeof(privkey.bytes), test_sig, siglen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite,
+                   ECDSA_sign_msg(test_msg, msglen, privkey.bytes, sizeof(privkey.bytes), test_sig, siglen) == CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, ECDSA_validate_msg_signature(test_msg, msglen, pubkey.bytes, sizeof(pubkey.bytes), test_sig, siglen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite,
+                   ECDSA_validate_msg_signature(test_msg, msglen, pubkey.bytes, sizeof(pubkey.bytes), test_sig, siglen) ==
+                       CHIP_NO_ERROR);
 }
 
 static void TestSPAKE2P_spake2p_FEMul(nlTestSuite * inSuite, void * inContext)

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -902,6 +902,43 @@ static void TestPBKDF2_SHA256_TestVectors(nlTestSuite * inSuite, void * inContex
     NL_TEST_ASSERT(inSuite, numOfTestsRan > 0);
 }
 
+static void TestP256_Keygen(nlTestSuite * inSuite, void * inContext)
+{
+    uint8_t pubkey[65], privkey[32];
+    size_t pubkey_len = sizeof(pubkey);
+    size_t privkey_len = sizeof(privkey);
+
+    NL_TEST_ASSERT(inSuite, GenP256Keypair(nullptr, &pubkey_len, nullptr, &privkey_len) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, GenP256Keypair(pubkey, &pubkey_len, nullptr, &privkey_len) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, GenP256Keypair(pubkey, nullptr, privkey, &privkey_len) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, GenP256Keypair(pubkey, &pubkey_len, privkey, nullptr) == CHIP_ERROR_INVALID_ARGUMENT);
+
+    privkey_len = 0;
+    NL_TEST_ASSERT(inSuite, GenP256Keypair(pubkey, &pubkey_len, privkey, &privkey_len) == CHIP_ERROR_INVALID_ARGUMENT);
+
+    privkey_len = sizeof(privkey) - 1;
+    NL_TEST_ASSERT(inSuite, GenP256Keypair(pubkey, &pubkey_len, privkey, &privkey_len) != CHIP_NO_ERROR);
+
+    privkey_len = sizeof(privkey);
+    pubkey_len = 0;
+    NL_TEST_ASSERT(inSuite, GenP256Keypair(pubkey, &pubkey_len, privkey, &privkey_len) == CHIP_ERROR_INVALID_ARGUMENT);
+
+    pubkey_len = sizeof(pubkey);
+    privkey_len = sizeof(privkey);
+    NL_TEST_ASSERT(inSuite, GenP256Keypair(pubkey, &pubkey_len, privkey, &privkey_len) == CHIP_NO_ERROR);
+
+    const char * msg = "Test Message for Keygen";
+    const uint8_t * test_msg = Uint8::from_const_char(msg);
+    size_t msglen = strlen(msg);
+    uint8_t test_sig[kMax_ECDSA_Signature_Length];
+    size_t siglen = sizeof(test_sig);
+
+    NL_TEST_ASSERT(inSuite, ECDSA_sign_msg(test_msg, msglen, privkey, privkey_len, test_sig, siglen) == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, ECDSA_validate_msg_signature(test_msg, msglen, pubkey, pubkey_len, test_sig, siglen) == CHIP_NO_ERROR);
+
+}
+
 static void TestSPAKE2P_spake2p_FEMul(nlTestSuite * inSuite, void * inContext)
 {
     uint8_t fe_out[kMAX_FE_Length];
@@ -1329,6 +1366,7 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("Test ECDH sample vectors", TestECDH_SampleInputVectors),
     NL_TEST_DEF("Test adding entropy sources", TestAddEntropySources),
     NL_TEST_DEF("Test PBKDF2 SHA256", TestPBKDF2_SHA256_TestVectors),
+    NL_TEST_DEF("Test P256 Keygen", TestP256_Keygen),
     NL_TEST_DEF("Test Spake2p_spake2p FEMul", TestSPAKE2P_spake2p_FEMul),
     NL_TEST_DEF("Test Spake2p_spake2p FELoad/FEWrite", TestSPAKE2P_spake2p_FELoadWrite),
     NL_TEST_DEF("Test Spake2p_spake2p Mac", TestSPAKE2P_spake2p_Mac),

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -915,10 +915,10 @@ static void TestP256_Keygen(nlTestSuite * inSuite, void * inContext)
     uint8_t test_sig[kMax_ECDSA_Signature_Length];
     size_t siglen = sizeof(test_sig);
 
-    NL_TEST_ASSERT(inSuite, ECDSA_sign_msg(test_msg, msglen, privkey.Value(), privkey.Length(), test_sig, siglen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, ECDSA_sign_msg(test_msg, msglen, privkey, privkey.Length(), test_sig, siglen) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
-                   ECDSA_validate_msg_signature(test_msg, msglen, pubkey.Value(), pubkey.Length(), test_sig, siglen) ==
+                   ECDSA_validate_msg_signature(test_msg, msglen, pubkey, pubkey.Length(), test_sig, siglen) ==
                        CHIP_NO_ERROR);
 }
 

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -904,28 +904,14 @@ static void TestPBKDF2_SHA256_TestVectors(nlTestSuite * inSuite, void * inContex
 
 static void TestP256_Keygen(nlTestSuite * inSuite, void * inContext)
 {
-    uint8_t pubkey[65], privkey[32];
-    size_t pubkey_len  = sizeof(pubkey);
-    size_t privkey_len = sizeof(privkey);
+    P256PublicKey pubkey;
+    P256PrivateKey privkey;
 
-    NL_TEST_ASSERT(inSuite, GenP256Keypair(nullptr, &pubkey_len, nullptr, &privkey_len) == CHIP_ERROR_INVALID_ARGUMENT);
-    NL_TEST_ASSERT(inSuite, GenP256Keypair(pubkey, &pubkey_len, nullptr, &privkey_len) == CHIP_ERROR_INVALID_ARGUMENT);
-    NL_TEST_ASSERT(inSuite, GenP256Keypair(pubkey, nullptr, privkey, &privkey_len) == CHIP_ERROR_INVALID_ARGUMENT);
-    NL_TEST_ASSERT(inSuite, GenP256Keypair(pubkey, &pubkey_len, privkey, nullptr) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, GenP256Keypair(nullptr, nullptr) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, GenP256Keypair(&pubkey, nullptr) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, GenP256Keypair(nullptr, &privkey) == CHIP_ERROR_INVALID_ARGUMENT);
 
-    privkey_len = 0;
-    NL_TEST_ASSERT(inSuite, GenP256Keypair(pubkey, &pubkey_len, privkey, &privkey_len) == CHIP_ERROR_INVALID_ARGUMENT);
-
-    privkey_len = sizeof(privkey) - 1;
-    NL_TEST_ASSERT(inSuite, GenP256Keypair(pubkey, &pubkey_len, privkey, &privkey_len) != CHIP_NO_ERROR);
-
-    privkey_len = sizeof(privkey);
-    pubkey_len  = 0;
-    NL_TEST_ASSERT(inSuite, GenP256Keypair(pubkey, &pubkey_len, privkey, &privkey_len) == CHIP_ERROR_INVALID_ARGUMENT);
-
-    pubkey_len  = sizeof(pubkey);
-    privkey_len = sizeof(privkey);
-    NL_TEST_ASSERT(inSuite, GenP256Keypair(pubkey, &pubkey_len, privkey, &privkey_len) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, GenP256Keypair(&pubkey, &privkey) == CHIP_NO_ERROR);
 
     const char * msg         = "Test Message for Keygen";
     const uint8_t * test_msg = Uint8::from_const_char(msg);
@@ -933,9 +919,9 @@ static void TestP256_Keygen(nlTestSuite * inSuite, void * inContext)
     uint8_t test_sig[kMax_ECDSA_Signature_Length];
     size_t siglen = sizeof(test_sig);
 
-    NL_TEST_ASSERT(inSuite, ECDSA_sign_msg(test_msg, msglen, privkey, privkey_len, test_sig, siglen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, ECDSA_sign_msg(test_msg, msglen, privkey.bytes, sizeof(privkey.bytes), test_sig, siglen) == CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, ECDSA_validate_msg_signature(test_msg, msglen, pubkey, pubkey_len, test_sig, siglen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, ECDSA_validate_msg_signature(test_msg, msglen, pubkey.bytes, sizeof(pubkey.bytes), test_sig, siglen) == CHIP_NO_ERROR);
 }
 
 static void TestSPAKE2P_spake2p_FEMul(nlTestSuite * inSuite, void * inContext)


### PR DESCRIPTION
 #### Problem
Need an API to generate ECP256 keypair for session establishment protocol.

 #### Summary of Changes
Implemented the API for `OpenSSL` and `mbedTLS`.
Added unit tests.