### PR TITLE
Work around activate.sh failure after cleaning

### DIFF
--- a/scripts/helpers/clean_tree.sh
+++ b/scripts/helpers/clean_tree.sh
@@ -21,3 +21,9 @@ set -x
 git clean -Xdf
 
 git submodule foreach git clean -Xdf
+
+# TODO - Remove after fixing
+# https://bugs.chromium.org/p/pigweed/issues/detail?id=265
+if test -n "$PW_ENVIRONMENT_ROOT" -a -w "$PW_ENVIRONMENT_ROOT"; then
+    rm -rf "$PW_ENVIRONMENT_ROOT"
+fi


### PR DESCRIPTION
 #### Problem
"Clean Tree" VSCode tasks breaks the build.

 #### Summary of Changes
Remove pigweed environment during aggressive cleans.

fixes #2654