### PR TITLE
Fix incorrect handling of return from xEventGroupSetBitsFromISR

### DIFF
--- a/src/platform/EFR32/BLEManagerImpl.cpp
+++ b/src/platform/EFR32/BLEManagerImpl.cpp
@@ -186,11 +186,11 @@ void BLEManagerImpl::bluetoothStackEventHandler(void * p_arg)
     while (1)
     {
         // wait for Bluetooth stack events, do not consume set flag
-        flags |= xEventGroupWaitBits(bluetooth_event_flags,            /* The event group being tested. */
-                                     BLUETOOTH_EVENT_FLAG_EVT_WAITING, /* The bits within the event group to wait for. */
-                                     pdFALSE,                          /* Dont clear flags before returning */
-                                     pdFALSE,                          /* Any flag will do, dont wait for all flags to be set */
-                                     portMAX_DELAY);                   /* Wait for maximum duration for bit to be set */
+        flags = xEventGroupWaitBits(bluetooth_event_flags,            /* The event group being tested. */
+                                    BLUETOOTH_EVENT_FLAG_EVT_WAITING, /* The bits within the event group to wait for. */
+                                    pdFALSE,                          /* Dont clear flags before returning */
+                                    pdFALSE,                          /* Any flag will do, dont wait for all flags to be set */
+                                    portMAX_DELAY);                   /* Wait for maximum duration for bit to be set */
 
         if (flags & BLUETOOTH_EVENT_FLAG_EVT_WAITING)
         {
@@ -265,7 +265,7 @@ void BLEManagerImpl::bluetoothStackEventHandler(void * p_arg)
 
         PlatformMgr().UnlockChipStack();
 
-        flags = vRaiseEventFlagBasedOnContext(bluetooth_event_flags, BLUETOOTH_EVENT_FLAG_EVT_HANDLED, NULL);
+        vRaiseEventFlagBasedOnContext(bluetooth_event_flags, BLUETOOTH_EVENT_FLAG_EVT_HANDLED);
     }
 }
 

--- a/src/platform/EFR32/freertos_bluetooth.h
+++ b/src/platform/EFR32/freertos_bluetooth.h
@@ -72,8 +72,7 @@ extern void BluetoothLLCallback(void);
 void BluetoothPend(void);
 void BluetoothPost(void);
 
-EventBits_t vRaiseEventFlagBasedOnContext(EventGroupHandle_t xEventGroup, EventBits_t uxBitsToWaitFor,
-                                          BaseType_t * pxHigherPriorityTaskWoken);
+void vRaiseEventFlagBasedOnContext(EventGroupHandle_t xEventGroup, EventBits_t uxBitsToWaitFor);
 EventBits_t vSendToQueueBasedOnContext(QueueHandle_t xQueue, void * xItemToQueue, TickType_t xTicksToWait,
                                        BaseType_t * pxHigherPriorityTaskWoken);
 


### PR DESCRIPTION
xEventGroupSetBitsFromISR returns BaseType_t, not EventBits_t.  The
only good news was that no one looked at the return value anyway...

The other change here is removing the unused pxHigherPriorityTaskWoken
outparam.

 #### Problem
We are assigning a return value to a value of a totally different type.

 #### Summary of Changes
Stop doing that, clean up the function signature a bit in general.

fixes https://github.com/project-chip/connectedhomeip/issues/2602