### PR TITLE
Fix restyled handling of third-party integration code.

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -43,9 +43,9 @@ exclude:
     - ".github/workflows/*" # https://github.com/restyled-io/restyler/issues/73
     - ".github/**/*" # https://github.com/restyled-io/restyler/issues/73
     - ".github/*" # https://github.com/restyled-io/restyler/issues/73
-    - "**/third_party/*" # https://github.com/restyled-io/restyled.io/issues/213
-    - "**/third_party/**" # https://github.com/restyled-io/restyled.io/issues/213
-    - "**/third_party/**/*" # https://github.com/restyled-io/restyled.io/issues/213
+    - "*/**/third_party/*" # https://github.com/restyled-io/restyled.io/issues/213
+    - "*/**/third_party/**" # https://github.com/restyled-io/restyled.io/issues/213
+    - "*/**/third_party/**/*" # https://github.com/restyled-io/restyled.io/issues/213
     - "third_party/android/**/*"
     - "third_party/inipp/repo/**/*"
     - "third_party/jlink/**/*"


### PR DESCRIPTION
 #### Problem
restyled is no longer restyling files like `third_party/ot-br-posix/BUILD.gn`.

 #### Summary of Changes
Adjust the exclusions to only apply to non-toplevel `third_party` directories.

fixes https://github.com/project-chip/connectedhomeip/issues/2572
