### PR TITLE
prevent restyled loops

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 
 # Current reviewers-XXX teams, who review everything for approval.
 #* @reviewers-amazon @reviewers-apple @reviewers-comcast @reviewers-google @reviewers-samsung
-@chrisdecenzo @rwalker-apple @bzbarsky-apple @hawk248 @jelderton @robszewcyk @mspang @saurabhst @BroderickCarlin
+* @chrisdecenzo @rwalker-apple @bzbarsky-apple @hawk248 @jelderton @robszewcyk @mspang @saurabhst @BroderickCarlin
 
 # Owners of any files in these directories at the root of the repository and
 # any of its subdirectories.

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -43,6 +43,9 @@ exclude:
     - ".github/workflows/*" # https://github.com/restyled-io/restyler/issues/73
     - ".github/**/*" # https://github.com/restyled-io/restyler/issues/73
     - ".github/*" # https://github.com/restyled-io/restyler/issues/73
+    - "**/third_party/*" # https://github.com/restyled-io/restyled.io/issues/213
+    - "**/third_party/**" # https://github.com/restyled-io/restyled.io/issues/213
+    - "**/third_party/**/*" # https://github.com/restyled-io/restyled.io/issues/213
     - "third_party/android/**/*"
     - "third_party/inipp/repo/**/*"
     - "third_party/jlink/**/*"


### PR DESCRIPTION
#### Problem
Repositories with symbolic links that point upwards (e.g. https://github.com/project-chip/connectedhomeip/blob/master/examples/wifi-echo/server/esp32/third_party/connectedhomeip) send restyled into an infinite loop.

 #### Summary of Changes
 exclude places we know have upward symlinks

(also fixes CODEOWNERS)