### PR TITLE
Fix last LGTM issues

### DIFF
--- a/src/inet/IPAddress.h
+++ b/src/inet/IPAddress.h
@@ -133,6 +133,14 @@ typedef enum
 class DLL_EXPORT IPAddress
 {
 public:
+    IPAddress() = default;
+
+    /**
+     *  Copy constructor for the IPAddress class.
+     *
+     */
+    IPAddress(const IPAddress & other) = default;
+
     /**
      * @brief   Opaque word array to contain IP addresses (independent of protocol version)
      *

--- a/src/inet/IPPrefix.h
+++ b/src/inet/IPPrefix.h
@@ -46,6 +46,14 @@ namespace Inet {
 class IPPrefix
 {
 public:
+    IPPrefix() = default;
+
+    /**
+     *  Copy constructor for the IPPrefix class.
+     *
+     */
+    IPPrefix(const IPPrefix & other) = default;
+
     /** An IPv6 or IPv4 address. */
     IPAddress IPAddr;
 

--- a/src/inet/InetLayer.cpp
+++ b/src/inet/InetLayer.cpp
@@ -264,7 +264,7 @@ INET_ERROR InetLayer::Init(chip::System::Layer & aSystemLayer, void * aContext)
 
     mPlatformData = NULL;
 
-    Platform::InetLayer::WillInit(this, aContext);
+    err = Platform::InetLayer::WillInit(this, aContext);
     SuccessOrExit(err);
 
     mSystemLayer = &aSystemLayer;

--- a/src/inet/InetLayerBasis.h
+++ b/src/inet/InetLayerBasis.h
@@ -127,6 +127,12 @@ public:
     SocketEvents(const SocketEvents & other) { Value = other.Value; }
 
     /**
+     *  Copy assignment operator for the SocketEvents class.
+     *
+     */
+    SocketEvents & operator=(const SocketEvents & other) = default;
+
+    /**
      *  Check if any of the bit flags for the socket events are set.
      *
      *  @return true if set, otherwise false.


### PR DESCRIPTION
 #### Problem

LGTM show some warnings. Actually one of them is a real error since we are ignoring the return value of function that returns an INET_ERROR code and explicitly checks for it on the following line.

This PR should remove the last LGTM alerts. Not sure if there is a way to turn LGTM results as fatal now ?
 