### PR TITLE
Allow building CHIP without lwip checked out

### DIFF
--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -15,6 +15,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/gn/chip/tests.gni")
+import("${chip_root}/src/lwip/lwip.gni")
 
 config("includes") {
   include_dirs = [
@@ -46,11 +47,12 @@ if (chip_build_tests) {
       "${chip_root}/src/transport/tests",
     ]
 
+    if (chip_with_lwip) {
+      deps += [ "${chip_root}/src/lwip/tests" ]
+    }
+
     if (current_os != "zephyr") {
-      deps += [
-        "${chip_root}/src/lib/shell/tests",
-        "${chip_root}/src/lwip/tests",
-      ]
+      deps += [ "${chip_root}/src/lib/shell/tests" ]
     }
   }
 }

--- a/src/inet/BUILD.gn
+++ b/src/inet/BUILD.gn
@@ -19,6 +19,7 @@ import("//build_overrides/nlio.gni")
 
 import("${chip_root}/gn/chip/buildconfig_header.gni")
 import("${chip_root}/gn/chip/tests.gni")
+import("${chip_root}/src/lwip/lwip.gni")
 import("${chip_root}/src/platform/device.gni")
 import("inet.gni")
 
@@ -97,10 +98,13 @@ static_library("inet") {
   public_deps = [
     ":inet_config_header",
     "${chip_root}/src/lib/support",
-    "${chip_root}/src/lwip",
     "${chip_root}/src/system",
     "${nlio_root}:nlio",
   ]
+
+  if (chip_with_lwip) {
+    public_deps += [ "${chip_root}/src/lwip" ]
+  }
 
   if (chip_inet_config_enable_raw_endpoint) {
     sources += [

--- a/src/lwip/BUILD.gn
+++ b/src/lwip/BUILD.gn
@@ -16,7 +16,10 @@ import("//build_overrides/chip.gni")
 import("//build_overrides/lwip.gni")
 
 import("${chip_root}/gn/chip/buildconfig_header.gni")
+import("${chip_root}/src/lwip/lwip.gni")
 import("${lwip_root}/lwip.gni")
+
+assert(chip_with_lwip)
 
 declare_args() {
   # lwIP platform: standalone, freertos.

--- a/src/lwip/lwip.gni
+++ b/src/lwip/lwip.gni
@@ -12,19 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import("//build_overrides/chip.gni")
-
-import("${chip_root}/gn/chip/chip_test.gni")
-import("${chip_root}/gn/chip/chip_test_group.gni")
-import("${chip_root}/src/lwip/lwip.gni")
-
-assert(chip_with_lwip)
-
-chip_test("TestLwIP") {
-  sources = [ "tests.c" ]
-  deps = [ "${chip_root}/src/lwip" ]
-}
-
-chip_test_group("tests") {
-  deps = [ ":TestLwIP" ]
+declare_args() {
+  # Have the the lwIP library available.
+  chip_with_lwip = current_os != "zephyr"
 }

--- a/src/lwip/lwip.gni
+++ b/src/lwip/lwip.gni
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 declare_args() {
-  # Have the the lwIP library available.
+  # Have the lwIP library available.
   chip_with_lwip = current_os != "zephyr"
 }

--- a/src/system/system.gni
+++ b/src/system/system.gni
@@ -12,9 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//build_overrides/chip.gni")
+
+import("${chip_root}/src/lwip/lwip.gni")
+
 declare_args() {
   # Use the lwIP library.
-  chip_system_config_use_lwip = current_os == "freertos"
+  chip_system_config_use_lwip = chip_with_lwip && current_os == "freertos"
 
   # Use BSD/POSIX socket API.
   chip_system_config_use_sockets = current_os != "freertos"


### PR DESCRIPTION
This used to work prior to #2325, which added an unconditional
dependency on lwip even if we're using sockets. Make it conditional.

 #### Problem
Projects that use CHIP with sockets require an unused lwIP in their checkout.

 #### Summary of Changes
Make the dependency conditional on use of lwIP.