### PR TITLE
Flashing wrappers need python3

### DIFF
--- a/scripts/flashing/firmware_utils.py
+++ b/scripts/flashing/firmware_utils.py
@@ -263,7 +263,7 @@ class Flasher:
                 sys.exit({module}.Flasher(DEFAULTS).flash_command(sys.argv))
         """
 
-        script = ('#!/usr/bin/env python' + textwrap.dedent(script).format(
+        script = ('#!/usr/bin/env python3' + textwrap.dedent(script).format(
             module=self.module, defaults='\n'.join(defaults)))
 
         try:

--- a/scripts/flashing/gen_flashing_script.py
+++ b/scripts/flashing/gen_flashing_script.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright (c) 2020 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -10,7 +11,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.!/usr/bin/env python
+# limitations under the License.
 """Generate script to flash or erase a device."""
 
 import importlib


### PR DESCRIPTION
#### Problem

Flashing wrapper scripts began with `#!/usr/bin/env python` but could be
run in an environment where python is python2, and they don't work.

#### Summary of Changes

Changed generated wrappers to contain `#!/usr/bin/env python3`.