### PR TITLE
Add extra bootstrap hint to gn_build.sh

### DIFF
--- a/gn_build.sh
+++ b/gn_build.sh
@@ -37,6 +37,10 @@ _chip_banner "Environment bringup"
 
 git -C "$CHIP_ROOT" submodule update --init
 
+# TODO: Fix pigweed to bootstrap if necessary in activate.sh.
+echo
+echo "NB: If this fails run \"source scripts/bootstrap.sh\""
+
 source "$CHIP_ROOT/scripts/activate.sh"
 
 _chip_banner "Instructions"


### PR DESCRIPTION
This is pretty confusing right now due to the transition, and has
tripped up multiple people. Add an extra note before bootstrap about
what "run bootstrap" means for us.

 #### Problem
Instruction to "Run bootstrap" is not clear while we still have multiple bootstraps.

 #### Summary of Changes
Add a note saying which bootstrap to run.