### PR TITLE
fix lwIP Thread interface address synchronization

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -88,6 +88,7 @@ protected:
 
     CHIP_ERROR DoInit(otInstance * otInst);
     bool IsThreadAttachedNoLock(void);
+    bool IsThreadInterfaceUpNoLock(void);
     CHIP_ERROR AdjustPollingInterval(void);
 
     CHIP_ERROR _JoinerStart(void);

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.ipp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.ipp
@@ -837,6 +837,12 @@ bool GenericThreadStackManagerImpl_OpenThread<ImplClass>::IsThreadAttachedNoLock
 }
 
 template <class ImplClass>
+bool GenericThreadStackManagerImpl_OpenThread<ImplClass>::IsThreadInterfaceUpNoLock(void)
+{
+    return otIp6IsEnabled(mOTInst);
+}
+
+template <class ImplClass>
 CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::AdjustPollingInterval(void)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;


### PR DESCRIPTION
 #### Problem
The link local address is not added to the lwip interface when OpenThread has just enabled IP.

 #### Summary of Changes
Modify the lwip interface behavior to check whether Thread has enabled networking rather than whether Thread is attached.

