### PR TITLE
Use VerifyOrDie instead of assert() in inet and platform code

### DIFF
--- a/src/inet/TCPEndPoint.cpp
+++ b/src/inet/TCPEndPoint.cpp
@@ -60,7 +60,6 @@
 
 #include "arpa-inet-compatibility.h"
 
-#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -1231,7 +1230,7 @@ INET_ERROR TCPEndPoint::DriveSending()
                 uint8_t * sendData = mUnsentQueue->Start() + mUnsentOffset;
 
                 // Determine the amount of data to send from the current buffer.
-                assert(bufDataLen >= mUnsentOffset);
+                VerifyOrDie(bufDataLen >= mUnsentOffset);
                 uint16_t sendLen = static_cast<uint16_t>(bufDataLen - mUnsentOffset);
                 if (sendLen > sendWindowSize)
                     sendLen = sendWindowSize;
@@ -2463,9 +2462,9 @@ void TCPEndPoint::ReceiveData()
         // Otherwise, add the new data onto the receive queue.
         else if (isNewBuf)
         {
-            assert(rcvLen > 0);
+            VerifyOrDie(rcvLen > 0);
             size_t newDataLength = rcvBuf->DataLength() + static_cast<size_t>(rcvLen);
-            assert(CanCastTo<uint16_t>(newDataLength));
+            VerifyOrDie(CanCastTo<uint16_t>(newDataLength));
             rcvBuf->SetDataLength(static_cast<uint16_t>(newDataLength));
             if (mRcvQueue == NULL)
                 mRcvQueue = rcvBuf;
@@ -2475,9 +2474,9 @@ void TCPEndPoint::ReceiveData()
 
         else
         {
-            assert(rcvLen > 0);
+            VerifyOrDie(rcvLen > 0);
             size_t newDataLength = rcvBuf->DataLength() + static_cast<size_t>(rcvLen);
-            assert(CanCastTo<uint16_t>(newDataLength));
+            VerifyOrDie(CanCastTo<uint16_t>(newDataLength));
             rcvBuf->SetDataLength(static_cast<uint16_t>(newDataLength), mRcvQueue);
         }
     }

--- a/src/platform/K32W/Logging.cpp
+++ b/src/platform/K32W/Logging.cpp
@@ -102,12 +102,12 @@ void FillPrefix(char * buf, uint8_t bufLen, uint8_t chipCategory, uint8_t otLogL
     size_t prefixLen;
 
     /* add the error string */
-    assert(bufLen > ChipLoggingChipPrefixLen);
+    VerifyOrDie(bufLen > ChipLoggingChipPrefixLen);
     ::GetMessageString(buf, chipCategory, otLogLevel);
 
     /* add the module name string */
     prefixLen = strlen(buf);
-    assert(bufLen > (prefixLen + ChipLoggingModuleNameLen + 3));
+    VerifyOrDie(bufLen > (prefixLen + ChipLoggingModuleNameLen + 3));
     buf[prefixLen++] = '[';
     GetModuleName(buf + prefixLen, module);
     prefixLen        = strlen(buf);
@@ -156,7 +156,7 @@ void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
 
             // Append the log message.
             writtenLen = vsnprintf(formattedMsg + prefixLen, sizeof(formattedMsg) - prefixLen - EOL_CHARS_LEN, msg, v);
-            assert(writtenLen > 0);
+            VerifyOrDie(writtenLen > 0);
             memcpy(formattedMsg + prefixLen + writtenLen, EOL_CHARS, EOL_CHARS_LEN);
 
             K32WWriteBlocking((const uint8_t *) formattedMsg, strlen(formattedMsg));
@@ -233,7 +233,7 @@ extern "C" void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const ch
 
     // Append the log message.
     writtenLen = vsnprintf(formattedMsg + prefixLen, sizeof(formattedMsg) - prefixLen - EOL_CHARS_LEN, aFormat, v);
-    assert(writtenLen > 0);
+    VerifyOrDie(writtenLen > 0);
     memcpy(formattedMsg + prefixLen + writtenLen, EOL_CHARS, EOL_CHARS_LEN);
 
     K32WWriteBlocking((const uint8_t *) formattedMsg, strlen(formattedMsg));


### PR DESCRIPTION
 #### Problem
We're including nlABORT anyway, so might as well use it instead of `assert`.

 #### Summary of Changes
Replace `assert` uses with `VerifyOrDie`.

fixes https://github.com/project-chip/connectedhomeip/issues/2637
