### PR TITLE
Convert ConfigurationManager::[Get/Store]SetupDiscriminator to uint16_t

### DIFF
--- a/examples/lighting-app/nrf5/main/AppTask.cpp
+++ b/examples/lighting-app/nrf5/main/AppTask.cpp
@@ -163,7 +163,7 @@ int AppTask::Init()
         CHIP_ERROR err = CHIP_NO_ERROR;
         chip::SetupPayload payload;
         uint32_t setUpPINCode       = 0;
-        uint32_t setUpDiscriminator = 0;
+        uint16_t setUpDiscriminator = 0;
 
         err = ConfigurationMgr().GetSetupPinCode(setUpPINCode);
         if (err != CHIP_NO_ERROR)

--- a/examples/lock-app/efr32/src/AppTask.cpp
+++ b/examples/lock-app/efr32/src/AppTask.cpp
@@ -131,7 +131,7 @@ int AppTask::Init()
 #ifdef DISPLAY_ENABLED
     chip::SetupPayload payload;
     uint32_t setUpPINCode       = 0;
-    uint32_t setUpDiscriminator = 0;
+    uint16_t setUpDiscriminator = 0;
 
     err = ConfigurationMgr().GetSetupPinCode(setUpPINCode);
     if (err != CHIP_NO_ERROR)

--- a/examples/lock-app/nrf5/main/AppTask.cpp
+++ b/examples/lock-app/nrf5/main/AppTask.cpp
@@ -173,7 +173,7 @@ int AppTask::Init()
         CHIP_ERROR err = CHIP_NO_ERROR;
         chip::SetupPayload payload;
         uint32_t setUpPINCode       = 0;
