### PR TITLE
Allow to reconnect to RendezvousSession after an initial successful c…

### DIFF
--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -183,6 +183,7 @@ void RendezvousSession::OnRendezvousConnectionClosed()
 
     if (!mParams.HasDiscriminator())
     {
+        mSecureSession.Reset();
         CHIP_ERROR err = WaitForPairing(mParams.GetLocalNodeId(), mParams.GetSetupPINCode());
         VerifyOrExit(err == CHIP_NO_ERROR, OnPairingError(err));
     }

--- a/src/transport/SecurePairingSession.cpp
+++ b/src/transport/SecurePairingSession.cpp
@@ -95,6 +95,7 @@ CHIP_ERROR SecurePairingSession::WaitForPairing(uint32_t mySetUpPINCode, uint32_
     SuccessOrExit(err);
 
     mNextExpectedMsg = Spake2pMsgType::kSpake2pCompute_pA;
+    mPairingComplete = false;
 
 exit:
     return err;


### PR DESCRIPTION
…onnection

 #### Problem
 Once a SecureSession has been established over BLE, the M5Stack does not want to create an other one after that.
You should basically reboot the M5Stack for that. That's not ultra practical for testing.

The current PR reset some internal states to allow it.