### PR TITLE
Move set -e prior to activate.sh

### DIFF
--- a/gn_build.sh
+++ b/gn_build.sh
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 set -e
 
 CHIP_ROOT="$(dirname "$0")"
@@ -36,9 +37,7 @@ _chip_banner "Environment bringup"
 
 git -C "$CHIP_ROOT" submodule update --init
 
-set +e
 source "$CHIP_ROOT/scripts/activate.sh"
-set -e
 
 _chip_banner "Instructions"
 

--- a/scripts/build/default.sh
+++ b/scripts/build/default.sh
@@ -16,11 +16,13 @@
 # limitations under the License.
 #
 
+set -e
+
 CHIP_ROOT="$(dirname "$0")/../.."
 
 PW_ENVSETUP_QUIET=1 source "$CHIP_ROOT/scripts/activate.sh"
 
-set -ex
+set -x
 
 env
 

--- a/scripts/build/gn_bootstrap.sh
+++ b/scripts/build/gn_bootstrap.sh
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+set -e
+
 # Bootstrap script for GN build GitHub workflow.
 
 # This is used to account bootstrap time in a dedicated workflow step; there's

--- a/scripts/build/gn_build.sh
+++ b/scripts/build/gn_build.sh
@@ -16,13 +16,15 @@
 # limitations under the License.
 #
 
+set -e
+
 # Build script for GN build GitHub workflow.
 
 CHIP_ROOT="$(dirname "$0")/../.."
 
 source "$CHIP_ROOT/scripts/activate.sh"
 
-set -ex
+set -x
 
 env
 

--- a/scripts/build/gn_gen.sh
+++ b/scripts/build/gn_gen.sh
@@ -16,13 +16,15 @@
 # limitations under the License.
 #
 
+set -e
+
 # GN gen script for GN build GitHub workflow.
 
 CHIP_ROOT="$(dirname "$0")/../.."
 
 source "$CHIP_ROOT/scripts/activate.sh"
 
-set -ex
+set -x
 
 env
 

--- a/scripts/examples/gn_build_example.sh
+++ b/scripts/examples/gn_build_example.sh
@@ -16,6 +16,8 @@
 #    limitations under the License.
 #
 
+set -e
+
 # Build script for GN examples GitHub workflow.
 
 CHIP_ROOT="$(dirname "$0")/../.."
@@ -45,7 +47,6 @@ for arg; do
     esac
 done
 
-set -e
 set -x
 env
 

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -16,13 +16,14 @@
 #    limitations under the License.
 #
 
+set -e
+
 # Build script for GN EFT32 examples GitHub workflow.
 
 CHIP_ROOT="$(dirname "$0")/../.."
 
 source "$CHIP_ROOT/scripts/activate.sh"
 
-set -e
 set -x
 env
 

--- a/scripts/examples/gn_nrf_example.sh
+++ b/scripts/examples/gn_nrf_example.sh
@@ -16,13 +16,14 @@
 #    limitations under the License.
 #
 
+set -e
+
 # Build script for GN nRF5 examples GitHub workflow.
 
 CHIP_ROOT="$(dirname "$0")/../.."
 
 source "$CHIP_ROOT/scripts/activate.sh"
 
-set -e
 set -x
 env
 

--- a/scripts/helpers/update_compile_commands.sh
+++ b/scripts/helpers/update_compile_commands.sh
@@ -15,15 +15,13 @@
 # limitations under the License.
 #
 
-# Update compilation database in VS Code devcontainer.
-
 set -e
+
+# Update compilation database in VS Code devcontainer.
 
 CHIP_ROOT="$(dirname "$0")/../.."
 
-set +e
 source "$CHIP_ROOT/scripts/activate.sh"
-set -e
 
 gn --root="$CHIP_ROOT" gen "$CHIP_ROOT/out/debug" --export-compile-commands=all_host_gcc
 mv "$CHIP_ROOT/out/debug/compile_commands.json" "$CHIP_ROOT/out/debug/compile_commands.gcc.json"

--- a/scripts/tests/all_tests.sh
+++ b/scripts/tests/all_tests.sh
@@ -16,11 +16,13 @@
 # limitations under the License.
 #
 
+set -e
+
 CHIP_ROOT="$(dirname "$0")/../.."
 
 PW_ENVSETUP_QUIET=1 source "$CHIP_ROOT/scripts/activate.sh"
 
-set -ex
+set -x
 
 gn gen out/default
 

--- a/scripts/tests/gn_tests.sh
+++ b/scripts/tests/gn_tests.sh
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+set -e
+
 # Test script for GN GitHub workflow.
 
 CHIP_ROOT="$(dirname "$0")/../.."
@@ -24,6 +26,6 @@ source "$CHIP_ROOT/scripts/activate.sh"
 
 env
 
-set -ex
+set -x
 
 ninja -v -C "$CHIP_ROOT/out/$BUILD_TYPE" check

--- a/src/darwin/Framework/chip_xcode_build_connector.sh
+++ b/src/darwin/Framework/chip_xcode_build_connector.sh
@@ -105,11 +105,10 @@ fi
 }
 
 (
-    # activate.sh isn't 'set -e' safe
     cd "$CHIP_ROOT" # pushd and popd because we need the env vars from activate
-    set +ex
+    set +x
     PW_ENVSETUP_QUIET=1 . scripts/activate.sh
-    set -ex
+    set -x
 
     cd "$TEMP_DIR"
     # [[ -f out/build.ninja ]] ?

--- a/src/test_driver/linux-cirque/do_on-off-cluster-test.sh
+++ b/src/test_driver/linux-cirque/do_on-off-cluster-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+set -ex
 
 SOURCE="${BASH_SOURCE[0]}"
 SOURCE_DIR="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"


### PR DESCRIPTION
#### Problem
Errors during activate.sh don't fail immediately.

#### Summary of Changes
Use set -e during activate.sh in scripts now that this works.