### PR TITLE
[BUILD FIX] Use uint16_t for discriminator in examples/lighting-app/nrfconnect/ma…

### DIFF
--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -113,7 +113,7 @@ void AppTask::PrintQRCode() const
 {
     CHIP_ERROR err              = CHIP_NO_ERROR;
     uint32_t setUpPINCode       = 0;
-    uint32_t setUpDiscriminator = 0;
+    uint16_t setUpDiscriminator = 0;
 
     err = ConfigurationMgr().GetSetupPinCode(setUpPINCode);
     if (err != CHIP_NO_ERROR)


### PR DESCRIPTION
…in/AppTask.cpp

 #### Problem
Seems like the build is broken because of a collision. 
#2590 has landed a bit before #2531. But #2531 introduce a new uint32_t discriminator that should be a uint16_t.

 #### Summary of Changes
Use uint16_t instead of uint32_t.
