### PR TITLE
Add nanopb as git submodule (#2668)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -82,3 +82,6 @@
 	branch = master
 	ignore = dirty
 	commit = 72102da049234815ba2c0184a7a13f1cb5ab4263
+[submodule "nanopb"]
+	path = third_party/nanopb/repo
+	url = https://github.com/nanopb/nanopb.git

--- a/third_party/nanopb/README.md
+++ b/third_party/nanopb/README.md
@@ -1,0 +1,8 @@
+# nanopb
+
+[Github repo](https://github.com/nanopb/nanopb)
+
+Nanopb is a small code-size Protocol Buffers implementation in ansi C.
+
+In CHIP it is included for on-device test support only. Eventually serialization
+will be harmonized across the whole codebase.


### PR DESCRIPTION
 #### Problem
nanopb is a lightweight protobuf implementation. Protobufs are required e.g. by some modules of Pigweed which already is a submodule.

 #### Summary of Changes
Adds https://github.com/nanopb/nanopb.git as a git submodule to
third_party/nanopb/repo

fixes #2668
