### PR TITLE
Add libdbus-1-dev & libglib2.0-dev to build dependencies

### DIFF
--- a/docs/BUILDING-GN.md
+++ b/docs/BUILDING-GN.md
@@ -42,7 +42,7 @@ On Debian-based Linux distributions such as Ubuntu, these dependencies can be
 satisfied with the following:
 
 ```
-sudo apt-get install git-core gcc g++ python pkg-config libssl-dev
+sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev libglib2.0-dev
 ```
 
 #### How to install prerequisites on macOS


### PR DESCRIPTION
We've added some build dependencies that need to be documented. Add
them.

Closes #2375