### PR TITLE
Remove 'import sys' from gn/chip/write_buildconfig_header.py

### DIFF
--- a/gn/chip/write_buildconfig_header.py
+++ b/gn/chip/write_buildconfig_header.py
@@ -54,7 +54,6 @@
 import optparse
 import os
 import shlex
-import sys
 
 
 class Options:


### PR DESCRIPTION
 #### Problem
Just found this alert on LGTM while debugging an issue with an other PR and LGTM.
```Import of 'sys' is not used.
This alert was introduced in1fcb6dd18 days ago```

 #### Summary of Changes
 * Remove it