### PR TITLE
Enable TestInetEndPoint and TestInetLayerDNS

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,6 +37,7 @@ jobs:
             image: connectedhomeip/chip-build:0.4.6
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
+            options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1"
 
         steps:
             - name: Checkout

--- a/src/inet/tests/BUILD.gn
+++ b/src/inet/tests/BUILD.gn
@@ -53,5 +53,7 @@ chip_test_suite("tests") {
   tests = [
     "TestInetAddress",
     "TestInetErrorStr",
+    "TestInetEndPoint",
+    "TestInetLayerDNS",
   ]
 }

--- a/src/inet/tests/Makefile.am
+++ b/src/inet/tests/Makefile.am
@@ -181,15 +181,20 @@ TestLwIPDNS_LDADD                                     = libTestInetCommon.a $(CO
 TestInetAddress_SOURCES                               = TestInetAddressDriver.cpp
 TestInetAddress_LDADD                                 = $(COMMON_LDADD)
 
-TestInetEndPoint_SOURCES                              = TestInetEndPoint.cpp    \
+TestInetEndPoint_SOURCES                              = TestInetEndPointDriver.cpp    \
+                                                        TestInetEndPoint.cpp          \
                                                         $(NULL)
+
 TestInetEndPoint_LDADD                                = libTestInetCommon.a $(COMMON_LDADD)
 
 TestInetErrorStr_SOURCES                              = TestInetErrorStrDriver.cpp    \
                                                         $(NULL)
 TestInetErrorStr_LDADD                                = $(COMMON_LDADD)
 
-TestInetLayerDNS_SOURCES                              = TestInetLayerDNS.cpp
+TestInetLayerDNS_SOURCES                              = TestInetLayerDNSDriver.cpp    \
+                                                        TestInetLayerDNS.cpp          \
+                                                        $(NULL)
+
 TestInetLayerDNS_LDADD                                = libTestInetCommon.a $(COMMON_LDADD)
 
 TestInetLayer_SOURCES                                 = TestInetLayer.cpp    \

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -28,6 +28,8 @@
 #define __STDC_LIMIT_MACROS
 #endif
 
+#include "TestInetLayer.h"
+
 #include <errno.h>
 #include <inttypes.h>
 #include <stdint.h>
@@ -54,11 +56,6 @@ using namespace chip::Inet;
 using namespace chip::System;
 
 #define TOOL_NAME "TestInetEndPoint"
-
-static ArgParser::HelpOptions gHelpOptions(TOOL_NAME, "Usage: " TOOL_NAME " [<options...>]\n",
-                                           CHIP_VERSION_STRING "\n" CHIP_TOOL_COPYRIGHT);
-
-static ArgParser::OptionSet * gToolOptionSets[] = { &gNetworkOptions, &gFaultInjectionOptions, &gHelpOptions, NULL };
 
 bool callbackHandlerCalled = false;
 
@@ -129,7 +126,7 @@ static void TestInetPre(nlTestSuite * inSuite, void * inContext)
 // Test Inet ResolveHostAddress functionality
 static void TestResolveHostAddress(nlTestSuite * inSuite, void * inContext)
 {
-    char testHostName1[20] = "www.nest.com";
+    char testHostName1[20] = "www.google.com";
     char testHostName2[20] = "127.0.0.1";
     char testHostName3[20] = "";
     char testHostName4[260];
@@ -191,7 +188,7 @@ static void TestResolveHostAddress(nlTestSuite * inSuite, void * inContext)
 static void TestParseHost(nlTestSuite * inSuite, void * inContext)
 {
     char correctHostName[7][30] = {
-        "10.0.0.1", "10.0.0.1:3000", "www.nest.com", "www.nest.com:3000", "[fd00:0:1:1::1]:3000", "[fd00:0:1:1::1]:300%wpan0",
+        "10.0.0.1", "10.0.0.1:3000", "www.google.com", "www.google.com:3000", "[fd00:0:1:1::1]:3000", "[fd00:0:1:1::1]:300%wpan0",
         "%wpan0"
     };
     char invalidHostName[4][30] = { "[fd00::1]5", "[fd00:0:1:1::1:3000", "10.0.0.1:1234567", "10.0.0.1:er31" };
@@ -296,7 +293,7 @@ static void TestInetInterface(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, !addrIterator.HasBroadcastAddress());
 }
 
-static void TestInetEndPoint(nlTestSuite * inSuite, void * inContext)
+static void TestInetEndPointInternal(nlTestSuite * inSuite, void * inContext)
 {
     INET_ERROR err;
     IPAddress addr_any = IPAddress::Any;
@@ -525,7 +522,7 @@ static const nlTest sTests[] = { NL_TEST_DEF("InetEndPoint::PreTest", TestInetPr
                                  NL_TEST_DEF("InetEndPoint::TestParseHost", TestParseHost),
                                  NL_TEST_DEF("InetEndPoint::TestInetError", TestInetError),
                                  NL_TEST_DEF("InetEndPoint::TestInetInterface", TestInetInterface),
-                                 NL_TEST_DEF("InetEndPoint::TestInetEndPoint", TestInetEndPoint),
+                                 NL_TEST_DEF("InetEndPoint::TestInetEndPoint", TestInetEndPointInternal),
                                  NL_TEST_DEF("InetEndPoint::TestEndPointLimit", TestInetEndPointLimit),
                                  NL_TEST_SENTINEL() };
 
@@ -550,7 +547,7 @@ static int TestTeardown(void * inContext)
 }
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
-int TestInetEndPoint(void)
+int TestInetEndPointInternal(void)
 {
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
     // clang-format off
@@ -574,20 +571,15 @@ int TestInetEndPoint(void)
 
 static void __attribute__((constructor)) TestCHIPInetEndpointCtor(void)
 {
-    VerifyOrDie(RegisterUnitTests(&TestInetEndPoint) == CHIP_NO_ERROR);
+    VerifyOrDie(RegisterUnitTests(&TestInetEndPointInternal) == CHIP_NO_ERROR);
 }
 
-int main(int argc, char * argv[])
+int TestInetEndPoint()
 {
     SetSIGUSR1Handler();
-
-    if (!ParseArgs(TOOL_NAME, argc, argv, gToolOptionSets, NULL))
-    {
-        exit(EXIT_FAILURE);
-    }
 
     // Generate machine-readable, comma-separated value (CSV) output.
     nlTestSetOutputStyle(OUTPUT_CSV);
 
-    return (TestInetEndPoint());
+    return (TestInetEndPointInternal());
 }

--- a/src/inet/tests/TestInetEndPointDriver.cpp
+++ b/src/inet/tests/TestInetEndPointDriver.cpp
@@ -17,26 +17,20 @@
 
 /**
  *    @file
- *      This file declares test entry points for CHIP Internet (inet)
- *      layer library unit tests.
+ *      This file implements a standalone/native program executable
+ *      test driver for the CHIP Internet (inet) library address unit
+ *      tests.
  *
  */
 
-#ifndef TESTINETLAYER_H
-#define TESTINETLAYER_H
+#include "TestInetLayer.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include <nlunit-test.h>
 
-int TestInetAddress(void);
-int TestInetBuffer(void);
-int TestInetErrorStr(void);
-int TestInetTimer(void);
-int TestInetEndPoint(void);
-int TestInetLayerDNS(void);
-#ifdef __cplusplus
+int main(void)
+{
+    // Generate machine-readable, comma-separated value (CSV) output.
+    nlTestSetOutputStyle(OUTPUT_CSV);
+
+    return (TestInetEndPoint());
 }
-#endif
-
-#endif // TESTINETLAYER_H

--- a/src/inet/tests/TestInetLayerDNS.cpp
+++ b/src/inet/tests/TestInetLayerDNS.cpp
@@ -27,6 +27,8 @@
 #define __STDC_LIMIT_MACROS
 #endif
 
+#include "TestInetLayer.h"
+
 #include <inttypes.h>
 #include <stdint.h>
 #include <string.h>
@@ -81,20 +83,6 @@ static void StartTestCase(DNSResolutionTestContext & testContext);
 static void HandleResolutionComplete(void * appState, INET_ERROR err, uint8_t addrCount, IPAddress * addrArray);
 static void ServiceNetworkUntilDone(uint32_t timeoutMS);
 static void HandleSIGUSR1(int sig);
-
-// clang-format off
-static ArgParser::HelpOptions gHelpOptions(TOOL_NAME,
-                                           "Usage: " TOOL_NAME " [<options...>]\n",
-                                           CHIP_VERSION_STRING "\n" CHIP_TOOL_COPYRIGHT);
-
-static ArgParser::OptionSet * gToolOptionSets[] =
-{
-    &gNetworkOptions,
-    &gFaultInjectionOptions,
-    &gHelpOptions,
-    NULL
-};
-// clang-format on
 
 /**
  * Test basic name resolution functionality.
@@ -678,7 +666,7 @@ static void HandleSIGUSR1(int sig)
     exit(0);
 }
 
-int TestInetLayerDNS(void)
+int TestInetLayerDNSInternal(void)
 {
     // clang-format off
     const nlTest DNSTests[] =
@@ -719,12 +707,11 @@ int TestInetLayerDNS(void)
 
 static void __attribute__((constructor)) TestCHIPInetLayerDNSCtor(void)
 {
-    VerifyOrDie(RegisterUnitTests(&TestInetLayerDNS) == CHIP_NO_ERROR);
+    VerifyOrDie(RegisterUnitTests(&TestInetLayerDNSInternal) == CHIP_NO_ERROR);
 }
-
 #else // !INET_CONFIG_ENABLE_DNS_RESOLVER
 
-int TestInetLayerDNS(void)
+int TestInetLayerDNSInternal(void)
 {
     fprintf(stderr, "Please assert INET_CONFIG_ENABLE_DNS_RESOLVER to use this test.\n");
 
@@ -733,19 +720,11 @@ int TestInetLayerDNS(void)
 
 #endif // !INET_CONFIG_ENABLE_DNS_RESOLVER
 
-int main(int argc, char * argv[])
+int TestInetLayerDNS()
 {
-    SetupFaultInjectionContext(argc, argv);
-
     SetSignalHandler(HandleSIGUSR1);
-
-    if (!ParseArgsFromEnvVar(TOOL_NAME, TOOL_OPTIONS_ENV_VAR_NAME, gToolOptionSets, NULL, true) ||
-        !ParseArgs(TOOL_NAME, argc, argv, gToolOptionSets, NULL))
-    {
-        exit(EXIT_FAILURE);
-    }
 
     nlTestSetOutputStyle(OUTPUT_CSV);
 
-    return (TestInetLayerDNS());
+    return (TestInetLayerDNSInternal());
 }

--- a/src/inet/tests/TestInetLayerDNSDriver.cpp
+++ b/src/inet/tests/TestInetLayerDNSDriver.cpp
@@ -17,26 +17,20 @@
 
 /**
  *    @file
- *      This file declares test entry points for CHIP Internet (inet)
- *      layer library unit tests.
+ *      This file implements a standalone/native program executable
+ *      test driver for the CHIP Internet (inet) library address unit
+ *      tests.
  *
  */
 
-#ifndef TESTINETLAYER_H
-#define TESTINETLAYER_H
+#include "TestInetLayer.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include <nlunit-test.h>
 
-int TestInetAddress(void);
-int TestInetBuffer(void);
-int TestInetErrorStr(void);
-int TestInetTimer(void);
-int TestInetEndPoint(void);
-int TestInetLayerDNS(void);
-#ifdef __cplusplus
+int main(void)
+{
+    // Generate machine-readable, comma-separated value (CSV) output.
+    nlTestSetOutputStyle(OUTPUT_CSV);
+
+    return (TestInetLayerDNS());
 }
-#endif
-
-#endif // TESTINETLAYER_H


### PR DESCRIPTION
 #### Problem
Missing TestInetEndPoint and TestInetLayerDNS for Inet layer

 #### Summary of Changes
Add TestInetEndPoint and TestInetLayerDNS
Add IPv6 support when bringing up docker

Fix #329