### PR TITLE
Disable privileged mode for builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
             image: connectedhomeip/chip-build:0.4.7
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
-            options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1"
+            options: --sysctl "net.ipv6.conf.all.disable_ipv6=0 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1"
 
         steps:
             - name: Checkout


### PR DESCRIPTION
 #### Problem
Our main builds are running with unneeded, dangerous permissions.

 #### Summary of Changes
Remove unneeded permissions.