### PR TITLE
Remove '-Wno-deprecated-declarations' from src/controller/BUILD.gn

### DIFF
--- a/src/controller/BUILD.gn
+++ b/src/controller/BUILD.gn
@@ -14,11 +14,6 @@
 
 import("//build_overrides/chip.gni")
 
-# FIXME: remove after actual key exchange is implemented
-config("controller_wno_deprecate") {
-  cflags = [ "-Wno-deprecated-declarations" ]
-}
-
 static_library("controller") {
   output_name = "libChipController"
 
@@ -33,6 +28,4 @@ static_library("controller") {
     "${chip_root}/src/platform",
     "${chip_root}/src/transport",
   ]
-
-  configs += [ ":controller_wno_deprecate" ]
 }


### PR DESCRIPTION
 #### Problem
This has been introduced to accommodate the deprecated TemporaryManualKeyExchange that was done in src/controller.
I don't think we need that anymore since this code has been removed.

 #### Summary of Changes
* Remove the cflags from src/controller/BUILD.gn