### PR TITLE
Switch response-sending in cluster code to just use a node id.

### DIFF
--- a/examples/chip-tool/server.cpp
+++ b/examples/chip-tool/server.cpp
@@ -22,6 +22,13 @@ namespace {
 chip::SecureSessionMgr<chip::Transport::UDP> sessions;
 }
 
+namespace chip {
+SecureSessionMgrBase & SessionManager()
+{
+    return sessions;
+}
+} // namespace chip
+
 extern "C" {
 void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
@@ -107,13 +114,12 @@ private:
             return;
         }
 
-        ChipResponseDestination responseDest(header.GetSourceNodeId().Value(), mgr);
         uint8_t * message;
         uint16_t messageLen = extractMessage(buffer->Start(), buffer->DataLength(), &message);
         ok                  = emberAfProcessMessage(&frame,
                                    0, // type
                                    message, messageLen,
-                                   &responseDest, // source identifier
+                                   header.GetSourceNodeId().Value(), // source identifier
                                    NULL);
 
         System::PacketBuffer::Free(buffer);

--- a/examples/lock-app/efr32/src/Server.cpp
+++ b/examples/lock-app/efr32/src/Server.cpp
@@ -127,13 +127,12 @@ private:
             System::PacketBuffer::Free(buffer);
             return;
         }
-        ChipResponseDestination responseDest(header.GetSourceNodeId().Value(), mgr);
         uint8_t * message;
         uint16_t messageLen = extractMessage(buffer->Start(), buffer->DataLength(), &message);
         ret                 = emberAfProcessMessage(&frame,
                                     0, // type
                                     message, messageLen,
-                                    &responseDest, // source identifier
+                                    header.GetSourceNodeId().Value(), // source identifier
                                     NULL);
 
         System::PacketBuffer::Free(buffer);

--- a/examples/lock-app/efr32/src/main.cpp
+++ b/examples/lock-app/efr32/src/main.cpp
@@ -62,6 +62,17 @@ using namespace ::chip::DeviceLayer;
 
 #define UNUSED_PARAMETER(a) (a = a)
 
+namespace {
+DemoSessionManager * sessions;
+} // namespace
+
+namespace chip {
+SecureSessionMgrBase & SessionManager()
+{
+    return *sessions;
+}
+} // namespace chip
+
 volatile int apperror_cnt;
 // ================================================================================
 // App Error
@@ -90,8 +101,8 @@ extern "C" void vApplicationIdleHook(void)
 // ================================================================================
 int main(void)
 {
-    int ret                       = CHIP_ERROR_MAX;
-    DemoSessionManager * sessions = new DemoSessionManager;
+    int ret  = CHIP_ERROR_MAX;
+    sessions = new DemoSessionManager;
 
 #if CHIP_ENABLE_OPENTHREAD
     otSysInit(0, NULL);

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -59,6 +59,13 @@ using namespace ::chip::DeviceLayer;
 AppTask AppTask::sAppTask;
 DemoSessionManager sSessions;
 
+namespace chip {
+SecureSessionMgrBase & SessionManager()
+{
+    return sSessions;
+}
+} // namespace chip
+
 int AppTask::Init()
 {
     // Initialize LEDs

--- a/examples/lock-app/nrfconnect/main/Server.cpp
+++ b/examples/lock-app/nrfconnect/main/Server.cpp
@@ -109,13 +109,12 @@ private:
             return;
         }
 
-        ChipResponseDestination responseDest(header.GetSourceNodeId().Value(), mgr);
         uint8_t * message;
         uint16_t messageLen = extractMessage(buffer->Start(), buffer->DataLength(), &message);
         ok                  = emberAfProcessMessage(&frame,
                                    0, // type
                                    message, messageLen,
-                                   &responseDest, // source identifier
+                                   header.GetSourceNodeId().Value(), // source identifier
                                    NULL);
 
         System::PacketBuffer::Free(buffer);

--- a/examples/platform/nrf528xx/app/Server.cpp
+++ b/examples/platform/nrf528xx/app/Server.cpp
@@ -126,13 +126,12 @@ private:
             return;
         }
 
-        ChipResponseDestination responseDest(header.GetSourceNodeId().Value(), mgr);
         uint8_t * message;
         uint16_t messageLen = extractMessage(buffer->Start(), buffer->DataLength(), &message);
         ok                  = emberAfProcessMessage(&frame,
                                    0, // type
                                    message, messageLen,
-                                   &responseDest, // source identifier
+                                   header.GetSourceNodeId().Value(), // source identifier
                                    NULL);
 
         System::PacketBuffer::Free(buffer);

