### PR TITLE
Remove no-op esp32 config

### DIFF
--- a/config/esp32/BUILD.gn
+++ b/config/esp32/BUILD.gn
@@ -17,16 +17,6 @@
 
 import("//build_overrides/chip.gni")
 
-config("esp32_config") {
-  defines = []
-  if (is_debug) {
-    defines = [ "BUILD_RELEASE=0" ]
-  } else {
-    defines = [ "BUILD_RELEASE=1" ]
-  }
-}
-
 group("esp32") {
   deps = [ "${chip_root}/src/lib" ]
-  public_configs = [ ":esp32_config" ]
 }


### PR DESCRIPTION
This doesn't do anything as configs on a target don't apply to its
dependencies; information flows exclusively the other way. The
target_defines argument can be used for this, but there's no code in
libCHIP that uses BUILD_RELEASE anyway (in any case, we should probably
just use !defined(NDEBUG) as that aligns with the C standard).

 #### Problem
No-op code in config/esp32.

 #### Summary of Changes
Remove it.