### PR TITLE
Add interface argument to chip-tool

### DIFF
--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -23,6 +23,7 @@
 
 #include <controller/CHIPDeviceController.h>
 #include <core/CHIPError.h>
+#include <inet/InetInterface.h>
 #include <support/CHIPLogging.h>
 
 enum ArgumentType
@@ -49,6 +50,12 @@ public:
     using PacketBuffer         = ::chip::System::PacketBuffer;
     using NodeId               = ::chip::NodeId;
 
+    struct AddressWithInterface
+    {
+        ::chip::Inet::IPAddress address;
+        ::chip::Inet::InterfaceId interfaceId;
+    };
+
     Command(const char * commandName) : mName(commandName) {}
 
     const char * GetName(void) const { return mName; };
@@ -59,7 +66,7 @@ public:
     bool InitArguments(int argc, char * argv[]);
     size_t AddArgument(const char * name, const char * value);
     size_t AddArgument(const char * name, uint32_t min, uint32_t max, uint32_t * out);
-    size_t AddArgument(const char * name, IPAddress * out);
+    size_t AddArgument(const char * name, AddressWithInterface * out);
 
     virtual CHIP_ERROR Run(ChipDeviceController * dc, NodeId remoteId) = 0;
 

--- a/examples/chip-tool/commands/common/NetworkCommand.cpp
+++ b/examples/chip-tool/commands/common/NetworkCommand.cpp
@@ -86,8 +86,9 @@ CHIP_ERROR NetworkCommand::ConnectBLE(ChipDeviceController * dc, NodeId remoteId
 CHIP_ERROR NetworkCommand::ConnectUDP(ChipDeviceController * dc, NodeId remoteId)
 {
     char hostIpStr[40];
-    mRemoteAddr.ToString(hostIpStr, sizeof(hostIpStr));
+    mRemoteAddr.address.ToString(hostIpStr, sizeof(hostIpStr));
     snprintf(mName, sizeof(mName), "%s:%d", hostIpStr, mRemotePort);
 
-    return dc->ConnectDeviceWithoutSecurePairing(remoteId, mRemoteAddr, nullptr, onConnect, onMessage, onError, mRemotePort);
+    return dc->ConnectDeviceWithoutSecurePairing(remoteId, mRemoteAddr.address, nullptr, onConnect, onMessage, onError, mRemotePort,
+                                                 mRemoteAddr.interfaceId);
 }

--- a/examples/chip-tool/commands/common/NetworkCommand.h
+++ b/examples/chip-tool/commands/common/NetworkCommand.h
@@ -60,7 +60,7 @@ private:
     CHIP_ERROR ConnectUDP(ChipDeviceController * dc, NodeId remoteId);
 
     char mName[46];
-    IPAddress mRemoteAddr;
+    Command::AddressWithInterface mRemoteAddr;
     uint32_t mRemotePort;
     uint32_t mDiscriminator;
     uint32_t mSetupPINCode;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -187,7 +187,8 @@ exit:
 CHIP_ERROR ChipDeviceController::ConnectDeviceUsingPairing(NodeId remoteDeviceId, IPAddress deviceAddr, void * appReqState,
                                                            NewConnectionHandler onConnected,
                                                            MessageReceiveHandler onMessageReceived, ErrorHandler onError,
-                                                           uint16_t devicePort, SecurePairingSession * pairing)
+                                                           uint16_t devicePort, Inet::InterfaceId interfaceId,
+                                                           SecurePairingSession * pairing)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -215,8 +216,8 @@ CHIP_ERROR ChipDeviceController::ConnectDeviceUsingPairing(NodeId remoteDeviceId
     mOnComplete.Response = onMessageReceived;
     mOnError             = onError;
 
-    err = mSessionManager->NewPairing(Optional<Transport::PeerAddress>::Value(Transport::PeerAddress::UDP(deviceAddr, devicePort)),
-                                      pairing);
+    err = mSessionManager->NewPairing(
+        Optional<Transport::PeerAddress>::Value(Transport::PeerAddress::UDP(deviceAddr, devicePort, interfaceId)), pairing);
     SuccessOrExit(err);
 
     mMessageNumber = 1;
@@ -242,20 +243,20 @@ exit:
 
 CHIP_ERROR ChipDeviceController::ConnectDevice(NodeId remoteDeviceId, IPAddress deviceAddr, void * appReqState,
                                                NewConnectionHandler onConnected, MessageReceiveHandler onMessageReceived,
-                                               ErrorHandler onError, uint16_t devicePort)
+                                               ErrorHandler onError, uint16_t devicePort, Inet::InterfaceId interfaceId)
 {
     return ConnectDeviceUsingPairing(remoteDeviceId, deviceAddr, appReqState, onConnected, onMessageReceived, onError, devicePort,
-                                     &mPairingSession);
+                                     interfaceId, &mPairingSession);
 }
 
 CHIP_ERROR ChipDeviceController::ConnectDeviceWithoutSecurePairing(NodeId remoteDeviceId, IPAddress deviceAddr, void * appReqState,
                                                                    NewConnectionHandler onConnected,
                                                                    MessageReceiveHandler onMessageReceived, ErrorHandler onError,
-                                                                   uint16_t devicePort)
+                                                                   uint16_t devicePort, Inet::InterfaceId interfaceId)
 {
     SecurePairingUsingTestSecret pairing(Optional<NodeId>::Value(remoteDeviceId), 0, 0);
     return ConnectDeviceUsingPairing(remoteDeviceId, deviceAddr, appReqState, onConnected, onMessageReceived, onError, devicePort,
-                                     &pairing);
+                                     interfaceId, &pairing);
 }
 
 CHIP_ERROR ChipDeviceController::PopulatePeerAddress(Transport::PeerAddress & peerAddress)

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -101,7 +101,8 @@ public:
      * @return CHIP_ERROR           The connection status
      */
     CHIP_ERROR ConnectDevice(NodeId remoteDeviceId, IPAddress deviceAddr, void * appReqState, NewConnectionHandler onConnected,
-                             MessageReceiveHandler onMessageReceived, ErrorHandler onError, uint16_t devicePort = CHIP_PORT);
+                             MessageReceiveHandler onMessageReceived, ErrorHandler onError, uint16_t devicePort = CHIP_PORT,
+                             Inet::InterfaceId interfaceId = INET_NULL_INTERFACEID);
 
     /**
      * @brief
@@ -120,7 +121,8 @@ public:
     [[deprecated("Available until Rendezvous is implemented")]] CHIP_ERROR
     ConnectDeviceWithoutSecurePairing(NodeId remoteDeviceId, IPAddress deviceAddr, void * appReqState,
                                       NewConnectionHandler onConnected, MessageReceiveHandler onMessageReceived,
-                                      ErrorHandler onError, uint16_t devicePort = CHIP_PORT);
+                                      ErrorHandler onError, uint16_t devicePort = CHIP_PORT,
+                                      Inet::InterfaceId interfaceId = INET_NULL_INTERFACEID);
 
     /**
      * @brief
@@ -239,7 +241,8 @@ private:
 
     CHIP_ERROR ConnectDeviceUsingPairing(NodeId remoteDeviceId, IPAddress deviceAddr, void * appReqState,
                                          NewConnectionHandler onConnected, MessageReceiveHandler onMessageReceived,
-                                         ErrorHandler onError, uint16_t devicePort, SecurePairingSession * pairing);
+                                         ErrorHandler onError, uint16_t devicePort, Inet::InterfaceId interfaceId,
+                                         SecurePairingSession * pairing);
 };
 
 } // namespace DeviceController

--- a/src/transport/PeerAddress.h
+++ b/src/transport/PeerAddress.h
@@ -27,6 +27,7 @@
 #include <stdio.h>
 
 #include <inet/IPAddress.h>
+#include <inet/InetInterface.h>
 
 namespace chip {
 namespace Transport {
@@ -56,7 +57,8 @@ enum class Type
 class PeerAddress
 {
 public:
-    PeerAddress(const Inet::IPAddress & addr, Type type) : mIPAddress(addr), mTransportType(type) {}
+    PeerAddress(const Inet::IPAddress & addr, Type type) : mIPAddress(addr), mTransportType(type), mInterface(INET_NULL_INTERFACEID)
+    {}
     PeerAddress(Type type) : mTransportType(type) {}
 
     PeerAddress(PeerAddress &&)      = default;
@@ -82,6 +84,13 @@ public:
     PeerAddress & SetPort(uint16_t port)
     {
         mPort = port;
+        return *this;
+    }
+
+    Inet::InterfaceId GetInterface() const { return mInterface; }
+    PeerAddress & SetInterface(Inet::InterfaceId interface)
+    {
+        mInterface = interface;
         return *this;
     }
 
@@ -133,11 +142,16 @@ public:
     static PeerAddress BLE() { return PeerAddress(Type::kBle); }
     static PeerAddress UDP(const Inet::IPAddress & addr) { return PeerAddress(addr, Type::kUdp); }
     static PeerAddress UDP(const Inet::IPAddress & addr, uint16_t port) { return UDP(addr).SetPort(port); }
+    static PeerAddress UDP(const Inet::IPAddress & addr, uint16_t port, Inet::InterfaceId interface)
+    {
+        return UDP(addr).SetPort(port).SetInterface(interface);
+    }
 
 private:
     Inet::IPAddress mIPAddress;
     Type mTransportType;
     uint16_t mPort = CHIP_PORT; ///< Relevant for UDP data sending.
+    Inet::InterfaceId mInterface;
 };
 
 } // namespace Transport

--- a/src/transport/UDP.cpp
+++ b/src/transport/UDP.cpp
@@ -97,6 +97,7 @@ CHIP_ERROR UDP::SendMessage(const MessageHeader & header, const Transport::PeerA
 
     addrInfo.DestAddress = address.GetIPAddress();
     addrInfo.DestPort    = address.GetPort();
+    addrInfo.Interface   = address.GetInterface();
 
     VerifyOrExit(msgBuf->EnsureReservedSize(headerSize), err = CHIP_ERROR_NO_MEMORY);
 


### PR DESCRIPTION
 #### Problem
We cannot specify which interface to use when sending to link local addresses using chip-tool.

 #### Summary of Changes
This PR adds `interfaceId` to the `peerAddr` struct and updates the command line parsing code to parse the interface.

Test: `chip-tool on fe80::xxxx%wpan0 11095 1`