--- a/examples/platform/nrf528xx/app/chipinit.cpp
+++ b/examples/platform/nrf528xx/app/chipinit.cpp
@@ -58,6 +58,13 @@ using namespace ::chip::DeviceLayer;
 
 DemoSessionManager sessions;
 
+namespace chip {
+SecureSessionMgrBase & SessionManager()
+{
+    return sessions;
+}
+} // namespace chip
+
 #if CHIP_ENABLE_OPENTHREAD
 static void * ot_calloc(size_t n, size_t size)
 {

--- a/examples/wifi-echo/server/esp32/main/DataModelHandler.cpp
+++ b/examples/wifi-echo/server/esp32/main/DataModelHandler.cpp
@@ -59,13 +59,12 @@ void HandleDataModelMessage(const MessageHeader & header, System::PacketBuffer *
         return;
     }
 
-    ChipResponseDestination responseDest(header.GetSourceNodeId().Value(), mgr);
     uint8_t * message;
     uint16_t messageLen = extractMessage(buffer->Start(), buffer->DataLength(), &message);
     ok                  = emberAfProcessMessage(&frame,
                                0, // type
                                message, messageLen,
-                               &responseDest, // source identifier
+                               header.GetSourceNodeId().Value(), // source identifier
                                NULL);
 
     System::PacketBuffer::Free(buffer);

--- a/examples/wifi-echo/server/esp32/main/EchoServer.cpp
+++ b/examples/wifi-echo/server/esp32/main/EchoServer.cpp
@@ -238,6 +238,13 @@ SecureSessionMgr<Transport::UDP, // IPV6
 
 } // namespace
 
