### PR TITLE
Add --check args to gn gen in our example scripts.

### DIFF
--- a/scripts/examples/gn_build_example.sh
+++ b/scripts/examples/gn_build_example.sh
@@ -50,6 +50,6 @@ done
 set -x
 env
 
-gn gen --root="$EXAMPLE_DIR" "$OUTPUT_DIR" --args="${GN_ARGS[*]}"
+gn gen --check --root="$EXAMPLE_DIR" "$OUTPUT_DIR" --args="${GN_ARGS[*]}"
 
 ninja -C "$OUTPUT_DIR" "${NINJA_ARGS[@]}"

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -28,10 +28,10 @@ set -x
 env
 
 if [ -z "$3" ]; then
-    gn gen --root="$1" --args="efr32_sdk_root=\"$EFR32_SDK_ROOT\"" "$2"/"$EFR32_BOARD"/
+    gn gen --check --root="$1" --args="efr32_sdk_root=\"$EFR32_SDK_ROOT\"" "$2"/"$EFR32_BOARD"/
     ninja -v -C "$2"/"$EFR32_BOARD"/
 else
-    gn gen --root="$1" --args="efr32_sdk_root=\"$EFR32_SDK_ROOT\" efr32_board=\"$3\"" "$2/$3"
+    gn gen --check --root="$1" --args="efr32_sdk_root=\"$EFR32_SDK_ROOT\" efr32_board=\"$3\"" "$2/$3"
     ninja -v -C "$2/$3"
 fi
 

--- a/scripts/examples/gn_nrf_example.sh
+++ b/scripts/examples/gn_nrf_example.sh
@@ -27,6 +27,6 @@ source "$CHIP_ROOT/scripts/activate.sh"
 set -x
 env
 
-gn gen --root="$1" --args="nrf5_sdk_root=\"$NRF5_SDK_ROOT\"" "$2"
+gn gen --check --root="$1" --args="nrf5_sdk_root=\"$NRF5_SDK_ROOT\"" "$2"
 
 ninja -v -C "$2"


### PR DESCRIPTION
Our toplevel gn_build.sh uses these args, but that's not what runs in CI.

 #### Problem
CI doesn't pass `--check` args for things that manual builds do, so it's possible for CI to be ok but manual builds to break

 #### Summary of Changes
Add `--check` args.

fixes https://github.com/project-chip/connectedhomeip/issues/2651
