### PR TITLE
Restore useful error message when an unknown command name is passed to chip-tool

### DIFF
--- a/examples/chip-tool/commands/Commands.h
+++ b/examples/chip-tool/commands/Commands.h
@@ -91,8 +91,15 @@ CHIP_ERROR RunCommand(chip::DeviceController::ChipDeviceController * dc, chip::N
 
             err = cmd->Run(dc, remoteId);
             SuccessOrExit(err);
+
+            return err;
         }
     }
+
+    // No command found.
+    ChipLogError(chipTool, "Unknown command: %s", argv[1]);
+    ShowUsage(commands, ArraySize(commands), argv[0]);
+    return CHIP_ERROR_NOT_IMPLEMENTED;
 
 exit:
     if (err != CHIP_NO_ERROR)


### PR DESCRIPTION
 #### Problem
`chip-tool santa-claus` will silently do nothing instead of printing usage.

 #### Summary of Changes
Log that the command is unknown and print usage.

fixes https://github.com/project-chip/connectedhomeip/issues/2600