+namespace chip {
+SecureSessionMgrBase & SessionManager()
+{
+    return sessions;
+}
+} // namespace chip
+
 void PairingComplete(Optional<NodeId> peerNodeId, uint16_t peerKeyId, uint16_t localKeyId, SecurePairingSession * pairing)
 {
     Optional<Transport::PeerAddress> peer(Transport::Type::kUndefined);

--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -56,12 +56,11 @@
 extern "C" {
 #endif // __cplusplus
 #include "gen/enums.h"
-#include "types_stub.h" // For various types.
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus
 
-#include "chip-response.h" // For ChipResponseDestination
+#include "types_stub.h" // For various types.
 
 #ifdef __cplusplus
 extern "C" {
@@ -465,7 +464,7 @@ typedef struct
      */
     EmberApsFrame * apsFrame;
     EmberIncomingMessageType type;
-    ChipResponseDestination * source;
+    ChipNodeId source;
     uint8_t * buffer;
     uint16_t bufLen;
     bool clusterSpecific;

--- a/src/app/util/chip-response.cpp
+++ b/src/app/util/chip-response.cpp
@@ -25,13 +25,22 @@
 #include <assert.h>
 #include <inet/InetLayer.h> // PacketBuffer and the like
 #include <support/logging/CHIPLogging.h>
+#include <transport/SecureSessionMgr.h> // For SecureSessionMgrBase
 
 using namespace chip;
 
+// TODO: This is not ideal, but we're still sorting out how secure session
+// managers end up working and whether they're singletons.  In the long term,
+// there will be some sane API that lets us send a message to a given node id.
+//
+// https://github.com/project-chip/connectedhomeip/issues/2566 tracks that API.
+namespace chip {
+extern SecureSessionMgrBase & SessionManager();
+}
+
 extern "C" {
 
-EmberStatus chipSendResponse(ChipResponseDestination * destination, EmberApsFrame * apsFrame, uint16_t messageLength,
-                             uint8_t * message)
+EmberStatus chipSendResponse(NodeId destination, EmberApsFrame * apsFrame, uint16_t messageLength, uint8_t * message)
 {
     uint16_t frameSize  = encodeApsFrame(nullptr, 0, apsFrame);
     uint32_t dataLength = uint32_t(frameSize) + uint32_t(messageLength);
@@ -66,7 +75,7 @@ EmberStatus chipSendResponse(ChipResponseDestination * destination, EmberApsFram
     memcpy(buffer->Start() + frameSize, message, messageLength);
     buffer->SetDataLength(dataLength);
 
-    CHIP_ERROR err = destination->mSecureSessionManager->SendMessage(destination->mSourceNodeId, buffer);
+    CHIP_ERROR err = SessionManager().SendMessage(destination, buffer);
     if (err != CHIP_NO_ERROR)
     {
         // FIXME: Figure out better translations between our error types?

--- a/src/app/util/chip-response.h
+++ b/src/app/util/chip-response.h
@@ -17,66 +17,32 @@
 
 /**
  * @file
- *   This file declares the ChipResponseDestination struct and a function that
- *   can be called to send a response (in the form of a buffer and length)
- *   to a given response destination.
- *
- *   This file is designed to be included from both C and C++ code.  When
- *   included from C it provides only an opaque declaration of the destination
- *   struct, because the types in the struct can only be used in C++.
+ *   This file declares a function that can be called to send a response (in the
+ *   form of a buffer and length) to a given response destination node id.
  */
 
 #ifndef CHIP_RESPONSE_H
 #define CHIP_RESPONSE_H
 
-#include "types_stub.h" // For EmberApsFrame and EmberStatus
+#include "types_stub.h" // For EmberApsFrame, EmberStatus, node ids.
 
-#ifdef __cplusplus
-
-#include <transport/MessageHeader.h>    // For NodeId
-#include <transport/SecureSessionMgr.h> // For SecureSessionMgrBase
-
-/**
- * @brief
- *   This struct encapsulates the information needed to send a message in
- *   response to an incoming message: the source node id and the session the
- *   incoming message came in on, for now.  This struct is intended to have
- *   stack lifetime (to ensure that the SecureSessionMgrBase pointer remains
- *   valid).  Consumers must not store references to this struct in a way that
- *   would violate stack discipline.
- */
-struct ChipResponseDestination
-{
-    ChipResponseDestination(chip::NodeId sourceNodeId, chip::SecureSessionMgrBase * secureSessionManager) :
-        mSourceNodeId(sourceNodeId), mSecureSessionManager(secureSessionManager)
-    {}
-    chip::NodeId mSourceNodeId;
-    chip::SecureSessionMgrBase * mSecureSessionManager;
-};
-
-#else // __cplusplus
-
-typedef struct ChipResponseDestination ChipResponseDestination;
-
-#endif // __cplusplus
-
-#ifdef __cplusplus
-extern "C" {
-#endif // __cplusplus
 /**
  * @brief
  *    Called to send a response to a message.  The message is constructed
  *    by serializing the given APS frame followed by the actual message
  *    buffer passed in.
  *
- * @param[in] destination The destination to send the response to.
+ * @param[in] destination The destination node id to send the response to.
  * @param[in] apsFrame The APS frame to use for the response.
  * @param[in] messageLength The length of the message to send after the APS
  *                          frame.
  * @param[in] message The message to send after the APS frame.
  */
-EmberStatus chipSendResponse(ChipResponseDestination * destination, EmberApsFrame * apsFrame, uint16_t messageLength,
-                             uint8_t * message);
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+EmberStatus chipSendResponse(ChipNodeId destination, EmberApsFrame * apsFrame, uint16_t messageLength, uint8_t * message);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/app/util/common.h
+++ b/src/app/util/common.h
@@ -53,6 +53,6 @@
 extern EmberApsFrame emberAfResponseApsFrame;
 extern uint8_t appResponseData[EMBER_AF_RESPONSE_BUFFER_LEN];
 extern uint16_t appResponseLength;
-extern ChipResponseDestination * emberAfResponseDestination;
+extern ChipNodeId emberAfResponseDestination;
 
 #endif // SILABS_COMMON_H

--- a/src/app/util/message.c
+++ b/src/app/util/message.c
@@ -53,7 +53,7 @@
 // receives multiple ZCL messages, the stack will queue these and hand
 // these to the application via emberIncomingMsgHandler one at a time.
 EmberApsFrame emberAfResponseApsFrame;
-ChipResponseDestination * emberAfResponseDestination;
+ChipNodeId emberAfResponseDestination;
 uint8_t appResponseData[EMBER_AF_RESPONSE_BUFFER_LEN];
 uint16_t appResponseLength;
 

--- a/src/app/util/types_stub.h
+++ b/src/app/util/types_stub.h
@@ -46,6 +46,10 @@
 
 #include <app/chip-zcl-zpro-codec.h> // For EmberApsFrame
 
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
 #include "gen/gen_config.h"
 
 /**
@@ -1933,5 +1937,22 @@ typedef struct
 #define emberAfPluginColorControlServerComputePwmFromXyCallback(endpoint) (void) 0
 #define emberAfPluginColorControlServerComputePwmFromHsvCallback(endpoint) (void) 0
 #define emberAfPluginColorControlServerComputePwmFromTempCallback(endpoint) (void) 0
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+/**
+ * Try to use our chip::NodeId definition if we are C++; otherwise define a
+ * ChipNodeId that's compatible.
+ */
+#ifdef __cplusplus
+#include <transport/MessageHeader.h>
+static_assert(sizeof(chip::NodeId) == sizeof(uint64_t), "Unexpected node if size");
+// Make it easier to have unified function declarations across C and C++ source
+// files.
+typedef chip::NodeId ChipNodeId;
+#else
+typedef uint64_t ChipNodeId;
+#endif // __cplusplus
 
 #endif // TYPES_STUB_H

--- a/src/app/util/util.c
+++ b/src/app/util/util.c
@@ -42,6 +42,7 @@
 
 #include "af-main.h"
 #include "af.h"
+#include "chip-response.h"
 #include "common.h"
 //#include "../plugin/time-server/time-server.h"
 #include "af-event.h"
@@ -447,7 +448,7 @@ static bool dispatchZclMessage(EmberAfClusterCommand * cmd)
 }
 
 bool emberAfProcessMessageIntoZclCmd(EmberApsFrame * apsFrame, EmberIncomingMessageType type, uint8_t * message,
-                                     uint16_t messageLength, ChipResponseDestination * source, InterPanHeader * interPanHeader,
+                                     uint16_t messageLength, ChipNodeId source, InterPanHeader * interPanHeader,
                                      EmberAfClusterCommand * returnCmd)
 {
     uint8_t minLength =
@@ -493,7 +494,7 @@ bool emberAfProcessMessageIntoZclCmd(EmberApsFrame * apsFrame, EmberIncomingMess
 
 // a single call to process global and cluster-specific messages and callbacks.
 bool emberAfProcessMessage(EmberApsFrame * apsFrame, EmberIncomingMessageType type, uint8_t * message, uint16_t msgLen,
-                           ChipResponseDestination * source, InterPanHeader * interPanHeader)
+                           ChipNodeId source, InterPanHeader * interPanHeader)
 {
     EmberStatus sendStatus;
     bool msgHandled = false;
@@ -690,7 +691,7 @@ void emAfApplyDisableDefaultResponse(uint8_t * frame_control)
     }
 }
 
-static bool isBroadcastDestination(ChipResponseDestination * responseDestination)
+static bool isBroadcastDestination(ChipNodeId responseDestination)
 {
     // FIXME: Will need to actually figure out how to test for this!
     return false;
@@ -849,7 +850,7 @@ EmberStatus emberAfSendDefaultResponse(const EmberAfClusterCommand * cmd, EmberA
 }
 
 bool emberAfDetermineIfLinkSecurityIsRequired(uint8_t commandId, bool incoming, bool broadcast, EmberAfProfileId profileId,
-                                              EmberAfClusterId clusterId, ChipResponseDestination * remoteNodeId)
+                                              EmberAfClusterId clusterId, ChipNodeId remoteNodeId)
 {
     (void) afNoSecurityForDefaultResponse; // remove warning if not used
 

--- a/src/app/util/util.h
+++ b/src/app/util/util.h
@@ -162,10 +162,10 @@ void emberAfDecodeAndPrintCluster(uint16_t cluster);
 void emberAfDecodeAndPrintClusterWithMfgCode(uint16_t cluster, uint16_t mfgCode);
 
 bool emberAfProcessMessage(EmberApsFrame * apsFrame, EmberIncomingMessageType type, uint8_t * message, uint16_t msgLen,
-                           ChipResponseDestination * source, InterPanHeader * interPanHeader);
+                           ChipNodeId source, InterPanHeader * interPanHeader);
 
 bool emberAfProcessMessageIntoZclCmd(EmberApsFrame * apsFrame, EmberIncomingMessageType type, uint8_t * message,
-                                     uint16_t messageLength, ChipResponseDestination * source, InterPanHeader * interPanHeader,
+                                     uint16_t messageLength, ChipNodeId source, InterPanHeader * interPanHeader,
                                      EmberAfClusterCommand * returnCmd);
 
 /**
@@ -232,7 +232,7 @@ void emberAfSetNoReplyForNextMessage(bool set);
 // the message. It is based on the clusterId and specified in the SE
 // app profile.  If the message is outgoing then the
 bool emberAfDetermineIfLinkSecurityIsRequired(uint8_t commandId, bool incoming, bool broadcast, EmberAfProfileId profileId,
-                                              EmberAfClusterId clusterId, ChipResponseDestination * remoteNodeId);
+                                              EmberAfClusterId clusterId, ChipNodeId remoteNodeId);
 
 #define isThisDataTypeSentLittleEndianOTA(dataType) (!(emberAfIsThisDataTypeAStringType(dataType)))
 


### PR DESCRIPTION
We're going to need to send non-response messages too, and at that
point we won't have a caller-provided secure session manager.  Switch
to only using a node id to send responses, with the secure session
manager provided out-of-band, since we will need that mechanism
anyway.

 #### Problem
As we import clusters that need to send non-response messages, the current setup of passing around a stack-allocated `ChipResponseDestination` no longer works.

 #### Summary of Changes
Just pass around a `chip::NodeId` that encodes the response destination, and make the code that actually sends the response responsible for finding the right session for that node id.

fixes https://github.com/project-chip/connectedhomeip/issues/2554