### PR TITLE
[BLE] Allow connect CHIPDeviceController to specific peripheral MAC address

### DIFF
--- a/src/ble/BleConnectionDelegate.h
+++ b/src/ble/BleConnectionDelegate.h
@@ -52,6 +52,10 @@ public:
     // Call this function to delegate the connection steps required to get a BLE_CONNECTION_OBJECT
     // out of a peripheral discriminator.
     virtual void NewConnection(BleLayer * bleLayer, void * appState, const uint16_t connDiscriminator) = 0;
+
+    // Call this function to delegate the connection steps required to get a BLE_CONNECTION_OBJECT
+    // out of a peripheral MAC address.
+    virtual void NewConnection(BleLayer * bleLayer, void * appState, const uint8_t (&connMacAddress)[6]) = 0;
 };
 
 } /* namespace Ble */

--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -387,6 +387,23 @@ exit:
     return err;
 }
 
+BLE_ERROR BleLayer::NewBleConnection(void * appState, const uint8_t (&connMacAddress)[6],
+                                     BleConnectionDelegate::OnConnectionCompleteFunct onConnectionComplete,
+                                     BleConnectionDelegate::OnConnectionErrorFunct onConnectionError)
+{
+    BLE_ERROR err = BLE_NO_ERROR;
+
+    VerifyOrExit(mState == kState_Initialized, err = BLE_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mConnectionDelegate != nullptr, err = BLE_ERROR_INCORRECT_STATE);
+
+    mConnectionDelegate->OnConnectionComplete = onConnectionComplete;
+    mConnectionDelegate->OnConnectionError    = onConnectionError;
+    mConnectionDelegate->NewConnection(this, appState, connMacAddress);
+
+exit:
+    return err;
+}
+
 BLE_ERROR BleLayer::NewBleEndPoint(BLEEndPoint ** retEndPoint, BLE_CONNECTION_OBJECT connObj, BleRole role, bool autoClose)
 {
     *retEndPoint = NULL;

--- a/src/ble/BleLayer.h
+++ b/src/ble/BleLayer.h
@@ -256,6 +256,9 @@ public:
     BLE_ERROR NewBleConnection(void * appState, const uint16_t connDiscriminator,
                                BleConnectionDelegate::OnConnectionCompleteFunct onConnectionComplete,
                                BleConnectionDelegate::OnConnectionErrorFunct onConnectionError);
+    BLE_ERROR NewBleConnection(void * appState, const uint8_t (&connMacAddress)[6],
+                               BleConnectionDelegate::OnConnectionCompleteFunct onConnectionComplete,
+                               BleConnectionDelegate::OnConnectionErrorFunct onConnectionError);
     BLE_ERROR NewBleEndPoint(BLEEndPoint ** retEndPoint, BLE_CONNECTION_OBJECT connObj, BleRole role, bool autoClose);
 
     chip::System::Error ScheduleWork(chip::System::Layer::TimerCompleteFunct aComplete, void * aAppState)

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -228,6 +228,7 @@ CHIP_ERROR ChipDeviceController::ConnectDevice(const BLEDeviceConnectionParamete
 
 #if CONFIG_NETWORK_LAYER_BLE
     Transport::BLE * transport;
+    Transport::BleConnectionParameters bleConnectionParameters(this, params.GetBleLayer());
 
     ChipLogProgress(Controller, "Received new pairing request");
     ChipLogProgress(Controller, "mState %d. mConState %d", mState, mConState);
@@ -248,9 +249,16 @@ CHIP_ERROR ChipDeviceController::ConnectDevice(const BLEDeviceConnectionParamete
     mSetupPINCode = params.GetSetupPINCode();
 
     transport = new Transport::BLE();
-    err       = transport->Init(Transport::BleConnectionParameters(this, params.GetBleLayer())
-                              .SetDiscriminator(params.GetDiscriminator())
-                              .SetSetupPINCode(params.GetSetupPINCode()));
+    bleConnectionParameters.SetSetupPINCode(params.GetSetupPINCode());
+    if (params.GetDiscriminator() != 0)
+    {
+        bleConnectionParameters.SetDiscriminator(params.GetDiscriminator());
+    }
+    else
+    {
+        bleConnectionParameters.SetMacAddress(params.GetMacAddress());
+    }
+    err = transport->Init(bleConnectionParameters);
     SuccessOrExit(err);
 
     mUnsecuredTransport = transport->Retain();

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -77,6 +77,13 @@ public:
         return *this;
     }
 
+    const BLEMacAddress & GetMacAddress() const { return macAddress; }
+    BLEDeviceConnectionParameters & SetMacAddress(const BLEMacAddress & value)
+    {
+        memcpy(macAddress, value, sizeof(macAddress));
+        return *this;
+    }
+
     void * GetAppReqState() const { return appReqState; }
     BLEDeviceConnectionParameters & SetAppReqState(void * value)
     {
@@ -116,6 +123,7 @@ private:
     NodeId remoteDeviceId                   = 0;
     uint16_t discriminator                  = 0;
     uint32_t setupPINCode                   = 0;
+    BLEMacAddress macAddress                = {};
     void * appReqState                      = nullptr;
     NewConnectionHandler onConnected        = nullptr;
     MessageReceiveHandler onMessageReceived = nullptr;
@@ -165,6 +173,32 @@ public:
         return ConnectDevice(BLEDeviceConnectionParameters()
                                  .SetRemoteDeviceId(remoteDeviceId)
                                  .SetDiscriminator(discriminator)
+                                 .SetSetupPINCode(setupPINCode)
+                                 .SetAppReqState(appReqState)
+                                 .SetOnConnected(onConnected)
+                                 .SetOnMessageReceived(onMessageReceived)
+                                 .SetOnError(onError));
+    }
+
+    /**
+     * @brief
+     *   Connect to a CHIP device with a given mac address for Rendezvous
+     *
+     * @param[in] remoteDeviceId        The remote device Id.
+     * @param[in] macAddress            The mac address of the requested Device
+     * @param[in] setupPINCode          The setup PIN code of the requested Device
+     * @param[in] appReqState           Application specific context to be passed back when a message is received or on error
+     * @param[in] onConnected           Callback for when the connection is established
+     * @param[in] onMessageReceived     Callback for when a message is received
+     * @param[in] onError               Callback for when an error occurs
+     * @return CHIP_ERROR               The connection status
+     */
+    CHIP_ERROR ConnectDevice(NodeId remoteDeviceId, BLEMacAddress & macAddress, const uint32_t setupPINCode, void * appReqState,
+                             NewConnectionHandler onConnected, MessageReceiveHandler onMessageReceived, ErrorHandler onError)
+    {
+        return ConnectDevice(BLEDeviceConnectionParameters()
+                                 .SetRemoteDeviceId(remoteDeviceId)
+                                 .SetMacAddress(macAddress)
                                  .SetSetupPINCode(setupPINCode)
                                  .SetAppReqState(appReqState)
                                  .SetOnConnected(onConnected)

--- a/src/transport/BLE.h
+++ b/src/transport/BLE.h
@@ -37,6 +37,8 @@
 #include <support/DLLUtil.h>
 #include <transport/Base.h>
 
+using BLEMacAddress = uint8_t[6];
+
 namespace chip {
 namespace Transport {
 
@@ -84,12 +86,24 @@ public:
         return *this;
     }
 
+    bool HasMacAddress() const { return mHasMacAddress; };
+    const BLEMacAddress & GetMacAddress() { return mMacAddress; };
+    BleConnectionParameters & SetMacAddress(const BLEMacAddress & macAddress)
+    {
+        memcpy(mMacAddress, macAddress, sizeof(mMacAddress));
+        mHasMacAddress = true;
+
+        return *this;
+    }
+
 private:
     BLECallbackHandler * mCallbackHandler = nullptr;
     Ble::BleLayer * mLayer                = nullptr; ///< Associated ble layer
     BLE_CONNECTION_OBJECT mConnectionObj  = 0;       ///< the target peripheral BLE_CONNECTION_OBJECT
     uint16_t mDiscriminator               = 0;       ///< the target peripheral discriminator
     uint32_t mSetupPINCode                = 0;       ///< the target peripheral setup PIN Code
+    BLEMacAddress mMacAddress             = {};      ///< the target peripheral mac address
+    bool mHasMacAddress                   = false;
 };
 
 /** Implements a transport using BLE.
@@ -131,6 +145,7 @@ public:
 private:
     CHIP_ERROR InitInternal(Ble::BleLayer * bleLayer, BLE_CONNECTION_OBJECT connObj);
     CHIP_ERROR DelegateConnection(Ble::BleLayer * bleLayer, const uint16_t connDiscriminator);
+    CHIP_ERROR DelegateConnection(Ble::BleLayer * bleLayer, const BLEMacAddress & connMacAddress);
 
     // Those functions are BLEConnectionDelegate callbacks used when the connection
     // parameters used a name instead of a BLE_CONNECTION_OBJECT.


### PR DESCRIPTION
 #### Problem
Support directly use of peripheral MAC address (discovered by external scanner) for BTP connection

 #### Summary of Changes
1) Add macAddress in BLEDeviceConnectionParameters and BleConnectionParameters
2) Add APIs in BleConnectionDelegate and CHIPDeviceController to allow connecting to specific MAC address
