### PR TITLE
Fix CHIPTool builds for iOS emulator

### DIFF
--- a/gn/build/toolchain/ios/BUILD.gn
+++ b/gn/build/toolchain/ios/BUILD.gn
@@ -30,3 +30,11 @@ gcc_toolchain("ios_arm64") {
     is_clang = false
   }
 }
+
+gcc_toolchain("ios_x86_64") {
+  toolchain_args = {
+    current_os = "ios"
+    current_cpu = "x86_64"
+    is_clang = false
+  }
+}


### PR DESCRIPTION
 #### Problem
Can't build CHIPTool for iOS emulator.

 #### Summary of Changes
Add a toolchain definition for iOS that targets x86-64.

fixes https://github.com/project-chip/connectedhomeip/issues/2540