### PR TITLE
Sync up CI with latest docker images

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -45,7 +45,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Setup Build
               run: |
-                  GN_ARGS="is_clang=true target_os=\"android\" target_cpu=\"${{ matrix.type }}\" android_ndk_root=\"/usr/local/share/android-ndk-r21b\""
+                  GN_ARGS="is_clang=true target_os=\"android\" target_cpu=\"${{ matrix.type }}\" android_ndk_root=\"/opt/android/android-ndk-r21b\""
                   scripts/build/gn_gen.sh --args="$GN_ARGS"
             - name: Run Build
               run: |

--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -32,7 +32,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build-android:0.4.2
+            image: connectedhomeip/chip-build-android:0.4.4
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/.github/workflows/bloat_check.yaml
+++ b/.github/workflows/bloat_check.yaml
@@ -24,7 +24,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build:0.4.1
+            image: connectedhomeip/chip-build:0.4.4
 
         steps:
             - name: Checkout

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build:0.4.1
+            image: connectedhomeip/chip-build:0.4.4
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/.github/workflows/examples-autotools.yaml
+++ b/.github/workflows/examples-autotools.yaml
@@ -28,7 +28,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build-esp32:0.4.1
+            image: connectedhomeip/chip-build-esp32:0.4.4
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
                 - "/tmp/output_binaries:/tmp/output_binaries"

--- a/.github/workflows/examples-gn.yml
+++ b/.github/workflows/examples-gn.yml
@@ -28,7 +28,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build-esp32:0.4.1
+            image: connectedhomeip/chip-build-esp32:0.4.4
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
                 - "/tmp/output_binaries:/tmp/output_binaries"

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -82,7 +82,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build:0.4.1
+            image: connectedhomeip/chip-build:0.4.4
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
                 - "/tmp/output_binaries:/tmp/output_binaries"
@@ -130,7 +130,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build-efr32:0.4.1
+            image: connectedhomeip/chip-build-efr32:0.4.4
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
                 - "/tmp/output_binaries:/tmp/output_binaries"
@@ -167,7 +167,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build-nrf-platform:0.4.3
+            image: connectedhomeip/chip-build-nrf-platform:0.4.4
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
                 - "/tmp/output_binaries:/tmp/output_binaries"

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -28,7 +28,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build-esp32-qemu:0.4.1
+            image: connectedhomeip/chip-build-esp32-qemu:0.4.4
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 


### PR DESCRIPTION
 #### Problem
Docker images used by GitHub actions are not up to date.

 #### Summary of Changes
Update all docker images used by GitHub actions to 0.4.4.