### PR TITLE
Optimizations to asymmetric keypair

### DIFF
--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -56,6 +56,7 @@ const size_t kP256_PublicKey_Length  = 65;
  */
 const size_t kMAX_Spake2p_Context_Size     = 1024;
 const size_t kMAX_Hash_SHA256_Context_Size = 256;
+const size_t kMAX_P256Keypair_Context_Size = 512;
 
 /**
  * Spake2+ parameters for P256
@@ -153,17 +154,6 @@ typedef CapacityBoundBuffer<kMax_ECDSA_Signature_Length> P256ECDSASignature;
 
 typedef CapacityBoundBuffer<kMax_ECDH_Secret_Length> P256ECDHDerivedSecret;
 
-class P256PrivateKey : public ECPKey<P256ECDSASignature>
-{
-public:
-    SupportedECPKeyTypes Type() const override { return SupportedECPKeyTypes::ECP256R1; }
-    size_t Length() const override { return kP256_PrivateKey_Length; }
-    operator uint8_t *() const override { return (uint8_t *) bytes; }
-
-private:
-    uint8_t bytes[kP256_PrivateKey_Length];
-};
-
 class P256PublicKey : public ECPKey<P256ECDSASignature>
 {
 public:
@@ -212,13 +202,33 @@ public:
     virtual const PK & Pubkey() = 0;
 };
 
+struct P256KeypairContext
+{
+    uint8_t mBytes[kMAX_P256Keypair_Context_Size];
+};
+
+typedef CapacityBoundBuffer<kP256_PublicKey_Length + kP256_PrivateKey_Length> P256SerializedKeypair;
+
 class P256Keypair : public ECPKeypair<P256PublicKey, P256ECDHDerivedSecret, P256ECDSASignature>
 {
 public:
+    P256Keypair() {}
+    ~P256Keypair();
+
     /** @brief Initialize the keypair.
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
     CHIP_ERROR Initialize();
+
+    /** @brief Serialize the keypair.
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR Serialize(P256SerializedKeypair & output);
+
+    /** @brief Deserialize the keypair.
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR Deserialize(P256SerializedKeypair & input);
 
     /** @brief Generate a new Certificate Signing Request (CSR).
      * @param csr Newly generated CSR
@@ -252,8 +262,9 @@ public:
     const P256PublicKey & Pubkey() override { return mPublicKey; }
 
 private:
-    P256PrivateKey mPrivateKey;
     P256PublicKey mPublicKey;
+    P256KeypairContext mKeypair;
+    bool mInitialized = false;
 };
 
 /**

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -37,6 +37,7 @@
 #include <mbedtls/x509_csr.h>
 
 #include <core/CHIPSafeCasts.h>
+#include <support/BufBound.h>
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
 
@@ -400,6 +401,18 @@ mbedtls_ecp_group_id MapECPGroupId(SupportedECPKeyTypes keyType)
     }
 }
 
+static inline mbedtls_ecp_keypair * to_keypair(P256KeypairContext * context)
+{
+    nlSTATIC_ASSERT_PRINT(sizeof(P256KeypairContext) >= sizeof(mbedtls_ecp_keypair), "Need more memory for mbedtls_ecp_keypair");
+    return reinterpret_cast<mbedtls_ecp_keypair *>(context->mBytes);
+}
+
+static inline const mbedtls_ecp_keypair * to_const_keypair(const P256KeypairContext * context)
+{
+    nlSTATIC_ASSERT_PRINT(sizeof(P256KeypairContext) >= sizeof(mbedtls_ecp_keypair), "Need more memory for mbedtls_ecp_keypair");
+    return reinterpret_cast<const mbedtls_ecp_keypair *>(context->mBytes);
+}
+
 CHIP_ERROR P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_length, P256ECDSASignature & out_signature)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
@@ -407,34 +420,28 @@ CHIP_ERROR P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_len
     uint8_t hash[NUM_BYTES_IN_SHA256_HASH];
     size_t siglen = out_signature.Capacity();
 
-    mbedtls_ecp_keypair keypair;
-    mbedtls_ecp_keypair_init(&keypair);
+    const mbedtls_ecp_keypair * keypair = to_const_keypair(&mKeypair);
 
     mbedtls_ecdsa_context ecdsa_ctxt;
     mbedtls_ecdsa_init(&ecdsa_ctxt);
 
-    VerifyOrExit(msg != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(mInitialized, error = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(msg != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(msg_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    result = mbedtls_ecp_group_load(&keypair.grp, MapECPGroupId(mPrivateKey.Type()));
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-
-    result = mbedtls_mpi_read_binary(&keypair.d, Uint8::to_const_uchar(mPrivateKey), mPrivateKey.Length());
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-
-    result = mbedtls_ecdsa_from_keypair(&ecdsa_ctxt, &keypair);
+    result = mbedtls_ecdsa_from_keypair(&ecdsa_ctxt, keypair);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
     result = mbedtls_sha256_ret(Uint8::to_const_uchar(msg), msg_length, hash, 0);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
     result = mbedtls_ecdsa_write_signature(&ecdsa_ctxt, MBEDTLS_MD_SHA256, hash, sizeof(hash), Uint8::to_uchar(out_signature),
-                                           &siglen, CryptoRNG, NULL);
+                                           &siglen, CryptoRNG, nullptr);
     SuccessOrExit(out_signature.SetLength(siglen));
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
 exit:
-    mbedtls_ecp_keypair_free(&keypair);
+    keypair = nullptr;
     mbedtls_ecdsa_free(&ecdsa_ctxt);
     _log_mbedTLS_error(result);
     return error;
@@ -493,25 +500,18 @@ CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_k
     mbedtls_ecp_point ecp_pubkey;
     mbedtls_ecp_point_init(&ecp_pubkey);
 
-    mbedtls_mpi mpi_privkey;
-    mbedtls_mpi_init(&mpi_privkey);
+    const mbedtls_ecp_keypair * keypair = to_const_keypair(&mKeypair);
 
-    mbedtls_ecdh_context ecdh_ctxt;
-    mbedtls_ecdh_init(&ecdh_ctxt);
+    VerifyOrExit(mInitialized, error = CHIP_ERROR_INCORRECT_STATE);
 
-    VerifyOrExit(remote_public_key.Type() == mPrivateKey.Type(), error = CHIP_ERROR_INVALID_ARGUMENT);
-
-    result = mbedtls_ecp_group_load(&ecp_grp, MapECPGroupId(mPrivateKey.Type()));
+    result = mbedtls_ecp_group_load(&ecp_grp, MapECPGroupId(remote_public_key.Type()));
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
-
-    result = mbedtls_mpi_read_binary(&mpi_privkey, Uint8::to_const_uchar(mPrivateKey), mPrivateKey.Length());
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     result =
         mbedtls_ecp_point_read_binary(&ecp_grp, &ecp_pubkey, Uint8::to_const_uchar(remote_public_key), remote_public_key.Length());
     VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    result = mbedtls_ecdh_compute_shared(&ecp_grp, &mpi_secret, &ecp_pubkey, &mpi_privkey, CryptoRNG, NULL);
+    result = mbedtls_ecdh_compute_shared(&ecp_grp, &mpi_secret, &ecp_pubkey, &keypair->d, CryptoRNG, NULL);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
     result = mbedtls_mpi_write_binary(&mpi_secret, Uint8::to_uchar(out_secret), secret_length);
@@ -519,11 +519,10 @@ CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_k
     SuccessOrExit(out_secret.SetLength(secret_length));
 
 exit:
-    mbedtls_ecdh_free(&ecdh_ctxt);
+    keypair = nullptr;
     mbedtls_ecp_group_free(&ecp_grp);
     mbedtls_mpi_free(&mpi_secret);
     mbedtls_ecp_point_free(&ecp_pubkey);
-    mbedtls_mpi_free(&mpi_privkey);
     _log_mbedTLS_error(result);
     return error;
 }
@@ -542,28 +541,98 @@ CHIP_ERROR P256Keypair::Initialize()
 
     mbedtls_ecp_group_id group = MapECPGroupId(mPublicKey.Type());
 
-    mbedtls_ecp_keypair keypair;
-    mbedtls_ecp_keypair_init(&keypair);
+    mbedtls_ecp_keypair * keypair = to_keypair(&mKeypair);
+    mbedtls_ecp_keypair_init(keypair);
 
-    VerifyOrExit(group == MapECPGroupId(mPrivateKey.Type()), error = CHIP_ERROR_INVALID_ARGUMENT);
-
-    result = mbedtls_ecp_gen_key(group, &keypair, CryptoRNG, nullptr);
+    result = mbedtls_ecp_gen_key(group, keypair, CryptoRNG, nullptr);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
-    result = mbedtls_ecp_point_write_binary(&keypair.grp, &keypair.Q, MBEDTLS_ECP_PF_UNCOMPRESSED, &pubkey_size,
+    result = mbedtls_ecp_point_write_binary(&keypair->grp, &keypair->Q, MBEDTLS_ECP_PF_UNCOMPRESSED, &pubkey_size,
                                             Uint8::to_uchar(mPublicKey), mPublicKey.Length());
     VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(pubkey_size == mPublicKey.Length(), error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    VerifyOrExit(mbedtls_mpi_size(&keypair.d) == mPrivateKey.Length(), error = CHIP_ERROR_INVALID_ARGUMENT);
-
-    result = mbedtls_mpi_write_binary(&keypair.d, Uint8::to_uchar(mPrivateKey), mPrivateKey.Length());
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+    keypair      = nullptr;
+    mInitialized = true;
 
 exit:
-    mbedtls_ecp_keypair_free(&keypair);
+    if (keypair != nullptr)
+    {
+        mbedtls_ecp_keypair_free(keypair);
+        keypair = nullptr;
+    }
+
     _log_mbedTLS_error(result);
     return error;
+}
+
+CHIP_ERROR P256Keypair::Serialize(P256SerializedKeypair & output)
+{
+    const mbedtls_ecp_keypair * keypair = to_const_keypair(&mKeypair);
+    size_t len                          = output.Length() == 0 ? output.Capacity() : output.Length();
+    BufBound bbuf(output, len);
+    uint8_t privkey[kP256_PrivateKey_Length];
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    int result       = 0;
+
+    bbuf.Put(mPublicKey, mPublicKey.Length());
+
+    VerifyOrExit(bbuf.Available() == sizeof(privkey), error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(mbedtls_mpi_size(&keypair->d) == bbuf.Available(), error = CHIP_ERROR_INTERNAL);
+
+    result = mbedtls_mpi_write_binary(&keypair->d, Uint8::to_uchar(privkey), sizeof(privkey));
+    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
+
+    bbuf.Put(privkey, sizeof(privkey));
+    VerifyOrExit(bbuf.Fit(), error = CHIP_ERROR_NO_MEMORY);
+
+    output.SetLength(bbuf.Written());
+
+exit:
+    memset(privkey, 0, sizeof(privkey));
+    _log_mbedTLS_error(result);
+    return error;
+}
+
+CHIP_ERROR P256Keypair::Deserialize(P256SerializedKeypair & input)
+{
+    BufBound bbuf(mPublicKey, mPublicKey.Length());
+
+    int result       = 0;
+    CHIP_ERROR error = CHIP_NO_ERROR;
+
+    mbedtls_ecp_keypair * keypair = to_keypair(&mKeypair);
+    mbedtls_ecp_keypair_init(keypair);
+
+    result = mbedtls_ecp_group_load(&keypair->grp, MapECPGroupId(mPublicKey.Type()));
+    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
+
+    VerifyOrExit(input.Length() == mPublicKey.Length() + kP256_PrivateKey_Length, error = CHIP_ERROR_INVALID_ARGUMENT);
+    bbuf.Put((const uint8_t *) input, mPublicKey.Length());
+    VerifyOrExit(bbuf.Fit(), error = CHIP_ERROR_NO_MEMORY);
+
+    result = mbedtls_ecp_point_read_binary(&keypair->grp, &keypair->Q, Uint8::to_const_uchar(mPublicKey), mPublicKey.Length());
+    VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+
+    {
+        const uint8_t * privkey = Uint8::to_const_uchar(input) + mPublicKey.Length();
+        result                  = mbedtls_mpi_read_binary(&keypair->d, privkey, kP256_PrivateKey_Length);
+        VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+    }
+    mInitialized = true;
+
+exit:
+    _log_mbedTLS_error(result);
+    return error;
+}
+
+P256Keypair::~P256Keypair()
+{
+    if (mInitialized)
+    {
+        mbedtls_ecp_keypair * keypair = to_keypair(&mKeypair);
+        mbedtls_ecp_keypair_free(keypair);
+    }
 }
 
 CHIP_ERROR P256Keypair::NewCertificateSigningRequest(uint8_t * out_csr, size_t & csr_length)
@@ -572,7 +641,7 @@ CHIP_ERROR P256Keypair::NewCertificateSigningRequest(uint8_t * out_csr, size_t &
     int result       = 0;
     size_t length    = csr_length;
 
-    mbedtls_ecp_keypair * keypair = nullptr;
+    const mbedtls_ecp_keypair * keypair = to_const_keypair(&mKeypair);
 
     mbedtls_x509write_csr csr;
     mbedtls_x509write_csr_init(&csr);
@@ -580,27 +649,15 @@ CHIP_ERROR P256Keypair::NewCertificateSigningRequest(uint8_t * out_csr, size_t &
     mbedtls_pk_context pk;
     mbedtls_pk_init(&pk);
 
-    mbedtls_ecp_group_id group = MapECPGroupId(mPublicKey.Type());
-
     const mbedtls_pk_info_t * pk_info = mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY);
     VerifyOrExit(pk_info != nullptr, error = CHIP_ERROR_INTERNAL);
+
+    VerifyOrExit(mInitialized, error = CHIP_ERROR_INCORRECT_STATE);
 
     result = mbedtls_pk_setup(&pk, pk_info);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
-    keypair = mbedtls_pk_ec(pk);
-    mbedtls_ecp_keypair_init(keypair);
-
-    VerifyOrExit(group == MapECPGroupId(mPrivateKey.Type()), error = CHIP_ERROR_INVALID_ARGUMENT);
-
-    result = mbedtls_ecp_group_load(&keypair->grp, group);
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
-
-    result = mbedtls_ecp_point_read_binary(&keypair->grp, &keypair->Q, Uint8::to_const_uchar(mPublicKey), mPublicKey.Length());
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-
-    result = mbedtls_mpi_read_binary(&keypair->d, Uint8::to_const_uchar(mPrivateKey), mPrivateKey.Length());
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+    memcpy(mbedtls_pk_ec(pk), keypair, sizeof(mbedtls_ecp_keypair));
 
     mbedtls_x509write_csr_set_key(&csr, &pk);
 
@@ -612,7 +669,9 @@ CHIP_ERROR P256Keypair::NewCertificateSigningRequest(uint8_t * out_csr, size_t &
     result     = 0;
 
 exit:
+    keypair = nullptr;
     mbedtls_x509write_csr_free(&csr);
+    mbedtls_ecp_keypair_init(mbedtls_pk_ec(pk));
     mbedtls_pk_free(&pk);
     _log_mbedTLS_error(result);
     return error;

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -797,6 +797,29 @@ static void TestCSR_Gen(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, keypair.NewCertificateSigningRequest(csr, length) == CHIP_NO_ERROR);
 }
 
+static void TestKeypair_Serialize(nlTestSuite * inSuite, void * inContext)
+{
+    P256Keypair keypair;
+    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+
+    P256SerializedKeypair serialized;
+    NL_TEST_ASSERT(inSuite, keypair.Serialize(serialized) == CHIP_NO_ERROR);
+
+    P256Keypair keypair_dup;
+    NL_TEST_ASSERT(inSuite, keypair_dup.Deserialize(serialized) == CHIP_NO_ERROR);
+
+    const char * msg         = "Test Message for Keygen";
+    const uint8_t * test_msg = Uint8::from_const_char(msg);
+    size_t msglen            = strlen(msg);
+
+    P256ECDSASignature test_sig;
+    NL_TEST_ASSERT(inSuite, keypair.ECDSA_sign_msg(test_msg, msglen, test_sig) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair_dup.Pubkey().ECDSA_validate_msg_signature(test_msg, msglen, test_sig) == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, keypair_dup.ECDSA_sign_msg(test_msg, msglen, test_sig) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Pubkey().ECDSA_validate_msg_signature(test_msg, msglen, test_sig) == CHIP_NO_ERROR);
+}
+
 static void TestSPAKE2P_spake2p_FEMul(nlTestSuite * inSuite, void * inContext)
 {
     uint8_t fe_out[kMAX_FE_Length];
@@ -1224,6 +1247,7 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("Test PBKDF2 SHA256", TestPBKDF2_SHA256_TestVectors),
     NL_TEST_DEF("Test P256 Keygen", TestP256_Keygen),
     NL_TEST_DEF("Test CSR Generation", TestCSR_Gen),
+    NL_TEST_DEF("Test Keypair Serialize", TestKeypair_Serialize),
     NL_TEST_DEF("Test Spake2p_spake2p FEMul", TestSPAKE2P_spake2p_FEMul),
     NL_TEST_DEF("Test Spake2p_spake2p FELoad/FEWrite", TestSPAKE2P_spake2p_FELoadWrite),
     NL_TEST_DEF("Test Spake2p_spake2p Mac", TestSPAKE2P_spake2p_Mac),


### PR DESCRIPTION
 #### Problem
The keypair class is working on serialized public/private keys. This means that every key pair operation requires the crypto key pair to be reconstructed from these serialized keys.

Also, the current key pair does not provide any mechanism to output a fully serialized key that can be stored in persistent storage.

 #### Summary of Changes
Updated class to use generated key pairs, instead of serialized keys. Also, added accessor methods to serialize/deserialize key pairs. The application can call these accessors when the keys are persisted, or loaded from the persistent storage.

For hardware backed keys, where the private keys are not available in memory, the serialize and deserialize methods may not work. The implementation for such key pairs will override the class.
