### PR TITLE
Remove <iostream>

### DIFF
--- a/src/setup_payload/Base41.cpp
+++ b/src/setup_payload/Base41.cpp
@@ -29,8 +29,6 @@
 
 #include "Base41.h"
 
-#include <iostream>
-
 using namespace std;
 
 namespace chip {

--- a/src/setup_payload/ManualSetupPayloadParser.cpp
+++ b/src/setup_payload/ManualSetupPayloadParser.cpp
@@ -26,7 +26,6 @@
 #include <support/logging/CHIPLogging.h>
 #include <support/verhoeff/Verhoeff.h>
 
-#include <iostream>
 #include <math.h>
 #include <string>
 #include <vector>

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -34,7 +34,6 @@
 #include <support/CodeUtils.h>
 #include <support/RandUtils.h>
 
-#include <iostream>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -24,7 +24,6 @@
 #include "QRCodeSetupPayloadParser.h"
 #include "Base41.h"
 
-#include <iostream>
 #include <math.h>
 #include <memory>
 #include <string.h>

--- a/src/setup_payload/tests/TestQRCode.cpp
+++ b/src/setup_payload/tests/TestQRCode.cpp
@@ -25,7 +25,6 @@
 #include "TestQRCode.h"
 #include "TestHelpers.h"
 
-#include <iostream>
 #include <nlbyteorder.h>
 #include <nlunit-test.h>
 

--- a/src/setup_payload/tests/TestQRCodeTLV.cpp
+++ b/src/setup_payload/tests/TestQRCodeTLV.cpp
@@ -17,7 +17,6 @@
 #include "TestQRCodeTLV.h"
 #include "TestHelpers.h"
 
-#include <iostream>
 #include <nlbyteorder.h>
 #include <nlunit-test.h>
 


### PR DESCRIPTION
This is worth 148K of code size for chip-nrf52840-lock-example (27%)

```
   text    data     bss     dec     hex filename
 514216    1140   82168  597524   91e14 out/release/nrf5_lock_app/chip-nrf52840-lock-example.old
 362552     504   76432  439488   6b4c0 out/release/nrf5_lock_app/chip-nrf52840-lock-example
 559952    1140   82308  643400   9d148 out/debug/nrf5_lock_app/chip-nrf52840-lock-example.old
 408476     504   76576  485556   768b4 out/debug/nrf5_lock_app/chip-nrf52840-lock-example
```

 #### Problem
CHIP is too large.

 #### Summary of Changes
Remove some very bloated #includes.