### PR TITLE
Extend chip-tool to send identify and identify-query commands

### DIFF
--- a/examples/chip-tool/commands/Commands.h
+++ b/examples/chip-tool/commands/Commands.h
@@ -23,6 +23,7 @@
 
 #include "Echo.h"
 #include "EchoBle.h"
+#include "Identify-Cluster-Commands.h"
 #include "Off.h"
 #include "On.h"
 #include "ReadOnOff.h"
@@ -74,10 +75,10 @@ CHIP_ERROR RunCommand(chip::DeviceController::ChipDeviceController * dc, chip::N
     Off off;
     Toggle toggle;
     ReadOnOff readOnOff;
+    IdentifyQuery identifyQuery;
+    Identify identify;
 
-    Command * commands[] = {
-        &echoBle, &echo, &on, &off, &toggle, &readOnOff,
-    };
+    Command * commands[] = { &echoBle, &echo, &on, &off, &toggle, &readOnOff, &identify, &identifyQuery };
     // End list of available commands
 
     VerifyOrExit(argc > 1, err = CHIP_ERROR_INVALID_ARGUMENT);

--- a/examples/chip-tool/commands/Identify-Cluster-Commands.h
+++ b/examples/chip-tool/commands/Identify-Cluster-Commands.h
@@ -1,0 +1,56 @@
+/*
+ *   Copyright (c) 2020 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#ifndef __CHIPTOOL_IDENTIFY_H__
+#define __CHIPTOOL_IDENTIFY_H__
+#include "common/ModelCommand.h"
+#include <core/CHIPEncoding.h>
+
+class IdentifyQuery : public ModelCommand
+{
+public:
+    IdentifyQuery() : ModelCommand("identify-query"){};
+    size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
+    {
+        return encodeIdentifyQueryCommand(buffer->Start(), bufferSize, endPointId);
+    }
+
+    void HandleClusterResponse(uint16_t clusterId, uint16_t endPointId, uint16_t commandId, uint8_t * message,
+                               uint16_t messageLen) const override
+    {
+        uint16_t identify_time = 0;
+        ChipLogProgress(chipTool, "Parsing identify cluster response id %d", commandId);
+        CHECK_MESSAGE_LENGTH(messageLen == 2);
+        identify_time = chip::Encoding::LittleEndian::Read16(message);
+        ChipLogProgress(chipTool, "Identify query response %d", identify_time);
+
+    exit:
+        return;
+    }
+};
+
+class Identify : public ModelCommand
+{
+public:
+    Identify() : ModelCommand("identify"){};
+    size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
+    {
+        return encodeIdentifyCommand(buffer->Start(), bufferSize, endPointId, 10);
+    }
+};
+#endif

--- a/examples/chip-tool/commands/Identify-Cluster-Commands.h
+++ b/examples/chip-tool/commands/Identify-Cluster-Commands.h
@@ -47,7 +47,7 @@ public:
 class Identify : public ModelCommand
 {
 public:
-    Identify() : ModelCommand("identify"){};
+    Identify() : ModelCommand("identify") {}
     size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
     {
         return encodeIdentifyCommand(buffer->Start(), bufferSize, endPointId, 10);

--- a/examples/chip-tool/commands/Identify-Cluster-Commands.h
+++ b/examples/chip-tool/commands/Identify-Cluster-Commands.h
@@ -24,7 +24,7 @@
 class IdentifyQuery : public ModelCommand
 {
 public:
-    IdentifyQuery() : ModelCommand("identify-query"){};
+    IdentifyQuery() : ModelCommand("identify-query", 0x03){};
     size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
     {
         return encodeIdentifyQueryCommand(buffer->Start(), bufferSize, endPointId);
@@ -33,8 +33,13 @@ public:
     void HandleClusterResponse(uint16_t clusterId, uint16_t endPointId, uint16_t commandId, uint8_t * message,
                                uint16_t messageLen) const override
     {
+        if (clusterId != getClusterId())
+        {
+            ChipLogError(Zcl, "Got invalid clusterID %d for Identify cluster. Expected cluster id %d", clusterId, getClusterId());
+            return;
+        }
         uint16_t identify_time = 0;
-        ChipLogProgress(chipTool, "Parsing identify cluster response id %d", commandId);
+        ChipLogProgress(chipTool, "Parsing identify cluster response command id %d", commandId);
         CHECK_MESSAGE_LENGTH(messageLen == 2);
         identify_time = chip::Encoding::LittleEndian::Read16(message);
         ChipLogProgress(chipTool, "Identify query response %d", identify_time);
@@ -47,7 +52,7 @@ public:
 class Identify : public ModelCommand
 {
 public:
-    Identify() : ModelCommand("identify") {}
+    Identify() : ModelCommand("identify", 0x03) {}
     size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
     {
         return encodeIdentifyCommand(buffer->Start(), bufferSize, endPointId, 10);

--- a/examples/chip-tool/commands/Off.h
+++ b/examples/chip-tool/commands/Off.h
@@ -24,7 +24,7 @@
 class Off : public ModelCommand
 {
 public:
-    Off() : ModelCommand("off") {}
+    Off() : ModelCommand("off", 0x06) {}
 
     size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
     {

--- a/examples/chip-tool/commands/On.h
+++ b/examples/chip-tool/commands/On.h
@@ -24,7 +24,7 @@
 class On : public ModelCommand
 {
 public:
-    On() : ModelCommand("on") {}
+    On() : ModelCommand("on", 0x06) {}
 
     size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
     {

--- a/examples/chip-tool/commands/ReadOnOff.h
+++ b/examples/chip-tool/commands/ReadOnOff.h
@@ -24,7 +24,7 @@
 class ReadOnOff : public ModelCommand
 {
 public:
-    ReadOnOff() : ModelCommand("read") { AddArgument("attr-name", "onoff"); }
+    ReadOnOff() : ModelCommand("read", 0x06) { AddArgument("attr-name", "onoff"); }
 
     size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
     {

--- a/examples/chip-tool/commands/Toggle.h
+++ b/examples/chip-tool/commands/Toggle.h
@@ -24,7 +24,7 @@
 class Toggle : public ModelCommand
 {
 public:
-    Toggle() : ModelCommand("toggle") {}
+    Toggle() : ModelCommand("toggle", 0x06) {}
 
     size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
     {

--- a/examples/chip-tool/commands/common/ModelCommand.h
+++ b/examples/chip-tool/commands/common/ModelCommand.h
@@ -31,6 +31,9 @@
 #define CHIP_ZCL_ENDPOINT_MIN 0x01
 #define CHIP_ZCL_ENDPOINT_MAX 0xF0
 
+#define CHECK_MESSAGE_LENGTH(rv)                                                                                                   \
+    VerifyOrExit(rv, ChipLogError(chipTool, "%s: Unexpected response length: %d", __FUNCTION__, messageLen));
+
 class ModelCommand : public NetworkCommand
 {
 public:
@@ -48,6 +51,8 @@ public:
     void OnMessage(ChipDeviceController * dc, PacketBuffer * buffer) override;
 
     virtual size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) = 0;
+    virtual void HandleClusterResponse(uint16_t clusterId, uint16_t endPointId, uint16_t commandId, uint8_t * message,
+                                       uint16_t messageLen) const;
 
 private:
     void SendCommand(ChipDeviceController * dc);
@@ -58,6 +63,7 @@ private:
     void ParseReadAttributeResponseCommandSuccess(uint16_t clusterId, uint16_t attrId, uint8_t * message,
                                                   uint16_t messageLen) const;
     void ParseReadAttributeResponseCommandFailure(uint16_t clusterId, uint16_t attrId, uint8_t status, uint16_t messageLen) const;
+    void ParseIdentifyClusterCommand(uint16_t endpointID, uint8_t * message, uint16_t messageLen) const;
 
     void UpdateWaitForResponse(bool value);
     void WaitForResponse(void);

--- a/examples/chip-tool/commands/common/ModelCommand.h
+++ b/examples/chip-tool/commands/common/ModelCommand.h
@@ -63,7 +63,6 @@ private:
     void ParseReadAttributeResponseCommandSuccess(uint16_t clusterId, uint16_t attrId, uint8_t * message,
                                                   uint16_t messageLen) const;
     void ParseReadAttributeResponseCommandFailure(uint16_t clusterId, uint16_t attrId, uint8_t status, uint16_t messageLen) const;
-    void ParseIdentifyClusterCommand(uint16_t endpointID, uint8_t * message, uint16_t messageLen) const;
 
     void UpdateWaitForResponse(bool value);
     void WaitForResponse(void);

--- a/examples/chip-tool/commands/common/ModelCommand.h
+++ b/examples/chip-tool/commands/common/ModelCommand.h
@@ -37,9 +37,10 @@
 class ModelCommand : public NetworkCommand
 {
 public:
-    ModelCommand(const char * commandName) : NetworkCommand(commandName, NetworkType::UDP)
+    ModelCommand(const char * commandName, const uint16_t clusterId) : NetworkCommand(commandName, NetworkType::UDP)
     {
         AddArgument("endpoint-id", CHIP_ZCL_ENDPOINT_MIN, CHIP_ZCL_ENDPOINT_MAX, &mEndPointId);
+        mClusterId = clusterId;
     }
 
     /////////// Command Interface /////////
@@ -53,6 +54,7 @@ public:
     virtual size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) = 0;
     virtual void HandleClusterResponse(uint16_t clusterId, uint16_t endPointId, uint16_t commandId, uint8_t * message,
                                        uint16_t messageLen) const;
+    uint16_t getClusterId() const { return mClusterId; };
 
 private:
     void SendCommand(ChipDeviceController * dc);
@@ -72,6 +74,7 @@ private:
     std::mutex cvWaitingForResponseMutex;
     bool mWaitingForResponse{ false };
     uint32_t mEndPointId;
+    uint16_t mClusterId;
 };
 
 #endif // __CHIPTOOL_MODELCOMMAND_H__

--- a/examples/wifi-echo/server/esp32/main/EchoDeviceCallbacks.cpp
+++ b/examples/wifi-echo/server/esp32/main/EchoDeviceCallbacks.cpp
@@ -99,7 +99,7 @@ void EchoDeviceCallbacks::PostAttributeChangeCallback(uint8_t endpoint, EmberAfC
 {
     if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
     {
-        ESP_LOGI(TAG, "Unknown cluster ID: %d", clusterId);
+        ESP_LOGI(TAG, "PostAttributeChangeCallback for unhandled cluster ID: %d", clusterId);
         return;
     }
 

--- a/examples/wifi-echo/server/esp32/main/gen/callback-stub.c
+++ b/examples/wifi-echo/server/esp32/main/gen/callback-stub.c
@@ -2387,6 +2387,7 @@ void halSleepCallback(bool enter, SleepModes sleepMode) {}
  */
 bool emberAfPluginIdentifyStartFeedbackCallback(uint8_t endpoint, uint16_t identifyTime)
 {
+    emberAfPrintln(EMBER_AF_PRINT_IDENTIFY_CLUSTER, "Start idenitfy callback on endpoint %d time %d", endpoint, identifyTime);
     return false;
 }
 
@@ -2398,5 +2399,6 @@ bool emberAfPluginIdentifyStartFeedbackCallback(uint8_t endpoint, uint16_t ident
  */
 bool emberAfPluginIdentifyStopFeedbackCallback(uint8_t endpoint)
 {
+    emberAfPrintln(EMBER_AF_PRINT_IDENTIFY_CLUSTER, "Stop idenitfy callback on endpoint %d", endpoint);
     return false;
 }

--- a/examples/wifi-echo/server/esp32/main/gen/callback-stub.c
+++ b/examples/wifi-echo/server/esp32/main/gen/callback-stub.c
@@ -2387,7 +2387,7 @@ void halSleepCallback(bool enter, SleepModes sleepMode) {}
  */
 bool emberAfPluginIdentifyStartFeedbackCallback(uint8_t endpoint, uint16_t identifyTime)
 {
-    emberAfPrintln(EMBER_AF_PRINT_IDENTIFY_CLUSTER, "Start idenitfy callback on endpoint %d time %d", endpoint, identifyTime);
+    emberAfPrintln(EMBER_AF_PRINT_IDENTIFY_CLUSTER, "Start identify callback on endpoint %d time %d", endpoint, identifyTime);
     return false;
 }
 
@@ -2399,6 +2399,6 @@ bool emberAfPluginIdentifyStartFeedbackCallback(uint8_t endpoint, uint16_t ident
  */
 bool emberAfPluginIdentifyStopFeedbackCallback(uint8_t endpoint)
 {
-    emberAfPrintln(EMBER_AF_PRINT_IDENTIFY_CLUSTER, "Stop idenitfy callback on endpoint %d", endpoint);
+    emberAfPrintln(EMBER_AF_PRINT_IDENTIFY_CLUSTER, "Stop identify callback on endpoint %d", endpoint);
     return false;
 }

--- a/src/app/chip-zcl-zpro-codec.h
+++ b/src/app/chip-zcl-zpro-codec.h
@@ -114,6 +114,27 @@ void printApsFrame(EmberApsFrame * frame);
  */
 uint16_t encodeApsFrame(uint8_t * buffer, uint16_t buf_length, EmberApsFrame * apsFrame);
 
+/**
+ * Idenfity cluster commands
+ * */
+
+/**
+ * @brief Encode an identify query command for the identify cluster
+ * @param buffer Buffer to encode into
+ * @param buf_length Length of buffer
+ * @param destination_endpoint destination endpoint
+ * */
+uint16_t encodeIdentifyQueryCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+
+/**
+ * @brief Encode an identify command for the identify cluster
+ * @param buffer Buffer to encode into
+ * @param buf_length Length of buffer
+ * @param destination_endpoint destination endpoint
+ * @param duration The duration for which the device will identify itself
+ * */
+uint16_t encodeIdentifyCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint16_t duration);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/app/chip-zcl-zpro-codec.h
+++ b/src/app/chip-zcl-zpro-codec.h
@@ -115,7 +115,7 @@ void printApsFrame(EmberApsFrame * frame);
 uint16_t encodeApsFrame(uint8_t * buffer, uint16_t buf_length, EmberApsFrame * apsFrame);
 
 /**
- * Idenfity cluster commands
+ * Identify cluster commands
  * */
 
 /**

--- a/src/app/clusters/identify/identify.c
+++ b/src/app/clusters/identify/identify.c
@@ -126,6 +126,15 @@ bool emberAfIdentifyClusterIdentifyQueryCallback(void)
     status = readIdentifyTime(emberAfCurrentEndpoint(), &identifyTime);
     if (status != EMBER_ZCL_STATUS_SUCCESS || identifyTime == 0)
     {
+        if (status != EMBER_ZCL_STATUS_SUCCESS)
+        {
+            emberAfIdentifyClusterPrintln("Error reading identify time");
+        }
+        else
+        {
+            emberAfIdentifyClusterPrintln("identifyTime is at 0");
+        }
+        emberAfIdentifyClusterPrintln("Sending back default response");
         sendStatus = emberAfSendImmediateDefaultResponse(status);
         if (EMBER_SUCCESS != sendStatus)
         {
@@ -136,6 +145,7 @@ bool emberAfIdentifyClusterIdentifyQueryCallback(void)
         return true;
     }
 
+    emberAfIdentifyClusterPrintln("Identifying for %d more seconds", identifyTime);
     emberAfFillCommandIdentifyClusterIdentifyQueryResponse(identifyTime);
     sendStatus = emberAfSendResponse();
     if (EMBER_SUCCESS != sendStatus)

--- a/src/app/encoder.cpp
+++ b/src/app/encoder.cpp
@@ -177,33 +177,9 @@ uint16_t encodeReadOnOffCommand(uint8_t * buffer, uint16_t buf_length, uint8_t d
 uint16_t _encodeIdentifyClusterCommand(uint8_t * buffer, uint16_t buf_length, uint8_t command_id, uint8_t destination_endpoint,
                                        uint16_t * identify_duration)
 {
-    uint32_t result = 0;
-    // pick cluster id as 3 for now.
-    // pick source and destination end points as 1 for now.
-    // Profile is 65535 because that matches our simple generated code, but we
-    // should sort out the profile situation.
-    if (!buffer)
-    {
-        return 0;
-    }
-    BufBound buf        = BufBound(buffer, buf_length);
-    uint16_t cluster_id = 3;
-    result              = doEncodeApsFrame(buf, 65535, cluster_id, 1, destination_endpoint, 0, 0, 0, 0, false);
-    if (result == 0)
-    {
-        ChipLogError(Zcl, "Error encoding aps frame result %" PRIu32 "\n", result);
-        return result;
-    }
 
-    // This is a cluster-specific command so low two bits are 0b01.  The command
-    // is standard, so does not need a manufacturer code, and we're sending
-    // client to server, so all the remaining bits are 0.
-    buf.Put(uint8_t(1));
-
-    // Transaction sequence number.  Just pick something.
-    buf.Put(uint8_t(1));
-
-    buf.Put(uint8_t(command_id));
+    BufBound buf    = BufBound(buffer, buf_length);
+    uint16_t result = _encodeClusterSpecificCommand(buf, destination_endpoint, 0x0003, command_id);
 
     if (identify_duration)
     {
@@ -218,20 +194,14 @@ uint16_t _encodeIdentifyClusterCommand(uint8_t * buffer, uint16_t buf_length, ui
 uint16_t encodeIdentifyQueryCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
 {
     uint16_t result = _encodeIdentifyClusterCommand(buffer, buf_length, 1, destination_endpoint, nullptr);
-    if (result == 0)
-    {
-        ChipLogError(Zcl, "Error encoding identify query cmd");
-    }
+    CHECK_COMMAND_LENGTH(result, "Identify Query");
     return result;
 }
 
 uint16_t encodeIdentifyCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint16_t duration)
 {
     uint16_t result = _encodeIdentifyClusterCommand(buffer, buf_length, 0, destination_endpoint, &duration);
-    if (result == 0)
-    {
-        ChipLogError(Zcl, "Error encoding identify query cmd");
-    }
+    CHECK_COMMAND_LENGTH(result, "Identify");
     return result;
 }
 


### PR DESCRIPTION
Add two new classes for two new commands - identify and identify-query.
Also adds ability to handle cluster specific responses.
fixes #2751
