### PR TITLE
[apps] move ble handlers to common server

### DIFF
--- a/examples/common/chip-app-server/Server.cpp
+++ b/examples/common/chip-app-server/Server.cpp
@@ -65,6 +65,10 @@ namespace {
 
 void HandleBLEConnectionClosed(chip::Ble::BLEEndPoint * endPoint, BLE_ERROR err)
 {
+    if (err != BLE_NO_ERROR)
+    {
+        ChipLogError(AppServer, "BLE Error: %d", err);
+    }
     ChipLogProgress(AppServer, "BLE Connection closed");
 }
 

--- a/examples/common/chip-app-server/Server.cpp
+++ b/examples/common/chip-app-server/Server.cpp
@@ -80,26 +80,46 @@ void HandleBLEMessageReceived(chip::Ble::BLEEndPoint * endPoint, chip::System::P
     chip::DeviceLayer::Internal::DeviceNetworkInfo networkInfo;
     ChipLogProgress(AppServer, "Receive BLE message size=%u", bufferLen);
 
+    VerifyOrExit(bufferLen >= sizeof(networkInfo.ThreadNetworkName),
+                 ChipLogProgress(AppServer, "Invalid network provision message"));
     memcpy(networkInfo.ThreadNetworkName, data, sizeof(networkInfo.ThreadNetworkName));
     data += sizeof(networkInfo.ThreadNetworkName);
+    bufferLen -= sizeof(networkInfo.ThreadNetworkName);
 
+    VerifyOrExit(bufferLen >= sizeof(networkInfo.ThreadExtendedPANId),
+                 ChipLogProgress(AppServer, "Invalid network provision message"));
     memcpy(networkInfo.ThreadExtendedPANId, data, sizeof(networkInfo.ThreadExtendedPANId));
     data += sizeof(networkInfo.ThreadExtendedPANId);
+    bufferLen -= sizeof(networkInfo.ThreadExtendedPANId);
 
+    VerifyOrExit(bufferLen >= sizeof(networkInfo.ThreadMeshPrefix),
+                 ChipLogProgress(AppServer, "Invalid network provision message"));
     memcpy(networkInfo.ThreadMeshPrefix, data, sizeof(networkInfo.ThreadMeshPrefix));
     data += sizeof(networkInfo.ThreadMeshPrefix);
+    bufferLen -= sizeof(networkInfo.ThreadMeshPrefix);
 
+    VerifyOrExit(bufferLen >= sizeof(networkInfo.ThreadNetworkKey),
+                 ChipLogProgress(AppServer, "Invalid network provision message"));
     memcpy(networkInfo.ThreadNetworkKey, data, sizeof(networkInfo.ThreadNetworkKey));
     data += sizeof(networkInfo.ThreadNetworkKey);
+    bufferLen -= sizeof(networkInfo.ThreadNetworkKey);
 
+    VerifyOrExit(bufferLen >= sizeof(networkInfo.ThreadPSKc), ChipLogProgress(AppServer, "Invalid network provision message"));
     memcpy(networkInfo.ThreadPSKc, data, sizeof(networkInfo.ThreadPSKc));
     data += sizeof(networkInfo.ThreadPSKc);
+    bufferLen -= sizeof(networkInfo.ThreadPSKc);
 
+    VerifyOrExit(bufferLen >= sizeof(networkInfo.ThreadPANId), ChipLogProgress(AppServer, "Invalid network provision message"));
     networkInfo.ThreadPANId = data[0] | (data[1] << 8);
     data += sizeof(networkInfo.ThreadPANId);
+    bufferLen -= sizeof(networkInfo.ThreadPANId);
+
+    VerifyOrExit(bufferLen >= sizeof(networkInfo.ThreadChannel), ChipLogProgress(AppServer, "Invalid network provision message"));
     networkInfo.ThreadChannel = data[0];
     data += sizeof(networkInfo.ThreadChannel);
+    bufferLen -= sizeof(networkInfo.ThreadChannel);
 
+    VerifyOrExit(bufferLen >= 3, ChipLogProgress(AppServer, "Invalid network provision message"));
     networkInfo.FieldPresent.ThreadExtendedPANId = *data;
     data++;
     networkInfo.FieldPresent.ThreadMeshPrefix = *data;
@@ -114,6 +134,7 @@ void HandleBLEMessageReceived(chip::Ble::BLEEndPoint * endPoint, chip::System::P
     ThreadStackMgr().SetThreadEnabled(true);
 
 #endif
+exit:
     endPoint->Close();
     chip::System::PacketBuffer::Free(buffer);
 }

--- a/examples/lock-app/nrf5/main/AppTask.cpp
+++ b/examples/lock-app/nrf5/main/AppTask.cpp
@@ -216,67 +216,6 @@ int AppTask::Init()
     return ret;
 }
 
-void AppTask::HandleBLEConnectionOpened(chip::Ble::BLEEndPoint * endPoint)
-{
-    NRF_LOG_INFO("AppTask: Connection opened");
-
-    GetAppTask().mBLEEndPoint    = endPoint;
-    endPoint->OnMessageReceived  = AppTask::HandleBLEMessageReceived;
-    endPoint->OnConnectionClosed = AppTask::HandleBLEConnectionClosed;
-}
-
-void AppTask::HandleBLEConnectionClosed(chip::Ble::BLEEndPoint * endPoint, BLE_ERROR err)
-{
-    NRF_LOG_INFO("AppTask: Connection closed");
-
-    GetAppTask().mBLEEndPoint = nullptr;
-}
-
-void AppTask::HandleBLEMessageReceived(chip::Ble::BLEEndPoint * endPoint, chip::System::PacketBuffer * buffer)
-{
-#if CHIP_ENABLE_OPENTHREAD
-    uint16_t bufferLen = buffer->DataLength();
-    uint8_t * data     = buffer->Start();
-    chip::DeviceLayer::Internal::DeviceNetworkInfo networkInfo;
-    NRF_LOG_INFO("AppTask: Receive message size %u", bufferLen);
-
-    memcpy(networkInfo.ThreadNetworkName, data, sizeof(networkInfo.ThreadNetworkName));
-    data += sizeof(networkInfo.ThreadNetworkName);
-
-    memcpy(networkInfo.ThreadExtendedPANId, data, sizeof(networkInfo.ThreadExtendedPANId));
-    data += sizeof(networkInfo.ThreadExtendedPANId);
-
-    memcpy(networkInfo.ThreadMeshPrefix, data, sizeof(networkInfo.ThreadMeshPrefix));
-    data += sizeof(networkInfo.ThreadMeshPrefix);
-
-    memcpy(networkInfo.ThreadNetworkKey, data, sizeof(networkInfo.ThreadNetworkKey));
-    data += sizeof(networkInfo.ThreadNetworkKey);
-
-    memcpy(networkInfo.ThreadPSKc, data, sizeof(networkInfo.ThreadPSKc));
-    data += sizeof(networkInfo.ThreadPSKc);
-
-    networkInfo.ThreadPANId = data[0] | (data[1] << 8);
-    data += sizeof(networkInfo.ThreadPANId);
-    networkInfo.ThreadChannel = data[0];
-    data += sizeof(networkInfo.ThreadChannel);
-
-    networkInfo.FieldPresent.ThreadExtendedPANId = *data;
-    data++;
-    networkInfo.FieldPresent.ThreadMeshPrefix = *data;
-    data++;
-    networkInfo.FieldPresent.ThreadPSKc = *data;
-    data++;
-    networkInfo.NetworkId              = 0;
-    networkInfo.FieldPresent.NetworkId = true;
-
-    ThreadStackMgr().SetThreadEnabled(false);
-    ThreadStackMgr().SetThreadProvision(networkInfo);
-    ThreadStackMgr().SetThreadEnabled(true);
-#endif
-    endPoint->Close();
-    chip::System::PacketBuffer::Free(buffer);
-}
-
 void AppTask::AppTaskMain(void * pvParameter)
 {
     ret_code_t ret;
@@ -290,7 +229,6 @@ void AppTask::AppTaskMain(void * pvParameter)
         APP_ERROR_HANDLER(ret);
     }
 
-    chip::DeviceLayer::ConnectivityMgr().AddCHIPoBLEConnectionHandler(&AppTask::HandleBLEConnectionOpened);
     SetDeviceName("LockDemo._chip._udp.local.");
 
     while (true)

--- a/examples/lock-app/nrf5/main/include/AppTask.h
+++ b/examples/lock-app/nrf5/main/include/AppTask.h
@@ -29,8 +29,6 @@
 #include "AppEvent.h"
 #include "BoltLockManager.h"
 
-#include <ble/BLEEndPoint.h>
-
 class AppTask
 {
 public:
@@ -60,10 +58,6 @@ private:
     static void ButtonEventHandler(uint8_t pin_no, uint8_t button_action);
     static void TimerEventHandler(void * p_context);
 
-    static void HandleBLEConnectionOpened(chip::Ble::BLEEndPoint * endPoint);
-    static void HandleBLEConnectionClosed(chip::Ble::BLEEndPoint * endPoint, BLE_ERROR err);
-    static void HandleBLEMessageReceived(chip::Ble::BLEEndPoint * endPoint, chip::System::PacketBuffer * buffer);
-
     void StartTimer(uint32_t aTimeoutInMs);
 
     enum Function_t
@@ -77,7 +71,6 @@ private:
 
     Function_t mFunction;
     bool mFunctionTimerActive;
-    chip::Ble::BLEEndPoint * mBLEEndPoint;
 
     static AppTask sAppTask;
 };


### PR DESCRIPTION
 #### Problem

Network provision over BLE prototype is missing in the light app.

 #### Summary of Changes

Move BLE network provision code from lock app to the common server.
