### PR TITLE
Rendezvous rendezvous parameters ble connection object

### DIFF
--- a/src/transport/BLE.h
+++ b/src/transport/BLE.h
@@ -83,7 +83,7 @@ public:
 
 private:
     CHIP_ERROR InitInternal(BLE_CONNECTION_OBJECT connObj);
-    CHIP_ERROR DelegateConnection(Ble::BleLayer * bleLayer, const uint16_t connDiscriminator);
+    CHIP_ERROR DelegateConnection(const uint16_t connDiscriminator);
     void SetupEvents(Ble::BLEEndPoint * endPoint);
 
     /**

--- a/src/transport/RendezvousParameters.h
+++ b/src/transport/RendezvousParameters.h
@@ -57,6 +57,14 @@ public:
         mBleLayer = value;
         return *this;
     }
+
+    bool HasConnectionObject() const { return mConnectionObject != 0; };
+    BLE_CONNECTION_OBJECT GetConnectionObject() const { return mConnectionObject; };
+    RendezvousParameters & SetConnectionObject(BLE_CONNECTION_OBJECT connObj)
+    {
+        mConnectionObject = connObj;
+        return *this;
+    }
 #endif // CONFIG_NETWORK_LAYER_BLE
 
 private:
@@ -65,7 +73,8 @@ private:
     uint16_t mDiscriminator = 0;   ///< the target peripheral discriminator
 
 #if CONFIG_NETWORK_LAYER_BLE
-    Ble::BleLayer * mBleLayer = nullptr;
+    Ble::BleLayer * mBleLayer               = nullptr;
+    BLE_CONNECTION_OBJECT mConnectionObject = 0;
 #endif // CONFIG_NETWORK_LAYER_BLE
 };
 } // namespace chip


### PR DESCRIPTION
 #### Problem

Android is initiating the connection directly from the controller side. Because of this it may require to pass directly a BLE_CONNECTION_OBJECT to start the underlying RendezvousSession.

 #### Summary of Changes
* Add BLE_CONNECTION_OBJECT as a member of RendezvousParameters
* Use the BLE_CONNECTION_OBJECT is there is not discriminator (which means the initial connection is not delegated to RendezvousSession itself).
