### PR TITLE
RFC: Add the standalone build back

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
 
         strategy:
             matrix:
-                type: [main, clang, mbedtls]
+                type: [main, clang, mbedtls, standalone]
         env:
             BUILD_TYPE: ${{ matrix.type }}
             BUILD_VERSION: 0.2.18
@@ -51,6 +51,7 @@ jobs:
                      "main") GN_ARGS='';;
                      "clang") GN_ARGS='is_clang=true';;
                      "mbedtls") GN_ARGS='chip_crypto="mbedtls"';;
+                     "standalone") GN_ARGS='import("//config/standalone/args.gni")';;
                      *) ;;
                   esac
 

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -63,6 +63,7 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
 
     if (chip_build_tools) {
       deps += [
+        "${chip_root}/examples/chip-tool",
         "${chip_root}/examples/shell",
         "${chip_root}/src/qrcodetool",
         "${chip_root}/src/setup_payload",

--- a/config/standalone/args.gni
+++ b/config/standalone/args.gni
@@ -15,5 +15,4 @@
 # Options from standalone-chip.mk that differ from configure defaults. These
 # options are used from examples/.
 chip_build_tests = false
-chip_inet_config_enable_raw_endpoint = false
-chip_inet_config_enable_dns_resolver = false
+chip_device_platform = "none"

--- a/examples/chip-tool/args.gni
+++ b/examples/chip-tool/args.gni
@@ -12,6 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import("//build_overrides/chip.gni")
-
-import("${chip_root}/config/standalone/args.gni")
+chip_build_tests = false

--- a/examples/shell/args.gni
+++ b/examples/shell/args.gni
@@ -12,6 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import("//build_overrides/chip.gni")
-
-import("${chip_root}/config/standalone/args.gni")
+chip_build_tests = false

--- a/src/darwin/Framework/chip_xcode_build_connector.sh
+++ b/src/darwin/Framework/chip_xcode_build_connector.sh
@@ -100,7 +100,6 @@ fi
     args+=(
         'target_os="mac"'
         'chip_project_config_include_dirs=["'"$CHIP_ROOT"'/config/standalone"]'
-        'import("'"$CHIP_ROOT"'/config/standalone/args.gni")'
     )
 }
 


### PR DESCRIPTION
This adds back coverage of a build without device layer on Linux.

 #### Problem
We removed coverage of the "standalone" build when device layer was enabled by default.

 #### Summary of Changes
Add a standalone config back to CI.

fixes #1713