-        uint32_t setUpDiscriminator = 0;
+        uint16_t setUpDiscriminator = 0;
 
         err = ConfigurationMgr().GetSetupPinCode(setUpPINCode);
         if (err != CHIP_NO_ERROR)

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -105,7 +105,7 @@ void AppTask::PrintQRCode() const
 {
     CHIP_ERROR err              = CHIP_NO_ERROR;
     uint32_t setUpPINCode       = 0;
-    uint32_t setUpDiscriminator = 0;
+    uint16_t setUpDiscriminator = 0;
 
     err = ConfigurationMgr().GetSetupPinCode(setUpPINCode);
     if (err != CHIP_NO_ERROR)

--- a/examples/shell/cmd_device.cpp
+++ b/examples/shell/cmd_device.cpp
@@ -345,7 +345,7 @@ static CHIP_ERROR ConfigGetSetupDiscriminator(bool printHeader)
 {
     CHIP_ERROR error  = CHIP_NO_ERROR;
     streamer_t * sout = streamer_get();
-    uint32_t setupDiscriminator;
+    uint16_t setupDiscriminator;
 
     if (printHeader)
     {

--- a/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
@@ -369,7 +369,7 @@ std::string createSetupPayload()
     CHIP_ERROR err = CHIP_NO_ERROR;
     std::string result;
 
-    uint32_t discriminator;
+    uint16_t discriminator;
     err = ConfigurationMgr().GetSetupDiscriminator(discriminator);
     if (err != CHIP_NO_ERROR)
     {

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -81,7 +81,7 @@ public:
     CHIP_ERROR GetManufacturerDeviceIntermediateCACerts(uint8_t * buf, size_t bufSize, size_t & certsLen);
     CHIP_ERROR GetManufacturerDevicePrivateKey(uint8_t * buf, size_t bufSize, size_t & keyLen);
     CHIP_ERROR GetSetupPinCode(uint32_t & setupPinCode);
-    CHIP_ERROR GetSetupDiscriminator(uint32_t & setupDiscriminator);
+    CHIP_ERROR GetSetupDiscriminator(uint16_t & setupDiscriminator);
     CHIP_ERROR GetServiceId(uint64_t & serviceId);
     CHIP_ERROR GetFabricId(uint64_t & fabricId);
     CHIP_ERROR GetServiceConfig(uint8_t * buf, size_t bufSize, size_t & serviceConfigLen);
@@ -104,7 +104,7 @@ public:
     CHIP_ERROR StoreManufacturerDeviceIntermediateCACerts(const uint8_t * certs, size_t certsLen);
     CHIP_ERROR StoreManufacturerDevicePrivateKey(const uint8_t * key, size_t keyLen);
     CHIP_ERROR StoreSetupPinCode(uint32_t setupPinCode);
-    CHIP_ERROR StoreSetupDiscriminator(uint32_t setupDiscriminator);
+    CHIP_ERROR StoreSetupDiscriminator(uint16_t setupDiscriminator);
     CHIP_ERROR StoreServiceProvisioningData(uint64_t serviceId, const uint8_t * serviceConfig, size_t serviceConfigLen,
                                             const char * accountId, size_t accountIdLen);
     CHIP_ERROR ClearServiceProvisioningData();
@@ -301,7 +301,7 @@ inline CHIP_ERROR ConfigurationManager::GetSetupPinCode(uint32_t & setupPinCode)
     return static_cast<ImplClass *>(this)->_GetSetupPinCode(setupPinCode);
 }
 
-inline CHIP_ERROR ConfigurationManager::GetSetupDiscriminator(uint32_t & setupDiscriminator)
+inline CHIP_ERROR ConfigurationManager::GetSetupDiscriminator(uint16_t & setupDiscriminator)
 {
     return static_cast<ImplClass *>(this)->_GetSetupDiscriminator(setupDiscriminator);
 }
@@ -405,7 +405,7 @@ inline CHIP_ERROR ConfigurationManager::StoreSetupPinCode(uint32_t setupPinCode)
     return static_cast<ImplClass *>(this)->_StoreSetupPinCode(setupPinCode);
 }
 
-inline CHIP_ERROR ConfigurationManager::StoreSetupDiscriminator(uint32_t setupDiscriminator)
+inline CHIP_ERROR ConfigurationManager::StoreSetupDiscriminator(uint16_t setupDiscriminator)
 {
     return static_cast<ImplClass *>(this)->_StoreSetupDiscriminator(setupDiscriminator);
 }

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -85,8 +85,8 @@ public:
     CHIP_ERROR _StoreManufacturerDevicePrivateKey(const uint8_t * key, size_t keyLen);
     CHIP_ERROR _GetSetupPinCode(uint32_t & setupPinCode);
     CHIP_ERROR _StoreSetupPinCode(uint32_t setupPinCode);
-    CHIP_ERROR _GetSetupDiscriminator(uint32_t & setupDiscriminator);
-    CHIP_ERROR _StoreSetupDiscriminator(uint32_t setupDiscriminator);
+    CHIP_ERROR _GetSetupDiscriminator(uint16_t & setupDiscriminator);
+    CHIP_ERROR _StoreSetupDiscriminator(uint16_t setupDiscriminator);
     CHIP_ERROR _GetFabricId(uint64_t & fabricId);
     CHIP_ERROR _StoreFabricId(uint64_t fabricId);
     CHIP_ERROR _GetServiceId(uint64_t & serviceId);

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -570,15 +570,16 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StoreSetupPinCode(uint32
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetSetupDiscriminator(uint32_t & setupDiscriminator)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetSetupDiscriminator(uint16_t & setupDiscriminator)
 {
     CHIP_ERROR err;
+    uint32_t val;
 
-    err = Impl()->ReadConfigValue(ImplClass::kConfigKey_SetupDiscriminator, setupDiscriminator);
+    err = Impl()->ReadConfigValue(ImplClass::kConfigKey_SetupDiscriminator, val);
 #if defined(CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR) && CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
-        setupDiscriminator = CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR;
+        val = CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR;
         ChipLogProgress(DeviceLayer, "Setup PIN discriminator not found; using default: %03x",
                         CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR);
         err = CHIP_NO_ERROR;
@@ -586,14 +587,16 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetSetupDiscriminator(ui
 #endif // defined(CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR) && CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR
     SuccessOrExit(err);
 
+    setupDiscriminator = (uint16_t) val;
+
 exit:
     return err;
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StoreSetupDiscriminator(uint32_t setupDiscriminator)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StoreSetupDiscriminator(uint16_t setupDiscriminator)
 {
-    return Impl()->WriteConfigValue(ImplClass::kConfigKey_SetupDiscriminator, setupDiscriminator);
+    return Impl()->WriteConfigValue(ImplClass::kConfigKey_SetupDiscriminator, (uint32_t) setupDiscriminator);
 }
 
 template <class ImplClass>
@@ -784,7 +787,7 @@ GenericConfigurationManagerImpl<ImplClass>::_GetBLEDeviceIdentificationInfo(Ble:
 {
     CHIP_ERROR err;
     uint16_t id;
-    uint32_t discriminator;
+    uint16_t discriminator;
 
     deviceIdInfo.Init();
 

--- a/src/platform/ESP32/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/BLEManagerImpl.cpp
@@ -630,7 +630,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
 
     // If a custom device name has not been specified, generate a CHIP-standard name based on the
     // discriminator value
-    uint32_t discriminator;
+    uint16_t discriminator;
     SuccessOrExit(err = ConfigurationMgr().GetSetupDiscriminator(discriminator));
 
     if (!GetFlag(mFlags, kFlag_UseCustomDeviceName))

--- a/src/platform/ESP32/ConnectivityManagerImpl.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl.cpp
@@ -844,7 +844,7 @@ CHIP_ERROR ConnectivityManagerImpl::ConfigureWiFiAP()
 
     memset(&wifiConfig, 0, sizeof(wifiConfig));
 
-    uint32_t discriminator;
+    uint16_t discriminator;
     SuccessOrExit(err = ConfigurationMgr().GetSetupDiscriminator(discriminator));
 
     snprintf((char *) wifiConfig.ap.ssid, sizeof(wifiConfig.ap.ssid), "%s%04u", CHIP_DEVICE_CONFIG_WIFI_AP_SSID_PREFIX,

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.ipp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.ipp
@@ -918,13 +918,13 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_JoinerStart(voi
 
     {
         otJoinerDiscerner discerner;
-        uint32_t discriminator;
+        uint16_t discriminator;
 
         SuccessOrExit(error = ConfigurationMgr().GetSetupDiscriminator(discriminator));
         discerner.mLength = 12;
         discerner.mValue  = discriminator;
 
-        ChipLogProgress(DeviceLayer, "Joiner Discerner: %u", discriminator);
+        ChipLogProgress(DeviceLayer, "Joiner Discerner: %hu", discriminator);
         otJoinerSetDiscerner(mOTInst, &discerner);
     }
 

--- a/src/platform/tests/TestConfigurationMgr.cpp
+++ b/src/platform/tests/TestConfigurationMgr.cpp
@@ -294,8 +294,8 @@ static void TestConfigurationMgr_SetupDiscriminator(nlTestSuite * inSuite, void 
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    const uint32_t setSetupDiscriminator = 0xBA0;
-    uint32_t getSetupDiscriminator       = 0;
+    const uint16_t setSetupDiscriminator = 0xBA0;
+    uint16_t getSetupDiscriminator       = 0;
 
     err = ConfigurationMgr().StoreSetupDiscriminator(setSetupDiscriminator);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);


### PR DESCRIPTION
 #### Problem

discriminator is really a 16-bit value while the code tries to read/store it as a uint32_t.

 #### Summary of Changes
Change the ConfigurationManager API to use uint16_t instead of uint32_t

fixes #2562 
