### PR TITLE
Fix Android build with OpenJDK 11

### DIFF
--- a/gn/chip/java/rules.gni
+++ b/gn/chip/java/rules.gni
@@ -121,6 +121,11 @@ template("android_library") {
     javac_flags += [
       "-classpath",
       "${android_sdk_root}/platforms/android-${android_sdk_version}/android.jar",
+      "-Xlint:-options",
+      "-source",
+      "8",
+      "-target",
+      "8",
     ]
   }
 }


### PR DESCRIPTION
We need to target Java 8, not 11, so pass the argument explicitly. This
avoids dex errors when launching the application on the phone:

Suppressed: java.io.IOException: Failed to open dex files from /data/app/~~f8ynkbFXC9Wk5KqkL_6evA==/com.google.chip.chiptool-zDQFz6dhQ1G1vVGvQcGP0w==/base.apk because: Failure to verify dex file '/data/app/~~f8ynkbFXC9Wk5KqkL_6evA==/com.google.chip.chiptool-zDQFz6dhQ1G1vVGvQcGP0w==/base.apk': Method 25081(Lchip/devicecontroller/AndroidChipStack;.-$$Nest$mhandleConnectionError) has code, but is marked native or abstract

 #### Problem
Android app doesn't load with JARs built with GN & OpenJDK 11.

 #### Summary of Changes
Fix the javac options to target Java 8.