### PR TITLE
Rework Crypto APIs to define a Keypair class

### DIFF
--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -28,9 +28,10 @@
 #endif
 
 #include <core/CHIPError.h>
+#include <support/CodeUtils.h>
+
 #include <stddef.h>
 #include <string.h>
-#include <support/CodeUtils.h>
 
 namespace chip {
 namespace Crypto {

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -122,7 +122,7 @@ public:
 
 private:
     uint8_t bytes[kMax_ECDSA_Signature_Length];
-    size_t length = sizeof(bytes); //kMax_ECDSA_Signature_Length;
+    size_t length = sizeof(bytes); // kMax_ECDSA_Signature_Length;
 };
 
 class P256ECDHDerivedSecret
@@ -155,7 +155,8 @@ public:
     size_t Length() const override { return kP256_PublicKey_Length; }
     operator uint8_t *() const override { return (uint8_t *) bytes; }
 
-    CHIP_ERROR ECDSA_validate_msg_signature(const uint8_t * msg, const size_t msg_length, const P256ECDSASignature & signature) const override;
+    CHIP_ERROR ECDSA_validate_msg_signature(const uint8_t * msg, const size_t msg_length,
+                                            const P256ECDSASignature & signature) const override;
 
 private:
     uint8_t bytes[kP256_PublicKey_Length];
@@ -228,7 +229,8 @@ public:
      * @param out_secret Buffer to write out secret into. This is a byte array representing the x coordinate of the shared secret.
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    virtual CHIP_ERROR ECDH_derive_secret(const P256PublicKey & remote_public_key, P256ECDHDerivedSecret & out_secret) const override;
+    virtual CHIP_ERROR ECDH_derive_secret(const P256PublicKey & remote_public_key,
+                                          P256ECDHDerivedSecret & out_secret) const override;
 
     /** @brief Return public key for the keypair.
      **/

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -28,9 +28,9 @@
 #endif
 
 #include <core/CHIPError.h>
-#include <support/CodeUtils.h>
 #include <stddef.h>
 #include <string.h>
+#include <support/CodeUtils.h>
 
 namespace chip {
 namespace Crypto {
@@ -126,7 +126,7 @@ public:
         CHIP_ERROR error = CHIP_NO_ERROR;
         VerifyOrExit(len <= sizeof(bytes), error = CHIP_ERROR_INVALID_ARGUMENT);
         length = len;
-exit:
+    exit:
         return error;
     }
 
@@ -244,8 +244,7 @@ public:
      * @param out_secret Buffer to write out secret into. This is a byte array representing the x coordinate of the shared secret.
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR ECDH_derive_secret(const P256PublicKey & remote_public_key,
-                                          P256ECDHDerivedSecret & out_secret) const override;
+    CHIP_ERROR ECDH_derive_secret(const P256PublicKey & remote_public_key, P256ECDHDerivedSecret & out_secret) const override;
 
     /** @brief Return public key for the keypair.
      **/

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -106,9 +106,11 @@ public:
     virtual size_t Length() const             = 0;
     virtual operator uint8_t *() const        = 0;
 
-    virtual CHIP_ERROR ECDSA_validate_msg_signature(const uint8_t * msg, const size_t msg_length,
-                                            const uint8_t * signature, const size_t signature_length) const { return CHIP_ERROR_NOT_IMPLEMENTED; }
-
+    virtual CHIP_ERROR ECDSA_validate_msg_signature(const uint8_t * msg, const size_t msg_length, const uint8_t * signature,
+                                                    const size_t signature_length) const
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
 };
 
 class P256PrivateKey : public ECPKey
@@ -129,9 +131,8 @@ public:
     size_t Length() const override { return kP256_PublicKey_Length; }
     operator uint8_t *() const override { return (uint8_t *) bytes; }
 
-    CHIP_ERROR ECDSA_validate_msg_signature(const uint8_t * msg, const size_t msg_length,
-                                            const uint8_t * signature, const size_t signature_length) const override;
-
+    CHIP_ERROR ECDSA_validate_msg_signature(const uint8_t * msg, const size_t msg_length, const uint8_t * signature,
+                                            const size_t signature_length) const override;
 
 private:
     uint8_t bytes[kP256_PublicKey_Length];
@@ -144,7 +145,8 @@ class ECPKeypair
 public:
     /** @brief Generate a new Certificate Signing Request (CSR).
      * @param csr Newly generated CSR
-     * @param csr_length The caller provides the length of input buffer (csr). The function returns the actual length of generated CSR.
+     * @param csr_length The caller provides the length of input buffer (csr). The function returns the actual length of generated
+     *CSR.
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
     virtual CHIP_ERROR NewCertificateSigningRequest(uint8_t * csr, size_t & csr_length) = 0;
@@ -153,13 +155,13 @@ public:
      * @brief A function to sign a msg using ECDSA
      * @param msg Message that needs to be signed
      * @param msg_length Length of message
-     * @param out_signature Buffer that will hold the output signature. The signature consists of: 2 EC elements (r and s), represented
-     * as ASN.1 DER integers, plus the ASN.1 sequence Header
+     * @param out_signature Buffer that will hold the output signature. The signature consists of: 2 EC elements (r and s),
+     *represented as ASN.1 DER integers, plus the ASN.1 sequence Header
      * @param out_signature_length Length of out buffer
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
     virtual CHIP_ERROR ECDSA_sign_msg(const uint8_t * msg, const size_t msg_length, uint8_t * out_signature,
-                              size_t & out_signature_length) = 0;
+                                      size_t & out_signature_length) = 0;
 
     /** @brief A function to derive a shared secret using ECDH
      * @param remote_public_key Public key of remote peer with which we are trying to establish secure channel. remote_public_key is
@@ -169,10 +171,10 @@ public:
      * @param out_secret_length Length of out_secret
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    virtual CHIP_ERROR ECDH_derive_secret(const ECPKey & remote_public_key, uint8_t * out_secret, size_t & out_secret_length) const = 0;
+    virtual CHIP_ERROR ECDH_derive_secret(const ECPKey & remote_public_key, uint8_t * out_secret,
+                                          size_t & out_secret_length) const = 0;
 
     virtual const ECPKey & Pubkey() = 0;
-
 };
 
 class P256Keypair : public ECPKeypair
@@ -185,7 +187,8 @@ public:
 
     /** @brief Generate a new Certificate Signing Request (CSR).
      * @param csr Newly generated CSR
-     * @param csr_length The caller provides the length of input buffer (csr). The function returns the actual length of generated CSR.
+     * @param csr_length The caller provides the length of input buffer (csr). The function returns the actual length of generated
+     *CSR.
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
     virtual CHIP_ERROR NewCertificateSigningRequest(uint8_t * csr, size_t & csr_length) override;
@@ -194,8 +197,8 @@ public:
      * @brief A function to sign a msg using ECDSA
      * @param msg Message that needs to be signed
      * @param msg_length Length of message
-     * @param out_signature Buffer that will hold the output signature. The signature consists of: 2 EC elements (r and s), represented
-     * as ASN.1 DER integers, plus the ASN.1 sequence Header
+     * @param out_signature Buffer that will hold the output signature. The signature consists of: 2 EC elements (r and s),
+     *represented as ASN.1 DER integers, plus the ASN.1 sequence Header
      * @param out_signature_length Length of out buffer
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
@@ -210,7 +213,8 @@ public:
      * @param out_secret_length Length of out_secret
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    virtual CHIP_ERROR ECDH_derive_secret(const ECPKey & remote_public_key, uint8_t * out_secret, size_t & out_secret_length) const override;
+    virtual CHIP_ERROR ECDH_derive_secret(const ECPKey & remote_public_key, uint8_t * out_secret,
+                                          size_t & out_secret_length) const override;
 
     /** @brief Return public key for the keypair.
      **/
@@ -347,7 +351,6 @@ CHIP_ERROR add_entropy_source(entropy_source fn_source, void * p_source, size_t 
  **/
 CHIP_ERROR pbkdf2_sha256(const uint8_t * password, size_t plen, const uint8_t * salt, size_t slen, unsigned int iteration_count,
                          uint32_t key_length, uint8_t * output);
-
 
 /**
  * The below class implements the draft 01 version of the Spake2+ protocol as

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -554,7 +554,8 @@ exit:
     return error;
 }
 
-CHIP_ERROR P256PublicKey::ECDSA_validate_msg_signature(const uint8_t * msg, const size_t msg_length, const P256ECDSASignature & signature) const
+CHIP_ERROR P256PublicKey::ECDSA_validate_msg_signature(const uint8_t * msg, const size_t msg_length,
+                                                       const P256ECDSASignature & signature) const
 {
     ERR_clear_error();
     CHIP_ERROR error            = CHIP_ERROR_INTERNAL;
@@ -644,7 +645,8 @@ exit:
 }
 
 // helper function to populate octet key into EVP_PKEY out_evp_pkey. Caller must free out_evp_pkey
-static CHIP_ERROR _create_evp_key_from_binary_p256_key(const ECPKey<P256ECDSASignature> & key, EVP_PKEY ** out_evp_pkey, bool isPrivateKey)
+static CHIP_ERROR _create_evp_key_from_binary_p256_key(const ECPKey<P256ECDSASignature> & key, EVP_PKEY ** out_evp_pkey,
+                                                       bool isPrivateKey)
 {
 
     CHIP_ERROR error     = CHIP_NO_ERROR;

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -460,7 +460,7 @@ ECName MapECName(SupportedECPKeyTypes keyType)
 }
 
 CHIP_ERROR P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_length, uint8_t * out_signature,
-                          size_t & out_signature_length)
+                                       size_t & out_signature_length)
 {
     ERR_clear_error();
 
@@ -556,8 +556,8 @@ exit:
     return error;
 }
 
-CHIP_ERROR P256PublicKey::ECDSA_validate_msg_signature(const uint8_t * msg, const size_t msg_length,
-                                        const uint8_t * signature, const size_t signature_length) const
+CHIP_ERROR P256PublicKey::ECDSA_validate_msg_signature(const uint8_t * msg, const size_t msg_length, const uint8_t * signature,
+                                                       const size_t signature_length) const
 {
     ERR_clear_error();
     CHIP_ERROR error            = CHIP_ERROR_INTERNAL;
@@ -731,8 +731,7 @@ exit:
     return error;
 }
 
-CHIP_ERROR P256Keypair::ECDH_derive_secret(const ECPKey & remote_public_key, uint8_t * out_secret,
-                              size_t & out_secret_length) const
+CHIP_ERROR P256Keypair::ECDH_derive_secret(const ECPKey & remote_public_key, uint8_t * out_secret, size_t & out_secret_length) const
 {
     ERR_clear_error();
     CHIP_ERROR error      = CHIP_NO_ERROR;
@@ -825,9 +824,9 @@ CHIP_ERROR P256Keypair::Initialize()
         const EC_POINT * pubkey_ecp = EC_KEY_get0_public_key(ec_key);
         VerifyOrExit(pubkey_ecp != nullptr, error = CHIP_ERROR_INTERNAL);
 
-        pubkey_size =
-            EC_POINT_point2oct(group, pubkey_ecp, POINT_CONVERSION_UNCOMPRESSED, Uint8::to_uchar(mPublicKey), mPublicKey.Length(), nullptr);
-        pubkey_ecp = nullptr;
+        pubkey_size = EC_POINT_point2oct(group, pubkey_ecp, POINT_CONVERSION_UNCOMPRESSED, Uint8::to_uchar(mPublicKey),
+                                         mPublicKey.Length(), nullptr);
+        pubkey_ecp  = nullptr;
 
         VerifyOrExit(pubkey_size == mPublicKey.Length(), error = CHIP_ERROR_INTERNAL);
     }

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -441,8 +441,8 @@ exit:
     return error;
 }
 
-CHIP_ERROR P256PublicKey::ECDSA_validate_msg_signature(const uint8_t * msg, const size_t msg_length,
-                                                       const uint8_t * signature, const size_t signature_length) const
+CHIP_ERROR P256PublicKey::ECDSA_validate_msg_signature(const uint8_t * msg, const size_t msg_length, const uint8_t * signature,
+                                                       const size_t signature_length) const
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
@@ -481,8 +481,7 @@ exit:
     return error;
 }
 
-CHIP_ERROR P256Keypair::ECDH_derive_secret(const ECPKey & remote_public_key, uint8_t * out_secret,
-                                           size_t & out_secret_length) const
+CHIP_ERROR P256Keypair::ECDH_derive_secret(const ECPKey & remote_public_key, uint8_t * out_secret, size_t & out_secret_length) const
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -400,8 +400,8 @@ mbedtls_ecp_group_id MapECPGroupId(SupportedECPKeyTypes keyType)
     }
 }
 
-CHIP_ERROR ECDSA_sign_msg(const uint8_t * msg, const size_t msg_length, const ECPKey & private_key, uint8_t * out_signature,
-                          size_t & out_signature_length)
+CHIP_ERROR P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_length, uint8_t * out_signature,
+                                       size_t & out_signature_length)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
@@ -418,10 +418,10 @@ CHIP_ERROR ECDSA_sign_msg(const uint8_t * msg, const size_t msg_length, const EC
     VerifyOrExit(out_signature != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(out_signature_length >= kMax_ECDSA_Signature_Length, error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    result = mbedtls_ecp_group_load(&keypair.grp, MapECPGroupId(private_key.Type()));
+    result = mbedtls_ecp_group_load(&keypair.grp, MapECPGroupId(mPrivateKey.Type()));
     VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    result = mbedtls_mpi_read_binary(&keypair.d, Uint8::to_const_uchar(private_key), private_key.Length());
+    result = mbedtls_mpi_read_binary(&keypair.d, Uint8::to_const_uchar(mPrivateKey), mPrivateKey.Length());
     VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     result = mbedtls_ecdsa_from_keypair(&ecdsa_ctxt, &keypair);
@@ -441,8 +441,8 @@ exit:
     return error;
 }
 
-CHIP_ERROR ECDSA_validate_msg_signature(const uint8_t * msg, const size_t msg_length, const ECPKey & public_key,
-                                        const uint8_t * signature, const size_t signature_length)
+CHIP_ERROR P256PublicKey::ECDSA_validate_msg_signature(const uint8_t * msg, const size_t msg_length,
+                                                       const uint8_t * signature, const size_t signature_length) const
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
@@ -459,10 +459,10 @@ CHIP_ERROR ECDSA_validate_msg_signature(const uint8_t * msg, const size_t msg_le
     VerifyOrExit(signature != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(signature_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    result = mbedtls_ecp_group_load(&keypair.grp, MapECPGroupId(public_key.Type()));
+    result = mbedtls_ecp_group_load(&keypair.grp, MapECPGroupId(Type()));
     VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    result = mbedtls_ecp_point_read_binary(&keypair.grp, &keypair.Q, Uint8::to_const_uchar(public_key), public_key.Length());
+    result = mbedtls_ecp_point_read_binary(&keypair.grp, &keypair.Q, Uint8::to_const_uchar(*this), Length());
     VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     result = mbedtls_ecdsa_from_keypair(&ecdsa_ctxt, &keypair);
@@ -481,8 +481,8 @@ exit:
     return error;
 }
 
-CHIP_ERROR ECDH_derive_secret(const ECPKey & remote_public_key, const ECPKey & local_private_key, uint8_t * out_secret,
-                              size_t & out_secret_length)
+CHIP_ERROR P256Keypair::ECDH_derive_secret(const ECPKey & remote_public_key, uint8_t * out_secret,
+                                           size_t & out_secret_length) const
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
@@ -504,12 +504,12 @@ CHIP_ERROR ECDH_derive_secret(const ECPKey & remote_public_key, const ECPKey & l
 
     VerifyOrExit(out_secret != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(out_secret_length >= kMax_ECDH_Secret_Length, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(remote_public_key.Type() == local_private_key.Type(), error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(remote_public_key.Type() == mPrivateKey.Type(), error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    result = mbedtls_ecp_group_load(&ecp_grp, MapECPGroupId(local_private_key.Type()));
+    result = mbedtls_ecp_group_load(&ecp_grp, MapECPGroupId(mPrivateKey.Type()));
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
-    result = mbedtls_mpi_read_binary(&mpi_privkey, Uint8::to_const_uchar(local_private_key), local_private_key.Length());
+    result = mbedtls_mpi_read_binary(&mpi_privkey, Uint8::to_const_uchar(mPrivateKey), mPrivateKey.Length());
     VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     result =
@@ -537,31 +537,31 @@ void ClearSecretData(uint8_t * buf, uint32_t len)
     memset(buf, 0, len);
 }
 
-CHIP_ERROR NewECPKeypair(ECPKey & pubkey, ECPKey & privkey)
+CHIP_ERROR P256Keypair::Initialize()
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
 
     size_t pubkey_size = 0;
 
-    mbedtls_ecp_group_id group = MapECPGroupId(pubkey.Type());
+    mbedtls_ecp_group_id group = MapECPGroupId(mPublicKey.Type());
 
     mbedtls_ecp_keypair keypair;
     mbedtls_ecp_keypair_init(&keypair);
 
-    VerifyOrExit(group == MapECPGroupId(privkey.Type()), error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(group == MapECPGroupId(mPrivateKey.Type()), error = CHIP_ERROR_INVALID_ARGUMENT);
 
     result = mbedtls_ecp_gen_key(group, &keypair, CryptoRNG, nullptr);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
     result = mbedtls_ecp_point_write_binary(&keypair.grp, &keypair.Q, MBEDTLS_ECP_PF_UNCOMPRESSED, &pubkey_size,
-                                            Uint8::to_uchar(pubkey), pubkey.Length());
+                                            Uint8::to_uchar(mPublicKey), mPublicKey.Length());
     VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(pubkey_size == pubkey.Length(), error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(pubkey_size == mPublicKey.Length(), error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    VerifyOrExit(mbedtls_mpi_size(&keypair.d) == privkey.Length(), error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(mbedtls_mpi_size(&keypair.d) == mPrivateKey.Length(), error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    result = mbedtls_mpi_write_binary(&keypair.d, Uint8::to_uchar(privkey), privkey.Length());
+    result = mbedtls_mpi_write_binary(&keypair.d, Uint8::to_uchar(mPrivateKey), mPrivateKey.Length());
     VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
 
 exit:
@@ -570,7 +570,7 @@ exit:
     return error;
 }
 
-CHIP_ERROR NewCertificateSigningRequest(ECPKey & pubkey, ECPKey & privkey, uint8_t * out_csr, size_t & csr_length)
+CHIP_ERROR P256Keypair::NewCertificateSigningRequest(uint8_t * out_csr, size_t & csr_length)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
@@ -584,7 +584,7 @@ CHIP_ERROR NewCertificateSigningRequest(ECPKey & pubkey, ECPKey & privkey, uint8
     mbedtls_pk_context pk;
     mbedtls_pk_init(&pk);
 
-    mbedtls_ecp_group_id group = MapECPGroupId(pubkey.Type());
+    mbedtls_ecp_group_id group = MapECPGroupId(mPublicKey.Type());
 
     const mbedtls_pk_info_t * pk_info = mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY);
     VerifyOrExit(pk_info != nullptr, error = CHIP_ERROR_INTERNAL);
@@ -595,15 +595,15 @@ CHIP_ERROR NewCertificateSigningRequest(ECPKey & pubkey, ECPKey & privkey, uint8
     keypair = mbedtls_pk_ec(pk);
     mbedtls_ecp_keypair_init(keypair);
 
-    VerifyOrExit(group == MapECPGroupId(privkey.Type()), error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(group == MapECPGroupId(mPrivateKey.Type()), error = CHIP_ERROR_INVALID_ARGUMENT);
 
     result = mbedtls_ecp_group_load(&keypair->grp, group);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
-    result = mbedtls_ecp_point_read_binary(&keypair->grp, &keypair->Q, Uint8::to_const_uchar(pubkey), pubkey.Length());
+    result = mbedtls_ecp_point_read_binary(&keypair->grp, &keypair->Q, Uint8::to_const_uchar(mPublicKey), mPublicKey.Length());
     VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    result = mbedtls_mpi_read_binary(&keypair->d, Uint8::to_const_uchar(privkey), privkey.Length());
+    result = mbedtls_mpi_read_binary(&keypair->d, Uint8::to_const_uchar(mPrivateKey), mPrivateKey.Length());
     VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     mbedtls_x509write_csr_set_key(&csr, &pk);

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -440,7 +440,8 @@ exit:
     return error;
 }
 
-CHIP_ERROR P256PublicKey::ECDSA_validate_msg_signature(const uint8_t * msg, const size_t msg_length, const P256ECDSASignature & signature) const
+CHIP_ERROR P256PublicKey::ECDSA_validate_msg_signature(const uint8_t * msg, const size_t msg_length,
+                                                       const P256ECDSASignature & signature) const
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -607,13 +607,12 @@ static void TestECDSA_Signing_SHA256(nlTestSuite * inSuite, void * inContext)
     P256Keypair keypair;
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
-    uint8_t signature[kMax_ECDSA_Signature_Length];
-    size_t signature_length  = sizeof(signature);
-    CHIP_ERROR signing_error = keypair.ECDSA_sign_msg((const uint8_t *) msg, msg_length, signature, signature_length);
+    P256ECDSASignature signature;
+    CHIP_ERROR signing_error = keypair.ECDSA_sign_msg((const uint8_t *) msg, msg_length, signature);
     NL_TEST_ASSERT(inSuite, signing_error == CHIP_NO_ERROR);
 
     CHIP_ERROR validation_error =
-        keypair.Pubkey().ECDSA_validate_msg_signature((const uint8_t *) msg, msg_length, signature, signature_length);
+        keypair.Pubkey().ECDSA_validate_msg_signature((const uint8_t *) msg, msg_length, signature);
     NL_TEST_ASSERT(inSuite, validation_error == CHIP_NO_ERROR);
 }
 
@@ -625,15 +624,14 @@ static void TestECDSA_ValidationFailsDifferentMessage(nlTestSuite * inSuite, voi
     P256Keypair keypair;
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
-    uint8_t signature[kMax_ECDSA_Signature_Length];
-    size_t signature_length  = sizeof(signature);
-    CHIP_ERROR signing_error = keypair.ECDSA_sign_msg((const uint8_t *) msg, msg_length, signature, signature_length);
+    P256ECDSASignature signature;
+    CHIP_ERROR signing_error = keypair.ECDSA_sign_msg((const uint8_t *) msg, msg_length, signature);
     NL_TEST_ASSERT(inSuite, signing_error == CHIP_NO_ERROR);
 
     const char * diff_msg  = "NOT Hello World!";
     size_t diff_msg_length = strlen((const char *) msg);
     CHIP_ERROR validation_error =
-        keypair.Pubkey().ECDSA_validate_msg_signature((const uint8_t *) diff_msg, diff_msg_length, signature, signature_length);
+        keypair.Pubkey().ECDSA_validate_msg_signature((const uint8_t *) diff_msg, diff_msg_length, signature);
     NL_TEST_ASSERT(inSuite, validation_error != CHIP_NO_ERROR);
 }
 
@@ -645,14 +643,13 @@ static void TestECDSA_ValidationFailIncorrectSignature(nlTestSuite * inSuite, vo
     P256Keypair keypair;
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
-    uint8_t signature[kMax_ECDSA_Signature_Length];
-    size_t signature_length  = sizeof(signature);
-    CHIP_ERROR signing_error = keypair.ECDSA_sign_msg((const uint8_t *) msg, msg_length, signature, signature_length);
+    P256ECDSASignature signature;
+    CHIP_ERROR signing_error = keypair.ECDSA_sign_msg((const uint8_t *) msg, msg_length, signature);
     NL_TEST_ASSERT(inSuite, signing_error == CHIP_NO_ERROR);
     signature[0] = ~signature[0]; // Flipping bits should invalidate the signature.
 
     CHIP_ERROR validation_error =
-        keypair.Pubkey().ECDSA_validate_msg_signature((const uint8_t *) msg, msg_length, signature, signature_length);
+        keypair.Pubkey().ECDSA_validate_msg_signature((const uint8_t *) msg, msg_length, signature);
     NL_TEST_ASSERT(inSuite, validation_error == CHIP_ERROR_INVALID_SIGNATURE);
 }
 
@@ -664,17 +661,12 @@ static void TestECDSA_SigningInvalidParams(nlTestSuite * inSuite, void * inConte
     P256Keypair keypair;
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
-    uint8_t signature[kMax_ECDSA_Signature_Length];
-    size_t signature_length  = sizeof(signature);
-    CHIP_ERROR signing_error = keypair.ECDSA_sign_msg(NULL, msg_length, signature, signature_length);
+    P256ECDSASignature signature;
+    CHIP_ERROR signing_error = keypair.ECDSA_sign_msg(NULL, msg_length, signature);
     NL_TEST_ASSERT(inSuite, signing_error == CHIP_ERROR_INVALID_ARGUMENT);
     signing_error = CHIP_NO_ERROR;
 
-    signing_error = keypair.ECDSA_sign_msg(msg, 0, signature, signature_length);
-    NL_TEST_ASSERT(inSuite, signing_error == CHIP_ERROR_INVALID_ARGUMENT);
-    signing_error = CHIP_NO_ERROR;
-
-    signing_error = keypair.ECDSA_sign_msg(msg, msg_length, NULL, signature_length);
+    signing_error = keypair.ECDSA_sign_msg(msg, 0, signature);
     NL_TEST_ASSERT(inSuite, signing_error == CHIP_ERROR_INVALID_ARGUMENT);
     signing_error = CHIP_NO_ERROR;
 }
@@ -687,24 +679,15 @@ static void TestECDSA_ValidationInvalidParam(nlTestSuite * inSuite, void * inCon
     P256Keypair keypair;
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
-    uint8_t signature[kMax_ECDSA_Signature_Length];
-    size_t signature_length  = sizeof(signature);
-    CHIP_ERROR signing_error = keypair.ECDSA_sign_msg((const uint8_t *) msg, msg_length, signature, signature_length);
+    P256ECDSASignature signature;
+    CHIP_ERROR signing_error = keypair.ECDSA_sign_msg((const uint8_t *) msg, msg_length, signature);
     NL_TEST_ASSERT(inSuite, signing_error == CHIP_NO_ERROR);
 
-    CHIP_ERROR validation_error = keypair.Pubkey().ECDSA_validate_msg_signature(NULL, msg_length, signature, signature_length);
+    CHIP_ERROR validation_error = keypair.Pubkey().ECDSA_validate_msg_signature(NULL, msg_length, signature);
     NL_TEST_ASSERT(inSuite, validation_error == CHIP_ERROR_INVALID_ARGUMENT);
     validation_error = CHIP_NO_ERROR;
 
-    validation_error = keypair.Pubkey().ECDSA_validate_msg_signature((const uint8_t *) msg, 0, signature, signature_length);
-    NL_TEST_ASSERT(inSuite, validation_error == CHIP_ERROR_INVALID_ARGUMENT);
-    validation_error = CHIP_NO_ERROR;
-
-    validation_error = keypair.Pubkey().ECDSA_validate_msg_signature((const uint8_t *) msg, msg_length, NULL, signature_length);
-    NL_TEST_ASSERT(inSuite, validation_error == CHIP_ERROR_INVALID_ARGUMENT);
-    validation_error = CHIP_NO_ERROR;
-
-    validation_error = keypair.Pubkey().ECDSA_validate_msg_signature((const uint8_t *) msg, msg_length, signature, 0);
+    validation_error = keypair.Pubkey().ECDSA_validate_msg_signature((const uint8_t *) msg, 0, signature);
     NL_TEST_ASSERT(inSuite, validation_error == CHIP_ERROR_INVALID_ARGUMENT);
     validation_error = CHIP_NO_ERROR;
 }
@@ -717,44 +700,26 @@ static void TestECDH_EstablishSecret(nlTestSuite * inSuite, void * inContext)
     P256Keypair keypair2;
     NL_TEST_ASSERT(inSuite, keypair2.Initialize() == CHIP_NO_ERROR);
 
-    uint8_t out_secret1[kMax_ECDH_Secret_Length] = { 0 };
-    size_t out_size1                             = sizeof(out_secret1);
+    P256ECDHDerivedSecret out_secret1;
+    out_secret1[0] = 0;
 
-    uint8_t out_secret2[kMax_ECDH_Secret_Length] = { 1 };
-    size_t out_size2                             = sizeof(out_secret2);
-    CHIP_ERROR error                             = CHIP_NO_ERROR;
-    NL_TEST_ASSERT(inSuite, memcmp(out_secret1, out_secret2, out_size1) != 0); // Validate that buffers are indeed different.
+    P256ECDHDerivedSecret out_secret2;
+    out_secret2[0] = 1;
 
-    error = keypair2.ECDH_derive_secret(keypair1.Pubkey(), out_secret1, out_size1);
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    NL_TEST_ASSERT(inSuite, memcmp(Uint8::to_uchar(out_secret1), Uint8::to_uchar(out_secret2), out_secret1.Length()) != 0); // Validate that buffers are indeed different.
+
+    error = keypair2.ECDH_derive_secret(keypair1.Pubkey(), out_secret1);
     NL_TEST_ASSERT(inSuite, error == CHIP_NO_ERROR);
 
-    error = keypair1.ECDH_derive_secret(keypair2.Pubkey(), out_secret2, out_size2);
+    error = keypair1.ECDH_derive_secret(keypair2.Pubkey(), out_secret2);
     NL_TEST_ASSERT(inSuite, error == CHIP_NO_ERROR);
 
-    bool signature_lengths_match = out_size1 == out_size2;
+    bool signature_lengths_match = out_secret1.Length() == out_secret2.Length();
     NL_TEST_ASSERT(inSuite, signature_lengths_match);
 
-    bool signatures_match = (memcmp(out_secret1, out_secret2, out_size1) == 0);
+    bool signatures_match = (memcmp(Uint8::to_uchar(out_secret1), Uint8::to_uchar(out_secret2), out_secret1.Length()) == 0);
     NL_TEST_ASSERT(inSuite, signatures_match);
-}
-
-static void TestECDH_InvalidParams(nlTestSuite * inSuite, void * inContext)
-{
-    P256Keypair keypair1;
-    NL_TEST_ASSERT(inSuite, keypair1.Initialize() == CHIP_NO_ERROR);
-
-    P256Keypair keypair2;
-    NL_TEST_ASSERT(inSuite, keypair2.Initialize() == CHIP_NO_ERROR);
-
-    uint8_t out_secret[kMax_ECDH_Secret_Length] = { 0 };
-    size_t out_size                             = sizeof(out_secret);
-
-    CHIP_ERROR error = keypair1.ECDH_derive_secret(keypair2.Pubkey(), NULL, out_size);
-    NL_TEST_ASSERT(inSuite, error == CHIP_ERROR_INVALID_ARGUMENT);
-
-    size_t bad_size = 0;
-    error           = keypair1.ECDH_derive_secret(keypair2.Pubkey(), out_secret, bad_size);
-    NL_TEST_ASSERT(inSuite, error == CHIP_ERROR_INVALID_ARGUMENT);
 }
 
 #if CHIP_CRYPTO_OPENSSL
@@ -816,12 +781,10 @@ static void TestP256_Keygen(nlTestSuite * inSuite, void * inContext)
     const char * msg         = "Test Message for Keygen";
     const uint8_t * test_msg = Uint8::from_const_char(msg);
     size_t msglen            = strlen(msg);
-    uint8_t test_sig[kMax_ECDSA_Signature_Length];
-    size_t siglen = sizeof(test_sig);
 
-    NL_TEST_ASSERT(inSuite, keypair.ECDSA_sign_msg(test_msg, msglen, test_sig, siglen) == CHIP_NO_ERROR);
-
-    NL_TEST_ASSERT(inSuite, keypair.Pubkey().ECDSA_validate_msg_signature(test_msg, msglen, test_sig, siglen) == CHIP_NO_ERROR);
+    P256ECDSASignature test_sig;
+    NL_TEST_ASSERT(inSuite, keypair.ECDSA_sign_msg(test_msg, msglen, test_sig) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Pubkey().ECDSA_validate_msg_signature(test_msg, msglen, test_sig) == CHIP_NO_ERROR);
 }
 
 static void TestCSR_Gen(nlTestSuite * inSuite, void * inContext)
@@ -831,7 +794,6 @@ static void TestCSR_Gen(nlTestSuite * inSuite, void * inContext)
 
     P256Keypair keypair;
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
-
     NL_TEST_ASSERT(inSuite, keypair.NewCertificateSigningRequest(csr, length) == CHIP_NO_ERROR);
 }
 
@@ -1258,7 +1220,6 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("Test DRBG invalid inputs", TestDRBG_InvalidInputs),
     NL_TEST_DEF("Test DRBG output", TestDRBG_Output),
     NL_TEST_DEF("Test ECDH derive shared secret", TestECDH_EstablishSecret),
-    NL_TEST_DEF("Test ECDH invalid params", TestECDH_InvalidParams),
     NL_TEST_DEF("Test adding entropy sources", TestAddEntropySources),
     NL_TEST_DEF("Test PBKDF2 SHA256", TestPBKDF2_SHA256_TestVectors),
     NL_TEST_DEF("Test P256 Keygen", TestP256_Keygen),

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -56,21 +56,6 @@ static int test_entropy_source(void * data, uint8_t * output, size_t len, size_t
     return 0;
 }
 
-class TestECPKey : public ECPKey
-{
-public:
-    SupportedECPKeyTypes Type() const override { return type; }
-    size_t Length() const override { return len; }
-    operator uint8_t *() const override { return bytes; }
-
-    TestECPKey(uint8_t * data, size_t length, SupportedECPKeyTypes t) : bytes(data), len(length), type(t) {}
-
-private:
-    uint8_t * bytes;
-    size_t len;
-    SupportedECPKeyTypes type;
-};
-
 static void TestAES_CCM_256EncryptTestVectors(nlTestSuite * inSuite, void * inContext)
 {
     int numOfTestVectors = ArraySize(ccm_test_vectors);
@@ -619,24 +604,16 @@ static void TestECDSA_Signing_SHA256(nlTestSuite * inSuite, void * inContext)
     const char * msg  = "Hello World!";
     size_t msg_length = strlen((const char *) msg);
 
-    uint8_t hex_private_key[] = { 0xc6, 0x1a, 0x2f, 0x89, 0x36, 0x67, 0x2b, 0x26, 0x12, 0x47, 0x4f, 0x11, 0x0e, 0x34, 0x15, 0x81,
-                                  0x81, 0x12, 0xfc, 0x36, 0xeb, 0x65, 0x61, 0x07, 0xaa, 0x63, 0xe8, 0xc5, 0x22, 0xac, 0x52, 0xa1 };
-
-    uint8_t hex_public_key[] = { 0x04, 0xe2, 0x07, 0x64, 0xff, 0x6f, 0x6a, 0x91, 0xd9, 0xc2, 0xc3, 0x0a, 0xc4,
-                                 0x3c, 0x56, 0x4b, 0x42, 0x8a, 0xf3, 0xb4, 0x49, 0x29, 0x39, 0x95, 0xa2, 0xf7,
-                                 0x02, 0x8c, 0xa5, 0xce, 0xf3, 0xc9, 0xca, 0x24, 0xc5, 0xd4, 0x5c, 0x60, 0x79,
-                                 0x48, 0x30, 0x3c, 0x53, 0x86, 0xd9, 0x23, 0xe6, 0x61, 0x1f, 0x5a, 0x3d, 0xdf,
-                                 0x9f, 0xdc, 0x35, 0xea, 0xd0, 0xde, 0x16, 0x7e, 0x64, 0xde, 0x7f, 0x3c, 0xa6 };
+    P256Keypair keypair;
+    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
     uint8_t signature[kMax_ECDSA_Signature_Length];
     size_t signature_length = sizeof(signature);
-    TestECPKey privk(hex_private_key, sizeof(hex_private_key), SupportedECPKeyTypes::ECP256R1);
-    CHIP_ERROR signing_error = ECDSA_sign_msg((const uint8_t *) msg, msg_length, privk, signature, signature_length);
+    CHIP_ERROR signing_error = keypair.ECDSA_sign_msg((const uint8_t *) msg, msg_length, signature, signature_length);
     NL_TEST_ASSERT(inSuite, signing_error == CHIP_NO_ERROR);
 
-    TestECPKey pubk(hex_public_key, sizeof(hex_public_key), SupportedECPKeyTypes::ECP256R1);
     CHIP_ERROR validation_error =
-        ECDSA_validate_msg_signature((const uint8_t *) msg, msg_length, pubk, signature, signature_length);
+        keypair.Pubkey().ECDSA_validate_msg_signature((const uint8_t *) msg, msg_length, signature, signature_length);
     NL_TEST_ASSERT(inSuite, validation_error == CHIP_NO_ERROR);
 }
 
@@ -645,26 +622,18 @@ static void TestECDSA_ValidationFailsDifferentMessage(nlTestSuite * inSuite, voi
     const char * msg  = "Hello World!";
     size_t msg_length = strlen((const char *) msg);
 
-    uint8_t hex_private_key[] = { 0xc6, 0x1a, 0x2f, 0x89, 0x36, 0x67, 0x2b, 0x26, 0x12, 0x47, 0x4f, 0x11, 0x0e, 0x34, 0x15, 0x81,
-                                  0x81, 0x12, 0xfc, 0x36, 0xeb, 0x65, 0x61, 0x07, 0xaa, 0x63, 0xe8, 0xc5, 0x22, 0xac, 0x52, 0xa1 };
-
-    uint8_t hex_public_key[] = { 0x04, 0xe2, 0x07, 0x64, 0xff, 0x6f, 0x6a, 0x91, 0xd9, 0xc2, 0xc3, 0x0a, 0xc4,
-                                 0x3c, 0x56, 0x4b, 0x42, 0x8a, 0xf3, 0xb4, 0x49, 0x29, 0x39, 0x95, 0xa2, 0xf7,
-                                 0x02, 0x8c, 0xa5, 0xce, 0xf3, 0xc9, 0xca, 0x24, 0xc5, 0xd4, 0x5c, 0x60, 0x79,
-                                 0x48, 0x30, 0x3c, 0x53, 0x86, 0xd9, 0x23, 0xe6, 0x61, 0x1f, 0x5a, 0x3d, 0xdf,
-                                 0x9f, 0xdc, 0x35, 0xea, 0xd0, 0xde, 0x16, 0x7e, 0x64, 0xde, 0x7f, 0x3c, 0xa6 };
+    P256Keypair keypair;
+    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
     uint8_t signature[kMax_ECDSA_Signature_Length];
     size_t signature_length = sizeof(signature);
-    TestECPKey privk(hex_private_key, sizeof(hex_private_key), SupportedECPKeyTypes::ECP256R1);
-    CHIP_ERROR signing_error = ECDSA_sign_msg((const uint8_t *) msg, msg_length, privk, signature, signature_length);
+    CHIP_ERROR signing_error = keypair.ECDSA_sign_msg((const uint8_t *) msg, msg_length, signature, signature_length);
     NL_TEST_ASSERT(inSuite, signing_error == CHIP_NO_ERROR);
 
     const char * diff_msg  = "NOT Hello World!";
     size_t diff_msg_length = strlen((const char *) msg);
-    TestECPKey pubk(hex_public_key, sizeof(hex_public_key), SupportedECPKeyTypes::ECP256R1);
     CHIP_ERROR validation_error =
-        ECDSA_validate_msg_signature((const uint8_t *) diff_msg, diff_msg_length, pubk, signature, signature_length);
+        keypair.Pubkey().ECDSA_validate_msg_signature((const uint8_t *) diff_msg, diff_msg_length, signature, signature_length);
     NL_TEST_ASSERT(inSuite, validation_error != CHIP_NO_ERROR);
 }
 
@@ -673,25 +642,17 @@ static void TestECDSA_ValidationFailIncorrectSignature(nlTestSuite * inSuite, vo
     const char * msg  = "Hello World!";
     size_t msg_length = strlen((const char *) msg);
 
-    uint8_t hex_private_key[] = { 0xc6, 0x1a, 0x2f, 0x89, 0x36, 0x67, 0x2b, 0x26, 0x12, 0x47, 0x4f, 0x11, 0x0e, 0x34, 0x15, 0x81,
-                                  0x81, 0x12, 0xfc, 0x36, 0xeb, 0x65, 0x61, 0x07, 0xaa, 0x63, 0xe8, 0xc5, 0x22, 0xac, 0x52, 0xa1 };
-
-    uint8_t hex_public_key[] = { 0x04, 0xe2, 0x07, 0x64, 0xff, 0x6f, 0x6a, 0x91, 0xd9, 0xc2, 0xc3, 0x0a, 0xc4,
-                                 0x3c, 0x56, 0x4b, 0x42, 0x8a, 0xf3, 0xb4, 0x49, 0x29, 0x39, 0x95, 0xa2, 0xf7,
-                                 0x02, 0x8c, 0xa5, 0xce, 0xf3, 0xc9, 0xca, 0x24, 0xc5, 0xd4, 0x5c, 0x60, 0x79,
-                                 0x48, 0x30, 0x3c, 0x53, 0x86, 0xd9, 0x23, 0xe6, 0x61, 0x1f, 0x5a, 0x3d, 0xdf,
-                                 0x9f, 0xdc, 0x35, 0xea, 0xd0, 0xde, 0x16, 0x7e, 0x64, 0xde, 0x7f, 0x3c, 0xa6 };
+    P256Keypair keypair;
+    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
     uint8_t signature[kMax_ECDSA_Signature_Length];
     size_t signature_length = sizeof(signature);
-    TestECPKey privk(hex_private_key, sizeof(hex_private_key), SupportedECPKeyTypes::ECP256R1);
-    CHIP_ERROR signing_error = ECDSA_sign_msg((const uint8_t *) msg, msg_length, privk, signature, signature_length);
+    CHIP_ERROR signing_error = keypair.ECDSA_sign_msg((const uint8_t *) msg, msg_length, signature, signature_length);
     NL_TEST_ASSERT(inSuite, signing_error == CHIP_NO_ERROR);
     signature[0] = ~signature[0]; // Flipping bits should invalidate the signature.
 
-    TestECPKey pubk(hex_public_key, sizeof(hex_public_key), SupportedECPKeyTypes::ECP256R1);
     CHIP_ERROR validation_error =
-        ECDSA_validate_msg_signature((const uint8_t *) msg, msg_length, pubk, signature, signature_length);
+        keypair.Pubkey().ECDSA_validate_msg_signature((const uint8_t *) msg, msg_length, signature, signature_length);
     NL_TEST_ASSERT(inSuite, validation_error == CHIP_ERROR_INVALID_SIGNATURE);
 }
 
@@ -699,21 +660,21 @@ static void TestECDSA_SigningInvalidParams(nlTestSuite * inSuite, void * inConte
 {
     const uint8_t * msg       = (uint8_t *) "Hello World!";
     size_t msg_length         = strlen((const char *) msg);
-    uint8_t hex_private_key[] = { 0xc6, 0x1a, 0x2f, 0x89, 0x36, 0x67, 0x2b, 0x26, 0x12, 0x47, 0x4f, 0x11, 0x0e, 0x34, 0x15, 0x81,
-                                  0x81, 0x12, 0xfc, 0x36, 0xeb, 0x65, 0x61, 0x07, 0xaa, 0x63, 0xe8, 0xc5, 0x22, 0xac, 0x52, 0xa1 };
+
+    P256Keypair keypair;
+    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
     uint8_t signature[kMax_ECDSA_Signature_Length];
     size_t signature_length = sizeof(signature);
-    TestECPKey privk(hex_private_key, sizeof(hex_private_key), SupportedECPKeyTypes::ECP256R1);
-    CHIP_ERROR signing_error = ECDSA_sign_msg(NULL, msg_length, privk, signature, signature_length);
+    CHIP_ERROR signing_error = keypair.ECDSA_sign_msg(NULL, msg_length, signature, signature_length);
     NL_TEST_ASSERT(inSuite, signing_error == CHIP_ERROR_INVALID_ARGUMENT);
     signing_error = CHIP_NO_ERROR;
 
-    signing_error = ECDSA_sign_msg(msg, 0, privk, signature, signature_length);
+    signing_error = keypair.ECDSA_sign_msg(msg, 0, signature, signature_length);
     NL_TEST_ASSERT(inSuite, signing_error == CHIP_ERROR_INVALID_ARGUMENT);
     signing_error = CHIP_NO_ERROR;
 
-    signing_error = ECDSA_sign_msg(msg, msg_length, privk, NULL, signature_length);
+    signing_error = keypair.ECDSA_sign_msg(msg, msg_length, NULL, signature_length);
     NL_TEST_ASSERT(inSuite, signing_error == CHIP_ERROR_INVALID_ARGUMENT);
     signing_error = CHIP_NO_ERROR;
 }
@@ -723,56 +684,38 @@ static void TestECDSA_ValidationInvalidParam(nlTestSuite * inSuite, void * inCon
     const char * msg  = "Hello World!";
     size_t msg_length = strlen((const char *) msg);
 
-    uint8_t hex_private_key[] = { 0xc6, 0x1a, 0x2f, 0x89, 0x36, 0x67, 0x2b, 0x26, 0x12, 0x47, 0x4f, 0x11, 0x0e, 0x34, 0x15, 0x81,
-                                  0x81, 0x12, 0xfc, 0x36, 0xeb, 0x65, 0x61, 0x07, 0xaa, 0x63, 0xe8, 0xc5, 0x22, 0xac, 0x52, 0xa1 };
+    P256Keypair keypair;
+    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
-    uint8_t hex_public_key[] = { 0x04, 0xe2, 0x07, 0x64, 0xff, 0x6f, 0x6a, 0x91, 0xd9, 0xc2, 0xc3, 0x0a, 0xc4,
-                                 0x3c, 0x56, 0x4b, 0x42, 0x8a, 0xf3, 0xb4, 0x49, 0x29, 0x39, 0x95, 0xa2, 0xf7,
-                                 0x02, 0x8c, 0xa5, 0xce, 0xf3, 0xc9, 0xca, 0x24, 0xc5, 0xd4, 0x5c, 0x60, 0x79,
-                                 0x48, 0x30, 0x3c, 0x53, 0x86, 0xd9, 0x23, 0xe6, 0x61, 0x1f, 0x5a, 0x3d, 0xdf,
-                                 0x9f, 0xdc, 0x35, 0xea, 0xd0, 0xde, 0x16, 0x7e, 0x64, 0xde, 0x7f, 0x3c, 0xa6 };
-
-    TestECPKey privk(hex_private_key, sizeof(hex_private_key), SupportedECPKeyTypes::ECP256R1);
     uint8_t signature[kMax_ECDSA_Signature_Length];
     size_t signature_length  = sizeof(signature);
-    CHIP_ERROR signing_error = ECDSA_sign_msg((const uint8_t *) msg, msg_length, privk, signature, signature_length);
+    CHIP_ERROR signing_error = keypair.ECDSA_sign_msg((const uint8_t *) msg, msg_length, signature, signature_length);
     NL_TEST_ASSERT(inSuite, signing_error == CHIP_NO_ERROR);
 
-    TestECPKey pubk(hex_public_key, sizeof(hex_public_key), SupportedECPKeyTypes::ECP256R1);
-    CHIP_ERROR validation_error = ECDSA_validate_msg_signature(NULL, msg_length, pubk, signature, signature_length);
+    CHIP_ERROR validation_error = keypair.Pubkey().ECDSA_validate_msg_signature(NULL, msg_length, signature, signature_length);
     NL_TEST_ASSERT(inSuite, validation_error == CHIP_ERROR_INVALID_ARGUMENT);
     validation_error = CHIP_NO_ERROR;
 
-    validation_error = ECDSA_validate_msg_signature((const uint8_t *) msg, 0, pubk, signature, signature_length);
+    validation_error = keypair.Pubkey().ECDSA_validate_msg_signature((const uint8_t *) msg, 0, signature, signature_length);
     NL_TEST_ASSERT(inSuite, validation_error == CHIP_ERROR_INVALID_ARGUMENT);
     validation_error = CHIP_NO_ERROR;
 
-    validation_error = ECDSA_validate_msg_signature((const uint8_t *) msg, msg_length, pubk, NULL, signature_length);
+    validation_error = keypair.Pubkey().ECDSA_validate_msg_signature((const uint8_t *) msg, msg_length, NULL, signature_length);
     NL_TEST_ASSERT(inSuite, validation_error == CHIP_ERROR_INVALID_ARGUMENT);
     validation_error = CHIP_NO_ERROR;
 
-    validation_error = ECDSA_validate_msg_signature((const uint8_t *) msg, msg_length, pubk, signature, 0);
+    validation_error = keypair.Pubkey().ECDSA_validate_msg_signature((const uint8_t *) msg, msg_length, signature, 0);
     NL_TEST_ASSERT(inSuite, validation_error == CHIP_ERROR_INVALID_ARGUMENT);
     validation_error = CHIP_NO_ERROR;
 }
 
 static void TestECDH_EstablishSecret(nlTestSuite * inSuite, void * inContext)
 {
-    uint8_t private_key1[] = { 0xc6, 0x1a, 0x2f, 0x89, 0x36, 0x67, 0x2b, 0x26, 0x12, 0x47, 0x4f, 0x11, 0x0e, 0x34, 0x15, 0x81,
-                               0x81, 0x12, 0xfc, 0x36, 0xeb, 0x65, 0x61, 0x07, 0xaa, 0x63, 0xe8, 0xc5, 0x22, 0xac, 0x52, 0xa1 };
+    P256Keypair keypair1;
+    NL_TEST_ASSERT(inSuite, keypair1.Initialize() == CHIP_NO_ERROR);
 
-    uint8_t public_key1[] = { 0x04, 0xe2, 0x07, 0x64, 0xff, 0x6f, 0x6a, 0x91, 0xd9, 0xc2, 0xc3, 0x0a, 0xc4, 0x3c, 0x56, 0x4b, 0x42,
-                              0x8a, 0xf3, 0xb4, 0x49, 0x29, 0x39, 0x95, 0xa2, 0xf7, 0x02, 0x8c, 0xa5, 0xce, 0xf3, 0xc9, 0xca, 0x24,
-                              0xc5, 0xd4, 0x5c, 0x60, 0x79, 0x48, 0x30, 0x3c, 0x53, 0x86, 0xd9, 0x23, 0xe6, 0x61, 0x1f, 0x5a, 0x3d,
-                              0xdf, 0x9f, 0xdc, 0x35, 0xea, 0xd0, 0xde, 0x16, 0x7e, 0x64, 0xde, 0x7f, 0x3c, 0xa6 };
-
-    uint8_t private_key2[] = { 0x00, 0xd1, 0x90, 0xd9, 0xb3, 0x95, 0x1c, 0x5f, 0xa4, 0xe7, 0x47, 0x92, 0x5b, 0x0a, 0xa9, 0xa7, 0xc1,
-                               0x1c, 0xe7, 0x06, 0x10, 0xe2, 0xdd, 0x16, 0x41, 0x52, 0x55, 0xb7, 0xb8, 0x80, 0x8d, 0x87, 0xa1 };
-
-    uint8_t public_key2[] = { 0x04, 0x30, 0x77, 0x2c, 0xe7, 0xd4, 0x0a, 0xf2, 0xf3, 0x19, 0xbd, 0xfb, 0x1f, 0xcc, 0x88, 0xd9, 0x83,
-                              0x25, 0x89, 0xf2, 0x09, 0xf3, 0xab, 0xe4, 0x33, 0xb6, 0x7a, 0xff, 0x73, 0x3b, 0x01, 0x35, 0x34, 0x92,
-                              0x73, 0x14, 0x59, 0x0b, 0xbd, 0x44, 0x72, 0x1b, 0xcd, 0xb9, 0x02, 0x53, 0xd9, 0xaf, 0xcc, 0x1a, 0xcd,
-                              0xae, 0xe8, 0x87, 0x2e, 0x52, 0x3b, 0x98, 0xf0, 0xa1, 0x88, 0x4a, 0xe3, 0x03, 0x75 };
+    P256Keypair keypair2;
+    NL_TEST_ASSERT(inSuite, keypair2.Initialize() == CHIP_NO_ERROR);
 
     uint8_t out_secret1[kMax_ECDH_Secret_Length] = { 0 };
     size_t out_size1                             = sizeof(out_secret1);
@@ -782,14 +725,10 @@ static void TestECDH_EstablishSecret(nlTestSuite * inSuite, void * inContext)
     CHIP_ERROR error                             = CHIP_NO_ERROR;
     NL_TEST_ASSERT(inSuite, memcmp(out_secret1, out_secret2, out_size1) != 0); // Validate that buffers are indeed different.
 
-    TestECPKey pubk1(public_key1, sizeof(public_key1), SupportedECPKeyTypes::ECP256R1);
-    TestECPKey privk2(private_key2, sizeof(private_key2), SupportedECPKeyTypes::ECP256R1);
-    error = ECDH_derive_secret(pubk1, privk2, out_secret1, out_size1);
+    error = keypair2.ECDH_derive_secret(keypair1.Pubkey(), out_secret1, out_size1);
     NL_TEST_ASSERT(inSuite, error == CHIP_NO_ERROR);
 
-    TestECPKey pubk2(public_key2, sizeof(public_key2), SupportedECPKeyTypes::ECP256R1);
-    TestECPKey privk1(private_key1, sizeof(private_key1), SupportedECPKeyTypes::ECP256R1);
-    error = ECDH_derive_secret(pubk2, privk1, out_secret2, out_size2);
+    error = keypair1.ECDH_derive_secret(keypair2.Pubkey(), out_secret2, out_size2);
     NL_TEST_ASSERT(inSuite, error == CHIP_NO_ERROR);
 
     bool signature_lengths_match = out_size1 == out_size2;
@@ -801,48 +740,21 @@ static void TestECDH_EstablishSecret(nlTestSuite * inSuite, void * inContext)
 
 static void TestECDH_InvalidParams(nlTestSuite * inSuite, void * inContext)
 {
-    uint8_t private_key1[] = { 0xc6, 0x1a, 0x2f, 0x89, 0x36, 0x67, 0x2b, 0x26, 0x12, 0x47, 0x4f, 0x11, 0x0e, 0x34, 0x15, 0x81,
-                               0x81, 0x12, 0xfc, 0x36, 0xeb, 0x65, 0x61, 0x07, 0xaa, 0x63, 0xe8, 0xc5, 0x22, 0xac, 0x52, 0xa1 };
+    P256Keypair keypair1;
+    NL_TEST_ASSERT(inSuite, keypair1.Initialize() == CHIP_NO_ERROR);
 
-    uint8_t public_key2[] = { 0x04, 0x30, 0x77, 0x2c, 0xe7, 0xd4, 0x0a, 0xf2, 0xf3, 0x19, 0xbd, 0xfb, 0x1f, 0xcc, 0x88, 0xd9, 0x83,
-                              0x25, 0x89, 0xf2, 0x09, 0xf3, 0xab, 0xe4, 0x33, 0xb6, 0x7a, 0xff, 0x73, 0x3b, 0x01, 0x35, 0x34, 0x92,
-                              0x73, 0x14, 0x59, 0x0b, 0xbd, 0x44, 0x72, 0x1b, 0xcd, 0xb9, 0x02, 0x53, 0xd9, 0xaf, 0xcc, 0x1a, 0xcd,
-                              0xae, 0xe8, 0x87, 0x2e, 0x52, 0x3b, 0x98, 0xf0, 0xa1, 0x88, 0x4a, 0xe3, 0x03, 0x75 };
+    P256Keypair keypair2;
+    NL_TEST_ASSERT(inSuite, keypair2.Initialize() == CHIP_NO_ERROR);
 
     uint8_t out_secret[kMax_ECDH_Secret_Length] = { 0 };
     size_t out_size                             = sizeof(out_secret);
 
-    TestECPKey pubk2(public_key2, sizeof(public_key2), SupportedECPKeyTypes::ECP256R1);
-    TestECPKey privk1(private_key1, sizeof(private_key1), SupportedECPKeyTypes::ECP256R1);
-
-    CHIP_ERROR error = ECDH_derive_secret(pubk2, privk1, NULL, out_size);
+    CHIP_ERROR error = keypair1.ECDH_derive_secret(keypair2.Pubkey(), NULL, out_size);
     NL_TEST_ASSERT(inSuite, error == CHIP_ERROR_INVALID_ARGUMENT);
 
     size_t bad_size = 0;
-    error           = ECDH_derive_secret(pubk2, privk1, out_secret, bad_size);
+    error           = keypair1.ECDH_derive_secret(keypair2.Pubkey(), out_secret, bad_size);
     NL_TEST_ASSERT(inSuite, error == CHIP_ERROR_INVALID_ARGUMENT);
-}
-
-static void TestECDH_SampleInputVectors(nlTestSuite * inSuite, void * inContext)
-{
-
-    size_t numOfTestsExecuted = 0;
-    for (numOfTestsExecuted = 0; numOfTestsExecuted < ArraySize(ecdh_test_vectors); numOfTestsExecuted++)
-    {
-        uint8_t out_secret[kMax_ECDH_Secret_Length] = { 0 };
-        size_t out_secret_length                    = sizeof(out_secret);
-        ECDH_P256_test_vector v                     = ecdh_test_vectors[numOfTestsExecuted];
-        TestECPKey pubk(v.remote_pub_key, v.remote_pub_key_length, SupportedECPKeyTypes::ECP256R1);
-        TestECPKey privk(v.local_pvt_key, v.local_pvt_key_length, SupportedECPKeyTypes::ECP256R1);
-        CHIP_ERROR error = ECDH_derive_secret(pubk, privk, out_secret, out_secret_length);
-        NL_TEST_ASSERT(inSuite, error == CHIP_NO_ERROR);
-        if (error == CHIP_NO_ERROR)
-        {
-            int result = memcmp(out_secret, v.shared_secret, out_secret_length) == 0;
-            NL_TEST_ASSERT(inSuite, result == true);
-        }
-    }
-    NL_TEST_ASSERT(inSuite, numOfTestsExecuted > 0);
 }
 
 #if CHIP_CRYPTO_OPENSSL
@@ -898,10 +810,8 @@ static void TestPBKDF2_SHA256_TestVectors(nlTestSuite * inSuite, void * inContex
 
 static void TestP256_Keygen(nlTestSuite * inSuite, void * inContext)
 {
-    P256PublicKey pubkey;
-    P256PrivateKey privkey;
-
-    NL_TEST_ASSERT(inSuite, NewECPKeypair(pubkey, privkey) == CHIP_NO_ERROR);
+    P256Keypair keypair;
+    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
     const char * msg         = "Test Message for Keygen";
     const uint8_t * test_msg = Uint8::from_const_char(msg);
@@ -909,20 +819,20 @@ static void TestP256_Keygen(nlTestSuite * inSuite, void * inContext)
     uint8_t test_sig[kMax_ECDSA_Signature_Length];
     size_t siglen = sizeof(test_sig);
 
-    NL_TEST_ASSERT(inSuite, ECDSA_sign_msg(test_msg, msglen, privkey, test_sig, siglen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.ECDSA_sign_msg(test_msg, msglen, test_sig, siglen) == CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, ECDSA_validate_msg_signature(test_msg, msglen, pubkey, test_sig, siglen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Pubkey().ECDSA_validate_msg_signature(test_msg, msglen, test_sig, siglen) == CHIP_NO_ERROR);
 }
 
 static void TestCSR_Gen(nlTestSuite * inSuite, void * inContext)
 {
-    P256PublicKey pubkey;
-    P256PrivateKey privkey;
     uint8_t csr[kMAX_CSR_Length];
     size_t length = sizeof(csr);
 
-    NL_TEST_ASSERT(inSuite, NewECPKeypair(pubkey, privkey) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, NewCertificateSigningRequest(pubkey, privkey, csr, length) == CHIP_NO_ERROR);
+    P256Keypair keypair;
+    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, keypair.NewCertificateSigningRequest(csr, length) == CHIP_NO_ERROR);
 }
 
 static void TestSPAKE2P_spake2p_FEMul(nlTestSuite * inSuite, void * inContext)
@@ -1349,7 +1259,6 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("Test DRBG output", TestDRBG_Output),
     NL_TEST_DEF("Test ECDH derive shared secret", TestECDH_EstablishSecret),
     NL_TEST_DEF("Test ECDH invalid params", TestECDH_InvalidParams),
-    NL_TEST_DEF("Test ECDH sample vectors", TestECDH_SampleInputVectors),
     NL_TEST_DEF("Test adding entropy sources", TestAddEntropySources),
     NL_TEST_DEF("Test PBKDF2 SHA256", TestPBKDF2_SHA256_TestVectors),
     NL_TEST_DEF("Test P256 Keygen", TestP256_Keygen),

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -706,7 +706,7 @@ static void TestECDH_EstablishSecret(nlTestSuite * inSuite, void * inContext)
 
     CHIP_ERROR error = CHIP_NO_ERROR;
     NL_TEST_ASSERT(inSuite,
-                   memcmp(Uint8::to_uchar(out_secret1), Uint8::to_uchar(out_secret2), out_secret1.Length()) !=
+                   memcmp(Uint8::to_uchar(out_secret1), Uint8::to_uchar(out_secret2), out_secret1.Capacity()) !=
                        0); // Validate that buffers are indeed different.
 
     error = keypair2.ECDH_derive_secret(keypair1.Pubkey(), out_secret1);

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -608,7 +608,7 @@ static void TestECDSA_Signing_SHA256(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
     uint8_t signature[kMax_ECDSA_Signature_Length];
-    size_t signature_length = sizeof(signature);
+    size_t signature_length  = sizeof(signature);
     CHIP_ERROR signing_error = keypair.ECDSA_sign_msg((const uint8_t *) msg, msg_length, signature, signature_length);
     NL_TEST_ASSERT(inSuite, signing_error == CHIP_NO_ERROR);
 
@@ -626,7 +626,7 @@ static void TestECDSA_ValidationFailsDifferentMessage(nlTestSuite * inSuite, voi
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
     uint8_t signature[kMax_ECDSA_Signature_Length];
-    size_t signature_length = sizeof(signature);
+    size_t signature_length  = sizeof(signature);
     CHIP_ERROR signing_error = keypair.ECDSA_sign_msg((const uint8_t *) msg, msg_length, signature, signature_length);
     NL_TEST_ASSERT(inSuite, signing_error == CHIP_NO_ERROR);
 
@@ -646,7 +646,7 @@ static void TestECDSA_ValidationFailIncorrectSignature(nlTestSuite * inSuite, vo
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
     uint8_t signature[kMax_ECDSA_Signature_Length];
-    size_t signature_length = sizeof(signature);
+    size_t signature_length  = sizeof(signature);
     CHIP_ERROR signing_error = keypair.ECDSA_sign_msg((const uint8_t *) msg, msg_length, signature, signature_length);
     NL_TEST_ASSERT(inSuite, signing_error == CHIP_NO_ERROR);
     signature[0] = ~signature[0]; // Flipping bits should invalidate the signature.
@@ -658,14 +658,14 @@ static void TestECDSA_ValidationFailIncorrectSignature(nlTestSuite * inSuite, vo
 
 static void TestECDSA_SigningInvalidParams(nlTestSuite * inSuite, void * inContext)
 {
-    const uint8_t * msg       = (uint8_t *) "Hello World!";
-    size_t msg_length         = strlen((const char *) msg);
+    const uint8_t * msg = (uint8_t *) "Hello World!";
+    size_t msg_length   = strlen((const char *) msg);
 
     P256Keypair keypair;
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
     uint8_t signature[kMax_ECDSA_Signature_Length];
-    size_t signature_length = sizeof(signature);
+    size_t signature_length  = sizeof(signature);
     CHIP_ERROR signing_error = keypair.ECDSA_sign_msg(NULL, msg_length, signature, signature_length);
     NL_TEST_ASSERT(inSuite, signing_error == CHIP_ERROR_INVALID_ARGUMENT);
     signing_error = CHIP_NO_ERROR;

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -611,8 +611,7 @@ static void TestECDSA_Signing_SHA256(nlTestSuite * inSuite, void * inContext)
     CHIP_ERROR signing_error = keypair.ECDSA_sign_msg((const uint8_t *) msg, msg_length, signature);
     NL_TEST_ASSERT(inSuite, signing_error == CHIP_NO_ERROR);
 
-    CHIP_ERROR validation_error =
-        keypair.Pubkey().ECDSA_validate_msg_signature((const uint8_t *) msg, msg_length, signature);
+    CHIP_ERROR validation_error = keypair.Pubkey().ECDSA_validate_msg_signature((const uint8_t *) msg, msg_length, signature);
     NL_TEST_ASSERT(inSuite, validation_error == CHIP_NO_ERROR);
 }
 
@@ -648,8 +647,7 @@ static void TestECDSA_ValidationFailIncorrectSignature(nlTestSuite * inSuite, vo
     NL_TEST_ASSERT(inSuite, signing_error == CHIP_NO_ERROR);
     signature[0] = ~signature[0]; // Flipping bits should invalidate the signature.
 
-    CHIP_ERROR validation_error =
-        keypair.Pubkey().ECDSA_validate_msg_signature((const uint8_t *) msg, msg_length, signature);
+    CHIP_ERROR validation_error = keypair.Pubkey().ECDSA_validate_msg_signature((const uint8_t *) msg, msg_length, signature);
     NL_TEST_ASSERT(inSuite, validation_error == CHIP_ERROR_INVALID_SIGNATURE);
 }
 
@@ -707,7 +705,9 @@ static void TestECDH_EstablishSecret(nlTestSuite * inSuite, void * inContext)
     out_secret2[0] = 1;
 
     CHIP_ERROR error = CHIP_NO_ERROR;
-    NL_TEST_ASSERT(inSuite, memcmp(Uint8::to_uchar(out_secret1), Uint8::to_uchar(out_secret2), out_secret1.Length()) != 0); // Validate that buffers are indeed different.
+    NL_TEST_ASSERT(inSuite,
+                   memcmp(Uint8::to_uchar(out_secret1), Uint8::to_uchar(out_secret2), out_secret1.Length()) !=
+                       0); // Validate that buffers are indeed different.
 
     error = keypair2.ECDH_derive_secret(keypair1.Pubkey(), out_secret1);
     NL_TEST_ASSERT(inSuite, error == CHIP_NO_ERROR);

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -69,7 +69,7 @@ exit:
     return error;
 }
 
-CHIP_ERROR SecureSession::Init(const Crypto::ECPKey & remote_public_key, const Crypto::ECPKey & local_private_key,
+CHIP_ERROR SecureSession::Init(const Crypto::ECPKeypair & local_keypair, const Crypto::ECPKey & remote_public_key,
                                const uint8_t * salt, const size_t salt_length, const uint8_t * info, const size_t info_length)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
@@ -85,7 +85,7 @@ CHIP_ERROR SecureSession::Init(const Crypto::ECPKey & remote_public_key, const C
     VerifyOrExit(info_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(info != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    error = ECDH_derive_secret(remote_public_key, local_private_key, secret, secret_size);
+    error = local_keypair.ECDH_derive_secret(remote_public_key, secret, secret_size);
     SuccessOrExit(error);
 
     error = InitFromSecret(secret, secret_size, salt, salt_length, info, info_length);

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -69,12 +69,11 @@ exit:
     return error;
 }
 
-CHIP_ERROR SecureSession::Init(const Crypto::ECPKeypair & local_keypair, const Crypto::ECPKey & remote_public_key,
+CHIP_ERROR SecureSession::Init(const Crypto::P256Keypair & local_keypair, const Crypto::P256PublicKey & remote_public_key,
                                const uint8_t * salt, const size_t salt_length, const uint8_t * info, const size_t info_length)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
-    uint8_t secret[kMax_ECDH_Secret_Length];
-    size_t secret_size = sizeof(secret);
+    P256ECDHDerivedSecret secret;
 
     VerifyOrExit(mKeyAvailable == false, error = CHIP_ERROR_INCORRECT_STATE);
     if (salt_length > 0)
@@ -85,10 +84,10 @@ CHIP_ERROR SecureSession::Init(const Crypto::ECPKeypair & local_keypair, const C
     VerifyOrExit(info_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(info != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    error = local_keypair.ECDH_derive_secret(remote_public_key, secret, secret_size);
+    error = local_keypair.ECDH_derive_secret(remote_public_key, secret);
     SuccessOrExit(error);
 
-    error = InitFromSecret(secret, secret_size, salt, salt_length, info, info_length);
+    error = InitFromSecret(secret, secret.Length(), salt, salt_length, info, info_length);
 
 exit:
     return error;

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -52,7 +52,7 @@ public:
      * @param salt_length        Length of the initial salt
      * @return CHIP_ERROR        The result of key derivation
      */
-    CHIP_ERROR Init(const Crypto::ECPKeypair & local_keypair, const Crypto::ECPKey & remote_public_key, const uint8_t * salt,
+    CHIP_ERROR Init(const Crypto::P256Keypair & local_keypair, const Crypto::P256PublicKey & remote_public_key, const uint8_t * salt,
                     const size_t salt_length, const uint8_t * info, const size_t info_length);
 
     /**

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -52,8 +52,8 @@ public:
      * @param salt_length        Length of the initial salt
      * @return CHIP_ERROR        The result of key derivation
      */
-    CHIP_ERROR Init(const Crypto::P256Keypair & local_keypair, const Crypto::P256PublicKey & remote_public_key, const uint8_t * salt,
-                    const size_t salt_length, const uint8_t * info, const size_t info_length);
+    CHIP_ERROR Init(const Crypto::P256Keypair & local_keypair, const Crypto::P256PublicKey & remote_public_key,
+                    const uint8_t * salt, const size_t salt_length, const uint8_t * info, const size_t info_length);
 
     /**
      * @brief

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -46,13 +46,13 @@ public:
      *   Derive a shared key. The derived key will be used for encryting/decrypting
      *   data exchanged on the secure channel.
      *
+     * @param local_keypair      A pointer to local ECP keypair
      * @param remote_public_key  A pointer to peer's public key
-     * @param local_private_key  A pointer to local private key
      * @param salt               A pointer to the initial salt used for deriving the keys
      * @param salt_length        Length of the initial salt
      * @return CHIP_ERROR        The result of key derivation
      */
-    CHIP_ERROR Init(const Crypto::ECPKey & remote_public_key, const Crypto::ECPKey & local_private_key, const uint8_t * salt,
+    CHIP_ERROR Init(const Crypto::ECPKeypair & local_keypair, const Crypto::ECPKey & remote_public_key, const uint8_t * salt,
                     const size_t salt_length, const uint8_t * info, const size_t info_length);
 
     /**

--- a/src/transport/tests/TestSecureSession.cpp
+++ b/src/transport/tests/TestSecureSession.cpp
@@ -52,17 +52,20 @@ void SecureChannelInitTest(nlTestSuite * inSuite, void * inContext)
 
     // Test the channel is successfully created with valid parameters
     const char * info = "Test Info";
-    NL_TEST_ASSERT(inSuite, channel.Init(keypair, keypair2.Pubkey(), NULL, 0, (const uint8_t *) info, sizeof(info)) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite,
+                   channel.Init(keypair, keypair2.Pubkey(), NULL, 0, (const uint8_t *) info, sizeof(info)) == CHIP_NO_ERROR);
 
     // Test the channel cannot be reinitialized
-    NL_TEST_ASSERT(inSuite, channel.Init(keypair, keypair2.Pubkey(), NULL, 0, (const uint8_t *) info, sizeof(info)) == CHIP_ERROR_INCORRECT_STATE);
+    NL_TEST_ASSERT(inSuite,
+                   channel.Init(keypair, keypair2.Pubkey(), NULL, 0, (const uint8_t *) info, sizeof(info)) ==
+                       CHIP_ERROR_INCORRECT_STATE);
 
     // Test the channel can be initialized with valid salt
     const char * salt = "Test Salt";
     SecureSession channel2;
     NL_TEST_ASSERT(inSuite,
-                   channel2.Init(keypair, keypair2.Pubkey(), (const uint8_t *) salt, sizeof(salt), (const uint8_t *) info, sizeof(info)) ==
-                       CHIP_NO_ERROR);
+                   channel2.Init(keypair, keypair2.Pubkey(), (const uint8_t *) salt, sizeof(salt), (const uint8_t *) info,
+                                 sizeof(info)) == CHIP_NO_ERROR);
 }
 
 void SecureChannelEncryptTest(nlTestSuite * inSuite, void * inContext)
@@ -85,8 +88,8 @@ void SecureChannelEncryptTest(nlTestSuite * inSuite, void * inContext)
     const char * info = "Test Info";
     const char * salt = "Test Salt";
     NL_TEST_ASSERT(inSuite,
-                   channel.Init(keypair, keypair2.Pubkey(), (const uint8_t *) salt, sizeof(salt), (const uint8_t *) info, sizeof(info)) ==
-                       CHIP_NO_ERROR);
+                   channel.Init(keypair, keypair2.Pubkey(), (const uint8_t *) salt, sizeof(salt), (const uint8_t *) info,
+                                sizeof(info)) == CHIP_NO_ERROR);
 
     // Test initialized channel, but invalid arguments
     NL_TEST_ASSERT(inSuite, channel.Encrypt(NULL, 0, NULL, header) == CHIP_ERROR_INVALID_ARGUMENT);
@@ -114,8 +117,8 @@ void SecureChannelDecryptTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, keypair2.Initialize() == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
-                   channel.Init(keypair, keypair2.Pubkey(), (const uint8_t *) salt, sizeof(salt), (const uint8_t *) info, sizeof(info)) ==
-                       CHIP_NO_ERROR);
+                   channel.Init(keypair, keypair2.Pubkey(), (const uint8_t *) salt, sizeof(salt), (const uint8_t *) info,
+                                sizeof(info)) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, channel.Encrypt(plain_text, sizeof(plain_text), encrypted, header) == CHIP_NO_ERROR);
 
     SecureSession channel2;
@@ -124,8 +127,8 @@ void SecureChannelDecryptTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite,
                    channel2.Decrypt(encrypted, sizeof(plain_text), output, header) == CHIP_ERROR_INVALID_USE_OF_SESSION_KEY);
     NL_TEST_ASSERT(inSuite,
-                   channel2.Init(keypair2, keypair.Pubkey(), (const uint8_t *) salt, sizeof(salt), (const uint8_t *) info, sizeof(info)) ==
-                       CHIP_NO_ERROR);
+                   channel2.Init(keypair2, keypair.Pubkey(), (const uint8_t *) salt, sizeof(salt), (const uint8_t *) info,
+                                 sizeof(info)) == CHIP_NO_ERROR);
 
     // Channel initialized, but invalid arguments to decrypt
     NL_TEST_ASSERT(inSuite, channel2.Decrypt(NULL, 0, NULL, header) == CHIP_ERROR_INVALID_ARGUMENT);

--- a/src/transport/tests/TestSecureSession.cpp
+++ b/src/transport/tests/TestSecureSession.cpp
@@ -36,65 +36,32 @@
 using namespace chip;
 using namespace Crypto;
 
-static uint8_t secure_channel_test_private_key1[] = { 0xc6, 0x1a, 0x2f, 0x89, 0x36, 0x67, 0x2b, 0x26, 0x12, 0x47, 0x4f,
-                                                      0x11, 0x0e, 0x34, 0x15, 0x81, 0x81, 0x12, 0xfc, 0x36, 0xeb, 0x65,
-                                                      0x61, 0x07, 0xaa, 0x63, 0xe8, 0xc5, 0x22, 0xac, 0x52, 0xa1 };
-
-static uint8_t secure_channel_test_public_key1[] = { 0x04, 0xe2, 0x07, 0x64, 0xff, 0x6f, 0x6a, 0x91, 0xd9, 0xc2, 0xc3, 0x0a, 0xc4,
-                                                     0x3c, 0x56, 0x4b, 0x42, 0x8a, 0xf3, 0xb4, 0x49, 0x29, 0x39, 0x95, 0xa2, 0xf7,
-                                                     0x02, 0x8c, 0xa5, 0xce, 0xf3, 0xc9, 0xca, 0x24, 0xc5, 0xd4, 0x5c, 0x60, 0x79,
-                                                     0x48, 0x30, 0x3c, 0x53, 0x86, 0xd9, 0x23, 0xe6, 0x61, 0x1f, 0x5a, 0x3d, 0xdf,
-                                                     0x9f, 0xdc, 0x35, 0xea, 0xd0, 0xde, 0x16, 0x7e, 0x64, 0xde, 0x7f, 0x3c, 0xa6 };
-
-static uint8_t secure_channel_test_private_key2[] = { 0x00, 0xd1, 0x90, 0xd9, 0xb3, 0x95, 0x1c, 0x5f, 0xa4, 0xe7, 0x47,
-                                                      0x92, 0x5b, 0x0a, 0xa9, 0xa7, 0xc1, 0x1c, 0xe7, 0x06, 0x10, 0xe2,
-                                                      0xdd, 0x16, 0x41, 0x52, 0x55, 0xb7, 0xb8, 0x80, 0x8d, 0x87, 0xa1 };
-
-static uint8_t secure_channel_test_public_key2[] = { 0x04, 0x30, 0x77, 0x2c, 0xe7, 0xd4, 0x0a, 0xf2, 0xf3, 0x19, 0xbd, 0xfb, 0x1f,
-                                                     0xcc, 0x88, 0xd9, 0x83, 0x25, 0x89, 0xf2, 0x09, 0xf3, 0xab, 0xe4, 0x33, 0xb6,
-                                                     0x7a, 0xff, 0x73, 0x3b, 0x01, 0x35, 0x34, 0x92, 0x73, 0x14, 0x59, 0x0b, 0xbd,
-                                                     0x44, 0x72, 0x1b, 0xcd, 0xb9, 0x02, 0x53, 0xd9, 0xaf, 0xcc, 0x1a, 0xcd, 0xae,
-                                                     0xe8, 0x87, 0x2e, 0x52, 0x3b, 0x98, 0xf0, 0xa1, 0x88, 0x4a, 0xe3, 0x03, 0x75 };
-
-class TestECPKey : public ECPKey
-{
-public:
-    SupportedECPKeyTypes Type() const override { return type; }
-    size_t Length() const override { return len; }
-    operator uint8_t *() const override { return bytes; }
-
-    TestECPKey(uint8_t * data, size_t length, SupportedECPKeyTypes t) : bytes(data), len(length), type(t) {}
-
-private:
-    uint8_t * bytes;
-    size_t len;
-    SupportedECPKeyTypes type;
-};
-
 void SecureChannelInitTest(nlTestSuite * inSuite, void * inContext)
 {
     SecureSession channel;
-    TestECPKey pubk(secure_channel_test_public_key1, sizeof(secure_channel_test_public_key1),
-                    Crypto::SupportedECPKeyTypes::ECP256R1);
-    TestECPKey privk(secure_channel_test_private_key2, sizeof(secure_channel_test_private_key2),
-                     Crypto::SupportedECPKeyTypes::ECP256R1);
+
+    P256Keypair keypair;
+    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+
+    P256Keypair keypair2;
+    NL_TEST_ASSERT(inSuite, keypair2.Initialize() == CHIP_NO_ERROR);
 
     // Test all combinations of invalid parameters
-    NL_TEST_ASSERT(inSuite, channel.Init(pubk, privk, NULL, 0, NULL, 0) == CHIP_ERROR_INVALID_ARGUMENT);
-    NL_TEST_ASSERT(inSuite, channel.Init(pubk, privk, NULL, 10, NULL, 0) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, channel.Init(keypair, keypair2.Pubkey(), NULL, 0, NULL, 0) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, channel.Init(keypair, keypair2.Pubkey(), NULL, 10, NULL, 0) == CHIP_ERROR_INVALID_ARGUMENT);
 
     // Test the channel is successfully created with valid parameters
     const char * info = "Test Info";
-    NL_TEST_ASSERT(inSuite, channel.Init(pubk, privk, NULL, 0, (const uint8_t *) info, sizeof(info)) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, channel.Init(keypair, keypair2.Pubkey(), NULL, 0, (const uint8_t *) info, sizeof(info)) == CHIP_NO_ERROR);
 
     // Test the channel cannot be reinitialized
-    NL_TEST_ASSERT(inSuite, channel.Init(pubk, privk, NULL, 0, (const uint8_t *) info, sizeof(info)) == CHIP_ERROR_INCORRECT_STATE);
+    NL_TEST_ASSERT(inSuite, channel.Init(keypair, keypair2.Pubkey(), NULL, 0, (const uint8_t *) info, sizeof(info)) == CHIP_ERROR_INCORRECT_STATE);
 
     // Test the channel can be initialized with valid salt
     const char * salt = "Test Salt";
     SecureSession channel2;
     NL_TEST_ASSERT(inSuite,
-                   channel2.Init(pubk, privk, (const uint8_t *) salt, sizeof(salt), (const uint8_t *) info, sizeof(info)) ==
+                   channel2.Init(keypair, keypair2.Pubkey(), (const uint8_t *) salt, sizeof(salt), (const uint8_t *) info, sizeof(info)) ==
                        CHIP_NO_ERROR);
 }
 
@@ -105,10 +72,11 @@ void SecureChannelEncryptTest(nlTestSuite * inSuite, void * inContext)
     uint8_t output[128];
     MessageHeader header;
 
-    TestECPKey pubk(secure_channel_test_public_key1, sizeof(secure_channel_test_public_key1),
-                    Crypto::SupportedECPKeyTypes::ECP256R1);
-    TestECPKey privk(secure_channel_test_private_key2, sizeof(secure_channel_test_private_key2),
-                     Crypto::SupportedECPKeyTypes::ECP256R1);
+    P256Keypair keypair;
+    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+
+    P256Keypair keypair2;
+    NL_TEST_ASSERT(inSuite, keypair2.Initialize() == CHIP_NO_ERROR);
 
     // Test uninitialized channel
     NL_TEST_ASSERT(inSuite,
@@ -117,7 +85,7 @@ void SecureChannelEncryptTest(nlTestSuite * inSuite, void * inContext)
     const char * info = "Test Info";
     const char * salt = "Test Salt";
     NL_TEST_ASSERT(inSuite,
-                   channel.Init(pubk, privk, (const uint8_t *) salt, sizeof(salt), (const uint8_t *) info, sizeof(info)) ==
+                   channel.Init(keypair, keypair2.Pubkey(), (const uint8_t *) salt, sizeof(salt), (const uint8_t *) info, sizeof(info)) ==
                        CHIP_NO_ERROR);
 
     // Test initialized channel, but invalid arguments
@@ -139,27 +107,24 @@ void SecureChannelDecryptTest(nlTestSuite * inSuite, void * inContext)
     const char * info = "Test Info";
     const char * salt = "Test Salt";
 
-    TestECPKey pubk(secure_channel_test_public_key1, sizeof(secure_channel_test_public_key1),
-                    Crypto::SupportedECPKeyTypes::ECP256R1);
-    TestECPKey privk(secure_channel_test_private_key2, sizeof(secure_channel_test_private_key2),
-                     Crypto::SupportedECPKeyTypes::ECP256R1);
+    P256Keypair keypair;
+    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+
+    P256Keypair keypair2;
+    NL_TEST_ASSERT(inSuite, keypair2.Initialize() == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
-                   channel.Init(pubk, privk, (const uint8_t *) salt, sizeof(salt), (const uint8_t *) info, sizeof(info)) ==
+                   channel.Init(keypair, keypair2.Pubkey(), (const uint8_t *) salt, sizeof(salt), (const uint8_t *) info, sizeof(info)) ==
                        CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, channel.Encrypt(plain_text, sizeof(plain_text), encrypted, header) == CHIP_NO_ERROR);
 
     SecureSession channel2;
     uint8_t output[128];
     // Uninitialized channel
-    TestECPKey pubk2(secure_channel_test_public_key2, sizeof(secure_channel_test_public_key2),
-                     Crypto::SupportedECPKeyTypes::ECP256R1);
-    TestECPKey privk1(secure_channel_test_private_key1, sizeof(secure_channel_test_private_key1),
-                      Crypto::SupportedECPKeyTypes::ECP256R1);
     NL_TEST_ASSERT(inSuite,
                    channel2.Decrypt(encrypted, sizeof(plain_text), output, header) == CHIP_ERROR_INVALID_USE_OF_SESSION_KEY);
     NL_TEST_ASSERT(inSuite,
-                   channel2.Init(pubk2, privk1, (const uint8_t *) salt, sizeof(salt), (const uint8_t *) info, sizeof(info)) ==
+                   channel2.Init(keypair2, keypair.Pubkey(), (const uint8_t *) salt, sizeof(salt), (const uint8_t *) info, sizeof(info)) ==
                        CHIP_NO_ERROR);
 
     // Channel initialized, but invalid arguments to decrypt


### PR DESCRIPTION
 #### Problem
Crypto APIs require caller to provide a buffer containing private key. This exposes the private key to various other layers in the system. Also, when HW is used for generating the key pair, the private key may not be accessible in memory. This will prevent us from using the current crypto APIs.

 #### Summary of Changes
Define a new `Keypair` interface. The new interface does not expose or require private key. Its implementation class provides methods that internally use the generated private key.

