### PR TITLE
Fix warnings -Warray-bounds

### DIFF
--- a/examples/platform/nrf528xx/args.gni
+++ b/examples/platform/nrf528xx/args.gni
@@ -37,6 +37,6 @@ chip_inet_config_enable_raw_endpoint = false
 chip_with_nlfaultinjection = true
 
 segger_rtt_buffer_size_up = 4096
-segger_rtt_max_num_up_buffers = 1
-segger_rtt_max_num_down_buffers = 1
+segger_rtt_max_num_up_buffers = 2
+segger_rtt_max_num_down_buffers = 2
 segger_rtt_mode_default = "SEGGER_RTT_MODE_NO_BLOCK_TRIM"


### PR DESCRIPTION
This only happens in optimized builds:

../../examples/lock-app/nrf5/third_party/connectedhomeip/third_party/jlink/segger_rtt/RTT/SEGGER_RTT.c: In function 'SEGGER_RTT_ConfigUpBuffer':
../../examples/lock-app/nrf5/third_party/connectedhomeip/third_party/jlink/segger_rtt/RTT/SEGGER_RTT.c:1759:28: error: array subscript 1 is above array bounds of 'SEGGER_RTT_BUFFER_UP[1]' {aka 'struct <anonymous>[1]'} [-Werror=array-bounds]
 1759 |             _SEGGER_RTT.aUp[BufferIndex].sName        = sName;
      |             ~~~~~~~~~~~~~~~^~~~~~~~~~~~~

 #### Problem
Nordic examples don't build in release.

 #### Summary of Changes
Increase the number of RTT buffers to 2 to avoid the warning.