### PR TITLE
Fix warnings -Warray-bounds & disable -Wunused

### DIFF
--- a/gn/build/config/compiler/BUILD.gn
+++ b/gn/build/config/compiler/BUILD.gn
@@ -142,6 +142,10 @@ config("disabled_warnings") {
     "-Wno-non-virtual-dtor",
     "-Wno-deprecated-copy",
   ]
+  if (!is_debug) {
+    # assert() causes unused variable warnings in release.
+    cflags += [ "-Wno-unused" ]
+  }
   if (!is_clang) {
     cflags += [
       "-Wno-psabi",

--- a/src/app/util/af-event.cpp
+++ b/src/app/util/af-event.cpp
@@ -79,6 +79,7 @@ const char * emAfEventStrings[] = {
     EMBER_AF_GENERATED_EVENT_STRINGS
 #endif
 
+        NULL,
 };
 
 EmberEventData emAfEvents[] = {


### PR DESCRIPTION
OpenThread EFR32 platform has many instances of variables only used by
assert(), which is a no-op in release builds. Pass -Wno-ununused in
these builds to avoid the warning.

Also, add a trailing NULL to emAfEventStrings to avoid a warning from
-Warray-bounds:

```
../../src/app/util/af-event.cpp: In function 'const char* emberAfGetEventString(uint8_t)':
../../src/app/util/af-event.cpp:103:74: error: array subscript 0 is above array bounds of 'const char* [0]' [-Werror=array-bounds]
  103 |     return (index == 0XFF ? emAfStackEventString : emAfEventStrings[index]);
      |                                                    ~~~~~~~~~~~~~~~~~~~~~~^

```