### PR TITLE
break reviewer teams back out again

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,8 @@
 # Each line is a file pattern followed by one or more owners.
 
 # Current reviewers-XXX teams, who review everything for approval.
-* @reviewers-amazon @reviewers-apple @reviewers-comcast @reviewers-google @reviewers-samsung
+#* @reviewers-amazon @reviewers-apple @reviewers-comcast @reviewers-google @reviewers-samsung
+@chrisdecenzo @rwalker-apple @bzbarsky-apple @hawk248 @jelderton @robszewcyk @mspang @saurabhst @BroderickCarlin
 
 # Owners of any files in these directories at the root of the repository and
 # any of its subdirectories.


### PR DESCRIPTION
#### Problem
 github apparently doesn't support teams as CODEOWNERS

 #### Summary of Changes
 break individual members back out