### PR TITLE
Add BLE connection object to RendezvousParameters.

### DIFF
--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -62,6 +62,7 @@ using namespace chip::DeviceController;
 
 static void HandleKeyExchange(ChipDeviceController * deviceController, Transport::PeerConnectionState * state, void * appReqState);
 static void HandleEchoResponse(ChipDeviceController * deviceController, void * appReqState, System::PacketBuffer * payload);
+static void HandleSimpleOperationComplete(ChipDeviceController * deviceController, void * appReqState);
 static void HandleNotifyChipConnectionClosed(BLE_CONNECTION_OBJECT connObj);
 static bool HandleSendCharacteristic(BLE_CONNECTION_OBJECT connObj, const uint8_t * svcId, const uint8_t * charId,
                                      const uint8_t * characteristicData, uint32_t characteristicDataLen);
@@ -245,17 +246,18 @@ exit:
     return result;
 }
 
-JNI_METHOD(void, beginConnectDevice)(JNIEnv * env, jobject self, jlong deviceControllerPtr, jint discriminator, jlong pinCode)
+JNI_METHOD(void, beginConnectDevice)(JNIEnv * env, jobject self, jlong deviceControllerPtr, jint connObj, jlong pinCode)
 {
     CHIP_ERROR err                          = CHIP_NO_ERROR;
-    void * appReqState                      = (void *) "ConnectDevice";
+    void * appReqState                      = (void *) self;
     ChipDeviceController * deviceController = (ChipDeviceController *) deviceControllerPtr;
 
-    ChipLogProgress(Controller, "beginConnectDevice() called with discriminator and pincode on 0x%08lX", (long) self);
+    ChipLogProgress(Controller, "beginConnectDevice() called with connection object and pincode");
 
     pthread_mutex_lock(&sStackLock);
-    sBleLayer.mAppState         = appReqState;
-    RendezvousParameters params = RendezvousParameters(pinCode).SetDiscriminator(discriminator).SetBleLayer(&sBleLayer);
+    sBleLayer.mAppState = appReqState;
+    RendezvousParameters params =
+        RendezvousParameters(pinCode).SetConnectionObject(reinterpret_cast<BLE_CONNECTION_OBJECT>(connObj)).SetBleLayer(&sBleLayer);
     err = deviceController->ConnectDevice(kRemoteDeviceId, params, appReqState, HandleKeyExchange, HandleEchoResponse, HandleError);
 
     pthread_mutex_unlock(&sStackLock);
@@ -415,7 +417,75 @@ JNI_METHOD(void, deleteDeviceController)(JNIEnv * env, jobject self, jlong devic
     }
 }
 
-void HandleKeyExchange(ChipDeviceController * deviceController, Transport::PeerConnectionState * state, void * appReqState) {}
+void HandleSimpleOperationComplete(ChipDeviceController * deviceController, void * appReqState)
+{
+    JNIEnv * env;
+    jclass deviceControllerCls;
+    jmethodID methodID;
+    char methodName[128];
+    jobject self   = (jobject) deviceController->AppState;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    ChipLogProgress(Controller, "Received response to %s request", (const char *) appReqState);
+
+    sJVM->GetEnv((void **) &env, JNI_VERSION_1_6);
+
+    deviceControllerCls = env->GetObjectClass(self);
+    VerifyOrExit(deviceControllerCls != NULL, err = CDC_JNI_ERROR_TYPE_NOT_FOUND);
+
+    snprintf(methodName, sizeof(methodName) - 1, "on%sComplete", (const char *) appReqState);
+    methodName[sizeof(methodName) - 1] = 0;
+    methodID                           = env->GetMethodID(deviceControllerCls, methodName, "()V");
+    VerifyOrExit(methodID != NULL, err = CDC_JNI_ERROR_METHOD_NOT_FOUND);
+
+    ChipLogProgress(Controller, "Calling Java %s method", methodName);
+
+    env->ExceptionClear();
+    env->CallVoidMethod(self, methodID);
+    VerifyOrExit(!env->ExceptionCheck(), err = CDC_JNI_ERROR_EXCEPTION_THROWN);
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        const char * functName = __FUNCTION__;
+
+        if (err == CDC_JNI_ERROR_EXCEPTION_THROWN)
+        {
+            ChipLogError(Controller, "Java Exception thrown in %s", functName);
+            env->ExceptionDescribe();
+        }
+        else
+        {
+            const char * errStr;
+            switch (err)
+            {
+            case CDC_JNI_ERROR_TYPE_NOT_FOUND:
+                errStr = "JNI type not found";
+                break;
+            case CDC_JNI_ERROR_METHOD_NOT_FOUND:
+                errStr = "JNI method not found";
+                break;
+            case CDC_JNI_ERROR_FIELD_NOT_FOUND:
+                errStr = "JNI field not found";
+                break;
+            default:
+                errStr = ErrorStr(err);
+                break;
+            }
+            ChipLogError(Controller, "Error in %s : %s", functName, errStr);
+        }
+    }
+    env->ExceptionClear();
+}
+
+void HandleKeyExchange(ChipDeviceController * deviceController, Transport::PeerConnectionState * state, void * appReqState)
+{
+    JNIEnv * env;
+
+    sJVM->GetEnv((void **) &env, JNI_VERSION_1_6);
+
+    HandleSimpleOperationComplete(deviceController, appReqState);
+}
 
 void HandleEchoResponse(ChipDeviceController * deviceController, void * appReqState, System::PacketBuffer * payload)
 {

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -26,7 +26,7 @@ public class ChipDeviceController {
   private static final String TAG = ChipDeviceController.class.getSimpleName();
 
   private long deviceControllerPtr;
-  private long connectionId;
+  private int connectionId;
   private BluetoothGatt bleGatt;
   private CompletionListener completionListener;
 
@@ -46,7 +46,7 @@ public class ChipDeviceController {
     return AndroidChipStack.getInstance().getCallback();
   }
 
-  public void beginConnectDeviceBle(BluetoothGatt bleServer, int discriminator, int setupPincode) {
+  public void beginConnectDeviceBle(BluetoothGatt bleServer, long setupPincode) {
     if (connectionId == 0) {
       bleGatt = bleServer;
 
@@ -58,7 +58,7 @@ public class ChipDeviceController {
       }
 
       Log.d(TAG, "Bluetooth connection added with ID: " + connectionId);
-      beginConnectDevice(deviceControllerPtr, discriminator, setupPincode);
+      beginConnectDevice(deviceControllerPtr, connectionId, setupPincode);
     } else {
       Log.e(TAG, "Bluetooth connection already in use.");
       completionListener.onError(new Exception("Bluetooth connection already in use."));
@@ -135,7 +135,7 @@ public class ChipDeviceController {
 
   private native long newDeviceController();
 
-  private native void beginConnectDevice(long deviceControllerPtr, int discrimnator, long pinCode);
+  private native void beginConnectDevice(long deviceControllerPtr, int connectionId, long pinCode);
 
   private native void beginConnectDeviceIp(long deviceControllerPtr, String ipAddress);
 


### PR DESCRIPTION
#### Problem
BluetoothGatt connection is established in the Android layer, hence, it needs to be forwarded to the RendezvousParameters to connect to CHIP device over BLE.

 #### Summary of Changes
Forward the BLE connection object from Android apps to the 
RendezvousSession via RendezvousParameters.
Also added callback from CHIPDeviceController-JNI to notify Android apps 
of successful connection to CHIP device.

fixes #1935 
