### PR TITLE
clang-tidy: Apply fixes "modernize-use-nullptr"

### DIFF
--- a/examples/shell/cmd_base64.cpp
+++ b/examples/shell/cmd_base64.cpp
@@ -44,7 +44,7 @@ int cmd_base64_help_iterator(shell_command_t * command, void * arg)
 
 int cmd_base64_help(int argc, char ** argv)
 {
-    theShellBase64.ForEachCommand(cmd_base64_help_iterator, NULL);
+    theShellBase64.ForEachCommand(cmd_base64_help_iterator, nullptr);
     return 0;
 }
 

--- a/examples/shell/cmd_btp.cpp
+++ b/examples/shell/cmd_btp.cpp
@@ -45,7 +45,7 @@ int cmd_btp_help_iterator(shell_command_t * command, void * arg)
 
 int cmd_btp_help(int argc, char ** argv)
 {
-    sShellDeviceSubcommands.ForEachCommand(cmd_btp_help_iterator, NULL);
+    sShellDeviceSubcommands.ForEachCommand(cmd_btp_help_iterator, nullptr);
     return 0;
 }
 

--- a/examples/shell/cmd_device.cpp
+++ b/examples/shell/cmd_device.cpp
@@ -47,7 +47,7 @@ int cmd_device_help_iterator(shell_command_t * command, void * arg)
 
 int cmd_device_help(int argc, char ** argv)
 {
-    sShellDeviceSubcommands.ForEachCommand(cmd_device_help_iterator, NULL);
+    sShellDeviceSubcommands.ForEachCommand(cmd_device_help_iterator, nullptr);
     return 0;
 }
 
@@ -167,7 +167,7 @@ static CHIP_ERROR ConfigGetDeviceCert(bool printHeader)
 {
     CHIP_ERROR error  = CHIP_NO_ERROR;
     streamer_t * sout = streamer_get();
-    uint8_t * certBuf = NULL;
+    uint8_t * certBuf = nullptr;
     size_t certLen;
 
     if (printHeader)
@@ -175,7 +175,7 @@ static CHIP_ERROR ConfigGetDeviceCert(bool printHeader)
         streamer_printf(sout, "DeviceCert:      ");
     }
     // Determine the length of the device certificate.
-    error = ConfigurationMgr().GetDeviceCertificate((uint8_t *) NULL, 0, certLen);
+    error = ConfigurationMgr().GetDeviceCertificate((uint8_t *) nullptr, 0, certLen);
     SuccessOrExit(error);
 
     // Fail if no certificate has been configured.
@@ -183,7 +183,7 @@ static CHIP_ERROR ConfigGetDeviceCert(bool printHeader)
 
     // Create a temporary buffer to hold the certificate.
     certBuf = (uint8_t *) MemoryAlloc(certLen);
-    VerifyOrExit(certBuf != NULL, error = CHIP_ERROR_NO_MEMORY);
+    VerifyOrExit(certBuf != nullptr, error = CHIP_ERROR_NO_MEMORY);
 
     // Read the certificate
     error = ConfigurationMgr().GetDeviceCertificate(certBuf, certLen, certLen);
@@ -192,7 +192,7 @@ static CHIP_ERROR ConfigGetDeviceCert(bool printHeader)
     streamer_print_hex(sout, const_cast<const uint8_t *>(certBuf), certLen);
 
 exit:
-    if (certBuf != NULL)
+    if (certBuf != nullptr)
     {
         MemoryFree(certBuf);
     }
@@ -203,7 +203,7 @@ static CHIP_ERROR ConfigGetDeviceCaCerts(bool printHeader)
 {
     CHIP_ERROR error  = CHIP_NO_ERROR;
     streamer_t * sout = streamer_get();
-    uint8_t * certBuf = NULL;
+    uint8_t * certBuf = nullptr;
     size_t certLen;
 
     if (printHeader)
@@ -211,7 +211,7 @@ static CHIP_ERROR ConfigGetDeviceCaCerts(bool printHeader)
         streamer_printf(sout, "DeviceCaCerts:   ");
     }
     // Determine the length of the device certificate.
-    error = ConfigurationMgr().GetDeviceIntermediateCACerts((uint8_t *) NULL, 0, certLen);
+    error = ConfigurationMgr().GetDeviceIntermediateCACerts((uint8_t *) nullptr, 0, certLen);
     SuccessOrExit(error);
 
     // Fail if no certificate has been configured.
@@ -219,7 +219,7 @@ static CHIP_ERROR ConfigGetDeviceCaCerts(bool printHeader)
 
     // Create a temporary buffer to hold the certificate.
     certBuf = (uint8_t *) MemoryAlloc(certLen);
-    VerifyOrExit(certBuf != NULL, error = CHIP_ERROR_NO_MEMORY);
+    VerifyOrExit(certBuf != nullptr, error = CHIP_ERROR_NO_MEMORY);
 
     // Read the certificate
     error = ConfigurationMgr().GetDeviceIntermediateCACerts(certBuf, certLen, certLen);
@@ -228,7 +228,7 @@ static CHIP_ERROR ConfigGetDeviceCaCerts(bool printHeader)
     streamer_print_hex(sout, const_cast<const uint8_t *>(certBuf), certLen);
 
 exit:
-    if (certBuf != NULL)
+    if (certBuf != nullptr)
     {
         MemoryFree(certBuf);
     }
@@ -256,7 +256,7 @@ static CHIP_ERROR ConfigGetManufacturerDeviceCert(bool printHeader)
 {
     CHIP_ERROR error  = CHIP_NO_ERROR;
     streamer_t * sout = streamer_get();
-    uint8_t * certBuf = NULL;
+    uint8_t * certBuf = nullptr;
     size_t certLen;
 
     if (printHeader)
@@ -264,7 +264,7 @@ static CHIP_ERROR ConfigGetManufacturerDeviceCert(bool printHeader)
         streamer_printf(sout, "MfrDeviceCert:   ");
     }
     // Determine the length of the device certificate.
-    error = ConfigurationMgr().GetManufacturerDeviceCertificate((uint8_t *) NULL, 0, certLen);
+    error = ConfigurationMgr().GetManufacturerDeviceCertificate((uint8_t *) nullptr, 0, certLen);
     SuccessOrExit(error);
 
     // Fail if no certificate has been configured.
@@ -272,7 +272,7 @@ static CHIP_ERROR ConfigGetManufacturerDeviceCert(bool printHeader)
 
     // Create a temporary buffer to hold the certificate.
     certBuf = (uint8_t *) MemoryAlloc(certLen);
-    VerifyOrExit(certBuf != NULL, error = CHIP_ERROR_NO_MEMORY);
+    VerifyOrExit(certBuf != nullptr, error = CHIP_ERROR_NO_MEMORY);
 
     // Read the certificate
     error = ConfigurationMgr().GetManufacturerDeviceCertificate(certBuf, certLen, certLen);
@@ -281,7 +281,7 @@ static CHIP_ERROR ConfigGetManufacturerDeviceCert(bool printHeader)
     streamer_print_hex(sout, const_cast<const uint8_t *>(certBuf), certLen);
 
 exit:
-    if (certBuf != NULL)
+    if (certBuf != nullptr)
     {
         MemoryFree(certBuf);
     }
@@ -292,7 +292,7 @@ static CHIP_ERROR ConfigGetManufacturerDeviceCaCerts(bool printHeader)
 {
     CHIP_ERROR error  = CHIP_NO_ERROR;
     streamer_t * sout = streamer_get();
-    uint8_t * certBuf = NULL;
+    uint8_t * certBuf = nullptr;
     size_t certLen;
 
     if (printHeader)
@@ -300,7 +300,7 @@ static CHIP_ERROR ConfigGetManufacturerDeviceCaCerts(bool printHeader)
         streamer_printf(sout, "MfgDeviceCaCerts:");
     }
     // Determine the length of the device certificate.
-    error = ConfigurationMgr().GetManufacturerDeviceIntermediateCACerts((uint8_t *) NULL, 0, certLen);
+    error = ConfigurationMgr().GetManufacturerDeviceIntermediateCACerts((uint8_t *) nullptr, 0, certLen);
     SuccessOrExit(error);
 
     // Fail if no certificate has been configured.
@@ -308,7 +308,7 @@ static CHIP_ERROR ConfigGetManufacturerDeviceCaCerts(bool printHeader)
 
     // Create a temporary buffer to hold the certificate.
     certBuf = (uint8_t *) MemoryAlloc(certLen);
-    VerifyOrExit(certBuf != NULL, error = CHIP_ERROR_NO_MEMORY);
+    VerifyOrExit(certBuf != nullptr, error = CHIP_ERROR_NO_MEMORY);
 
     // Read the certificate
     error = ConfigurationMgr().GetManufacturerDeviceIntermediateCACerts(certBuf, certLen, certLen);
@@ -317,7 +317,7 @@ static CHIP_ERROR ConfigGetManufacturerDeviceCaCerts(bool printHeader)
     streamer_print_hex(sout, const_cast<const uint8_t *>(certBuf), certLen);
 
 exit:
-    if (certBuf != NULL)
+    if (certBuf != nullptr)
     {
         MemoryFree(certBuf);
     }

--- a/examples/shell/cmd_otcli.cpp
+++ b/examples/shell/cmd_otcli.cpp
@@ -60,7 +60,7 @@ int cmd_otcli_help_iterator(shell_command_t * command, void * arg)
 
 int cmd_otcli_help(int argc, char ** argv)
 {
-    sShellOtcliSubcommands.ForEachCommand(cmd_otcli_help_iterator, NULL);
+    sShellOtcliSubcommands.ForEachCommand(cmd_otcli_help_iterator, nullptr);
     return 0;
 }
 

--- a/examples/shell/main.cpp
+++ b/examples/shell/main.cpp
@@ -110,6 +110,6 @@ int main(void)
     cmd_btp_init();
     cmd_otcli_init();
 
-    shell_task(NULL);
+    shell_task(nullptr);
     return 0;
 }

--- a/src/app/decoder.cpp
+++ b/src/app/decoder.cpp
@@ -49,7 +49,7 @@ extern "C" {
 
 uint16_t extractApsFrame(uint8_t * buffer, uint32_t buf_length, EmberApsFrame * outApsFrame)
 {
-    if (buffer == NULL || buf_length == 0 || outApsFrame == NULL)
+    if (buffer == nullptr || buf_length == 0 || outApsFrame == nullptr)
     {
         ChipLogError(Zcl, "Error extracting APS frame. invalid inputs");
         return 0;
@@ -111,7 +111,7 @@ uint16_t extractMessage(uint8_t * buffer, uint16_t buffer_length, uint8_t ** msg
     }
     else if (msg)
     {
-        *msg = NULL;
+        *msg = nullptr;
     }
     return result;
 }

--- a/src/ble/BLEEndPoint.cpp
+++ b/src/ble/BLEEndPoint.cpp
@@ -105,7 +105,7 @@ BLE_ERROR BLEEndPoint::StartConnect()
 {
     BLE_ERROR err = BLE_NO_ERROR;
     BleTransportCapabilitiesRequestMessage req;
-    PacketBuffer * buf = NULL;
+    PacketBuffer * buf = nullptr;
     int i;
     int numVersions;
 
@@ -115,7 +115,7 @@ BLE_ERROR BLEEndPoint::StartConnect()
 
     // Build BLE transport protocol capabilities request.
     buf = PacketBuffer::New();
-    VerifyOrExit(buf != NULL, err = BLE_ERROR_NO_MEMORY);
+    VerifyOrExit(buf != nullptr, err = BLE_ERROR_NO_MEMORY);
 
     // Zero-initialize BLE transport capabilities request.
     memset(&req, 0, sizeof(req));
@@ -149,10 +149,10 @@ BLE_ERROR BLEEndPoint::StartConnect()
     // Free request buffer on write confirmation. Stash a reference to it in mSendQueue, which we don't use anyway
     // until the connection has been set up.
     QueueTx(buf, kType_Data);
-    buf = NULL;
+    buf = nullptr;
 
 exit:
-    if (buf != NULL)
+    if (buf != nullptr)
     {
         PacketBuffer::Free(buf);
     }
@@ -177,7 +177,7 @@ BLE_ERROR BLEEndPoint::HandleConnectComplete()
     StopConnectTimer();
 
     // We've successfully completed the BLE transport protocol handshake, so let the application know we're open for business.
-    if (OnConnectComplete != NULL)
+    if (OnConnectComplete != nullptr)
     {
         // Indicate connect complete to next-higher layer.
         OnConnectComplete(this, BLE_NO_ERROR);
@@ -202,7 +202,7 @@ BLE_ERROR BLEEndPoint::HandleReceiveConnectionComplete()
     StopReceiveConnectionTimer();
 
     // We've successfully completed the BLE transport protocol handshake, so let the application know we're open for business.
-    if (mBle->OnChipBleConnectReceived != NULL)
+    if (mBle->OnChipBleConnectReceived != nullptr)
     {
         // Indicate BLE transport protocol connection received to next-higher layer.
         mBle->OnChipBleConnectReceived(this);
@@ -220,7 +220,7 @@ void BLEEndPoint::HandleSubscribeReceived()
     BLE_ERROR err = BLE_NO_ERROR;
 
     VerifyOrExit(mState == kState_Connecting || mState == kState_Aborting, err = BLE_ERROR_INCORRECT_STATE);
-    VerifyOrExit(mSendQueue != NULL, err = BLE_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mSendQueue != nullptr, err = BLE_ERROR_INCORRECT_STATE);
 
     // Send BTP capabilities response to peripheral via GATT indication.
 #if CHIP_ENABLE_CHIPOBLE_TEST
@@ -231,7 +231,7 @@ void BLEEndPoint::HandleSubscribeReceived()
         // Ensure transmit queue is empty and set to NULL.
         QueueTxLock();
         PacketBuffer::Free(mSendQueue);
-        mSendQueue = NULL;
+        mSendQueue = nullptr;
         QueueTxUnlock();
 
         ChipLogError(Ble, "cap resp ind failed");
@@ -305,9 +305,9 @@ bool BLEEndPoint::IsUnsubscribePending() const
 void BLEEndPoint::Abort()
 {
     // No more callbacks after this point, since application explicitly called Abort().
-    OnConnectComplete  = NULL;
-    OnConnectionClosed = NULL;
-    OnMessageReceived  = NULL;
+    OnConnectComplete  = nullptr;
+    OnConnectionClosed = nullptr;
+    OnMessageReceived  = nullptr;
 #if CHIP_ENABLE_CHIPOBLE_TEST
     OnCommandReceived = NULL;
 #endif
@@ -318,9 +318,9 @@ void BLEEndPoint::Abort()
 void BLEEndPoint::Close()
 {
     // No more callbacks after this point, since application explicitly called Close().
-    OnConnectComplete  = NULL;
-    OnConnectionClosed = NULL;
-    OnMessageReceived  = NULL;
+    OnConnectComplete  = nullptr;
+    OnConnectionClosed = nullptr;
+    OnMessageReceived  = nullptr;
 #if CHIP_ENABLE_CHIPOBLE_TEST
     OnCommandReceived = NULL;
 #endif
@@ -380,7 +380,7 @@ void BLEEndPoint::FinalizeClose(uint8_t oldState, uint8_t flags, BLE_ERROR err)
     // Ensure transmit queue is empty and set to NULL.
     QueueTxLock();
     PacketBuffer::Free(mSendQueue);
-    mSendQueue = NULL;
+    mSendQueue = nullptr;
     QueueTxUnlock();
 
 #if CHIP_ENABLE_CHIPOBLE_TEST
@@ -444,22 +444,22 @@ void BLEEndPoint::DoCloseCallback(uint8_t state, uint8_t flags, BLE_ERROR err)
 {
     if (state == kState_Connecting)
     {
-        if (OnConnectComplete != NULL)
+        if (OnConnectComplete != nullptr)
         {
             OnConnectComplete(this, err);
         }
     }
     else
     {
-        if (OnConnectionClosed != NULL)
+        if (OnConnectionClosed != nullptr)
         {
             OnConnectionClosed(this, err);
         }
     }
 
     // Callback fires once per end point lifetime.
-    OnConnectComplete  = NULL;
-    OnConnectionClosed = NULL;
+    OnConnectComplete  = nullptr;
+    OnConnectionClosed = nullptr;
 }
 
 void BLEEndPoint::ReleaseBleConnection()
@@ -508,9 +508,9 @@ void BLEEndPoint::Free()
 #endif
 
     // Clear callbacks.
-    OnConnectComplete  = NULL;
-    OnMessageReceived  = NULL;
-    OnConnectionClosed = NULL;
+    OnConnectComplete  = nullptr;
+    OnMessageReceived  = nullptr;
+    OnConnectionClosed = nullptr;
 
     // Clear handle to underlying BLE connection.
     mConnObj = BLE_CONNECTION_UNINITIALIZED;
@@ -540,10 +540,10 @@ BLE_ERROR BLEEndPoint::Init(BleLayer * bleLayer, BLE_CONNECTION_OBJECT connObj, 
     bool expectInitialAck;
 
     // Fail if already initialized.
-    VerifyOrExit(mBle == NULL, err = BLE_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mBle == nullptr, err = BLE_ERROR_INCORRECT_STATE);
 
     // Validate args.
-    VerifyOrExit(bleLayer != NULL, err = BLE_ERROR_BAD_ARGS);
+    VerifyOrExit(bleLayer != nullptr, err = BLE_ERROR_BAD_ARGS);
     VerifyOrExit(connObj != BLE_CONNECTION_UNINITIALIZED, err = BLE_ERROR_BAD_ARGS);
     VerifyOrExit((role == kBleRole_Central || role == kBleRole_Peripheral), err = BLE_ERROR_BAD_ARGS);
 
@@ -592,8 +592,8 @@ BLE_ERROR BLEEndPoint::Init(BleLayer * bleLayer, BLE_CONNECTION_OBJECT connObj, 
     mLocalReceiveWindowSize  = 0;
     mRemoteReceiveWindowSize = 0;
     mReceiveWindowMaxSize    = 0;
-    mSendQueue               = NULL;
-    mAckToSend               = NULL;
+    mSendQueue               = nullptr;
+    mAckToSend               = nullptr;
 
     ChipLogDebugBleEndPoint(Ble, "initialized local rx window, size = %u", mLocalReceiveWindowSize);
 
@@ -652,7 +652,7 @@ void BLEEndPoint::QueueTx(PacketBuffer * data, PacketType_t type)
 
     QueueTxLock();
 
-    if (mSendQueue == NULL)
+    if (mSendQueue == nullptr)
     {
         mSendQueue = data;
         ChipLogDebugBleEndPoint(Ble, "%s: Set data as new mSendQueue %p, type %d", __FUNCTION__, mSendQueue, type);
@@ -672,16 +672,16 @@ BLE_ERROR BLEEndPoint::Send(PacketBuffer * data)
 
     BLE_ERROR err = BLE_NO_ERROR;
 
-    VerifyOrExit(data != NULL, err = BLE_ERROR_BAD_ARGS);
+    VerifyOrExit(data != nullptr, err = BLE_ERROR_BAD_ARGS);
     VerifyOrExit(IsConnected(mState), err = BLE_ERROR_INCORRECT_STATE);
 
     // Ensure outgoing message fits in a single contiguous PacketBuffer, as currently required by the
     // message fragmentation and reassembly engine.
-    if (data->Next() != NULL)
+    if (data->Next() != nullptr)
     {
         data->CompactHead();
 
-        if (data->Next() != NULL)
+        if (data->Next() != nullptr)
         {
             err = BLE_ERROR_OUTBOUND_MESSAGE_TOO_BIG;
             ExitNow();
@@ -690,7 +690,7 @@ BLE_ERROR BLEEndPoint::Send(PacketBuffer * data)
 
     // Add new message to send queue.
     QueueTx(data, kType_Data);
-    data = NULL; // Buffer freed when send queue freed on close, or on completion of current message transmission.
+    data = nullptr; // Buffer freed when send queue freed on close, or on completion of current message transmission.
 
     // Send first fragment of new message, if we can.
     err = DriveSending();
@@ -699,7 +699,7 @@ BLE_ERROR BLEEndPoint::Send(PacketBuffer * data)
 exit:
     ChipLogDebugBleEndPoint(Ble, "exiting Send");
 
-    if (data != NULL)
+    if (data != nullptr)
     {
         PacketBuffer::Free(data);
     }
@@ -763,7 +763,7 @@ BLE_ERROR BLEEndPoint::SendNextMessage()
 
     // Hand whole message payload to the fragmenter.
     VerifyOrExit(PrepareNextFragment(data, sentAck), err = BLE_ERROR_CHIPOBLE_PROTOCOL_ABORT);
-    data = NULL; // Ownership passed to fragmenter's tx buf on PrepareNextFragment success.
+    data = nullptr; // Ownership passed to fragmenter's tx buf on PrepareNextFragment success.
 
     /*
      // Todo: reenabled it after integrating fault injection
@@ -794,7 +794,7 @@ BLE_ERROR BLEEndPoint::SendNextMessage()
     SuccessOrExit(err);
 
 exit:
-    if (data != NULL)
+    if (data != nullptr)
     {
         PacketBuffer::Free(data);
     }
@@ -807,7 +807,7 @@ BLE_ERROR BLEEndPoint::ContinueMessageSend()
     BLE_ERROR err;
     bool sentAck;
 
-    if (!PrepareNextFragment(NULL, sentAck))
+    if (!PrepareNextFragment(nullptr, sentAck))
     {
         // Log BTP error
         ChipLogError(Ble, "btp fragmenter error on send!");
@@ -867,7 +867,7 @@ BLE_ERROR BLEEndPoint::HandleHandshakeConfirmationReceived()
         {
             // If local receive window size has shrunk to or below immediate ack threshold, AND a message fragment is not
             // pending on which to piggyback an ack, send immediate stand-alone ack.
-            if (mLocalReceiveWindowSize <= BLE_CONFIG_IMMEDIATE_ACK_WINDOW_THRESHOLD && mSendQueue == NULL)
+            if (mLocalReceiveWindowSize <= BLE_CONFIG_IMMEDIATE_ACK_WINDOW_THRESHOLD && mSendQueue == nullptr)
             {
                 err = DriveStandAloneAck(); // Encode stand-alone ack and drive sending.
                 SuccessOrExit(err);
@@ -922,7 +922,7 @@ BLE_ERROR BLEEndPoint::HandleFragmentConfirmationReceived()
     {
         // If confirmation was received for stand-alone ack, free its tx buffer.
         PacketBuffer::Free(mAckToSend);
-        mAckToSend = NULL;
+        mAckToSend = nullptr;
 
         SetFlag(mConnStateFlags, kConnState_StandAloneAckInFlight, false);
     }
@@ -934,7 +934,7 @@ BLE_ERROR BLEEndPoint::HandleFragmentConfirmationReceived()
     // the stand-alone ack, and also the case where a window size < the immediate ack threshold was detected in
     // Receive(), but the stand-alone ack was deferred due to a pending outbound message fragment.
     if (mLocalReceiveWindowSize <= BLE_CONFIG_IMMEDIATE_ACK_WINDOW_THRESHOLD &&
-        !(mSendQueue != NULL || mBtpEngine.TxState() == BtpEngine::kState_InProgress))
+        !(mSendQueue != nullptr || mBtpEngine.TxState() == BtpEngine::kState_InProgress))
     {
         err = DriveStandAloneAck(); // Encode stand-alone ack and drive sending.
         SuccessOrExit(err);
@@ -982,10 +982,10 @@ BLE_ERROR BLEEndPoint::DriveStandAloneAck()
     StopSendAckTimer();
 
     // If stand-alone ack not already pending, allocate new payload buffer here.
-    if (mAckToSend == NULL)
+    if (mAckToSend == nullptr)
     {
         mAckToSend = PacketBuffer::New();
-        VerifyOrExit(mAckToSend != NULL, err = BLE_ERROR_NO_MEMORY);
+        VerifyOrExit(mAckToSend != nullptr, err = BLE_ERROR_NO_MEMORY);
     }
 
     // Attempt to send stand-alone ack.
@@ -1028,7 +1028,7 @@ BLE_ERROR BLEEndPoint::DriveSending()
     // If receiver's window is almost closed and we don't have an ack to send, OR we do have an ack to send but
     // receiver's window is completely empty, OR another GATT operation is in flight, awaiting confirmation...
     if ((mRemoteReceiveWindowSize <= BTP_WINDOW_NO_ACK_SEND_THRESHOLD &&
-         !GetFlag(mTimerStateFlags, kTimerState_SendAckTimerRunning) && mAckToSend == NULL) ||
+         !GetFlag(mTimerStateFlags, kTimerState_SendAckTimerRunning) && mAckToSend == nullptr) ||
         (mRemoteReceiveWindowSize == 0) || (GetFlag(mConnStateFlags, kConnState_GattOperationInFlight)))
     {
 #ifdef CHIP_BLE_END_POINT_DEBUG_LOGGING_ENABLED
@@ -1055,7 +1055,7 @@ BLE_ERROR BLEEndPoint::DriveSending()
 
     // Otherwise, let's see what we can send.
 
-    if (mAckToSend != NULL) // If immediate, stand-alone ack is pending, send it.
+    if (mAckToSend != nullptr) // If immediate, stand-alone ack is pending, send it.
     {
         err = DoSendStandAloneAck();
         SuccessOrExit(err);
@@ -1063,7 +1063,7 @@ BLE_ERROR BLEEndPoint::DriveSending()
     else if (mBtpEngine.TxState() == BtpEngine::kState_Idle) // Else send next message fragment, if any.
     {
         // Fragmenter's idle, let's see what's in the send queue...
-        if (mSendQueue != NULL)
+        if (mSendQueue != nullptr)
         {
             // Transmit first fragment of next whole message in send queue.
             err = SendNextMessage();
@@ -1091,9 +1091,9 @@ BLE_ERROR BLEEndPoint::DriveSending()
 
         // Free sent buffer.
         PacketBuffer::Free(sentBuf);
-        sentBuf = NULL;
+        sentBuf = nullptr;
 
-        if (mSendQueue != NULL)
+        if (mSendQueue != nullptr)
         {
             // Transmit first fragment of next whole message in send queue.
             err = SendNextMessage();
@@ -1119,10 +1119,10 @@ BLE_ERROR BLEEndPoint::HandleCapabilitiesRequestReceived(PacketBuffer * data)
     BLE_ERROR err = BLE_NO_ERROR;
     BleTransportCapabilitiesRequestMessage req;
     BleTransportCapabilitiesResponseMessage resp;
-    PacketBuffer * responseBuf = NULL;
+    PacketBuffer * responseBuf = nullptr;
     uint16_t mtu;
 
-    VerifyOrExit(data != NULL, err = BLE_ERROR_BAD_ARGS);
+    VerifyOrExit(data != nullptr, err = BLE_ERROR_BAD_ARGS);
 
     mState = kState_Connecting;
 
@@ -1131,7 +1131,7 @@ BLE_ERROR BLEEndPoint::HandleCapabilitiesRequestReceived(PacketBuffer * data)
     SuccessOrExit(err);
 
     responseBuf = PacketBuffer::New();
-    VerifyOrExit(responseBuf != NULL, err = BLE_ERROR_NO_MEMORY);
+    VerifyOrExit(responseBuf != nullptr, err = BLE_ERROR_NO_MEMORY);
 
     // Determine BLE connection's negotiated ATT MTU, if possible.
     if (req.mMtu > 0) // If MTU was observed and provided by central...
@@ -1194,19 +1194,19 @@ BLE_ERROR BLEEndPoint::HandleCapabilitiesRequestReceived(PacketBuffer * data)
 
     // Stash capabilities response payload and wait for subscription from central.
     QueueTx(responseBuf, kType_Data);
-    responseBuf = NULL;
+    responseBuf = nullptr;
 
     // Start receive timer. Canceled when end point freed or connection established.
     err = StartReceiveConnectionTimer();
     SuccessOrExit(err);
 
 exit:
-    if (responseBuf != NULL)
+    if (responseBuf != nullptr)
     {
         PacketBuffer::Free(responseBuf);
     }
 
-    if (data != NULL)
+    if (data != nullptr)
     {
         PacketBuffer::Free(data);
     }
@@ -1219,7 +1219,7 @@ BLE_ERROR BLEEndPoint::HandleCapabilitiesResponseReceived(PacketBuffer * data)
     BLE_ERROR err = BLE_NO_ERROR;
     BleTransportCapabilitiesResponseMessage resp;
 
-    VerifyOrExit(data != NULL, err = BLE_ERROR_BAD_ARGS);
+    VerifyOrExit(data != nullptr, err = BLE_ERROR_BAD_ARGS);
 
     // Decode BTP capabilities response.
     err = BleTransportCapabilitiesResponseMessage::Decode((*data), resp);
@@ -1275,7 +1275,7 @@ BLE_ERROR BLEEndPoint::HandleCapabilitiesResponseReceived(PacketBuffer * data)
     SuccessOrExit(err);
 
 exit:
-    if (data != NULL)
+    if (data != nullptr)
     {
         PacketBuffer::Free(data);
     }
@@ -1343,7 +1343,7 @@ BLE_ERROR BLEEndPoint::Receive(PacketBuffer * data)
                 SetFlag(mConnStateFlags, kConnState_CapabilitiesMsgReceived, true);
 
                 err  = HandleCapabilitiesResponseReceived(data);
-                data = NULL;
+                data = nullptr;
                 SuccessOrExit(err);
             }
             else // Or, a peripheral receiving a capabilities request write...
@@ -1353,7 +1353,7 @@ BLE_ERROR BLEEndPoint::Receive(PacketBuffer * data)
                 SetFlag(mConnStateFlags, kConnState_CapabilitiesMsgReceived, true);
 
                 err  = HandleCapabilitiesRequestReceived(data);
-                data = NULL;
+                data = nullptr;
 
                 if (err != BLE_NO_ERROR)
                 {
@@ -1387,7 +1387,7 @@ BLE_ERROR BLEEndPoint::Receive(PacketBuffer * data)
 
     // Pass received packet into BTP protocol engine.
     err  = mBtpEngine.HandleCharacteristicReceived(data, receivedAck, didReceiveAck);
-    data = NULL; // Buffer consumed by protocol engine; either freed or added to message reassembly area.
+    data = nullptr; // Buffer consumed by protocol engine; either freed or added to message reassembly area.
 
     ChipLogDebugBleEndPoint(Ble, "BTP rx'd characteristic, state after:");
     mBtpEngine.LogStateDebug();
@@ -1409,7 +1409,7 @@ BLE_ERROR BLEEndPoint::Receive(PacketBuffer * data)
             ChipLogDebugBleEndPoint(Ble, "got ack for last outstanding fragment");
             StopAckReceivedTimer();
 
-            if (mState == kState_Closing && mSendQueue == NULL && mBtpEngine.TxState() == BtpEngine::kState_Idle)
+            if (mState == kState_Closing && mSendQueue == nullptr && mBtpEngine.TxState() == BtpEngine::kState_Idle)
             {
                 // If end point closing, got confirmation for last send, and waiting for last ack, finalize close.
                 FinalizeClose(mState, kBleCloseFlag_SuppressCallback, BLE_NO_ERROR);
@@ -1506,7 +1506,7 @@ BLE_ERROR BLEEndPoint::Receive(PacketBuffer * data)
     }
 
 exit:
-    if (data != NULL)
+    if (data != nullptr)
     {
         PacketBuffer::Free(data);
     }

--- a/src/ble/BleError.cpp
+++ b/src/ble/BleError.cpp
@@ -40,14 +40,14 @@ namespace Ble {
  */
 void RegisterLayerErrorFormatter(void)
 {
-    static ErrorFormatter sBleLayerErrorFormatter = { FormatLayerError, NULL };
+    static ErrorFormatter sBleLayerErrorFormatter = { FormatLayerError, nullptr };
 
     RegisterErrorFormatter(&sBleLayerErrorFormatter);
 }
 
 bool FormatLayerError(char * buf, uint16_t bufSize, int32_t err)
 {
-    const char * desc = NULL;
+    const char * desc = nullptr;
 
     if (err < BLE_ERROR_MIN || err > BLE_ERROR_MAX)
     {

--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -114,7 +114,7 @@ public:
         }
         else
         {
-            return NULL;
+            return nullptr;
         }
     }
 
@@ -122,19 +122,19 @@ public:
     {
         if (c == BLE_CONNECTION_UNINITIALIZED)
         {
-            return NULL;
+            return nullptr;
         }
 
         for (int i = 0; i < BLE_LAYER_NUM_BLE_ENDPOINTS; i++)
         {
             BLEEndPoint * elem = Get(i);
-            if (elem->mBle != NULL && elem->mConnObj == c)
+            if (elem->mBle != nullptr && elem->mConnObj == c)
             {
                 return elem;
             }
         }
 
-        return NULL;
+        return nullptr;
     }
 
     BLEEndPoint * GetFree() const
@@ -142,12 +142,12 @@ public:
         for (int i = 0; i < BLE_LAYER_NUM_BLE_ENDPOINTS; i++)
         {
             BLEEndPoint * elem = Get(i);
-            if (elem->mBle == NULL)
+            if (elem->mBle == nullptr)
             {
                 return elem;
             }
         }
-        return NULL;
+        return nullptr;
     }
 };
 
@@ -172,7 +172,7 @@ void BleLayerObject::Release()
     mRefCount--;
     if (mRefCount == 0)
     {
-        mBle = NULL;
+        mBle = nullptr;
     }
 }
 
@@ -306,9 +306,9 @@ BLE_ERROR BleLayer::Init(BlePlatformDelegate * platformDelegate, BleConnectionDe
 
     // It is totally valid to not have a connDelegate. In this case the client application
     // will take care of the connection steps.
-    VerifyOrExit(platformDelegate != NULL, err = BLE_ERROR_BAD_ARGS);
-    VerifyOrExit(appDelegate != NULL, err = BLE_ERROR_BAD_ARGS);
-    VerifyOrExit(systemLayer != NULL, err = BLE_ERROR_BAD_ARGS);
+    VerifyOrExit(platformDelegate != nullptr, err = BLE_ERROR_BAD_ARGS);
+    VerifyOrExit(appDelegate != nullptr, err = BLE_ERROR_BAD_ARGS);
+    VerifyOrExit(systemLayer != nullptr, err = BLE_ERROR_BAD_ARGS);
 
     if (mState != kState_NotInitialized)
     {
@@ -335,7 +335,7 @@ exit:
 BLE_ERROR BleLayer::Init(BlePlatformDelegate * platformDelegate, BleApplicationDelegate * appDelegate,
                          chip::System::Layer * systemLayer)
 {
-    return Init(platformDelegate, NULL, appDelegate, systemLayer);
+    return Init(platformDelegate, nullptr, appDelegate, systemLayer);
 }
 
 BLE_ERROR BleLayer::Shutdown()
@@ -348,7 +348,7 @@ BLE_ERROR BleLayer::Shutdown()
         BLEEndPoint * elem = sBLEEndPointPool.Get(i);
 
         // If end point was initialized, and has not since been freed...
-        if (elem->mBle != NULL)
+        if (elem->mBle != nullptr)
         {
             // If end point hasn't already been closed...
             if (elem->mState != BLEEndPoint::kState_Closed)
@@ -389,7 +389,7 @@ exit:
 
 BLE_ERROR BleLayer::NewBleEndPoint(BLEEndPoint ** retEndPoint, BLE_CONNECTION_OBJECT connObj, BleRole role, bool autoClose)
 {
-    *retEndPoint = NULL;
+    *retEndPoint = nullptr;
 
     if (mState != kState_Initialized)
     {
@@ -402,7 +402,7 @@ BLE_ERROR BleLayer::NewBleEndPoint(BLEEndPoint ** retEndPoint, BLE_CONNECTION_OB
     }
 
     *retEndPoint = sBLEEndPointPool.GetFree();
-    if (*retEndPoint == NULL)
+    if (*retEndPoint == nullptr)
     {
         ChipLogError(Ble, "%s endpoint pool FULL", "Ble");
         return BLE_ERROR_NO_ENDPOINTS;
@@ -421,7 +421,7 @@ BLE_ERROR BleLayer::NewBleEndPoint(BLEEndPoint ** retEndPoint, BLE_CONNECTION_OB
 BLE_ERROR BleLayer::HandleBleTransportConnectionInitiated(BLE_CONNECTION_OBJECT connObj, PacketBuffer * pBuf)
 {
     BLE_ERROR err             = BLE_NO_ERROR;
-    BLEEndPoint * newEndPoint = NULL;
+    BLEEndPoint * newEndPoint = nullptr;
 
     // Only BLE peripherals can receive GATT writes, so specify this role in our creation of the BLEEndPoint.
     // Set autoClose = false. Peripherals only notify the application when an end point releases a BLE connection.
@@ -431,18 +431,18 @@ BLE_ERROR BleLayer::HandleBleTransportConnectionInitiated(BLE_CONNECTION_OBJECT 
     newEndPoint->mAppState = mAppState;
 
     err  = newEndPoint->Receive(pBuf);
-    pBuf = NULL;
+    pBuf = nullptr;
     SuccessOrExit(err); // If we fail here, end point will have already released connection and freed itself.
 
 exit:
-    if (pBuf != NULL)
+    if (pBuf != nullptr)
     {
         PacketBuffer::Free(pBuf);
     }
 
     // If we failed to allocate a new end point, release underlying BLE connection. Central's handshake will time out
     // if the application decides to keep the BLE connection open.
-    if (newEndPoint == NULL)
+    if (newEndPoint == nullptr)
     {
         mApplicationDelegate->NotifyChipConnectionClosed(connObj);
     }
@@ -466,7 +466,7 @@ bool BleLayer::HandleWriteReceived(BLE_CONNECTION_OBJECT connObj, const ChipBleU
 
     if (UUIDsMatch(&CHIP_BLE_CHAR_1_ID, charId))
     {
-        if (pBuf == NULL)
+        if (pBuf == nullptr)
         {
             ChipLogError(Ble, "rcvd null ble write");
             ExitNow();
@@ -475,10 +475,10 @@ bool BleLayer::HandleWriteReceived(BLE_CONNECTION_OBJECT connObj, const ChipBleU
         // Find matching connection end point.
         BLEEndPoint * endPoint = sBLEEndPointPool.Find(connObj);
 
-        if (endPoint != NULL)
+        if (endPoint != nullptr)
         {
             BLE_ERROR status = endPoint->Receive(pBuf);
-            pBuf             = NULL;
+            pBuf             = nullptr;
             if (status != BLE_NO_ERROR)
             {
                 ChipLogError(Ble, "BLEEndPoint rcv failed, err = %d", status);
@@ -487,7 +487,7 @@ bool BleLayer::HandleWriteReceived(BLE_CONNECTION_OBJECT connObj, const ChipBleU
         else
         {
             BLE_ERROR status = HandleBleTransportConnectionInitiated(connObj, pBuf);
-            pBuf             = NULL;
+            pBuf             = nullptr;
             if (status != BLE_NO_ERROR)
             {
                 ChipLogError(Ble, "failed handle new chip BLE connection, status = %d", status);
@@ -500,7 +500,7 @@ bool BleLayer::HandleWriteReceived(BLE_CONNECTION_OBJECT connObj, const ChipBleU
     }
 
 exit:
-    if (pBuf != NULL)
+    if (pBuf != nullptr)
     {
         PacketBuffer::Free(pBuf);
     }
@@ -518,7 +518,7 @@ bool BleLayer::HandleIndicationReceived(BLE_CONNECTION_OBJECT connObj, const Chi
 
     if (UUIDsMatch(&CHIP_BLE_CHAR_2_ID, charId))
     {
-        if (pBuf == NULL)
+        if (pBuf == nullptr)
         {
             ChipLogError(Ble, "rcvd null ble indication");
             ExitNow();
@@ -527,10 +527,10 @@ bool BleLayer::HandleIndicationReceived(BLE_CONNECTION_OBJECT connObj, const Chi
         // find matching connection end point.
         BLEEndPoint * endPoint = sBLEEndPointPool.Find(connObj);
 
-        if (endPoint != NULL)
+        if (endPoint != nullptr)
         {
             BLE_ERROR status = endPoint->Receive(pBuf);
-            pBuf             = NULL;
+            pBuf             = nullptr;
             if (status != BLE_NO_ERROR)
             {
                 ChipLogError(Ble, "BLEEndPoint rcv failed, err = %d", status);
@@ -547,7 +547,7 @@ bool BleLayer::HandleIndicationReceived(BLE_CONNECTION_OBJECT connObj, const Chi
     }
 
 exit:
-    if (pBuf != NULL)
+    if (pBuf != nullptr)
     {
         PacketBuffer::Free(pBuf);
     }
@@ -598,7 +598,7 @@ void BleLayer::HandleAckReceived(BLE_CONNECTION_OBJECT connObj)
     // find matching connection end point.
     BLEEndPoint * endPoint = sBLEEndPointPool.Find(connObj);
 
-    if (endPoint != NULL)
+    if (endPoint != nullptr)
     {
         BLE_ERROR status = endPoint->HandleGattSendConfirmationReceived();
 
@@ -625,7 +625,7 @@ bool BleLayer::HandleSubscribeReceived(BLE_CONNECTION_OBJECT connObj, const Chip
         // Find end point already associated with BLE connection, if any.
         BLEEndPoint * endPoint = sBLEEndPointPool.Find(connObj);
 
-        if (endPoint != NULL)
+        if (endPoint != nullptr)
         {
             endPoint->HandleSubscribeReceived();
         }
@@ -649,7 +649,7 @@ bool BleLayer::HandleSubscribeComplete(BLE_CONNECTION_OBJECT connObj, const Chip
     {
         BLEEndPoint * endPoint = sBLEEndPointPool.Find(connObj);
 
-        if (endPoint != NULL)
+        if (endPoint != nullptr)
         {
             endPoint->HandleSubscribeComplete();
         }
@@ -674,7 +674,7 @@ bool BleLayer::HandleUnsubscribeReceived(BLE_CONNECTION_OBJECT connObj, const Ch
         // Find end point already associated with BLE connection, if any.
         BLEEndPoint * endPoint = sBLEEndPointPool.Find(connObj);
 
-        if (endPoint != NULL)
+        if (endPoint != nullptr)
         {
             endPoint->DoClose(kBleCloseFlag_AbortTransmission, BLE_ERROR_CENTRAL_UNSUBSCRIBED);
         }
@@ -699,7 +699,7 @@ bool BleLayer::HandleUnsubscribeComplete(BLE_CONNECTION_OBJECT connObj, const Ch
         // Find end point already associated with BLE connection, if any.
         BLEEndPoint * endPoint = sBLEEndPointPool.Find(connObj);
 
-        if (endPoint != NULL)
+        if (endPoint != nullptr)
         {
             endPoint->HandleUnsubscribeComplete();
         }
@@ -717,7 +717,7 @@ void BleLayer::HandleConnectionError(BLE_CONNECTION_OBJECT connObj, BLE_ERROR er
     // BLE connection has failed somehow, we must find and abort matching connection end point.
     BLEEndPoint * endPoint = sBLEEndPointPool.Find(connObj);
 
-    if (endPoint != NULL)
+    if (endPoint != nullptr)
     {
         if (err == BLE_ERROR_GATT_UNSUBSCRIBE_FAILED && endPoint->IsUnsubscribePending())
         {

--- a/src/ble/BleUUID.cpp
+++ b/src/ble/BleUUID.cpp
@@ -33,7 +33,7 @@ const ChipBleUUID CHIP_BLE_SVC_ID = { { // 0000FEAF-0000-1000-8000-00805F9B34FB
 
 bool UUIDsMatch(const ChipBleUUID * idOne, const ChipBleUUID * idTwo)
 {
-    if ((idOne == NULL) || (idTwo == NULL))
+    if ((idOne == nullptr) || (idTwo == nullptr))
     {
         return false;
     }

--- a/src/ble/BtpEngine.cpp
+++ b/src/ble/BtpEngine.cpp
@@ -96,12 +96,12 @@ BLE_ERROR BtpEngine::Init(void * an_app_state, bool expect_first_ack)
 {
     mAppState              = an_app_state;
     mRxState               = kState_Idle;
-    mRxBuf                 = NULL;
+    mRxBuf                 = nullptr;
     mRxNewestUnackedSeqNum = 0;
     mRxOldestUnackedSeqNum = 0;
     mRxFragmentSize        = sDefaultFragmentSize;
     mTxState               = kState_Idle;
-    mTxBuf                 = NULL;
+    mTxBuf                 = nullptr;
     mTxFragmentSize        = sDefaultFragmentSize;
     mRxCharCount           = 0;
     mRxPacketCount         = 0;
@@ -267,7 +267,7 @@ BLE_ERROR BtpEngine::HandleCharacteristicReceived(PacketBuffer * data, SequenceN
     uint8_t cursor           = 0;
     uint8_t * characteristic = data->Start();
 
-    VerifyOrExit(data != NULL, err = BLE_ERROR_BAD_ARGS);
+    VerifyOrExit(data != nullptr, err = BLE_ERROR_BAD_ARGS);
 
     mRxCharCount++;
 
@@ -305,7 +305,7 @@ BLE_ERROR BtpEngine::HandleCharacteristicReceived(PacketBuffer * data, SequenceN
     {
         // Free stand-alone ack buffer.
         PacketBuffer::Free(data);
-        data = NULL;
+        data = nullptr;
 
         ExitNow();
     }
@@ -332,11 +332,11 @@ BLE_ERROR BtpEngine::HandleCharacteristicReceived(PacketBuffer * data, SequenceN
         // Create a new buffer for use as the Rx re-assembly area.
         mRxBuf = PacketBuffer::New();
 
-        VerifyOrExit(mRxBuf != NULL, err = BLE_ERROR_NO_MEMORY);
+        VerifyOrExit(mRxBuf != nullptr, err = BLE_ERROR_NO_MEMORY);
 
         mRxBuf->AddToEnd(data);
         mRxBuf->CompactHead(); // will free 'data' and adjust rx buf's end/length
-        data = NULL;
+        data = nullptr;
     }
     else if (mRxState == kState_InProgress)
     {
@@ -351,11 +351,11 @@ BLE_ERROR BtpEngine::HandleCharacteristicReceived(PacketBuffer * data, SequenceN
         data->SetStart(&(characteristic[cursor]));
         mRxBuf->AddToEnd(data);
         mRxBuf->CompactHead(); // will free 'data' and adjust rx buf's end/length
-        data = NULL;
+        data = nullptr;
 
         // For now, limit BtpEngine message size to max length of 1 pbuf, as we do for chip messages sent via IP.
         // TODO add support for BtpEngine messages longer than 1 pbuf
-        VerifyOrExit(mRxBuf->Next() == NULL, err = BLE_ERROR_RECEIVED_MESSAGE_TOO_BIG);
+        VerifyOrExit(mRxBuf->Next() == nullptr, err = BLE_ERROR_RECEIVED_MESSAGE_TOO_BIG);
     }
     else
     {
@@ -392,16 +392,16 @@ exit:
         {
             ChipLogError(Ble, "With rx'd ack = %u", receivedAck);
         }
-        if (mRxBuf != NULL)
+        if (mRxBuf != nullptr)
         {
             ChipLogError(Ble, "With rx buf data length = %u", mRxBuf->DataLength());
         }
         LogState();
 
-        if (data != NULL)
+        if (data != nullptr)
         {
             // Tack received data onto rx buffer, to be freed when end point resets protocol engine on close.
-            if (mRxBuf != NULL)
+            if (mRxBuf != nullptr)
             {
                 mRxBuf->AddToEnd(data);
             }
@@ -425,7 +425,7 @@ bool BtpEngine::ClearRxPacket()
     if (mRxState == kState_Complete)
     {
         mRxState = kState_Idle;
-        mRxBuf   = NULL;
+        mRxBuf   = nullptr;
         // do not reset mRxNextSeqNum
         return true;
     }
@@ -449,7 +449,7 @@ bool BtpEngine::HandleCharacteristicSend(PacketBuffer * data, bool send_ack)
 
     if (mTxState == kState_Idle)
     {
-        if (data == NULL)
+        if (data == nullptr)
         {
             return false;
         }
@@ -471,7 +471,7 @@ bool BtpEngine::HandleCharacteristicSend(PacketBuffer * data, bool send_ack)
             // handle error
             ChipLogError(Ble, "HandleCharacteristicSend: not enough headroom");
             mTxState = kState_Error;
-            mTxBuf   = NULL; // Avoid double-free after assignment above, as caller frees data on error.
+            mTxBuf   = nullptr; // Avoid double-free after assignment above, as caller frees data on error.
 
             return false;
         }
@@ -519,7 +519,7 @@ bool BtpEngine::HandleCharacteristicSend(PacketBuffer * data, bool send_ack)
     }
     else if (mTxState == kState_InProgress)
     {
-        if (data != NULL)
+        if (data != nullptr)
         {
             return false;
         }
@@ -587,7 +587,7 @@ bool BtpEngine::ClearTxPacket()
     if (mTxState == kState_Complete)
     {
         mTxState = kState_Idle;
-        mTxBuf   = NULL;
+        mTxBuf   = nullptr;
         // do not reset mTxNextSeqNum
         return true;
     }

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -57,13 +57,13 @@ using namespace chip::Encoding;
 ChipDeviceController::ChipDeviceController()
 {
     mState             = kState_NotInitialized;
-    AppState           = NULL;
+    AppState           = nullptr;
     mConState          = kConnectionState_NotConnected;
-    mRendezvousSession = NULL;
-    mSessionManager    = NULL;
-    mCurReqMsg         = NULL;
-    mOnError           = NULL;
-    mOnNewConnection   = NULL;
+    mRendezvousSession = nullptr;
+    mSessionManager    = nullptr;
+    mCurReqMsg         = nullptr;
+    mOnError           = nullptr;
+    mOnNewConnection   = nullptr;
     mDeviceAddr        = IPAddress::Any;
     mDevicePort        = CHIP_PORT;
     mLocalDeviceId     = 0;
@@ -121,25 +121,25 @@ CHIP_ERROR ChipDeviceController::Shutdown()
     delete mInetLayer;
 #endif // CONFIG_DEVICE_LAYER
 
-    mSystemLayer = NULL;
-    mInetLayer   = NULL;
+    mSystemLayer = nullptr;
+    mInetLayer   = nullptr;
 
-    if (mSessionManager != NULL)
+    if (mSessionManager != nullptr)
     {
         delete mSessionManager;
-        mSessionManager = NULL;
+        mSessionManager = nullptr;
     }
 
-    if (mRendezvousSession != NULL)
+    if (mRendezvousSession != nullptr)
     {
         delete mRendezvousSession;
-        mRendezvousSession = NULL;
+        mRendezvousSession = nullptr;
     }
 
     mConState = kConnectionState_NotConnected;
     memset(&mOnComplete, 0, sizeof(mOnComplete));
-    mOnError         = NULL;
-    mOnNewConnection = NULL;
+    mOnError         = nullptr;
+    mOnNewConnection = nullptr;
     mMessageNumber   = 0;
     mRemoteDeviceId.ClearValue();
 
@@ -192,7 +192,7 @@ CHIP_ERROR ChipDeviceController::ConnectDeviceUsingPairing(NodeId remoteDeviceId
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    if (mState != kState_Initialized || mSessionManager != NULL || mConState != kConnectionState_NotConnected)
+    if (mState != kState_Initialized || mSessionManager != nullptr || mConState != kConnectionState_NotConnected)
     {
         return CHIP_ERROR_INCORRECT_STATE;
     }
@@ -224,17 +224,17 @@ CHIP_ERROR ChipDeviceController::ConnectDeviceUsingPairing(NodeId remoteDeviceId
 
     if (mOnNewConnection)
     {
-        mOnNewConnection(this, NULL, mAppReqState);
+        mOnNewConnection(this, nullptr, mAppReqState);
     }
 
 exit:
 
     if (err != CHIP_NO_ERROR)
     {
-        if (mSessionManager != NULL)
+        if (mSessionManager != nullptr)
         {
             delete mSessionManager;
-            mSessionManager = NULL;
+            mSessionManager = nullptr;
         }
         mConState = kConnectionState_NotConnected;
     }
@@ -292,16 +292,16 @@ CHIP_ERROR ChipDeviceController::DisconnectDevice()
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
-    if (mSessionManager != NULL)
+    if (mSessionManager != nullptr)
     {
         delete mSessionManager;
-        mSessionManager = NULL;
+        mSessionManager = nullptr;
     }
 
-    if (mRendezvousSession != NULL)
+    if (mRendezvousSession != nullptr)
     {
         delete mRendezvousSession;
-        mRendezvousSession = NULL;
+        mRendezvousSession = nullptr;
     }
 
     mConState = kConnectionState_NotConnected;
@@ -317,7 +317,7 @@ CHIP_ERROR ChipDeviceController::SendMessage(void * appReqState, PacketBuffer * 
 
     mAppReqState = appReqState;
 
-    if (mRendezvousSession != NULL)
+    if (mRendezvousSession != nullptr)
     {
         err = mRendezvousSession->SendMessage(buffer);
     }
@@ -363,10 +363,10 @@ exit:
 
 void ChipDeviceController::ClearRequestState()
 {
-    if (mCurReqMsg != NULL)
+    if (mCurReqMsg != nullptr)
     {
         PacketBuffer::Free(mCurReqMsg);
-        mCurReqMsg = NULL;
+        mCurReqMsg = nullptr;
     }
 }
 
@@ -387,7 +387,7 @@ void ChipDeviceController::OnMessageReceived(const MessageHeader & header, Trans
             ChipLogError(Controller, "Received message from an unexpected source node id.");
         }
     }
-    if (IsSecurelyConnected() && mOnComplete.Response != NULL)
+    if (IsSecurelyConnected() && mOnComplete.Response != nullptr)
     {
         mOnComplete.Response(this, mAppReqState, msgBuf);
     }
@@ -397,7 +397,7 @@ void ChipDeviceController::OnRendezvousError(CHIP_ERROR err)
 {
     if (mOnError)
     {
-        mOnError(this, mAppReqState, err, NULL);
+        mOnError(this, mAppReqState, err, nullptr);
     }
 }
 
@@ -408,7 +408,7 @@ void ChipDeviceController::OnRendezvousConnectionOpened()
 
     if (mOnNewConnection)
     {
-        mOnNewConnection(this, NULL, mAppReqState);
+        mOnNewConnection(this, nullptr, mAppReqState);
     }
 }
 

--- a/src/crypto/CHIPCryptoPAL.cpp
+++ b/src/crypto/CHIPCryptoPAL.cpp
@@ -44,7 +44,7 @@ CHIP_ERROR Spake2p::InternalHash(const uint8_t * in, size_t in_len)
 
     error = Hash(lb, sizeof(lb));
     VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
-    if (in != NULL)
+    if (in != nullptr)
     {
         error = Hash(in, in_len);
         VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
@@ -182,8 +182,8 @@ exit:
 CHIP_ERROR Spake2p::ComputeRoundOne(uint8_t * out, size_t * out_len)
 {
     CHIP_ERROR error = CHIP_ERROR_INTERNAL;
-    void * MN        = NULL; // Choose M if a prover, N if a verifier
-    void * XY        = NULL; // Choose X if a prover, Y if a verifier
+    void * MN        = nullptr; // Choose M if a prover, N if a verifier
+    void * XY        = nullptr; // Choose X if a prover, Y if a verifier
 
     VerifyOrExit(state == CHIP_SPAKE2P_STATE::STARTED, error = CHIP_ERROR_INTERNAL);
     VerifyOrExit(*out_len >= point_size, error = CHIP_ERROR_INTERNAL);
@@ -201,8 +201,8 @@ CHIP_ERROR Spake2p::ComputeRoundOne(uint8_t * out, size_t * out_len)
         MN = N;
         XY = Y;
     }
-    VerifyOrExit(MN != NULL, error = CHIP_ERROR_INTERNAL);
-    VerifyOrExit(XY != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(MN != nullptr, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(XY != nullptr, error = CHIP_ERROR_INTERNAL);
 
     error = PointAddMul(XY, G, xy, MN, w0);
     VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
@@ -221,9 +221,9 @@ CHIP_ERROR Spake2p::ComputeRoundTwo(const uint8_t * in, size_t in_len, uint8_t *
 {
     CHIP_ERROR error = CHIP_ERROR_INTERNAL;
     uint8_t point_buffer[kMAX_Point_Length];
-    void * MN        = NULL; // Choose N if a prover, M if a verifier
-    void * XY        = NULL; // Choose Y if a prover, X if a verifier
-    uint8_t * Kcaorb = NULL; // Choose Kca if a prover, Kcb if a verifier
+    void * MN        = nullptr; // Choose N if a prover, M if a verifier
+    void * XY        = nullptr; // Choose Y if a prover, X if a verifier
+    uint8_t * Kcaorb = nullptr; // Choose Kca if a prover, Kcb if a verifier
 
     VerifyOrExit(*out_len >= hash_size, error = CHIP_ERROR_INTERNAL);
     VerifyOrExit(state == CHIP_SPAKE2P_STATE::R1, error = CHIP_ERROR_INTERNAL);
@@ -259,9 +259,8 @@ CHIP_ERROR Spake2p::ComputeRoundTwo(const uint8_t * in, size_t in_len, uint8_t *
         XY     = X;
         Kcaorb = Kcb;
     }
-    VerifyOrExit(MN != NULL, error = CHIP_ERROR_INTERNAL);
-    VerifyOrExit(XY != NULL, error = CHIP_ERROR_INTERNAL);
-    VerifyOrExit(Kcab != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(MN != nullptr, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(XY != nullptr, error = CHIP_ERROR_INTERNAL);
 
     error = PointLoad(in, in_len, XY);
     VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
@@ -332,7 +331,7 @@ CHIP_ERROR Spake2p::GenerateKeys(void)
     error = HashFinalize(Kae);
     VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
 
-    error = KDF(Ka, hash_size / 2, NULL, 0, info_keyconfirm, sizeof(info_keyconfirm), Kcab, hash_size);
+    error = KDF(Ka, hash_size / 2, nullptr, 0, info_keyconfirm, sizeof(info_keyconfirm), Kcab, hash_size);
     VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
 
     error = CHIP_NO_ERROR;
@@ -344,8 +343,8 @@ CHIP_ERROR Spake2p::KeyConfirm(const uint8_t * in, size_t in_len)
 {
     CHIP_ERROR error = CHIP_ERROR_INTERNAL;
     uint8_t point_buffer[kP256_Point_Length];
-    void * XY        = NULL; // Choose X if a prover, Y if a verifier
-    uint8_t * Kcaorb = NULL; // Choose Kcb if a prover, Kca if a verifier
+    void * XY        = nullptr; // Choose X if a prover, Y if a verifier
+    uint8_t * Kcaorb = nullptr; // Choose Kcb if a prover, Kca if a verifier
 
     VerifyOrExit(state == CHIP_SPAKE2P_STATE::R2, error = CHIP_ERROR_INTERNAL);
 
@@ -359,8 +358,8 @@ CHIP_ERROR Spake2p::KeyConfirm(const uint8_t * in, size_t in_len)
         XY     = Y;
         Kcaorb = Kca;
     }
-    VerifyOrExit(XY != NULL, error = CHIP_ERROR_INTERNAL);
-    VerifyOrExit(Kcaorb != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(XY != nullptr, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(Kcaorb != nullptr, error = CHIP_ERROR_INTERNAL);
 
     error = PointWrite(XY, point_buffer, point_size);
     VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -120,7 +120,7 @@ static const EVP_MD * _digestForType(DigestType digestType)
         break;
 
     default:
-        return NULL;
+        return nullptr;
         break;
     }
 }
@@ -129,52 +129,52 @@ CHIP_ERROR AES_CCM_encrypt(const uint8_t * plaintext, size_t plaintext_length, c
                            const uint8_t * key, size_t key_length, const uint8_t * iv, size_t iv_length, uint8_t * ciphertext,
                            uint8_t * tag, size_t tag_length)
 {
-    EVP_CIPHER_CTX * context = NULL;
+    EVP_CIPHER_CTX * context = nullptr;
     int bytesWritten         = 0;
     size_t ciphertext_length = 0;
     CHIP_ERROR error         = CHIP_NO_ERROR;
     int result               = 1;
-    const EVP_CIPHER * type  = NULL;
+    const EVP_CIPHER * type  = nullptr;
 
-    VerifyOrExit(plaintext != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(plaintext != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(plaintext_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(key != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(key != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(_isValidKeyLength(key_length), error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(iv != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(iv != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(iv_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(tag != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(tag != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(_isValidTagLength(tag_length), error = CHIP_ERROR_INVALID_ARGUMENT);
 
     // 16 bytes key for AES-CCM-128
     type = (key_length == 16) ? EVP_aes_128_ccm() : EVP_aes_256_ccm();
 
     context = EVP_CIPHER_CTX_new();
-    VerifyOrExit(context != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(context != nullptr, error = CHIP_ERROR_INTERNAL);
 
     // Pass in cipher
-    result = EVP_EncryptInit_ex(context, type, NULL, NULL, NULL);
+    result = EVP_EncryptInit_ex(context, type, nullptr, nullptr, nullptr);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
     // Pass in IV length
-    result = EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_CCM_SET_IVLEN, iv_length, NULL);
+    result = EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_CCM_SET_IVLEN, iv_length, nullptr);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
     // Pass in tag length
-    result = EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_CCM_SET_TAG, tag_length, NULL);
+    result = EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_CCM_SET_TAG, tag_length, nullptr);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
     // Pass in key + iv
-    result = EVP_EncryptInit_ex(context, NULL, NULL, Uint8::to_const_uchar(key), Uint8::to_const_uchar(iv));
+    result = EVP_EncryptInit_ex(context, nullptr, nullptr, Uint8::to_const_uchar(key), Uint8::to_const_uchar(iv));
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
     // Pass in plain text length
-    result = EVP_EncryptUpdate(context, NULL, &bytesWritten, NULL, plaintext_length);
+    result = EVP_EncryptUpdate(context, nullptr, &bytesWritten, nullptr, plaintext_length);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
     // Pass in AAD
-    if (aad_length > 0 && aad != NULL)
+    if (aad_length > 0 && aad != nullptr)
     {
-        result = EVP_EncryptUpdate(context, NULL, &bytesWritten, Uint8::to_const_uchar(aad), aad_length);
+        result = EVP_EncryptUpdate(context, nullptr, &bytesWritten, Uint8::to_const_uchar(aad), aad_length);
         VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
     }
 
@@ -194,10 +194,10 @@ CHIP_ERROR AES_CCM_encrypt(const uint8_t * plaintext, size_t plaintext_length, c
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
 exit:
-    if (context != NULL)
+    if (context != nullptr)
     {
         EVP_CIPHER_CTX_free(context);
-        context = NULL;
+        context = nullptr;
     }
 
     return error;
@@ -207,33 +207,33 @@ CHIP_ERROR AES_CCM_decrypt(const uint8_t * ciphertext, size_t ciphertext_length,
                            const uint8_t * tag, size_t tag_length, const uint8_t * key, size_t key_length, const uint8_t * iv,
                            size_t iv_length, uint8_t * plaintext)
 {
-    EVP_CIPHER_CTX * context = NULL;
+    EVP_CIPHER_CTX * context = nullptr;
     CHIP_ERROR error         = CHIP_NO_ERROR;
     int bytesOutput          = 0;
     int result               = 1;
-    const EVP_CIPHER * type  = NULL;
+    const EVP_CIPHER * type  = nullptr;
 
-    VerifyOrExit(ciphertext != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(ciphertext != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(ciphertext_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(tag != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(tag != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(_isValidTagLength(tag_length), error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(key != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(key != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(_isValidKeyLength(key_length), error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(iv != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(iv != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(iv_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     // 16 bytes key for AES-CCM-128
     type = (key_length == 16) ? EVP_aes_128_ccm() : EVP_aes_256_ccm();
 
     context = EVP_CIPHER_CTX_new();
-    VerifyOrExit(context != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(context != nullptr, error = CHIP_ERROR_INTERNAL);
 
     // Pass in cipher
-    result = EVP_DecryptInit_ex(context, type, NULL, NULL, NULL);
+    result = EVP_DecryptInit_ex(context, type, nullptr, nullptr, nullptr);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
     // Pass in IV length
-    result = EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_CCM_SET_IVLEN, iv_length, NULL);
+    result = EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_CCM_SET_IVLEN, iv_length, nullptr);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
     // Pass in expected tag
@@ -241,17 +241,17 @@ CHIP_ERROR AES_CCM_decrypt(const uint8_t * ciphertext, size_t ciphertext_length,
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
     // Pass in key + iv
-    result = EVP_DecryptInit_ex(context, NULL, NULL, Uint8::to_const_uchar(key), Uint8::to_const_uchar(iv));
+    result = EVP_DecryptInit_ex(context, nullptr, nullptr, Uint8::to_const_uchar(key), Uint8::to_const_uchar(iv));
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
     // Pass in cipher text length
-    result = EVP_DecryptUpdate(context, NULL, &bytesOutput, NULL, ciphertext_length);
+    result = EVP_DecryptUpdate(context, nullptr, &bytesOutput, nullptr, ciphertext_length);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
     // Pass in aad
-    if (aad_length > 0 && aad != NULL)
+    if (aad_length > 0 && aad != nullptr)
     {
-        result = EVP_DecryptUpdate(context, NULL, &bytesOutput, Uint8::to_const_uchar(aad), aad_length);
+        result = EVP_DecryptUpdate(context, nullptr, &bytesOutput, Uint8::to_const_uchar(aad), aad_length);
         VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
     }
 
@@ -261,10 +261,10 @@ CHIP_ERROR AES_CCM_decrypt(const uint8_t * ciphertext, size_t ciphertext_length,
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
 exit:
-    if (context != NULL)
+    if (context != nullptr)
     {
         EVP_CIPHER_CTX_free(context);
-        context = NULL;
+        context = nullptr;
     }
 
     return error;
@@ -276,7 +276,7 @@ CHIP_ERROR Hash_SHA256(const uint8_t * data, const size_t data_length, uint8_t *
 
     // zero data length hash is supported.
 
-    VerifyOrExit(out_buffer != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(out_buffer != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     SHA256(data, data_length, Uint8::to_uchar(out_buffer));
 
@@ -348,22 +348,22 @@ CHIP_ERROR HKDF_SHA256(const uint8_t * secret, const size_t secret_length, const
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 1;
 
-    context = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, NULL);
-    VerifyOrExit(context != NULL, error = CHIP_ERROR_INTERNAL);
+    context = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, nullptr);
+    VerifyOrExit(context != nullptr, error = CHIP_ERROR_INTERNAL);
 
-    VerifyOrExit(secret != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(secret != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(secret_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     // Salt is optional
     if (salt_length > 0)
     {
-        VerifyOrExit(salt != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrExit(salt != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     }
 
     VerifyOrExit(info_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(info != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(info != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(out_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(out_buffer != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(out_buffer != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     result = EVP_PKEY_derive_init(context);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
@@ -374,7 +374,7 @@ CHIP_ERROR HKDF_SHA256(const uint8_t * secret, const size_t secret_length, const
     result = EVP_PKEY_CTX_set1_hkdf_key(context, Uint8::to_const_uchar(secret), secret_length);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
-    if (salt_length > 0 && salt != NULL)
+    if (salt_length > 0 && salt != nullptr)
     {
         result = EVP_PKEY_CTX_set1_hkdf_salt(context, Uint8::to_const_uchar(salt), salt_length);
         VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
@@ -391,7 +391,7 @@ CHIP_ERROR HKDF_SHA256(const uint8_t * secret, const size_t secret_length, const
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
 exit:
-    if (context != NULL)
+    if (context != nullptr)
     {
         EVP_PKEY_CTX_free(context);
     }
@@ -403,17 +403,17 @@ CHIP_ERROR pbkdf2_sha256(const uint8_t * password, size_t plen, const uint8_t * 
 {
     CHIP_ERROR error  = CHIP_NO_ERROR;
     int result        = 1;
-    const EVP_MD * md = NULL;
+    const EVP_MD * md = nullptr;
 
-    VerifyOrExit(password != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(password != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(plen > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(salt != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(salt != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(slen > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(key_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(output != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(output != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     md = _digestForType(DigestType::SHA256);
-    VerifyOrExit(md != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(md != nullptr, error = CHIP_ERROR_INTERNAL);
 
     result = PKCS5_PBKDF2_HMAC(Uint8::to_const_char(password), plen, Uint8::to_const_uchar(salt), slen, iteration_count, md,
                                key_length, Uint8::to_uchar(output));
@@ -439,7 +439,7 @@ CHIP_ERROR DRBG_get_bytes(uint8_t * out_buffer, const size_t out_length)
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
 
-    VerifyOrExit(out_buffer != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(out_buffer != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(out_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     result = RAND_priv_bytes(Uint8::to_uchar(out_buffer), out_length);
@@ -484,35 +484,35 @@ CHIP_ERROR P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_len
 
     CHIP_ERROR error       = CHIP_NO_ERROR;
     int result             = 0;
-    EVP_MD_CTX * context   = NULL;
+    EVP_MD_CTX * context   = nullptr;
     int nid                = NID_undef;
-    EC_KEY * ec_key        = NULL;
-    EVP_PKEY * signing_key = NULL;
-    const EVP_MD * md      = NULL;
+    EC_KEY * ec_key        = nullptr;
+    EVP_PKEY * signing_key = nullptr;
+    const EVP_MD * md      = nullptr;
     DigestType digest      = DigestType::SHA256;
     size_t out_length      = 0;
 
     VerifyOrExit(mInitialized, error = CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrExit(msg != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(msg != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(msg_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     nid = _nidForCurve(MapECName(mPublicKey.Type()));
     VerifyOrExit(nid != NID_undef, error = CHIP_ERROR_INVALID_ARGUMENT);
     md = _digestForType(digest);
-    VerifyOrExit(md != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(md != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     ec_key = to_EC_KEY(&mKeypair);
-    VerifyOrExit(ec_key != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(ec_key != nullptr, error = CHIP_ERROR_INTERNAL);
 
     signing_key = EVP_PKEY_new();
-    VerifyOrExit(signing_key != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(signing_key != nullptr, error = CHIP_ERROR_INTERNAL);
 
     result = EVP_PKEY_set1_EC_KEY(signing_key, ec_key);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
     context = EVP_MD_CTX_create();
-    VerifyOrExit(context != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(context != nullptr, error = CHIP_ERROR_INTERNAL);
 
-    result = EVP_DigestSignInit(context, NULL, md, NULL, signing_key);
+    result = EVP_DigestSignInit(context, nullptr, md, nullptr, signing_key);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
     result = EVP_DigestSignUpdate(context, Uint8::to_const_uchar(msg), msg_length);
@@ -520,7 +520,7 @@ CHIP_ERROR P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_len
 
     // Call the EVP_DigestSignFinal with a NULL param to get length of the signature.
 
-    result = EVP_DigestSignFinal(context, NULL, &out_length);
+    result = EVP_DigestSignFinal(context, nullptr, &out_length);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
     VerifyOrExit(out_signature.Capacity() >= out_length, error = CHIP_ERROR_INVALID_ARGUMENT);
 
@@ -530,17 +530,17 @@ CHIP_ERROR P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_len
     SuccessOrExit(out_signature.SetLength(out_length));
 
 exit:
-    ec_key = NULL;
+    ec_key = nullptr;
 
-    if (context != NULL)
+    if (context != nullptr)
     {
         EVP_MD_CTX_destroy(context);
-        context = NULL;
+        context = nullptr;
     }
-    if (signing_key != NULL)
+    if (signing_key != nullptr)
     {
         EVP_PKEY_free(signing_key);
-        signing_key = NULL;
+        signing_key = nullptr;
     }
 
     if (error != CHIP_NO_ERROR)
@@ -557,34 +557,34 @@ CHIP_ERROR P256PublicKey::ECDSA_validate_msg_signature(const uint8_t * msg, cons
     ERR_clear_error();
     CHIP_ERROR error            = CHIP_ERROR_INTERNAL;
     int nid                     = NID_undef;
-    const EVP_MD * md           = NULL;
-    EC_KEY * ec_key             = NULL;
-    EVP_PKEY * verification_key = NULL;
-    EC_POINT * key_point        = NULL;
-    EC_GROUP * ec_group         = NULL;
+    const EVP_MD * md           = nullptr;
+    EC_KEY * ec_key             = nullptr;
+    EVP_PKEY * verification_key = nullptr;
+    EC_POINT * key_point        = nullptr;
+    EC_GROUP * ec_group         = nullptr;
     int result                  = 0;
-    EVP_MD_CTX * md_context     = NULL;
+    EVP_MD_CTX * md_context     = nullptr;
     DigestType digest           = DigestType::SHA256;
 
-    VerifyOrExit(msg != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(msg != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(msg_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     nid = _nidForCurve(MapECName(Type()));
     VerifyOrExit(nid != NID_undef, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     md = _digestForType(digest);
-    VerifyOrExit(md != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(md != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     ec_group = EC_GROUP_new_by_curve_name(nid);
-    VerifyOrExit(ec_group != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(ec_group != nullptr, error = CHIP_ERROR_INTERNAL);
 
     key_point = EC_POINT_new(ec_group);
-    VerifyOrExit(key_point != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(key_point != nullptr, error = CHIP_ERROR_INTERNAL);
 
-    result = EC_POINT_oct2point(ec_group, key_point, Uint8::to_const_uchar(*this), Length(), NULL);
+    result = EC_POINT_oct2point(ec_group, key_point, Uint8::to_const_uchar(*this), Length(), nullptr);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
     ec_key = EC_KEY_new_by_curve_name(nid);
-    VerifyOrExit(ec_key != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(ec_key != nullptr, error = CHIP_ERROR_INTERNAL);
 
     result = EC_KEY_set_public_key(ec_key, key_point);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
@@ -593,15 +593,15 @@ CHIP_ERROR P256PublicKey::ECDSA_validate_msg_signature(const uint8_t * msg, cons
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
     verification_key = EVP_PKEY_new();
-    VerifyOrExit(verification_key != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(verification_key != nullptr, error = CHIP_ERROR_INTERNAL);
 
     result = EVP_PKEY_set1_EC_KEY(verification_key, ec_key);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
     md_context = EVP_MD_CTX_create();
-    VerifyOrExit(md_context != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(md_context != nullptr, error = CHIP_ERROR_INTERNAL);
 
-    result = EVP_DigestVerifyInit(md_context, NULL, md, NULL, verification_key);
+    result = EVP_DigestVerifyInit(md_context, nullptr, md, nullptr, verification_key);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
     result = EVP_DigestVerifyUpdate(md_context, Uint8::to_const_uchar(msg), msg_length);
@@ -613,30 +613,30 @@ CHIP_ERROR P256PublicKey::ECDSA_validate_msg_signature(const uint8_t * msg, cons
 
 exit:
     _logSSLError();
-    if (ec_group != NULL)
+    if (ec_group != nullptr)
     {
         EC_GROUP_free(ec_group);
-        ec_group = NULL;
+        ec_group = nullptr;
     }
-    if (key_point != NULL)
+    if (key_point != nullptr)
     {
         EC_POINT_clear_free(key_point);
-        key_point = NULL;
+        key_point = nullptr;
     }
     if (md_context)
     {
         EVP_MD_CTX_destroy(md_context);
-        md_context = NULL;
+        md_context = nullptr;
     }
-    if (ec_key != NULL)
+    if (ec_key != nullptr)
     {
         EC_KEY_free(ec_key);
-        ec_key = NULL;
+        ec_key = nullptr;
     }
-    if (verification_key != NULL)
+    if (verification_key != nullptr)
     {
         EVP_PKEY_free(verification_key);
-        verification_key = NULL;
+        verification_key = nullptr;
     }
     return error;
 }
@@ -646,27 +646,27 @@ static CHIP_ERROR _create_evp_key_from_binary_p256_key(const P256PublicKey & key
 {
 
     CHIP_ERROR error = CHIP_NO_ERROR;
-    EC_KEY * ec_key  = NULL;
+    EC_KEY * ec_key  = nullptr;
     int result       = -1;
-    EC_POINT * point = NULL;
-    EC_GROUP * group = NULL;
+    EC_POINT * point = nullptr;
+    EC_GROUP * group = nullptr;
     int nid          = NID_undef;
 
-    VerifyOrExit(*out_evp_pkey == NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(*out_evp_pkey == nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     nid = _nidForCurve(MapECName(key.Type()));
     VerifyOrExit(nid != NID_undef, error = CHIP_ERROR_INTERNAL);
 
     ec_key = EC_KEY_new_by_curve_name(nid);
-    VerifyOrExit(ec_key != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(ec_key != nullptr, error = CHIP_ERROR_INTERNAL);
 
     group = EC_GROUP_new_by_curve_name(nid);
-    VerifyOrExit(group != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(group != nullptr, error = CHIP_ERROR_INTERNAL);
 
     point = EC_POINT_new(group);
-    VerifyOrExit(point != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(point != nullptr, error = CHIP_ERROR_INTERNAL);
 
-    result = EC_POINT_oct2point(group, point, Uint8::to_const_uchar(key), key.Length(), NULL);
+    result = EC_POINT_oct2point(group, point, Uint8::to_const_uchar(key), key.Length(), nullptr);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
     result = EC_KEY_set_public_key(ec_key, point);
@@ -674,34 +674,34 @@ static CHIP_ERROR _create_evp_key_from_binary_p256_key(const P256PublicKey & key
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
     *out_evp_pkey = EVP_PKEY_new();
-    VerifyOrExit(*out_evp_pkey != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(*out_evp_pkey != nullptr, error = CHIP_ERROR_INTERNAL);
 
     result = EVP_PKEY_set1_EC_KEY(*out_evp_pkey, ec_key);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
 exit:
-    if (ec_key != NULL)
+    if (ec_key != nullptr)
     {
         EC_KEY_free(ec_key);
-        ec_key = NULL;
+        ec_key = nullptr;
     }
 
     if (error != CHIP_NO_ERROR && *out_evp_pkey)
     {
         EVP_PKEY_free(*out_evp_pkey);
-        out_evp_pkey = NULL;
+        out_evp_pkey = nullptr;
     }
 
-    if (point != NULL)
+    if (point != nullptr)
     {
         EC_POINT_free(point);
-        point = NULL;
+        point = nullptr;
     }
 
-    if (group != NULL)
+    if (group != nullptr)
     {
         EC_GROUP_free(group);
-        group = NULL;
+        group = nullptr;
     }
 
     return error;
@@ -712,10 +712,10 @@ CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_k
     ERR_clear_error();
     CHIP_ERROR error      = CHIP_NO_ERROR;
     int result            = -1;
-    EVP_PKEY * local_key  = NULL;
-    EVP_PKEY * remote_key = NULL;
+    EVP_PKEY * local_key  = nullptr;
+    EVP_PKEY * remote_key = nullptr;
 
-    EVP_PKEY_CTX * context = NULL;
+    EVP_PKEY_CTX * context = nullptr;
     size_t out_buf_length  = 0;
 
     EC_KEY * ec_key = EC_KEY_dup(to_const_EC_KEY(&mKeypair));
@@ -724,7 +724,7 @@ CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_k
     VerifyOrExit(mInitialized, error = CHIP_ERROR_INCORRECT_STATE);
 
     local_key = EVP_PKEY_new();
-    VerifyOrExit(local_key != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(local_key != nullptr, error = CHIP_ERROR_INTERNAL);
 
     result = EVP_PKEY_set1_EC_KEY(local_key, ec_key);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
@@ -732,8 +732,8 @@ CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_k
     error = _create_evp_key_from_binary_p256_key(remote_public_key, &remote_key);
     SuccessOrExit(error);
 
-    context = EVP_PKEY_CTX_new(local_key, NULL);
-    VerifyOrExit(context != NULL, error = CHIP_ERROR_INTERNAL);
+    context = EVP_PKEY_CTX_new(local_key, nullptr);
+    VerifyOrExit(context != nullptr, error = CHIP_ERROR_INTERNAL);
 
     result = EVP_PKEY_derive_init(context);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
@@ -747,28 +747,28 @@ CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_k
     SuccessOrExit(out_secret.SetLength(out_buf_length));
 
 exit:
-    if (ec_key != NULL)
+    if (ec_key != nullptr)
     {
         EC_KEY_free(ec_key);
-        ec_key = NULL;
+        ec_key = nullptr;
     }
 
-    if (local_key != NULL)
+    if (local_key != nullptr)
     {
         EVP_PKEY_free(local_key);
-        local_key = NULL;
+        local_key = nullptr;
     }
 
-    if (remote_key != NULL)
+    if (remote_key != nullptr)
     {
         EVP_PKEY_free(remote_key);
-        remote_key = NULL;
+        remote_key = nullptr;
     }
 
-    if (context != NULL)
+    if (context != nullptr)
     {
         EVP_PKEY_CTX_free(context);
-        context = NULL;
+        context = nullptr;
     }
 
     _logSSLError();
@@ -1080,21 +1080,21 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal(void)
 
     Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
-    context->curve   = NULL;
-    context->bn_ctx  = NULL;
-    context->md_info = NULL;
+    context->curve   = nullptr;
+    context->bn_ctx  = nullptr;
+    context->md_info = nullptr;
 
     context->curve = EC_GROUP_new_by_curve_name(NID_X9_62_prime256v1);
-    VerifyOrExit(context->curve != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(context->curve != nullptr, error = CHIP_ERROR_INTERNAL);
 
     G = (void *) EC_GROUP_get0_generator(context->curve);
-    VerifyOrExit(G != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(G != nullptr, error = CHIP_ERROR_INTERNAL);
 
     context->bn_ctx = BN_CTX_secure_new();
-    VerifyOrExit(context->bn_ctx != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(context->bn_ctx != nullptr, error = CHIP_ERROR_INTERNAL);
 
     context->md_info = EVP_sha256();
-    VerifyOrExit(context->md_info != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(context->md_info != nullptr, error = CHIP_ERROR_INTERNAL);
 
     init_point(M);
     init_point(N);
@@ -1154,9 +1154,9 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::Mac(const uint8_t * key, size_t key_le
     Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
     HMAC_CTX * mac_ctx = HMAC_CTX_new();
-    VerifyOrExit(mac_ctx != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(mac_ctx != nullptr, error = CHIP_ERROR_INTERNAL);
 
-    error_openssl = HMAC_Init_ex(mac_ctx, Uint8::to_const_uchar(key), key_len, context->md_info, NULL);
+    error_openssl = HMAC_Init_ex(mac_ctx, Uint8::to_const_uchar(key), key_len, context->md_info, nullptr);
     VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
 
     error_openssl = HMAC_Update(mac_ctx, Uint8::to_const_uchar(in), in_len);
@@ -1282,7 +1282,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointMul(void * R, const void * P1, co
 
     Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
-    error_openssl = EC_POINT_mul(context->curve, (EC_POINT *) R, NULL, (EC_POINT *) P1, (BIGNUM *) fe1, context->bn_ctx);
+    error_openssl = EC_POINT_mul(context->curve, (EC_POINT *) R, nullptr, (EC_POINT *) P1, (BIGNUM *) fe1, context->bn_ctx);
     VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
 
     error = CHIP_NO_ERROR;
@@ -1295,12 +1295,12 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointAddMul(void * R, const void * P1,
 {
     CHIP_ERROR error   = CHIP_ERROR_INTERNAL;
     int error_openssl  = 0;
-    EC_POINT * scratch = NULL;
+    EC_POINT * scratch = nullptr;
 
     Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
     scratch = EC_POINT_new(context->curve);
-    VerifyOrExit(scratch != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(scratch != nullptr, error = CHIP_ERROR_INTERNAL);
 
     error = PointMul(scratch, P1, fe1);
     VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
@@ -1342,22 +1342,22 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_le
 {
     CHIP_ERROR error      = CHIP_ERROR_INTERNAL;
     int error_openssl     = 0;
-    BIGNUM * w1_bn        = NULL;
-    EC_POINT * Lout_point = NULL;
+    BIGNUM * w1_bn        = nullptr;
+    EC_POINT * Lout_point = nullptr;
 
     Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
     w1_bn = BN_new();
-    VerifyOrExit(w1_bn != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(w1_bn != nullptr, error = CHIP_ERROR_INTERNAL);
 
     Lout_point = EC_POINT_new(context->curve);
-    VerifyOrExit(Lout_point != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(Lout_point != nullptr, error = CHIP_ERROR_INTERNAL);
 
     BN_bin2bn(Uint8::to_const_uchar(w1in), w1in_len, w1_bn);
     error_openssl = BN_mod(w1_bn, w1_bn, (BIGNUM *) order, context->bn_ctx);
     VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
 
-    error_openssl = EC_POINT_mul(context->curve, Lout_point, w1_bn, NULL, NULL, context->bn_ctx);
+    error_openssl = EC_POINT_mul(context->curve, Lout_point, w1_bn, nullptr, nullptr, context->bn_ctx);
     VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
 
     *L_len = EC_POINT_point2oct(context->curve, Lout_point, POINT_CONVERSION_UNCOMPRESSED, Uint8::to_uchar(Lout), *L_len,

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -151,7 +151,7 @@ static void TestAES_CCM_256EncryptNilKey(nlTestSuite * inSuite, void * inContext
             uint8_t out_ct[vector->ct_len];
             uint8_t out_tag[vector->tag_len];
 
-            CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, NULL, 32, vector->iv,
+            CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, nullptr, 32, vector->iv,
                                              vector->iv_len, out_ct, out_tag, vector->tag_len);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
@@ -236,7 +236,7 @@ static void TestAES_CCM_256DecryptInvalidKey(nlTestSuite * inSuite, void * inCon
             numOfTestsRan++;
             uint8_t out_pt[vector->pt_len];
             CHIP_ERROR err = AES_CCM_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag, vector->tag_len,
-                                             NULL, 32, vector->iv, vector->iv_len, out_pt);
+                                             nullptr, 32, vector->iv, vector->iv_len, out_pt);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -387,7 +387,7 @@ static void TestAES_CCM_128EncryptNilKey(nlTestSuite * inSuite, void * inContext
             uint8_t out_ct[vector->ct_len];
             uint8_t out_tag[vector->tag_len];
 
-            CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, NULL, 0, vector->iv,
+            CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, nullptr, 0, vector->iv,
                                              vector->iv_len, out_ct, out_tag, vector->tag_len);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
@@ -472,7 +472,7 @@ static void TestAES_CCM_128DecryptInvalidKey(nlTestSuite * inSuite, void * inCon
             numOfTestsRan++;
             uint8_t out_pt[vector->pt_len];
             CHIP_ERROR err = AES_CCM_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag, vector->tag_len,
-                                             NULL, 0, vector->iv, vector->iv_len, out_pt);
+                                             nullptr, 0, vector->iv, vector->iv_len, out_pt);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -579,7 +579,7 @@ static void TestHKDF_SHA256(nlTestSuite * inSuite, void * inContext)
 static void TestDRBG_InvalidInputs(nlTestSuite * inSuite, void * inContext)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
-    error            = DRBG_get_bytes(NULL, 10);
+    error            = DRBG_get_bytes(nullptr, 10);
     NL_TEST_ASSERT(inSuite, error == CHIP_ERROR_INVALID_ARGUMENT);
     error = CHIP_NO_ERROR;
     uint8_t buffer[5];
@@ -660,7 +660,7 @@ static void TestECDSA_SigningInvalidParams(nlTestSuite * inSuite, void * inConte
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
     P256ECDSASignature signature;
-    CHIP_ERROR signing_error = keypair.ECDSA_sign_msg(NULL, msg_length, signature);
+    CHIP_ERROR signing_error = keypair.ECDSA_sign_msg(nullptr, msg_length, signature);
     NL_TEST_ASSERT(inSuite, signing_error == CHIP_ERROR_INVALID_ARGUMENT);
     signing_error = CHIP_NO_ERROR;
 
@@ -681,7 +681,7 @@ static void TestECDSA_ValidationInvalidParam(nlTestSuite * inSuite, void * inCon
     CHIP_ERROR signing_error = keypair.ECDSA_sign_msg((const uint8_t *) msg, msg_length, signature);
     NL_TEST_ASSERT(inSuite, signing_error == CHIP_NO_ERROR);
 
-    CHIP_ERROR validation_error = keypair.Pubkey().ECDSA_validate_msg_signature(NULL, msg_length, signature);
+    CHIP_ERROR validation_error = keypair.Pubkey().ECDSA_validate_msg_signature(nullptr, msg_length, signature);
     NL_TEST_ASSERT(inSuite, validation_error == CHIP_ERROR_INVALID_ARGUMENT);
     validation_error = CHIP_NO_ERROR;
 
@@ -725,7 +725,7 @@ static void TestECDH_EstablishSecret(nlTestSuite * inSuite, void * inContext)
 #if CHIP_CRYPTO_OPENSSL
 static void TestAddEntropySources(nlTestSuite * inSuite, void * inContext)
 {
-    CHIP_ERROR error = add_entropy_source(test_entropy_source, NULL, 10);
+    CHIP_ERROR error = add_entropy_source(test_entropy_source, nullptr, 10);
     NL_TEST_ASSERT(inSuite, error == CHIP_NO_ERROR);
     uint8_t buffer[5];
     NL_TEST_ASSERT(inSuite, DRBG_get_bytes(buffer, sizeof(buffer)) == CHIP_NO_ERROR);
@@ -831,7 +831,7 @@ static void TestSPAKE2P_spake2p_FEMul(nlTestSuite * inSuite, void * inContext)
         const struct spake2p_fe_mul_tv * vector = fe_mul_tvs[vectorIndex];
 
         Spake2p_P256_SHA256_HKDF_HMAC spake2p;
-        CHIP_ERROR err = spake2p.Init(NULL, 0);
+        CHIP_ERROR err = spake2p.Init(nullptr, 0);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
         err = spake2p.FELoad(vector->fe1, vector->fe1_len, spake2p.w0);
@@ -864,7 +864,7 @@ static void TestSPAKE2P_spake2p_FELoadWrite(nlTestSuite * inSuite, void * inCont
         const struct spake2p_fe_rw_tv * vector = fe_rw_tvs[vectorIndex];
 
         Spake2p_P256_SHA256_HKDF_HMAC spake2p;
-        CHIP_ERROR err = spake2p.Init(NULL, 0);
+        CHIP_ERROR err = spake2p.Init(nullptr, 0);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
         err = spake2p.FELoad(vector->fe_in, vector->fe_in_len, spake2p.w0);
@@ -891,7 +891,7 @@ static void TestSPAKE2P_spake2p_Mac(nlTestSuite * inSuite, void * inContext)
         const struct spake2p_hmac_tv * vector = hmac_tvs[vectorIndex];
 
         Spake2p_P256_SHA256_HKDF_HMAC spake2p;
-        CHIP_ERROR err = spake2p.Init(NULL, 0);
+        CHIP_ERROR err = spake2p.Init(nullptr, 0);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
         err = spake2p.Mac(vector->key, vector->key_len, vector->input, vector->input_len, mac);
@@ -921,7 +921,7 @@ static void TestSPAKE2P_spake2p_PointMul(nlTestSuite * inSuite, void * inContext
         const struct spake2p_point_mul_tv * vector = point_mul_tvs[vectorIndex];
 
         Spake2p_P256_SHA256_HKDF_HMAC spake2p;
-        CHIP_ERROR err = spake2p.Init(NULL, 0);
+        CHIP_ERROR err = spake2p.Init(nullptr, 0);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
         err = spake2p.PointLoad(vector->point, vector->point_len, spake2p.L);
@@ -957,7 +957,7 @@ static void TestSPAKE2P_spake2p_PointMulAdd(nlTestSuite * inSuite, void * inCont
         const struct spake2p_point_muladd_tv * vector = point_muladd_tvs[vectorIndex];
 
         Spake2p_P256_SHA256_HKDF_HMAC spake2p;
-        CHIP_ERROR err = spake2p.Init(NULL, 0);
+        CHIP_ERROR err = spake2p.Init(nullptr, 0);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
         err = spake2p.PointLoad(vector->point1, vector->point1_len, spake2p.X);
@@ -999,7 +999,7 @@ static void TestSPAKE2P_spake2p_PointLoadWrite(nlTestSuite * inSuite, void * inC
         const struct spake2p_point_rw_tv * vector = point_rw_tvs[vectorIndex];
 
         Spake2p_P256_SHA256_HKDF_HMAC spake2p;
-        CHIP_ERROR err = spake2p.Init(NULL, 0);
+        CHIP_ERROR err = spake2p.Init(nullptr, 0);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
         err = spake2p.PointLoad(vector->point, vector->point_len, spake2p.L);
@@ -1025,7 +1025,7 @@ static void TestSPAKE2P_spake2p_PointIsValid(nlTestSuite * inSuite, void * inCon
         const struct spake2p_point_valid_tv * vector = point_valid_tvs[vectorIndex];
 
         Spake2p_P256_SHA256_HKDF_HMAC spake2p;
-        CHIP_ERROR err = spake2p.Init(NULL, 0);
+        CHIP_ERROR err = spake2p.Init(nullptr, 0);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
         err = spake2p.PointLoad(vector->point, vector->point_len, spake2p.L);
@@ -1266,14 +1266,14 @@ int TestCHIPCryptoPAL(void)
     {
         "CHIP Crypto PAL tests",
         &sTests[0],
-        NULL,
-        NULL
+        nullptr,
+        nullptr
     };
     // clang-format on
     // Run test suit againt one context.
-    nlTestRunner(&theSuite, NULL);
+    nlTestRunner(&theSuite, nullptr);
 
-    add_entropy_source(test_entropy_source, NULL, 16);
+    add_entropy_source(test_entropy_source, nullptr, 16);
     return (nlTestRunnerStats(&theSuite));
 }
 

--- a/src/crypto/tests/PBKDF2_SHA256_test_vectors.h
+++ b/src/crypto/tests/PBKDF2_SHA256_test_vectors.h
@@ -148,7 +148,7 @@ static const struct pbkdf2_test_vector chiptest_test_vector_10 = { .password = c
                                                                    .slen     = 4,
                                                                    .iter     = 16777216,
                                                                    .key_len  = 20,
-                                                                   .key      = NULL,
+                                                                   .key      = nullptr,
                                                                    .tcId     = 10,
                                                                    .result   = CHIP_ERROR_INVALID_ARGUMENT };
 

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -662,7 +662,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StorePairedAccountId(con
     err = Impl()->WriteConfigValueStr(ImplClass::kConfigKey_PairedAccountId, accountId, accountIdLen);
     SuccessOrExit(err);
 
-    SetFlag(mFlags, kFlag_IsPairedToAccount, (accountId != NULL && accountIdLen != 0));
+    SetFlag(mFlags, kFlag_IsPairedToAccount, (accountId != nullptr && accountIdLen != 0));
 
 exit:
     return err;
@@ -686,7 +686,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StoreServiceProvisioning
     SuccessOrExit(err);
 
     SetFlag(mFlags, kFlag_IsServiceProvisioned);
-    SetFlag(mFlags, kFlag_IsPairedToAccount, (accountId != NULL && accountIdLen != 0));
+    SetFlag(mFlags, kFlag_IsPairedToAccount, (accountId != nullptr && accountIdLen != 0));
 
 exit:
     if (err != CHIP_NO_ERROR)

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_BLE.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_BLE.h
@@ -92,7 +92,7 @@ template <class ImplClass>
 inline void GenericConnectivityManagerImpl_BLE<ImplClass>::_RemoveCHIPoBLEConnectionHandler(void)
 {
     BleLayer * bleLayer                = BLEMgr().GetBleLayer();
-    bleLayer->OnChipBleConnectReceived = NULL;
+    bleLayer->OnChipBleConnectReceived = nullptr;
 }
 
 template <class ImplClass>

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
@@ -204,7 +204,7 @@ inline void GenericConnectivityManagerImpl_WiFi<ImplClass>::_OnWiFiStationProvis
 template <class ImplClass>
 inline const char * GenericConnectivityManagerImpl_WiFi<ImplClass>::_WiFiAPModeToStr(ConnectivityManager::WiFiAPMode mode)
 {
-    return NULL;
+    return nullptr;
 }
 
 } // namespace Internal

--- a/src/include/platform/internal/GenericPlatformManagerImpl.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.ipp
@@ -63,7 +63,7 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack(void)
 
     // Initialize the CHIP system layer.
     new (&SystemLayer) System::Layer();
-    err = SystemLayer.Init(NULL);
+    err = SystemLayer.Init(nullptr);
     if (err != CHIP_SYSTEM_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "SystemLayer initialization failed: %s", ErrorStr(err));
@@ -72,7 +72,7 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack(void)
 
     // Initialize the CHIP Inet layer.
     new (&InetLayer) Inet::InetLayer();
-    err = InetLayer.Init(SystemLayer, NULL);
+    err = InetLayer.Init(SystemLayer, nullptr);
     if (err != INET_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "InetLayer initialization failed: %s", ErrorStr(err));
@@ -118,7 +118,7 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_AddEventHandler(PlatformManag
     AppEventHandler * eventHandler;
 
     // Do nothing if the event handler is already registered.
-    for (eventHandler = mAppEventHandlerList; eventHandler != NULL; eventHandler = eventHandler->Next)
+    for (eventHandler = mAppEventHandlerList; eventHandler != nullptr; eventHandler = eventHandler->Next)
     {
         if (eventHandler->Handler == handler && eventHandler->Arg == arg)
         {
@@ -127,7 +127,7 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_AddEventHandler(PlatformManag
     }
 
     eventHandler = (AppEventHandler *) chip::Platform::MemoryAlloc(sizeof(AppEventHandler));
-    VerifyOrExit(eventHandler != NULL, err = CHIP_ERROR_NO_MEMORY);
+    VerifyOrExit(eventHandler != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     eventHandler->Next    = mAppEventHandlerList;
     eventHandler->Handler = handler;
@@ -144,7 +144,7 @@ void GenericPlatformManagerImpl<ImplClass>::_RemoveEventHandler(PlatformManager:
 {
     AppEventHandler ** eventHandlerIndirectPtr;
 
-    for (eventHandlerIndirectPtr = &mAppEventHandlerList; *eventHandlerIndirectPtr != NULL;)
+    for (eventHandlerIndirectPtr = &mAppEventHandlerList; *eventHandlerIndirectPtr != nullptr;)
     {
         AppEventHandler * eventHandler = (*eventHandlerIndirectPtr);
 
@@ -252,7 +252,7 @@ template <class ImplClass>
 void GenericPlatformManagerImpl<ImplClass>::DispatchEventToApplication(const ChipDeviceEvent * event)
 {
     // Dispatch the event to each of the registered application event handlers.
-    for (AppEventHandler * eventHandler = mAppEventHandlerList; eventHandler != NULL; eventHandler = eventHandler->Next)
+    for (AppEventHandler * eventHandler = mAppEventHandlerList; eventHandler != nullptr; eventHandler = eventHandler->Next)
     {
         eventHandler->Handler(event, eventHandler->Arg);
     }

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
@@ -201,7 +201,7 @@ void * GenericPlatformManagerImpl_POSIX<ImplClass>::EventLoopTaskMain(void * arg
     ChipLogDetail(DeviceLayer, "CHIP task running");
 
     static_cast<GenericPlatformManagerImpl_POSIX<ImplClass> *>(arg)->Impl()->RunEventLoop();
-    return NULL;
+    return nullptr;
 }
 
 template <class ImplClass>
@@ -227,7 +227,7 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_Shutdown(void)
     mShouldRunEventLoop.store(false, std::memory_order_relaxed);
     if (mChipTask)
     {
-        SuccessOrExit(err = pthread_join(mChipTask, NULL));
+        SuccessOrExit(err = pthread_join(mChipTask, nullptr));
     }
 
 exit:

--- a/src/include/platform/internal/testing/ConfigUnitTest.h
+++ b/src/include/platform/internal/testing/ConfigUnitTest.h
@@ -119,7 +119,7 @@ void RunConfigUnitTest(void)
         char buf[64];
         size_t strLen;
 
-        err = ConfigClass::WriteConfigValueStr(ConfigClass::kConfigKey_PairedAccountId, NULL);
+        err = ConfigClass::WriteConfigValueStr(ConfigClass::kConfigKey_PairedAccountId, nullptr);
         VerifyOrDie(err == CHIP_NO_ERROR);
 
         err = ConfigClass::ReadConfigValueStr(ConfigClass::kConfigKey_PairedAccountId, buf, sizeof(buf), strLen);
@@ -161,7 +161,7 @@ void RunConfigUnitTest(void)
         uint8_t buf[512];
         size_t dataLen;
 
-        err = ConfigClass::WriteConfigValueBin(ConfigClass::kConfigKey_MfrDeviceCert, NULL, 0);
+        err = ConfigClass::WriteConfigValueBin(ConfigClass::kConfigKey_MfrDeviceCert, nullptr, 0);
         VerifyOrDie(err == CHIP_NO_ERROR);
 
         err = ConfigClass::ReadConfigValueBin(ConfigClass::kConfigKey_MfrDeviceCert, buf, sizeof(buf), dataLen);

--- a/src/inet/AsyncDNSResolverSockets.cpp
+++ b/src/inet/AsyncDNSResolverSockets.cpp
@@ -56,19 +56,19 @@ INET_ERROR AsyncDNSResolverSockets::Init(InetLayer * aInet)
 
     mInet = aInet;
 
-    mAsyncDNSQueueHead = NULL;
-    mAsyncDNSQueueTail = NULL;
+    mAsyncDNSQueueHead = nullptr;
+    mAsyncDNSQueueTail = nullptr;
 
-    pthreadErr = pthread_cond_init(&mAsyncDNSCondVar, NULL);
+    pthreadErr = pthread_cond_init(&mAsyncDNSCondVar, nullptr);
     VerifyOrDie(pthreadErr == 0);
 
-    pthreadErr = pthread_mutex_init(&mAsyncDNSMutex, NULL);
+    pthreadErr = pthread_mutex_init(&mAsyncDNSMutex, nullptr);
     VerifyOrDie(pthreadErr == 0);
 
     // Create the thread pool for asynchronous DNS resolution.
     for (int i = 0; i < INET_CONFIG_DNS_ASYNC_MAX_THREAD_COUNT; i++)
     {
-        pthreadErr = pthread_create(&mAsyncDNSThreadHandle[i], NULL, &AsyncDNSThreadRun, this);
+        pthreadErr = pthread_create(&mAsyncDNSThreadHandle[i], nullptr, &AsyncDNSThreadRun, this);
         VerifyOrDie(pthreadErr == 0);
     }
 
@@ -100,7 +100,7 @@ INET_ERROR AsyncDNSResolverSockets::Shutdown(void)
     // Have the CHIP thread join the thread pool for asynchronous DNS resolution.
     for (int i = 0; i < INET_CONFIG_DNS_ASYNC_MAX_THREAD_COUNT; i++)
     {
-        pthreadErr = pthread_join(mAsyncDNSThreadHandle[i], NULL);
+        pthreadErr = pthread_join(mAsyncDNSThreadHandle[i], nullptr);
         VerifyOrDie(pthreadErr == 0);
     }
 
@@ -152,7 +152,7 @@ INET_ERROR AsyncDNSResolverSockets::PrepareDNSResolver(DNSResolver & resolver, c
     resolver.OnComplete                    = onComplete;
     resolver.asyncDNSResolveResult         = INET_NO_ERROR;
     resolver.mState                        = DNSResolver::kState_Active;
-    resolver.pNextAsyncDNSResolver         = NULL;
+    resolver.pNextAsyncDNSResolver         = nullptr;
 
     return err;
 }
@@ -177,12 +177,12 @@ INET_ERROR AsyncDNSResolverSockets::EnqueueRequest(DNSResolver & resolver)
     AsyncMutexLock();
 
     // Add the DNSResolver object to the queue.
-    if (mAsyncDNSQueueHead == NULL)
+    if (mAsyncDNSQueueHead == nullptr)
     {
         mAsyncDNSQueueHead = &resolver;
     }
 
-    if (mAsyncDNSQueueTail != NULL)
+    if (mAsyncDNSQueueTail != nullptr)
     {
         mAsyncDNSQueueTail->pNextAsyncDNSResolver = &resolver;
     }
@@ -210,7 +210,7 @@ INET_ERROR AsyncDNSResolverSockets::DequeueRequest(DNSResolver ** outResolver)
     AsyncMutexLock();
 
     // block until there is work to do or we detect a shutdown
-    while ((mAsyncDNSQueueHead == NULL) && (mInet->State == InetLayer::kState_Initialized))
+    while ((mAsyncDNSQueueHead == nullptr) && (mInet->State == InetLayer::kState_Initialized))
     {
         pthreadErr = pthread_cond_wait(&mAsyncDNSCondVar, &mAsyncDNSMutex);
         VerifyOrDie(pthreadErr == 0);
@@ -221,7 +221,7 @@ INET_ERROR AsyncDNSResolverSockets::DequeueRequest(DNSResolver ** outResolver)
     // on shutdown, return NULL. Otherwise, pop the head of the DNS request queue
     if (mInet->State != InetLayer::kState_Initialized)
     {
-        *outResolver = NULL;
+        *outResolver = nullptr;
     }
     else
     {
@@ -229,10 +229,10 @@ INET_ERROR AsyncDNSResolverSockets::DequeueRequest(DNSResolver ** outResolver)
 
         mAsyncDNSQueueHead = mAsyncDNSQueueHead->pNextAsyncDNSResolver;
 
-        if (mAsyncDNSQueueHead == NULL)
+        if (mAsyncDNSQueueHead == nullptr)
         {
             // Queue is empty
-            mAsyncDNSQueueTail = NULL;
+            mAsyncDNSQueueTail = nullptr;
         }
     }
 
@@ -263,7 +263,7 @@ void AsyncDNSResolverSockets::UpdateDNSResult(DNSResolver & resolver, struct add
 {
     resolver.NumAddrs = 0;
 
-    for (struct addrinfo * addr = inLookupRes; addr != NULL && resolver.NumAddrs < resolver.MaxAddrs;
+    for (struct addrinfo * addr = inLookupRes; addr != nullptr && resolver.NumAddrs < resolver.MaxAddrs;
          addr                   = addr->ai_next, resolver.NumAddrs++)
     {
         resolver.AddrArray[resolver.NumAddrs] = IPAddress::FromSockAddr(*addr->ai_addr);
@@ -273,14 +273,14 @@ void AsyncDNSResolverSockets::UpdateDNSResult(DNSResolver & resolver, struct add
 void AsyncDNSResolverSockets::Resolve(DNSResolver & resolver)
 {
     struct addrinfo gaiHints;
-    struct addrinfo * gaiResults = NULL;
+    struct addrinfo * gaiResults = nullptr;
     int gaiReturnCode;
 
     // Configure the hints argument for getaddrinfo()
     resolver.InitAddrInfoHints(gaiHints);
 
     // Call getaddrinfo() to perform the name resolution.
-    gaiReturnCode = getaddrinfo(resolver.asyncHostNameBuf, NULL, &gaiHints, &gaiResults);
+    gaiReturnCode = getaddrinfo(resolver.asyncHostNameBuf, nullptr, &gaiHints, &gaiResults);
 
     // Mutex protects the read and write operation on resolver->mState
     AsyncMutexLock();
@@ -326,7 +326,7 @@ void * AsyncDNSResolverSockets::AsyncDNSThreadRun(void * args)
 
     while (true)
     {
-        DNSResolver * request = NULL;
+        DNSResolver * request = nullptr;
 
         // Dequeue a DNSResolver for resolution. This function would block until there
         // is an item in the queue or shutdown has been called.
@@ -334,7 +334,7 @@ void * AsyncDNSResolverSockets::AsyncDNSThreadRun(void * args)
 
         // If shutdown has been called, DeQueue would return with an empty request.
         // In that case, break out of the loop and exit thread.
-        VerifyOrExit(err == INET_NO_ERROR && request != NULL, );
+        VerifyOrExit(err == INET_NO_ERROR && request != nullptr, );
 
         if (request->mState != DNSResolver::kState_Canceled)
         {
@@ -346,7 +346,7 @@ void * AsyncDNSResolverSockets::AsyncDNSThreadRun(void * args)
 
 exit:
     ChipLogDetail(Inet, "Async DNS worker thread exiting.");
-    return NULL;
+    return nullptr;
 }
 
 void AsyncDNSResolverSockets::AsyncMutexLock(void)

--- a/src/inet/DNSResolver.cpp
+++ b/src/inet/DNSResolver.cpp
@@ -210,14 +210,14 @@ INET_ERROR DNSResolver::Resolve(const char * hostName, uint16_t hostNameLen, uin
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
     struct addrinfo gaiHints;
-    struct addrinfo * gaiResults = NULL;
+    struct addrinfo * gaiResults = nullptr;
     int gaiReturnCode;
 
     // Configure the hints argument for getaddrinfo()
     InitAddrInfoHints(gaiHints);
 
     // Call getaddrinfo() to perform the name resolution.
-    gaiReturnCode = getaddrinfo(hostNameBuf, NULL, &gaiHints, &gaiResults);
+    gaiReturnCode = getaddrinfo(hostNameBuf, nullptr, &gaiHints, &gaiResults);
 
     // Process the return code and results list returned by getaddrinfo(). If the call
     // was successful this will copy the resultant addresses into the caller's array.
@@ -276,8 +276,8 @@ INET_ERROR DNSResolver::Cancel()
 
     InetLayer & inet = Layer();
 
-    OnComplete = NULL;
-    AppState   = NULL;
+    OnComplete = nullptr;
+    AppState   = nullptr;
     inet.mAsyncDNSResolver.Cancel(*this);
 
 #endif // INET_CONFIG_ENABLE_ASYNC_DNS_SOCKETS
@@ -486,7 +486,7 @@ INET_ERROR DNSResolver::ProcessGetAddrInfoResult(int returnCode, struct addrinfo
     }
 
     // Free the results structure.
-    if (results != NULL)
+    if (results != nullptr)
         freeaddrinfo(results);
 
     return err;
@@ -494,7 +494,7 @@ INET_ERROR DNSResolver::ProcessGetAddrInfoResult(int returnCode, struct addrinfo
 
 void DNSResolver::CopyAddresses(int family, uint8_t count, const struct addrinfo * addrs)
 {
-    for (const struct addrinfo * addr = addrs; addr != NULL && NumAddrs < MaxAddrs && count > 0; addr = addr->ai_next)
+    for (const struct addrinfo * addr = addrs; addr != nullptr && NumAddrs < MaxAddrs && count > 0; addr = addr->ai_next)
     {
         if (family == AF_UNSPEC || addr->ai_addr->sa_family == family)
         {
@@ -508,7 +508,7 @@ uint8_t DNSResolver::CountAddresses(int family, const struct addrinfo * addrs)
 {
     uint8_t count = 0;
 
-    for (const struct addrinfo * addr = addrs; addr != NULL && count < UINT8_MAX; addr = addr->ai_next)
+    for (const struct addrinfo * addr = addrs; addr != nullptr && count < UINT8_MAX; addr = addr->ai_next)
     {
         if (family == AF_UNSPEC || addr->ai_addr->sa_family == family)
         {

--- a/src/inet/EndPointBasis.h
+++ b/src/inet/EndPointBasis.h
@@ -130,7 +130,7 @@ protected:
     void DeferredFree(chip::System::Object::ReleaseDeferralErrorTactic aTactic);
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
-    void InitEndPointBasis(InetLayer & aInetLayer, void * aAppState = NULL);
+    void InitEndPointBasis(InetLayer & aInetLayer, void * aAppState = nullptr);
 };
 
 #if CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK

--- a/src/inet/IPAddress-StringFuncts.cpp
+++ b/src/inet/IPAddress-StringFuncts.cpp
@@ -84,7 +84,7 @@ char * IPAddress::ToString(char * buf, uint32_t bufSize) const
 bool IPAddress::FromString(const char * str, IPAddress & output)
 {
 #if INET_CONFIG_ENABLE_IPV4
-    if (strchr(str, ':') == NULL)
+    if (strchr(str, ':') == nullptr)
     {
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 #if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5

--- a/src/inet/IPEndPointBasis.cpp
+++ b/src/inet/IPEndPointBasis.cpp
@@ -810,7 +810,7 @@ INET_ERROR IPEndPointBasis::SendMsg(const IPPacketInfo * aPktInfo, chip::System:
     VerifyOrExit(mAddrType == aPktInfo->DestAddress.Type(), res = INET_ERROR_BAD_ARGS);
 
     // For now the entire message must fit within a single buffer.
-    VerifyOrExit(aBuffer->Next() == NULL, res = INET_ERROR_MESSAGE_TOO_LONG);
+    VerifyOrExit(aBuffer->Next() == nullptr, res = INET_ERROR_MESSAGE_TOO_LONG);
 
     memset(&msgHeader, 0, sizeof(msgHeader));
 
@@ -1045,7 +1045,7 @@ SocketEvents IPEndPointBasis::PrepareIO(void)
 {
     SocketEvents res;
 
-    if (mState == kState_Listening && OnMessageReceived != NULL)
+    if (mState == kState_Listening && OnMessageReceived != nullptr)
         res.SetRead();
 
     return res;
@@ -1062,7 +1062,7 @@ void IPEndPointBasis::HandlePendingIO(uint16_t aPort)
 
     lBuffer = PacketBuffer::New(0);
 
-    if (lBuffer != NULL)
+    if (lBuffer != nullptr)
     {
         struct iovec msgIOV;
         PeerSockAddr lPeerSockAddr;
@@ -1117,7 +1117,7 @@ void IPEndPointBasis::HandlePendingIO(uint16_t aPort)
 
         if (lStatus == INET_NO_ERROR)
         {
-            for (struct cmsghdr * controlHdr = CMSG_FIRSTHDR(&msgHeader); controlHdr != NULL;
+            for (struct cmsghdr * controlHdr = CMSG_FIRSTHDR(&msgHeader); controlHdr != nullptr;
                  controlHdr                  = CMSG_NXTHDR(&msgHeader, controlHdr))
             {
 #if INET_CONFIG_ENABLE_IPV4
@@ -1164,8 +1164,8 @@ void IPEndPointBasis::HandlePendingIO(uint16_t aPort)
     else
     {
         PacketBuffer::Free(lBuffer);
-        if (OnReceiveError != NULL && lStatus != chip::System::MapErrorPOSIX(EAGAIN))
-            OnReceiveError(this, lStatus, NULL);
+        if (OnReceiveError != nullptr && lStatus != chip::System::MapErrorPOSIX(EAGAIN))
+            OnReceiveError(this, lStatus, nullptr);
     }
 
     return;

--- a/src/inet/InetError.cpp
+++ b/src/inet/InetError.cpp
@@ -38,7 +38,7 @@ namespace Inet {
  */
 void RegisterLayerErrorFormatter(void)
 {
-    static chip::ErrorFormatter sInetLayerErrorFormatter = { FormatLayerError, NULL };
+    static chip::ErrorFormatter sInetLayerErrorFormatter = { FormatLayerError, nullptr };
 
     RegisterErrorFormatter(&sInetLayerErrorFormatter);
 }
@@ -57,7 +57,7 @@ void RegisterLayerErrorFormatter(void)
  */
 bool FormatLayerError(char * buf, uint16_t bufSize, int32_t err)
 {
-    const char * desc = NULL;
+    const char * desc = nullptr;
 
     if (err < INET_ERROR_MIN || err > INET_ERROR_MAX)
     {

--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -97,7 +97,7 @@ DLL_EXPORT INET_ERROR GetInterfaceName(InterfaceId intfId, char * nameBuf, size_
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS && CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
         char intfName[IF_NAMESIZE];
-        if (if_indextoname(intfId, intfName) == NULL)
+        if (if_indextoname(intfId, intfName) == nullptr)
             return chip::System::MapErrorPOSIX(errno);
         if (strlen(intfName) >= nameBufSize)
             return INET_ERROR_NO_MEMORY;
@@ -394,7 +394,7 @@ exit:
 
 InterfaceIterator::InterfaceIterator(void)
 {
-    mIntfArray       = NULL;
+    mIntfArray       = nullptr;
     mCurIntf         = 0;
     mIntfFlags       = 0;
     mIntfFlagsCached = 0;
@@ -419,14 +419,14 @@ InterfaceIterator::InterfaceIterator() : mCurrentInterface(net_if_get_by_index(m
 
 InterfaceIterator::~InterfaceIterator(void)
 {
-    if (mIntfArray != NULL)
+    if (mIntfArray != nullptr)
     {
 #if __ANDROID__ && __ANDROID_API__ < 24
         backport_if_freenameindex(mIntfArray);
 #else
         if_freenameindex(mIntfArray);
 #endif
-        mIntfArray = NULL;
+        mIntfArray = nullptr;
     }
 }
 
@@ -444,7 +444,7 @@ InterfaceIterator::~InterfaceIterator(void)
 #if CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
 bool InterfaceIterator::HasCurrent(void)
 {
-    return (mIntfArray != NULL) ? mIntfArray[mCurIntf].if_index != 0 : Next();
+    return (mIntfArray != nullptr) ? mIntfArray[mCurIntf].if_index != 0 : Next();
 }
 #endif // CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
 
@@ -479,7 +479,7 @@ bool InterfaceIterator::Next(void)
 {
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS && CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
 
-    if (mIntfArray == NULL)
+    if (mIntfArray == nullptr)
     {
 #if __ANDROID__ && __ANDROID_API__ < 24
         mIntfArray = backport_if_nameindex();
@@ -493,7 +493,7 @@ bool InterfaceIterator::Next(void)
         mIntfFlags       = 0;
         mIntfFlagsCached = false;
     }
-    return (mIntfArray != NULL && mIntfArray[mCurIntf].if_index != 0);
+    return (mIntfArray != nullptr && mIntfArray[mCurIntf].if_index != 0);
 
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS && CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
 
@@ -705,8 +705,8 @@ short InterfaceIterator::GetFlags(void)
  */
 InterfaceAddressIterator::InterfaceAddressIterator(void)
 {
-    mAddrsList = NULL;
-    mCurAddr   = NULL;
+    mAddrsList = nullptr;
+    mCurAddr   = nullptr;
 }
 #endif // CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
 
@@ -726,10 +726,10 @@ InterfaceAddressIterator::InterfaceAddressIterator() = default;
 #if CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
 InterfaceAddressIterator::~InterfaceAddressIterator(void)
 {
-    if (mAddrsList != NULL)
+    if (mAddrsList != nullptr)
     {
         freeifaddrs(mAddrsList);
-        mAddrsList = mCurAddr = NULL;
+        mAddrsList = mCurAddr = nullptr;
     }
 }
 #endif // CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
@@ -745,7 +745,7 @@ InterfaceAddressIterator::~InterfaceAddressIterator(void)
 bool InterfaceAddressIterator::HasCurrent(void)
 {
 #if CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
-    return (mAddrsList != NULL) ? (mCurAddr != NULL) : Next();
+    return (mAddrsList != nullptr) ? (mCurAddr != nullptr) : Next();
 #endif // CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
 
 #if CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
@@ -778,7 +778,7 @@ bool InterfaceAddressIterator::Next(void)
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS && CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
     while (true)
     {
-        if (mAddrsList == NULL)
+        if (mAddrsList == nullptr)
         {
             int res = getifaddrs(&mAddrsList);
             if (res < 0)
@@ -787,17 +787,17 @@ bool InterfaceAddressIterator::Next(void)
             }
             mCurAddr = mAddrsList;
         }
-        else if (mCurAddr != NULL)
+        else if (mCurAddr != nullptr)
         {
             mCurAddr = mCurAddr->ifa_next;
         }
 
-        if (mCurAddr == NULL)
+        if (mCurAddr == nullptr)
         {
             return false;
         }
 
-        if (mCurAddr->ifa_addr != NULL &&
+        if (mCurAddr->ifa_addr != nullptr &&
             (mCurAddr->ifa_addr->sa_family == AF_INET6
 #if INET_CONFIG_ENABLE_IPV4
              || mCurAddr->ifa_addr->sa_family == AF_INET

--- a/src/inet/InetLayer.cpp
+++ b/src/inet/InetLayer.cpp
@@ -262,7 +262,7 @@ INET_ERROR InetLayer::Init(chip::System::Layer & aSystemLayer, void * aContext)
     // member. Ensure it is set to a sane default value before
     // invoking platform-specific initialization.
 
-    mPlatformData = NULL;
+    mPlatformData = nullptr;
 
     err = Platform::InetLayer::WillInit(this, aContext);
     SuccessOrExit(err);
@@ -322,7 +322,7 @@ INET_ERROR InetLayer::Shutdown(void)
         for (size_t i = 0; i < DNSResolver::sPool.Size(); i++)
         {
             DNSResolver * lResolver = DNSResolver::sPool.Get(*mSystemLayer, i);
-            if ((lResolver != NULL) && lResolver->IsCreatedByInetLayer(*this))
+            if ((lResolver != nullptr) && lResolver->IsCreatedByInetLayer(*this))
             {
                 lResolver->Cancel();
             }
@@ -340,7 +340,7 @@ INET_ERROR InetLayer::Shutdown(void)
         for (size_t i = 0; i < RawEndPoint::sPool.Size(); i++)
         {
             RawEndPoint * lEndPoint = RawEndPoint::sPool.Get(*mSystemLayer, i);
-            if ((lEndPoint != NULL) && lEndPoint->IsCreatedByInetLayer(*this))
+            if ((lEndPoint != nullptr) && lEndPoint->IsCreatedByInetLayer(*this))
             {
                 lEndPoint->Close();
             }
@@ -352,7 +352,7 @@ INET_ERROR InetLayer::Shutdown(void)
         for (size_t i = 0; i < TCPEndPoint::sPool.Size(); i++)
         {
             TCPEndPoint * lEndPoint = TCPEndPoint::sPool.Get(*mSystemLayer, i);
-            if ((lEndPoint != NULL) && lEndPoint->IsCreatedByInetLayer(*this))
+            if ((lEndPoint != nullptr) && lEndPoint->IsCreatedByInetLayer(*this))
             {
                 lEndPoint->Abort();
             }
@@ -364,7 +364,7 @@ INET_ERROR InetLayer::Shutdown(void)
         for (size_t i = 0; i < UDPEndPoint::sPool.Size(); i++)
         {
             UDPEndPoint * lEndPoint = UDPEndPoint::sPool.Get(*mSystemLayer, i);
-            if ((lEndPoint != NULL) && lEndPoint->IsCreatedByInetLayer(*this))
+            if ((lEndPoint != nullptr) && lEndPoint->IsCreatedByInetLayer(*this))
             {
                 lEndPoint->Close();
             }
@@ -415,7 +415,7 @@ bool InetLayer::IsIdleTimerRunning(void)
     {
         TCPEndPoint * lEndPoint = TCPEndPoint::sPool.Get(*mSystemLayer, i);
 
-        if ((lEndPoint != NULL) && (lEndPoint->mIdleTimeout != 0))
+        if ((lEndPoint != nullptr) && (lEndPoint->mIdleTimeout != 0))
         {
             timerRunning = true;
             break;
@@ -452,7 +452,7 @@ INET_ERROR InetLayer::GetLinkLocalAddr(InterfaceId link, IPAddress * llAddr)
 #endif //! LWIP_IPV6
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
-    if (llAddr == NULL)
+    if (llAddr == nullptr)
     {
         err = INET_ERROR_BAD_ARGS;
         goto exit;
@@ -487,10 +487,10 @@ INET_ERROR InetLayer::GetLinkLocalAddr(InterfaceId link, IPAddress * llAddr)
     if (rv != -1)
     {
         struct ifaddrs * ifaddr_iter = ifaddr;
-        while (ifaddr_iter != NULL)
+        while (ifaddr_iter != nullptr)
         {
 
-            if (ifaddr_iter->ifa_addr != NULL)
+            if (ifaddr_iter->ifa_addr != nullptr)
             {
                 if ((ifaddr_iter->ifa_addr->sa_family == AF_INET6) &&
                     ((link == INET_NULL_INTERFACEID) || (if_nametoindex(ifaddr_iter->ifa_name) == link)))
@@ -555,12 +555,12 @@ exit:
 INET_ERROR InetLayer::NewRawEndPoint(IPVersion ipVer, IPProtocol ipProto, RawEndPoint ** retEndPoint)
 {
     INET_ERROR err = INET_NO_ERROR;
-    *retEndPoint   = NULL;
+    *retEndPoint   = nullptr;
 
     VerifyOrExit(State == kState_Initialized, err = INET_ERROR_INCORRECT_STATE);
 
     *retEndPoint = RawEndPoint::sPool.TryCreate(*mSystemLayer);
-    if (*retEndPoint != NULL)
+    if (*retEndPoint != nullptr)
     {
         (*retEndPoint)->Inet::RawEndPoint::Init(this, ipVer, ipProto);
         SYSTEM_STATS_INCREMENT(chip::System::Stats::kInetLayer_NumRawEps);
@@ -597,12 +597,12 @@ exit:
 INET_ERROR InetLayer::NewTCPEndPoint(TCPEndPoint ** retEndPoint)
 {
     INET_ERROR err = INET_NO_ERROR;
-    *retEndPoint   = NULL;
+    *retEndPoint   = nullptr;
 
     VerifyOrExit(State == kState_Initialized, err = INET_ERROR_INCORRECT_STATE);
 
     *retEndPoint = TCPEndPoint::sPool.TryCreate(*mSystemLayer);
-    if (*retEndPoint != NULL)
+    if (*retEndPoint != nullptr)
     {
         (*retEndPoint)->Init(this);
         SYSTEM_STATS_INCREMENT(chip::System::Stats::kInetLayer_NumTCPEps);
@@ -639,12 +639,12 @@ exit:
 INET_ERROR InetLayer::NewUDPEndPoint(UDPEndPoint ** retEndPoint)
 {
     INET_ERROR err = INET_NO_ERROR;
-    *retEndPoint   = NULL;
+    *retEndPoint   = nullptr;
 
     VerifyOrExit(State == kState_Initialized, err = INET_ERROR_INCORRECT_STATE);
 
     *retEndPoint = UDPEndPoint::sPool.TryCreate(*mSystemLayer);
-    if (*retEndPoint != NULL)
+    if (*retEndPoint != nullptr)
     {
         (*retEndPoint)->Init(this);
         SYSTEM_STATS_INCREMENT(chip::System::Stats::kInetLayer_NumUDPEps);
@@ -809,7 +809,7 @@ INET_ERROR InetLayer::ResolveHostAddress(const char * hostName, uint16_t hostNam
                                          IPAddress * addrArray, DNSResolveCompleteFunct onComplete, void * appState)
 {
     INET_ERROR err         = INET_NO_ERROR;
-    DNSResolver * resolver = NULL;
+    DNSResolver * resolver = nullptr;
 
     VerifyOrExit(State == kState_Initialized, err = INET_ERROR_INCORRECT_STATE);
 
@@ -820,7 +820,7 @@ INET_ERROR InetLayer::ResolveHostAddress(const char * hostName, uint16_t hostNam
     VerifyOrExit(maxAddrs > 0, err = INET_ERROR_NO_MEMORY);
 
     resolver = DNSResolver::sPool.TryCreate(*mSystemLayer);
-    if (resolver != NULL)
+    if (resolver != nullptr)
     {
         resolver->InitInetLayerBasis(*this);
     }
@@ -852,7 +852,7 @@ INET_ERROR InetLayer::ResolveHostAddress(const char * hostName, uint16_t hostNam
         }
 
         resolver->Release();
-        resolver = NULL;
+        resolver = nullptr;
 
         ExitNow(err = INET_NO_ERROR);
     }
@@ -905,7 +905,7 @@ void InetLayer::CancelResolveHostAddress(DNSResolveCompleteFunct onComplete, voi
     {
         DNSResolver * lResolver = DNSResolver::sPool.Get(*mSystemLayer, i);
 
-        if (lResolver == NULL)
+        if (lResolver == nullptr)
         {
             continue;
         }
@@ -1017,7 +1017,7 @@ void InetLayer::HandleTCPInactivityTimer(chip::System::Layer * aSystemLayer, voi
     {
         TCPEndPoint * lEndPoint = TCPEndPoint::sPool.Get(*aSystemLayer, i);
 
-        if (lEndPoint == NULL)
+        if (lEndPoint == nullptr)
             continue;
         if (!lEndPoint->IsCreatedByInetLayer(lInetLayer))
             continue;
@@ -1139,7 +1139,7 @@ void InetLayer::PrepareSelect(int & nfds, fd_set * readfds, fd_set * writefds, f
     for (size_t i = 0; i < RawEndPoint::sPool.Size(); i++)
     {
         RawEndPoint * lEndPoint = RawEndPoint::sPool.Get(*mSystemLayer, i);
-        if ((lEndPoint != NULL) && lEndPoint->IsCreatedByInetLayer(*this))
+        if ((lEndPoint != nullptr) && lEndPoint->IsCreatedByInetLayer(*this))
             lEndPoint->PrepareIO().SetFDs(lEndPoint->mSocket, nfds, readfds, writefds, exceptfds);
     }
 #endif // INET_CONFIG_ENABLE_RAW_ENDPOINT
@@ -1148,7 +1148,7 @@ void InetLayer::PrepareSelect(int & nfds, fd_set * readfds, fd_set * writefds, f
     for (size_t i = 0; i < TCPEndPoint::sPool.Size(); i++)
     {
         TCPEndPoint * lEndPoint = TCPEndPoint::sPool.Get(*mSystemLayer, i);
-        if ((lEndPoint != NULL) && lEndPoint->IsCreatedByInetLayer(*this))
+        if ((lEndPoint != nullptr) && lEndPoint->IsCreatedByInetLayer(*this))
             lEndPoint->PrepareIO().SetFDs(lEndPoint->mSocket, nfds, readfds, writefds, exceptfds);
     }
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
@@ -1157,7 +1157,7 @@ void InetLayer::PrepareSelect(int & nfds, fd_set * readfds, fd_set * writefds, f
     for (size_t i = 0; i < UDPEndPoint::sPool.Size(); i++)
     {
         UDPEndPoint * lEndPoint = UDPEndPoint::sPool.Get(*mSystemLayer, i);
-        if ((lEndPoint != NULL) && lEndPoint->IsCreatedByInetLayer(*this))
+        if ((lEndPoint != nullptr) && lEndPoint->IsCreatedByInetLayer(*this))
             lEndPoint->PrepareIO().SetFDs(lEndPoint->mSocket, nfds, readfds, writefds, exceptfds);
     }
 #endif // INET_CONFIG_ENABLE_UDP_ENDPOINT
@@ -1205,7 +1205,7 @@ void InetLayer::HandleSelectResult(int selectRes, fd_set * readfds, fd_set * wri
         for (size_t i = 0; i < RawEndPoint::sPool.Size(); i++)
         {
             RawEndPoint * lEndPoint = RawEndPoint::sPool.Get(*mSystemLayer, i);
-            if ((lEndPoint != NULL) && lEndPoint->IsCreatedByInetLayer(*this))
+            if ((lEndPoint != nullptr) && lEndPoint->IsCreatedByInetLayer(*this))
             {
                 lEndPoint->mPendingIO = SocketEvents::FromFDs(lEndPoint->mSocket, readfds, writefds, exceptfds);
             }
@@ -1216,7 +1216,7 @@ void InetLayer::HandleSelectResult(int selectRes, fd_set * readfds, fd_set * wri
         for (size_t i = 0; i < TCPEndPoint::sPool.Size(); i++)
         {
             TCPEndPoint * lEndPoint = TCPEndPoint::sPool.Get(*mSystemLayer, i);
-            if ((lEndPoint != NULL) && lEndPoint->IsCreatedByInetLayer(*this))
+            if ((lEndPoint != nullptr) && lEndPoint->IsCreatedByInetLayer(*this))
             {
                 lEndPoint->mPendingIO = SocketEvents::FromFDs(lEndPoint->mSocket, readfds, writefds, exceptfds);
             }
@@ -1227,7 +1227,7 @@ void InetLayer::HandleSelectResult(int selectRes, fd_set * readfds, fd_set * wri
         for (size_t i = 0; i < UDPEndPoint::sPool.Size(); i++)
         {
             UDPEndPoint * lEndPoint = UDPEndPoint::sPool.Get(*mSystemLayer, i);
-            if ((lEndPoint != NULL) && lEndPoint->IsCreatedByInetLayer(*this))
+            if ((lEndPoint != nullptr) && lEndPoint->IsCreatedByInetLayer(*this))
             {
                 lEndPoint->mPendingIO = SocketEvents::FromFDs(lEndPoint->mSocket, readfds, writefds, exceptfds);
             }
@@ -1239,7 +1239,7 @@ void InetLayer::HandleSelectResult(int selectRes, fd_set * readfds, fd_set * wri
         for (size_t i = 0; i < RawEndPoint::sPool.Size(); i++)
         {
             RawEndPoint * lEndPoint = RawEndPoint::sPool.Get(*mSystemLayer, i);
-            if ((lEndPoint != NULL) && lEndPoint->IsCreatedByInetLayer(*this))
+            if ((lEndPoint != nullptr) && lEndPoint->IsCreatedByInetLayer(*this))
             {
                 lEndPoint->HandlePendingIO();
             }
@@ -1250,7 +1250,7 @@ void InetLayer::HandleSelectResult(int selectRes, fd_set * readfds, fd_set * wri
         for (size_t i = 0; i < TCPEndPoint::sPool.Size(); i++)
         {
             TCPEndPoint * lEndPoint = TCPEndPoint::sPool.Get(*mSystemLayer, i);
-            if ((lEndPoint != NULL) && lEndPoint->IsCreatedByInetLayer(*this))
+            if ((lEndPoint != nullptr) && lEndPoint->IsCreatedByInetLayer(*this))
             {
                 lEndPoint->HandlePendingIO();
             }
@@ -1261,7 +1261,7 @@ void InetLayer::HandleSelectResult(int selectRes, fd_set * readfds, fd_set * wri
         for (size_t i = 0; i < UDPEndPoint::sPool.Size(); i++)
         {
             UDPEndPoint * lEndPoint = UDPEndPoint::sPool.Get(*mSystemLayer, i);
-            if ((lEndPoint != NULL) && lEndPoint->IsCreatedByInetLayer(*this))
+            if ((lEndPoint != nullptr) && lEndPoint->IsCreatedByInetLayer(*this))
             {
                 lEndPoint->HandlePendingIO();
             }

--- a/src/inet/InetLayerBasis.h
+++ b/src/inet/InetLayerBasis.h
@@ -57,7 +57,7 @@ public:
     bool IsCreatedByInetLayer(const InetLayer & aInetLayer) const;
 
 protected:
-    void InitInetLayerBasis(InetLayer & aInetLayer, void * aAppState = NULL);
+    void InitInetLayerBasis(InetLayer & aInetLayer, void * aAppState = nullptr);
 
 private:
     InetLayer * mInetLayer; /**< Pointer to the InetLayer object that owns this object. */

--- a/src/inet/InetUtils.cpp
+++ b/src/inet/InetUtils.cpp
@@ -82,7 +82,7 @@ DLL_EXPORT INET_ERROR ParseHostAndPort(const char * aString, uint16_t aStringLen
     {
         // Search for the end bracket.
         p = (const char *) memchr(aString, ']', aStringLen);
-        if (p == NULL)
+        if (p == nullptr)
             return INET_ERROR_INVALID_HOST_NAME;
 
         // Return the IPv6 address.
@@ -110,7 +110,7 @@ DLL_EXPORT INET_ERROR ParseHostAndPort(const char * aString, uint16_t aStringLen
         //
         // Note: The cast is safe because p points into the string of p is not
         // null, so end - p - 1 can't be negative.
-        if (p == NULL || memchr(p + 1, ':', static_cast<size_t>(end - p - 1)) != NULL)
+        if (p == nullptr || memchr(p + 1, ':', static_cast<size_t>(end - p - 1)) != nullptr)
             p = end;
 
         // Return the host/address portion.
@@ -201,7 +201,7 @@ DLL_EXPORT INET_ERROR ParseHostPortAndInterface(const char * aString, uint16_t a
 {
     const char * end = aString + aStringLen;
 
-    aInterface    = NULL;
+    aInterface    = nullptr;
     aInterfaceLen = 0;
 
     for (uint16_t i = 1; i < aStringLen; i++)

--- a/src/inet/RawEndPoint.cpp
+++ b/src/inet/RawEndPoint.cpp
@@ -747,7 +747,8 @@ INET_ERROR RawEndPoint::SetICMPFilter(uint8_t numICMPTypes, const uint8_t * aICM
 
     VerifyOrExit(IPVer == kIPVersion_6, err = INET_ERROR_WRONG_ADDRESS_TYPE);
     VerifyOrExit(IPProto == kIPProtocol_ICMPv6, err = INET_ERROR_WRONG_PROTOCOL_TYPE);
-    VerifyOrExit((numICMPTypes == 0 && aICMPTypes == NULL) || (numICMPTypes != 0 && aICMPTypes != NULL), err = INET_ERROR_BAD_ARGS);
+    VerifyOrExit((numICMPTypes == 0 && aICMPTypes == nullptr) || (numICMPTypes != 0 && aICMPTypes != nullptr),
+                 err = INET_ERROR_BAD_ARGS);
 
     err = INET_NO_ERROR;
 
@@ -1108,7 +1109,7 @@ SocketEvents RawEndPoint::PrepareIO(void)
 
 void RawEndPoint::HandlePendingIO(void)
 {
-    if (mState == kState_Listening && OnMessageReceived != NULL && mPendingIO.IsReadable())
+    if (mState == kState_Listening && OnMessageReceived != nullptr && mPendingIO.IsReadable())
     {
         const uint16_t lPort = 0;
 

--- a/src/inet/TCPEndPoint.cpp
+++ b/src/inet/TCPEndPoint.cpp
@@ -443,7 +443,7 @@ INET_ERROR TCPEndPoint::Connect(IPAddress addr, uint16_t port, InterfaceId intfI
     fcntl(mSocket, F_SETFL, flags | O_NONBLOCK);
 
     socklen_t sockaddrsize       = 0;
-    const sockaddr * sockaddrptr = NULL;
+    const sockaddr * sockaddrptr = nullptr;
 
     union
     {
@@ -494,7 +494,7 @@ INET_ERROR TCPEndPoint::Connect(IPAddress addr, uint16_t port, InterfaceId intfI
     if (conRes == 0)
     {
         State = kState_Connected;
-        if (OnConnectComplete != NULL)
+        if (OnConnectComplete != nullptr)
             OnConnectComplete(this, INET_NO_ERROR);
     }
     else
@@ -544,7 +544,7 @@ void TCPEndPoint::TCPConnectTimeoutHandler(chip::System::Layer * aSystemLayer, v
 {
     TCPEndPoint * tcpEndPoint = reinterpret_cast<TCPEndPoint *>(aAppState);
 
-    VerifyOrDie((aSystemLayer != NULL) && (tcpEndPoint != NULL));
+    VerifyOrDie((aSystemLayer != nullptr) && (tcpEndPoint != nullptr));
 
     // Close Connection as we have timed out and Connect has not returned to
     // stop this timer.
@@ -700,7 +700,7 @@ INET_ERROR TCPEndPoint::Send(PacketBuffer * data, bool push)
         return INET_ERROR_INCORRECT_STATE;
     }
 
-    if (mSendQueue == NULL)
+    if (mSendQueue == nullptr)
         mSendQueue = data;
     else
         mSendQueue->AddToEnd(data);
@@ -1036,7 +1036,7 @@ INET_ERROR TCPEndPoint::PutBackReceivedData(PacketBuffer * data)
 
 uint32_t TCPEndPoint::PendingSendLength()
 {
-    if (mSendQueue != NULL)
+    if (mSendQueue != nullptr)
         return mSendQueue->TotalLength();
     else
         return 0;
@@ -1044,7 +1044,7 @@ uint32_t TCPEndPoint::PendingSendLength()
 
 uint32_t TCPEndPoint::PendingReceiveLength()
 {
-    if (mRcvQueue != NULL)
+    if (mRcvQueue != nullptr)
         return mRcvQueue->TotalLength();
     else
         return 0;
@@ -1075,12 +1075,12 @@ INET_ERROR TCPEndPoint::Close()
 {
     // Clear the receive queue.
     PacketBuffer::Free(mRcvQueue);
-    mRcvQueue = NULL;
+    mRcvQueue = nullptr;
 
     // Suppress closing callbacks, since the application explicitly called Close().
-    OnConnectionClosed = NULL;
-    OnPeerClose        = NULL;
-    OnConnectComplete  = NULL;
+    OnConnectionClosed = nullptr;
+    OnPeerClose        = nullptr;
+    OnConnectComplete  = nullptr;
 
     // Perform a graceful close.
     return DoClose(INET_NO_ERROR, true);
@@ -1089,9 +1089,9 @@ INET_ERROR TCPEndPoint::Close()
 void TCPEndPoint::Abort()
 {
     // Suppress closing callbacks, since the application explicitly called Abort().
-    OnConnectionClosed = NULL;
-    OnPeerClose        = NULL;
-    OnConnectComplete  = NULL;
+    OnConnectionClosed = nullptr;
+    OnPeerClose        = nullptr;
+    OnConnectComplete  = nullptr;
 
     DoClose(INET_ERROR_CONNECTION_ABORTED, true);
 }
@@ -1101,13 +1101,13 @@ void TCPEndPoint::Free()
     INET_ERROR err;
 
     // Ensure no callbacks to the app after this point.
-    OnAcceptError        = NULL;
-    OnConnectComplete    = NULL;
-    OnConnectionReceived = NULL;
-    OnConnectionClosed   = NULL;
-    OnPeerClose          = NULL;
-    OnDataReceived       = NULL;
-    OnDataSent           = NULL;
+    OnAcceptError        = nullptr;
+    OnConnectComplete    = nullptr;
+    OnConnectionReceived = nullptr;
+    OnConnectionClosed   = nullptr;
+    OnPeerClose          = nullptr;
+    OnDataReceived       = nullptr;
+    OnDataSent           = nullptr;
 
     // Ensure the end point is Closed or Closing.
     err = Close();
@@ -1289,7 +1289,7 @@ INET_ERROR TCPEndPoint::DriveSending()
         return err;
     });
 
-    while (mSendQueue != NULL)
+    while (mSendQueue != nullptr)
     {
         uint16_t bufLen = mSendQueue->DataLength();
 
@@ -1319,7 +1319,7 @@ INET_ERROR TCPEndPoint::DriveSending()
         else
             mSendQueue = PacketBuffer::FreeHead(mSendQueue);
 
-        if (OnDataSent != NULL)
+        if (OnDataSent != nullptr)
             OnDataSent(this, lenSent);
 
 #if INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
@@ -1362,7 +1362,7 @@ INET_ERROR TCPEndPoint::DriveSending()
     if (err == INET_NO_ERROR)
     {
         // If we're in the SendShutdown state and the send queue is now empty, shutdown writing on the socket.
-        if (State == kState_SendShutdown && mSendQueue == NULL)
+        if (State == kState_SendShutdown && mSendQueue == nullptr)
         {
             if (shutdown(mSocket, SHUT_WR) != 0)
                 err = chip::System::MapErrorPOSIX(errno);
@@ -1383,16 +1383,16 @@ void TCPEndPoint::DriveReceiving()
 {
     // If there's data in the receive queue and the app is ready to receive it then call the app's callback
     // with the entire receive queue.
-    if (mRcvQueue != NULL && ReceiveEnabled && OnDataReceived != NULL)
+    if (mRcvQueue != nullptr && ReceiveEnabled && OnDataReceived != nullptr)
     {
         PacketBuffer * rcvQueue = mRcvQueue;
-        mRcvQueue               = NULL;
+        mRcvQueue               = nullptr;
         OnDataReceived(this, rcvQueue);
     }
 
     // If the connection is closing, and the receive queue is now empty, call DoClose() to complete
     // the process of closing the connection.
-    if (State == kState_Closing && mRcvQueue == NULL)
+    if (State == kState_Closing && mRcvQueue == nullptr)
         DoClose(INET_NO_ERROR, false);
 }
 
@@ -1408,7 +1408,7 @@ void TCPEndPoint::HandleConnectComplete(INET_ERROR err)
         MarkActive();
 
         State = kState_Connected;
-        if (OnConnectComplete != NULL)
+        if (OnConnectComplete != nullptr)
             OnConnectComplete(this, INET_NO_ERROR);
     }
 
@@ -1430,7 +1430,7 @@ INET_ERROR TCPEndPoint::DoClose(INET_ERROR err, bool suppressCallback)
     // AND there is data waiting to be processed on either the send or receive queues
     // ... THEN enter the Closing state, allowing the queued data to drain,
     // ... OTHERWISE go straight to the Closed state.
-    if (IsConnected() && err == INET_NO_ERROR && (mSendQueue != NULL || mRcvQueue != NULL))
+    if (IsConnected() && err == INET_NO_ERROR && (mSendQueue != nullptr || mRcvQueue != nullptr))
         State = kState_Closing;
     else
         State = kState_Closed;
@@ -1520,7 +1520,7 @@ INET_ERROR TCPEndPoint::DoClose(INET_ERROR err, bool suppressCallback)
         // If entering the Closed state
         // OR if entering the Closing state, and there's no unsent data in the send queue
         // THEN close the socket.
-        if (State == kState_Closed || (State == kState_Closing && mSendQueue == NULL))
+        if (State == kState_Closed || (State == kState_Closing && mSendQueue == nullptr))
         {
             chip::System::Layer & lSystemLayer = SystemLayer();
 
@@ -1558,21 +1558,21 @@ INET_ERROR TCPEndPoint::DoClose(INET_ERROR err, bool suppressCallback)
     {
         // Clear clear the send and receive queues.
         PacketBuffer::Free(mSendQueue);
-        mSendQueue = NULL;
+        mSendQueue = nullptr;
         PacketBuffer::Free(mRcvQueue);
-        mRcvQueue = NULL;
+        mRcvQueue = nullptr;
 
         // Call the appropriate app callback if allowed.
         if (!suppressCallback)
         {
             if (oldState == kState_Connecting)
             {
-                if (OnConnectComplete != NULL)
+                if (OnConnectComplete != nullptr)
                     OnConnectComplete(this, err);
             }
             else if ((oldState == kState_Connected || oldState == kState_SendShutdown || oldState == kState_ReceiveShutdown ||
                       oldState == kState_Closing) &&
-                     OnConnectionClosed != NULL)
+                     OnConnectionClosed != nullptr)
                 OnConnectionClosed(this, err);
         }
 
@@ -1602,7 +1602,7 @@ void TCPEndPoint::TCPUserTimeoutHandler(chip::System::Layer * aSystemLayer, void
 {
     TCPEndPoint * tcpEndPoint = reinterpret_cast<TCPEndPoint *>(aAppState);
 
-    VerifyOrDie((aSystemLayer != NULL) && (tcpEndPoint != NULL));
+    VerifyOrDie((aSystemLayer != nullptr) && (tcpEndPoint != nullptr));
 
     // Set the timer running flag to false
     tcpEndPoint->mUserTimeoutTimerRunning = false;
@@ -2259,14 +2259,14 @@ SocketEvents TCPEndPoint::PrepareIO()
     // If initiating a new connection...
     // OR if connected and there is data to be sent...
     // THEN arrange for the kernel to alert us when the socket is ready to be written.
-    if (State == kState_Connecting || (IsConnected() && mSendQueue != NULL))
+    if (State == kState_Connecting || (IsConnected() && mSendQueue != nullptr))
         ioType.SetWrite();
 
     // If listening for incoming connections and the app is ready to receive a connection...
     // OR if in a state where receiving is allowed, and the app is ready to receive data...
     // THEN arrange for the kernel to alert us when the socket is ready to be read.
-    if ((State == kState_Listening && OnConnectionReceived != NULL) ||
-        ((State == kState_Connected || State == kState_SendShutdown) && ReceiveEnabled && OnDataReceived != NULL))
+    if ((State == kState_Listening && OnConnectionReceived != nullptr) ||
+        ((State == kState_Connected || State == kState_SendShutdown) && ReceiveEnabled && OnDataReceived != nullptr))
         ioType.SetRead();
 
     return ioType;
@@ -2281,7 +2281,7 @@ void TCPEndPoint::HandlePendingIO()
     // ready to be received on the socket, process the incoming connection.
     if (State == kState_Listening)
     {
-        if (OnConnectionReceived != NULL && mPendingIO.IsReadable())
+        if (OnConnectionReceived != nullptr && mPendingIO.IsReadable())
             HandleIncomingConnection();
     }
 
@@ -2307,12 +2307,12 @@ void TCPEndPoint::HandlePendingIO()
     {
         // If in a state where sending is allowed, and there is data to be sent, and the socket is ready for
         // writing, drive outbound data into the connection.
-        if (IsConnected() && mSendQueue != NULL && mPendingIO.IsWriteable())
+        if (IsConnected() && mSendQueue != nullptr && mPendingIO.IsWriteable())
             DriveSending();
 
         // If in a state were receiving is allowed, and the app is ready to receive data, and data is ready
         // on the socket, receive inbound data from the connection.
-        if ((State == kState_Connected || State == kState_SendShutdown) && ReceiveEnabled && OnDataReceived != NULL &&
+        if ((State == kState_Connected || State == kState_SendShutdown) && ReceiveEnabled && OnDataReceived != nullptr &&
             mPendingIO.IsReadable())
             ReceiveData();
     }
@@ -2327,12 +2327,12 @@ void TCPEndPoint::ReceiveData()
     PacketBuffer * rcvBuf;
     bool isNewBuf = true;
 
-    if (mRcvQueue == NULL)
+    if (mRcvQueue == nullptr)
         rcvBuf = PacketBuffer::New(0);
     else
     {
         rcvBuf = mRcvQueue;
-        for (PacketBuffer * nextBuf = rcvBuf->Next(); nextBuf != NULL; rcvBuf = nextBuf, nextBuf = nextBuf->Next())
+        for (PacketBuffer * nextBuf = rcvBuf->Next(); nextBuf != nullptr; rcvBuf = nextBuf, nextBuf = nextBuf->Next())
             ;
 
         if (rcvBuf->AvailableDataLength() == 0)
@@ -2344,7 +2344,7 @@ void TCPEndPoint::ReceiveData()
         }
     }
 
-    if (rcvBuf == NULL)
+    if (rcvBuf == nullptr)
     {
         DoClose(INET_ERROR_NO_MEMORY, false);
         return;
@@ -2427,13 +2427,13 @@ void TCPEndPoint::ReceiveData()
             // the app to decide whether to keep the send side of the connection open after
             // the peer has closed. If no OnPeerClose is provided, we assume that the app
             // wants to close both directions and automatically enter the Closing state.
-            if (State == kState_Connected && OnPeerClose != NULL)
+            if (State == kState_Connected && OnPeerClose != nullptr)
                 State = kState_ReceiveShutdown;
             else
                 State = kState_Closing;
 
             // Call the app's OnPeerClose.
-            if (OnPeerClose != NULL)
+            if (OnPeerClose != nullptr)
                 OnPeerClose(this);
         }
 
@@ -2444,7 +2444,7 @@ void TCPEndPoint::ReceiveData()
             size_t newDataLength = rcvBuf->DataLength() + static_cast<size_t>(rcvLen);
             VerifyOrDie(CanCastTo<uint16_t>(newDataLength));
             rcvBuf->SetDataLength(static_cast<uint16_t>(newDataLength));
-            if (mRcvQueue == NULL)
+            if (mRcvQueue == nullptr)
                 mRcvQueue = rcvBuf;
             else
                 mRcvQueue->AddToEnd(rcvBuf);
@@ -2466,7 +2466,7 @@ void TCPEndPoint::ReceiveData()
 void TCPEndPoint::HandleIncomingConnection()
 {
     INET_ERROR err      = INET_NO_ERROR;
-    TCPEndPoint * conEP = NULL;
+    TCPEndPoint * conEP = nullptr;
     IPAddress peerAddr;
     uint16_t peerPort;
 
@@ -2485,7 +2485,7 @@ void TCPEndPoint::HandleIncomingConnection()
         err = chip::System::MapErrorPOSIX(errno);
 
     // If there's no callback available, fail with an error.
-    if (err == INET_NO_ERROR && OnConnectionReceived == NULL)
+    if (err == INET_NO_ERROR && OnConnectionReceived == nullptr)
         err = INET_ERROR_NO_CONNECTION_HANDLER;
 
     // Extract the peer's address information.
@@ -2537,13 +2537,13 @@ void TCPEndPoint::HandleIncomingConnection()
     {
         if (conSocket != -1)
             close(conSocket);
-        if (conEP != NULL)
+        if (conEP != nullptr)
         {
             if (conEP->State == kState_Connected)
                 conEP->Release();
             conEP->Release();
         }
-        if (OnAcceptError != NULL)
+        if (OnAcceptError != nullptr)
             OnAcceptError(this, err);
     }
 }

--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -979,7 +979,7 @@ SocketEvents UDPEndPoint::PrepareIO(void)
 
 void UDPEndPoint::HandlePendingIO(void)
 {
-    if (mState == kState_Listening && OnMessageReceived != NULL && mPendingIO.IsReadable())
+    if (mState == kState_Listening && OnMessageReceived != nullptr && mPendingIO.IsReadable())
     {
         const uint16_t lPort = mBoundPort;
 

--- a/src/inet/tests/TestInetCommon.cpp
+++ b/src/inet/tests/TestInetCommon.cpp
@@ -153,7 +153,7 @@ static void UseStdoutLineBuffering()
 {
     // Set stdout to be line buffered with a buffer of 512 (will flush on new line
     // or when the buffer of 512 is exceeded).
-    setvbuf(stdout, NULL, _IOLBF, 512);
+    setvbuf(stdout, nullptr, _IOLBF, 512);
 }
 
 void InitTestInetCommon()
@@ -184,7 +184,7 @@ void SetSignalHandler(SignalHandler handler)
 
     for (i = 0; i < sizeof(signals) / sizeof(signals[0]); i++)
     {
-        if (sigaction(signals[i], &sa, NULL) == -1)
+        if (sigaction(signals[i], &sa, nullptr) == -1)
         {
             perror("Can't catch signal");
             exit(1);
@@ -199,7 +199,7 @@ void InitSystemLayer()
 
     gSystemLayer.Init(sLwIPEventQueue);
 #else  // !CHIP_SYSTEM_CONFIG_USE_LWIP
-    gSystemLayer.Init(NULL);
+    gSystemLayer.Init(nullptr);
 #endif // !CHIP_SYSTEM_CONFIG_USE_LWIP
 }
 
@@ -265,7 +265,7 @@ static void PrintNetworkState()
 
 void InitNetwork()
 {
-    void * lContext = NULL;
+    void * lContext = nullptr;
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
@@ -624,7 +624,7 @@ void ShutdownNetwork()
 
 void DumpMemory(const uint8_t * mem, uint32_t len, const char * prefix, uint32_t rowWidth)
 {
-    int indexWidth = snprintf(NULL, 0, "%X", len);
+    int indexWidth = snprintf(nullptr, 0, "%X", len);
 
     if (indexWidth < 4)
         indexWidth = 4;
@@ -670,7 +670,7 @@ static void RebootCallbackFn(void)
         ExitNow();
     }
 
-    for (i = 0; sRestartCallbackCtx.mArgv[i] != NULL; i++)
+    for (i = 0; sRestartCallbackCtx.mArgv[i] != nullptr; i++)
     {
         if (strcmp(sRestartCallbackCtx.mArgv[i], "--faults") == 0)
         {
@@ -681,9 +681,9 @@ static void RebootCallbackFn(void)
         lArgv[j++] = sRestartCallbackCtx.mArgv[i];
     }
 
-    lArgv[j] = NULL;
+    lArgv[j] = nullptr;
 
-    for (i = 0; lArgv[i] != NULL; i++)
+    for (i = 0; lArgv[i] != nullptr; i++)
     {
         printf("argv[%d]: %s\n", i, lArgv[i]);
     }
@@ -759,7 +759,7 @@ static bool PrintSystemFaultInjectionMaxArgCbFn(nl::FaultInjection::Identifier a
 
 void SetupFaultInjectionContext(int argc, char * argv[])
 {
-    SetupFaultInjectionContext(argc, argv, NULL, NULL);
+    SetupFaultInjectionContext(argc, argv, nullptr, nullptr);
 }
 
 void SetupFaultInjectionContext(int argc, char * argv[], int32_t (*aNumEventsAvailable)(void),

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -82,13 +82,13 @@ void HandleTimer(Layer * aLayer, void * aAppState, Error aError)
 static void TestInetPre(nlTestSuite * inSuite, void * inContext)
 {
 #if INET_CONFIG_ENABLE_RAW_ENDPOINT
-    RawEndPoint * testRawEP = NULL;
+    RawEndPoint * testRawEP = nullptr;
 #endif // INET_CONFIG_ENABLE_RAW_ENDPOINT
 #if INET_CONFIG_ENABLE_UDP_ENDPOINT
-    UDPEndPoint * testUDPEP = NULL;
+    UDPEndPoint * testUDPEP = nullptr;
 #endif // INET_CONFIG_ENABLE_UDP_ENDPOINT
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-    TCPEndPoint * testTCPEP = NULL;
+    TCPEndPoint * testTCPEP = nullptr;
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
     INET_ERROR err         = INET_NO_ERROR;
     IPAddress testDestAddr = IPAddress::Any;
@@ -109,11 +109,11 @@ static void TestInetPre(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == INET_ERROR_INCORRECT_STATE);
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
-    err = gSystemLayer.StartTimer(10, HandleTimer, NULL);
+    err = gSystemLayer.StartTimer(10, HandleTimer, nullptr);
     NL_TEST_ASSERT(inSuite, err == CHIP_SYSTEM_ERROR_UNEXPECTED_STATE);
 
 #if INET_CONFIG_ENABLE_DNS_RESOLVER
-    err = gInet.ResolveHostAddress(testHostName, 1, &testDestAddr, HandleDNSResolveComplete, NULL);
+    err = gInet.ResolveHostAddress(testHostName, 1, &testDestAddr, HandleDNSResolveComplete, nullptr);
     NL_TEST_ASSERT(inSuite, err == INET_ERROR_INCORRECT_STATE);
 #endif // INET_CONFIG_ENABLE_DNS_RESOLVER
 
@@ -242,7 +242,7 @@ static void TestInetInterface(nlTestSuite * inSuite, void * inContext)
     err = gInet.GetInterfaceFromAddr(addr, intId);
     NL_TEST_ASSERT(inSuite, intId == INET_NULL_INTERFACEID);
 
-    err = gInet.GetLinkLocalAddr(intId, NULL);
+    err = gInet.GetLinkLocalAddr(intId, nullptr);
     NL_TEST_ASSERT(inSuite, err == INET_ERROR_BAD_ARGS);
 
     printf("    Interfaces:\n");
@@ -278,7 +278,7 @@ static void TestInetInterface(nlTestSuite * inSuite, void * inContext)
         memset(intName, 42, sizeof(intName));
         err = addrIterator.GetInterfaceName(intName, sizeof(intName));
         NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, intName[0] != '\0' && memchr(intName, '\0', sizeof(intName)) != NULL);
+        NL_TEST_ASSERT(inSuite, intName[0] != '\0' && memchr(intName, '\0', sizeof(intName)) != nullptr);
         printf("     %s/%d, interface id: 0x%" PRIxPTR
                ", interface name: %s, interface state: %s, %s multicast, %s broadcast addr\n",
                addrStr, addrWithPrefix.Length, (uintptr_t)(intId), intName, addrIterator.IsUp() ? "UP" : "DOWN",
@@ -304,12 +304,12 @@ static void TestInetEndPointInternal(nlTestSuite * inSuite, void * inContext)
     InterfaceId intId;
 
     // EndPoint
-    RawEndPoint * testRaw6EP = NULL;
+    RawEndPoint * testRaw6EP = nullptr;
 #if INET_CONFIG_ENABLE_IPV4
-    RawEndPoint * testRaw4EP = NULL;
+    RawEndPoint * testRaw4EP = nullptr;
 #endif // INET_CONFIG_ENABLE_IPV4
-    UDPEndPoint * testUDPEP  = NULL;
-    TCPEndPoint * testTCPEP1 = NULL;
+    UDPEndPoint * testUDPEP  = nullptr;
+    TCPEndPoint * testTCPEP1 = nullptr;
     PacketBuffer * buf       = PacketBuffer::New();
     bool didBind             = false;
     bool didListen           = false;
@@ -436,7 +436,7 @@ static void TestInetEndPointInternal(nlTestSuite * inSuite, void * inContext)
 #endif // INET_CONFIG_ENABLE_IPV4
 
     // TcpEndPoint special cases to cover the error branch
-    err = testTCPEP1->GetPeerInfo(NULL, NULL);
+    err = testTCPEP1->GetPeerInfo(nullptr, nullptr);
     NL_TEST_ASSERT(inSuite, err == INET_ERROR_INCORRECT_STATE);
     buf = PacketBuffer::New();
     err = testTCPEP1->Send(buf, false);
@@ -450,7 +450,7 @@ static void TestInetEndPointInternal(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, !testTCPEP1->PendingReceiveLength());
     err = testTCPEP1->Listen(4);
     NL_TEST_ASSERT(inSuite, err == INET_ERROR_INCORRECT_STATE);
-    err = testTCPEP1->GetLocalInfo(NULL, NULL);
+    err = testTCPEP1->GetLocalInfo(nullptr, nullptr);
     NL_TEST_ASSERT(inSuite, err == INET_ERROR_INCORRECT_STATE);
 
     err = testTCPEP1->Bind(kIPAddressType_Unknown, addr_any, 3000, true);
@@ -477,9 +477,9 @@ static void TestInetEndPointInternal(nlTestSuite * inSuite, void * inContext)
 // Test the InetLayer resource limitation
 static void TestInetEndPointLimit(nlTestSuite * inSuite, void * inContext)
 {
-    RawEndPoint * testRawEP = NULL;
-    UDPEndPoint * testUDPEP = NULL;
-    TCPEndPoint * testTCPEP = NULL;
+    RawEndPoint * testRawEP = nullptr;
+    UDPEndPoint * testUDPEP = nullptr;
+    TCPEndPoint * testTCPEP = nullptr;
     INET_ERROR err;
     char numTimersTest[CHIP_SYSTEM_CONFIG_NUM_TIMERS + 1];
 
@@ -498,7 +498,7 @@ static void TestInetEndPointLimit(nlTestSuite * inSuite, void * inContext)
     // Verify same aComplete and aAppState args do not exhaust timer pool
     for (int i = 0; i < CHIP_SYSTEM_CONFIG_NUM_TIMERS + 1; i++)
     {
-        err = gSystemLayer.StartTimer(10, HandleTimer, NULL);
+        err = gSystemLayer.StartTimer(10, HandleTimer, nullptr);
         NL_TEST_ASSERT(inSuite, err == CHIP_SYSTEM_NO_ERROR);
     }
 
@@ -561,7 +561,7 @@ int TestInetEndPointInternal(void)
     // clang-format on
 
     // Run test suite against one context.
-    nlTestRunner(&theSuite, NULL);
+    nlTestRunner(&theSuite, nullptr);
 
     return nlTestRunnerStats(&theSuite);
 #else  // !CHIP_SYSTEM_CONFIG_USE_SOCKETS

--- a/src/inet/tests/TestInetErrorStr.cpp
+++ b/src/inet/tests/TestInetErrorStr.cpp
@@ -100,12 +100,12 @@ static void CheckInetErrorStr(nlTestSuite * inSuite, void * inContext)
 
         // Assert that the error string contains the error number in hex.
         snprintf(expectedText, sizeof(expectedText), "%08" PRIX32, err);
-        NL_TEST_ASSERT(inSuite, (strstr(errStr, expectedText) != NULL));
+        NL_TEST_ASSERT(inSuite, (strstr(errStr, expectedText) != nullptr));
 
 #if !CHIP_CONFIG_SHORT_ERROR_STR
         // Assert that the error string contains a description, which is signaled
         // by a presence of a colon proceeding the description.
-        NL_TEST_ASSERT(inSuite, (strchr(errStr, ':') != NULL));
+        NL_TEST_ASSERT(inSuite, (strchr(errStr, ':') != nullptr));
 #endif // !CHIP_CONFIG_SHORT_ERROR_STR
     }
 }
@@ -130,8 +130,8 @@ int TestInetErrorStr(void)
 	{
         "Inet-Error-Strings",
         &sTests[0],
-        NULL,
-        NULL
+        nullptr,
+        nullptr
     };
     // clang-format on
 

--- a/src/inet/tests/TestInetLayer.cpp
+++ b/src/inet/tests/TestInetLayer.cpp
@@ -90,10 +90,10 @@ static const uint32_t kExpectedTxSizeDefault = kExpectedRxSizeDefault;
 
 static const uint32_t kOptFlagsDefault = (kOptFlagUseIPv6 | kOptFlagUseUDPIP);
 
-static RawEndPoint * sRawIPEndPoint       = NULL;
-static TCPEndPoint * sTCPIPEndPoint       = NULL; // Used for connect/send/receive
-static TCPEndPoint * sTCPIPListenEndPoint = NULL; // Used for accept/listen
-static UDPEndPoint * sUDPIPEndPoint       = NULL;
+static RawEndPoint * sRawIPEndPoint       = nullptr;
+static TCPEndPoint * sTCPIPEndPoint       = nullptr; // Used for connect/send/receive
+static TCPEndPoint * sTCPIPListenEndPoint = nullptr; // Used for accept/listen
+static UDPEndPoint * sUDPIPEndPoint       = nullptr;
 
 static const uint16_t kTCPPort = kUDPPort;
 // clang-format off
@@ -105,7 +105,7 @@ static TestState         sTestState             =
 // clang-format on
 
 static IPAddress sDestinationAddress   = IPAddress::Any;
-static const char * sDestinationString = NULL;
+static const char * sDestinationString = nullptr;
 
 // clang-format off
 static OptionDef         sToolOptionDefs[] =
@@ -184,7 +184,7 @@ static OptionSet *       sToolOptionSets[] =
     &gNetworkOptions,
     &gFaultInjectionOptions,
     &sHelpOptions,
-    NULL
+    nullptr
 };
 // clang-format on
 
@@ -247,7 +247,7 @@ int main(int argc, char * argv[])
         goto exit;
     }
 
-    if (!ParseArgsFromEnvVar(kToolName, TOOL_OPTIONS_ENV_VAR_NAME, sToolOptionSets, NULL, true) ||
+    if (!ParseArgsFromEnvVar(kToolName, TOOL_OPTIONS_ENV_VAR_NAME, sToolOptionSets, nullptr, true) ||
         !ParseArgs(kToolName, argc, argv, sToolOptionSets, HandleNonOptionArgs))
     {
         lSuccessful = false;
@@ -262,7 +262,7 @@ int main(int argc, char * argv[])
     // including LwIP TUN/TAP shim interfaces. Validate the
     // -I/--interface argument, if present.
 
-    if (gInterfaceName != NULL)
+    if (gInterfaceName != nullptr)
     {
         lStatus = InterfaceNameToId(gInterfaceName, gInterfaceId);
         if (lStatus != INET_NO_ERROR)
@@ -544,7 +544,7 @@ void HandleTCPConnectionComplete(TCPEndPoint * aEndPoint, INET_ERROR aError)
         printf("TCP connection established to %s:%u\n", lPeerAddressBuffer, lPeerPort);
 
         if (sTCPIPEndPoint->PendingReceiveLength() == 0)
-            sTCPIPEndPoint->PutBackReceivedData(NULL);
+            sTCPIPEndPoint->PutBackReceivedData(nullptr);
 
         sTCPIPEndPoint->DisableReceive();
         sTCPIPEndPoint->EnableKeepAlive(10, 100);
@@ -558,11 +558,11 @@ void HandleTCPConnectionComplete(TCPEndPoint * aEndPoint, INET_ERROR aError)
         printf("TCP connection FAILED: %s\n", ErrorStr(aError));
 
         aEndPoint->Free();
-        aEndPoint = NULL;
+        aEndPoint = nullptr;
 
         gSendIntervalExpired = false;
-        gSystemLayer.CancelTimer(Common::HandleSendTimerComplete, NULL);
-        gSystemLayer.StartTimer(gSendIntervalMs, Common::HandleSendTimerComplete, NULL);
+        gSystemLayer.CancelTimer(Common::HandleSendTimerComplete, nullptr);
+        gSystemLayer.StartTimer(gSendIntervalMs, Common::HandleSendTimerComplete, nullptr);
 
         SetStatusFailed(sTestState.mStatus);
     }
@@ -585,7 +585,7 @@ static void HandleTCPConnectionClosed(TCPEndPoint * aEndPoint, INET_ERROR aError
 
     if (aEndPoint == sTCPIPEndPoint)
     {
-        sTCPIPEndPoint = NULL;
+        sTCPIPEndPoint = nullptr;
     }
 }
 
@@ -608,13 +608,13 @@ static void HandleTCPDataReceived(TCPEndPoint * aEndPoint, PacketBuffer * aBuffe
     // Check that we did not lose information in our narrowing cast.
     VerifyOrExit(lFirstValue == lFirstValueReceived, lStatus = INET_ERROR_UNEXPECTED_EVENT);
 
-    VerifyOrExit(aEndPoint != NULL, lStatus = INET_ERROR_BAD_ARGS);
-    VerifyOrExit(aBuffer != NULL, lStatus = INET_ERROR_BAD_ARGS);
+    VerifyOrExit(aEndPoint != nullptr, lStatus = INET_ERROR_BAD_ARGS);
+    VerifyOrExit(aBuffer != nullptr, lStatus = INET_ERROR_BAD_ARGS);
 
     if (aEndPoint->State != TCPEndPoint::kState_Connected)
     {
         lStatus = aEndPoint->PutBackReceivedData(aBuffer);
-        aBuffer = NULL;
+        aBuffer = nullptr;
         INET_FAIL_ERROR(lStatus, "TCPEndPoint::PutBackReceivedData failed");
         goto exit;
     }
@@ -634,7 +634,7 @@ static void HandleTCPDataReceived(TCPEndPoint * aEndPoint, PacketBuffer * aBuffe
     INET_FAIL_ERROR(lStatus, "TCPEndPoint::AckReceive failed");
 
 exit:
-    if (aBuffer != NULL)
+    if (aBuffer != nullptr)
     {
         PacketBuffer::Free(aBuffer);
     }
@@ -678,9 +678,9 @@ static void HandleRawMessageReceived(IPEndPointBasis * aEndPoint, PacketBuffer *
     IPAddressType lAddressType;
     bool lStatus;
 
-    VerifyOrExit(aEndPoint != NULL, lStatus = false);
-    VerifyOrExit(aBuffer != NULL, lStatus = false);
-    VerifyOrExit(aPacketInfo != NULL, lStatus = false);
+    VerifyOrExit(aEndPoint != nullptr, lStatus = false);
+    VerifyOrExit(aBuffer != nullptr, lStatus = false);
+    VerifyOrExit(aPacketInfo != nullptr, lStatus = false);
 
     Common::HandleRawMessageReceived(aEndPoint, aBuffer, aPacketInfo);
 
@@ -709,7 +709,7 @@ static void HandleRawMessageReceived(IPEndPointBasis * aEndPoint, PacketBuffer *
     }
 
 exit:
-    if (aBuffer != NULL)
+    if (aBuffer != nullptr)
     {
         PacketBuffer::Free(aBuffer);
     }
@@ -734,16 +734,16 @@ static void HandleUDPMessageReceived(IPEndPointBasis * aEndPoint, PacketBuffer *
     const bool lCheckBuffer = true;
     bool lStatus;
 
-    VerifyOrExit(aEndPoint != NULL, lStatus = false);
-    VerifyOrExit(aBuffer != NULL, lStatus = false);
-    VerifyOrExit(aPacketInfo != NULL, lStatus = false);
+    VerifyOrExit(aEndPoint != nullptr, lStatus = false);
+    VerifyOrExit(aBuffer != nullptr, lStatus = false);
+    VerifyOrExit(aPacketInfo != nullptr, lStatus = false);
 
     Common::HandleUDPMessageReceived(aEndPoint, aBuffer, aPacketInfo);
 
     lStatus = HandleDataReceived(aBuffer, lCheckBuffer);
 
 exit:
-    if (aBuffer != NULL)
+    if (aBuffer != nullptr)
     {
         PacketBuffer::Free(aBuffer);
     }
@@ -767,15 +767,15 @@ static bool IsTransportReadyForSend(void)
 
     if ((gOptFlags & (kOptFlagUseRawIP)) == (kOptFlagUseRawIP))
     {
-        lStatus = (sRawIPEndPoint != NULL);
+        lStatus = (sRawIPEndPoint != nullptr);
     }
     else if ((gOptFlags & kOptFlagUseUDPIP) == kOptFlagUseUDPIP)
     {
-        lStatus = (sUDPIPEndPoint != NULL);
+        lStatus = (sUDPIPEndPoint != nullptr);
     }
     else if ((gOptFlags & kOptFlagUseTCPIP) == kOptFlagUseTCPIP)
     {
-        if (sTCPIPEndPoint != NULL)
+        if (sTCPIPEndPoint != nullptr)
         {
             if (sTCPIPEndPoint->PendingSendLength() == 0)
             {
@@ -802,7 +802,7 @@ static INET_ERROR PrepareTransportForSend(void)
 
     if (gOptFlags & kOptFlagUseTCPIP)
     {
-        if (sTCPIPEndPoint == NULL)
+        if (sTCPIPEndPoint == nullptr)
         {
             lStatus = gInet.NewTCPEndPoint(&sTCPIPEndPoint);
             INET_FAIL_ERROR(lStatus, "InetLayer::NewTCPEndPoint failed");
@@ -822,7 +822,7 @@ static INET_ERROR PrepareTransportForSend(void)
 
 static INET_ERROR DriveSendForDestination(const IPAddress & aAddress, uint16_t aSize)
 {
-    PacketBuffer * lBuffer = NULL;
+    PacketBuffer * lBuffer = nullptr;
     INET_ERROR lStatus     = INET_NO_ERROR;
 
     if ((gOptFlags & (kOptFlagUseRawIP)) == (kOptFlagUseRawIP))
@@ -835,13 +835,13 @@ static INET_ERROR DriveSendForDestination(const IPAddress & aAddress, uint16_t a
         if ((gOptFlags & kOptFlagUseIPv6) == (kOptFlagUseIPv6))
         {
             lBuffer = Common::MakeICMPv6DataBuffer(aSize);
-            VerifyOrExit(lBuffer != NULL, lStatus = INET_ERROR_NO_MEMORY);
+            VerifyOrExit(lBuffer != nullptr, lStatus = INET_ERROR_NO_MEMORY);
         }
 #if INET_CONFIG_ENABLE_IPV4
         else if ((gOptFlags & kOptFlagUseIPv4) == (kOptFlagUseIPv4))
         {
             lBuffer = Common::MakeICMPv4DataBuffer(aSize);
-            VerifyOrExit(lBuffer != NULL, lStatus = INET_ERROR_NO_MEMORY);
+            VerifyOrExit(lBuffer != nullptr, lStatus = INET_ERROR_NO_MEMORY);
         }
 #endif // INET_CONFIG_ENABLE_IPV4
 
@@ -858,7 +858,7 @@ static INET_ERROR DriveSendForDestination(const IPAddress & aAddress, uint16_t a
             // patterned from zero to aSize - 1.
 
             lBuffer = Common::MakeDataBuffer(aSize, lFirstValue);
-            VerifyOrExit(lBuffer != NULL, lStatus = INET_ERROR_NO_MEMORY);
+            VerifyOrExit(lBuffer != nullptr, lStatus = INET_ERROR_NO_MEMORY);
 
             lStatus = sUDPIPEndPoint->SendTo(aAddress, kUDPPort, lBuffer);
             SuccessOrExit(lStatus);
@@ -874,7 +874,7 @@ static INET_ERROR DriveSendForDestination(const IPAddress & aAddress, uint16_t a
             // sTestState.mStats.mTransmit.mExpected - 1.
 
             lBuffer = Common::MakeDataBuffer(aSize, uint8_t(lFirstValue));
-            VerifyOrExit(lBuffer != NULL, lStatus = INET_ERROR_NO_MEMORY);
+            VerifyOrExit(lBuffer != nullptr, lStatus = INET_ERROR_NO_MEMORY);
 
             lStatus = sTCPIPEndPoint->Send(lBuffer);
             SuccessOrExit(lStatus);
@@ -903,7 +903,7 @@ void DriveSend(void)
     else
     {
         gSendIntervalExpired = false;
-        gSystemLayer.StartTimer(gSendIntervalMs, Common::HandleSendTimerComplete, NULL);
+        gSystemLayer.StartTimer(gSendIntervalMs, Common::HandleSendTimerComplete, nullptr);
 
         if (sTestState.mStats.mTransmit.mActual < sTestState.mStats.mTransmit.mExpected)
         {
@@ -1049,16 +1049,16 @@ static void CleanupTest(void)
     INET_ERROR lStatus;
 
     gSendIntervalExpired = false;
-    gSystemLayer.CancelTimer(Common::HandleSendTimerComplete, NULL);
+    gSystemLayer.CancelTimer(Common::HandleSendTimerComplete, nullptr);
 
     // Release the resources associated with the allocated end points.
 
-    if (sRawIPEndPoint != NULL)
+    if (sRawIPEndPoint != nullptr)
     {
         sRawIPEndPoint->Free();
     }
 
-    if (sTCPIPEndPoint != NULL)
+    if (sTCPIPEndPoint != nullptr)
     {
         lStatus = sTCPIPEndPoint->Close();
         INET_FAIL_ERROR(lStatus, "TCPEndPoint::Close failed");
@@ -1066,13 +1066,13 @@ static void CleanupTest(void)
         sTCPIPEndPoint->Free();
     }
 
-    if (sTCPIPListenEndPoint != NULL)
+    if (sTCPIPListenEndPoint != nullptr)
     {
         sTCPIPListenEndPoint->Shutdown();
         sTCPIPListenEndPoint->Free();
     }
 
-    if (sUDPIPEndPoint != NULL)
+    if (sUDPIPEndPoint != nullptr)
     {
         sUDPIPEndPoint->Free();
     }

--- a/src/inet/tests/TestInetLayerCommon.cpp
+++ b/src/inet/tests/TestInetLayerCommon.cpp
@@ -82,7 +82,7 @@ bool gSendIntervalExpired = true;
 
 uint32_t gSendIntervalMs = 1000;
 
-const char * gInterfaceName = NULL;
+const char * gInterfaceName = nullptr;
 
 InterfaceId gInterfaceId = INET_NULL_INTERFACEID;
 
@@ -164,12 +164,12 @@ exit:
 
 static PacketBuffer * MakeDataBuffer(uint16_t aDesiredLength, uint16_t aPatternStartOffset, uint8_t aFirstValue)
 {
-    PacketBuffer * lBuffer = NULL;
+    PacketBuffer * lBuffer = nullptr;
 
     VerifyOrExit(aPatternStartOffset <= aDesiredLength, );
 
     lBuffer = PacketBuffer::New();
-    VerifyOrExit(lBuffer != NULL, );
+    VerifyOrExit(lBuffer != nullptr, );
 
     aDesiredLength = min(lBuffer->MaxDataLength(), aDesiredLength);
 
@@ -184,10 +184,10 @@ exit:
 static PacketBuffer * MakeDataBuffer(uint16_t aDesiredLength, uint16_t aPatternStartOffset)
 {
     const uint8_t lFirstValue = 0;
-    PacketBuffer * lBuffer    = NULL;
+    PacketBuffer * lBuffer    = nullptr;
 
     lBuffer = MakeDataBuffer(aDesiredLength, aPatternStartOffset, lFirstValue);
-    VerifyOrExit(lBuffer != NULL, );
+    VerifyOrExit(lBuffer != nullptr, );
 
 exit:
     return (lBuffer);
@@ -198,14 +198,14 @@ static PacketBuffer * MakeICMPDataBuffer(uint16_t aDesiredUserLength, uint16_t a
                                          uint8_t aType)
 {
     static uint16_t lSequenceNumber = 0;
-    PacketBuffer * lBuffer          = NULL;
+    PacketBuffer * lBuffer          = nullptr;
 
     // To ensure there is enough room for the user data and the ICMP
     // header, include both the user data size and the ICMP header length.
 
     lBuffer = MakeDataBuffer(aDesiredUserLength + aHeaderLength, aPatternStartOffset);
 
-    if (lBuffer != NULL)
+    if (lBuffer != nullptr)
     {
         tType * lHeader = reinterpret_cast<tType *>(lBuffer->Start());
 
@@ -224,7 +224,7 @@ PacketBuffer * MakeICMPv4DataBuffer(uint16_t aDesiredUserLength)
     const uint16_t lICMPHeaderLength   = sizeof(ICMPv4EchoHeader);
     const uint16_t lPatternStartOffset = lICMPHeaderLength;
     const uint8_t lType                = gICMPv4Types[kICMP_EchoRequestIndex];
-    PacketBuffer * lBuffer             = NULL;
+    PacketBuffer * lBuffer             = nullptr;
 
     lBuffer = MakeICMPDataBuffer<ICMPv4EchoHeader>(aDesiredUserLength, lICMPHeaderLength, lPatternStartOffset, lType);
 
@@ -236,7 +236,7 @@ PacketBuffer * MakeICMPv6DataBuffer(uint16_t aDesiredUserLength)
     const uint16_t lICMPHeaderLength   = sizeof(ICMPv6EchoHeader);
     const uint16_t lPatternStartOffset = lICMPHeaderLength;
     const uint8_t lType                = gICMPv6Types[kICMP_EchoRequestIndex];
-    PacketBuffer * lBuffer             = NULL;
+    PacketBuffer * lBuffer             = nullptr;
 
     lBuffer = MakeICMPDataBuffer<ICMPv6EchoHeader>(aDesiredUserLength, lICMPHeaderLength, lPatternStartOffset, lType);
 
@@ -246,7 +246,7 @@ PacketBuffer * MakeICMPv6DataBuffer(uint16_t aDesiredUserLength)
 PacketBuffer * MakeDataBuffer(uint16_t aDesiredLength, uint8_t aFirstValue)
 {
     const uint16_t lPatternStartOffset = 0;
-    PacketBuffer * lBuffer             = NULL;
+    PacketBuffer * lBuffer             = nullptr;
 
     lBuffer = MakeDataBuffer(aDesiredLength, lPatternStartOffset, aFirstValue);
 
@@ -256,7 +256,7 @@ PacketBuffer * MakeDataBuffer(uint16_t aDesiredLength, uint8_t aFirstValue)
 PacketBuffer * MakeDataBuffer(uint16_t aDesiredLength)
 {
     const uint16_t lPatternStartOffset = 0;
-    PacketBuffer * lBuffer             = NULL;
+    PacketBuffer * lBuffer             = nullptr;
 
     lBuffer = MakeDataBuffer(aDesiredLength, lPatternStartOffset);
 
@@ -272,7 +272,7 @@ static bool HandleDataReceived(const PacketBuffer * aBuffer, TransferStats & aSt
     // Walk through each buffer in the packet chain, checking the
     // buffer for the expected pattern, if requested.
 
-    for (const PacketBuffer * lBuffer = aBuffer; lBuffer != NULL; lBuffer = lBuffer->Next())
+    for (const PacketBuffer * lBuffer = aBuffer; lBuffer != nullptr; lBuffer = lBuffer->Next())
     {
         const uint16_t lDataLength = lBuffer->DataLength();
 
@@ -399,7 +399,7 @@ void HandleRawReceiveError(const IPEndPointBasis * aEndPoint, const INET_ERROR &
 {
     char lAddressBuffer[INET6_ADDRSTRLEN];
 
-    if (aPacketInfo != NULL)
+    if (aPacketInfo != nullptr)
     {
         aPacketInfo->SrcAddress.ToString(lAddressBuffer, sizeof(lAddressBuffer));
     }
@@ -430,7 +430,7 @@ void HandleUDPReceiveError(const IPEndPointBasis * aEndPoint, const INET_ERROR &
     char lAddressBuffer[INET6_ADDRSTRLEN];
     uint16_t lSourcePort;
 
-    if (aPacketInfo != NULL)
+    if (aPacketInfo != nullptr)
     {
         aPacketInfo->SrcAddress.ToString(lAddressBuffer, sizeof(lAddressBuffer));
         lSourcePort = aPacketInfo->SrcPort;

--- a/src/inet/tests/TestInetLayerDNS.cpp
+++ b/src/inet/tests/TestInetLayerDNS.cpp
@@ -685,8 +685,8 @@ int TestInetLayerDNSInternal(void)
     {
         "DNS",
         &DNSTests[0],
-        NULL,
-        NULL
+        nullptr,
+        nullptr
     };
     // clang-format on
 
@@ -697,7 +697,7 @@ int TestInetLayerDNSInternal(void)
 
     // Run all tests in Suite
 
-    nlTestRunner(&DNSTestSuite, NULL);
+    nlTestRunner(&DNSTestSuite, nullptr);
 
     ShutdownNetwork();
     ShutdownSystemLayer();

--- a/src/inet/tests/TestInetLayerMulticast.cpp
+++ b/src/inet/tests/TestInetLayerMulticast.cpp
@@ -106,8 +106,8 @@ static void CleanupTest(void);
 // clang-format off
 static const uint32_t    kOptFlagsDefault       = (kOptFlagUseIPv6 | kOptFlagUseRawIP);
 
-static RawEndPoint *     sRawIPEndPoint         = NULL;
-static UDPEndPoint *     sUDPIPEndPoint         = NULL;
+static RawEndPoint *     sRawIPEndPoint         = nullptr;
+static UDPEndPoint *     sUDPIPEndPoint         = nullptr;
 
 static GroupAddresses<4> sGroupAddresses;
 
@@ -198,7 +198,7 @@ static OptionSet *       sToolOptionSets[] =
     &gNetworkOptions,
     &gFaultInjectionOptions,
     &sHelpOptions,
-    NULL
+    nullptr
 };
 // clang-format on
 
@@ -272,7 +272,7 @@ int main(int argc, char * argv[])
         goto exit;
     }
 
-    if (!ParseArgsFromEnvVar(kToolName, TOOL_OPTIONS_ENV_VAR_NAME, sToolOptionSets, NULL, true) ||
+    if (!ParseArgsFromEnvVar(kToolName, TOOL_OPTIONS_ENV_VAR_NAME, sToolOptionSets, nullptr, true) ||
         !ParseArgs(kToolName, argc, argv, sToolOptionSets, HandleNonOptionArgs))
     {
         lSuccessful = false;
@@ -287,7 +287,7 @@ int main(int argc, char * argv[])
     // including LwIP TUN/TAP shim interfaces. Validate the
     // -I/--interface argument, if present.
 
-    if (gInterfaceName != NULL)
+    if (gInterfaceName != nullptr)
     {
         lStatus = InterfaceNameToId(gInterfaceName, gInterfaceId);
         if (lStatus != INET_NO_ERROR)
@@ -573,7 +573,7 @@ exit:
 
 static GroupAddress * FindGroupAddress(const IPAddress & aSourceAddress)
 {
-    GroupAddress * lResult = NULL;
+    GroupAddress * lResult = nullptr;
 
     for (size_t i = 0; i < sGroupAddresses.mSize; i++)
     {
@@ -616,7 +616,7 @@ static bool HandleDataReceived(const PacketBuffer * aBuffer, const IPPacketInfo 
 
     lGroupAddress = FindGroupAddress(aPacketInfo.DestAddress);
 
-    if (lGroupAddress != NULL)
+    if (lGroupAddress != nullptr)
     {
         lStatus = HandleDataReceived(aBuffer, *lGroupAddress, aCheckBuffer);
         VerifyOrExit(lStatus == true, );
@@ -636,15 +636,15 @@ static void HandleRawMessageReceived(IPEndPointBasis * aEndPoint, PacketBuffer *
     bool lStatus = true;
     GroupAddress * lGroupAddress;
 
-    VerifyOrExit(aEndPoint != NULL, lStatus = false);
-    VerifyOrExit(aBuffer != NULL, lStatus = false);
-    VerifyOrExit(aPacketInfo != NULL, lStatus = false);
+    VerifyOrExit(aEndPoint != nullptr, lStatus = false);
+    VerifyOrExit(aBuffer != nullptr, lStatus = false);
+    VerifyOrExit(aPacketInfo != nullptr, lStatus = false);
 
     Common::HandleRawMessageReceived(aEndPoint, aBuffer, aPacketInfo);
 
     lGroupAddress = FindGroupAddress(aPacketInfo->DestAddress);
 
-    if (lGroupAddress != NULL)
+    if (lGroupAddress != nullptr)
     {
         lAddressType = aPacketInfo->DestAddress.Type();
 
@@ -672,7 +672,7 @@ static void HandleRawMessageReceived(IPEndPointBasis * aEndPoint, PacketBuffer *
     }
 
 exit:
-    if (aBuffer != NULL)
+    if (aBuffer != nullptr)
     {
         PacketBuffer::Free(aBuffer);
     }
@@ -697,16 +697,16 @@ static void HandleUDPMessageReceived(IPEndPointBasis * aEndPoint, PacketBuffer *
     const bool lCheckBuffer = true;
     bool lStatus;
 
-    VerifyOrExit(aEndPoint != NULL, lStatus = false);
-    VerifyOrExit(aBuffer != NULL, lStatus = false);
-    VerifyOrExit(aPacketInfo != NULL, lStatus = false);
+    VerifyOrExit(aEndPoint != nullptr, lStatus = false);
+    VerifyOrExit(aBuffer != nullptr, lStatus = false);
+    VerifyOrExit(aPacketInfo != nullptr, lStatus = false);
 
     Common::HandleUDPMessageReceived(aEndPoint, aBuffer, aPacketInfo);
 
     lStatus = HandleDataReceived(aBuffer, *aPacketInfo, lCheckBuffer);
 
 exit:
-    if (aBuffer != NULL)
+    if (aBuffer != nullptr)
     {
         PacketBuffer::Free(aBuffer);
     }
@@ -730,11 +730,11 @@ static bool IsTransportReadyForSend(void)
 
     if ((gOptFlags & (kOptFlagUseRawIP)) == (kOptFlagUseRawIP))
     {
-        lStatus = (sRawIPEndPoint != NULL);
+        lStatus = (sRawIPEndPoint != nullptr);
     }
     else if ((gOptFlags & kOptFlagUseUDPIP) == kOptFlagUseUDPIP)
     {
-        lStatus = (sUDPIPEndPoint != NULL);
+        lStatus = (sUDPIPEndPoint != nullptr);
     }
 
     return (lStatus);
@@ -749,7 +749,7 @@ static INET_ERROR PrepareTransportForSend(void)
 
 static INET_ERROR DriveSendForDestination(const IPAddress & aAddress, uint16_t aSize)
 {
-    PacketBuffer * lBuffer = NULL;
+    PacketBuffer * lBuffer = nullptr;
     INET_ERROR lStatus     = INET_NO_ERROR;
 
     if ((gOptFlags & (kOptFlagUseRawIP)) == (kOptFlagUseRawIP))
@@ -762,13 +762,13 @@ static INET_ERROR DriveSendForDestination(const IPAddress & aAddress, uint16_t a
         if ((gOptFlags & kOptFlagUseIPv6) == (kOptFlagUseIPv6))
         {
             lBuffer = Common::MakeICMPv6DataBuffer(aSize);
-            VerifyOrExit(lBuffer != NULL, lStatus = INET_ERROR_NO_MEMORY);
+            VerifyOrExit(lBuffer != nullptr, lStatus = INET_ERROR_NO_MEMORY);
         }
 #if INET_CONFIG_ENABLE_IPV4
         else if ((gOptFlags & kOptFlagUseIPv4) == (kOptFlagUseIPv4))
         {
             lBuffer = Common::MakeICMPv4DataBuffer(aSize);
-            VerifyOrExit(lBuffer != NULL, lStatus = INET_ERROR_NO_MEMORY);
+            VerifyOrExit(lBuffer != nullptr, lStatus = INET_ERROR_NO_MEMORY);
         }
 #endif // INET_CONFIG_ENABLE_IPV4
 
@@ -785,7 +785,7 @@ static INET_ERROR DriveSendForDestination(const IPAddress & aAddress, uint16_t a
             // patterned from zero to aSize - 1.
 
             lBuffer = Common::MakeDataBuffer(aSize, lFirstValue);
-            VerifyOrExit(lBuffer != NULL, lStatus = INET_ERROR_NO_MEMORY);
+            VerifyOrExit(lBuffer != nullptr, lStatus = INET_ERROR_NO_MEMORY);
 
             lStatus = sUDPIPEndPoint->SendTo(aAddress, kUDPPort, lBuffer);
             SuccessOrExit(lStatus);
@@ -853,7 +853,7 @@ void DriveSend(void)
     else
     {
         gSendIntervalExpired = false;
-        gSystemLayer.StartTimer(gSendIntervalMs, Common::HandleSendTimerComplete, NULL);
+        gSystemLayer.StartTimer(gSendIntervalMs, Common::HandleSendTimerComplete, nullptr);
 
         lStatus = DriveSendForGroups(sGroupAddresses);
         SuccessOrExit(lStatus);
@@ -874,7 +874,7 @@ static void StartTest(void)
     IPProtocol lIPProtocol       = kIPProtocol_ICMPv6;
     IPVersion lIPVersion         = kIPVersion_6;
     IPAddress lAddress           = IPAddress::Any;
-    IPEndPointBasis * lEndPoint  = NULL;
+    IPEndPointBasis * lEndPoint  = nullptr;
     const bool lUseLoopback      = ((gOptFlags & kOptFlagNoLoopback) == 0);
     INET_ERROR lStatus;
 
@@ -962,7 +962,7 @@ static void StartTest(void)
         GroupAddress & lGroupAddress  = sGroupAddresses.mAddresses[i];
         IPAddress & lMulticastAddress = lGroupAddress.mMulticastAddress;
 
-        if ((lEndPoint != NULL) && IsInterfaceIdPresent(gInterfaceId))
+        if ((lEndPoint != nullptr) && IsInterfaceIdPresent(gInterfaceId))
         {
             if (gOptFlags & kOptFlagUseIPv4)
             {
@@ -990,11 +990,11 @@ static void StartTest(void)
 
 static void CleanupTest(void)
 {
-    IPEndPointBasis * lEndPoint = NULL;
+    IPEndPointBasis * lEndPoint = nullptr;
     INET_ERROR lStatus;
 
     gSendIntervalExpired = false;
-    gSystemLayer.CancelTimer(Common::HandleSendTimerComplete, NULL);
+    gSystemLayer.CancelTimer(Common::HandleSendTimerComplete, nullptr);
 
     //  Leave the multicast groups
 
@@ -1013,7 +1013,7 @@ static void CleanupTest(void)
         GroupAddress & lGroupAddress  = sGroupAddresses.mAddresses[i];
         IPAddress & lMulticastAddress = lGroupAddress.mMulticastAddress;
 
-        if ((lEndPoint != NULL) && IsInterfaceIdPresent(gInterfaceId))
+        if ((lEndPoint != nullptr) && IsInterfaceIdPresent(gInterfaceId))
         {
             lMulticastAddress.ToString(lAddressBuffer, sizeof(lAddressBuffer));
 
@@ -1026,12 +1026,12 @@ static void CleanupTest(void)
 
     // Release the resources associated with the allocated end points.
 
-    if (sRawIPEndPoint != NULL)
+    if (sRawIPEndPoint != nullptr)
     {
         sRawIPEndPoint->Free();
     }
 
-    if (sUDPIPEndPoint != NULL)
+    if (sUDPIPEndPoint != nullptr)
     {
         sUDPIPEndPoint->Free();
     }

--- a/src/inet/tests/TestLwIPDNS.cpp
+++ b/src/inet/tests/TestLwIPDNS.cpp
@@ -56,8 +56,8 @@ static uint8_t sNumIpAddrs = DNS_MAX_ADDRS_PER_NAME;
 static ip_addr_t sIpAddrs[DNS_MAX_ADDRS_PER_NAME];
 #endif // INET_LWIP
 
-static const char * sHostname      = NULL;
-static const char * sDNSServerAddr = NULL;
+static const char * sHostname      = nullptr;
+static const char * sDNSServerAddr = nullptr;
 
 // clang-format off
 static ArgParser::HelpOptions gHelpOptions(TOOL_NAME,
@@ -69,7 +69,7 @@ static ArgParser::OptionSet * gToolOptionSets[] =
     &gNetworkOptions,
     &gFaultInjectionOptions,
     &gHelpOptions,
-    NULL
+    nullptr
 };
 // clang-format on
 

--- a/src/lib/core/CHIPCircularTLVBuffer.cpp
+++ b/src/lib/core/CHIPCircularTLVBuffer.cpp
@@ -63,8 +63,8 @@ CHIPCircularTLVBuffer::CHIPCircularTLVBuffer(uint8_t * inBuffer, size_t inBuffer
     mQueueLength = 0;
     mQueueHead   = inHead;
 
-    mProcessEvictedElement = NULL;
-    mAppData               = NULL;
+    mProcessEvictedElement = nullptr;
+    mAppData               = nullptr;
 
     // use common as opposed to unspecified, s.t. the reader that
     // skips over the elements does not complain about implicit
@@ -87,8 +87,8 @@ CHIPCircularTLVBuffer::CHIPCircularTLVBuffer(uint8_t * inBuffer, size_t inBuffer
     mQueueLength = 0;
     mQueueHead   = mQueue;
 
-    mProcessEvictedElement = NULL;
-    mAppData               = NULL;
+    mProcessEvictedElement = nullptr;
+    mAppData               = nullptr;
 
     // use common as opposed to unspecified, s.t. the reader that
     // skips over the elements does not complain about implicit
@@ -139,7 +139,7 @@ CHIP_ERROR CHIPCircularTLVBuffer::EvictHead(void)
 
     // if a custom handler is installed, give it a chance to
     // process the element before we evict it from the buffer.
-    if (mProcessEvictedElement != NULL)
+    if (mProcessEvictedElement != nullptr)
     {
         // Reinitialize the reader
         reader.Init(this);
@@ -265,7 +265,7 @@ CHIP_ERROR CHIPCircularTLVBuffer::GetNextBuffer(TLVReader & ioReader, const uint
     uint8_t * tail              = QueueTail();
     const uint8_t * readerStart = outBufStart;
 
-    if (readerStart == NULL)
+    if (readerStart == nullptr)
     {
         outBufStart = mQueueHead;
 
@@ -292,7 +292,7 @@ CHIP_ERROR CHIPCircularTLVBuffer::GetNextBuffer(TLVReader & ioReader, const uint
         // (i.e. mQueue+mQueueSize).  This case tail == outBufStart
         // indicates that the buffer is completely full
         outBufLen = (mQueue + mQueueSize) - outBufStart;
-        if ((tail == outBufStart) && (readerStart != NULL))
+        if ((tail == outBufStart) && (readerStart != nullptr))
             outBufLen = 0;
     }
     else
@@ -453,7 +453,7 @@ void CircularTLVReader::Init(CHIPCircularTLVBuffer * buf)
     mBufHandle    = (uintptr_t) buf;
     GetNextBuffer = CHIPCircularTLVBuffer::GetNextBufferFunct;
     mLenRead      = 0;
-    mReadPoint    = NULL;
+    mReadPoint    = nullptr;
     GetNextBuffer(*this, mBufHandle, mReadPoint, bufLen);
     mBufEnd        = mReadPoint + bufLen;
     mMaxLen        = buf->DataLength();
@@ -463,7 +463,7 @@ void CircularTLVReader::Init(CHIPCircularTLVBuffer * buf)
     mContainerType = kTLVType_NotSpecified;
     SetContainerOpen(false);
     ImplicitProfileId = kProfileIdNotSpecified;
-    AppData           = NULL;
+    AppData           = nullptr;
 }
 
 } // namespace TLV

--- a/src/lib/core/CHIPError.cpp
+++ b/src/lib/core/CHIPError.cpp
@@ -33,7 +33,7 @@ namespace chip {
  */
 void RegisterCHIPLayerErrorFormatter(void)
 {
-    static ErrorFormatter sCHIPErrorFormatter = { FormatCHIPError, NULL };
+    static ErrorFormatter sCHIPErrorFormatter = { FormatCHIPError, nullptr };
 
     RegisterErrorFormatter(&sCHIPErrorFormatter);
 }
@@ -52,7 +52,7 @@ void RegisterCHIPLayerErrorFormatter(void)
  */
 bool FormatCHIPError(char * buf, uint16_t bufSize, int32_t err)
 {
-    const char * desc = NULL;
+    const char * desc = nullptr;
 
     if (err < CHIP_ERROR_MIN || err > CHIP_ERROR_MAX)
     {

--- a/src/lib/core/CHIPTLVDebug.cpp
+++ b/src/lib/core/CHIPTLVDebug.cpp
@@ -60,7 +60,7 @@ static void DumpHandler(DumpWriter aWriter, const char * aIndent, const TLVReade
     const TLVType type     = aReader.GetType();
     const uint64_t tag     = aReader.GetTag();
     const uint32_t len     = aReader.GetLength();
-    const uint8_t * strbuf = NULL;
+    const uint8_t * strbuf = nullptr;
     CHIP_ERROR err         = CHIP_NO_ERROR;
     TLVReader temp;
     TLVTagControl tagControl;
@@ -218,7 +218,7 @@ const char * DecodeTagControl(const TLVTagControl aTagControl)
         break;
 
     default:
-        retval = NULL;
+        retval = nullptr;
         break;
     }
 
@@ -287,7 +287,7 @@ const char * DecodeType(const TLVType aType)
         break;
 
     default:
-        retval = NULL;
+        retval = nullptr;
         break;
     }
 
@@ -336,11 +336,11 @@ CHIP_ERROR DumpHandler(const TLVReader & aReader, size_t aDepth, void * aContext
     CHIP_ERROR retval          = CHIP_NO_ERROR;
     DumpContext * context;
 
-    VerifyOrExit(aContext != NULL, retval = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(aContext != nullptr, retval = CHIP_ERROR_INVALID_ARGUMENT);
 
     context = static_cast<DumpContext *>(aContext);
 
-    VerifyOrExit(context->mWriter != NULL, retval = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(context->mWriter != nullptr, retval = CHIP_ERROR_INVALID_ARGUMENT);
 
     DumpHandler(context->mWriter, indent, aReader, aDepth);
 
@@ -362,7 +362,7 @@ exit:
  */
 CHIP_ERROR Dump(const TLVReader & aReader, DumpWriter aWriter)
 {
-    void * context          = NULL;
+    void * context          = nullptr;
     DumpContext dumpContext = { aWriter, context };
     CHIP_ERROR retval;
 

--- a/src/lib/core/CHIPTLVReader.cpp
+++ b/src/lib/core/CHIPTLVReader.cpp
@@ -156,8 +156,8 @@ void TLVReader::Init(const uint8_t * data, uint32_t dataLen)
     SetContainerOpen(false);
 
     ImplicitProfileId = kProfileIdNotSpecified;
-    AppData           = NULL;
-    GetNextBuffer     = NULL;
+    AppData           = nullptr;
+    GetNextBuffer     = nullptr;
 }
 
 /**
@@ -182,8 +182,8 @@ void TLVReader::Init(PacketBuffer * buf, uint32_t maxLen)
     SetContainerOpen(false);
 
     ImplicitProfileId = kProfileIdNotSpecified;
-    AppData           = NULL;
-    GetNextBuffer     = NULL;
+    AppData           = nullptr;
+    GetNextBuffer     = nullptr;
 }
 
 /**
@@ -214,7 +214,7 @@ void TLVReader::Init(PacketBuffer * buf, uint32_t maxLen, bool allowDiscontiguou
     SetContainerOpen(false);
 
     ImplicitProfileId = kProfileIdNotSpecified;
-    AppData           = NULL;
+    AppData           = nullptr;
 
     if (allowDiscontiguousBuffers)
     {
@@ -222,7 +222,7 @@ void TLVReader::Init(PacketBuffer * buf, uint32_t maxLen, bool allowDiscontiguou
     }
     else
     {
-        GetNextBuffer = NULL;
+        GetNextBuffer = nullptr;
     }
 }
 
@@ -689,7 +689,7 @@ CHIP_ERROR TLVReader::DupBytes(uint8_t *& buf, uint32_t & dataLen)
         return CHIP_ERROR_WRONG_TLV_TYPE;
 
     buf = (uint8_t *) malloc(mElemLenOrVal);
-    if (buf == NULL)
+    if (buf == nullptr)
         return CHIP_ERROR_NO_MEMORY;
 
     CHIP_ERROR err = ReadData(buf, (uint32_t) mElemLenOrVal);
@@ -738,7 +738,7 @@ CHIP_ERROR TLVReader::DupString(char *& buf)
         return CHIP_ERROR_WRONG_TLV_TYPE;
 
     buf = (char *) malloc(mElemLenOrVal + 1);
-    if (buf == NULL)
+    if (buf == nullptr)
         return CHIP_ERROR_NO_MEMORY;
 
     CHIP_ERROR err = ReadData((uint8_t *) buf, (uint32_t) mElemLenOrVal);
@@ -1231,7 +1231,7 @@ CHIP_ERROR TLVReader::SkipData(void)
 
     if (TLVTypeHasLength(elemType))
     {
-        err = ReadData(NULL, mElemLenOrVal);
+        err = ReadData(nullptr, mElemLenOrVal);
         if (err != CHIP_NO_ERROR)
             return err;
     }
@@ -1465,7 +1465,7 @@ CHIP_ERROR TLVReader::ReadData(uint8_t * buf, uint32_t len)
         if (readLen > remainingLen)
             readLen = remainingLen;
 
-        if (buf != NULL)
+        if (buf != nullptr)
         {
             memcpy(buf, mReadPoint, readLen);
             buf += readLen;
@@ -1487,7 +1487,7 @@ CHIP_ERROR TLVReader::EnsureData(CHIP_ERROR noDataErr)
         if (mLenRead == mMaxLen)
             return noDataErr;
 
-        if (GetNextBuffer == NULL)
+        if (GetNextBuffer == nullptr)
             return noDataErr;
 
         uint32_t bufLen;
@@ -1561,16 +1561,16 @@ CHIP_ERROR TLVReader::GetNextPacketBuffer(TLVReader & reader, uintptr_t & bufHan
 {
     PacketBuffer *& buf = (PacketBuffer *&) bufHandle;
 
-    if (buf != NULL)
+    if (buf != nullptr)
         buf = buf->Next();
-    if (buf != NULL)
+    if (buf != nullptr)
     {
         bufStart = buf->Start();
         bufLen   = buf->DataLength();
     }
     else
     {
-        bufStart = NULL;
+        bufStart = nullptr;
         bufLen   = 0;
     }
 

--- a/src/lib/core/CHIPTLVUpdater.cpp
+++ b/src/lib/core/CHIPTLVUpdater.cpp
@@ -57,7 +57,7 @@ CHIP_ERROR TLVUpdater::Init(uint8_t * buf, uint32_t dataLen, uint32_t maxLen)
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint32_t freeLen;
 
-    VerifyOrExit(buf != NULL, err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(buf != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
 
     VerifyOrExit(maxLen >= dataLen, err = CHIP_ERROR_BUFFER_TOO_SMALL);
 
@@ -118,7 +118,7 @@ CHIP_ERROR TLVUpdater::Init(TLVReader & aReader, uint32_t freeLen)
     VerifyOrExit(aReader.mBufHandle == 0, err = CHIP_ERROR_NOT_IMPLEMENTED);
 
     // TLVReader should point to a non-NULL buffer
-    VerifyOrExit(buf != NULL, err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(buf != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
 
     // If reader is already on an element, reset it to start of element
     if (aReader.ElementType() != kTLVElementType_NotSpecified)
@@ -150,7 +150,7 @@ CHIP_ERROR TLVUpdater::Init(TLVReader & aReader, uint32_t freeLen)
 
     mUpdaterReader.ImplicitProfileId = aReader.ImplicitProfileId;
     mUpdaterReader.AppData           = aReader.AppData;
-    mUpdaterReader.GetNextBuffer     = NULL;
+    mUpdaterReader.GetNextBuffer     = nullptr;
 
     // Initialize the internal writer object
     mUpdaterWriter.mBufHandle     = 0;
@@ -164,15 +164,15 @@ CHIP_ERROR TLVUpdater::Init(TLVReader & aReader, uint32_t freeLen)
     mUpdaterWriter.SetCloseContainerReserved(false);
 
     mUpdaterWriter.ImplicitProfileId = aReader.ImplicitProfileId;
-    mUpdaterWriter.GetNewBuffer      = NULL;
-    mUpdaterWriter.FinalizeBuffer    = NULL;
+    mUpdaterWriter.GetNewBuffer      = nullptr;
+    mUpdaterWriter.FinalizeBuffer    = nullptr;
 
     // Cache element start address for internal use
     mElementStartAddr = buf + freeLen;
 
     // Clear the input reader object before returning. The user can no longer
     // use the original TLVReader object anymore.
-    aReader.Init((const uint8_t *) NULL, 0);
+    aReader.Init((const uint8_t *) nullptr, 0);
 
 exit:
     return err;

--- a/src/lib/core/CHIPTLVUtilities.cpp
+++ b/src/lib/core/CHIPTLVUtilities.cpp
@@ -153,7 +153,7 @@ CHIP_ERROR Iterate(const TLVReader & aReader, IterateHandler aHandler, void * aC
     TLVReader temp;
     CHIP_ERROR retval = CHIP_ERROR_NOT_IMPLEMENTED;
 
-    VerifyOrExit(aHandler != NULL, retval = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(aHandler != nullptr, retval = CHIP_ERROR_INVALID_ARGUMENT);
 
     temp.Init(aReader);
 
@@ -181,7 +181,7 @@ static CHIP_ERROR CountHandler(const TLVReader & aReader, size_t aDepth, void * 
 {
     CHIP_ERROR retval = CHIP_NO_ERROR;
 
-    VerifyOrExit(aContext != NULL, retval = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(aContext != nullptr, retval = CHIP_ERROR_INVALID_ARGUMENT);
 
     *static_cast<size_t *>(aContext) += 1;
 
@@ -264,7 +264,7 @@ static CHIP_ERROR FindHandler(const TLVReader & aReader, size_t aDepth, void * a
     const FindContext * theContext = static_cast<const FindContext *>(aContext);
     CHIP_ERROR retval              = CHIP_NO_ERROR;
 
-    VerifyOrExit(aContext != NULL, retval = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(aContext != nullptr, retval = CHIP_ERROR_INVALID_ARGUMENT);
 
     if (theContext->mTag == aReader.GetTag())
     {

--- a/src/lib/core/CHIPTLVWriter.cpp
+++ b/src/lib/core/CHIPTLVWriter.cpp
@@ -179,8 +179,8 @@ NO_INLINE void TLVWriter::Init(uint8_t * buf, uint32_t maxLen)
     SetCloseContainerReserved(true);
 
     ImplicitProfileId = kProfileIdNotSpecified;
-    GetNewBuffer      = NULL;
-    FinalizeBuffer    = NULL;
+    GetNewBuffer      = nullptr;
+    FinalizeBuffer    = nullptr;
 }
 
 /**
@@ -210,7 +210,7 @@ void TLVWriter::Init(PacketBuffer * buf, uint32_t maxLen)
     SetCloseContainerReserved(true);
 
     ImplicitProfileId = kProfileIdNotSpecified;
-    GetNewBuffer      = NULL;
+    GetNewBuffer      = nullptr;
     FinalizeBuffer    = FinalizePacketBuffer;
 }
 
@@ -245,7 +245,7 @@ void TLVWriter::Init(PacketBuffer * buf, uint32_t maxLen, bool allowDiscontiguou
     }
     else
     {
-        GetNewBuffer = NULL;
+        GetNewBuffer = nullptr;
     }
 }
 
@@ -279,7 +279,7 @@ CHIP_ERROR TLVWriter::Finalize()
     CHIP_ERROR err = CHIP_NO_ERROR;
     if (IsContainerOpen())
         return CHIP_ERROR_TLV_CONTAINER_OPEN;
-    if (FinalizeBuffer != NULL)
+    if (FinalizeBuffer != nullptr)
         err = FinalizeBuffer(*this, mBufHandle, mBufStart, mWritePoint - mBufStart);
     return err;
 }
@@ -868,7 +868,7 @@ CHIP_ERROR TLVWriter::VPutStringF(uint64_t tag, const char * fmt, va_list ap)
 #endif
     va_copy(aq, ap);
 
-    dataLen = vsnprintf(NULL, 0, fmt, aq);
+    dataLen = vsnprintf(nullptr, 0, fmt, aq);
 
     va_end(aq);
 
@@ -943,7 +943,7 @@ CHIP_ERROR TLVWriter::VPutStringF(uint64_t tag, const char * fmt, va_list ap)
 #elif HAVE_MALLOC
 
     tmpBuf = static_cast<char *>(malloc(dataLen + 1));
-    VerifyOrExit(tmpBuf != NULL, err = CHIP_ERROR_NO_MEMORY);
+    VerifyOrExit(tmpBuf != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     va_copy(aq, ap);
 
@@ -1287,7 +1287,7 @@ CHIP_ERROR TLVWriter::CloseContainer(TLVWriter & containerWriter)
     SetContainerOpen(false);
 
     // Reset the container writer so that it can't accidentally be used again.
-    containerWriter.Init((uint8_t *) NULL, 0);
+    containerWriter.Init((uint8_t *) nullptr, 0);
 
     return WriteElementHead(kTLVElementType_EndOfContainer, AnonymousTag, 0);
 }
@@ -1804,9 +1804,9 @@ CHIP_ERROR TLVWriter::WriteData(const uint8_t * p, uint32_t len)
     {
         if (mRemainingLen == 0)
         {
-            VerifyOrExit(GetNewBuffer != NULL, err = CHIP_ERROR_NO_MEMORY);
+            VerifyOrExit(GetNewBuffer != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
-            if (FinalizeBuffer != NULL)
+            if (FinalizeBuffer != nullptr)
             {
                 err = FinalizeBuffer(*this, mBufHandle, mBufStart, mWritePoint - mBufStart);
                 SuccessOrExit(err);
@@ -1855,14 +1855,14 @@ CHIP_ERROR TLVWriter::GetNewPacketBuffer(TLVWriter & writer, uintptr_t & bufHand
     PacketBuffer * buf = (PacketBuffer *) bufHandle;
 
     PacketBuffer * newBuf = buf->Next();
-    if (newBuf == NULL)
+    if (newBuf == nullptr)
     {
         newBuf = PacketBuffer::New(0);
-        if (newBuf != NULL)
+        if (newBuf != nullptr)
             buf->AddToEnd(newBuf);
     }
 
-    if (newBuf != NULL)
+    if (newBuf != nullptr)
     {
         bufHandle = (uintptr_t) newBuf;
         bufStart  = newBuf->Start();
@@ -1870,7 +1870,7 @@ CHIP_ERROR TLVWriter::GetNewPacketBuffer(TLVWriter & writer, uintptr_t & bufHand
     }
     else
     {
-        bufStart = NULL;
+        bufStart = nullptr;
         bufLen   = 0;
     }
 

--- a/src/lib/core/tests/TestCHIPCallback.cpp
+++ b/src/lib/core/tests/TestCHIPCallback.cpp
@@ -235,12 +235,12 @@ int TestCHIPCallback(void)
 	{
         "CHIPCallback",
         &sTests[0],
-        NULL,
-        NULL
+        nullptr,
+        nullptr
     };
     // clang-format on
 
-    nlTestRunner(&theSuite, NULL);
+    nlTestRunner(&theSuite, nullptr);
 
     return (nlTestRunnerStats(&theSuite));
 }

--- a/src/lib/core/tests/TestCHIPErrorStr.cpp
+++ b/src/lib/core/tests/TestCHIPErrorStr.cpp
@@ -240,12 +240,12 @@ static void CheckCoreErrorStr(nlTestSuite * inSuite, void * inContext)
 
         // Assert that the error string contains the error number in hex.
         snprintf(expectedText, sizeof(expectedText), "%08" PRIX32, err);
-        NL_TEST_ASSERT(inSuite, (strstr(errStr, expectedText) != NULL));
+        NL_TEST_ASSERT(inSuite, (strstr(errStr, expectedText) != nullptr));
 
 #if !CHIP_CONFIG_SHORT_ERROR_STR
         // Assert that the error string contains a description, which is signaled
         // by a presence of a colon proceeding the description.
-        NL_TEST_ASSERT(inSuite, (strchr(errStr, ':') != NULL));
+        NL_TEST_ASSERT(inSuite, (strchr(errStr, ':') != nullptr));
 #endif // !CHIP_CONFIG_SHORT_ERROR_STR
     }
 }
@@ -270,8 +270,8 @@ int TestCHIPErrorStr(void)
 	{
         "Core-Error-Strings",
         &sTests[0],
-        NULL,
-        NULL
+        nullptr,
+        nullptr
     };
     // clang-format on
 

--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -165,7 +165,7 @@ void ForEachElement(nlTestSuite * inSuite, TLVReader & reader, void * context,
         }
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        if (cb != NULL)
+        if (cb != nullptr)
         {
             cb(inSuite, reader, context);
         }
@@ -257,7 +257,7 @@ void TestDupBytes(nlTestSuite * inSuite, TLVReader & reader, uint64_t tag, const
 
 void TestBufferContents(nlTestSuite * inSuite, PacketBuffer * buf, const uint8_t * expectedVal, uint32_t expectedLen)
 {
-    while (buf != NULL)
+    while (buf != nullptr)
     {
         uint16_t len = buf->DataLength();
         NL_TEST_ASSERT(inSuite, len <= expectedLen);
@@ -1563,7 +1563,7 @@ void CheckCHIPTLVUtilities(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, count == expectedCount);
 
     // Iterate
-    err = chip::TLV::Utilities::Iterate(reader, NullIterateHandler, NULL);
+    err = chip::TLV::Utilities::Iterate(reader, NullIterateHandler, nullptr);
     NL_TEST_ASSERT(inSuite, err == CHIP_END_OF_TLV);
 }
 
@@ -2782,8 +2782,8 @@ void CheckCHIPTLVWriter(nlTestSuite * inSuite, void * inContext)
 void SkipNonContainer(nlTestSuite * inSuite)
 {
     TLVReader reader;
-    const uint8_t * readpoint1 = NULL;
-    const uint8_t * readpoint2 = NULL;
+    const uint8_t * readpoint1 = nullptr;
+    const uint8_t * readpoint2 = nullptr;
 
     reader.Init(Encoding1, sizeof(Encoding1));
     reader.ImplicitProfileId = TestProfile_2;
@@ -2803,8 +2803,8 @@ void SkipNonContainer(nlTestSuite * inSuite)
 void SkipContainer(nlTestSuite * inSuite)
 {
     TLVReader reader;
-    const uint8_t * readpoint1 = NULL;
-    const uint8_t * readpoint2 = NULL;
+    const uint8_t * readpoint1 = nullptr;
+    const uint8_t * readpoint2 = nullptr;
 
     reader.Init(Encoding1, sizeof(Encoding1));
     reader.ImplicitProfileId = TestProfile_2;
@@ -3082,7 +3082,7 @@ void TestCHIPTLVReader_NextOverContainer_ProcessElement(nlTestSuite * inSuite, T
         // Manually advance one of the readers to the element immediately after the container (if any).
         err = readerClone1.EnterContainer(outerContainerType);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        ForEachElement(inSuite, readerClone1, NULL, NULL);
+        ForEachElement(inSuite, readerClone1, nullptr, nullptr);
         err = readerClone1.ExitContainer(outerContainerType);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
         nextRes1 = readerClone1.Next();
@@ -3109,7 +3109,7 @@ void TestCHIPTLVReader_NextOverContainer(nlTestSuite * inSuite)
     reader.Init(Encoding1, sizeof(Encoding1));
     reader.ImplicitProfileId = TestProfile_2;
 
-    ForEachElement(inSuite, reader, NULL, TestCHIPTLVReader_NextOverContainer_ProcessElement);
+    ForEachElement(inSuite, reader, nullptr, TestCHIPTLVReader_NextOverContainer_ProcessElement);
 }
 
 void TestCHIPTLVReader_SkipOverContainer_ProcessElement(nlTestSuite * inSuite, TLVReader & reader, void * context)
@@ -3127,7 +3127,7 @@ void TestCHIPTLVReader_SkipOverContainer_ProcessElement(nlTestSuite * inSuite, T
         // Manually advance one of the readers to immediately after the container.
         err = readerClone1.EnterContainer(outerContainerType);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        ForEachElement(inSuite, readerClone1, NULL, NULL);
+        ForEachElement(inSuite, readerClone1, nullptr, nullptr);
         err = readerClone1.ExitContainer(outerContainerType);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
@@ -3151,7 +3151,7 @@ void TestCHIPTLVReader_SkipOverContainer(nlTestSuite * inSuite)
     reader.Init(Encoding1, sizeof(Encoding1));
     reader.ImplicitProfileId = TestProfile_2;
 
-    ForEachElement(inSuite, reader, NULL, TestCHIPTLVReader_SkipOverContainer_ProcessElement);
+    ForEachElement(inSuite, reader, nullptr, TestCHIPTLVReader_SkipOverContainer_ProcessElement);
 }
 
 /**
@@ -3821,8 +3821,8 @@ int TestCHIPTLV(void)
     {
         "chip-tlv",
         &sTests[0],
-        NULL,
-        NULL
+        nullptr,
+        nullptr
     };
     // clang-format on
     TestTLVContext context;

--- a/src/lib/core/tests/TestReferenceCounted.cpp
+++ b/src/lib/core/tests/TestReferenceCounted.cpp
@@ -66,12 +66,12 @@ int TestReferenceCounted(void)
 	{
         "Reference-Counted",
         &sTests[0],
-        NULL,
-        NULL
+        nullptr,
+        nullptr
     };
     // clang-format on
 
-    nlTestRunner(&theSuite, NULL);
+    nlTestRunner(&theSuite, nullptr);
 
     return (nlTestRunnerStats(&theSuite));
 }

--- a/src/lib/message/CHIPBinding.cpp
+++ b/src/lib/message/CHIPBinding.cpp
@@ -301,14 +301,14 @@ CHIP_ERROR Binding::Init(void * apAppState, EventCallback aEventCallback)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    VerifyOrExit(aEventCallback != NULL, err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(aEventCallback != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
 
     mState    = kState_NotConfigured;
     mRefCount = 1;
     AppState  = apAppState;
     SetEventCallback(aEventCallback);
-    mProtocolLayerCallback = NULL;
-    mProtocolLayerState    = NULL;
+    mProtocolLayerCallback = nullptr;
+    mProtocolLayerState    = nullptr;
 
     ResetConfig();
 
@@ -380,11 +380,11 @@ void Binding::DoReset(State newState)
     // connection complete handler that may result from releasing the connection.
     if (GetFlag(kFlag_ConnectionReferenced))
     {
-        mCon->OnConnectionComplete = NULL;
+        mCon->OnConnectionComplete = nullptr;
         mCon->Release();
         ClearFlag(kFlag_ConnectionReferenced);
     }
-    mCon = NULL;
+    mCon = nullptr;
 
     // If a session establishment was in progress, cancel it.
     if (origState == kState_PreparingSecurity_EstablishSession)
@@ -416,9 +416,9 @@ void Binding::DoClose(void)
     if (mState != kState_Closed)
     {
         // Clear pointers to application state/code to prevent any further use.
-        AppState = NULL;
-        SetEventCallback(NULL);
-        SetProtocolLayerCallback(NULL, NULL);
+        AppState = nullptr;
+        SetEventCallback(nullptr);
+        SetProtocolLayerCallback(nullptr, nullptr);
 
         // Reset the binding and enter the Closed state.
         DoReset(kState_Closed);
@@ -438,9 +438,9 @@ void Binding::ResetConfig()
     mPeerAddress      = Inet::IPAddress::Any;
     mPeerPort         = CHIP_PORT;
     mInterfaceId      = INET_NULL_INTERFACEID;
-    mHostName         = NULL;
+    mHostName         = nullptr;
 
-    mCon = NULL;
+    mCon = nullptr;
 
     mTransportOption            = kTransport_NotSpecified;
     mDefaultResponseTimeoutMsec = 0;
@@ -571,7 +571,7 @@ CHIP_ERROR Binding::DoPrepare(CHIP_ERROR configErr)
 exit:
     if (CHIP_NO_ERROR != err)
     {
-        HandleBindingFailed(err, NULL, false);
+        HandleBindingFailed(err, nullptr, false);
     }
     ChipLogFunctError(err);
     return err;
@@ -589,7 +589,7 @@ void Binding::PrepareAddress()
     // If configured to use an existing connection, extract the peer IP addressing information from the
     // connection if available.  Although this won't be used in contacting the peer (since the connection
     // already exists) this makes the information available via the Binding API.
-    if ((mTransportOption == kTransport_TCP || mTransportOption == kTransport_ExistingConnection) && mCon != NULL)
+    if ((mTransportOption == kTransport_TCP || mTransportOption == kTransport_ExistingConnection) && mCon != nullptr)
     {
         if (mCon->NetworkType == ChipConnection::kNetworkType_IP)
         {
@@ -642,7 +642,7 @@ void Binding::PrepareAddress()
 exit:
     if (CHIP_NO_ERROR != err)
     {
-        HandleBindingFailed(err, NULL, false);
+        HandleBindingFailed(err, nullptr, false);
     }
 }
 
@@ -656,12 +656,12 @@ void Binding::PrepareTransport()
     mState = kState_PreparingTransport;
 
     // If the application has requested TCP, and no existing connection has been supplied...
-    if (mTransportOption == kTransport_TCP && mCon == NULL)
+    if (mTransportOption == kTransport_TCP && mCon == nullptr)
     {
         // Construct a new ChipConnection object.  This method implicitly establishes a reference
         // to the connection object, which will be owned by the Binding until it is closed or fails.
         mCon = mExchangeManager->MessageLayer->NewConnection();
-        VerifyOrExit(mCon != NULL, err = CHIP_ERROR_NO_MEMORY);
+        VerifyOrExit(mCon != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
         // Remember that we have to release the connection later when the binding closes.
         SetFlag(kFlag_ConnectionReferenced);
@@ -677,7 +677,7 @@ void Binding::PrepareTransport()
         // reference to the connection without using a callback function.  Because of this, leaving
         // in place the default connection closed handler, with its automatic close feature, the
         // would result in a double release.  Thus we suppress that here.
-        mCon->OnConnectionClosed = NULL;
+        mCon->OnConnectionClosed = nullptr;
 
         mState = kState_PreparingTransport_TCPConnect;
 
@@ -702,7 +702,7 @@ void Binding::PrepareTransport()
 exit:
     if (CHIP_NO_ERROR != err)
     {
-        HandleBindingFailed(err, NULL, true);
+        HandleBindingFailed(err, nullptr, true);
     }
 }
 
@@ -758,7 +758,7 @@ exit:
 
     if (CHIP_NO_ERROR != err)
     {
-        HandleBindingFailed(err, NULL, true);
+        HandleBindingFailed(err, nullptr, true);
     }
 }
 
@@ -825,7 +825,7 @@ void Binding::HandleBindingReady()
 
     // If the Binding is still in the Ready state, and a protocol layer callback has been registered,
     // tell the protocol layer that the Binding is ready for use.
-    if (mState == kState_Ready && mProtocolLayerCallback != NULL)
+    if (mState == kState_Ready && mProtocolLayerCallback != nullptr)
     {
         mProtocolLayerCallback(mProtocolLayerState, kEvent_BindingReady, inParam, outParam);
     }
@@ -875,7 +875,7 @@ void Binding::HandleBindingFailed(CHIP_ERROR err, Protocols::StatusReporting::St
     if (raiseEvents)
     {
         mAppEventCallback(AppState, eventType, inParam, outParam);
-        if (mProtocolLayerCallback != NULL)
+        if (mProtocolLayerCallback != nullptr)
         {
             mProtocolLayerCallback(mProtocolLayerState, eventType, inParam, outParam);
         }
@@ -908,7 +908,7 @@ void Binding::OnResolveComplete(void * appState, INET_ERROR err, uint8_t addrCou
     }
     else
     {
-        _this->HandleBindingFailed(err, NULL, true);
+        _this->HandleBindingFailed(err, nullptr, true);
     }
 }
 
@@ -953,7 +953,7 @@ void Binding::OnConnectionComplete(ChipConnection * con, CHIP_ERROR conErr)
     {
         ChipLogDetail(ExchangeManager, "Binding[%" PRIu8 "] (%" PRIu16 "): TCP con failed (%04" PRIX16 "): %s", _this->GetLogId(),
                       _this->mRefCount, con->LogId(), ErrorStr(conErr));
-        _this->HandleBindingFailed(conErr, NULL, true);
+        _this->HandleBindingFailed(conErr, nullptr, true);
     }
 }
 
@@ -979,7 +979,7 @@ void Binding::OnConnectionClosed(ChipConnection * con, CHIP_ERROR err)
     }
 
     // Transition the binding to a failed state.
-    HandleBindingFailed(err, NULL, true);
+    HandleBindingFailed(err, nullptr, true);
 
 exit:
     return;
@@ -1046,7 +1046,7 @@ void Binding::OnKeyFailed(uint64_t peerNodeId, uint32_t keyId, CHIP_ERROR keyErr
     VerifyOrExit(mState != kState_Ready || keyId == mKeyId, /* no-op */);
 
     // Fail the binding.
-    HandleBindingFailed(keyErr, NULL, true);
+    HandleBindingFailed(keyErr, nullptr, true);
 
 exit:
     return;
@@ -1128,7 +1128,7 @@ bool Binding::IsAuthenticMessageFromPeer(const chip::ChipMessageHeader * msgInfo
     if (msgInfo->SourceNodeId != mPeerNodeId)
         return false;
 
-    if (msgInfo->InCon != NULL)
+    if (msgInfo->InCon != nullptr)
     {
         if ((mTransportOption != kTransport_TCP && mTransportOption != kTransport_ExistingConnection) || msgInfo->InCon != mCon)
             return false;
@@ -1182,8 +1182,8 @@ uint32_t Binding::GetMaxChipPayloadSize(const System::PacketBuffer * msgBuf)
  */
 void Binding::GetPeerDescription(char * buf, uint32_t bufSize) const
 {
-    ChipMessageLayer::GetPeerDescription(buf, bufSize, mPeerNodeId, (mPeerAddress != Inet::IPAddress::Any) ? &mPeerAddress : NULL,
-                                         mPeerPort, mInterfaceId, mCon);
+    ChipMessageLayer::GetPeerDescription(
+        buf, bufSize, mPeerNodeId, (mPeerAddress != Inet::IPAddress::Any) ? &mPeerAddress : nullptr, mPeerPort, mInterfaceId, mCon);
 }
 
 /**
@@ -1206,14 +1206,14 @@ CHIP_ERROR Binding::NewExchangeContext(chip::ExchangeContext *& appExchangeConte
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    appExchangeContext = NULL;
+    appExchangeContext = nullptr;
 
     // Fail if the binding is not in the Ready state.
     VerifyOrExit(kState_Ready == mState, err = CHIP_ERROR_INCORRECT_STATE);
 
     // Attempt to allocate a new exchange context.
-    appExchangeContext = mExchangeManager->NewContext(mPeerNodeId, mPeerAddress, mPeerPort, mInterfaceId, NULL);
-    VerifyOrExit(NULL != appExchangeContext, err = CHIP_ERROR_NO_MEMORY);
+    appExchangeContext = mExchangeManager->NewContext(mPeerNodeId, mPeerAddress, mPeerPort, mInterfaceId, nullptr);
+    VerifyOrExit(nullptr != appExchangeContext, err = CHIP_ERROR_NO_MEMORY);
 
     // Set the default RMP configuration in the new exchange.
     appExchangeContext->mRMPConfig = mDefaultRMPConfig;
@@ -1262,10 +1262,10 @@ CHIP_ERROR Binding::NewExchangeContext(chip::ExchangeContext *& appExchangeConte
     SuccessOrExit(err);
 
 exit:
-    if (err != CHIP_NO_ERROR && appExchangeContext != NULL)
+    if (err != CHIP_NO_ERROR && appExchangeContext != nullptr)
     {
         appExchangeContext->Close();
-        appExchangeContext = NULL;
+        appExchangeContext = nullptr;
     }
     ChipLogFunctError(err);
     return err;
@@ -1300,7 +1300,7 @@ CHIP_ERROR Binding::AllocateRightSizedBuffer(PacketBuffer *& buf, const uint32_t
     bufferAllocSize += weaveTrailerSize;
 
     buf = PacketBuffer::NewWithAvailableSize(weaveHeaderSize, bufferAllocSize);
-    VerifyOrExit(buf != NULL, err = CHIP_ERROR_NO_MEMORY);
+    VerifyOrExit(buf != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     maxChipPayloadSize = GetMaxChipPayloadSize(buf);
 
@@ -1311,7 +1311,7 @@ CHIP_ERROR Binding::AllocateRightSizedBuffer(PacketBuffer *& buf, const uint32_t
         err = CHIP_ERROR_BUFFER_TOO_SMALL;
 
         PacketBuffer::Free(buf);
-        buf = NULL;
+        buf = nullptr;
     }
 
 exit:
@@ -1817,7 +1817,7 @@ Binding::Configuration & Binding::Configuration::ConfigureFromMessage(const chip
 {
     mBinding.mPeerNodeId = aMsgInfo->SourceNodeId;
 
-    if (aMsgInfo->InCon != NULL)
+    if (aMsgInfo->InCon != nullptr)
     {
         Transport_ExistingConnection(aMsgInfo->InCon);
     }

--- a/src/lib/message/CHIPConnection.cpp
+++ b/src/lib/message/CHIPConnection.cpp
@@ -73,8 +73,8 @@ void ChipConnection::Release()
     if (mRefCount == 2 && State != kState_ReadyToConnect && State != kState_Closed)
     {
         // Suppress callbacks.
-        OnConnectionComplete = NULL;
-        OnConnectionClosed   = NULL;
+        OnConnectionComplete = nullptr;
+        OnConnectionClosed   = nullptr;
 
         // Perform a graceful close.
         DoClose(CHIP_NO_ERROR, kDoCloseFlag_SuppressCallback);
@@ -194,7 +194,7 @@ CHIP_ERROR ChipConnection::Connect(uint64_t peerNodeId, ChipAuthMode authMode, c
                  err = CHIP_ERROR_INVALID_ARGUMENT);
 
     // Can't request authentication if the security manager is not initialized.
-    VerifyOrExit(authMode == kChipAuthMode_Unauthenticated || MessageLayer->SecurityMgr != NULL,
+    VerifyOrExit(authMode == kChipAuthMode_Unauthenticated || MessageLayer->SecurityMgr != nullptr,
                  err = CHIP_ERROR_UNSUPPORTED_AUTH_MODE);
 
     // Application has made this an IP-based ChipConnection.
@@ -259,7 +259,7 @@ exit:
  */
 CHIP_ERROR ChipConnection::Connect(uint64_t peerNodeId, ChipAuthMode authMode, const char * peerAddr, uint16_t defaultPort)
 {
-    return Connect(peerNodeId, authMode, peerAddr, (peerAddr != NULL) ? strlen(peerAddr) : 0, defaultPort);
+    return Connect(peerNodeId, authMode, peerAddr, (peerAddr != nullptr) ? strlen(peerAddr) : 0, defaultPort);
 }
 
 /**
@@ -372,11 +372,11 @@ CHIP_ERROR ChipConnection::Connect(uint64_t peerNodeId, ChipAuthMode authMode, c
                  err = CHIP_ERROR_INVALID_ARGUMENT);
 
     // Can't request authentication if the security manager is not initialized.
-    VerifyOrExit(authMode == kChipAuthMode_Unauthenticated || MessageLayer->SecurityMgr != NULL,
+    VerifyOrExit(authMode == kChipAuthMode_Unauthenticated || MessageLayer->SecurityMgr != nullptr,
                  err = CHIP_ERROR_UNSUPPORTED_AUTH_MODE);
 
     // If no peer address given, connect using the node id.
-    if (peerAddr == NULL || peerAddrLen == 0)
+    if (peerAddr == nullptr || peerAddrLen == 0)
     {
         err = Connect(peerNodeId, authMode, IPAddress::Any, defaultPort);
         ExitNow();
@@ -392,7 +392,7 @@ CHIP_ERROR ChipConnection::Connect(uint64_t peerNodeId, ChipAuthMode authMode, c
         PeerPort = (defaultPort != 0) ? defaultPort : CHIP_PORT;
 
     // If an interface name has been specified, attempt to convert it to a network interface id.
-    if (intfName != NULL)
+    if (intfName != nullptr)
     {
         err = InterfaceNameToId(intfName, mTargetInterface);
         SuccessOrExit(err);
@@ -450,7 +450,7 @@ void ChipConnection::SetConnectTimeout(const uint32_t connTimeoutMsecs)
 CHIP_ERROR ChipConnection::GetPeerAddressInfo(IPPacketInfo & addrInfo)
 {
 #if CONFIG_NETWORK_LAYER_BLE
-    if (mBleEndPoint != NULL)
+    if (mBleEndPoint != nullptr)
         return CHIP_ERROR_NOT_IMPLEMENTED;
 #endif
 
@@ -472,7 +472,7 @@ CHIP_ERROR ChipConnection::GetPeerAddressInfo(IPPacketInfo & addrInfo)
  */
 void ChipConnection::GetPeerDescription(char * buf, size_t bufSize) const
 {
-    ChipMessageLayer::GetPeerDescription(buf, bufSize, PeerNodeId, (NetworkType == kNetworkType_IP) ? &PeerAddr : NULL,
+    ChipMessageLayer::GetPeerDescription(buf, bufSize, PeerNodeId, (NetworkType == kNetworkType_IP) ? &PeerAddr : nullptr,
                                          (NetworkType == kNetworkType_IP) ? PeerPort : 0, INET_NULL_INTERFACEID, this);
 }
 
@@ -545,7 +545,7 @@ CHIP_ERROR ChipConnection::SendMessage(ChipMessageInfo * msgInfo, PacketBuffer *
     msgBuf = PacketBuffer::RightSize(msgBuf);
 
 #if CONFIG_NETWORK_LAYER_BLE
-    if (mBleEndPoint != NULL)
+    if (mBleEndPoint != nullptr)
     {
         res = mBleEndPoint->Send(msgBuf);
     }
@@ -554,13 +554,13 @@ CHIP_ERROR ChipConnection::SendMessage(ChipMessageInfo * msgInfo, PacketBuffer *
     {
         res = mTcpEndPoint->Send(msgBuf, true);
     }
-    msgBuf = NULL;
+    msgBuf = nullptr;
 
 exit:
-    if (msgBuf != NULL)
+    if (msgBuf != nullptr)
     {
         PacketBuffer::Free(msgBuf);
-        msgBuf = NULL;
+        msgBuf = nullptr;
     }
 
     return res;
@@ -592,7 +592,7 @@ exit:
 CHIP_ERROR ChipConnection::Shutdown()
 {
 #if CONFIG_NETWORK_LAYER_BLE
-    if (mBleEndPoint != NULL)
+    if (mBleEndPoint != nullptr)
         return CHIP_ERROR_NOT_IMPLEMENTED;
 #endif
 
@@ -672,8 +672,8 @@ CHIP_ERROR ChipConnection::Close()
 CHIP_ERROR ChipConnection::Close(bool suppressCloseLog)
 {
     // Suppress callbacks.
-    OnConnectionComplete = NULL;
-    OnConnectionClosed   = NULL;
+    OnConnectionComplete = nullptr;
+    OnConnectionClosed   = nullptr;
 
     // Perform a graceful close.
     DoClose(CHIP_NO_ERROR, kDoCloseFlag_SuppressCallback | (suppressCloseLog ? kDoCloseFlag_SuppressLogging : 0));
@@ -704,8 +704,8 @@ CHIP_ERROR ChipConnection::Close(bool suppressCloseLog)
 void ChipConnection::Abort()
 {
     // Suppress callbacks.
-    OnConnectionComplete = NULL;
-    OnConnectionClosed   = NULL;
+    OnConnectionComplete = nullptr;
+    OnConnectionClosed   = nullptr;
 
     // Perform an abortive close of the connection.
     DoClose(CHIP_ERROR_CONNECTION_ABORTED, kDoCloseFlag_SuppressCallback);
@@ -787,7 +787,7 @@ void ChipConnection::DisableReceive()
 CHIP_ERROR ChipConnection::EnableKeepAlive(uint16_t interval, uint16_t timeoutCount)
 {
 #if CONFIG_NETWORK_LAYER_BLE
-    if (mBleEndPoint != NULL)
+    if (mBleEndPoint != nullptr)
         return CHIP_ERROR_NOT_IMPLEMENTED;
 #endif
 
@@ -823,7 +823,7 @@ CHIP_ERROR ChipConnection::EnableKeepAlive(uint16_t interval, uint16_t timeoutCo
 CHIP_ERROR ChipConnection::DisableKeepAlive()
 {
 #if CONFIG_NETWORK_LAYER_BLE
-    if (mBleEndPoint != NULL)
+    if (mBleEndPoint != nullptr)
         return CHIP_ERROR_NOT_IMPLEMENTED;
 #endif
 
@@ -869,7 +869,7 @@ CHIP_ERROR ChipConnection::DisableKeepAlive()
 CHIP_ERROR ChipConnection::SetUserTimeout(uint32_t userTimeoutMillis)
 {
 #if CONFIG_NETWORK_LAYER_BLE
-    if (mBleEndPoint != NULL)
+    if (mBleEndPoint != nullptr)
         return CHIP_ERROR_NOT_IMPLEMENTED;
 #endif
 
@@ -941,7 +941,7 @@ void ChipConnection::DoClose(CHIP_ERROR err, uint8_t flags)
     if (State != kState_Closed)
     {
 #if CONFIG_NETWORK_LAYER_BLE
-        if (mBleEndPoint != NULL)
+        if (mBleEndPoint != nullptr)
         {
             if (err == CHIP_NO_ERROR)
             {
@@ -955,19 +955,19 @@ void ChipConnection::DoClose(CHIP_ERROR err, uint8_t flags)
 
             // BleEndPoint frees itself once it finishes the close operation. It must stick around to negotiate the
             // close, potentially after it's emptied the remainder of its WoBle transmit buffer.
-            mBleEndPoint = NULL;
+            mBleEndPoint = nullptr;
         }
         else
 #endif
         {
-            if (mTcpEndPoint != NULL)
+            if (mTcpEndPoint != nullptr)
             {
                 if (err == CHIP_NO_ERROR)
                     err = mTcpEndPoint->Close();
                 if (err != CHIP_NO_ERROR)
                     mTcpEndPoint->Abort();
                 mTcpEndPoint->Free();
-                mTcpEndPoint = NULL;
+                mTcpEndPoint = nullptr;
             }
 
 #if CHIP_CONFIG_ENABLE_DNS_RESOLVER
@@ -985,7 +985,7 @@ void ChipConnection::DoClose(CHIP_ERROR err, uint8_t flags)
             ChipLogProgress(MessageLayer, "Con closed %04X %ld", LogId(), (long) err);
 
         // If the exchange manager has been initialized, call its callback.
-        if (MessageLayer->ExchangeMgr != NULL)
+        if (MessageLayer->ExchangeMgr != nullptr)
             MessageLayer->ExchangeMgr->HandleConnectionClosed(this, err);
 
         // Call the Fabric state object to alert it of the connection close.
@@ -996,10 +996,10 @@ void ChipConnection::DoClose(CHIP_ERROR err, uint8_t flags)
         {
             if (oldState == kState_Resolving || oldState == kState_Connecting || oldState == kState_EstablishingSession)
             {
-                if (OnConnectionComplete != NULL)
+                if (OnConnectionComplete != nullptr)
                     OnConnectionComplete(this, err);
             }
-            else if (OnConnectionClosed != NULL)
+            else if (OnConnectionClosed != nullptr)
                 OnConnectionClosed(this, err);
         }
 
@@ -1078,7 +1078,7 @@ void ChipConnection::StartSession()
         ChipLogProgress(MessageLayer, "Con complete %04X", LogId());
 
         // Call the app's completion function.
-        if (OnConnectionComplete != NULL)
+        if (OnConnectionComplete != nullptr)
             OnConnectionComplete(this, CHIP_NO_ERROR);
     }
 }
@@ -1185,7 +1185,7 @@ void ChipConnection::HandleConnectComplete(TCPEndPoint * endPoint, INET_ERROR co
 
         // Setup various callbacks on the end point.
         endPoint->OnDataReceived     = HandleDataReceived;
-        endPoint->OnDataSent         = NULL; // TODO: should handle flow control
+        endPoint->OnDataSent         = nullptr; // TODO: should handle flow control
         endPoint->OnConnectionClosed = HandleTcpConnectionClosed;
 
         // Disable TCP Nagle buffering by setting TCP_NODELAY socket option to true
@@ -1206,7 +1206,7 @@ void ChipConnection::HandleConnectComplete(TCPEndPoint * endPoint, INET_ERROR co
     {
         // Release the end point object.
         endPoint->Free();
-        con->mTcpEndPoint = NULL;
+        con->mTcpEndPoint = nullptr;
 
         // Attempt to connect to another address if available.
         con->TryNextPeerAddress(conRes);
@@ -1220,13 +1220,13 @@ void ChipConnection::HandleDataReceived(TCPEndPoint * endPoint, PacketBuffer * d
     ChipMessageLayer * msgLayer = con->MessageLayer;
 
     // While in a state that allows receiving, process the received data...
-    while (data != NULL && con->StateAllowsReceive() && con->ReceiveEnabled && (con->OnMessageReceived != NULL))
+    while (data != nullptr && con->StateAllowsReceive() && con->ReceiveEnabled && (con->OnMessageReceived != nullptr))
     {
         IPPacketInfo packetInfo;
         ChipMessageInfo msgInfo;
         uint8_t * payload;
         uint16_t payloadLen;
-        PacketBuffer * payloadBuf = NULL;
+        PacketBuffer * payloadBuf = nullptr;
         uint32_t frameLen;
 
         packetInfo.Clear();
@@ -1264,7 +1264,7 @@ void ChipConnection::HandleDataReceived(TCPEndPoint * endPoint, PacketBuffer * d
             // Attempt to allocate a buffer big enough to hold the entire message.  Fail with
             // CHIP_ERROR_MESSAGE_TOO_LONG if no such buffer is available.
             PacketBuffer * newBuf = PacketBuffer::NewWithAvailableSize(0, frameLen);
-            if (newBuf == NULL)
+            if (newBuf == nullptr)
             {
                 break;
             }
@@ -1284,7 +1284,7 @@ void ChipConnection::HandleDataReceived(TCPEndPoint * endPoint, PacketBuffer * d
         {
             // If there are more buffers in the queue, move as much data as possible into the head buffer
             // and try again.
-            if (data->Next() != NULL)
+            if (data->Next() != nullptr)
             {
                 data->CompactHead();
                 continue;
@@ -1332,7 +1332,7 @@ void ChipConnection::HandleDataReceived(TCPEndPoint * endPoint, PacketBuffer * d
             else
             {
                 payloadBuf = PacketBuffer::New(0);
-                if (payloadBuf != NULL)
+                if (payloadBuf != nullptr)
                 {
                     memcpy(payloadBuf->Start(), payload, payloadLen);
                     payloadBuf->SetDataLength(payloadLen);
@@ -1350,13 +1350,13 @@ void ChipConnection::HandleDataReceived(TCPEndPoint * endPoint, PacketBuffer * d
             // Send key error response to the peer if required.
             if (msgLayer->SecurityMgr->IsKeyError(err))
             {
-                if (data != NULL)
+                if (data != nullptr)
                 {
                     PacketBuffer::Free(data);
-                    data = NULL;
+                    data = nullptr;
                 }
 
-                msgLayer->SecurityMgr->SendKeyErrorMsg(&msgInfo, NULL, con, err);
+                msgLayer->SecurityMgr->SendKeyErrorMsg(&msgInfo, nullptr, con, err);
             }
 
             con->DisconnectOnError(err);
@@ -1381,19 +1381,19 @@ void ChipConnection::HandleDataReceived(TCPEndPoint * endPoint, PacketBuffer * d
     // TCP connection is closed (which means we're never going to receive any more data), fail with
     // a MESSAGE_INCOMPLETE error.  If the ChipConnection is closed (e.g. the app called close)
     // then simply discard the received data.
-    if (data != NULL)
+    if (data != nullptr)
     {
         if (con->StateAllowsReceive())
         {
             if (endPoint->State == TCPEndPoint::kState_Connected || endPoint->State == TCPEndPoint::kState_SendShutdown)
             {
                 endPoint->PutBackReceivedData(data);
-                data = NULL;
+                data = nullptr;
             }
             else
                 con->DoClose(CHIP_ERROR_MESSAGE_INCOMPLETE, 0);
         }
-        if (data != NULL)
+        if (data != nullptr)
             PacketBuffer::Free(data);
     }
 }
@@ -1420,7 +1420,7 @@ void ChipConnection::HandleSecureSessionEstablished(ChipSecurityManager * sm, Ch
     ChipLogProgress(MessageLayer, "Con complete %04X", con->LogId());
 
     // Invoke the app's completion function.
-    if (con->OnConnectionComplete != NULL)
+    if (con->OnConnectionComplete != nullptr)
         con->OnConnectionComplete(con, CHIP_NO_ERROR);
 }
 
@@ -1437,7 +1437,7 @@ void ChipConnection::Init(ChipMessageLayer * msgLayer)
     PeerNodeId            = 0;
     PeerAddr              = IPAddress::Any;
     MessageLayer          = msgLayer;
-    AppState              = NULL;
+    AppState              = nullptr;
     PeerPort              = 0;
     DefaultKeyId          = ChipKeyId::kNone;
     AuthMode              = kChipAuthMode_NotSpecified;
@@ -1445,14 +1445,14 @@ void ChipConnection::Init(ChipMessageLayer * msgLayer)
     State                 = ChipConnection::kState_ReadyToConnect;
     NetworkType           = kNetworkType_Unassigned;
     ReceiveEnabled        = true;
-    OnConnectionComplete  = NULL;
-    OnMessageReceived     = NULL;
+    OnConnectionComplete  = nullptr;
+    OnMessageReceived     = nullptr;
     OnConnectionClosed    = DefaultConnectionClosedHandler;
-    OnReceiveError        = NULL;
+    OnReceiveError        = nullptr;
     memset(&mPeerAddrs, 0, sizeof(mPeerAddrs));
-    mTcpEndPoint = NULL;
+    mTcpEndPoint = nullptr;
 #if CONFIG_NETWORK_LAYER_BLE
-    mBleEndPoint = NULL;
+    mBleEndPoint = nullptr;
 #endif
     mTargetInterface = INET_NULL_INTERFACEID;
     mRefCount        = 1;
@@ -1488,7 +1488,7 @@ void ChipConnection::MakeConnectedTcp(TCPEndPoint * endPoint, const IPAddress & 
     NetworkType                  = kNetworkType_IP;
     endPoint->AppState           = this;
     endPoint->OnDataReceived     = HandleDataReceived;
-    endPoint->OnDataSent         = NULL; // TODO: should handle flow control
+    endPoint->OnDataSent         = nullptr; // TODO: should handle flow control
     endPoint->OnConnectionClosed = HandleTcpConnectionClosed;
 
     PeerNodeId = (peerAddr.IsIPv6ULA()) ? IPv6InterfaceIdToChipNodeId(peerAddr.InterfaceId()) : kNodeIdNotSpecified;
@@ -1508,7 +1508,7 @@ void ChipConnection::MakeConnectedTcp(TCPEndPoint * endPoint, const IPAddress & 
         SendDestNodeId = true;
     }
 
-    AppState = NULL;
+    AppState = nullptr;
     mRefCount++;
 
     ReceiveEnabled = true;
@@ -1561,13 +1561,13 @@ CHIP_ERROR ChipConnection::ConnectBle(BLE_CONNECTION_OBJECT connObj, ChipAuthMod
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    VerifyOrExit(State == kState_ReadyToConnect && MessageLayer->mBle != NULL, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(State == kState_ReadyToConnect && MessageLayer->mBle != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     VerifyOrExit(authMode == kChipAuthMode_Unauthenticated || IsCASEAuthMode(authMode) || IsPASEAuthMode(authMode),
                  err = CHIP_ERROR_INVALID_ARGUMENT);
 
     // Can't request authentication if the security manager is not initialized.
-    VerifyOrExit(authMode == kChipAuthMode_Unauthenticated || MessageLayer->SecurityMgr != NULL,
+    VerifyOrExit(authMode == kChipAuthMode_Unauthenticated || MessageLayer->SecurityMgr != nullptr,
                  err = CHIP_ERROR_UNSUPPORTED_AUTH_MODE);
 
     // Application has made us a BLE-based ChipConnection.
@@ -1646,7 +1646,7 @@ void ChipConnection::HandleBleMessageReceived(BLEEndPoint * endPoint, PacketBuff
     msgInfo.InCon = con;
 
     // Verify received buffer is not part of a multi-buffer chain.
-    VerifyOrExit(data->Next() == NULL, err = BLE_ERROR_BAD_ARGS);
+    VerifyOrExit(data->Next() == nullptr, err = BLE_ERROR_BAD_ARGS);
 
     // Attempt to parse the message.
     err = msgLayer->DecodeMessageWithLength(data, con->PeerNodeId, con, &msgInfo, &payload, &payloadLen, &frameLen);
@@ -1661,7 +1661,7 @@ void ChipConnection::HandleBleMessageReceived(BLEEndPoint * endPoint, PacketBuff
 
     // Assign received data to payload buffer.
     payloadBuf = data;
-    data       = NULL;
+    data       = nullptr;
 
     // Adjust the buffer to point at the payload of the message.
     payloadBuf->SetStart(payload);
@@ -1676,12 +1676,12 @@ exit:
     {
         ChipLogError(MessageLayer, "HandleBleMessageReceived failed, err = %d", err);
 
-        if (data != NULL)
+        if (data != nullptr)
             PacketBuffer::Free(data);
 
         // Send key error response to the peer if required.
         if (msgLayer->SecurityMgr->IsKeyError(err))
-            msgLayer->SecurityMgr->SendKeyErrorMsg(&msgInfo, NULL, con, err);
+            msgLayer->SecurityMgr->SendKeyErrorMsg(&msgInfo, nullptr, con, err);
     }
 }
 
@@ -1713,11 +1713,11 @@ void ChipConnection::MakeConnectedBle(BLEEndPoint * endPoint)
 
 void ChipConnection::DisconnectOnError(CHIP_ERROR err)
 {
-    if (OnReceiveError != NULL)
+    if (OnReceiveError != nullptr)
     {
         OnReceiveError(this, err);
     }
-    else if (MessageLayer->OnReceiveError != NULL)
+    else if (MessageLayer->OnReceiveError != nullptr)
     {
         IPPacketInfo addrInfo;
         GetPeerAddressInfo(addrInfo);

--- a/src/lib/message/CHIPExchangeMgr.cpp
+++ b/src/lib/message/CHIPExchangeMgr.cpp
@@ -97,7 +97,7 @@ CHIP_ERROR ChipExchangeManager::Init(ChipMessageLayer * msgLayer)
     InitBindingPool();
 
     memset(UMHandlerPool, 0, sizeof(UMHandlerPool));
-    OnExchangeContextChanged = NULL;
+    OnExchangeContextChanged = nullptr;
 
     msgLayer->ExchangeMgr       = this;
     msgLayer->OnMessageReceived = HandleMessageReceived;
@@ -130,13 +130,13 @@ CHIP_ERROR ChipExchangeManager::Init(ChipMessageLayer * msgLayer)
  */
 CHIP_ERROR ChipExchangeManager::Shutdown()
 {
-    if (MessageLayer != NULL)
+    if (MessageLayer != nullptr)
     {
         if (MessageLayer->ExchangeMgr == this)
         {
-            MessageLayer->ExchangeMgr       = NULL;
-            MessageLayer->OnMessageReceived = NULL;
-            MessageLayer->OnAcceptError     = NULL;
+            MessageLayer->ExchangeMgr       = nullptr;
+            MessageLayer->OnMessageReceived = nullptr;
+            MessageLayer->OnAcceptError     = nullptr;
         }
 
         RMPStopTimer();
@@ -147,12 +147,12 @@ CHIP_ERROR ChipExchangeManager::Shutdown()
             ClearRetransmitTable(RetransTable[i]);
         }
 
-        MessageLayer = NULL;
+        MessageLayer = nullptr;
     }
 
-    OnExchangeContextChanged = NULL;
+    OnExchangeContextChanged = nullptr;
 
-    FabricState = NULL;
+    FabricState = nullptr;
 
     State = kState_NotInitialized;
 
@@ -216,7 +216,7 @@ ExchangeContext * ChipExchangeManager::NewContext(const uint64_t & peerNodeId, c
                                                   InterfaceId sendIntfId, void * appState)
 {
     ExchangeContext * ec = AllocContext();
-    if (ec != NULL)
+    if (ec != nullptr)
     {
         ec->ExchangeId = NextExchangeId++;
         ec->PeerNodeId = peerNodeId;
@@ -236,10 +236,10 @@ ExchangeContext * ChipExchangeManager::NewContext(const uint64_t & peerNodeId, c
         // Internal and for Debug Only; When set, Exchange Layer does not send Ack.
         ec->SetDropAck(false);
         // Initialize the App callbacks to NULL
-        ec->OnThrottleRcvd = NULL;
-        ec->OnDDRcvd       = NULL;
-        ec->OnAckRcvd      = NULL;
-        ec->OnSendError    = NULL;
+        ec->OnThrottleRcvd = nullptr;
+        ec->OnDDRcvd       = nullptr;
+        ec->OnAckRcvd      = nullptr;
+        ec->OnSendError    = nullptr;
 #if CHIP_CONFIG_ENABLE_EPHEMERAL_UDP_PORT
         ec->SetUseEphemeralUDPPort(MessageLayer->EphemeralUDPPortEnabled());
 #endif // CHIP_CONFIG_ENABLE_EPHEMERAL_UDP_PORT
@@ -263,7 +263,7 @@ ExchangeContext * ChipExchangeManager::NewContext(const uint64_t & peerNodeId, c
 ExchangeContext * ChipExchangeManager::NewContext(ChipConnection * con, void * appState)
 {
     ExchangeContext * ec = NewContext(con->PeerNodeId, con->PeerAddr, con->PeerPort, INET_NULL_INTERFACEID, appState);
-    if (ec != NULL)
+    if (ec != nullptr)
     {
         ec->Con            = con;
         ec->KeyId          = con->DefaultKeyId;
@@ -291,10 +291,10 @@ ExchangeContext * ChipExchangeManager::FindContext(uint64_t peerNodeId, ChipConn
 {
     ExchangeContext * ec = (ExchangeContext *) ContextPool;
     for (int i = 0; i < CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS; i++, ec++)
-        if (ec->ExchangeMgr != NULL && ec->PeerNodeId == peerNodeId && ec->Con == con && ec->AppState == appState &&
+        if (ec->ExchangeMgr != nullptr && ec->PeerNodeId == peerNodeId && ec->Con == con && ec->AppState == appState &&
             ec->IsInitiator() == isInitiator)
             return ec;
-    return NULL;
+    return nullptr;
 }
 
 /**
@@ -314,7 +314,7 @@ ExchangeContext * ChipExchangeManager::FindContext(uint64_t peerNodeId, ChipConn
 CHIP_ERROR ChipExchangeManager::RegisterUnsolicitedMessageHandler(uint32_t profileId, ExchangeContext::MessageReceiveFunct handler,
                                                                   void * appState)
 {
-    return RegisterUMH(profileId, (int16_t) -1, NULL, false, handler, appState);
+    return RegisterUMH(profileId, (int16_t) -1, nullptr, false, handler, appState);
 }
 
 /**
@@ -336,7 +336,7 @@ CHIP_ERROR ChipExchangeManager::RegisterUnsolicitedMessageHandler(uint32_t profi
 CHIP_ERROR ChipExchangeManager::RegisterUnsolicitedMessageHandler(uint32_t profileId, ExchangeContext::MessageReceiveFunct handler,
                                                                   bool allowDups, void * appState)
 {
-    return RegisterUMH(profileId, (int16_t) -1, NULL, allowDups, handler, appState);
+    return RegisterUMH(profileId, (int16_t) -1, nullptr, allowDups, handler, appState);
 }
 
 /**
@@ -357,7 +357,7 @@ CHIP_ERROR ChipExchangeManager::RegisterUnsolicitedMessageHandler(uint32_t profi
 CHIP_ERROR ChipExchangeManager::RegisterUnsolicitedMessageHandler(uint32_t profileId, uint8_t msgType,
                                                                   ExchangeContext::MessageReceiveFunct handler, void * appState)
 {
-    return RegisterUMH(profileId, (int16_t) msgType, NULL, false, handler, appState);
+    return RegisterUMH(profileId, (int16_t) msgType, nullptr, false, handler, appState);
 }
 
 /**
@@ -382,7 +382,7 @@ CHIP_ERROR ChipExchangeManager::RegisterUnsolicitedMessageHandler(uint32_t profi
                                                                   ExchangeContext::MessageReceiveFunct handler, bool allowDups,
                                                                   void * appState)
 {
-    return RegisterUMH(profileId, (int16_t) msgType, NULL, allowDups, handler, appState);
+    return RegisterUMH(profileId, (int16_t) msgType, nullptr, allowDups, handler, appState);
 }
 
 /**
@@ -450,7 +450,7 @@ CHIP_ERROR ChipExchangeManager::RegisterUnsolicitedMessageHandler(uint32_t profi
  */
 CHIP_ERROR ChipExchangeManager::UnregisterUnsolicitedMessageHandler(uint32_t profileId)
 {
-    return UnregisterUMH(profileId, (int16_t) -1, NULL);
+    return UnregisterUMH(profileId, (int16_t) -1, nullptr);
 }
 
 /**
@@ -466,7 +466,7 @@ CHIP_ERROR ChipExchangeManager::UnregisterUnsolicitedMessageHandler(uint32_t pro
  */
 CHIP_ERROR ChipExchangeManager::UnregisterUnsolicitedMessageHandler(uint32_t profileId, uint8_t msgType)
 {
-    return UnregisterUMH(profileId, (int16_t) msgType, NULL);
+    return UnregisterUMH(profileId, (int16_t) msgType, nullptr);
 }
 
 /**
@@ -508,17 +508,17 @@ void ChipExchangeManager::HandleConnectionClosed(ChipConnection * con, CHIP_ERRO
 
     ExchangeContext * ec = (ExchangeContext *) ContextPool;
     for (int i = 0; i < CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS; i++, ec++)
-        if (ec->ExchangeMgr != NULL && ec->Con == con)
+        if (ec->ExchangeMgr != nullptr && ec->Con == con)
         {
             ec->HandleConnectionClosed(conErr);
         }
 
     UnsolicitedMessageHandler * umh = (UnsolicitedMessageHandler *) UMHandlerPool;
     for (int i = 0; i < CHIP_CONFIG_MAX_UNSOLICITED_MESSAGE_HANDLERS; i++, umh++)
-        if (umh->Handler != NULL && umh->Con == con)
+        if (umh->Handler != nullptr && umh->Con == con)
         {
             SYSTEM_STATS_DECREMENT(chip::System::Stats::kExchangeMgr_NumUMHandlers);
-            umh->Handler = NULL;
+            umh->Handler = nullptr;
         }
 }
 
@@ -535,7 +535,7 @@ size_t ChipExchangeManager::ExpireExchangeTimers(void)
     ExchangeContext * ec = (ExchangeContext *) ContextPool;
     for (int i = 0; i < CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS; i++, ec++)
     {
-        if (ec->ExchangeMgr != NULL)
+        if (ec->ExchangeMgr != nullptr)
         {
             if (ec->ResponseTimeout)
             {
@@ -554,10 +554,10 @@ ExchangeContext * ChipExchangeManager::AllocContext()
 {
     ExchangeContext * ec = (ExchangeContext *) ContextPool;
 
-    CHIP_FAULT_INJECT(FaultInjection::kFault_AllocExchangeContext, return NULL);
+    CHIP_FAULT_INJECT(FaultInjection::kFault_AllocExchangeContext, return nullptr);
 
     for (int i = 0; i < CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS; i++, ec++)
-        if (ec->ExchangeMgr == NULL)
+        if (ec->ExchangeMgr == nullptr)
         {
             *ec             = ExchangeContext();
             ec->ExchangeMgr = this;
@@ -573,7 +573,7 @@ ExchangeContext * ChipExchangeManager::AllocContext()
             return ec;
         }
     ChipLogError(ExchangeManager, "Alloc ctxt FAILED");
-    return NULL;
+    return nullptr;
 }
 
 void ChipExchangeManager::RMPProcessDDMessage(uint32_t PauseTimeMillis, uint64_t DelayedNodeId)
@@ -624,11 +624,11 @@ static void DefaultOnMessageReceived(ExchangeContext * ec, const IPPacketInfo * 
 void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffer * msgBuf)
 {
     ChipExchangeHeader exchangeHeader;
-    UnsolicitedMessageHandler * umh         = NULL;
-    UnsolicitedMessageHandler * matchingUMH = NULL;
-    ExchangeContext * ec                    = NULL;
-    ChipConnection * msgCon                 = NULL;
-    const uint8_t * p                       = NULL;
+    UnsolicitedMessageHandler * umh         = nullptr;
+    UnsolicitedMessageHandler * matchingUMH = nullptr;
+    ExchangeContext * ec                    = nullptr;
+    ChipConnection * msgCon                 = nullptr;
+    const uint8_t * p                       = nullptr;
     uint32_t PauseTimeMillis                = 0;
     uint64_t DelayedNodeId                  = 0;
     bool dupMsg;
@@ -671,7 +671,7 @@ void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffe
     if (isMsgCounterSyncResp)
     {
         MessageLayer->SecurityMgr->HandleMsgCounterSyncRespMsg(msgInfo, msgBuf);
-        msgBuf = NULL;
+        msgBuf = nullptr;
     }
 
     // If message counter synchronization was requested.
@@ -718,7 +718,7 @@ void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffe
     ec = (ExchangeContext *) ContextPool;
     for (int i = 0; i < CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS; i++, ec++)
     {
-        if (ec->ExchangeMgr != NULL && ec->MatchExchange(msgCon, msgInfo, &exchangeHeader))
+        if (ec->ExchangeMgr != nullptr && ec->MatchExchange(msgCon, msgInfo, &exchangeHeader))
         {
             // Found a matching exchange. Set flag for correct subsequent RMP
             // retransmission timeout selection.
@@ -730,7 +730,7 @@ void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffe
             // Matched ExchangeContext; send to message handler.
             ec->HandleMessage(msgInfo, &exchangeHeader, msgBuf);
 
-            msgBuf = NULL;
+            msgBuf = nullptr;
 
             ExitNow(err = CHIP_NO_ERROR);
         }
@@ -749,10 +749,11 @@ void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffe
         // handle the message type over handlers that handle all messages for a profile.
         umh = (UnsolicitedMessageHandler *) UMHandlerPool;
 
-        matchingUMH = NULL;
+        matchingUMH = nullptr;
 
         for (int i = 0; i < CHIP_CONFIG_MAX_UNSOLICITED_MESSAGE_HANDLERS; i++, umh++)
-            if (umh->Handler != NULL && umh->ProfileId == exchangeHeader.ProfileId && (umh->Con == NULL || umh->Con == msgCon) &&
+            if (umh->Handler != nullptr && umh->ProfileId == exchangeHeader.ProfileId &&
+                (umh->Con == nullptr || umh->Con == msgCon) &&
                 (!(msgInfo->Flags & kChipMessageFlag_DuplicateMessage) || umh->AllowDuplicateMsgs))
             {
                 if (umh->MessageType == exchangeHeader.MessageType)
@@ -785,7 +786,7 @@ void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffe
     //       N      |     Y    |    -    |     -     | Create EC, ec->HandleMessage() sends ack (if needed) and App callback.
     //       N      |     N    |    -    |     -     | Do nothing.
     // Create new exchange to send ack for a duplicate message and then close this exchange.
-    sendAckAndCloseExchange = msgNeedsAck && (matchingUMH == NULL || (dupMsg && !matchingUMH->AllowDuplicateMsgs));
+    sendAckAndCloseExchange = msgNeedsAck && (matchingUMH == nullptr || (dupMsg && !matchingUMH->AllowDuplicateMsgs));
 
 #if CHIP_CONFIG_USE_APP_GROUP_KEYS_FOR_MSG_ENC
     // Don't create new EC only to send an ack if Peer's message counter synchronization is required.
@@ -794,17 +795,17 @@ void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffe
 #endif
 
     // If we found a handler or we need to open a new exchange to send ack for a duplicate message.
-    if (matchingUMH != NULL || sendAckAndCloseExchange)
+    if (matchingUMH != nullptr || sendAckAndCloseExchange)
     {
-        ExchangeContext::MessageReceiveFunct umhandler = NULL;
+        ExchangeContext::MessageReceiveFunct umhandler = nullptr;
 
         ec = AllocContext();
-        VerifyOrExit(ec != NULL, err = CHIP_ERROR_NO_MEMORY);
+        VerifyOrExit(ec != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
         ec->Con        = msgCon;
         ec->ExchangeId = exchangeHeader.ExchangeId;
         ec->PeerNodeId = msgInfo->SourceNodeId;
-        if (msgInfo->InPacketInfo != NULL)
+        if (msgInfo->InPacketInfo != nullptr)
         {
             ec->PeerAddr = msgInfo->InPacketInfo->SrcAddress;
             ec->PeerPort = msgInfo->InPacketInfo->SrcPort;
@@ -817,7 +818,7 @@ void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffe
             // effect on routing and source address selection. Thus it is only done when
             // required by the type of destination address.
             //
-            if (ec->Con == NULL && ec->PeerAddr.IsIPv6LinkLocal())
+            if (ec->Con == nullptr && ec->PeerAddr.IsIPv6LinkLocal())
             {
                 ec->PeerIntf = msgInfo->InPacketInfo->Interface;
             }
@@ -869,7 +870,7 @@ void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffe
         ec->SetAutoReleaseKey(true);
 
         ec->HandleMessage(msgInfo, &exchangeHeader, msgBuf, umhandler);
-        msgBuf = NULL;
+        msgBuf = nullptr;
 
         // Close exchange if it was created only to send ack for a duplicate message.
         if (sendAckAndCloseExchange)
@@ -882,7 +883,7 @@ exit:
         ChipLogError(ExchangeManager, "DispatchMessage failed, err = %d", err);
     }
 
-    if (msgBuf != NULL)
+    if (msgBuf != nullptr)
     {
         PacketBuffer::Free(msgBuf);
     }
@@ -894,12 +895,12 @@ CHIP_ERROR ChipExchangeManager::RegisterUMH(uint32_t profileId, int16_t msgType,
                                             ExchangeContext::MessageReceiveFunct handler, void * appState)
 {
     UnsolicitedMessageHandler * umh      = (UnsolicitedMessageHandler *) UMHandlerPool;
-    UnsolicitedMessageHandler * selected = NULL;
+    UnsolicitedMessageHandler * selected = nullptr;
     for (int i = 0; i < CHIP_CONFIG_MAX_UNSOLICITED_MESSAGE_HANDLERS; i++, umh++)
     {
-        if (umh->Handler == NULL)
+        if (umh->Handler == nullptr)
         {
-            if (selected == NULL)
+            if (selected == nullptr)
                 selected = umh;
         }
         else if (umh->ProfileId == profileId && umh->MessageType == msgType && umh->Con == con)
@@ -910,7 +911,7 @@ CHIP_ERROR ChipExchangeManager::RegisterUMH(uint32_t profileId, int16_t msgType,
         }
     }
 
-    if (selected == NULL)
+    if (selected == nullptr)
         return CHIP_ERROR_TOO_MANY_UNSOLICITED_MESSAGE_HANDLERS;
 
     selected->Handler            = handler;
@@ -930,9 +931,9 @@ CHIP_ERROR ChipExchangeManager::UnregisterUMH(uint32_t profileId, int16_t msgTyp
     UnsolicitedMessageHandler * umh = (UnsolicitedMessageHandler *) UMHandlerPool;
     for (int i = 0; i < CHIP_CONFIG_MAX_UNSOLICITED_MESSAGE_HANDLERS; i++, umh++)
     {
-        if (umh->Handler != NULL && umh->ProfileId == profileId && umh->MessageType == msgType && umh->Con == con)
+        if (umh->Handler != nullptr && umh->ProfileId == profileId && umh->MessageType == msgType && umh->Con == con)
         {
-            umh->Handler = NULL;
+            umh->Handler = nullptr;
             SYSTEM_STATS_DECREMENT(chip::System::Stats::kExchangeMgr_NumUMHandlers);
             return CHIP_NO_ERROR;
         }
@@ -954,7 +955,7 @@ CHIP_ERROR ChipExchangeManager::PrependHeader(ChipExchangeHeader * exchangeHeade
 {
     CHIP_ERROR err   = CHIP_NO_ERROR;
     uint16_t headLen = 8; // Constant part: Version/Flags + Msg Type + Exch Id + Profile Id
-    uint8_t * p      = NULL;
+    uint8_t * p      = nullptr;
 
     // Make sure the buffer has a reserved size big enough to hold the full CHIP header.
     if (!buf->EnsureReservedSize(CHIP_HEADER_RESERVE_SIZE))
@@ -1014,7 +1015,7 @@ CHIP_ERROR ChipExchangeManager::DecodeHeader(ChipExchangeHeader * exchangeHeader
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    uint8_t * p = NULL;
+    uint8_t * p = nullptr;
     uint8_t versionFlags;
     uint16_t msgLen  = buf->DataLength();
     uint8_t * msgEnd = buf->Start() + msgLen;
@@ -1080,7 +1081,7 @@ void ChipExchangeManager::NotifyKeyFailed(uint64_t peerNodeId, uint16_t keyId, C
 
     for (int i = 0; i < CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS; i++, ec++)
     {
-        if (ec->ExchangeMgr != NULL && ec->KeyId == keyId && ec->PeerNodeId == peerNodeId)
+        if (ec->ExchangeMgr != nullptr && ec->KeyId == keyId && ec->PeerNodeId == peerNodeId)
         {
             // Ensure the exchange context stays around until we're done with it.
             ec->AddRef();
@@ -1131,7 +1132,7 @@ void ChipExchangeManager::ClearMsgCounterSyncReq(uint64_t peerNodeId)
     // Find all retransmit entries (re) matching peerNodeId and using application group key.
     for (int i = 0; i < CHIP_CONFIG_RMP_RETRANS_TABLE_SIZE; i++, re++)
     {
-        if (re->exchContext != NULL && re->exchContext->PeerNodeId == peerNodeId &&
+        if (re->exchContext != nullptr && re->exchContext->PeerNodeId == peerNodeId &&
             ChipKeyId::IsAppGroupKey(re->exchContext->KeyId))
         {
             // Clear MsgCounterSyncReq flag.
@@ -1156,7 +1157,7 @@ void ChipExchangeManager::RetransPendingAppGroupMsgs(uint64_t peerNodeId)
     // Find all retransmit entries (re) matching peerNodeId and using application group key.
     for (int i = 0; i < CHIP_CONFIG_RMP_RETRANS_TABLE_SIZE; i++, re++)
     {
-        if (re->exchContext != NULL && re->exchContext->PeerNodeId == peerNodeId &&
+        if (re->exchContext != nullptr && re->exchContext->PeerNodeId == peerNodeId &&
             ChipKeyId::IsAppGroupKey(re->exchContext->KeyId))
         {
             // Decrement counter to discount the first sent message, which
@@ -1228,7 +1229,7 @@ void ChipExchangeManager::TicklessDebugDumpRetransTable(const char * log)
  */
 void ChipExchangeManager::RMPExecuteActions(void)
 {
-    ExchangeContext * ec = NULL;
+    ExchangeContext * ec = nullptr;
 
     // Process Ack Tables for all ExchangeContexts
     ec = (ExchangeContext *) ContextPool;
@@ -1239,7 +1240,7 @@ void ChipExchangeManager::RMPExecuteActions(void)
 
     for (int i = 0; i < CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS; i++, ec++)
     {
-        if (ec->ExchangeMgr != NULL && ec->IsAckPending())
+        if (ec->ExchangeMgr != nullptr && ec->IsAckPending())
         {
             if (0 == ec->mRMPNextAckTime)
             {
@@ -1323,7 +1324,7 @@ void ChipExchangeManager::RMPExecuteActions(void)
 void ChipExchangeManager::RMPExpireTicks(void)
 {
     uint64_t now         = 0;
-    ExchangeContext * ec = NULL;
+    ExchangeContext * ec = nullptr;
     uint32_t deltaTicks;
 
     // Process Ack Tables for all ExchangeContexts
@@ -1349,7 +1350,7 @@ void ChipExchangeManager::RMPExpireTicks(void)
 
     for (int i = 0; i < CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS; i++, ec++)
     {
-        if (ec->ExchangeMgr != NULL && ec->IsAckPending())
+        if (ec->ExchangeMgr != nullptr && ec->IsAckPending())
         {
             // Decrement counter of Ack timestamp by the elapsed timer ticks
             if (ec->mRMPNextAckTime >= deltaTicks)
@@ -1426,7 +1427,7 @@ void ChipExchangeManager::RMPTimeout(System::Layer * aSystemLayer, void * aAppSt
 {
     ChipExchangeManager * exchangeMgr = reinterpret_cast<ChipExchangeManager *>(aAppState);
 
-    VerifyOrDie((aSystemLayer != NULL) && (exchangeMgr != NULL));
+    VerifyOrDie((aSystemLayer != nullptr) && (exchangeMgr != nullptr));
 
 #if defined(RMP_TICKLESS_DEBUG)
     ChipLogProgress(ExchangeManager, "RMPTimeout\n");
@@ -1514,7 +1515,7 @@ CHIP_ERROR ChipExchangeManager::SendFromRetransTable(RetransTableEntry * entry)
 {
     CHIP_ERROR err        = CHIP_NO_ERROR;
     uint16_t msgSendFlags = 0;
-    uint8_t * p           = NULL;
+    uint8_t * p           = nullptr;
     uint32_t len          = 0;
     ExchangeContext * ec  = entry->exchContext;
 
@@ -1607,12 +1608,12 @@ void ChipExchangeManager::ClearRetransmitTable(RetransTableEntry & rEntry)
         RMPExpireTicks();
 
         rEntry.exchContext->Release();
-        rEntry.exchContext = NULL;
+        rEntry.exchContext = nullptr;
 
         if (rEntry.msgBuf)
         {
             PacketBuffer::Free(rEntry.msgBuf);
-            rEntry.msgBuf = NULL;
+            rEntry.msgBuf = nullptr;
         }
 
         // Clear all other fields
@@ -1661,14 +1662,14 @@ void ChipExchangeManager::RMPStartTimer()
     CHIP_ERROR res        = CHIP_NO_ERROR;
     uint32_t nextWakeTime = UINT32_MAX;
     bool foundWake        = false;
-    ExchangeContext * ec  = NULL;
+    ExchangeContext * ec  = nullptr;
 
     // When do we need to next wake up to send an ACK?
     ec = (ExchangeContext *) ContextPool;
 
     for (int i = 0; i < CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS; i++, ec++)
     {
-        if (ec->ExchangeMgr != NULL && ec->IsAckPending() && ec->mRMPNextAckTime < nextWakeTime)
+        if (ec->ExchangeMgr != nullptr && ec->IsAckPending() && ec->mRMPNextAckTime < nextWakeTime)
         {
             nextWakeTime = ec->mRMPNextAckTime;
             foundWake    = true;
@@ -1780,9 +1781,9 @@ void ChipExchangeManager::InitBindingPool(void)
  */
 Binding * ChipExchangeManager::AllocBinding(void)
 {
-    Binding * pResult = NULL;
+    Binding * pResult = nullptr;
 
-    CHIP_FAULT_INJECT(FaultInjection::kFault_AllocBinding, return NULL);
+    CHIP_FAULT_INJECT(FaultInjection::kFault_AllocBinding, return nullptr);
 
     for (size_t i = 0; i < CHIP_CONFIG_MAX_BINDINGS; ++i)
     {
@@ -1824,7 +1825,7 @@ void ChipExchangeManager::FreeBinding(Binding * binding)
 Binding * ChipExchangeManager::NewBinding(Binding::EventCallback eventCallback, void * appState)
 {
     Binding * pResult = AllocBinding();
-    if (NULL != pResult)
+    if (nullptr != pResult)
     {
         pResult->Init(appState, eventCallback);
     }

--- a/src/lib/message/CHIPExchangeMgr.h
+++ b/src/lib/message/CHIPExchangeMgr.h
@@ -163,9 +163,9 @@ public:
 #endif
 
     CHIP_ERROR SendMessage(uint32_t profileId, uint8_t msgType, PacketBuffer * msgPayload, uint16_t sendFlags = 0,
-                           void * msgCtxt = 0);
+                           void * msgCtxt = nullptr);
     CHIP_ERROR SendMessage(uint32_t profileId, uint8_t msgType, PacketBuffer * msgBuf, uint16_t sendFlags,
-                           ChipMessageInfo * msgInfo, void * msgCtxt = 0);
+                           ChipMessageInfo * msgInfo, void * msgCtxt = nullptr);
     CHIP_ERROR SendCommonNullMessage(void);
     CHIP_ERROR EncodeExchHeader(ChipExchangeHeader * exchangeHeader, uint32_t profileId, uint8_t msgType, PacketBuffer * msgBuf,
                                 uint16_t sendFlags);
@@ -388,15 +388,15 @@ public:
     size_t ExpireExchangeTimers(void);
 #endif
 
-    ExchangeContext * NewContext(const uint64_t & peerNodeId, void * appState = NULL);
-    ExchangeContext * NewContext(const uint64_t & peerNodeId, const IPAddress & peerAddr, void * appState = NULL);
+    ExchangeContext * NewContext(const uint64_t & peerNodeId, void * appState = nullptr);
+    ExchangeContext * NewContext(const uint64_t & peerNodeId, const IPAddress & peerAddr, void * appState = nullptr);
     ExchangeContext * NewContext(const uint64_t & peerNodeId, const IPAddress & peerAddr, uint16_t peerPort, InterfaceId sendIntfId,
-                                 void * appState = NULL);
-    ExchangeContext * NewContext(ChipConnection * con, void * appState = NULL);
+                                 void * appState = nullptr);
+    ExchangeContext * NewContext(ChipConnection * con, void * appState = nullptr);
 
     ExchangeContext * FindContext(uint64_t peerNodeId, ChipConnection * con, void * appState, bool isInitiator);
 
-    Binding * NewBinding(Binding::EventCallback eventCallback = Binding::DefaultEventHandler, void * appState = NULL);
+    Binding * NewBinding(Binding::EventCallback eventCallback = Binding::DefaultEventHandler, void * appState = nullptr);
 
     CHIP_ERROR RegisterUnsolicitedMessageHandler(uint32_t profileId, ExchangeContext::MessageReceiveFunct handler, void * appState);
     CHIP_ERROR RegisterUnsolicitedMessageHandler(uint32_t profileId, ExchangeContext::MessageReceiveFunct handler, bool allowDups,

--- a/src/lib/message/CHIPFabricState.cpp
+++ b/src/lib/message/CHIPFabricState.cpp
@@ -122,7 +122,7 @@ void ChipSessionKey::Init(void)
     NodeId = kNodeIdNotSpecified;
     NextMsgId.Init(0);
     MaxRcvdMsgId = 0;
-    BoundCon     = NULL;
+    BoundCon     = nullptr;
     RcvFlags     = 0;
     AuthMode     = kChipAuthMode_NotSpecified;
     memset(&MsgEncKey, 0, sizeof(MsgEncKey));
@@ -228,7 +228,7 @@ CHIP_ERROR ChipFabricState::Init(GroupKeyStoreBase * groupKeyStore)
     if (State != kState_NotInitialized)
         return CHIP_ERROR_INCORRECT_STATE;
 
-    if (groupKeyStore == NULL)
+    if (groupKeyStore == nullptr)
         return CHIP_ERROR_INVALID_ARGUMENT;
 
 #ifdef CHIP_NON_PRODUCTION_MARKER
@@ -242,7 +242,7 @@ CHIP_ERROR ChipFabricState::Init(GroupKeyStoreBase * groupKeyStore)
 
     FabricId      = kFabricIdNotSpecified;
     LocalNodeId   = 1;
-    PairingCode   = NULL;
+    PairingCode   = nullptr;
     DefaultSubnet = kChipSubnetId_PrimaryWiFi;
     PeerCount     = 0;
     NextUnencUDPMsgId.Init(GetRandU32());
@@ -260,7 +260,7 @@ CHIP_ERROR ChipFabricState::Init(GroupKeyStoreBase * groupKeyStore)
     AppKeyCache.Init();
 #endif
     memset(&PeerStates, 0, sizeof(PeerStates));
-    Delegate = NULL;
+    Delegate = nullptr;
     memset(SharedSessionsNodes, 0, sizeof(SharedSessionsNodes));
 
 #if CHIP_CONFIG_SECURITY_TEST_MODE
@@ -288,7 +288,7 @@ CHIP_ERROR ChipFabricState::Init(GroupKeyStoreBase * groupKeyStore)
 
 #endif
 
-    sessionEndCallbackList = NULL;
+    sessionEndCallbackList = nullptr;
 
     State = kState_Initialized;
 
@@ -446,7 +446,7 @@ ChipSessionKey * ChipFabricState::FindSharedSession(uint64_t terminatingNodeId, 
         }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 /**
@@ -532,7 +532,7 @@ CHIP_ERROR ChipFabricState::AddSharedSessionEndNode(ChipSessionKey * sessionKey,
 {
     CHIP_ERROR err                     = CHIP_NO_ERROR;
     SharedSessionEndNode * endNode     = SharedSessionsNodes;
-    SharedSessionEndNode * freeEndNode = NULL;
+    SharedSessionEndNode * freeEndNode = nullptr;
     uint8_t endNodeCount               = 0;
 
     // No need to add new shared entry record if the end node is also the terminating node.
@@ -552,7 +552,7 @@ CHIP_ERROR ChipFabricState::AddSharedSessionEndNode(ChipSessionKey * sessionKey,
                 endNodeCount++;
             }
         }
-        else if (endNode->EndNodeId == kNodeIdNotSpecified && freeEndNode == NULL)
+        else if (endNode->EndNodeId == kNodeIdNotSpecified && freeEndNode == nullptr)
         {
             freeEndNode = endNode;
         }
@@ -560,7 +560,7 @@ CHIP_ERROR ChipFabricState::AddSharedSessionEndNode(ChipSessionKey * sessionKey,
 
     // Verify that there is free entry in the list and that we don't exit maximum
     // allowed number of end nodes per single shared session.
-    VerifyOrExit(freeEndNode != NULL && endNodeCount <= CHIP_CONFIG_MAX_END_NODES_PER_SHARED_SESSION,
+    VerifyOrExit(freeEndNode != nullptr && endNodeCount <= CHIP_CONFIG_MAX_END_NODES_PER_SHARED_SESSION,
                  err = CHIP_ERROR_TOO_MANY_SHARED_SESSION_END_NODES);
 
     // Add new end node.
@@ -647,7 +647,7 @@ CHIP_ERROR ChipFabricState::SuspendSession(uint16_t keyId, uint64_t peerNodeId, 
     // Assert various requirements about the session.
     VerifyOrExit(sessionKey->IsKeySet(), err = CHIP_ERROR_KEY_NOT_FOUND);
     VerifyOrExit(!sessionKey->IsSuspended(), err = CHIP_ERROR_SESSION_KEY_SUSPENDED);
-    VerifyOrExit(sessionKey->BoundCon == NULL, err = CHIP_ERROR_INVALID_USE_OF_SESSION_KEY);
+    VerifyOrExit(sessionKey->BoundCon == nullptr, err = CHIP_ERROR_INVALID_USE_OF_SESSION_KEY);
     VerifyOrExit(IsCertAuthMode(sessionKey->AuthMode), err = CHIP_ERROR_INVALID_USE_OF_SESSION_KEY);
 
     {
@@ -760,7 +760,7 @@ CHIP_ERROR ChipFabricState::RestoreSession(uint8_t * serializedSession, uint16_t
     TLVType container;
     uint16_t keyId;
     uint64_t peerNodeId;
-    ChipSessionKey * sessionKey = NULL;
+    ChipSessionKey * sessionKey = nullptr;
     bool removeSessionOnError   = false;
 
     reader.Init(serializedSession, serializedSessionLen);
@@ -788,7 +788,7 @@ CHIP_ERROR ChipFabricState::RestoreSession(uint8_t * serializedSession, uint16_t
     {
         sessionKey->MsgEncKey.KeyId = keyId;
         sessionKey->NodeId          = peerNodeId;
-        sessionKey->BoundCon        = NULL;
+        sessionKey->BoundCon        = nullptr;
         sessionKey->ReserveCount    = 0;
         sessionKey->Flags           = 0;
     }
@@ -931,14 +931,14 @@ CHIP_ERROR ChipFabricState::GetSessionState(uint64_t remoteNodeId, uint16_t keyI
         if (encType != kChipEncryptionType_None)
             return CHIP_ERROR_WRONG_ENCRYPTION_TYPE;
 
-        if (con == NULL)
+        if (con == nullptr)
         {
             FindOrAllocPeerEntry(remoteNodeId, true, peerIndex);
-            outSessionState = ChipSessionState(NULL, kChipAuthMode_Unauthenticated, &NextUnencUDPMsgId,
+            outSessionState = ChipSessionState(nullptr, kChipAuthMode_Unauthenticated, &NextUnencUDPMsgId,
                                                &PeerStates.MaxUnencUDPMsgIdRcvd[peerIndex], &PeerStates.UnencRcvFlags[peerIndex]);
         }
         else
-            outSessionState = ChipSessionState(NULL, kChipAuthMode_Unauthenticated, &NextUnencTCPMsgId, NULL, NULL);
+            outSessionState = ChipSessionState(nullptr, kChipAuthMode_Unauthenticated, &NextUnencTCPMsgId, nullptr, nullptr);
         break;
 
     case ChipKeyId::kType_Session:
@@ -951,7 +951,7 @@ CHIP_ERROR ChipFabricState::GetSessionState(uint64_t remoteNodeId, uint16_t keyI
         if (sessionKey->MsgEncKey.EncType != encType)
             return (sessionKey->MsgEncKey.EncType == kChipEncryptionType_None) ? CHIP_ERROR_KEY_NOT_FOUND
                                                                                : CHIP_ERROR_WRONG_ENCRYPTION_TYPE;
-        if (sessionKey->BoundCon != NULL && sessionKey->BoundCon != con)
+        if (sessionKey->BoundCon != nullptr && sessionKey->BoundCon != con)
             return CHIP_ERROR_INVALID_USE_OF_SESSION_KEY;
         outSessionState = ChipSessionState(&sessionKey->MsgEncKey, sessionKey->AuthMode, &sessionKey->NextMsgId,
                                            &sessionKey->MaxRcvdMsgId, &sessionKey->RcvFlags);
@@ -971,7 +971,7 @@ CHIP_ERROR ChipFabricState::GetSessionState(uint64_t remoteNodeId, uint16_t keyI
                 ChipSessionState(applicationKey, authMode, &NextGroupKeyMsgId, &PeerStates.MaxGroupKeyMsgIdRcvd[peerIndex],
                                  &PeerStates.GroupKeyRcvFlags[peerIndex]);
         else
-            outSessionState = ChipSessionState(applicationKey, authMode, &NextGroupKeyMsgId, NULL, NULL);
+            outSessionState = ChipSessionState(applicationKey, authMode, &NextGroupKeyMsgId, nullptr, nullptr);
         break;
     }
 #endif
@@ -1121,7 +1121,7 @@ void ChipFabricState::OnMsgCounterSyncRespTimeout(System::Layer * aSystemLayer, 
     ChipFabricState * fabricState = reinterpret_cast<ChipFabricState *>(aAppState);
     uint32_t freshWindoWidth;
 
-    VerifyOrDie(fabricState != NULL && fabricState->MessageLayer->SystemLayer == aSystemLayer);
+    VerifyOrDie(fabricState != nullptr && fabricState->MessageLayer->SystemLayer == aSystemLayer);
 
     // If message counter synchronization request was sent this period.
     if (fabricState->MsgCounterSyncStatus & fabricState->kFlag_ReqSentThisPeriod)
@@ -1345,8 +1345,8 @@ CHIP_ERROR ChipFabricState::RegisterSessionEndCallback(SessionEndCbCtxt * sessio
 
     VerifyOrExit(sessionEndCb, err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    sessionEndCb->next = NULL;
-    if (sessionEndCallbackList == NULL)
+    sessionEndCb->next = nullptr;
+    if (sessionEndCallbackList == nullptr)
     {
         sessionEndCallbackList = sessionEndCb;
         ExitNow();
@@ -1386,7 +1386,7 @@ CHIP_ERROR ChipFabricState::GetPassword(uint8_t pwSrc, const char *& ps, uint16_
     switch (pwSrc)
     {
     case kPasswordSource_PairingCode:
-        if (PairingCode == NULL)
+        if (PairingCode == nullptr)
             return CHIP_ERROR_INVALID_ARGUMENT; // TODO: use proper error code
         ps    = PairingCode;
         pwLen = (uint16_t) strlen(PairingCode);
@@ -1446,7 +1446,7 @@ CHIP_ERROR ChipFabricState::CreateFabric()
     err = GroupKeyStore->StoreGroupKey(fabricSecret);
     SuccessOrExit(err);
 
-    if (Delegate != NULL)
+    if (Delegate != nullptr)
         Delegate->DidJoinFabric(this, FabricId);
 
 exit:
@@ -1468,7 +1468,7 @@ void ChipFabricState::ClearFabricState()
 
     if (oldFabricId != kFabricIdNotSpecified)
     {
-        if (Delegate != NULL)
+        if (Delegate != nullptr)
             Delegate->DidLeaveFabric(this, oldFabricId);
     }
 }
@@ -1657,7 +1657,7 @@ CHIP_ERROR ChipFabricState::JoinExistingFabric(const uint8_t * fabricState, uint
         }
     }
 
-    if (Delegate != NULL)
+    if (Delegate != nullptr)
         Delegate->DidJoinFabric(this, FabricId);
 
 exit:
@@ -1686,11 +1686,11 @@ void ChipFabricState::HandleConnectionClosed(ChipConnection * con)
 
 ChipSessionState::ChipSessionState(void)
 {
-    MsgEncKey    = NULL;
+    MsgEncKey    = nullptr;
     AuthMode     = kChipAuthMode_NotSpecified;
-    NextMsgId    = NULL;
-    MaxMsgIdRcvd = NULL;
-    RcvFlags     = NULL;
+    NextMsgId    = nullptr;
+    MaxMsgIdRcvd = nullptr;
+    RcvFlags     = nullptr;
 }
 
 ChipSessionState::ChipSessionState(ChipMsgEncryptionKey * msgEncKey, ChipAuthMode authMode,
@@ -1714,7 +1714,7 @@ uint32_t ChipSessionState::NewMessageId(void)
 
 bool ChipSessionState::MessageIdNotSynchronized(void)
 {
-    return (RcvFlags == NULL) || (((*RcvFlags) & kReceiveFlags_MessageIdSynchronized) == 0);
+    return (RcvFlags == nullptr) || (((*RcvFlags) & kReceiveFlags_MessageIdSynchronized) == 0);
 }
 
 bool ChipSessionState::IsDuplicateMessage(uint32_t msgId)
@@ -1744,7 +1744,7 @@ bool ChipSessionState::IsDuplicateMessage(uint32_t msgId)
         // This happens for unencrypted messages sent over TCP. Such messages provide no security against replay
         // attacks (since they are not encrypted) and are not subject to message reordering in the network layer
         // (since TCP eliminates such reorderings). Thus duplicate message detection is unnecessary in this case.
-        if (MsgEncKey == NULL && RcvFlags == NULL)
+        if (MsgEncKey == nullptr && RcvFlags == nullptr)
         {
             ExitNow();
         }
@@ -1752,7 +1752,7 @@ bool ChipSessionState::IsDuplicateMessage(uint32_t msgId)
         // Mark message as a duplicate and exit if it was encrypted with application group key.
         // In this case, peer's message counter synchronization can only be done by
         // ChipSecurityManager::HandleMsgCounterSyncRespMsg() function.
-        else if (MsgEncKey != NULL && ChipKeyId::IsAppGroupKey(MsgEncKey->KeyId))
+        else if (MsgEncKey != nullptr && ChipKeyId::IsAppGroupKey(MsgEncKey->KeyId))
         {
             ExitNow(isDup = true);
         }
@@ -1826,7 +1826,7 @@ bool ChipSessionState::IsDuplicateMessage(uint32_t msgId)
         else
         {
             // If the message was encrypted then assume the message is a duplicate.
-            if (MsgEncKey != NULL)
+            if (MsgEncKey != nullptr)
             {
                 ExitNow(isDup = true);
             }
@@ -1870,7 +1870,7 @@ exit:
 CHIP_ERROR ChipFabricState::FindSessionKey(uint16_t keyId, uint64_t peerNodeId, bool create, ChipSessionKey *& retRec)
 {
     ChipSessionKey * curRec  = SessionKeys;
-    ChipSessionKey * freeRec = NULL;
+    ChipSessionKey * freeRec = nullptr;
 
     if (!ChipKeyId::IsSessionKey(keyId))
         return CHIP_ERROR_WRONG_KEY_TYPE;
@@ -1882,7 +1882,7 @@ CHIP_ERROR ChipFabricState::FindSessionKey(uint16_t keyId, uint64_t peerNodeId, 
     {
         if (!curRec->IsAllocated())
         {
-            if (freeRec == NULL)
+            if (freeRec == nullptr)
                 freeRec = curRec;
         }
         else if (curRec->MsgEncKey.KeyId == keyId &&
@@ -1896,7 +1896,7 @@ CHIP_ERROR ChipFabricState::FindSessionKey(uint16_t keyId, uint64_t peerNodeId, 
     if (!create)
         return CHIP_ERROR_KEY_NOT_FOUND;
 
-    if (freeRec == NULL)
+    if (freeRec == nullptr)
         return CHIP_ERROR_TOO_MANY_KEYS;
 
     retRec = freeRec;
@@ -1976,7 +1976,7 @@ CHIP_ERROR ChipFabricState::DeriveMsgEncAppKey(uint32_t keyId, uint8_t encType, 
     keyDiversifier[sizeof(kChipMsgEncAppKeyDiversifier)] = encType;
 
     // Derive application key data.
-    err = GroupKeyStore->DeriveApplicationKey(keyId, NULL, 0, keyDiversifier, kChipMsgEncAppKeyDiversifierSize, keyData,
+    err = GroupKeyStore->DeriveApplicationKey(keyId, nullptr, 0, keyDiversifier, kChipMsgEncAppKeyDiversifierSize, keyData,
                                               sizeof(keyData), ChipEncryptionKey_AES128CTRSHA1::KeySize, appGroupGlobalId);
     SuccessOrExit(err);
 
@@ -2021,7 +2021,7 @@ bool ChipFabricState::RemoveIdleSessionKeys()
 
             // Ignore the session if it is bound to a connection. (Connection bound
             // sessions persist until their connections close).
-            if (sessionKey->BoundCon != NULL)
+            if (sessionKey->BoundCon != nullptr)
                 continue;
 
             // If the session is marked for remove-on-idle and is not currently reserved...

--- a/src/lib/message/CHIPMessageLayer.cpp
+++ b/src/lib/message/CHIPMessageLayer.cpp
@@ -120,7 +120,7 @@ CHIP_ERROR ChipMessageLayer::Init(InitContext * context)
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     VerifyOrExit(State == kState_NotInitialized, err = CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrExit(context != NULL, err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(context != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
 
     State = kState_Initializing;
 
@@ -132,17 +132,17 @@ CHIP_ERROR ChipMessageLayer::Init(InitContext * context)
 
     FabricState                           = context->fabricState;
     FabricState->MessageLayer             = this;
-    OnMessageReceived                     = NULL;
-    OnReceiveError                        = NULL;
-    OnConnectionReceived                  = NULL;
-    OnUnsecuredConnectionReceived         = NULL;
-    OnUnsecuredConnectionCallbacksRemoved = NULL;
-    OnAcceptError                         = NULL;
-    OnMessageLayerActivityChange          = NULL;
+    OnMessageReceived                     = nullptr;
+    OnReceiveError                        = nullptr;
+    OnConnectionReceived                  = nullptr;
+    OnUnsecuredConnectionReceived         = nullptr;
+    OnUnsecuredConnectionCallbacksRemoved = nullptr;
+    OnAcceptError                         = nullptr;
+    OnMessageLayerActivityChange          = nullptr;
     memset(mConPool, 0, sizeof(mConPool));
-    AppState               = NULL;
-    ExchangeMgr            = NULL;
-    SecurityMgr            = NULL;
+    AppState               = nullptr;
+    ExchangeMgr            = nullptr;
+    SecurityMgr            = nullptr;
     IsListening            = context->listenTCP || context->listenUDP;
     IncomingConIdleTimeout = CHIP_CONFIG_DEFAULT_INCOMING_CONNECTION_IDLE_TIMEOUT;
 
@@ -155,25 +155,25 @@ CHIP_ERROR ChipMessageLayer::Init(InitContext * context)
     SetEphemeralUDPPortEnabled(context->enableEphemeralUDPPort);
 #endif
 
-    mIPv6TCPListen = NULL;
-    mIPv6UDP       = NULL;
+    mIPv6TCPListen = nullptr;
+    mIPv6UDP       = nullptr;
 
 #if INET_CONFIG_ENABLE_IPV4
-    mIPv4TCPListen = NULL;
-    mIPv4UDP       = NULL;
+    mIPv4TCPListen = nullptr;
+    mIPv4UDP       = nullptr;
 #endif // INET_CONFIG_ENABLE_IPV4
 
 #if CHIP_CONFIG_ENABLE_TARGETED_LISTEN
-    mIPv6UDPMulticastRcv = NULL;
+    mIPv6UDPMulticastRcv = nullptr;
 #if INET_CONFIG_ENABLE_IPV4
-    mIPv4UDPBroadcastRcv = NULL;
+    mIPv4UDPBroadcastRcv = nullptr;
 #endif // INET_CONFIG_ENABLE_IPV4
 #endif // CHIP_CONFIG_ENABLE_TARGETED_LISTEN
 
 #if CHIP_CONFIG_ENABLE_EPHEMERAL_UDP_PORT
-    mIPv6EphemeralUDP = NULL;
+    mIPv6EphemeralUDP = nullptr;
 #if INET_CONFIG_ENABLE_IPV4
-    mIPv4EphemeralUDP = NULL;
+    mIPv4EphemeralUDP = nullptr;
 #endif // INET_CONFIG_ENABLE_IPV4
 #endif // CHIP_CONFIG_ENABLE_EPHEMERAL_UDP_PORT
 
@@ -185,7 +185,7 @@ CHIP_ERROR ChipMessageLayer::Init(InitContext * context)
     SuccessOrExit(err);
 
 #if CONFIG_NETWORK_LAYER_BLE
-    if (context->listenBLE && mBle != NULL)
+    if (context->listenBLE && mBle != nullptr)
     {
         mBle->mAppState                = this;
         mBle->OnChipBleConnectReceived = HandleIncomingBleConnection;
@@ -221,25 +221,25 @@ CHIP_ERROR ChipMessageLayer::Shutdown()
     CloseEndpoints();
 
 #if CONFIG_NETWORK_LAYER_BLE
-    if (mBle != NULL && mBle->mAppState == this)
+    if (mBle != nullptr && mBle->mAppState == this)
     {
-        mBle->mAppState                = NULL;
-        mBle->OnChipBleConnectReceived = NULL;
+        mBle->mAppState                = nullptr;
+        mBle->OnChipBleConnectReceived = nullptr;
     }
 #endif // CONFIG_NETWORK_LAYER_BLE
 
     State                         = kState_NotInitialized;
     IsListening                   = false;
-    FabricState                   = NULL;
-    OnMessageReceived             = NULL;
-    OnReceiveError                = NULL;
-    OnUnsecuredConnectionReceived = NULL;
-    OnConnectionReceived          = NULL;
-    OnAcceptError                 = NULL;
-    OnMessageLayerActivityChange  = NULL;
+    FabricState                   = nullptr;
+    OnMessageReceived             = nullptr;
+    OnReceiveError                = nullptr;
+    OnUnsecuredConnectionReceived = nullptr;
+    OnConnectionReceived          = nullptr;
+    OnAcceptError                 = nullptr;
+    OnMessageLayerActivityChange  = nullptr;
     memset(mConPool, 0, sizeof(mConPool));
-    ExchangeMgr = NULL;
-    AppState    = NULL;
+    ExchangeMgr = nullptr;
+    AppState    = nullptr;
     mFlags      = 0;
 
     return CHIP_NO_ERROR;
@@ -293,7 +293,7 @@ CHIP_ERROR ChipMessageLayer::EncodeMessage(const IPAddress & destAddr, uint16_t 
         msgInfo->Flags |= kChipMessageFlag_DestNodeId;
 
     // Encode the CHIP message. NOTE that this results in the payload buffer containing the entire encoded message.
-    res = EncodeMessage(msgInfo, payload, NULL, UINT16_MAX, 0);
+    res = EncodeMessage(msgInfo, payload, nullptr, UINT16_MAX, 0);
 
     return res;
 }
@@ -403,7 +403,7 @@ CHIP_ERROR ChipMessageLayer::SendMessage(const IPAddress & aDestAddr, uint16_t d
     return SendMessage(destAddr, destPort, sendIntfId, payload, msgInfo->Flags);
 
 exit:
-    if ((res != CHIP_NO_ERROR) && (payload != NULL) && ((msgInfo->Flags & kChipMessageFlag_RetainBuffer) == 0))
+    if ((res != CHIP_NO_ERROR) && (payload != nullptr) && ((msgInfo->Flags & kChipMessageFlag_RetainBuffer) == 0))
     {
         PacketBuffer::Free(payload);
     }
@@ -585,7 +585,7 @@ CHIP_ERROR ChipMessageLayer::SendMessage(const IPAddress & destAddr, uint16_t de
         // message buffer. If a send interface was specified, the message is sent over that interface.
         udpSendFlags = GetFlag(msgFlags, kChipMessageFlag_RetainBuffer) ? UDPEndPoint::kSendFlag_RetainBuffer : 0;
         err          = ep->SendMsg(&pktInfo, payload, udpSendFlags);
-        payload      = NULL; // Prevent call to Free() in exit code
+        payload      = nullptr; // Prevent call to Free() in exit code
         CheckForceRefreshUDPEndPointsNeeded(err);
         err = FilterUDPSendError(err, sendAction == kMulticast_OneInterface);
         break;
@@ -634,7 +634,7 @@ CHIP_ERROR ChipMessageLayer::SendMessage(const IPAddress & destAddr, uint16_t de
     }
 
 exit:
-    if (payload != NULL && !GetFlag(msgFlags, kChipMessageFlag_RetainBuffer))
+    if (payload != nullptr && !GetFlag(msgFlags, kChipMessageFlag_RetainBuffer))
         PacketBuffer::Free(payload);
     return err;
 }
@@ -693,7 +693,7 @@ CHIP_ERROR ChipMessageLayer::SelectOutboundUDPEndPoint(const IPAddress & destAdd
         ExitNow(err = CHIP_ERROR_INVALID_ARGUMENT);
     }
 
-    VerifyOrExit(ep != NULL, err = CHIP_ERROR_NO_ENDPOINT);
+    VerifyOrExit(ep != nullptr, err = CHIP_ERROR_NO_ENDPOINT);
 
 exit:
     return err;
@@ -793,7 +793,7 @@ CHIP_ERROR ChipMessageLayer::ResendMessage(const IPAddress & aDestAddr, uint16_t
 
     return SendMessage(destAddr, destPort, interfaceId, payload, msgInfo->Flags);
 exit:
-    if ((res != CHIP_NO_ERROR) && (payload != NULL) && ((msgInfo->Flags & kChipMessageFlag_RetainBuffer) == 0))
+    if ((res != CHIP_NO_ERROR) && (payload != nullptr) && ((msgInfo->Flags & kChipMessageFlag_RetainBuffer) == 0))
     {
         PacketBuffer::Free(payload);
     }
@@ -841,7 +841,7 @@ ChipConnection * ChipMessageLayer::NewConnection()
     }
 
     ChipLogError(ExchangeManager, "New con FAILED");
-    return NULL;
+    return nullptr;
 }
 
 void ChipMessageLayer::GetIncomingTCPConCount(const IPAddress & peerAddr, uint16_t & count, uint16_t & countFromIP)
@@ -879,16 +879,16 @@ CHIP_ERROR ChipMessageLayer::SetUnsecuredConnectionListener(ConnectionReceiveFun
     }
 
     // New OnUnsecuredConnectionReceived cannot be null. To clear, use ClearOnUnsecuredConnectionReceived().
-    VerifyOrExit(newOnUnsecuredConnectionReceived != NULL, err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(newOnUnsecuredConnectionReceived != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    if (OnUnsecuredConnectionReceived != NULL)
+    if (OnUnsecuredConnectionReceived != nullptr)
     {
         if (force == false)
         {
             err = CHIP_ERROR_INCORRECT_STATE;
             ExitNow();
         }
-        else if (OnUnsecuredConnectionCallbacksRemoved != NULL)
+        else if (OnUnsecuredConnectionCallbacksRemoved != nullptr)
         {
             // Notify application that its previous OnUnsecuredConnectionReceived callback has been removed.
             OnUnsecuredConnectionCallbacksRemoved(UnsecuredConnectionReceivedAppState);
@@ -930,9 +930,9 @@ CHIP_ERROR ChipMessageLayer::ClearUnsecuredConnectionListener(ConnectionReceiveF
         SuccessOrExit(err);
     }
 
-    OnUnsecuredConnectionReceived         = NULL;
-    OnUnsecuredConnectionCallbacksRemoved = NULL;
-    UnsecuredConnectionReceivedAppState   = NULL;
+    OnUnsecuredConnectionReceived         = nullptr;
+    OnUnsecuredConnectionCallbacksRemoved = nullptr;
+    UnsecuredConnectionReceivedAppState   = nullptr;
 
 exit:
     return err;
@@ -1065,7 +1065,7 @@ CHIP_ERROR ChipMessageLayer::DecodeHeader(PacketBuffer * msgBuf, ChipMessageInfo
         msgInfo->KeyId = ChipKeyId::kNone;
     }
 
-    if (payloadStart != NULL)
+    if (payloadStart != nullptr)
     {
         *payloadStart = p;
     }
@@ -1093,7 +1093,7 @@ CHIP_ERROR ChipMessageLayer::ReEncodeMessage(PacketBuffer * msgBuf)
 
     encryptionLen = msgLen - (p - msgStart);
 
-    err = FabricState->GetSessionState(msgInfo.SourceNodeId, msgInfo.KeyId, msgInfo.EncryptionType, NULL, sessionState);
+    err = FabricState->GetSessionState(msgInfo.SourceNodeId, msgInfo.KeyId, msgInfo.EncryptionType, nullptr, sessionState);
     if (err != CHIP_NO_ERROR)
         return err;
 
@@ -1501,7 +1501,7 @@ void ChipMessageLayer::HandleUDPMessage(UDPEndPoint * endPoint, PacketBuffer * m
                                                          : kNodeIdNotSpecified;
 
         // Attempt to decode the message.
-        err = msgLayer->DecodeMessage(msg, sourceNodeId, NULL, &msgInfo, &payload, &payloadLen);
+        err = msgLayer->DecodeMessage(msg, sourceNodeId, nullptr, &msgInfo, &payload, &payloadLen);
 
         if (err == CHIP_NO_ERROR)
         {
@@ -1532,7 +1532,7 @@ void ChipMessageLayer::HandleUDPMessage(UDPEndPoint * endPoint, PacketBuffer * m
 #endif // CHIP_CONFIG_ENABLE_EPHEMERAL_UDP_PORT
 
     // Call the supplied OnMessageReceived callback.
-    if (msgLayer->OnMessageReceived != NULL)
+    if (msgLayer->OnMessageReceived != nullptr)
     {
         msgLayer->OnMessageReceived(msgLayer, &msgInfo, msg);
     }
@@ -1551,9 +1551,9 @@ exit:
         // Send key error response to the peer if required.
         // Key error response is sent only if the received message is not a multicast.
         if (!pktInfo->DestAddress.IsMulticast() && msgLayer->SecurityMgr->IsKeyError(err))
-            msgLayer->SecurityMgr->SendKeyErrorMsg(&msgInfo, pktInfo, NULL, err);
+            msgLayer->SecurityMgr->SendKeyErrorMsg(&msgInfo, pktInfo, nullptr, err);
 
-        if (msgLayer->OnReceiveError != NULL)
+        if (msgLayer->OnReceiveError != nullptr)
             msgLayer->OnReceiveError(msgLayer, err, pktInfo);
     }
 
@@ -1565,7 +1565,7 @@ void ChipMessageLayer::HandleUDPReceiveError(UDPEndPoint * endPoint, INET_ERROR 
     ChipLogError(MessageLayer, "HandleUDPReceiveError Error %s", ErrorStr(err));
 
     ChipMessageLayer * msgLayer = (ChipMessageLayer *) endPoint->AppState;
-    if (msgLayer->OnReceiveError != NULL)
+    if (msgLayer->OnReceiveError != nullptr)
         msgLayer->OnReceiveError(msgLayer, err, pktInfo);
 }
 
@@ -1575,20 +1575,20 @@ void ChipMessageLayer::HandleIncomingBleConnection(BLEEndPoint * bleEP)
     ChipMessageLayer * msgLayer = (ChipMessageLayer *) bleEP->mAppState;
 
     // Immediately close the connection if there's no callback registered.
-    if (msgLayer->OnConnectionReceived == NULL && msgLayer->ExchangeMgr == NULL)
+    if (msgLayer->OnConnectionReceived == nullptr && msgLayer->ExchangeMgr == nullptr)
     {
         bleEP->Close();
-        if (msgLayer->OnAcceptError != NULL)
+        if (msgLayer->OnAcceptError != nullptr)
             msgLayer->OnAcceptError(msgLayer, CHIP_ERROR_NO_CONNECTION_HANDLER);
         return;
     }
 
     // Attempt to allocate a connection object. Fail if too many connections.
     ChipConnection * con = msgLayer->NewConnection();
-    if (con == NULL)
+    if (con == nullptr)
     {
         bleEP->Close();
-        if (msgLayer->OnAcceptError != NULL)
+        if (msgLayer->OnAcceptError != nullptr)
             msgLayer->OnAcceptError(msgLayer, CHIP_ERROR_TOO_MANY_CONNECTIONS);
         return;
     }
@@ -1609,11 +1609,11 @@ void ChipMessageLayer::HandleIncomingBleConnection(BLEEndPoint * bleEP)
     con->SetIncoming(true);
 
     // If the exchange manager has been initialized, call its callback.
-    if (msgLayer->ExchangeMgr != NULL)
+    if (msgLayer->ExchangeMgr != nullptr)
         msgLayer->ExchangeMgr->HandleConnectionReceived(con);
 
     // Call the app's OnConnectionReceived callback.
-    if (msgLayer->OnConnectionReceived != NULL)
+    if (msgLayer->OnConnectionReceived != nullptr)
         msgLayer->OnConnectionReceived(msgLayer, con);
 }
 #endif /* CONFIG_NETWORK_LAYER_BLE */
@@ -1629,10 +1629,10 @@ void ChipMessageLayer::HandleIncomingTcpConnection(TCPEndPoint * listeningEP, TC
     ChipMessageLayer * msgLayer = (ChipMessageLayer *) listeningEP->AppState;
 
     // Immediately close the connection if there's no callback registered.
-    if (msgLayer->OnConnectionReceived == NULL && msgLayer->ExchangeMgr == NULL)
+    if (msgLayer->OnConnectionReceived == nullptr && msgLayer->ExchangeMgr == nullptr)
     {
         conEP->Free();
-        if (msgLayer->OnAcceptError != NULL)
+        if (msgLayer->OnAcceptError != nullptr)
             msgLayer->OnAcceptError(msgLayer, CHIP_ERROR_NO_CONNECTION_HANDLER);
         return;
     }
@@ -1643,17 +1643,17 @@ void ChipMessageLayer::HandleIncomingTcpConnection(TCPEndPoint * listeningEP, TC
         incomingTCPConCountFromIP == CHIP_CONFIG_MAX_INCOMING_TCP_CON_FROM_SINGLE_IP)
     {
         conEP->Free();
-        if (msgLayer->OnAcceptError != NULL)
+        if (msgLayer->OnAcceptError != nullptr)
             msgLayer->OnAcceptError(msgLayer, CHIP_ERROR_TOO_MANY_CONNECTIONS);
         return;
     }
 
     // Attempt to allocate a connection object. Fail if too many connections.
     ChipConnection * con = msgLayer->NewConnection();
-    if (con == NULL)
+    if (con == nullptr)
     {
         conEP->Free();
-        if (msgLayer->OnAcceptError != NULL)
+        if (msgLayer->OnAcceptError != nullptr)
             msgLayer->OnAcceptError(msgLayer, CHIP_ERROR_TOO_MANY_CONNECTIONS);
         return;
     }
@@ -1663,7 +1663,7 @@ void ChipMessageLayer::HandleIncomingTcpConnection(TCPEndPoint * listeningEP, TC
     if (err != INET_NO_ERROR)
     {
         conEP->Free();
-        if (msgLayer->OnAcceptError != NULL)
+        if (msgLayer->OnAcceptError != nullptr)
             msgLayer->OnAcceptError(msgLayer, err);
         return;
     }
@@ -1686,15 +1686,15 @@ void ChipMessageLayer::HandleIncomingTcpConnection(TCPEndPoint * listeningEP, TC
     con->SetIncoming(true);
 
     // If the exchange manager has been initialized, call its callback.
-    if (msgLayer->ExchangeMgr != NULL)
+    if (msgLayer->ExchangeMgr != nullptr)
         msgLayer->ExchangeMgr->HandleConnectionReceived(con);
 
     // Call the app's OnConnectionReceived callback.
-    if (msgLayer->OnConnectionReceived != NULL)
+    if (msgLayer->OnConnectionReceived != nullptr)
         msgLayer->OnConnectionReceived(msgLayer, con);
 
     // If connection was received on unsecured port, call the app's OnUnsecuredConnectionReceived callback.
-    if (msgLayer->OnUnsecuredConnectionReceived != NULL && conEP->GetLocalInfo(&localAddr, &localPort) == CHIP_NO_ERROR &&
+    if (msgLayer->OnUnsecuredConnectionReceived != nullptr && conEP->GetLocalInfo(&localAddr, &localPort) == CHIP_NO_ERROR &&
         localPort == CHIP_UNSECURED_PORT)
         msgLayer->OnUnsecuredConnectionReceived(msgLayer, con);
 }
@@ -1702,7 +1702,7 @@ void ChipMessageLayer::HandleIncomingTcpConnection(TCPEndPoint * listeningEP, TC
 void ChipMessageLayer::HandleAcceptError(TCPEndPoint * ep, INET_ERROR err)
 {
     ChipMessageLayer * msgLayer = (ChipMessageLayer *) ep->AppState;
-    if (msgLayer->OnAcceptError != NULL)
+    if (msgLayer->OnAcceptError != nullptr)
         msgLayer->OnAcceptError(msgLayer, err);
 }
 
@@ -1913,14 +1913,14 @@ CHIP_ERROR ChipMessageLayer::RefreshEndpoint(TCPEndPoint *& endPoint, bool enabl
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     // Release any existing endpoint as needed.
-    if (endPoint != NULL && !enable)
+    if (endPoint != nullptr && !enable)
     {
         endPoint->Free();
-        endPoint = NULL;
+        endPoint = nullptr;
     }
 
     // If needed, create and bind a new endpoint...
-    if (endPoint == NULL && enable)
+    if (endPoint == nullptr && enable)
     {
         // Create a new TCP endpoint object.
         err = Inet->NewTCPEndPoint(&endPoint);
@@ -1949,10 +1949,10 @@ CHIP_ERROR ChipMessageLayer::RefreshEndpoint(TCPEndPoint *& endPoint, bool enabl
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        if (endPoint != NULL)
+        if (endPoint != nullptr)
         {
             endPoint->Free();
-            endPoint = NULL;
+            endPoint = nullptr;
         }
         ChipLogError(MessageLayer, "Error initializing %s endpoint: %s", name, ErrorStr(err));
     }
@@ -1965,14 +1965,14 @@ CHIP_ERROR ChipMessageLayer::RefreshEndpoint(UDPEndPoint *& endPoint, bool enabl
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     // Release any existing endpoint as needed.
-    if (endPoint != NULL && (!enable || GetFlag(mFlags, kFlag_ForceRefreshUDPEndPoints)))
+    if (endPoint != nullptr && (!enable || GetFlag(mFlags, kFlag_ForceRefreshUDPEndPoints)))
     {
         endPoint->Free();
-        endPoint = NULL;
+        endPoint = nullptr;
     }
 
     // If needed, create and bind a new endpoint...
-    if (endPoint == NULL && enable)
+    if (endPoint == nullptr && enable)
     {
         // Create a new UDP endpoint object.
         err = Inet->NewUDPEndPoint(&endPoint);
@@ -2011,10 +2011,10 @@ CHIP_ERROR ChipMessageLayer::RefreshEndpoint(UDPEndPoint *& endPoint, bool enabl
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        if (endPoint != NULL)
+        if (endPoint != nullptr)
         {
             endPoint->Free();
-            endPoint = NULL;
+            endPoint = nullptr;
         }
         ChipLogError(MessageLayer, "Error initializing %s endpoint: %s", name, ErrorStr(err));
     }
@@ -2097,34 +2097,34 @@ void ChipMessageLayer::CloseListeningEndpoints(void)
 {
     ChipBindLog("Closing endpoints");
 
-    if (mIPv6TCPListen != NULL)
+    if (mIPv6TCPListen != nullptr)
     {
         mIPv6TCPListen->Free();
-        mIPv6TCPListen = NULL;
+        mIPv6TCPListen = nullptr;
     }
 
-    if (mIPv6UDP != NULL)
+    if (mIPv6UDP != nullptr)
     {
         mIPv6UDP->Free();
-        mIPv6UDP = NULL;
+        mIPv6UDP = nullptr;
     }
 
 #if CHIP_CONFIG_ENABLE_EPHEMERAL_UDP_PORT
 
-    if (mIPv6EphemeralUDP != NULL)
+    if (mIPv6EphemeralUDP != nullptr)
     {
         mIPv6EphemeralUDP->Free();
-        mIPv6EphemeralUDP = NULL;
+        mIPv6EphemeralUDP = nullptr;
     }
 
 #endif // CHIP_CONFIG_ENABLE_EPHEMERAL_UDP_PORT
 
 #if CHIP_CONFIG_ENABLE_TARGETED_LISTEN
 
-    if (mIPv6UDPMulticastRcv != NULL)
+    if (mIPv6UDPMulticastRcv != nullptr)
     {
         mIPv6UDPMulticastRcv->Free();
-        mIPv6UDPMulticastRcv = NULL;
+        mIPv6UDPMulticastRcv = nullptr;
     }
 
 #endif // CHIP_CONFIG_ENABLE_TARGETED_LISTEN
@@ -2141,34 +2141,34 @@ void ChipMessageLayer::CloseListeningEndpoints(void)
 
 #if INET_CONFIG_ENABLE_IPV4
 
-    if (mIPv4TCPListen != NULL)
+    if (mIPv4TCPListen != nullptr)
     {
         mIPv4TCPListen->Free();
-        mIPv4TCPListen = NULL;
+        mIPv4TCPListen = nullptr;
     }
 
-    if (mIPv4UDP != NULL)
+    if (mIPv4UDP != nullptr)
     {
         mIPv4UDP->Free();
-        mIPv4UDP = NULL;
+        mIPv4UDP = nullptr;
     }
 
 #if CHIP_CONFIG_ENABLE_EPHEMERAL_UDP_PORT
 
-    if (mIPv4EphemeralUDP != NULL)
+    if (mIPv4EphemeralUDP != nullptr)
     {
         mIPv4EphemeralUDP->Free();
-        mIPv4EphemeralUDP = NULL;
+        mIPv4EphemeralUDP = nullptr;
     }
 
 #endif // CHIP_CONFIG_ENABLE_EPHEMERAL_UDP_PORT
 
 #if CHIP_CONFIG_ENABLE_TARGETED_LISTEN
 
-    if (mIPv4UDPBroadcastRcv != NULL)
+    if (mIPv4UDPBroadcastRcv != nullptr)
     {
         mIPv4UDPBroadcastRcv->Free();
-        mIPv4UDPBroadcastRcv = NULL;
+        mIPv4UDPBroadcastRcv = nullptr;
     }
 
 #endif // CHIP_CONFIG_ENABLE_TARGETED_LISTEN
@@ -2318,7 +2318,7 @@ void ChipMessageLayer::GetPeerDescription(char * buf, size_t bufSize, uint64_t n
     }
     VerifyOrExit(len < bufSize, /* no-op */);
 
-    if (addr != NULL)
+    if (addr != nullptr)
     {
         buf[len++] = '[';
         VerifyOrExit(len < bufSize, /* no-op */);
@@ -2348,7 +2348,7 @@ void ChipMessageLayer::GetPeerDescription(char * buf, size_t bufSize, uint64_t n
         sep = ", ";
     }
 
-    if (con != NULL)
+    if (con != nullptr)
     {
         const char * conType;
         switch (con->NetworkType)
@@ -2389,10 +2389,10 @@ exit:
  */
 void ChipMessageLayer::GetPeerDescription(char * buf, size_t bufSize, const ChipMessageInfo * msgInfo)
 {
-    GetPeerDescription(buf, bufSize, msgInfo->SourceNodeId,
-                       (msgInfo->InPacketInfo != NULL) ? &msgInfo->InPacketInfo->SrcAddress : NULL,
-                       (msgInfo->InPacketInfo != NULL) ? msgInfo->InPacketInfo->SrcPort : 0,
-                       (msgInfo->InPacketInfo != NULL) ? msgInfo->InPacketInfo->Interface : INET_NULL_INTERFACEID, msgInfo->InCon);
+    GetPeerDescription(
+        buf, bufSize, msgInfo->SourceNodeId, (msgInfo->InPacketInfo != nullptr) ? &msgInfo->InPacketInfo->SrcAddress : nullptr,
+        (msgInfo->InPacketInfo != nullptr) ? msgInfo->InPacketInfo->SrcPort : 0,
+        (msgInfo->InPacketInfo != nullptr) ? msgInfo->InPacketInfo->Interface : INET_NULL_INTERFACEID, msgInfo->InCon);
 }
 
 /**

--- a/src/lib/message/CHIPMessageLayer.h
+++ b/src/lib/message/CHIPMessageLayer.h
@@ -467,13 +467,13 @@ public:
          */
         InitContext(void)
         {
-            systemLayer = NULL;
-            inet        = NULL;
-            fabricState = NULL;
+            systemLayer = nullptr;
+            inet        = nullptr;
+            fabricState = nullptr;
             listenTCP   = true;
             listenUDP   = true;
 #if CONFIG_NETWORK_LAYER_BLE
-            ble       = NULL;
+            ble       = nullptr;
             listenBLE = true;
 #endif
 #if CHIP_CONFIG_ENABLE_EPHEMERAL_UDP_PORT

--- a/src/lib/message/CHIPSecurityMgr.cpp
+++ b/src/lib/message/CHIPSecurityMgr.cpp
@@ -66,7 +66,7 @@ using namespace chip::Encoding;
 ChipSecurityManager::ChipSecurityManager(void)
 {
     State        = kState_NotInitialized;
-    mSystemLayer = NULL;
+    mSystemLayer = nullptr;
 }
 
 CHIP_ERROR ChipSecurityManager::Init(ChipExchangeManager & aExchangeMgr, System::Layer & aSystemLayer)
@@ -81,17 +81,17 @@ CHIP_ERROR ChipSecurityManager::Init(ChipExchangeManager & aExchangeMgr, System:
     SessionEstablishTimeout = CHIP_CONFIG_DEFAULT_SECURITY_SESSION_ESTABLISHMENT_TIMEOUT;
     IdleSessionTimeout      = CHIP_CONFIG_DEFAULT_SECURITY_SESSION_IDLE_TIMEOUT;
     FabricState             = aExchangeMgr.FabricState;
-    OnSessionEstablished    = NULL;
-    OnSessionError          = NULL;
-    OnKeyErrorMsgRcvd       = NULL;
-    mEC                     = NULL;
-    mCon                    = NULL;
+    OnSessionEstablished    = nullptr;
+    OnSessionError          = nullptr;
+    OnKeyErrorMsgRcvd       = nullptr;
+    mEC                     = nullptr;
+    mCon                    = nullptr;
 #if CHIP_CONFIG_SECURITY_TEST_MODE
     CASEUseKnownECDHKey = false;
 #endif
-    mStartSecureSession_OnComplete = NULL;
-    mStartSecureSession_OnError    = NULL;
-    mStartSecureSession_ReqState   = NULL;
+    mStartSecureSession_OnComplete = nullptr;
+    mStartSecureSession_OnError    = nullptr;
+    mStartSecureSession_ReqState   = nullptr;
     mRequestedAuthMode             = kChipAuthMode_NotSpecified;
     mSessionKeyId                  = ChipKeyId::kNone;
     mEncType                       = kChipEncryptionType_None;
@@ -114,7 +114,7 @@ CHIP_ERROR ChipSecurityManager::Shutdown(void)
     if (State != kState_NotInitialized)
     {
         ExchangeManager->UnregisterUnsolicitedMessageHandler(kChipProtocol_Security);
-        ExchangeManager = NULL;
+        ExchangeManager = nullptr;
 
         // TODO: clean-up in-progress session establishment
 
@@ -137,8 +137,8 @@ void ChipSecurityManager::HandleUnsolicitedMessage(ExchangeContext * ec, const I
     if (profileId == kChipProtocol_Security && msgType == kMsgType_KeyError)
     {
         secMgr->HandleKeyErrorMsg(ec, msgBuf);
-        msgBuf = NULL;
-        ec     = NULL;
+        msgBuf = nullptr;
+        ec     = nullptr;
 
         ExitNow();
     }
@@ -154,16 +154,16 @@ void ChipSecurityManager::HandleUnsolicitedMessage(ExchangeContext * ec, const I
     if (!ec->HasPeerRequestedAck())
     {
         // Reject the request if it did not arrive over a connection.
-        VerifyOrExit(ec->Con != NULL, err = CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrExit(ec->Con != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
     }
     // Reject all other message types.
     else
         ExitNow(err = CHIP_ERROR_INVALID_MESSAGE_TYPE);
 
 exit:
-    if (msgBuf != NULL)
+    if (msgBuf != nullptr)
         PacketBuffer::Free(msgBuf);
-    if (ec != NULL)
+    if (ec != nullptr)
     {
         if (err != CHIP_NO_ERROR)
             SendStatusReport(err, ec);
@@ -216,15 +216,15 @@ CHIP_ERROR ChipSecurityManager::SendKeyErrorMsg(ChipMessageInfo * rcvdMsgInfo, c
                                                 ChipConnection * con, CHIP_ERROR keyErr)
 {
     CHIP_ERROR err        = CHIP_NO_ERROR;
-    ExchangeContext * ec  = NULL;
-    PacketBuffer * msgBuf = NULL;
+    ExchangeContext * ec  = nullptr;
+    PacketBuffer * msgBuf = nullptr;
     uint8_t * p;
     uint16_t keyErrCode;
 
     // Create new exchange context.
-    if (con == NULL)
+    if (con == nullptr)
     {
-        VerifyOrExit(rcvdMsgPacketInfo != NULL, err = CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrExit(rcvdMsgPacketInfo != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
         ec = ExchangeManager->NewContext(rcvdMsgInfo->SourceNodeId, rcvdMsgPacketInfo->SrcAddress, rcvdMsgPacketInfo->SrcPort,
                                          rcvdMsgPacketInfo->Interface, this);
     }
@@ -232,7 +232,7 @@ CHIP_ERROR ChipSecurityManager::SendKeyErrorMsg(ChipMessageInfo * rcvdMsgInfo, c
     {
         ec = ExchangeManager->NewContext(con, this);
     }
-    VerifyOrExit(ec != NULL, err = CHIP_ERROR_NO_MEMORY);
+    VerifyOrExit(ec != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     // Encode key error status code.
     switch (keyErr)
@@ -259,7 +259,7 @@ CHIP_ERROR ChipSecurityManager::SendKeyErrorMsg(ChipMessageInfo * rcvdMsgInfo, c
 
     // Allocate new buffer.
     msgBuf = PacketBuffer::New();
-    VerifyOrExit(msgBuf != NULL, err = CHIP_ERROR_NO_MEMORY);
+    VerifyOrExit(msgBuf != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     // Verify that the buffer is big enough for this message.
     VerifyOrExit(msgBuf->AvailableDataLength() >= kChipKeyErrorMessageSize, err = CHIP_ERROR_BUFFER_TOO_SMALL);
@@ -284,13 +284,13 @@ CHIP_ERROR ChipSecurityManager::SendKeyErrorMsg(ChipMessageInfo * rcvdMsgInfo, c
 
     // Send key error message.
     err    = ec->SendMessage(kChipProtocol_Security, kMsgType_KeyError, msgBuf, 0);
-    msgBuf = NULL;
+    msgBuf = nullptr;
 
 exit:
-    if (msgBuf != NULL)
+    if (msgBuf != nullptr)
         PacketBuffer::Free(msgBuf);
 
-    if (ec != NULL)
+    if (ec != nullptr)
         ec->Close();
 
     return err;
@@ -323,11 +323,11 @@ void ChipSecurityManager::HandleKeyErrorMsg(ExchangeContext * ec, PacketBuffer *
 
     // Free the received message buffer so that it can be reused to initiate additional communication.
     PacketBuffer::Free(msgBuf);
-    msgBuf = NULL;
+    msgBuf = nullptr;
 
     // Close exchange context that delivered key error message.
     ec->Close();
-    ec = NULL;
+    ec = nullptr;
 
     // Decode error status code.
     switch (keyErrCode)
@@ -400,14 +400,14 @@ void ChipSecurityManager::HandleKeyErrorMsg(ExchangeContext * ec, PacketBuffer *
     // TODO: fail the current in-progress session if the key error identifies the proposed key.
 
     // Call the general key error message handler.
-    if (OnKeyErrorMsgRcvd != NULL)
+    if (OnKeyErrorMsgRcvd != nullptr)
         OnKeyErrorMsgRcvd(keyId, encType, messageId, srcNodeId, keyErr);
 
 exit:
-    if (msgBuf != NULL)
+    if (msgBuf != nullptr)
         PacketBuffer::Free(msgBuf);
 
-    if (ec != NULL)
+    if (ec != nullptr)
         ec->Close();
 
     return;
@@ -417,24 +417,24 @@ CHIP_ERROR ChipSecurityManager::NewSessionExchange(uint64_t peerNodeId, IPAddres
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    if (mEC != NULL)
+    if (mEC != nullptr)
     {
         mEC->Close();
-        mEC = NULL;
+        mEC = nullptr;
     }
 
     // Create a new exchange context.
     if (mCon)
     {
         mEC = ExchangeManager->NewContext(mCon, this);
-        VerifyOrExit(mEC != NULL, err = CHIP_ERROR_NO_MEMORY);
+        VerifyOrExit(mEC != nullptr, err = CHIP_ERROR_NO_MEMORY);
     }
     else
     {
         VerifyOrExit(peerNodeId != kNodeIdNotSpecified && peerNodeId != kAnyNodeId, err = CHIP_ERROR_INVALID_ARGUMENT);
 
         mEC = ExchangeManager->NewContext(peerNodeId, peerAddr, peerPort, INET_NULL_INTERFACEID, this);
-        VerifyOrExit(mEC != NULL, err = CHIP_ERROR_NO_MEMORY);
+        VerifyOrExit(mEC != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
         mEC->OnAckRcvd   = RMPHandleAckRcvd;
         mEC->OnSendError = RMPHandleSendError;
@@ -453,7 +453,7 @@ CHIP_ERROR ChipSecurityManager::NewMsgCounterSyncExchange(const ChipMessageInfo 
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     // Verify input arguments.
-    VerifyOrExit(rcvdMsgInfo != NULL && rcvdMsgPacketInfo != NULL, err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(rcvdMsgInfo != nullptr && rcvdMsgPacketInfo != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
 
     // Message counter synchronization protocol is only applicable for application group keys.
     VerifyOrExit(ChipKeyId::IsAppGroupKey(rcvdMsgInfo->KeyId), err = CHIP_ERROR_INVALID_ARGUMENT);
@@ -461,7 +461,7 @@ CHIP_ERROR ChipSecurityManager::NewMsgCounterSyncExchange(const ChipMessageInfo 
     // Create new exchange context.
     ec = ExchangeManager->NewContext(rcvdMsgInfo->SourceNodeId, rcvdMsgPacketInfo->SrcAddress, rcvdMsgPacketInfo->SrcPort,
                                      rcvdMsgPacketInfo->Interface, this);
-    VerifyOrExit(ec != NULL, err = CHIP_ERROR_NO_MEMORY);
+    VerifyOrExit(ec != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     // Set encryption type and key Id.
     ec->EncryptionType = rcvdMsgInfo->EncryptionType;
@@ -490,7 +490,7 @@ CHIP_ERROR ChipSecurityManager::SendSolitaryMsgCounterSyncReq(const ChipMessageI
                                                               const IPPacketInfo * rcvdMsgPacketInfo)
 {
     CHIP_ERROR err       = CHIP_NO_ERROR;
-    ExchangeContext * ec = NULL;
+    ExchangeContext * ec = nullptr;
 
     // Create and initialize new exchange.
     err = NewMsgCounterSyncExchange(rcvdMsgInfo, rcvdMsgPacketInfo, ec);
@@ -501,7 +501,7 @@ CHIP_ERROR ChipSecurityManager::SendSolitaryMsgCounterSyncReq(const ChipMessageI
     SuccessOrExit(err);
 
 exit:
-    if (ec != NULL)
+    if (ec != nullptr)
         ec->Close();
 
     return err;
@@ -527,8 +527,8 @@ exit:
 CHIP_ERROR ChipSecurityManager::SendMsgCounterSyncResp(const ChipMessageInfo * rcvdMsgInfo, const IPPacketInfo * rcvdMsgPacketInfo)
 {
     CHIP_ERROR err        = CHIP_NO_ERROR;
-    ExchangeContext * ec  = NULL;
-    PacketBuffer * msgBuf = NULL;
+    ExchangeContext * ec  = nullptr;
+    PacketBuffer * msgBuf = nullptr;
 
     // Create and initialize new exchange.
     err = NewMsgCounterSyncExchange(rcvdMsgInfo, rcvdMsgPacketInfo, ec);
@@ -536,7 +536,7 @@ CHIP_ERROR ChipSecurityManager::SendMsgCounterSyncResp(const ChipMessageInfo * r
 
     // Allocate new buffer.
     msgBuf = PacketBuffer::New();
-    VerifyOrExit(msgBuf != NULL, err = CHIP_ERROR_NO_MEMORY);
+    VerifyOrExit(msgBuf != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     // Verify that the buffer is big enough for this message.
     VerifyOrExit(msgBuf->AvailableDataLength() >= kChipMsgCounterSyncRespMsgSize, err = CHIP_ERROR_BUFFER_TOO_SMALL);
@@ -549,13 +549,13 @@ CHIP_ERROR ChipSecurityManager::SendMsgCounterSyncResp(const ChipMessageInfo * r
 
     // Send message counter synchronization response message.
     err    = ec->SendMessage(kChipProtocol_Security, kMsgType_MsgCounterSyncResp, msgBuf);
-    msgBuf = NULL;
+    msgBuf = nullptr;
 
 exit:
-    if (msgBuf != NULL)
+    if (msgBuf != nullptr)
         PacketBuffer::Free(msgBuf);
 
-    if (ec != NULL)
+    if (ec != nullptr)
         ec->Close();
 
     return err;
@@ -623,11 +623,11 @@ void ChipSecurityManager::HandleSessionComplete(void)
     Reset();
 
     // Call the general session established handler.
-    if (OnSessionEstablished != NULL)
-        OnSessionEstablished(this, con, NULL, sessionKeyId, peerNodeId, encType);
+    if (OnSessionEstablished != nullptr)
+        OnSessionEstablished(this, con, nullptr, sessionKeyId, peerNodeId, encType);
 
     // Call the user's completion function.
-    if (userOnComplete != NULL)
+    if (userOnComplete != nullptr)
         userOnComplete(this, con, reqState, sessionKeyId, peerNodeId, encType);
 
     // If the session was initiated the remote party, release the reservation that was
@@ -668,7 +668,7 @@ void ChipSecurityManager::HandleSessionError(CHIP_ERROR err, PacketBuffer * stat
         SessionErrorFunct userOnError = mStartSecureSession_OnError;
         void * reqState               = mStartSecureSession_ReqState;
         StatusReport rcvdStatusReport;
-        StatusReport * statusReportPtr = NULL;
+        StatusReport * statusReportPtr = nullptr;
 
         // If a status report was received from the peer, parse it and arrange to pass it
         // to the callbacks.
@@ -692,11 +692,11 @@ void ChipSecurityManager::HandleSessionError(CHIP_ERROR err, PacketBuffer * stat
         Reset();
 
         // Call the general session error handler.
-        if (OnSessionError != NULL)
-            OnSessionError(this, con, NULL, err, peerNodeId, statusReportPtr);
+        if (OnSessionError != nullptr)
+            OnSessionError(this, con, nullptr, err, peerNodeId, statusReportPtr);
 
         // Call the user's error handler.
-        if (userOnError != NULL)
+        if (userOnError != nullptr)
             userOnError(this, con, reqState, err, peerNodeId, statusReportPtr);
 
         // Asynchronously notify other subsystems that the security manager is now available
@@ -713,7 +713,7 @@ void ChipSecurityManager::HandleConnectionClosed(ExchangeContext * ec, ChipConne
         conErr = CHIP_ERROR_CONNECTION_CLOSED_UNEXPECTEDLY;
 
     // Clean-up the local state and invoke the appropriate callbacks.
-    secMgr->HandleSessionError(conErr, NULL);
+    secMgr->HandleSessionError(conErr, nullptr);
 }
 
 CHIP_ERROR ChipSecurityManager::SendStatusReport(CHIP_ERROR localErr, ExchangeContext * ec)
@@ -724,9 +724,9 @@ CHIP_ERROR ChipSecurityManager::SendStatusReport(CHIP_ERROR localErr, ExchangeCo
     uint16_t sendFlags;
 
     // Verify that specified exchange isn't closed.
-    VerifyOrExit(ec != NULL, err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(ec != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    if (ec->Con != NULL)
+    if (ec->Con != nullptr)
     {
         // Verify that underlying connection isn't closed.
         VerifyOrExit(!ec->IsConnectionClosed(), err = CHIP_ERROR_INVALID_ARGUMENT);
@@ -824,10 +824,10 @@ exit:
 
 void ChipSecurityManager::Reset(void)
 {
-    if (mEC != NULL)
+    if (mEC != nullptr)
     {
         mEC->Abort();
-        mEC = NULL;
+        mEC = nullptr;
     }
 
     switch (State)
@@ -841,13 +841,13 @@ void ChipSecurityManager::Reset(void)
     CancelSessionTimer();
 
     State                          = kState_Idle;
-    mCon                           = NULL;
+    mCon                           = nullptr;
     mRequestedAuthMode             = kChipAuthMode_NotSpecified;
     mSessionKeyId                  = ChipKeyId::kNone;
     mEncType                       = kChipEncryptionType_None;
-    mStartSecureSession_OnComplete = NULL;
-    mStartSecureSession_OnError    = NULL;
-    mStartSecureSession_ReqState   = NULL;
+    mStartSecureSession_OnComplete = nullptr;
+    mStartSecureSession_OnError    = nullptr;
+    mStartSecureSession_ReqState   = nullptr;
 }
 
 void ChipSecurityManager::StartSessionTimer(void)
@@ -873,7 +873,7 @@ void ChipSecurityManager::HandleSessionTimeout(System::Layer * aSystemLayer, voi
     ChipSecurityManager * securityMgr = reinterpret_cast<ChipSecurityManager *>(aAppState);
     if (securityMgr)
     {
-        securityMgr->HandleSessionError(CHIP_ERROR_TIMEOUT, NULL);
+        securityMgr->HandleSessionError(CHIP_ERROR_TIMEOUT, nullptr);
     }
 }
 
@@ -929,7 +929,7 @@ void ChipSecurityManager::RMPHandleSendError(ExchangeContext * ec, CHIP_ERROR er
     ChipLogProgress(SecurityManager, "%s", __FUNCTION__);
     ChipSecurityManager * secMgr = (ChipSecurityManager *) ec->AppState;
 
-    secMgr->HandleSessionError(err, NULL);
+    secMgr->HandleSessionError(err, nullptr);
 }
 
 void ChipSecurityManager::AsyncNotifySecurityManagerAvailable()
@@ -965,10 +965,10 @@ CHIP_ERROR ChipSecurityManager::CancelSessionEstablishment(void * reqState)
         reqState == mStartSecureSession_ReqState)
     {
         // Clear the application's OnError handler to prevent a callback.
-        mStartSecureSession_OnError = NULL;
+        mStartSecureSession_OnError = nullptr;
 
         // Fail the session with a canceled error.
-        HandleSessionError(CHIP_ERROR_TRANSACTION_CANCELED, NULL);
+        HandleSessionError(CHIP_ERROR_TRANSACTION_CANCELED, nullptr);
 
         return CHIP_NO_ERROR;
     }
@@ -1069,7 +1069,7 @@ void ChipSecurityManager::ReleaseSessionKey(ChipSessionKey * sessionKey)
                   sessionKey->MsgEncKey.KeyId, sessionKey->NodeId, sessionKey->ReserveCount);
 
     // If the session key is subject to automatic removal and its reserve count is now zero...
-    if (sessionKey->BoundCon == NULL && sessionKey->IsKeySet() && sessionKey->ReserveCount == 0)
+    if (sessionKey->BoundCon == nullptr && sessionKey->IsKeySet() && sessionKey->ReserveCount == 0)
     {
         // If the session key is marked remove-on-idle, enable the idle session timer and mark the key as
         // recently active.  This will give it the maximum lifetime before it gets removed for inactivity.

--- a/src/lib/message/CHIPServerBase.cpp
+++ b/src/lib/message/CHIPServerBase.cpp
@@ -67,7 +67,7 @@ bool ChipServerBase::EnforceAccessControl(ExchangeContext * ec, uint32_t msgProf
                                           const ChipMessageInfo * msgInfo, ChipServerDelegateBase * delegate)
 {
     // Reject all messages if the application hasn't specified a delegate object.
-    if (delegate == NULL)
+    if (delegate == nullptr)
     {
         ChipServerBase::SendStatusReport(ec, kChipProtocol_Common, Common::kStatus_InternalError, CHIP_NO_ERROR);
         return false;
@@ -158,8 +158,8 @@ CHIP_ERROR ChipServerBase::SendStatusReport(ExchangeContext * ec, uint32_t statu
                           // EndContainer (1)
 
     respBuf = PacketBuffer::NewWithAvailableSize(respLen);
-    VerifyOrExit(respBuf != NULL, err = CHIP_ERROR_NO_MEMORY);
-    VerifyOrDie(ec != NULL);
+    VerifyOrExit(respBuf != nullptr, err = CHIP_ERROR_NO_MEMORY);
+    VerifyOrDie(ec != nullptr);
 
     p = respBuf->Start();
     LittleEndian::Write32(p, statusProfileId);
@@ -187,10 +187,10 @@ CHIP_ERROR ChipServerBase::SendStatusReport(ExchangeContext * ec, uint32_t statu
     }
 
     err     = ec->SendMessage(kChipProtocol_Common, Common::kMsgType_StatusReport, respBuf, sendFlags);
-    respBuf = NULL;
+    respBuf = nullptr;
 
 exit:
-    if (respBuf != NULL)
+    if (respBuf != nullptr)
         PacketBuffer::Free(respBuf);
     return err;
 }

--- a/src/lib/message/ExchangeContext.cpp
+++ b/src/lib/message/ExchangeContext.cpp
@@ -423,14 +423,14 @@ CHIP_ERROR ExchangeContext::SendMessage(uint32_t profileId, uint8_t msgType, Pac
 {
     CHIP_ERROR err                                 = CHIP_NO_ERROR;
     bool sendCalled                                = false;
-    ChipExchangeManager::RetransTableEntry * entry = NULL;
+    ChipExchangeManager::RetransTableEntry * entry = nullptr;
 
 #if CHIP_RETAIN_LOGGING
     uint16_t payloadLen = msgBuf->DataLength();
 #endif
 
     // Don't let method get called on a freed object.
-    VerifyOrDie(ExchangeMgr != NULL && mRefCount != 0);
+    VerifyOrDie(ExchangeMgr != nullptr && mRefCount != 0);
 
     // we hold the exchange context here in case the entity that
     // originally generated it tries to close it as a result of
@@ -439,13 +439,13 @@ CHIP_ERROR ExchangeContext::SendMessage(uint32_t profileId, uint8_t msgType, Pac
 
     // If sending via UDP and the auto-request ACK feature is enabled, automatically
     // request an acknowledgment, UNLESS the NoAutoRequestAck send flag has been specified.
-    if (Con == NULL && (mFlags & kFlagAutoRequestAck) != 0 && (sendFlags & kSendFlag_NoAutoRequestAck) == 0)
+    if (Con == nullptr && (mFlags & kFlagAutoRequestAck) != 0 && (sendFlags & kSendFlag_NoAutoRequestAck) == 0)
     {
         sendFlags |= kSendFlag_RequestAck;
     }
 
     // Do not allow RMP to be used over a TCP connection
-    if ((sendFlags & kSendFlag_RequestAck) && Con != NULL)
+    if ((sendFlags & kSendFlag_RequestAck) && Con != nullptr)
     {
         ExitNow(err = CHIP_ERROR_INVALID_ARGUMENT);
     }
@@ -511,14 +511,14 @@ CHIP_ERROR ExchangeContext::SendMessage(uint32_t profileId, uint8_t msgType, Pac
 #endif // CHIP_CONFIG_ENABLE_EPHEMERAL_UDP_PORT
 
     // Send the message via UDP or TCP/BLE based on the presence of a connection.
-    if (Con != NULL)
+    if (Con != nullptr)
     {
         // Hook the message received callback on the connection so that the ChipExchangeManager gets
         // called when messages arrive.
         Con->OnMessageReceived = ChipExchangeManager::HandleMessageReceived;
 
         err        = Con->SendMessage(msgInfo, msgBuf);
-        msgBuf     = NULL;
+        msgBuf     = nullptr;
         sendCalled = true;
     }
     else
@@ -536,7 +536,7 @@ CHIP_ERROR ExchangeContext::SendMessage(uint32_t profileId, uint8_t msgType, Pac
             // Add to Table for subsequent sending
             err = ExchangeMgr->AddToRetransTable(this, msgBuf, msgInfo->MessageId, msgCtxt, &entry);
             SuccessOrExit(err);
-            msgBuf = NULL;
+            msgBuf = nullptr;
 
             err        = ExchangeMgr->SendFromRetransTable(entry);
             sendCalled = true;
@@ -547,7 +547,7 @@ CHIP_ERROR ExchangeContext::SendMessage(uint32_t profileId, uint8_t msgType, Pac
         else
         {
             err        = ExchangeMgr->MessageLayer->SendMessage(PeerAddr, PeerPort, PeerIntf, msgInfo, msgBuf);
-            msgBuf     = NULL;
+            msgBuf     = nullptr;
             sendCalled = true;
             SuccessOrExit(err);
         }
@@ -565,11 +565,11 @@ exit:
         CancelResponseTimer();
         SetResponseExpected(false);
     }
-    if (msgBuf != NULL && (sendFlags & kSendFlag_RetainBuffer) == 0)
+    if (msgBuf != nullptr && (sendFlags & kSendFlag_RetainBuffer) == 0)
     {
         PacketBuffer::Free(msgBuf);
         if (msg == msgBuf)
-            msg = NULL;
+            msg = nullptr;
     }
 
     // Release the reference to the exchange context acquired above. Under normal circumstances
@@ -597,16 +597,16 @@ exit:
 CHIP_ERROR ExchangeContext::SendCommonNullMessage(void)
 {
     CHIP_ERROR err        = CHIP_NO_ERROR;
-    PacketBuffer * msgBuf = NULL;
+    PacketBuffer * msgBuf = nullptr;
 
     // Allocate a buffer for the null message
     msgBuf = PacketBuffer::NewWithAvailableSize(0);
-    VerifyOrExit(msgBuf != NULL, err = CHIP_ERROR_NO_MEMORY);
+    VerifyOrExit(msgBuf != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     // Send the null message
     err    = SendMessage(chip::Protocols::kChipProtocol_Common, chip::Protocols::Common::kMsgType_Null, msgBuf,
                       kSendFlag_NoAutoRequestAck);
-    msgBuf = NULL;
+    msgBuf = nullptr;
 
 exit:
     if (ChipMessageLayer::IsSendErrorNonCritical(err))
@@ -718,19 +718,19 @@ void ExchangeContext::AddRef()
 void ExchangeContext::DoClose(bool clearRetransTable)
 {
     // Clear app callbacks
-    OnMessageReceived       = NULL;
-    OnResponseTimeout       = NULL;
-    OnRetransmissionTimeout = NULL;
-    OnConnectionClosed      = NULL;
-    OnKeyError              = NULL;
+    OnMessageReceived       = nullptr;
+    OnResponseTimeout       = nullptr;
+    OnRetransmissionTimeout = nullptr;
+    OnConnectionClosed      = nullptr;
+    OnKeyError              = nullptr;
 
     // Expire any virtual ticks that have expired so all wakeup sources reflect the current time
     ExchangeMgr->RMPExpireTicks();
 
-    OnThrottleRcvd = NULL;
-    OnDDRcvd       = NULL;
-    OnSendError    = NULL;
-    OnAckRcvd      = NULL;
+    OnThrottleRcvd = nullptr;
+    OnDDRcvd       = nullptr;
+    OnSendError    = nullptr;
+    OnAckRcvd      = nullptr;
 
     // Flush any pending RMP acks
     RMPFlushAcks();
@@ -756,7 +756,7 @@ void ExchangeContext::DoClose(bool clearRetransTable)
  */
 void ExchangeContext::Close()
 {
-    VerifyOrDie(ExchangeMgr != NULL && mRefCount != 0);
+    VerifyOrDie(ExchangeMgr != nullptr && mRefCount != 0);
 
 #if defined(CHIP_EXCHANGE_CONTEXT_DETAIL_LOGGING)
     ChipLogProgress(ExchangeManager, "ec id: %d [%04" PRIX16 "], %s", EXCHANGE_CONTEXT_ID(this - ExchangeMgr->ContextPool),
@@ -773,7 +773,7 @@ void ExchangeContext::Close()
  */
 void ExchangeContext::Abort()
 {
-    VerifyOrDie(ExchangeMgr != NULL && mRefCount != 0);
+    VerifyOrDie(ExchangeMgr != nullptr && mRefCount != 0);
 
 #if defined(CHIP_EXCHANGE_CONTEXT_DETAIL_LOGGING)
     ChipLogProgress(ExchangeManager, "ec id: %d [%04" PRIX16 "], %s", EXCHANGE_CONTEXT_ID(this - ExchangeMgr->ContextPool),
@@ -792,7 +792,7 @@ void ExchangeContext::Abort()
  */
 void ExchangeContext::Release(void)
 {
-    VerifyOrDie(ExchangeMgr != NULL && mRefCount != 0);
+    VerifyOrDie(ExchangeMgr != nullptr && mRefCount != 0);
 
     if (mRefCount == 1)
     {
@@ -812,7 +812,7 @@ void ExchangeContext::Release(void)
         }
 
         // If configured, automatically release a reference to the ChipConnection object.
-        if (ShouldAutoReleaseConnection() && Con != NULL)
+        if (ShouldAutoReleaseConnection() && Con != nullptr)
         {
             SetShouldAutoReleaseConnection(false);
             Con->Release();
@@ -820,7 +820,7 @@ void ExchangeContext::Release(void)
 
         DoClose(false);
         mRefCount   = 0;
-        ExchangeMgr = NULL;
+        ExchangeMgr = nullptr;
 
         em->mContextsInUse--;
         em->MessageLayer->SignalMessageLayerActivityChanged();
@@ -846,7 +846,7 @@ CHIP_ERROR ExchangeContext::ResendMessage()
     CHIP_ERROR res;
     uint8_t * payload;
 
-    if (msg == NULL)
+    if (msg == nullptr)
     {
         return CHIP_ERROR_INCORRECT_STATE;
     }
@@ -890,7 +890,7 @@ void ExchangeContext::TimerT(System::Layer * aSystemLayer, void * aAppState, Sys
 {
     ExchangeContext * client = reinterpret_cast<ExchangeContext *>(aAppState);
 
-    if ((aSystemLayer == NULL) || (aAppState == NULL) || (aError != CHIP_SYSTEM_NO_ERROR))
+    if ((aSystemLayer == nullptr) || (aAppState == nullptr) || (aError != CHIP_SYSTEM_NO_ERROR))
     {
         return;
     }
@@ -904,7 +904,7 @@ void ExchangeContext::TimerTau(System::Layer * aSystemLayer, void * aAppState, S
 {
     ExchangeContext * ec = reinterpret_cast<ExchangeContext *>(aAppState);
 
-    if ((aSystemLayer == NULL) || (aAppState == NULL) || (aError != CHIP_SYSTEM_NO_ERROR))
+    if ((aSystemLayer == nullptr) || (aAppState == nullptr) || (aError != CHIP_SYSTEM_NO_ERROR))
     {
         return;
     }
@@ -961,7 +961,7 @@ bool ExchangeContext::MatchExchange(ChipConnection * msgCon, const ChipMessageIn
 void ExchangeContext::TeardownTrickleRetransmit()
 {
     System::Layer * lSystemLayer = ExchangeMgr->MessageLayer->SystemLayer;
-    if (lSystemLayer == NULL)
+    if (lSystemLayer == nullptr)
     {
         // this is an assertion error, which shall never happen
         return;
@@ -969,12 +969,12 @@ void ExchangeContext::TeardownTrickleRetransmit()
     lSystemLayer->CancelTimer(TimerT, this);
     lSystemLayer->CancelTimer(TimerTau, this);
     lSystemLayer->CancelTimer(CancelRetransmissionTimer, this);
-    if (msg != NULL)
+    if (msg != nullptr)
     {
         PacketBuffer::Free(msg);
     }
 
-    msg             = NULL;
+    msg             = nullptr;
     backoff         = 0;
     RetransInterval = 0;
 }
@@ -983,10 +983,10 @@ void ExchangeContext::CancelRetransmissionTimer(System::Layer * aSystemLayer, vo
 {
     ExchangeContext * ec = reinterpret_cast<ExchangeContext *>(aAppState);
 
-    if (ec == NULL)
+    if (ec == nullptr)
         return;
     ec->CancelRetrans();
-    if (ec->OnRetransmissionTimeout != NULL)
+    if (ec->OnRetransmissionTimeout != nullptr)
     {
         ec->OnRetransmissionTimeout(ec);
     }
@@ -1010,7 +1010,7 @@ void ExchangeContext::HandleResponseTimeout(System::Layer * aSystemLayer, void *
     // wants to never receive the response, they must close the exchange context.
 
     // Call the user's timeout handler.
-    if (ec->OnResponseTimeout != NULL)
+    if (ec->OnResponseTimeout != nullptr)
         ec->OnResponseTimeout(ec);
 }
 
@@ -1103,12 +1103,12 @@ uint32_t ExchangeContext::GetCurrentRetransmitTimeout(void)
 CHIP_ERROR ExchangeContext::RMPSendThrottleFlow(uint32_t pauseTimeMillis)
 {
     CHIP_ERROR err        = CHIP_NO_ERROR;
-    PacketBuffer * msgBuf = NULL;
-    uint8_t * p           = NULL;
+    PacketBuffer * msgBuf = nullptr;
+    uint8_t * p           = nullptr;
     uint8_t msgLen        = sizeof(pauseTimeMillis);
 
     msgBuf = PacketBuffer::NewWithAvailableSize(msgLen);
-    VerifyOrExit(msgBuf != NULL, err = CHIP_ERROR_NO_MEMORY);
+    VerifyOrExit(msgBuf != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     p = msgBuf->Start();
 
@@ -1123,7 +1123,7 @@ CHIP_ERROR ExchangeContext::RMPSendThrottleFlow(uint32_t pauseTimeMillis)
                       kSendFlag_NoAutoRequestAck);
 
 exit:
-    msgBuf = NULL;
+    msgBuf = nullptr;
 
     return err;
 }
@@ -1159,12 +1159,12 @@ exit:
 CHIP_ERROR ExchangeContext::RMPSendDelayedDelivery(uint32_t pauseTimeMillis, uint64_t delayedNodeId)
 {
     CHIP_ERROR err        = CHIP_NO_ERROR;
-    PacketBuffer * msgBuf = NULL;
-    uint8_t * p           = NULL;
+    PacketBuffer * msgBuf = nullptr;
+    uint8_t * p           = nullptr;
     uint8_t msgLen        = sizeof(pauseTimeMillis) + sizeof(delayedNodeId);
 
     msgBuf = PacketBuffer::NewWithAvailableSize(msgLen);
-    VerifyOrExit(msgBuf != NULL, err = CHIP_ERROR_NO_MEMORY);
+    VerifyOrExit(msgBuf != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     p = msgBuf->Start();
     // Set back the pointer by the length of the fields
@@ -1181,7 +1181,7 @@ CHIP_ERROR ExchangeContext::RMPSendDelayedDelivery(uint32_t pauseTimeMillis, uin
                       kSendFlag_NoAutoRequestAck);
 
 exit:
-    msgBuf = NULL;
+    msgBuf = nullptr;
 
     return err;
 }
@@ -1203,7 +1203,7 @@ exit:
  */
 CHIP_ERROR ExchangeContext::RMPHandleRcvdAck(const ChipExchangeHeader * exchHeader, const ChipMessageInfo * msgInfo)
 {
-    void * msgCtxt = NULL;
+    void * msgCtxt = nullptr;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     // Msg is an Ack; Check Retrans Table and remove message context
@@ -1356,7 +1356,7 @@ CHIP_ERROR ExchangeContext::HandleThrottleFlow(uint32_t PauseTimeMillis)
  */
 CHIP_ERROR ExchangeContext::HandleMessage(ChipMessageInfo * msgInfo, const ChipExchangeHeader * exchHeader, PacketBuffer * msgBuf)
 {
-    return HandleMessage(msgInfo, exchHeader, msgBuf, NULL);
+    return HandleMessage(msgInfo, exchHeader, msgBuf, nullptr);
 }
 
 /**
@@ -1383,7 +1383,7 @@ CHIP_ERROR ExchangeContext::HandleMessage(ChipMessageInfo * msgInfo, const ChipE
                                           ExchangeContext::MessageReceiveFunct umhandler)
 {
     CHIP_ERROR err           = CHIP_NO_ERROR;
-    const uint8_t * p        = NULL;
+    const uint8_t * p        = nullptr;
     uint32_t PauseTimeMillis = 0;
 
     // We hold a reference to the ExchangeContext here to
@@ -1446,13 +1446,13 @@ CHIP_ERROR ExchangeContext::HandleMessage(ChipMessageInfo * msgInfo, const ChipE
         {
             umhandler(this, msgInfo->InPacketInfo, const_cast<ChipMessageInfo *>(msgInfo), exchHeader->ProfileId,
                       exchHeader->MessageType, msgBuf);
-            msgBuf = NULL;
+            msgBuf = nullptr;
         }
-        else if (OnMessageReceived != NULL)
+        else if (OnMessageReceived != nullptr)
         {
             OnMessageReceived(this, msgInfo->InPacketInfo, const_cast<ChipMessageInfo *>(msgInfo), exchHeader->ProfileId,
                               exchHeader->MessageType, msgBuf);
-            msgBuf = NULL;
+            msgBuf = nullptr;
         }
         else
         {
@@ -1467,7 +1467,7 @@ exit:
     // already made a prior call to Close().
     Release();
 
-    if (msgBuf != NULL)
+    if (msgBuf != nullptr)
     {
         PacketBuffer::Free(msgBuf);
     }
@@ -1481,7 +1481,7 @@ void ExchangeContext::HandleConnectionClosed(CHIP_ERROR conErr)
     SetConnectionClosed(true);
 
     // If configured, automatically release the EC's reference to the ChipConnection object.
-    if (ShouldAutoReleaseConnection() && Con != NULL)
+    if (ShouldAutoReleaseConnection() && Con != nullptr)
     {
         SetShouldAutoReleaseConnection(false);
         Con->Release();
@@ -1489,10 +1489,10 @@ void ExchangeContext::HandleConnectionClosed(CHIP_ERROR conErr)
 
     // Discard the EC's pointer to the connection, preventing further use.
     ChipConnection * con = Con;
-    Con                  = NULL;
+    Con                  = nullptr;
 
     // Call the application's OnConnectionClosed handler, if set.
-    if (OnConnectionClosed != NULL)
+    if (OnConnectionClosed != nullptr)
         OnConnectionClosed(this, con, conErr);
 }
 
@@ -1507,7 +1507,7 @@ void ExchangeContext::HandleConnectionClosed(CHIP_ERROR conErr)
  */
 void ExchangeContext::GetPeerDescription(char * buf, uint32_t bufSize) const
 {
-    ChipMessageLayer::GetPeerDescription(buf, bufSize, PeerNodeId, (PeerAddr != IPAddress::Any) ? &PeerAddr : NULL, PeerPort,
+    ChipMessageLayer::GetPeerDescription(buf, bufSize, PeerNodeId, (PeerAddr != IPAddress::Any) ? &PeerAddr : nullptr, PeerPort,
                                          PeerIntf, Con);
 }
 

--- a/src/lib/protocols/common/CHIPMessage.h
+++ b/src/lib/protocols/common/CHIPMessage.h
@@ -271,7 +271,7 @@ public:
      * callback in hand, false otherwise.
      */
 
-    inline bool isEmpty(void) { return (theLength == 0 && theWriteCallback == NULL); }
+    inline bool isEmpty(void) { return (theLength == 0 && theWriteCallback == nullptr); }
 
     // packing and parsing
 

--- a/src/lib/protocols/status-report/StatusReportProtocol.h
+++ b/src/lib/protocols/status-report/StatusReportProtocol.h
@@ -64,7 +64,7 @@ public:
     StatusReport(void);
     ~StatusReport(void);
 
-    CHIP_ERROR init(uint32_t aProtocolId, uint16_t aCode, ReferencedTLVData * aInfo = NULL);
+    CHIP_ERROR init(uint32_t aProtocolId, uint16_t aCode, ReferencedTLVData * aInfo = nullptr);
 
     /*
      * this version of the intializer is provided as a convenience in

--- a/src/lib/shell/commands.cpp
+++ b/src/lib/shell/commands.cpp
@@ -50,7 +50,7 @@ int cmd_help_iterator(shell_command_t * command, void * arg)
 
 int cmd_help(int argc, char ** argv)
 {
-    shell_command_foreach(cmd_help_iterator, NULL);
+    shell_command_foreach(cmd_help_iterator, nullptr);
     return 0;
 }
 

--- a/src/lib/shell/shell.cpp
+++ b/src/lib/shell/shell.cpp
@@ -196,7 +196,7 @@ int Shell::TokenizeLine(char * buffer, char ** tokens, int max_tokens)
         }
     }
 
-    tokens[cursor] = 0;
+    tokens[cursor] = nullptr;
 
 exit:
     return cursor;

--- a/src/lib/shell/tests/TestShell.cpp
+++ b/src/lib/shell/tests/TestShell.cpp
@@ -100,10 +100,10 @@ static const nlTest sTests[] = {
 
 int TestShell(void)
 {
-    nlTestSuite theSuite = { "CHIP Shell tests", &sTests[0], NULL, NULL };
+    nlTestSuite theSuite = { "CHIP Shell tests", &sTests[0], nullptr, nullptr };
 
     // Run test suit againt one context.
-    nlTestRunner(&theSuite, NULL);
+    nlTestRunner(&theSuite, nullptr);
     return nlTestRunnerStats(&theSuite);
 }
 

--- a/src/lib/shell/tests/TestStreamerStdio.cpp
+++ b/src/lib/shell/tests/TestStreamerStdio.cpp
@@ -81,10 +81,10 @@ static const nlTest sTests[] = {
 
 int TestStreamerStdio(void)
 {
-    nlTestSuite theSuite = { "CHIP Streamer tests", &sTests[0], NULL, NULL };
+    nlTestSuite theSuite = { "CHIP Streamer tests", &sTests[0], nullptr, nullptr };
 
     // Run test suit againt one context.
-    nlTestRunner(&theSuite, NULL);
+    nlTestRunner(&theSuite, nullptr);
     return nlTestRunnerStats(&theSuite);
 }
 

--- a/src/lib/support/CHIPArgParser.cpp
+++ b/src/lib/support/CHIPArgParser.cpp
@@ -63,7 +63,7 @@ using namespace chip;
 
 static char * MakeShortOptions(OptionSet ** optSets);
 static struct option * MakeLongOptions(OptionSet ** optSets);
-static int32_t SplitArgs(char * argStr, char **& argList, char * initialArg = NULL);
+static int32_t SplitArgs(char * argStr, char **& argList, char * initialArg = nullptr);
 static bool GetNextArg(char *& parsePoint);
 static size_t CountOptionSets(OptionSet * optSets[]);
 static size_t CountAllOptions(OptionSet * optSets[]);
@@ -90,7 +90,7 @@ static inline bool IsShortOptionChar(int ch)
  * @details
  * This value will be NULL when no call to ParseArgs() is in progress.
  */
-OptionSet ** gActiveOptionSets = NULL;
+OptionSet ** gActiveOptionSets = nullptr;
 
 /**
  * @brief
@@ -285,15 +285,15 @@ bool ParseArgs(const char * progName, int argc, char * argv[], OptionSet * optSe
     bool res = false;
     char optName[64];
     char * optArg;
-    char * shortOpts         = NULL;
-    struct option * longOpts = NULL;
+    char * shortOpts         = nullptr;
+    struct option * longOpts = nullptr;
     OptionSet * curOptSet;
     OptionDef * curOpt;
     bool handlerRes;
 
     // The getopt() functions do not support recursion, so exit immediately with an
     // error if called recursively.
-    if (gActiveOptionSets != NULL)
+    if (gActiveOptionSets != nullptr)
     {
         PrintArgError("INTERNAL ERROR: ParseArgs() called recursively\n", progName);
         return false;
@@ -301,7 +301,7 @@ bool ParseArgs(const char * progName, int argc, char * argv[], OptionSet * optSe
 
     // The C standard mandates that argv[argc] == NULL and certain versions of getopt() require this
     // to function properly.  So fail if this is not true.
-    if (argv[argc] != NULL)
+    if (argv[argc] != nullptr)
     {
         PrintArgError("INTERNAL ERROR: argv[argc] != NULL\n", progName);
         return false;
@@ -317,7 +317,7 @@ bool ParseArgs(const char * progName, int argc, char * argv[], OptionSet * optSe
 
     // Generate a short options string in the format expected by getopt_long().
     shortOpts = MakeShortOptions(optSets);
-    if (shortOpts == NULL)
+    if (shortOpts == nullptr)
     {
         PrintArgError("%s: Memory allocation failure\n", progName);
         goto done;
@@ -325,7 +325,7 @@ bool ParseArgs(const char * progName, int argc, char * argv[], OptionSet * optSe
 
     // Generate a list of long option structures in the format expected by getopt_long().
     longOpts = MakeLongOptions(optSets);
-    if (longOpts == NULL)
+    if (longOpts == nullptr)
     {
         PrintArgError("%s: Memory allocation failure\n", progName);
         goto done;
@@ -341,7 +341,7 @@ bool ParseArgs(const char * progName, int argc, char * argv[], OptionSet * optSe
         int optIndex = -1;
 
         // Attempt to match the current option argument (argv[optind]) against the defined long and short options.
-        optarg = NULL;
+        optarg = nullptr;
         optopt = 0;
         id     = getopt_long(argc, argv, shortOpts, longOpts, &optIndex);
 
@@ -395,7 +395,7 @@ bool ParseArgs(const char * progName, int argc, char * argv[], OptionSet * optSe
 
         // Prevent handlers from inadvertently using the getopt global optarg.
         optArg = optarg;
-        optarg = NULL;
+        optarg = nullptr;
 
         // Call the option handler function defined for the matching option set.
         // Exit immediately if the option handler failed.
@@ -405,7 +405,7 @@ bool ParseArgs(const char * progName, int argc, char * argv[], OptionSet * optSe
     }
 
     // If supplied, call the non-option argument handler with the remaining arguments (if any).
-    if (nonOptArgHandler != NULL)
+    if (nonOptArgHandler != nullptr)
     {
         if (!nonOptArgHandler(progName, argc - optind, argv + optind))
             goto done;
@@ -422,12 +422,12 @@ bool ParseArgs(const char * progName, int argc, char * argv[], OptionSet * optSe
 
 done:
 
-    if (shortOpts != NULL)
+    if (shortOpts != nullptr)
         free(shortOpts);
-    if (longOpts != NULL)
+    if (longOpts != nullptr)
         free(longOpts);
 
-    gActiveOptionSets = NULL;
+    gActiveOptionSets = nullptr;
 
     return res;
 }
@@ -439,7 +439,7 @@ bool ParseArgs(const char * progName, int argc, char * argv[], OptionSet * optSe
 
 bool ParseArgs(const char * progName, int argc, char * argv[], OptionSet * optSets[])
 {
-    return ParseArgs(progName, argc, argv, optSets, NULL, false);
+    return ParseArgs(progName, argc, argv, optSets, nullptr, false);
 }
 
 /**
@@ -488,13 +488,13 @@ bool ParseArgs(const char * progName, int argc, char * argv[], OptionSet * optSe
 bool ParseArgsFromString(const char * progName, const char * argStr, OptionSet * optSets[],
                          NonOptionArgHandlerFunct nonOptArgHandler, bool ignoreUnknown)
 {
-    char * argStrCopy = NULL;
-    char ** argv      = NULL;
+    char * argStrCopy = nullptr;
+    char ** argv      = nullptr;
     int argc;
     bool res;
 
     argStrCopy = strdup(argStr);
-    if (argStrCopy == NULL)
+    if (argStrCopy == nullptr)
     {
         PrintArgError("%s: Memory allocation failure\n", progName);
         return false;
@@ -524,7 +524,7 @@ bool ParseArgsFromString(const char * progName, const char * argStr, OptionSet *
 
 bool ParseArgsFromString(const char * progName, const char * argStr, OptionSet * optSets[])
 {
-    return ParseArgsFromString(progName, argStr, optSets, NULL, false);
+    return ParseArgsFromString(progName, argStr, optSets, nullptr, false);
 }
 
 /**
@@ -559,14 +559,14 @@ bool ParseArgsFromEnvVar(const char * progName, const char * varName, OptionSet 
                          NonOptionArgHandlerFunct nonOptArgHandler, bool ignoreUnknown)
 {
     const char * argStr = getenv(varName);
-    if (argStr == NULL)
+    if (argStr == nullptr)
         return true;
     return ParseArgsFromString(progName, argStr, optSets, nonOptArgHandler, ignoreUnknown);
 }
 
 bool ParseArgsFromEnvVar(const char * progName, const char * varName, OptionSet * optSets[])
 {
-    return ParseArgsFromEnvVar(progName, varName, optSets, NULL, false);
+    return ParseArgsFromEnvVar(progName, varName, optSets, nullptr, false);
 }
 
 bool ParseArgsFromEnvVar(const char * progName, const char * varName, OptionSet * optSets[],
@@ -588,20 +588,20 @@ void PrintOptionHelp(OptionSet * optSets[], FILE * s)
 {
     // Get a list of the unique help group names for the given option sets.
     const char ** helpGroupNames = MakeUniqueHelpGroupNamesList(optSets);
-    if (helpGroupNames == NULL)
+    if (helpGroupNames == nullptr)
     {
         PrintArgError("Memory allocation failure\n");
         return;
     }
 
     // For each help group...
-    for (size_t nameIndex = 0; helpGroupNames[nameIndex] != NULL; nameIndex++)
+    for (size_t nameIndex = 0; helpGroupNames[nameIndex] != nullptr; nameIndex++)
     {
         // Print the group name.
         PutStringWithBlankLine(s, helpGroupNames[nameIndex]);
 
         // Print the option help text for all options that have the same group name.
-        for (size_t optSetIndex = 0; optSets[optSetIndex] != NULL; optSetIndex++)
+        for (size_t optSetIndex = 0; optSets[optSetIndex] != nullptr; optSetIndex++)
             if (strcasecmp(helpGroupNames[nameIndex], optSets[optSetIndex]->HelpGroupName) == 0)
             {
                 PutStringWithBlankLine(s, optSets[optSetIndex]->OptionHelp);
@@ -1074,7 +1074,7 @@ bool ParseHexString(const char * hexStr, uint32_t strLen, uint8_t * outBuf, uint
 // ===== HelpOptions Methods =====
 
 HelpOptions::HelpOptions(const char * appName, const char * appUsage, const char * appVersion) :
-    HelpOptions(appName, appUsage, appVersion, NULL)
+    HelpOptions(appName, appUsage, appVersion, nullptr)
 {
     return;
 }
@@ -1121,7 +1121,7 @@ void HelpOptions::PrintBriefUsage(FILE * s)
 void HelpOptions::PrintLongUsage(OptionSet ** optSets, FILE * s)
 {
     PutStringWithBlankLine(s, AppUsage);
-    if (AppDesc != NULL)
+    if (AppDesc != nullptr)
     {
         PutStringWithBlankLine(s, AppDesc);
     }
@@ -1131,7 +1131,7 @@ void HelpOptions::PrintLongUsage(OptionSet ** optSets, FILE * s)
 void HelpOptions::PrintVersion(FILE * s)
 {
     fprintf(s, "%s ", AppName);
-    PutStringWithNewLine(s, (AppVersion != NULL) ? AppVersion : "(unknown version)");
+    PutStringWithNewLine(s, (AppVersion != nullptr) ? AppVersion : "(unknown version)");
 }
 
 bool HelpOptions::HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg)
@@ -1178,18 +1178,18 @@ static char * MakeShortOptions(OptionSet ** optSets)
     // ":" and a terminating null.
     size_t arraySize = 2 + (totalOptions * 3);
     char * shortOpts = (char *) malloc(arraySize);
-    if (shortOpts == NULL)
-        return NULL;
+    if (shortOpts == nullptr)
+        return nullptr;
 
     // Prefix the string with ':'.  This tells getopt() to signal missing option arguments distinct
     // from unknown options.
     shortOpts[i++] = ':';
 
     // For each option set...
-    for (; *optSets != NULL; optSets++)
+    for (; *optSets != nullptr; optSets++)
     {
         // For each option in the current option set...
-        for (OptionDef * optDef = (*optSets)->OptionDefs; optDef->Name != NULL; optDef++)
+        for (OptionDef * optDef = (*optSets)->OptionDefs; optDef->Name != nullptr; optDef++)
         {
             // If the option id (val) is suitable as a short option character, add it to the short
             // option string. Append ":" if the option requires an argument and "::" if the argument
@@ -1218,26 +1218,26 @@ static struct option * MakeLongOptions(OptionSet ** optSets)
     // Allocate an array to hold the list of long options.
     size_t arraySize         = (sizeof(struct option) * (totalOptions + 1));
     struct option * longOpts = (struct option *) malloc(arraySize);
-    if (longOpts == NULL)
-        return NULL;
+    if (longOpts == nullptr)
+        return nullptr;
 
     // For each option set...
     size_t i = 0;
-    for (; *optSets != NULL; optSets++)
+    for (; *optSets != nullptr; optSets++)
     {
         // Copy the option definitions into the long options array.
-        for (OptionDef * optDef = (*optSets)->OptionDefs; optDef->Name != NULL; optDef++)
+        for (OptionDef * optDef = (*optSets)->OptionDefs; optDef->Name != nullptr; optDef++)
         {
             longOpts[i].name    = optDef->Name;
             longOpts[i].has_arg = (int) optDef->ArgType;
-            longOpts[i].flag    = NULL;
+            longOpts[i].flag    = nullptr;
             longOpts[i].val     = optDef->Id;
             i++;
         }
     }
 
     // Terminate the long options array.
-    longOpts[i].name = NULL;
+    longOpts[i].name = nullptr;
 
     return longOpts;
 }
@@ -1253,12 +1253,12 @@ static int32_t SplitArgs(char * argStr, char **& argList, char * initialArg)
 
     // Allocate an array to hold pointers to the arguments.
     argList = (char **) malloc(sizeof(char *) * InitialArgListSize);
-    if (argList == NULL)
+    if (argList == nullptr)
         return -1;
     argListSize = InitialArgListSize;
 
     // If an initial argument was supplied, make it the first argument in the array.
-    if (initialArg != NULL)
+    if (initialArg != nullptr)
     {
         argList[0] = (char *) initialArg;
         argCount   = 1;
@@ -1279,7 +1279,7 @@ static int32_t SplitArgs(char * argStr, char **& argList, char * initialArg)
         {
             argListSize *= 2;
             argList = (char **) realloc(argList, argListSize);
-            if (argList == NULL)
+            if (argList == nullptr)
                 return -1;
         }
 
@@ -1289,7 +1289,7 @@ static int32_t SplitArgs(char * argStr, char **& argList, char * initialArg)
 
     // Set the last element in the array to NULL, but do not include this in the count of elements.
     // This is mandated by the C standard and some versions of getopt_long() depend on it.
-    argList[argCount] = NULL;
+    argList[argCount] = nullptr;
 
     return argCount;
 }
@@ -1364,7 +1364,7 @@ static bool GetNextArg(char *& parsePoint)
 static size_t CountOptionSets(OptionSet ** optSets)
 {
     size_t count = 0;
-    for (; *optSets != NULL; optSets++)
+    for (; *optSets != nullptr; optSets++)
         count++;
     return count;
 }
@@ -1372,30 +1372,30 @@ static size_t CountOptionSets(OptionSet ** optSets)
 static size_t CountAllOptions(OptionSet ** optSets)
 {
     size_t count = 0;
-    for (; *optSets != NULL; optSets++)
-        for (OptionDef * optDef = (*optSets)->OptionDefs; optDef->Name != NULL; optDef++)
+    for (; *optSets != nullptr; optSets++)
+        for (OptionDef * optDef = (*optSets)->OptionDefs; optDef->Name != nullptr; optDef++)
             count++;
     return count;
 }
 
 static void FindOptionByIndex(OptionSet ** optSets, int optIndex, OptionSet *& optSet, OptionDef *& optDef)
 {
-    for (optSet = *optSets; optSet != NULL; optSet = *++optSets)
-        for (optDef = (*optSets)->OptionDefs; optDef->Name != NULL; optDef++)
+    for (optSet = *optSets; optSet != nullptr; optSet = *++optSets)
+        for (optDef = (*optSets)->OptionDefs; optDef->Name != nullptr; optDef++)
             if (optIndex-- == 0)
                 return;
-    optSet = NULL;
-    optDef = NULL;
+    optSet = nullptr;
+    optDef = nullptr;
 }
 
 static void FindOptionById(OptionSet ** optSets, int optId, OptionSet *& optSet, OptionDef *& optDef)
 {
-    for (optSet = *optSets; optSet != NULL; optSet = *++optSets)
-        for (optDef = (*optSets)->OptionDefs; optDef->Name != NULL; optDef++)
+    for (optSet = *optSets; optSet != nullptr; optSet = *++optSets)
+        for (optDef = (*optSets)->OptionDefs; optDef->Name != nullptr; optDef++)
             if (optDef->Id == optId)
                 return;
-    optSet = NULL;
-    optDef = NULL;
+    optSet = nullptr;
+    optDef = nullptr;
 }
 
 static const char ** MakeUniqueHelpGroupNamesList(OptionSet * optSets[])
@@ -1404,12 +1404,12 @@ static const char ** MakeUniqueHelpGroupNamesList(OptionSet * optSets[])
     size_t numGroups  = 0;
 
     const char ** groupNames = (const char **) malloc(sizeof(const char *) * (numOptSets + 1));
-    if (groupNames == NULL)
-        return NULL;
+    if (groupNames == nullptr)
+        return nullptr;
 
     for (size_t optSetIndex = 0; optSetIndex < numOptSets; optSetIndex++)
     {
-        if (optSets[optSetIndex] != NULL && optSets[optSetIndex]->OptionDefs[0].Name != NULL)
+        if (optSets[optSetIndex] != nullptr && optSets[optSetIndex]->OptionDefs[0].Name != nullptr)
         {
             for (size_t i = 0; i < numGroups; i++)
                 if (strcasecmp(groupNames[i], optSets[optSetIndex]->HelpGroupName) == 0)
@@ -1419,7 +1419,7 @@ static const char ** MakeUniqueHelpGroupNamesList(OptionSet * optSets[])
         }
     }
 
-    groupNames[numGroups] = NULL;
+    groupNames[numGroups] = nullptr;
 
     return groupNames;
 }
@@ -1449,9 +1449,9 @@ static bool SanityCheckOptions(OptionSet * optSets[])
     bool res = true;
 
     // Verify OptionHandler pointer
-    for (OptionSet ** optSetP = optSets; *optSetP != NULL; optSetP++)
+    for (OptionSet ** optSetP = optSets; *optSetP != nullptr; optSetP++)
     {
-        if ((*optSetP)->OptionHandler == NULL)
+        if ((*optSetP)->OptionHandler == nullptr)
         {
             PrintArgError("INTERNAL ERROR: Null OptionHandler in OptionSet (%s)\n", (*optSetP)->HelpGroupName);
             res = false;
@@ -1461,14 +1461,14 @@ static bool SanityCheckOptions(OptionSet * optSets[])
     // Verify that no two option sets use the same short option character.
     // (Re-use of the same short option character is allowed within a single option set
     // to allow for aliasing of long options).
-    for (OptionSet ** optSetP = optSets; *optSetP != NULL; optSetP++)
-        for (OptionDef * optionDef = (*optSetP)->OptionDefs; optionDef->Name != NULL; optionDef++)
+    for (OptionSet ** optSetP = optSets; *optSetP != nullptr; optSetP++)
+        for (OptionDef * optionDef = (*optSetP)->OptionDefs; optionDef->Name != nullptr; optionDef++)
             if (IsShortOptionChar(optionDef->Id))
             {
-                for (OptionSet ** optSetP2 = optSets; *optSetP2 != NULL; optSetP2++)
+                for (OptionSet ** optSetP2 = optSets; *optSetP2 != nullptr; optSetP2++)
                     if (optSetP2 != optSetP)
                     {
-                        for (OptionDef * optionDef2 = (*optSetP2)->OptionDefs; optionDef2->Name != NULL; optionDef2++)
+                        for (OptionDef * optionDef2 = (*optSetP2)->OptionDefs; optionDef2->Name != nullptr; optionDef2++)
                             if (optionDef->Id == optionDef2->Id)
                             {
                                 PrintArgError("INTERNAL ERROR: Multiple command line options configured to use "
@@ -1481,8 +1481,8 @@ static bool SanityCheckOptions(OptionSet * optSets[])
 
     // Fail if the option help texts do not contain a description for each option, including both
     // the option's long and short forms.
-    for (OptionSet ** optSetP = optSets; *optSetP != NULL; optSetP++)
-        for (OptionDef * optionDef = (*optSetP)->OptionDefs; optionDef->Name != NULL; optionDef++)
+    for (OptionSet ** optSetP = optSets; *optSetP != nullptr; optSetP++)
+        for (OptionDef * optionDef = (*optSetP)->OptionDefs; optionDef->Name != nullptr; optionDef++)
         {
             if (!HelpTextContainsLongOption(optionDef->Name, (*optSetP)->OptionHelp))
             {
@@ -1504,7 +1504,7 @@ static bool HelpTextContainsLongOption(const char * optName, const char * helpTe
 {
     size_t nameLen = strlen(optName);
 
-    for (const char * p = helpText; (p = strstr(p, optName)) != NULL; p += nameLen)
+    for (const char * p = helpText; (p = strstr(p, optName)) != nullptr; p += nameLen)
         if ((p - helpText) >= 2 && p[-1] == '-' && p[-2] == '-' && !isalnum(p[nameLen]) && p[nameLen] != '-')
             return true;
 
@@ -1518,7 +1518,7 @@ static bool HelpTextContainsShortOption(char optChar, const char * helpText)
     optStr[1] = optChar;
     optStr[2] = 0;
 
-    for (const char * p = helpText; (p = strstr(p, optStr)) != NULL; p += 2)
+    for (const char * p = helpText; (p = strstr(p, optStr)) != nullptr; p += 2)
         if ((p == helpText || (!isalnum(p[-1]) && p[-1] != '-')) && !isalnum(p[2]) && p[2] != '-')
             return true;
 

--- a/src/lib/support/CHIPMem.h
+++ b/src/lib/support/CHIPMem.h
@@ -56,7 +56,7 @@ namespace Platform {
  *                                         initialization function.
  *
  */
-extern CHIP_ERROR MemoryInit(void * buf = NULL, size_t bufSize = 0);
+extern CHIP_ERROR MemoryInit(void * buf = nullptr, size_t bufSize = 0);
 
 /**
  * This function is called by the CHIP layer to releases all resources that were allocated

--- a/src/lib/support/ErrorStr.cpp
+++ b/src/lib/support/ErrorStr.cpp
@@ -43,7 +43,7 @@ static char sErrorStr[CHIP_CONFIG_ERROR_STR_SIZE];
 /**
  * Linked-list of error formatter functions.
  */
-static ErrorFormatter * sErrorFormatterList = NULL;
+static ErrorFormatter * sErrorFormatterList = nullptr;
 
 /**
  * This routine returns a human-readable NULL-terminated C string
@@ -63,7 +63,7 @@ DLL_EXPORT const char * ErrorStr(int32_t err)
 
     // Search the registered error formatter for one that will format the given
     // error code.
-    for (const ErrorFormatter * errFormatter = sErrorFormatterList; errFormatter != NULL; errFormatter = errFormatter->Next)
+    for (const ErrorFormatter * errFormatter = sErrorFormatterList; errFormatter != nullptr; errFormatter = errFormatter->Next)
     {
         if (errFormatter->FormatError(sErrorStr, sizeof(sErrorStr), err))
         {
@@ -72,7 +72,7 @@ DLL_EXPORT const char * ErrorStr(int32_t err)
     }
 
     // Use a default formatting if no formatter found.
-    FormatError(sErrorStr, sizeof(sErrorStr), NULL, err, NULL);
+    FormatError(sErrorStr, sizeof(sErrorStr), nullptr, err, nullptr);
     return sErrorStr;
 }
 
@@ -89,7 +89,7 @@ DLL_EXPORT const char * ErrorStr(int32_t err)
 DLL_EXPORT void RegisterErrorFormatter(ErrorFormatter * errFormatter)
 {
     // Do nothing if a formatter with the same format function is already in the list.
-    for (ErrorFormatter * existingFormatter = sErrorFormatterList; existingFormatter != NULL;
+    for (ErrorFormatter * existingFormatter = sErrorFormatterList; existingFormatter != nullptr;
          existingFormatter                  = existingFormatter->Next)
     {
         if (existingFormatter->FormatError == errFormatter->FormatError)
@@ -112,7 +112,7 @@ DLL_EXPORT void RegisterErrorFormatter(ErrorFormatter * errFormatter)
 DLL_EXPORT void DeregisterErrorFormatter(ErrorFormatter * errFormatter)
 {
     // Remove the formatter if present
-    for (ErrorFormatter ** lfp = &sErrorFormatterList; *lfp != NULL; lfp = &(*lfp)->Next)
+    for (ErrorFormatter ** lfp = &sErrorFormatterList; *lfp != nullptr; lfp = &(*lfp)->Next)
     {
         // Remove the formatter from the global list, if found.
         if (*lfp == errFormatter)
@@ -155,12 +155,12 @@ DLL_EXPORT void FormatError(char * buf, uint16_t bufSize, const char * subsys, i
     const char * subsysSep = " ";
     const char * descSep   = ": ";
 
-    if (subsys == NULL)
+    if (subsys == nullptr)
     {
         subsys    = "";
         subsysSep = "";
     }
-    if (desc == NULL)
+    if (desc == nullptr)
     {
         desc    = "";
         descSep = "";

--- a/src/lib/support/tests/TestBufBound.cpp
+++ b/src/lib/support/tests/TestBufBound.cpp
@@ -189,10 +189,10 @@ static const nlTest sTests[] = { NL_TEST_DEF_FN(TestBufBound_Str), NL_TEST_DEF_F
 
 int TestBufBound(void)
 {
-    nlTestSuite theSuite = { "CHIP BufBound tests", &sTests[0], NULL, NULL };
+    nlTestSuite theSuite = { "CHIP BufBound tests", &sTests[0], nullptr, nullptr };
 
     // Run test suit againt one context.
-    nlTestRunner(&theSuite, NULL);
+    nlTestRunner(&theSuite, nullptr);
     return nlTestRunnerStats(&theSuite);
 }
 

--- a/src/lib/support/tests/TestCHIPArgParser.cpp
+++ b/src/lib/support/tests/TestCHIPArgParser.cpp
@@ -174,13 +174,13 @@ static void SimpleParseTest_SingleLongOption()
 {
     bool res;
 
-    static OptionSet * optionSets[] = { &sOptionSetA, &sOptionSetB, NULL };
+    static OptionSet * optionSets[] = { &sOptionSetA, &sOptionSetB, nullptr };
     // clang-format off
     static const char *argv[] =
     {
         "",
         "--foo",
-		NULL
+		nullptr
     };
     // clang-format on
     static int argc = sizeof(argv) / sizeof(argv[0]) - 1;
@@ -191,7 +191,7 @@ static void SimpleParseTest_SingleLongOption()
     res = ParseArgs(__FUNCTION__, argc, (char **) argv, optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == true, "ParseArgs() returned false");
     VerifyOrQuit(sCallbackRecordCount == 2, "Invalid value returned for sCallbackRecordCount");
-    VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", NULL);
+    VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", nullptr);
     VerifyHandleNonOptionArgsCallback(1, __FUNCTION__, 0);
 }
 
@@ -199,13 +199,13 @@ static void SimpleParseTest_SingleShortOption()
 {
     bool res;
 
-    static OptionSet * optionSets[] = { &sOptionSetA, &sOptionSetB, NULL };
+    static OptionSet * optionSets[] = { &sOptionSetA, &sOptionSetB, nullptr };
     // clang-format off
     static const char *argv[] =
     {
         "",
         "-s",
-		NULL
+		nullptr
     };
     // clang-format on
     static int argc = sizeof(argv) / sizeof(argv[0]) - 1;
@@ -216,7 +216,7 @@ static void SimpleParseTest_SingleShortOption()
     res = ParseArgs(__FUNCTION__, argc, (char **) argv, optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == true, "ParseArgs() returned false");
     VerifyOrQuit(sCallbackRecordCount == 2, "Invalid value returned for sCallbackRecordCount");
-    VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetB, 's', "-s", NULL);
+    VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetB, 's', "-s", nullptr);
     VerifyHandleNonOptionArgsCallback(1, __FUNCTION__, 0);
 }
 
@@ -224,13 +224,13 @@ static void SimpleParseTest_SingleLongOptionWithValue()
 {
     bool res;
 
-    static OptionSet * optionSets[] = { &sOptionSetA, &sOptionSetB, NULL };
+    static OptionSet * optionSets[] = { &sOptionSetA, &sOptionSetB, nullptr };
     // clang-format off
     static const char *argv[] =
     {
         "",
         "--run", "run-value",
-		NULL
+		nullptr
     };
     // clang-format on
     static int argc = sizeof(argv) / sizeof(argv[0]) - 1;
@@ -249,13 +249,13 @@ static void SimpleParseTest_SingleShortOptionWithValue()
 {
     bool res;
 
-    static OptionSet * optionSets[] = { &sOptionSetA, &sOptionSetB, NULL };
+    static OptionSet * optionSets[] = { &sOptionSetA, &sOptionSetB, nullptr };
     // clang-format off
     static const char *argv[] =
     {
         "",
         "-Z", "baz-value",
-		NULL
+		nullptr
     };
     // clang-format on
     static int argc = sizeof(argv) / sizeof(argv[0]) - 1;
@@ -274,7 +274,7 @@ static void SimpleParseTest_VariousShortAndLongWithArgs()
 {
     bool res;
 
-    static OptionSet * optionSets[] = { &sOptionSetA, &sOptionSetB, NULL };
+    static OptionSet * optionSets[] = { &sOptionSetA, &sOptionSetB, nullptr };
     // clang-format off
     static const char *argv[] =
     {
@@ -289,7 +289,7 @@ static void SimpleParseTest_VariousShortAndLongWithArgs()
         "non-opt-arg-2",
         "non-opt-arg-3",
         "non-opt-arg-4",
-		NULL
+		nullptr
     };
     // clang-format on
     static int argc = sizeof(argv) / sizeof(argv[0]) - 1;
@@ -300,11 +300,11 @@ static void SimpleParseTest_VariousShortAndLongWithArgs()
     res = ParseArgs(__FUNCTION__, argc, (char **) argv, optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == true, "ParseArgs() returned false");
     VerifyOrQuit(sCallbackRecordCount == 12, "Invalid value returned for sCallbackRecordCount");
-    VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", NULL);
+    VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", nullptr);
     VerifyHandleOptionCallback(1, __FUNCTION__, &sOptionSetB, 1000, "--run", "run-value");
-    VerifyHandleOptionCallback(2, __FUNCTION__, &sOptionSetB, 's', "-s", NULL);
-    VerifyHandleOptionCallback(3, __FUNCTION__, &sOptionSetA, 1001, "--bar", NULL);
-    VerifyHandleOptionCallback(4, __FUNCTION__, &sOptionSetA, '1', "-1", NULL);
+    VerifyHandleOptionCallback(2, __FUNCTION__, &sOptionSetB, 's', "-s", nullptr);
+    VerifyHandleOptionCallback(3, __FUNCTION__, &sOptionSetA, 1001, "--bar", nullptr);
+    VerifyHandleOptionCallback(4, __FUNCTION__, &sOptionSetA, '1', "-1", nullptr);
     VerifyHandleOptionCallback(5, __FUNCTION__, &sOptionSetA, 'Z', "-Z", "baz-value");
     VerifyHandleOptionCallback(6, __FUNCTION__, &sOptionSetB, 1000, "--run", "run-value-2");
     VerifyHandleNonOptionArgsCallback(7, __FUNCTION__, 4);
@@ -318,7 +318,7 @@ static void UnknownOptionTest_UnknownShortOption()
 {
     bool res;
 
-    static OptionSet * optionSets[] = { &sOptionSetB, &sOptionSetA, NULL };
+    static OptionSet * optionSets[] = { &sOptionSetB, &sOptionSetA, nullptr };
     // clang-format off
     static const char *argv[] =
     {
@@ -328,7 +328,7 @@ static void UnknownOptionTest_UnknownShortOption()
         "-q", // <-- unknown option -q
         "--bar",
         "non-opt-arg-1",
-		NULL
+		nullptr
     };
     // clang-format on
     static int argc = sizeof(argv) / sizeof(argv[0]) - 1;
@@ -339,7 +339,7 @@ static void UnknownOptionTest_UnknownShortOption()
     res = ParseArgs(__FUNCTION__, argc, (char **) argv, optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 3, "Invalid value returned for sCallbackRecordCount");
-    VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", NULL);
+    VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", nullptr);
     VerifyHandleOptionCallback(1, __FUNCTION__, &sOptionSetB, 1000, "--run", "run-value");
     VerifyPrintArgErrorCallback(2);
     VerifyArgErrorContains(2, "Unknown");
@@ -350,7 +350,7 @@ static void UnknownOptionTest_UnknownLongOption()
 {
     bool res;
 
-    static OptionSet * optionSets[] = { &sOptionSetB, &sOptionSetA, NULL };
+    static OptionSet * optionSets[] = { &sOptionSetB, &sOptionSetA, nullptr };
     // clang-format off
     static const char *argv[] =
     {
@@ -360,7 +360,7 @@ static void UnknownOptionTest_UnknownLongOption()
         "--bad", // <-- unknown option --bad
         "--bar",
         "non-opt-arg-1",
-		NULL
+		nullptr
     };
     // clang-format on
     static int argc = sizeof(argv) / sizeof(argv[0]) - 1;
@@ -371,7 +371,7 @@ static void UnknownOptionTest_UnknownLongOption()
     res = ParseArgs(__FUNCTION__, argc, (char **) argv, optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 3, "Invalid value returned for sCallbackRecordCount");
-    VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", NULL);
+    VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", nullptr);
     VerifyHandleOptionCallback(1, __FUNCTION__, &sOptionSetB, 1000, "--run", "run-value");
     VerifyPrintArgErrorCallback(2);
     VerifyArgErrorContains(2, "Unknown option");
@@ -382,7 +382,7 @@ static void UnknownOptionTest_UnknownShortOptionAfterKnown()
 {
     bool res;
 
-    static OptionSet * optionSets[] = { &sOptionSetB, &sOptionSetA, NULL };
+    static OptionSet * optionSets[] = { &sOptionSetB, &sOptionSetA, nullptr };
     // clang-format off
     static const char *argv[] =
     {
@@ -392,7 +392,7 @@ static void UnknownOptionTest_UnknownShortOptionAfterKnown()
         "-1Q", // <-- unknown option -Q
         "--bar",
         "non-opt-arg-1",
-		NULL
+		nullptr
     };
     // clang-format on
     static int argc = sizeof(argv) / sizeof(argv[0]) - 1;
@@ -403,9 +403,9 @@ static void UnknownOptionTest_UnknownShortOptionAfterKnown()
     res = ParseArgs(__FUNCTION__, argc, (char **) argv, optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 4, "Invalid value returned for sCallbackRecordCount");
-    VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", NULL);
+    VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", nullptr);
     VerifyHandleOptionCallback(1, __FUNCTION__, &sOptionSetB, 1000, "--run", "run-value");
-    VerifyHandleOptionCallback(2, __FUNCTION__, &sOptionSetA, '1', "-1", NULL);
+    VerifyHandleOptionCallback(2, __FUNCTION__, &sOptionSetA, '1', "-1", nullptr);
     VerifyPrintArgErrorCallback(3);
     VerifyArgErrorContains(3, "Unknown");
     VerifyArgErrorContains(3, "-Q");
@@ -415,13 +415,13 @@ static void UnknownOptionTest_UnknownShortOptionBeforeKnown()
 {
     bool res;
 
-    static OptionSet * optionSets[] = { &sOptionSetA, &sOptionSetB, NULL };
+    static OptionSet * optionSets[] = { &sOptionSetA, &sOptionSetB, nullptr };
     // clang-format off
     static const char *argv[] =
     {
         "",
         "-Q1", // <-- unknown option -Q
-		NULL
+		nullptr
     };
     // clang-format on
     static int argc = sizeof(argv) / sizeof(argv[0]) - 1;
@@ -441,7 +441,7 @@ static void UnknownOptionTest_UnknownShortOptionAfterArgs()
 {
     bool res;
 
-    static OptionSet * optionSets[] = { &sOptionSetA, &sOptionSetB, NULL };
+    static OptionSet * optionSets[] = { &sOptionSetA, &sOptionSetB, nullptr };
     // clang-format off
     static const char *argv[] =
     {
@@ -449,7 +449,7 @@ static void UnknownOptionTest_UnknownShortOptionAfterArgs()
         "non-opt-arg-1",
         "non-opt-arg-2",
         "-Q", // <-- unknown option -Q
-        NULL
+        nullptr
     };
     // clang-format on
     static int argc = sizeof(argv) / sizeof(argv[0]) - 1;
@@ -469,7 +469,7 @@ static void UnknownOptionTest_UnknownLongOptionAfterArgs()
 {
     bool res;
 
-    static OptionSet * optionSets[] = { &sOptionSetA, &sOptionSetB, NULL };
+    static OptionSet * optionSets[] = { &sOptionSetA, &sOptionSetB, nullptr };
     // clang-format off
     static const char *argv[] =
     {
@@ -477,7 +477,7 @@ static void UnknownOptionTest_UnknownLongOptionAfterArgs()
         "non-opt-arg-1",
         "non-opt-arg-2",
         "--barf", // <-- unknown option --barf
-		NULL
+		nullptr
     };
     // clang-format on
     static int argc = sizeof(argv) / sizeof(argv[0]) - 1;
@@ -497,7 +497,7 @@ static void UnknownOptionTest_IgnoreUnknownLongOption()
 {
     bool res;
 
-    static OptionSet * optionSets[] = { &sOptionSetA, &sOptionSetB, NULL };
+    static OptionSet * optionSets[] = { &sOptionSetA, &sOptionSetB, nullptr };
     // clang-format off
     static const char *argv[] =
     {
@@ -506,7 +506,7 @@ static void UnknownOptionTest_IgnoreUnknownLongOption()
         "non-opt-arg-2",
         "--foob", // <-- unknown option --foob
         "-Zbaz-value",
-		NULL
+		nullptr
     };
     // clang-format on
     static int argc = sizeof(argv) / sizeof(argv[0]) - 1;
@@ -529,7 +529,7 @@ static void UnknownOptionTest_IgnoreUnknownShortOption()
 {
     bool res;
 
-    static OptionSet * optionSets[] = { &sOptionSetA, &sOptionSetB, NULL };
+    static OptionSet * optionSets[] = { &sOptionSetA, &sOptionSetB, nullptr };
     // clang-format off
     static const char *argv[] =
     {
@@ -538,7 +538,7 @@ static void UnknownOptionTest_IgnoreUnknownShortOption()
         "non-opt-arg-2",
         "-Q1", // <-- unknown option -Q
         "-Zbaz-value",
-		NULL
+		nullptr
     };
     // clang-format on
     static int argc = sizeof(argv) / sizeof(argv[0]) - 1;
@@ -551,7 +551,7 @@ static void UnknownOptionTest_IgnoreUnknownShortOption()
 
     VerifyOrQuit(sCallbackRecordCount == 5, "Invalid value returned for sCallbackRecordCount");
 
-    VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "-1", NULL);
+    VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "-1", nullptr);
     VerifyHandleOptionCallback(1, __FUNCTION__, &sOptionSetA, 'Z', "-Z", "baz-value");
     VerifyHandleNonOptionArgsCallback(2, __FUNCTION__, 2);
     VerifyNonOptionArg(3, "non-opt-arg-1");
@@ -562,13 +562,13 @@ static void MissingValueTest_MissingShortOptionValue()
 {
     bool res;
 
-    static OptionSet * optionSets[] = { &sOptionSetA, &sOptionSetB, NULL };
+    static OptionSet * optionSets[] = { &sOptionSetA, &sOptionSetB, nullptr };
     // clang-format off
     static const char *argv[] =
     {
         "",
         "-Z",
-		NULL
+		nullptr
     };
     // clang-format on
     static int argc = sizeof(argv) / sizeof(argv[0]) - 1;
@@ -588,13 +588,13 @@ static void MissingValueTest_MissingLongOptionValue()
 {
     bool res;
 
-    static OptionSet * optionSets[] = { &sOptionSetA, &sOptionSetB, NULL };
+    static OptionSet * optionSets[] = { &sOptionSetA, &sOptionSetB, nullptr };
     // clang-format off
     static const char *argv[] =
     {
         "",
         "--run",
-		NULL
+		nullptr
     };
     // clang-format on
     static int argc = sizeof(argv) / sizeof(argv[0]) - 1;
@@ -614,13 +614,13 @@ static void ClearCallbackRecords()
 {
     for (size_t i = 0; i < sCallbackRecordCount; i++)
     {
-        if (sCallbackRecords[i].ProgName != NULL)
+        if (sCallbackRecords[i].ProgName != nullptr)
             free(sCallbackRecords[i].ProgName);
-        if (sCallbackRecords[i].Name != NULL)
+        if (sCallbackRecords[i].Name != nullptr)
             free(sCallbackRecords[i].Name);
-        if (sCallbackRecords[i].Arg != NULL)
+        if (sCallbackRecords[i].Arg != nullptr)
             free(sCallbackRecords[i].Arg);
-        if (sCallbackRecords[i].Error != NULL)
+        if (sCallbackRecords[i].Error != nullptr)
             free(sCallbackRecords[i].Error);
     }
     memset(sCallbackRecords, 0, sizeof(sCallbackRecords));
@@ -639,7 +639,7 @@ static bool HandleOption(const char * progName, OptionSet * optSet, int id, cons
     sCallbackRecords[sCallbackRecordCount].OptSet   = optSet;
     sCallbackRecords[sCallbackRecordCount].Id       = id;
     sCallbackRecords[sCallbackRecordCount].Name     = strdup(name);
-    sCallbackRecords[sCallbackRecordCount].Arg      = (arg != NULL) ? strdup(arg) : NULL;
+    sCallbackRecords[sCallbackRecordCount].Arg      = (arg != nullptr) ? strdup(arg) : nullptr;
     sCallbackRecordCount++;
     return true;
 }

--- a/src/lib/support/tests/TestCHIPCounter.cpp
+++ b/src/lib/support/tests/TestCHIPCounter.cpp
@@ -89,7 +89,7 @@ extern "C" int TestCHIPCounter(void)
     // clang-format on
 
     // Run test suit againt one context.
-    nlTestRunner(&theSuite, NULL);
+    nlTestRunner(&theSuite, nullptr);
 
     return nlTestRunnerStats(&theSuite);
 }

--- a/src/lib/support/tests/TestCHIPMem.cpp
+++ b/src/lib/support/tests/TestCHIPMem.cpp
@@ -46,29 +46,29 @@ using namespace chip::Platform;
 
 static void TestMemAlloc_Malloc(nlTestSuite * inSuite, void * inContext)
 {
-    char * p1 = NULL;
-    char * p2 = NULL;
-    char * p3 = NULL;
+    char * p1 = nullptr;
+    char * p2 = nullptr;
+    char * p3 = nullptr;
 
     // Verify long-term allocation
     p1 = (char *) MemoryAlloc(64, true);
-    NL_TEST_ASSERT(inSuite, p1 != NULL);
+    NL_TEST_ASSERT(inSuite, p1 != nullptr);
 
     p2 = (char *) MemoryAlloc(256, true);
-    NL_TEST_ASSERT(inSuite, p2 != NULL);
+    NL_TEST_ASSERT(inSuite, p2 != nullptr);
 
     chip::Platform::MemoryFree(p1);
     chip::Platform::MemoryFree(p2);
 
     // Verify short-term allocation
     p1 = (char *) MemoryAlloc(256);
-    NL_TEST_ASSERT(inSuite, p1 != NULL);
+    NL_TEST_ASSERT(inSuite, p1 != nullptr);
 
     p2 = (char *) MemoryAlloc(256);
-    NL_TEST_ASSERT(inSuite, p2 != NULL);
+    NL_TEST_ASSERT(inSuite, p2 != nullptr);
 
     p3 = (char *) MemoryAlloc(256);
-    NL_TEST_ASSERT(inSuite, p3 != NULL);
+    NL_TEST_ASSERT(inSuite, p3 != nullptr);
 
     chip::Platform::MemoryFree(p1);
     chip::Platform::MemoryFree(p2);
@@ -78,7 +78,7 @@ static void TestMemAlloc_Malloc(nlTestSuite * inSuite, void * inContext)
 static void TestMemAlloc_Calloc(nlTestSuite * inSuite, void * inContext)
 {
     char * p = (char *) MemoryCalloc(128, true);
-    NL_TEST_ASSERT(inSuite, p != NULL);
+    NL_TEST_ASSERT(inSuite, p != nullptr);
 
     for (int i = 0; i < 128; i++)
         NL_TEST_ASSERT(inSuite, p[i] == 0);
@@ -89,10 +89,10 @@ static void TestMemAlloc_Calloc(nlTestSuite * inSuite, void * inContext)
 static void TestMemAlloc_Realloc(nlTestSuite * inSuite, void * inContext)
 {
     char * pa = (char *) MemoryAlloc(128, true);
-    NL_TEST_ASSERT(inSuite, pa != NULL);
+    NL_TEST_ASSERT(inSuite, pa != nullptr);
 
     char * pb = (char *) MemoryRealloc(pa, 256);
-    NL_TEST_ASSERT(inSuite, pb != NULL);
+    NL_TEST_ASSERT(inSuite, pb != nullptr);
 
     chip::Platform::MemoryFree(pb);
 }
@@ -106,10 +106,10 @@ static const nlTest sTests[] = { NL_TEST_DEF("Test MemAlloc::Malloc", TestMemAll
 
 int TestMemAlloc(void)
 {
-    nlTestSuite theSuite = { "CHIP Memory Allocation tests", &sTests[0], NULL, NULL };
+    nlTestSuite theSuite = { "CHIP Memory Allocation tests", &sTests[0], nullptr, nullptr };
 
     // Run test suit againt one context.
-    nlTestRunner(&theSuite, NULL);
+    nlTestRunner(&theSuite, nullptr);
     return nlTestRunnerStats(&theSuite);
 }
 

--- a/src/lib/support/tests/TestErrorStr.cpp
+++ b/src/lib/support/tests/TestErrorStr.cpp
@@ -56,9 +56,9 @@ static bool trueFormat(char * buf, uint16_t bufSize, int32_t err)
 
 static bool testRegisterDeregisterErrorFormatter(void)
 {
-    static ErrorFormatter falseFormatter  = { falseFormat, NULL };
-    static ErrorFormatter falseFormatter2 = { falseFormat2, NULL };
-    static ErrorFormatter trueFormatter   = { trueFormat, NULL };
+    static ErrorFormatter falseFormatter  = { falseFormat, nullptr };
+    static ErrorFormatter falseFormatter2 = { falseFormat2, nullptr };
+    static ErrorFormatter trueFormatter   = { trueFormat, nullptr };
 
     // assume success
     bool ret = true;
@@ -144,19 +144,19 @@ static bool testFormatErr()
     ret &= CHECK_EQ_STR(buf, "subsys Error 1 (0x00000001): desc");
 
     // skip desc
-    FormatError(buf, kBufSize, subsys, 1, NULL);
+    FormatError(buf, kBufSize, subsys, 1, nullptr);
     ret &= CHECK_EQ_STR(buf, "subsys Error 1 (0x00000001)");
 
     // skip subsys
-    FormatError(buf, kBufSize, NULL, 1, desc);
+    FormatError(buf, kBufSize, nullptr, 1, desc);
     ret &= CHECK_EQ_STR(buf, "Error 1 (0x00000001): desc");
 
     // skip both
-    FormatError(buf, kBufSize, NULL, 1, NULL);
+    FormatError(buf, kBufSize, nullptr, 1, nullptr);
     ret &= CHECK_EQ_STR(buf, "Error 1 (0x00000001)");
 
     // negative
-    FormatError(buf, kBufSize, NULL, -1, NULL);
+    FormatError(buf, kBufSize, nullptr, -1, nullptr);
     ret &= CHECK_EQ_STR(buf, "Error -1 (0xFFFFFFFF)");
 #endif
 

--- a/src/lib/support/tests/TestPersistedCounter.cpp
+++ b/src/lib/support/tests/TestPersistedCounter.cpp
@@ -183,13 +183,13 @@ static const nlTest sTests[] = { NL_TEST_DEF("Out of box Test", CheckOOB), NL_TE
 static HelpOptions gHelpOptions(TOOL_NAME, "Usage: " TOOL_NAME " [<options...>]\n", CHIP_VERSION_STRING "\n" CHIP_TOOL_COPYRIGHT,
                                 "Test persisted counter API.  Without any options, the program invokes a suite of local tests.\n");
 
-static OptionSet * gOptionSets[] = { &gHelpOptions, NULL };
+static OptionSet * gOptionSets[] = { &gHelpOptions, nullptr };
 
 extern "C" int TestPersistedCounter(int argc, char * argv[])
 {
     TestPersistedCounterContext context;
 
-    if (!ParseArgsFromEnvVar(TOOL_NAME, TOOL_OPTIONS_ENV_VAR_NAME, gOptionSets, NULL, true) ||
+    if (!ParseArgsFromEnvVar(TOOL_NAME, TOOL_OPTIONS_ENV_VAR_NAME, gOptionSets, nullptr, true) ||
         !ParseArgs(TOOL_NAME, argc, argv, gOptionSets))
     {
         return EXIT_FAILURE;

--- a/src/lib/support/tests/TestPersistedStorageImplementation.cpp
+++ b/src/lib/support/tests/TestPersistedStorageImplementation.cpp
@@ -46,7 +46,7 @@ using namespace chip::ArgParser;
 
 std::map<std::string, std::string> sPersistentStore;
 
-FILE * sPersistentStoreFile = NULL;
+FILE * sPersistentStoreFile = nullptr;
 
 namespace chip {
 namespace Platform {
@@ -67,13 +67,13 @@ static CHIP_ERROR GetCounterValueFromFile(const char * aKey, uint32_t & aValue)
 
     rewind(sPersistentStoreFile);
 
-    while (fgets(key, sizeof(key), sPersistentStoreFile) != NULL)
+    while (fgets(key, sizeof(key), sPersistentStoreFile) != nullptr)
     {
         RemoveEndOfLineSymbol(key);
 
         if (strcmp(key, aKey) == 0)
         {
-            if (fgets(value, sizeof(value), sPersistentStoreFile) == NULL)
+            if (fgets(value, sizeof(value), sPersistentStoreFile) == nullptr)
             {
                 err = CHIP_ERROR_PERSISTED_STORAGE_FAILED;
             }
@@ -107,7 +107,7 @@ static CHIP_ERROR SaveCounterValueToFile(const char * aKey, uint32_t aValue)
     rewind(sPersistentStoreFile);
 
     // Find the stored counter value location in the file.
-    while (fgets(key, sizeof(key), sPersistentStoreFile) != NULL)
+    while (fgets(key, sizeof(key), sPersistentStoreFile) != nullptr)
     {
         RemoveEndOfLineSymbol(key);
 
@@ -142,7 +142,7 @@ CHIP_ERROR Read(const char * aKey, uint32_t & aValue)
     CHIP_ERROR err = CHIP_NO_ERROR;
     std::map<std::string, std::string>::iterator it;
 
-    VerifyOrExit(aKey != NULL, err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(aKey != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(strlen(aKey) <= CHIP_CONFIG_PERSISTED_STORAGE_MAX_KEY_LENGTH, err = CHIP_ERROR_INVALID_STRING_LENGTH);
 
     if (sPersistentStoreFile)
@@ -166,7 +166,7 @@ CHIP_ERROR Write(const char * aKey, uint32_t aValue)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    VerifyOrExit(aKey != NULL, err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(aKey != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(strlen(aKey) <= CHIP_CONFIG_PERSISTED_STORAGE_MAX_KEY_LENGTH, err = CHIP_ERROR_INVALID_STRING_LENGTH);
 
     if (sPersistentStoreFile)

--- a/src/platform/GeneralUtils.cpp
+++ b/src/platform/GeneralUtils.cpp
@@ -43,7 +43,7 @@ CHIP_ERROR ParseCompilerDateStr(const char * dateStr, uint16_t & year, uint8_t &
     monthStr[3] = 0;
 
     p = strstr(months, monthStr);
-    VerifyOrExit(p != NULL, err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(p != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
 
     month = ((p - months) / 3) + 1;
 
@@ -82,7 +82,7 @@ exit:
  */
 void RegisterDeviceLayerErrorFormatter(void)
 {
-    static ErrorFormatter sDeviceLayerErrorFormatter = { FormatDeviceLayerError, NULL };
+    static ErrorFormatter sDeviceLayerErrorFormatter = { FormatDeviceLayerError, nullptr };
 
     RegisterErrorFormatter(&sDeviceLayerErrorFormatter);
 }
@@ -101,7 +101,7 @@ void RegisterDeviceLayerErrorFormatter(void)
  */
 bool FormatDeviceLayerError(char * buf, uint16_t bufSize, int32_t err)
 {
-    const char * desc = NULL;
+    const char * desc = nullptr;
 
     if (err < CHIP_DEVICE_ERROR_MIN || err > CHIP_DEVICE_ERROR_MAX)
     {

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -63,7 +63,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
 
     mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Enabled;
     mFlags       = kFlag_AdvertisingEnabled;
-    mAppState    = NULL;
+    mAppState    = nullptr;
 
     memset(mDeviceName, 0, sizeof(mDeviceName));
 
@@ -139,7 +139,7 @@ CHIP_ERROR BLEManagerImpl::_SetDeviceName(const char * deviceName)
     {
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     }
-    if (deviceName != NULL && deviceName[0] != 0)
+    if (deviceName != nullptr && deviceName[0] != 0)
     {
         if (strlen(deviceName) >= kMaxDeviceNameLength)
         {
@@ -178,7 +178,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureBle(uint32_t aNodeId, bool aIsCentral)
     mBLEAdvConfig.mType             = ChipAdvType::BLUEZ_ADV_TYPE_UNDIRECTED_CONNECTABLE_SCANNABLE;
     mBLEAdvConfig.mpAdvertisingUUID = "0xFEAF";
 
-    mpBleAddr  = NULL;
+    mpBleAddr  = nullptr;
     mIsCentral = aIsCentral;
 
     return err;
@@ -315,7 +315,7 @@ exit:
 uint16_t BLEManagerImpl::GetMTU(BLE_CONNECTION_OBJECT conId) const
 {
     BluezConnection * con = static_cast<BluezConnection *>(conId);
-    return (con != NULL) ? con->mMtu : 0;
+    return (con != nullptr) ? con->mMtu : 0;
 }
 
 bool BLEManagerImpl::SubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, const ChipBleUUID * svcId, const ChipBleUUID * charId)
@@ -372,11 +372,11 @@ void BLEManagerImpl::CHIPoBluez_NewConnection(void * data)
 void BLEManagerImpl::HandleRXCharWrite(void * data, const uint8_t * value, size_t len)
 {
     CHIP_ERROR err     = CHIP_NO_ERROR;
-    PacketBuffer * buf = NULL;
+    PacketBuffer * buf = nullptr;
 
     // Copy the data to a PacketBuffer.
     buf = PacketBuffer::New();
-    VerifyOrExit(buf != NULL, err = CHIP_ERROR_NO_MEMORY);
+    VerifyOrExit(buf != nullptr, err = CHIP_ERROR_NO_MEMORY);
     VerifyOrExit(buf->AvailableDataLength() >= len, err = CHIP_ERROR_BUFFER_TOO_SMALL);
     memcpy(buf->Start(), value, len);
     buf->SetDataLength(len);
@@ -389,7 +389,7 @@ void BLEManagerImpl::HandleRXCharWrite(void * data, const uint8_t * value, size_
         event.CHIPoBLEWriteReceived.ConId = data;
         event.CHIPoBLEWriteReceived.Data  = buf;
         PlatformMgr().PostEvent(&event);
-        buf = NULL;
+        buf = nullptr;
     }
 
 exit:
@@ -398,7 +398,7 @@ exit:
         ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %s", ErrorStr(err));
     }
 
-    if (NULL != buf)
+    if (nullptr != buf)
     {
         chip::System::PacketBuffer::Free(buf);
     }
@@ -423,8 +423,8 @@ void BLEManagerImpl::HandleTXCharCCCDWrite(void * data)
     CHIP_ERROR err               = CHIP_NO_ERROR;
     BluezConnection * connection = static_cast<BluezConnection *>(data);
 
-    VerifyOrExit(connection != NULL, ChipLogProgress(DeviceLayer, "Connection is NULL in HandleTXCharCCCDWrite"));
-    VerifyOrExit(connection->mpC2 != NULL, ChipLogProgress(DeviceLayer, "C2 is NULL in HandleTXCharCCCDWrite"));
+    VerifyOrExit(connection != nullptr, ChipLogProgress(DeviceLayer, "Connection is NULL in HandleTXCharCCCDWrite"));
+    VerifyOrExit(connection->mpC2 != nullptr, ChipLogProgress(DeviceLayer, "C2 is NULL in HandleTXCharCCCDWrite"));
 
     // Post an event to the Chip queue to process either a CHIPoBLE Subscribe or Unsubscribe based on
     // whether the client is enabling or disabling indications.
@@ -481,7 +481,7 @@ void BLEManagerImpl::DriveBLEState()
     // Initializes the Bluez BLE layer if needed.
     if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !GetFlag(mFlags, kFlag_BluezBLELayerInitialized))
     {
-        err = InitBluezBleLayer(false, NULL, mBLEAdvConfig, mpAppState);
+        err = InitBluezBleLayer(false, nullptr, mBLEAdvConfig, mpAppState);
         SuccessOrExit(err);
         SetFlag(mFlags, kFlag_BluezBLELayerInitialized);
     }

--- a/src/platform/Linux/CHIPBluezHelper.cpp
+++ b/src/platform/Linux/CHIPBluezHelper.cpp
@@ -69,7 +69,7 @@ namespace DeviceLayer {
 namespace Internal {
 
 static int sBluezFD[2];
-static GMainLoop * sBluezMainLoop = NULL;
+static GMainLoop * sBluezMainLoop = nullptr;
 static pthread_t sBluezThread;
 static BluezConnection * GetBluezConnectionViaDevice(BluezEndpoint * apEndpoint);
 
@@ -77,8 +77,8 @@ static gboolean BluezAdvertisingRelease(BluezLEAdvertisement1 * aAdv, GDBusMetho
 {
     bool isSuccess           = false;
     BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apClosure);
-    VerifyOrExit(endpoint != NULL, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
-    VerifyOrExit(aAdv != NULL, ChipLogProgress(DeviceLayer, "BluezLEAdvertisement1 is NULL in %s", __func__));
+    VerifyOrExit(endpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
+    VerifyOrExit(aAdv != nullptr, ChipLogProgress(DeviceLayer, "BluezLEAdvertisement1 is NULL in %s", __func__));
     ChipLogProgress(DeviceLayer, "Release adv object in %s", __func__);
 
     g_dbus_object_manager_server_unexport(endpoint->mpRoot, endpoint->mpAdvPath);
@@ -91,7 +91,7 @@ exit:
 
 static BluezLEAdvertisement1 * BluezAdvertisingCreate(BluezEndpoint * apEndpoint)
 {
-    BluezLEAdvertisement1 * adv = NULL;
+    BluezLEAdvertisement1 * adv = nullptr;
     BluezObjectSkeleton * object;
     GVariant * serviceData;
     gchar * localName;
@@ -100,8 +100,8 @@ static BluezLEAdvertisement1 * BluezAdvertisingCreate(BluezEndpoint * apEndpoint
     char * debugStr;
     const gchar * array[1];
 
-    VerifyOrExit(apEndpoint != NULL, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
-    if (apEndpoint->mpAdvPath == NULL)
+    VerifyOrExit(apEndpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
+    if (apEndpoint->mpAdvPath == nullptr)
         apEndpoint->mpAdvPath = g_strdup_printf("%s/advertising", apEndpoint->mpRootPath);
 
     array[0] = g_strdup_printf("%s", apEndpoint->mpAdvertisingUUID);
@@ -119,7 +119,7 @@ static BluezLEAdvertisement1 * BluezAdvertisingCreate(BluezEndpoint * apEndpoint
         g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, apEndpoint->mpChipServiceData, sizeof(CHIPServiceData), sizeof(uint8_t)));
     g_variant_builder_add(&serviceUUIDsBuilder, "s", apEndpoint->mpAdvertisingUUID);
 
-    if (apEndpoint->mpAdapterName != NULL)
+    if (apEndpoint->mpAdapterName != nullptr)
         localName = g_strdup_printf("%s", apEndpoint->mpAdapterName);
     else
         localName = g_strdup_printf("%s%04x", CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, getpid() & 0xffff);
@@ -155,7 +155,7 @@ static BluezLEAdvertisement1 * BluezAdvertisingCreate(BluezEndpoint * apEndpoint
     g_dbus_object_manager_server_export(apEndpoint->mpRoot, G_DBUS_OBJECT_SKELETON(object));
     g_object_unref(object);
 
-    BLEManagerImpl::NotifyBLEPeripheralAdvConfiguredComplete(true, NULL);
+    BLEManagerImpl::NotifyBLEPeripheralAdvConfiguredComplete(true, nullptr);
 
 exit:
     return adv;
@@ -164,11 +164,11 @@ exit:
 static void BluezAdvStartDone(GObject * aObject, GAsyncResult * aResult, gpointer apClosure)
 {
     BluezLEAdvertisingManager1 * advMgr = BLUEZ_LEADVERTISING_MANAGER1(aObject);
-    GError * error                      = NULL;
+    GError * error                      = nullptr;
     BluezEndpoint * endpoint            = static_cast<BluezEndpoint *>(apClosure);
     gboolean success                    = FALSE;
 
-    VerifyOrExit(endpoint != NULL, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
+    VerifyOrExit(endpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
 
     success = bluez_leadvertising_manager1_call_register_advertisement_finish(advMgr, aResult, &error);
     if (success == FALSE)
@@ -182,8 +182,8 @@ static void BluezAdvStartDone(GObject * aObject, GAsyncResult * aResult, gpointe
     ChipLogProgress(DeviceLayer, "RegisterAdvertisement complete");
 
 exit:
-    BLEManagerImpl::NotifyBLEPeripheralAdvStopComplete(success == TRUE ? true : false, NULL);
-    if (error != NULL)
+    BLEManagerImpl::NotifyBLEPeripheralAdvStopComplete(success == TRUE ? true : false, nullptr);
+    if (error != nullptr)
         g_error_free(error);
 }
 
@@ -191,10 +191,10 @@ static void BluezAdvStopDone(GObject * aObject, GAsyncResult * aResult, gpointer
 {
     BluezLEAdvertisingManager1 * advMgr = BLUEZ_LEADVERTISING_MANAGER1(aObject);
     BluezEndpoint * endpoint            = static_cast<BluezEndpoint *>(apClosure);
-    GError * error                      = NULL;
+    GError * error                      = nullptr;
     gboolean success                    = FALSE;
 
-    VerifyOrExit(endpoint != NULL, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
+    VerifyOrExit(endpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
 
     success = bluez_leadvertising_manager1_call_unregister_advertisement_finish(advMgr, aResult, &error);
 
@@ -212,8 +212,8 @@ static void BluezAdvStopDone(GObject * aObject, GAsyncResult * aResult, gpointer
     ChipLogProgress(DeviceLayer, "UnregisterAdvertisement complete");
 
 exit:
-    BLEManagerImpl::NotifyBLEPeripheralAdvStopComplete(success == TRUE ? true : false, NULL);
-    if (error != NULL)
+    BLEManagerImpl::NotifyBLEPeripheralAdvStopComplete(success == TRUE ? true : false, nullptr);
+    if (error != nullptr)
         g_error_free(error);
 }
 
@@ -222,13 +222,13 @@ static gboolean BluezAdvSetup(void * apClosure)
     BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apClosure);
     BluezLEAdvertisement1 * adv;
 
-    VerifyOrExit(endpoint != NULL, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
+    VerifyOrExit(endpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
     VerifyOrExit(endpoint->mIsAdvertising == FALSE,
                  ChipLogProgress(DeviceLayer, "FAIL: Advertising already enabled in %s", __func__));
-    VerifyOrExit(endpoint->mpAdapter != NULL, ChipLogProgress(DeviceLayer, "FAIL: NULL endpoint->mpAdapter in %s", __func__));
+    VerifyOrExit(endpoint->mpAdapter != nullptr, ChipLogProgress(DeviceLayer, "FAIL: NULL endpoint->mpAdapter in %s", __func__));
 
     adv = BluezAdvertisingCreate(endpoint);
-    VerifyOrExit(adv != NULL, ChipLogProgress(DeviceLayer, "FAIL: NULL adv in %s", __func__));
+    VerifyOrExit(adv != nullptr, ChipLogProgress(DeviceLayer, "FAIL: NULL adv in %s", __func__));
 
 exit:
     return G_SOURCE_REMOVE;
@@ -237,26 +237,26 @@ exit:
 static gboolean BluezAdvStart(void * apClosure)
 {
     GDBusObject * adapter;
-    BluezLEAdvertisingManager1 * advMgr = NULL;
+    BluezLEAdvertisingManager1 * advMgr = nullptr;
     GVariantBuilder optionsBuilder;
     GVariant * options;
     BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apClosure);
 
-    VerifyOrExit(endpoint != NULL, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
+    VerifyOrExit(endpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
     VerifyOrExit(!endpoint->mIsAdvertising,
                  ChipLogProgress(DeviceLayer, "FAIL: Advertising has already been enabled in %s", __func__));
-    VerifyOrExit(endpoint->mpAdapter != NULL, ChipLogProgress(DeviceLayer, "FAIL: NULL endpoint->mpAdapter in %s", __func__));
+    VerifyOrExit(endpoint->mpAdapter != nullptr, ChipLogProgress(DeviceLayer, "FAIL: NULL endpoint->mpAdapter in %s", __func__));
 
     adapter = g_dbus_interface_get_object(G_DBUS_INTERFACE(endpoint->mpAdapter));
-    VerifyOrExit(adapter != NULL, ChipLogProgress(DeviceLayer, "FAIL: NULL adapter in %s", __func__));
+    VerifyOrExit(adapter != nullptr, ChipLogProgress(DeviceLayer, "FAIL: NULL adapter in %s", __func__));
 
     advMgr = bluez_object_get_leadvertising_manager1(BLUEZ_OBJECT(adapter));
-    VerifyOrExit(advMgr != NULL, ChipLogProgress(DeviceLayer, "FAIL: NULL advMgr in %s", __func__));
+    VerifyOrExit(advMgr != nullptr, ChipLogProgress(DeviceLayer, "FAIL: NULL advMgr in %s", __func__));
 
     g_variant_builder_init(&optionsBuilder, G_VARIANT_TYPE("a{sv}"));
     options = g_variant_builder_end(&optionsBuilder);
 
-    bluez_leadvertising_manager1_call_register_advertisement(advMgr, endpoint->mpAdvPath, options, NULL, BluezAdvStartDone,
+    bluez_leadvertising_manager1_call_register_advertisement(advMgr, endpoint->mpAdvPath, options, nullptr, BluezAdvStartDone,
                                                              apClosure);
 
 exit:
@@ -267,20 +267,20 @@ static gboolean BluezAdvStop(void * apClosure)
 {
     GDBusObject * adapter;
     BluezEndpoint * endpoint            = static_cast<BluezEndpoint *>(apClosure);
-    BluezLEAdvertisingManager1 * advMgr = NULL;
+    BluezLEAdvertisingManager1 * advMgr = nullptr;
 
-    VerifyOrExit(endpoint != NULL, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
+    VerifyOrExit(endpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
     VerifyOrExit(endpoint->mIsAdvertising,
                  ChipLogProgress(DeviceLayer, "FAIL: Advertising has already been disabled in %s", __func__));
-    VerifyOrExit(endpoint->mpAdapter != NULL, ChipLogProgress(DeviceLayer, "FAIL: NULL endpoint->mpAdapter in %s", __func__));
+    VerifyOrExit(endpoint->mpAdapter != nullptr, ChipLogProgress(DeviceLayer, "FAIL: NULL endpoint->mpAdapter in %s", __func__));
 
     adapter = g_dbus_interface_get_object(G_DBUS_INTERFACE(endpoint->mpAdapter));
-    VerifyOrExit(adapter != NULL, ChipLogProgress(DeviceLayer, "FAIL: NULL adapter in %s", __func__));
+    VerifyOrExit(adapter != nullptr, ChipLogProgress(DeviceLayer, "FAIL: NULL adapter in %s", __func__));
 
     advMgr = bluez_object_get_leadvertising_manager1(BLUEZ_OBJECT(adapter));
-    VerifyOrExit(advMgr != NULL, ChipLogProgress(DeviceLayer, "FAIL: NULL advMgr in %s", __func__));
+    VerifyOrExit(advMgr != nullptr, ChipLogProgress(DeviceLayer, "FAIL: NULL advMgr in %s", __func__));
 
-    bluez_leadvertising_manager1_call_unregister_advertisement(advMgr, endpoint->mpAdvPath, NULL, BluezAdvStopDone, apClosure);
+    bluez_leadvertising_manager1_call_unregister_advertisement(advMgr, endpoint->mpAdvPath, nullptr, BluezAdvStopDone, apClosure);
 
 exit:
     return G_SOURCE_REMOVE;
@@ -348,7 +348,7 @@ static gboolean BluezCharacteristicWriteFD(GIOChannel * aChannel, GIOCondition a
 
     BluezConnection * conn = static_cast<BluezConnection *>(apClosure);
 
-    VerifyOrExit(conn != NULL, ChipLogProgress(DeviceLayer, "No CHIP Bluez connection in %s", __func__));
+    VerifyOrExit(conn != nullptr, ChipLogProgress(DeviceLayer, "No CHIP Bluez connection in %s", __func__));
 
     VerifyOrExit(!(aCond & G_IO_HUP), ChipLogProgress(DeviceLayer, "INFO: socket disconnected in %s", __func__));
     VerifyOrExit(!(aCond & (G_IO_ERR | G_IO_NVAL)), ChipLogProgress(DeviceLayer, "INFO: socket error in %s", __func__));
@@ -378,7 +378,7 @@ static void Bluez_gatt_characteristic1_complete_acquire_write_with_fd(GDBusMetho
     GUnixFDList * fd_list = g_unix_fd_list_new();
     int index;
 
-    index = g_unix_fd_list_append(fd_list, fd, NULL);
+    index = g_unix_fd_list_append(fd_list, fd, nullptr);
 
     g_dbus_method_invocation_return_value_with_unix_fd_list(invocation, g_variant_new("(@hq)", g_variant_new_handle(index), mtu),
                                                             fd_list);
@@ -397,13 +397,13 @@ static gboolean BluezCharacteristicAcquireWrite(BluezGattCharacteristic1 * aChar
     char * errStr;
     GVariantDict options;
     bool isSuccess         = false;
-    BluezConnection * conn = NULL;
+    BluezConnection * conn = nullptr;
 
     BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apClosure);
-    VerifyOrExit(endpoint != NULL, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
+    VerifyOrExit(endpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
 
     conn = GetBluezConnectionViaDevice(endpoint);
-    VerifyOrExit(conn != NULL,
+    VerifyOrExit(conn != nullptr,
                  g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "No Chipoble connection"));
 
     ChipLogProgress(DeviceLayer, "BluezCharacteristicAcquireWrite is called, conn: %p", conn);
@@ -430,7 +430,7 @@ static gboolean BluezCharacteristicAcquireWrite(BluezGattCharacteristic1 * aChar
     }
 
     channel = g_io_channel_unix_new(fds[0]);
-    g_io_channel_set_encoding(channel, NULL, NULL);
+    g_io_channel_set_encoding(channel, nullptr, nullptr);
     g_io_channel_set_close_on_unref(channel, TRUE);
     g_io_channel_set_buffered(channel, FALSE);
 
@@ -464,14 +464,14 @@ static gboolean BluezCharacteristicAcquireNotify(BluezGattCharacteristic1 * aCha
     GIOChannel * channel;
     char * errStr;
     GVariantDict options;
-    BluezConnection * conn = NULL;
+    BluezConnection * conn = nullptr;
     bool isSuccess         = false;
 
     BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apClosure);
-    VerifyOrExit(endpoint != NULL, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
+    VerifyOrExit(endpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
 
     conn = GetBluezConnectionViaDevice(endpoint);
-    VerifyOrExit(conn != NULL,
+    VerifyOrExit(conn != nullptr,
                  g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "No Chipoble connection"));
 
     g_variant_dict_init(&options, aOptions);
@@ -493,12 +493,12 @@ static gboolean BluezCharacteristicAcquireNotify(BluezGattCharacteristic1 * aCha
         SuccessOrExit(false);
     }
     channel = g_io_channel_unix_new(fds[0]);
-    g_io_channel_set_encoding(channel, NULL, NULL);
+    g_io_channel_set_encoding(channel, nullptr, nullptr);
     g_io_channel_set_close_on_unref(channel, TRUE);
     g_io_channel_set_buffered(channel, FALSE);
     conn->mC2Channel.mpChannel = channel;
     conn->mC2Channel.mWatch = g_io_add_watch_full(channel, G_PRIORITY_DEFAULT_IDLE, (GIOCondition)(G_IO_HUP | G_IO_ERR | G_IO_NVAL),
-                                                  bluezCharacteristicDestroyFD, conn, NULL);
+                                                  bluezCharacteristicDestroyFD, conn, nullptr);
 
     bluez_gatt_characteristic1_set_notify_acquired(aChar, TRUE);
 
@@ -527,13 +527,13 @@ static gboolean BluezCharacteristicStartNotify(BluezGattCharacteristic1 * aChar,
                                                gpointer apClosure)
 {
     bool isSuccess         = false;
-    BluezConnection * conn = NULL;
+    BluezConnection * conn = nullptr;
 
     BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apClosure);
-    VerifyOrExit(endpoint != NULL, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
+    VerifyOrExit(endpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
 
     conn = GetBluezConnectionViaDevice(endpoint);
-    VerifyOrExit(conn != NULL,
+    VerifyOrExit(conn != nullptr,
                  g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "No Chipoble connection"));
 
     if (bluez_gatt_characteristic1_get_notifying(aChar) == TRUE)
@@ -564,13 +564,13 @@ static gboolean BluezCharacteristicStopNotify(BluezGattCharacteristic1 * aChar, 
                                               gpointer apClosure)
 {
     bool isSuccess         = false;
-    BluezConnection * conn = NULL;
+    BluezConnection * conn = nullptr;
 
     BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apClosure);
-    VerifyOrExit(endpoint != NULL, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
+    VerifyOrExit(endpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
 
     conn = GetBluezConnectionViaDevice(endpoint);
-    VerifyOrExit(conn != NULL,
+    VerifyOrExit(conn != nullptr,
                  g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "No Chipoble connection"));
 
     if (bluez_gatt_characteristic1_get_notifying(aChar) == FALSE)
@@ -674,14 +674,14 @@ static uint16_t BluezUUIDStringToShortServiceID(const char * aService)
 static void BluezConnectionInit(BluezConnection * apConn)
 {
     // populate the service and the characteristics
-    GList * objects = NULL;
+    GList * objects = nullptr;
     GList * l;
-    BluezEndpoint * endpoint = NULL;
+    BluezEndpoint * endpoint = nullptr;
 
-    VerifyOrExit(apConn != NULL, ChipLogProgress(DeviceLayer, "Bluez connection is NULL in %s", __func__));
+    VerifyOrExit(apConn != nullptr, ChipLogProgress(DeviceLayer, "Bluez connection is NULL in %s", __func__));
 
     endpoint = apConn->mpEndpoint;
-    VerifyOrExit(endpoint != NULL, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
+    VerifyOrExit(endpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
 
     if (!endpoint->mIsCentral)
     {
@@ -693,12 +693,12 @@ static void BluezConnectionInit(BluezConnection * apConn)
     {
         objects = g_dbus_object_manager_get_objects(endpoint->mpObjMgr);
 
-        for (l = objects; l != NULL; l = l->next)
+        for (l = objects; l != nullptr; l = l->next)
         {
             BluezObject * object        = BLUEZ_OBJECT(l->data);
             BluezGattService1 * service = bluez_object_get_gatt_service1(object);
 
-            if (service != NULL)
+            if (service != nullptr)
             {
                 if ((BluezIsServiceOnDevice(service, apConn->mpDevice)) == TRUE &&
                     (strcmp(bluez_gatt_service1_get_uuid(service), CHIP_BLE_UUID_SERVICE_STRING) == 0))
@@ -710,14 +710,14 @@ static void BluezConnectionInit(BluezConnection * apConn)
             }
         }
 
-        VerifyOrExit(apConn->mpService != NULL, ChipLogProgress(DeviceLayer, "FAIL: NULL service in %s", __func__));
+        VerifyOrExit(apConn->mpService != nullptr, ChipLogProgress(DeviceLayer, "FAIL: NULL service in %s", __func__));
 
-        for (l = objects; l != NULL; l = l->next)
+        for (l = objects; l != nullptr; l = l->next)
         {
             BluezObject * object             = BLUEZ_OBJECT(l->data);
             BluezGattCharacteristic1 * char1 = bluez_object_get_gatt_characteristic1(object);
 
-            if (char1 != NULL)
+            if (char1 != nullptr)
             {
                 if ((BluezIsCharOnService(char1, apConn->mpService) == TRUE) &&
                     (strcmp(bluez_gatt_characteristic1_get_uuid(char1), CHIP_PLAT_BLE_UUID_C1_STRING) == 0))
@@ -733,19 +733,19 @@ static void BluezConnectionInit(BluezConnection * apConn)
                 {
                     g_object_unref(char1);
                 }
-                if ((apConn->mpC1 != NULL) && (apConn->mpC2 != NULL))
+                if ((apConn->mpC1 != nullptr) && (apConn->mpC2 != nullptr))
                 {
                     break;
                 }
             }
         }
 
-        VerifyOrExit(apConn->mpC1 != NULL, ChipLogProgress(DeviceLayer, "FAIL: NULL C1 in %s", __func__));
-        VerifyOrExit(apConn->mpC2 != NULL, ChipLogProgress(DeviceLayer, "FAIL: NULL C2 in %s", __func__));
+        VerifyOrExit(apConn->mpC1 != nullptr, ChipLogProgress(DeviceLayer, "FAIL: NULL C1 in %s", __func__));
+        VerifyOrExit(apConn->mpC2 != nullptr, ChipLogProgress(DeviceLayer, "FAIL: NULL C2 in %s", __func__));
     }
 
 exit:
-    if (objects != NULL)
+    if (objects != nullptr)
         g_list_free_full(objects, g_object_unref);
 }
 
@@ -811,20 +811,20 @@ static BluezGattCharacteristic1 * BluezCharacteristicCreate(BluezGattService1 * 
 
 static void BluezPeripheralRegisterAppDone(GObject * aObject, GAsyncResult * aResult, gpointer apClosure)
 {
-    GError * error              = NULL;
+    GError * error              = nullptr;
     BluezGattManager1 * gattMgr = BLUEZ_GATT_MANAGER1(aObject);
 
     gboolean success = bluez_gatt_manager1_call_register_application_finish(gattMgr, aResult, &error);
 
     VerifyOrExit(success == TRUE, ChipLogProgress(DeviceLayer, "FAIL: RegisterApplication : %s", error->message));
 
-    BLEManagerImpl::NotifyBLEPeripheralRegisterAppComplete(true, NULL);
+    BLEManagerImpl::NotifyBLEPeripheralRegisterAppComplete(true, nullptr);
     ChipLogProgress(DeviceLayer, "BluezPeripheralRegisterAppDone done");
 
 exit:
-    if (error != NULL)
+    if (error != nullptr)
     {
-        BLEManagerImpl::NotifyBLEPeripheralRegisterAppComplete(false, NULL);
+        BLEManagerImpl::NotifyBLEPeripheralRegisterAppComplete(false, nullptr);
         g_error_free(error);
     }
     return;
@@ -838,19 +838,19 @@ gboolean BluezPeripheralRegisterApp(void * apClosure)
     GVariant * options;
 
     BluezEndpoint * endpoint = (BluezEndpoint *) apClosure;
-    VerifyOrExit(endpoint->mpAdapter != NULL, ChipLogProgress(DeviceLayer, "FAIL: NULL endpoint->mpAdapter in %s", __func__));
+    VerifyOrExit(endpoint->mpAdapter != nullptr, ChipLogProgress(DeviceLayer, "FAIL: NULL endpoint->mpAdapter in %s", __func__));
 
     adapter = g_dbus_interface_get_object(G_DBUS_INTERFACE(endpoint->mpAdapter));
-    VerifyOrExit(adapter != NULL, ChipLogProgress(DeviceLayer, "FAIL: NULL adapter in %s", __func__));
+    VerifyOrExit(adapter != nullptr, ChipLogProgress(DeviceLayer, "FAIL: NULL adapter in %s", __func__));
 
     gattMgr = bluez_object_get_gatt_manager1(BLUEZ_OBJECT(adapter));
-    VerifyOrExit(gattMgr != NULL, ChipLogProgress(DeviceLayer, "FAIL: NULL gattMgr in %s", __func__));
+    VerifyOrExit(gattMgr != nullptr, ChipLogProgress(DeviceLayer, "FAIL: NULL gattMgr in %s", __func__));
 
     g_variant_builder_init(&optionsBuilder, G_VARIANT_TYPE("a{sv}"));
     options = g_variant_builder_end(&optionsBuilder);
 
-    bluez_gatt_manager1_call_register_application(gattMgr, endpoint->mpRootPath, options, NULL, BluezPeripheralRegisterAppDone,
-                                                  NULL);
+    bluez_gatt_manager1_call_register_application(gattMgr, endpoint->mpRootPath, options, nullptr, BluezPeripheralRegisterAppDone,
+                                                  nullptr);
 
 exit:
     return G_SOURCE_REMOVE;
@@ -875,7 +875,7 @@ static void BluezHandleAdvertisementFromDevice(BluezDevice1 * aDevice)
     char * debugStr;
 
     // service data is optional and may not be present
-    SuccessOrExit(serviceData != NULL);
+    SuccessOrExit(serviceData != nullptr);
 
     src = g_new0(BluezAddress, 1);
 
@@ -890,7 +890,7 @@ static void BluezHandleAdvertisementFromDevice(BluezDevice1 * aDevice)
     g_variant_iter_init(&iter, serviceData);
 
     len = 0;
-    while ((entry = g_variant_iter_next_value(&iter)) != NULL)
+    while ((entry = g_variant_iter_next_value(&iter)) != nullptr)
     {
         GVariant * key    = g_variant_get_child_value(entry, 0);
         GVariant * val    = g_variant_get_child_value(entry, 1);
@@ -914,7 +914,7 @@ static void BluezHandleAdvertisementFromDevice(BluezDevice1 * aDevice)
         buf[i++] = BLUEZ_ADV_TYPE_FLAGS;
         buf[i++] = BLUEZ_ADV_FLAGS_LE_DISCOVERABLE | BLUEZ_ADV_FLAGS_EDR_UNSUPPORTED;
         g_variant_iter_init(&iter, serviceData);
-        while ((entry = g_variant_iter_next_value(&iter)) != NULL)
+        while ((entry = g_variant_iter_next_value(&iter)) != nullptr)
         {
             GVariant * key    = g_variant_get_child_value(entry, 0);
             GVariant * val    = g_variant_get_child_value(entry, 1);
@@ -946,8 +946,8 @@ static void BluezSignalInterfacePropertiesChanged(GDBusObjectManagerClient * aMa
 {
 
     BluezEndpoint * endpoint = (BluezEndpoint *) apClosure;
-    VerifyOrExit(endpoint != NULL, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
-    VerifyOrExit(endpoint->mpAdapter != NULL, ChipLogProgress(DeviceLayer, "FAIL: NULL endpoint->mpAdapter in %s", __func__));
+    VerifyOrExit(endpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
+    VerifyOrExit(endpoint->mpAdapter != nullptr, ChipLogProgress(DeviceLayer, "FAIL: NULL endpoint->mpAdapter in %s", __func__));
 
     if (strcmp(g_dbus_proxy_get_interface_name(aInterface), DEVICE_INTERFACE) == 0)
     {
@@ -974,11 +974,11 @@ static void BluezSignalInterfacePropertiesChanged(GDBusObjectManagerClient * aMa
                         // for a central, the connection has been already allocated.  For a peripheral, it has not.
                         // todo do we need this ? we could handle all connection the same wa...
                         if (endpoint->mIsCentral)
-                            SuccessOrExit(conn != NULL);
+                            SuccessOrExit(conn != nullptr);
 
                         if (!endpoint->mIsCentral)
                         {
-                            VerifyOrExit(conn == NULL,
+                            VerifyOrExit(conn == nullptr,
                                          ChipLogProgress(DeviceLayer, "FAIL: connection already tracked: conn: %x device: %s", conn,
                                                          g_dbus_proxy_get_object_path(aInterface)));
                             conn                = g_new0(BluezConnection, 1);
@@ -1008,7 +1008,7 @@ static void BluezSignalInterfacePropertiesChanged(GDBusObjectManagerClient * aMa
                     gboolean resolved;
                     resolved = g_variant_get_boolean(value);
 
-                    if (endpoint->mIsCentral && conn != NULL && resolved == TRUE)
+                    if (endpoint->mIsCentral && conn != nullptr && resolved == TRUE)
                     {
                         /* delay to idle, this is to workaround race in handling
                          * of interface-added and properites-changed signals
@@ -1042,7 +1042,7 @@ exit:
 
 static void BluezHandleNewDevice(BluezDevice1 * device, BluezEndpoint * apEndpoint)
 {
-    VerifyOrExit(apEndpoint != NULL, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
+    VerifyOrExit(apEndpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
     if (apEndpoint->mIsCentral)
     {
         BluezHandleAdvertisementFromDevice(device);
@@ -1053,7 +1053,7 @@ static void BluezHandleNewDevice(BluezDevice1 * device, BluezEndpoint * apEndpoi
         SuccessOrExit(bluez_device1_get_connected(device));
 
         conn = (BluezConnection *) g_hash_table_lookup(apEndpoint->mpConnMap, g_dbus_proxy_get_object_path(G_DBUS_PROXY(device)));
-        VerifyOrExit(conn == NULL,
+        VerifyOrExit(conn == nullptr,
                      ChipLogProgress(DeviceLayer, "FAIL: connection already tracked: conn: %x new device: %s", conn,
                                      g_dbus_proxy_get_object_path(G_DBUS_PROXY(device))));
 
@@ -1078,7 +1078,7 @@ static void BluezSignalOnObjectAdded(GDBusObjectManager * aManager, GDBusObject 
     BluezObject * o          = BLUEZ_OBJECT(aObject);
     BluezDevice1 * device    = bluez_object_get_device1(o);
     BluezEndpoint * endpoint = (BluezEndpoint *) apClosure;
-    if (device != NULL)
+    if (device != nullptr)
     {
         if (BluezIsDeviceOnAdapter(device, endpoint->mpAdapter) == TRUE)
         {
@@ -1121,29 +1121,29 @@ static BluezGattService1 * BluezServiceCreate(gpointer apClosure)
 
 static void bluezObjectsSetup(BluezEndpoint * apEndpoint)
 {
-    GList * objects = NULL;
+    GList * objects = nullptr;
     GList * l;
-    char * expectedPath = NULL;
+    char * expectedPath = nullptr;
 
-    VerifyOrExit(apEndpoint != NULL, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
+    VerifyOrExit(apEndpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
 
     expectedPath = g_strdup_printf("%s/hci%d", BLUEZ_PATH, apEndpoint->mNodeId);
     objects      = g_dbus_object_manager_get_objects(apEndpoint->mpObjMgr);
 
-    for (l = objects; l != NULL && apEndpoint->mpAdapter == NULL; l = l->next)
+    for (l = objects; l != nullptr && apEndpoint->mpAdapter == nullptr; l = l->next)
     {
         BluezObject * object = BLUEZ_OBJECT(l->data);
         GList * interfaces;
         GList * ll;
         interfaces = g_dbus_object_get_interfaces(G_DBUS_OBJECT(object));
 
-        for (ll = interfaces; ll != NULL; ll = ll->next)
+        for (ll = interfaces; ll != nullptr; ll = ll->next)
         {
             if (BLUEZ_IS_ADAPTER1(ll->data))
             { // we found the adapter
                 BluezAdapter1 * adapter = BLUEZ_ADAPTER1(ll->data);
                 char * addr             = (char *) bluez_adapter1_get_address(adapter);
-                if (apEndpoint->mpAdapterAddr == NULL) // no adapter address provided, bind to the hci indicated by nodeid
+                if (apEndpoint->mpAdapterAddr == nullptr) // no adapter address provided, bind to the hci indicated by nodeid
                 {
                     if (strcmp(g_dbus_proxy_get_object_path(G_DBUS_PROXY(adapter)), expectedPath) == 0)
                     {
@@ -1161,7 +1161,8 @@ static void bluezObjectsSetup(BluezEndpoint * apEndpoint)
         }
         g_list_free_full(interfaces, g_object_unref);
     }
-    VerifyOrExit(apEndpoint->mpAdapter != NULL, ChipLogProgress(DeviceLayer, "FAIL: NULL apEndpoint->mpAdapter in %s", __func__));
+    VerifyOrExit(apEndpoint->mpAdapter != nullptr,
+                 ChipLogProgress(DeviceLayer, "FAIL: NULL apEndpoint->mpAdapter in %s", __func__));
     bluez_adapter1_set_powered(apEndpoint->mpAdapter, TRUE);
 
     // with BLE we are discoverable only when advertising so this can be
@@ -1257,57 +1258,57 @@ exit:
 
 void EndpointCleanup(BluezEndpoint * apEndpoint)
 {
-    if (apEndpoint != NULL)
+    if (apEndpoint != nullptr)
     {
-        if (apEndpoint->mpOwningName != NULL)
+        if (apEndpoint->mpOwningName != nullptr)
         {
             g_free(apEndpoint->mpOwningName);
-            apEndpoint->mpOwningName = NULL;
+            apEndpoint->mpOwningName = nullptr;
         }
-        if (apEndpoint->mpAdapterName != NULL)
+        if (apEndpoint->mpAdapterName != nullptr)
         {
             g_free(apEndpoint->mpAdapterName);
-            apEndpoint->mpAdapterName = NULL;
+            apEndpoint->mpAdapterName = nullptr;
         }
-        if (apEndpoint->mpAdapterAddr != NULL)
+        if (apEndpoint->mpAdapterAddr != nullptr)
         {
             g_free(apEndpoint->mpAdapterAddr);
-            apEndpoint->mpAdapterAddr = NULL;
+            apEndpoint->mpAdapterAddr = nullptr;
         }
-        if (apEndpoint->mpRootPath != NULL)
+        if (apEndpoint->mpRootPath != nullptr)
         {
             g_free(apEndpoint->mpRootPath);
-            apEndpoint->mpRootPath = NULL;
+            apEndpoint->mpRootPath = nullptr;
         }
-        if (apEndpoint->mpAdvPath != NULL)
+        if (apEndpoint->mpAdvPath != nullptr)
         {
             g_free(apEndpoint->mpAdvPath);
-            apEndpoint->mpAdvPath = NULL;
+            apEndpoint->mpAdvPath = nullptr;
         }
-        if (apEndpoint->mpServicePath != NULL)
+        if (apEndpoint->mpServicePath != nullptr)
         {
             g_free(apEndpoint->mpServicePath);
-            apEndpoint->mpServicePath = NULL;
+            apEndpoint->mpServicePath = nullptr;
         }
-        if (apEndpoint->mpConnMap != NULL)
+        if (apEndpoint->mpConnMap != nullptr)
         {
             g_hash_table_destroy(apEndpoint->mpConnMap);
-            apEndpoint->mpConnMap = NULL;
+            apEndpoint->mpConnMap = nullptr;
         }
-        if (apEndpoint->mpAdvertisingUUID != NULL)
+        if (apEndpoint->mpAdvertisingUUID != nullptr)
         {
             g_free(apEndpoint->mpAdvertisingUUID);
-            apEndpoint->mpAdvertisingUUID = NULL;
+            apEndpoint->mpAdvertisingUUID = nullptr;
         }
-        if (apEndpoint->mpChipServiceData != NULL)
+        if (apEndpoint->mpChipServiceData != nullptr)
         {
             g_free(apEndpoint->mpChipServiceData);
-            apEndpoint->mpChipServiceData = NULL;
+            apEndpoint->mpChipServiceData = nullptr;
         }
-        if (apEndpoint->mpPeerDevicePath != NULL)
+        if (apEndpoint->mpPeerDevicePath != nullptr)
         {
             g_free(apEndpoint->mpPeerDevicePath);
-            apEndpoint->mpPeerDevicePath = NULL;
+            apEndpoint->mpPeerDevicePath = nullptr;
         }
 
         g_free(apEndpoint);
@@ -1323,11 +1324,11 @@ void BluezObjectsCleanup(BluezEndpoint * apEndpoint)
 static void BluezPeripheralObjectsSetup(gpointer apClosure)
 {
 
-    static const char * const c1_flags[] = { "write", NULL };
-    static const char * const c2_flags[] = { "read", "indicate", NULL };
+    static const char * const c1_flags[] = { "write", nullptr };
+    static const char * const c2_flags[] = { "read", "indicate", nullptr };
 
     BluezEndpoint * endpoint = (BluezEndpoint *) apClosure;
-    VerifyOrExit(endpoint != NULL, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
+    VerifyOrExit(endpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
 
     endpoint->mpService = BluezServiceCreate(apClosure);
     // C1 characteristic
@@ -1364,7 +1365,7 @@ exit:
 static void BluezOnBusAcquired(GDBusConnection * aConn, const gchar * aName, gpointer apClosure)
 {
     BluezEndpoint * endpoint = (BluezEndpoint *) apClosure;
-    VerifyOrExit(endpoint != NULL, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
+    VerifyOrExit(endpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
 
     ChipLogProgress(DeviceLayer, "TRACE: Bus acquired for name %s", aName);
 
@@ -1392,15 +1393,15 @@ static void BluezOnNameLost(GDBusConnection * aConn, const gchar * aName, gpoint
 static void * BluezMainLoop(void * apClosure)
 {
     GDBusObjectManager * manager;
-    GError * error           = NULL;
-    GDBusConnection * conn   = NULL;
+    GError * error           = nullptr;
+    GDBusConnection * conn   = nullptr;
     BluezEndpoint * endpoint = (BluezEndpoint *) apClosure;
-    VerifyOrExit(endpoint != NULL, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
+    VerifyOrExit(endpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
 
-    conn = g_bus_get_sync(G_BUS_TYPE_SYSTEM, NULL, &error);
-    VerifyOrExit(conn != NULL, ChipLogProgress(DeviceLayer, "FAIL: get bus sync in %s, error: %s", __func__, error->message));
+    conn = g_bus_get_sync(G_BUS_TYPE_SYSTEM, nullptr, &error);
+    VerifyOrExit(conn != nullptr, ChipLogProgress(DeviceLayer, "FAIL: get bus sync in %s, error: %s", __func__, error->message));
 
-    if (endpoint->mpAdapterName != NULL)
+    if (endpoint->mpAdapterName != nullptr)
         endpoint->mpOwningName = g_strdup_printf("%s", endpoint->mpAdapterName);
     else
         endpoint->mpOwningName = g_strdup_printf("C-%04x", getpid() & 0xffff);
@@ -1409,9 +1410,9 @@ static void * BluezMainLoop(void * apClosure)
 
     manager = g_dbus_object_manager_client_new_sync(
         conn, G_DBUS_OBJECT_MANAGER_CLIENT_FLAGS_NONE, BLUEZ_INTERFACE, "/", bluez_object_manager_client_get_proxy_type,
-        NULL /* unused user data in the Proxy Type Func */, NULL /*destroy notify */, NULL /* cancellable */, &error);
+        nullptr /* unused user data in the Proxy Type Func */, nullptr /*destroy notify */, nullptr /* cancellable */, &error);
 
-    VerifyOrExit(manager != NULL, ChipLogProgress(DeviceLayer, "FAIL: Error getting object manager client: %s", error->message));
+    VerifyOrExit(manager != nullptr, ChipLogProgress(DeviceLayer, "FAIL: Error getting object manager client: %s", error->message));
 
     endpoint->mpObjMgr = manager;
 
@@ -1435,65 +1436,65 @@ static void * BluezMainLoop(void * apClosure)
     BluezObjectsCleanup(endpoint);
 
 exit:
-    if (error != NULL)
+    if (error != nullptr)
         g_error_free(error);
-    return NULL;
+    return nullptr;
 }
 
 bool BluezRunOnBluezThread(int (*aCallback)(void *), void * apClosure)
 {
-    GMainContext * context = NULL;
-    const char * msg       = NULL;
+    GMainContext * context = nullptr;
+    const char * msg       = nullptr;
 
-    VerifyOrExit(sBluezMainLoop != NULL, msg = "FAIL: NULL sBluezMainLoop");
+    VerifyOrExit(sBluezMainLoop != nullptr, msg = "FAIL: NULL sBluezMainLoop");
     VerifyOrExit(g_main_loop_is_running(sBluezMainLoop), msg = "FAIL: sBluezMainLoop not running");
 
     context = g_main_loop_get_context(sBluezMainLoop);
-    VerifyOrExit(context != NULL, msg = "FAIL: NULL main context");
+    VerifyOrExit(context != nullptr, msg = "FAIL: NULL main context");
     g_main_context_invoke(context, aCallback, apClosure);
 
 exit:
-    if (msg != NULL)
+    if (msg != nullptr)
     {
         ChipLogProgress(DeviceLayer, "%s in %s", msg, __func__);
     }
 
-    return msg == NULL;
+    return msg == nullptr;
 }
 
 static gboolean BluezC2Indicate(void * apClosure)
 {
-    ConnectionDataBundle * closure = NULL;
-    BluezConnection * conn         = NULL;
-    GError * error                 = NULL;
+    ConnectionDataBundle * closure = nullptr;
+    BluezConnection * conn         = nullptr;
+    GError * error                 = nullptr;
     GIOStatus status;
     const char * buf;
     size_t len, written;
 
     closure = static_cast<ConnectionDataBundle *>(apClosure);
-    VerifyOrExit(closure != NULL, ChipLogProgress(DeviceLayer, "ConnectionDataBundle is NULL in %s", __func__));
+    VerifyOrExit(closure != nullptr, ChipLogProgress(DeviceLayer, "ConnectionDataBundle is NULL in %s", __func__));
 
     conn = closure->mpConn;
-    VerifyOrExit(conn != NULL, ChipLogProgress(DeviceLayer, "BluezConnection is NULL in %s", __func__));
-    VerifyOrExit(conn->mpC2 != NULL, ChipLogProgress(DeviceLayer, "FAIL: C2 Indicate: %s", "NULL C2"));
+    VerifyOrExit(conn != nullptr, ChipLogProgress(DeviceLayer, "BluezConnection is NULL in %s", __func__));
+    VerifyOrExit(conn->mpC2 != nullptr, ChipLogProgress(DeviceLayer, "FAIL: C2 Indicate: %s", "NULL C2"));
 
     if (bluez_gatt_characteristic1_get_notify_acquired(conn->mpC2) == TRUE)
     {
         buf    = (char *) g_variant_get_fixed_array(closure->mpVal, &len, sizeof(uint8_t));
         status = g_io_channel_write_chars(conn->mC2Channel.mpChannel, buf, len, &written, &error);
         g_variant_unref(closure->mpVal);
-        closure->mpVal = NULL;
+        closure->mpVal = nullptr;
 
         VerifyOrExit(status == G_IO_STATUS_NORMAL, ChipLogProgress(DeviceLayer, "FAIL: C2 Indicate: %s", error->message));
     }
     else
     {
         bluez_gatt_characteristic1_set_value(conn->mpC2, closure->mpVal);
-        closure->mpVal = NULL;
+        closure->mpVal = nullptr;
     }
 
 exit:
-    if (closure != NULL)
+    if (closure != nullptr)
     {
         if (closure->mpVal)
         {
@@ -1502,7 +1503,7 @@ exit:
         g_free(closure);
     }
 
-    if (error != NULL)
+    if (error != nullptr)
         g_error_free(error);
     return G_SOURCE_REMOVE;
 }
@@ -1510,12 +1511,12 @@ exit:
 bool SendBluezIndication(void * apConn, chip::System::PacketBuffer * apBuf)
 {
     ConnectionDataBundle * closure;
-    const char * msg = NULL;
+    const char * msg = nullptr;
     bool success     = false;
-    uint8_t * buffer = NULL;
+    uint8_t * buffer = nullptr;
     size_t len       = 0;
 
-    VerifyOrExit(apBuf != NULL, ChipLogProgress(DeviceLayer, "apBuf is NULL in %s", __func__));
+    VerifyOrExit(apBuf != nullptr, ChipLogProgress(DeviceLayer, "apBuf is NULL in %s", __func__));
     buffer = apBuf->Start();
     len    = apBuf->DataLength();
 
@@ -1527,12 +1528,12 @@ bool SendBluezIndication(void * apConn, chip::System::PacketBuffer * apBuf)
     success = BluezRunOnBluezThread(BluezC2Indicate, closure);
 
 exit:
-    if (NULL != msg)
+    if (nullptr != msg)
     {
         ChipLogError(Ble, msg);
     }
 
-    if (NULL != apBuf)
+    if (nullptr != apBuf)
     {
         chip::System::PacketBuffer::Free(apBuf);
     }
@@ -1543,19 +1544,19 @@ exit:
 static gboolean BluezDisconnect(void * apClosure)
 {
     BluezConnection * conn = static_cast<BluezConnection *>(apClosure);
-    GError * error         = NULL;
+    GError * error         = nullptr;
     gboolean success;
 
-    VerifyOrExit(conn != NULL, ChipLogProgress(DeviceLayer, "conn is NULL in %s", __func__));
-    VerifyOrExit(conn->mpDevice != NULL, ChipLogProgress(DeviceLayer, "FAIL: Disconnect: %s", "NULL Device"));
+    VerifyOrExit(conn != nullptr, ChipLogProgress(DeviceLayer, "conn is NULL in %s", __func__));
+    VerifyOrExit(conn->mpDevice != nullptr, ChipLogProgress(DeviceLayer, "FAIL: Disconnect: %s", "NULL Device"));
 
     ChipLogProgress(DeviceLayer, "%s peer=%s", __func__, bluez_device1_get_address(conn->mpDevice));
 
-    success = bluez_device1_call_disconnect_sync(conn->mpDevice, NULL, &error);
+    success = bluez_device1_call_disconnect_sync(conn->mpDevice, nullptr, &error);
     VerifyOrExit(success == TRUE, ChipLogProgress(DeviceLayer, "FAIL: Disconnect: %s", error->message));
 
 exit:
-    if (error != NULL)
+    if (error != nullptr)
         g_error_free(error);
     return G_SOURCE_REMOVE;
 }
@@ -1617,10 +1618,10 @@ CHIP_ERROR BluezGattsAppRegister(void * apAppState)
 
 CHIP_ERROR ConfigureBluezAdv(BLEAdvConfig & aBleAdvConfig, BluezEndpoint * apEndpoint)
 {
-    const char * msg = NULL;
+    const char * msg = nullptr;
     CHIP_ERROR err   = CHIP_NO_ERROR;
-    VerifyOrExit(aBleAdvConfig.mpBleName != NULL, msg = "FAIL: BLE name is NULL");
-    VerifyOrExit(aBleAdvConfig.mpAdvertisingUUID != NULL, msg = "FAIL: BLE mpAdvertisingUUID is NULL in %s");
+    VerifyOrExit(aBleAdvConfig.mpBleName != nullptr, msg = "FAIL: BLE name is NULL");
+    VerifyOrExit(aBleAdvConfig.mpAdvertisingUUID != nullptr, msg = "FAIL: BLE mpAdvertisingUUID is NULL in %s");
 
     apEndpoint->mpAdapterName                             = g_strdup(aBleAdvConfig.mpBleName);
     apEndpoint->mpAdvertisingUUID                         = g_strdup(aBleAdvConfig.mpAdvertisingUUID);
@@ -1639,14 +1640,14 @@ CHIP_ERROR ConfigureBluezAdv(BLEAdvConfig & aBleAdvConfig, BluezEndpoint * apEnd
     apEndpoint->mDuration                                 = aBleAdvConfig.mDuration;
 
 exit:
-    if (NULL != msg)
+    if (nullptr != msg)
     {
         ChipLogProgress(DeviceLayer, "%s in %s", msg, __func__);
         err = CHIP_ERROR_INCORRECT_STATE;
-        if (apEndpoint->mpChipServiceData != NULL)
+        if (apEndpoint->mpChipServiceData != nullptr)
         {
             g_free(apEndpoint->mpChipServiceData);
-            apEndpoint->mpChipServiceData = NULL;
+            apEndpoint->mpChipServiceData = nullptr;
         }
     }
     return err;
@@ -1658,18 +1659,18 @@ CHIP_ERROR InitBluezBleLayer(bool aIsCentral, char * apBleAddr, BLEAdvConfig & a
     bool retval    = false;
     int pthreadErr = 0;
     int tmpErrno;
-    BluezEndpoint * endpoint = NULL;
+    BluezEndpoint * endpoint = nullptr;
 
     VerifyOrExit(pipe2(sBluezFD, O_DIRECT) == 0, ChipLogProgress(DeviceLayer, "FAIL: open pipe in %s", __func__));
 
     // initialize server endpoint
     endpoint = g_new0(BluezEndpoint, 1);
-    VerifyOrExit(endpoint != NULL, ChipLogProgress(DeviceLayer, "FAIL: memory allocation in %s", __func__));
+    VerifyOrExit(endpoint != nullptr, ChipLogProgress(DeviceLayer, "FAIL: memory allocation in %s", __func__));
 
-    if (apBleAddr != NULL)
+    if (apBleAddr != nullptr)
         endpoint->mpAdapterAddr = g_strdup(apBleAddr);
     else
-        endpoint->mpAdapterAddr = NULL;
+        endpoint->mpAdapterAddr = nullptr;
 
     endpoint->mpConnMap  = g_hash_table_new(g_str_hash, g_str_equal);
     endpoint->mIsCentral = aIsCentral;
@@ -1677,10 +1678,10 @@ CHIP_ERROR InitBluezBleLayer(bool aIsCentral, char * apBleAddr, BLEAdvConfig & a
     err = ConfigureBluezAdv(aBleAdvConfig, endpoint);
     SuccessOrExit(err);
 
-    sBluezMainLoop = g_main_loop_new(NULL, FALSE);
-    VerifyOrExit(sBluezMainLoop != NULL, ChipLogProgress(DeviceLayer, "FAIL: memory alloc in %s", __func__));
+    sBluezMainLoop = g_main_loop_new(nullptr, FALSE);
+    VerifyOrExit(sBluezMainLoop != nullptr, ChipLogProgress(DeviceLayer, "FAIL: memory alloc in %s", __func__));
 
-    pthreadErr = pthread_create(&sBluezThread, NULL, BluezMainLoop, endpoint);
+    pthreadErr = pthread_create(&sBluezThread, nullptr, BluezMainLoop, endpoint);
     tmpErrno   = errno;
     VerifyOrExit(pthreadErr == 0, ChipLogProgress(DeviceLayer, "FAIL: pthread_create (%s) in %s", strerror(tmpErrno), __func__));
     sleep(1);

--- a/src/platform/Linux/CHIPLinuxStorage.cpp
+++ b/src/platform/Linux/CHIPLinuxStorage.cpp
@@ -199,7 +199,7 @@ CHIP_ERROR ChipLinuxStorage::WriteValueBin(const char * key, const uint8_t * dat
     static const size_t kMaxBlobSize = 5 * 1024;
 
     CHIP_ERROR retval         = CHIP_NO_ERROR;
-    char * encodedData        = NULL;
+    char * encodedData        = nullptr;
     size_t encodedDataLen     = 0;
     size_t expectedEncodedLen = ((dataLen + 3) * 4) / 3;
 
@@ -214,7 +214,7 @@ CHIP_ERROR ChipLinuxStorage::WriteValueBin(const char * key, const uint8_t * dat
     if (retval == CHIP_NO_ERROR)
     {
         encodedData = (char *) chip::Platform::MemoryAlloc(expectedEncodedLen + 1);
-        if (encodedData == NULL)
+        if (encodedData == nullptr)
         {
             retval = CHIP_ERROR_NO_MEMORY;
         }

--- a/src/platform/Linux/CHIPLinuxStorageIni.cpp
+++ b/src/platform/Linux/CHIPLinuxStorageIni.cpp
@@ -271,7 +271,7 @@ CHIP_ERROR ChipLinuxStorageIni::GetBinaryBlobDataAndLengths(const char * key, ch
 CHIP_ERROR ChipLinuxStorageIni::GetBinaryBlobValue(const char * key, uint8_t * decodedData, size_t bufSize, size_t & decodedDataLen)
 {
     CHIP_ERROR retval  = CHIP_NO_ERROR;
-    char * encodedData = NULL;
+    char * encodedData = nullptr;
     size_t encodedDataLen;
     size_t expectedDecodedLen = 0;
 
@@ -328,7 +328,7 @@ CHIP_ERROR ChipLinuxStorageIni::AddEntry(const char * key, const char * value)
 {
     CHIP_ERROR retval = CHIP_NO_ERROR;
 
-    if ((key != NULL) && (value != NULL))
+    if ((key != nullptr) && (value != nullptr))
     {
         std::map<std::string, std::string> & section = mConfigStore.sections["DEFAULT"];
         section[key]                                 = std::string(value);

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -67,13 +67,13 @@ CHIP_ERROR ConnectivityManagerImpl::_Init()
     mConnectivityFlag            = 0;
     mWpaSupplicant.state         = GDBusWpaSupplicant::INIT;
     mWpaSupplicant.scanState     = GDBusWpaSupplicant::WIFI_SCANNING_IDLE;
-    mWpaSupplicant.proxy         = NULL;
-    mWpaSupplicant.iface         = NULL;
-    mWpaSupplicant.interfacePath = NULL;
-    mWpaSupplicant.networkPath   = NULL;
+    mWpaSupplicant.proxy         = nullptr;
+    mWpaSupplicant.iface         = nullptr;
+    mWpaSupplicant.interfacePath = nullptr;
+    mWpaSupplicant.networkPath   = nullptr;
 
     wpa_fi_w1_wpa_supplicant1_proxy_new_for_bus(G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName,
-                                                kWpaSupplicantObjectPath, NULL, _OnWpaProxyReady, NULL);
+                                                kWpaSupplicantObjectPath, nullptr, _OnWpaProxyReady, nullptr);
 #endif
 
     SuccessOrExit(err);
@@ -108,7 +108,7 @@ bool ConnectivityManagerImpl::_HaveIPv6InternetConnectivity(void)
 bool ConnectivityManagerImpl::_IsWiFiStationConnected(void)
 {
     bool ret            = false;
-    const gchar * state = NULL;
+    const gchar * state = nullptr;
 
     if (mWpaSupplicant.state != GDBusWpaSupplicant::WPA_INTERFACE_CONNECTED)
     {
@@ -138,16 +138,16 @@ bool ConnectivityManagerImpl::_CanStartWiFiScan()
 
 void ConnectivityManagerImpl::_OnWpaInterfaceProxyReady(GObject * source_object, GAsyncResult * res, gpointer user_data)
 {
-    GError * err                            = NULL;
+    GError * err                            = nullptr;
     WpaFiW1Wpa_supplicant1Interface * iface = wpa_fi_w1_wpa_supplicant1_interface_proxy_new_for_bus_finish(res, &err);
 
     if (mWpaSupplicant.iface)
     {
         g_object_unref(mWpaSupplicant.iface);
-        mWpaSupplicant.iface = NULL;
+        mWpaSupplicant.iface = nullptr;
     }
 
-    if (iface != NULL && err == NULL)
+    if (iface != nullptr && err == nullptr)
     {
         mWpaSupplicant.iface = iface;
         mWpaSupplicant.state = GDBusWpaSupplicant::WPA_INTERFACE_CONNECTED;
@@ -161,13 +161,13 @@ void ConnectivityManagerImpl::_OnWpaInterfaceProxyReady(GObject * source_object,
         mWpaSupplicant.state = GDBusWpaSupplicant::WPA_NOT_CONNECTED;
     }
 
-    if (err != NULL)
+    if (err != nullptr)
         g_error_free(err);
 }
 
 void ConnectivityManagerImpl::_OnWpaInterfaceReady(GObject * source_object, GAsyncResult * res, gpointer user_data)
 {
-    GError * err = NULL;
+    GError * err = nullptr;
 
     gboolean result =
         wpa_fi_w1_wpa_supplicant1_call_get_interface_finish(mWpaSupplicant.proxy, &mWpaSupplicant.interfacePath, res, &err);
@@ -177,7 +177,8 @@ void ConnectivityManagerImpl::_OnWpaInterfaceReady(GObject * source_object, GAsy
         ChipLogProgress(DeviceLayer, "wpa_supplicant: WiFi interface: %s", mWpaSupplicant.interfacePath);
 
         wpa_fi_w1_wpa_supplicant1_interface_proxy_new_for_bus(G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName,
-                                                              mWpaSupplicant.interfacePath, NULL, _OnWpaInterfaceProxyReady, NULL);
+                                                              mWpaSupplicant.interfacePath, nullptr, _OnWpaInterfaceProxyReady,
+                                                              nullptr);
     }
     else
     {
@@ -189,11 +190,11 @@ void ConnectivityManagerImpl::_OnWpaInterfaceReady(GObject * source_object, GAsy
         if (mWpaSupplicant.interfacePath)
         {
             g_free(mWpaSupplicant.interfacePath);
-            mWpaSupplicant.interfacePath = NULL;
+            mWpaSupplicant.interfacePath = nullptr;
         }
     }
 
-    if (err != NULL)
+    if (err != nullptr)
         g_error_free(err);
 }
 
@@ -210,14 +211,15 @@ void ConnectivityManagerImpl::_OnWpaInterfaceAdded(WpaFiW1Wpa_supplicant1 * prox
         ChipLogProgress(DeviceLayer, "wpa_supplicant: WiFi interface added: %s", mWpaSupplicant.interfacePath);
 
         wpa_fi_w1_wpa_supplicant1_interface_proxy_new_for_bus(G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName,
-                                                              mWpaSupplicant.interfacePath, NULL, _OnWpaInterfaceProxyReady, NULL);
+                                                              mWpaSupplicant.interfacePath, nullptr, _OnWpaInterfaceProxyReady,
+                                                              nullptr);
     }
 }
 
 void ConnectivityManagerImpl::_OnWpaInterfaceRemoved(WpaFiW1Wpa_supplicant1 * proxy, const gchar * path, GVariant * properties,
                                                      gpointer user_data)
 {
-    if (mWpaSupplicant.interfacePath == NULL)
+    if (mWpaSupplicant.interfacePath == nullptr)
         return;
 
     if (g_strcmp0(mWpaSupplicant.interfacePath, path) == 0)
@@ -229,13 +231,13 @@ void ConnectivityManagerImpl::_OnWpaInterfaceRemoved(WpaFiW1Wpa_supplicant1 * pr
         if (mWpaSupplicant.interfacePath)
         {
             g_free(mWpaSupplicant.interfacePath);
-            mWpaSupplicant.interfacePath = NULL;
+            mWpaSupplicant.interfacePath = nullptr;
         }
 
         if (mWpaSupplicant.iface)
         {
             g_object_unref(mWpaSupplicant.iface);
-            mWpaSupplicant.iface = NULL;
+            mWpaSupplicant.iface = nullptr;
         }
 
         mWpaSupplicant.scanState = GDBusWpaSupplicant::WIFI_SCANNING_IDLE;
@@ -244,10 +246,10 @@ void ConnectivityManagerImpl::_OnWpaInterfaceRemoved(WpaFiW1Wpa_supplicant1 * pr
 
 void ConnectivityManagerImpl::_OnWpaProxyReady(GObject * source_object, GAsyncResult * res, gpointer user_data)
 {
-    GError * err = NULL;
+    GError * err = nullptr;
 
     mWpaSupplicant.proxy = wpa_fi_w1_wpa_supplicant1_proxy_new_for_bus_finish(res, &err);
-    if (mWpaSupplicant.proxy != NULL && err == NULL)
+    if (mWpaSupplicant.proxy != nullptr && err == nullptr)
     {
         mWpaSupplicant.state = GDBusWpaSupplicant::WPA_CONNECTED;
         ChipLogProgress(DeviceLayer, "wpa_supplicant: connected to wpa_supplicant proxy");
@@ -256,8 +258,8 @@ void ConnectivityManagerImpl::_OnWpaProxyReady(GObject * source_object, GAsyncRe
 
         g_signal_connect(mWpaSupplicant.proxy, "interface-removed", G_CALLBACK(_OnWpaInterfaceRemoved), NULL);
 
-        wpa_fi_w1_wpa_supplicant1_call_get_interface(mWpaSupplicant.proxy, CHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME, NULL,
-                                                     _OnWpaInterfaceReady, NULL);
+        wpa_fi_w1_wpa_supplicant1_call_get_interface(mWpaSupplicant.proxy, CHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME, nullptr,
+                                                     _OnWpaInterfaceReady, nullptr);
     }
     else
     {
@@ -266,7 +268,7 @@ void ConnectivityManagerImpl::_OnWpaProxyReady(GObject * source_object, GAsyncRe
         mWpaSupplicant.state = GDBusWpaSupplicant::WPA_NOT_CONNECTED;
     }
 
-    if (err != NULL)
+    if (err != nullptr)
         g_error_free(err);
 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WPA

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -49,9 +49,9 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     CHIP_ERROR err;
 
 #if CHIP_WITH_GIO
-    GError * error = NULL;
+    GError * error = nullptr;
 
-    this->mpGDBusConnection = UniqueGDBusConnection(g_bus_get_sync(G_BUS_TYPE_SYSTEM, NULL, &error));
+    this->mpGDBusConnection = UniqueGDBusConnection(g_bus_get_sync(G_BUS_TYPE_SYSTEM, nullptr, &error));
 
     std::thread gdbusThread(GDBus_Thread);
     gdbusThread.detach();

--- a/src/platform/Linux/PosixConfig.cpp
+++ b/src/platform/Linux/PosixConfig.cpp
@@ -87,7 +87,7 @@ ChipLinuxStorage * PosixConfig::GetStorageForNamespace(Key key)
     if (strcmp(key.Namespace, kConfigNamespace_ChipCounters) == 0)
         return &gChipLinuxCountersStorage;
 
-    return NULL;
+    return nullptr;
 }
 
 CHIP_ERROR PosixConfig::Init()
@@ -103,7 +103,7 @@ CHIP_ERROR PosixConfig::ReadConfigValue(Key key, bool & val)
     uint32_t intVal;
 
     storage = GetStorageForNamespace(key);
-    VerifyOrExit(storage != NULL, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
+    VerifyOrExit(storage != nullptr, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
 
     err = storage->ReadValue(key.Name, intVal);
     if (err == CHIP_ERROR_KEY_NOT_FOUND)
@@ -124,7 +124,7 @@ CHIP_ERROR PosixConfig::ReadConfigValue(Key key, uint32_t & val)
     ChipLinuxStorage * storage;
 
     storage = GetStorageForNamespace(key);
-    VerifyOrExit(storage != NULL, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
+    VerifyOrExit(storage != nullptr, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
 
     err = storage->ReadValue(key.Name, val);
     if (err == CHIP_ERROR_KEY_NOT_FOUND)
@@ -143,7 +143,7 @@ CHIP_ERROR PosixConfig::ReadConfigValue(Key key, uint64_t & val)
     ChipLinuxStorage * storage;
 
     storage = GetStorageForNamespace(key);
-    VerifyOrExit(storage != NULL, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
+    VerifyOrExit(storage != nullptr, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
 
     // Special case the MfrDeviceId value, optionally allowing it to be read as a blob containing
     // a 64-bit big-endian integer, instead of a u64 value.
@@ -178,7 +178,7 @@ CHIP_ERROR PosixConfig::ReadConfigValueStr(Key key, char * buf, size_t bufSize, 
     ChipLinuxStorage * storage;
 
     storage = GetStorageForNamespace(key);
-    VerifyOrExit(storage != NULL, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
+    VerifyOrExit(storage != nullptr, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
 
     err = storage->ReadValueStr(key.Name, buf, bufSize, outLen);
     if (err == CHIP_ERROR_KEY_NOT_FOUND)
@@ -188,7 +188,7 @@ CHIP_ERROR PosixConfig::ReadConfigValueStr(Key key, char * buf, size_t bufSize, 
     }
     else if (err == CHIP_ERROR_BUFFER_TOO_SMALL)
     {
-        err = (buf == NULL) ? CHIP_NO_ERROR : CHIP_ERROR_BUFFER_TOO_SMALL;
+        err = (buf == nullptr) ? CHIP_NO_ERROR : CHIP_ERROR_BUFFER_TOO_SMALL;
     }
     SuccessOrExit(err);
 
@@ -202,7 +202,7 @@ CHIP_ERROR PosixConfig::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSiz
     ChipLinuxStorage * storage;
 
     storage = GetStorageForNamespace(key);
-    VerifyOrExit(storage != NULL, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
+    VerifyOrExit(storage != nullptr, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
 
     err = storage->ReadValueBin(key.Name, buf, bufSize, outLen);
     if (err == CHIP_ERROR_KEY_NOT_FOUND)
@@ -212,7 +212,7 @@ CHIP_ERROR PosixConfig::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSiz
     }
     else if (err == CHIP_ERROR_BUFFER_TOO_SMALL)
     {
-        err = (buf == NULL) ? CHIP_NO_ERROR : CHIP_ERROR_BUFFER_TOO_SMALL;
+        err = (buf == nullptr) ? CHIP_NO_ERROR : CHIP_ERROR_BUFFER_TOO_SMALL;
     }
     SuccessOrExit(err);
 
@@ -226,7 +226,7 @@ CHIP_ERROR PosixConfig::WriteConfigValue(Key key, bool val)
     ChipLinuxStorage * storage;
 
     storage = GetStorageForNamespace(key);
-    VerifyOrExit(storage != NULL, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
+    VerifyOrExit(storage != nullptr, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
 
     err = storage->WriteValue(key.Name, val ? true : false);
     SuccessOrExit(err);
@@ -247,7 +247,7 @@ CHIP_ERROR PosixConfig::WriteConfigValue(Key key, uint32_t val)
     ChipLinuxStorage * storage;
 
     storage = GetStorageForNamespace(key);
-    VerifyOrExit(storage != NULL, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
+    VerifyOrExit(storage != nullptr, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
 
     err = storage->WriteValue(key.Name, val);
     SuccessOrExit(err);
@@ -268,7 +268,7 @@ CHIP_ERROR PosixConfig::WriteConfigValue(Key key, uint64_t val)
     ChipLinuxStorage * storage;
 
     storage = GetStorageForNamespace(key);
-    VerifyOrExit(storage != NULL, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
+    VerifyOrExit(storage != nullptr, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
 
     err = storage->WriteValue(key.Name, val);
     SuccessOrExit(err);
@@ -288,10 +288,10 @@ CHIP_ERROR PosixConfig::WriteConfigValueStr(Key key, const char * str)
     CHIP_ERROR err;
     ChipLinuxStorage * storage;
 
-    if (str != NULL)
+    if (str != nullptr)
     {
         storage = GetStorageForNamespace(key);
-        VerifyOrExit(storage != NULL, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
+        VerifyOrExit(storage != nullptr, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
 
         err = storage->WriteValueStr(key.Name, str);
         SuccessOrExit(err);
@@ -316,18 +316,18 @@ exit:
 CHIP_ERROR PosixConfig::WriteConfigValueStr(Key key, const char * str, size_t strLen)
 {
     CHIP_ERROR err;
-    char * strCopy = NULL;
+    char * strCopy = nullptr;
 
-    if (str != NULL)
+    if (str != nullptr)
     {
         strCopy = strndup(str, strLen);
-        VerifyOrExit(strCopy != NULL, err = CHIP_ERROR_NO_MEMORY);
+        VerifyOrExit(strCopy != nullptr, err = CHIP_ERROR_NO_MEMORY);
     }
 
     err = PosixConfig::WriteConfigValueStr(key, strCopy);
 
 exit:
-    if (strCopy != NULL)
+    if (strCopy != nullptr)
     {
         free(strCopy);
     }
@@ -339,10 +339,10 @@ CHIP_ERROR PosixConfig::WriteConfigValueBin(Key key, const uint8_t * data, size_
     CHIP_ERROR err;
     ChipLinuxStorage * storage;
 
-    if (data != NULL)
+    if (data != nullptr)
     {
         storage = GetStorageForNamespace(key);
-        VerifyOrExit(storage != NULL, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
+        VerifyOrExit(storage != nullptr, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
 
         err = storage->WriteValueBin(key.Name, data, dataLen);
         SuccessOrExit(err);
@@ -369,7 +369,7 @@ CHIP_ERROR PosixConfig::ClearConfigValue(Key key)
     ChipLinuxStorage * storage;
 
     storage = GetStorageForNamespace(key);
-    VerifyOrExit(storage != NULL, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
+    VerifyOrExit(storage != nullptr, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
 
     err = storage->ClearValue(key.Name);
     if (err == CHIP_ERROR_KEY_NOT_FOUND)
@@ -393,7 +393,7 @@ bool PosixConfig::ConfigValueExists(Key key)
     ChipLinuxStorage * storage;
 
     storage = GetStorageForNamespace(key);
-    if (storage == NULL)
+    if (storage == nullptr)
         return false;
 
     return storage->HasValue(key.Name);
@@ -402,7 +402,7 @@ bool PosixConfig::ConfigValueExists(Key key)
 CHIP_ERROR PosixConfig::EnsureNamespace(const char * ns)
 {
     CHIP_ERROR err             = CHIP_NO_ERROR;
-    ChipLinuxStorage * storage = NULL;
+    ChipLinuxStorage * storage = nullptr;
 
     if (strcmp(ns, kConfigNamespace_ChipFactory) == 0)
     {
@@ -429,7 +429,7 @@ exit:
 CHIP_ERROR PosixConfig::ClearNamespace(const char * ns)
 {
     CHIP_ERROR err             = CHIP_NO_ERROR;
-    ChipLinuxStorage * storage = NULL;
+    ChipLinuxStorage * storage = nullptr;
 
     if (strcmp(ns, kConfigNamespace_ChipConfig) == 0)
     {
@@ -440,7 +440,7 @@ CHIP_ERROR PosixConfig::ClearNamespace(const char * ns)
         storage = &gChipLinuxCountersStorage;
     }
 
-    VerifyOrExit(storage != NULL, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
+    VerifyOrExit(storage != nullptr, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
 
     err = storage->ClearAll();
     if (err != CHIP_NO_ERROR)
@@ -467,7 +467,7 @@ CHIP_ERROR PosixConfig::FactoryResetConfig(void)
     ChipLogProgress(DeviceLayer, "Performing factory reset");
 
     storage = &gChipLinuxConfigStorage;
-    if (storage == NULL)
+    if (storage == nullptr)
     {
         ChipLogError(DeviceLayer, "Storage get failed");
         err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;

--- a/src/platform/Linux/SystemTimeSupport.cpp
+++ b/src/platform/Linux/SystemTimeSupport.cpp
@@ -61,7 +61,7 @@ uint64_t GetClock_MonotonicHiRes(void)
 System::Error GetClock_RealTime(uint64_t & curTime)
 {
     struct timeval tv;
-    int res = gettimeofday(&tv, NULL);
+    int res = gettimeofday(&tv, nullptr);
     if (res != 0)
     {
         return MapErrorPOSIX(errno);
@@ -77,7 +77,7 @@ System::Error GetClock_RealTime(uint64_t & curTime)
 System::Error GetClock_RealTimeMS(uint64_t & curTime)
 {
     struct timeval tv;
-    int res = gettimeofday(&tv, NULL);
+    int res = gettimeofday(&tv, nullptr);
     if (res != 0)
     {
         return MapErrorPOSIX(errno);
@@ -95,7 +95,7 @@ System::Error SetClock_RealTime(uint64_t newCurTime)
     struct timeval tv;
     tv.tv_sec  = static_cast<time_t>(newCurTime / UINT64_C(1000000));
     tv.tv_usec = static_cast<long>(newCurTime % UINT64_C(1000000));
-    int res    = settimeofday(&tv, NULL);
+    int res    = settimeofday(&tv, nullptr);
     if (res != 0)
     {
         return (errno == EPERM) ? CHIP_SYSTEM_ERROR_ACCESS_DENIED : MapErrorPOSIX(errno);

--- a/src/platform/tests/TestConfigurationMgr.cpp
+++ b/src/platform/tests/TestConfigurationMgr.cpp
@@ -424,10 +424,10 @@ static const nlTest sTests[] = {
 
 int TestConfigurationMgr(void)
 {
-    nlTestSuite theSuite = { "CHIP DeviceLayer time tests", &sTests[0], NULL, NULL };
+    nlTestSuite theSuite = { "CHIP DeviceLayer time tests", &sTests[0], nullptr, nullptr };
 
     // Run test suit againt one context.
-    nlTestRunner(&theSuite, NULL);
+    nlTestRunner(&theSuite, nullptr);
     return nlTestRunnerStats(&theSuite);
 }
 

--- a/src/platform/tests/TestPlatformMgr.cpp
+++ b/src/platform/tests/TestPlatformMgr.cpp
@@ -102,9 +102,9 @@ static const nlTest sTests[] = {
 
 int TestPlatformMgr(void)
 {
-    nlTestSuite theSuite = { "CHIP DeviceLayer time tests", &sTests[0], NULL, NULL };
+    nlTestSuite theSuite = { "CHIP DeviceLayer time tests", &sTests[0], nullptr, nullptr };
 
     // Run test suit againt one context.
-    nlTestRunner(&theSuite, NULL);
+    nlTestRunner(&theSuite, nullptr);
     return nlTestRunnerStats(&theSuite);
 }

--- a/src/platform/tests/TestPlatformTime.cpp
+++ b/src/platform/tests/TestPlatformTime.cpp
@@ -81,7 +81,7 @@ void test_os_sleep_ms(uint64_t millisecs)
     sleep_time.tv_sec  = s;
     sleep_time.tv_nsec = millisecs * 1000000;
 
-    nanosleep(&sleep_time, NULL);
+    nanosleep(&sleep_time, nullptr);
 }
 
 void test_os_sleep_us(uint64_t microsecs)
@@ -93,7 +93,7 @@ void test_os_sleep_us(uint64_t microsecs)
     sleep_time.tv_sec  = s;
     sleep_time.tv_nsec = microsecs * 1000;
 
-    nanosleep(&sleep_time, NULL);
+    nanosleep(&sleep_time, nullptr);
 }
 
 // =================================
@@ -204,10 +204,10 @@ static const nlTest sTests[] = {
 
 int TestPlatformTime(void)
 {
-    nlTestSuite theSuite = { "CHIP DeviceLayer tests", &sTests[0], NULL, NULL };
+    nlTestSuite theSuite = { "CHIP DeviceLayer tests", &sTests[0], nullptr, nullptr };
 
     // Run test suit againt one context.
-    nlTestRunner(&theSuite, NULL);
+    nlTestRunner(&theSuite, nullptr);
     return nlTestRunnerStats(&theSuite);
 }
 

--- a/src/qrcodetool/qrcodetool.cpp
+++ b/src/qrcodetool/qrcodetool.cpp
@@ -30,8 +30,8 @@ static int match_command(const char * command_name, const char * name)
 
 static int help(int argc, char ** argv)
 {
-    qrcodetool_command_t * cmd = NULL;
-    for (cmd = commands; cmd->c_name != NULL; cmd++)
+    qrcodetool_command_t * cmd = nullptr;
+    for (cmd = commands; cmd->c_name != nullptr; cmd++)
     {
         ChipLogDetail(chipTool, "%s\t%s\n", cmd->c_name, cmd->c_help);
     }
@@ -44,7 +44,7 @@ static int usage(const char * prog_name)
                   "Usage: %s [-h] [command] [opt ...]\n"
                   "%s commands are:\n",
                   prog_name, prog_name);
-    help(0, NULL);
+    help(0, nullptr);
     return 2;
 }
 
@@ -54,7 +54,7 @@ static int execute_command(int argc, char ** argv)
     {
         return -1;
     }
-    const qrcodetool_command_t * command_to_execute = NULL;
+    const qrcodetool_command_t * command_to_execute = nullptr;
     bool found                                      = false;
 
     for (command_to_execute = commands; command_to_execute->c_name; command_to_execute++)
@@ -73,7 +73,7 @@ static int execute_command(int argc, char ** argv)
     }
     else
     {
-        return help(0, NULL);
+        return help(0, nullptr);
     }
 }
 
@@ -109,7 +109,7 @@ int main(int argc, char ** argv)
     if (do_help)
     {
         /* Munge argc/argv so that argv[0] is something. */
-        result = help(0, NULL);
+        result = help(0, nullptr);
     }
     else if (argc > 0)
     {

--- a/src/qrcodetool/setup_payload_commands.cpp
+++ b/src/qrcodetool/setup_payload_commands.cpp
@@ -38,7 +38,7 @@ static std::string _extractFilePath(int argc, char * const * argv)
         return path;
     }
     int ch;
-    const char * filePath = NULL;
+    const char * filePath = nullptr;
 
     while ((ch = getopt(argc, argv, "f:")) != -1)
     {

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -227,7 +227,7 @@ CHIP_ERROR QRCodeSetupPayloadGenerator::payloadBase41Representation(string & bas
 {
     // 6.1.2.2. Table: Packed Binary Data Structure
     // The TLV Data should be 0 length if TLV is not included.
-    return payloadBase41Representation(base41Representation, NULL, 0);
+    return payloadBase41Representation(base41Representation, nullptr, 0);
 }
 
 CHIP_ERROR QRCodeSetupPayloadGenerator::payloadBase41Representation(string & base41Representation, uint8_t * tlvDataStart,

--- a/src/setup_payload/tests/TestManualCode.cpp
+++ b/src/setup_payload/tests/TestManualCode.cpp
@@ -543,8 +543,8 @@ int TestManualSetupCode(void)
     {
         "chip-manual-code-general-Tests",
         &sTests[0],
-        NULL,
-        NULL
+        nullptr,
+        nullptr
     };
     // clang-format on
     TestContext context;

--- a/src/setup_payload/tests/TestQRCode.cpp
+++ b/src/setup_payload/tests/TestQRCode.cpp
@@ -339,8 +339,8 @@ int TestQuickResponseCode(void)
     {
         "chip-qrcode-general-tests",
         &sTests[0],
-        NULL,
-        NULL
+        nullptr,
+        nullptr
     };
     // clang-format on
     TestContext context;

--- a/src/setup_payload/tests/TestQRCodeTLV.cpp
+++ b/src/setup_payload/tests/TestQRCodeTLV.cpp
@@ -292,8 +292,8 @@ int TestQRCodeTLV(void)
     {
         "chip-qrcode-optional-info-tests",
         &sTests[0],
-        NULL,
-        NULL
+        nullptr,
+        nullptr
     };
     // clang-format on
     TestContext context;

--- a/src/system/SystemError.cpp
+++ b/src/system/SystemError.cpp
@@ -104,7 +104,7 @@ namespace System {
  */
 void RegisterLayerErrorFormatter(void)
 {
-    static ErrorFormatter sSystemLayerErrorFormatter = { FormatLayerError, NULL };
+    static ErrorFormatter sSystemLayerErrorFormatter = { FormatLayerError, nullptr };
 
     RegisterErrorFormatter(&sSystemLayerErrorFormatter);
 }
@@ -123,7 +123,7 @@ void RegisterLayerErrorFormatter(void)
  */
 bool FormatLayerError(char * buf, uint16_t bufSize, int32_t err)
 {
-    const char * desc = NULL;
+    const char * desc = nullptr;
 
     if (err < CHIP_SYSTEM_ERROR_MIN || err > CHIP_SYSTEM_ERROR_MAX)
     {
@@ -214,7 +214,7 @@ DLL_EXPORT bool IsErrorPOSIX(Error aError)
  */
 void RegisterPOSIXErrorFormatter(void)
 {
-    static ErrorFormatter sPOSIXErrorFormatter = { FormatPOSIXError, NULL };
+    static ErrorFormatter sPOSIXErrorFormatter = { FormatPOSIXError, nullptr };
 
     RegisterErrorFormatter(&sPOSIXErrorFormatter);
 }

--- a/src/system/SystemLayer.cpp
+++ b/src/system/SystemLayer.cpp
@@ -86,7 +86,7 @@ void LwIPEventHandlerDelegate::Prepend(const LwIPEventHandlerDelegate *& aDelega
 }
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
-Layer::Layer() : mLayerState(kLayerState_NotInitialized), mContext(NULL), mPlatformData(NULL)
+Layer::Layer() : mLayerState(kLayerState_NotInitialized), mContext(nullptr), mPlatformData(nullptr)
 {
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     if (!sSystemEventHandlerDelegate.IsInitialized())
@@ -161,13 +161,13 @@ Error Layer::Shutdown()
     {
         Timer * lTimer = Timer::sPool.Get(*this, i);
 
-        if (lTimer != NULL)
+        if (lTimer != nullptr)
         {
             lTimer->Cancel();
         }
     }
 
-    this->mContext    = NULL;
+    this->mContext    = nullptr;
     this->mLayerState = kLayerState_NotInitialized;
 
 exit:
@@ -199,7 +199,7 @@ void Layer::SetPlatformData(void * aPlatformData)
 
 Error Layer::NewTimer(Timer *& aTimerPtr)
 {
-    Timer * lTimer = NULL;
+    Timer * lTimer = nullptr;
 
     if (this->State() != kLayerState_Initialized)
         return CHIP_SYSTEM_ERROR_UNEXPECTED_STATE;
@@ -207,7 +207,7 @@ Error Layer::NewTimer(Timer *& aTimerPtr)
     lTimer    = Timer::sPool.TryCreate(*this);
     aTimerPtr = lTimer;
 
-    if (lTimer == NULL)
+    if (lTimer == nullptr)
     {
         ChipLogError(chipSystemLayer, "Timer pool EMPTY");
         return CHIP_SYSTEM_ERROR_NO_MEMORY;
@@ -325,7 +325,7 @@ void Layer::CancelTimer(Layer::TimerCompleteFunct aOnComplete, void * aAppState)
     {
         Timer * lTimer = Timer::sPool.Get(*this, i);
 
-        if (lTimer != NULL && lTimer->OnComplete == aOnComplete && lTimer->AppState == aAppState)
+        if (lTimer != nullptr && lTimer->OnComplete == aOnComplete && lTimer->AppState == aAppState)
         {
             lTimer->Cancel();
             break;
@@ -605,7 +605,7 @@ void Layer::PrepareSelect(int & aSetSize, fd_set * aReadSet, fd_set * aWriteSet,
     {
         Timer * lTimer = Timer::sPool.Get(*this, i);
 
-        if (lTimer != NULL)
+        if (lTimer != nullptr)
         {
             if (!Timer::IsEarlierEpoch(kCurrentEpoch, lTimer->mAwakenEpoch))
             {
@@ -689,7 +689,7 @@ void Layer::HandleSelectResult(int aSetSize, fd_set * aReadSet, fd_set * aWriteS
     {
         Timer * lTimer = Timer::sPool.Get(*this, i);
 
-        if (lTimer != NULL && !Timer::IsEarlierEpoch(kCurrentEpoch, lTimer->mAwakenEpoch))
+        if (lTimer != nullptr && !Timer::IsEarlierEpoch(kCurrentEpoch, lTimer->mAwakenEpoch))
         {
             lTimer->HandleComplete();
         }

--- a/src/system/SystemMutex.cpp
+++ b/src/system/SystemMutex.cpp
@@ -49,7 +49,7 @@ namespace System {
 #if CHIP_SYSTEM_CONFIG_POSIX_LOCKING
 DLL_EXPORT Error Mutex::Init(Mutex & aThis)
 {
-    int lSysError = pthread_mutex_init(&aThis.mPOSIXMutex, NULL);
+    int lSysError = pthread_mutex_init(&aThis.mPOSIXMutex, nullptr);
     Error lError;
 
     switch (lSysError)

--- a/src/system/SystemObject.cpp
+++ b/src/system/SystemObject.cpp
@@ -51,7 +51,7 @@ DLL_EXPORT void Object::Release(void)
 
     if (oldCount == 1)
     {
-        this->mSystemLayer = NULL;
+        this->mSystemLayer = nullptr;
         __sync_synchronize();
     }
     else if (oldCount == 0)
@@ -64,10 +64,10 @@ DLL_EXPORT bool Object::TryCreate(Layer & aLayer, size_t aOctets)
 {
     bool lReturn = false;
 
-    if (__sync_bool_compare_and_swap(&this->mSystemLayer, NULL, &aLayer))
+    if (__sync_bool_compare_and_swap(&this->mSystemLayer, nullptr, &aLayer))
     {
         this->mRefCount = 0;
-        this->AppState  = NULL;
+        this->AppState  = nullptr;
         memset(reinterpret_cast<char *>(this) + sizeof(*this), 0, aOctets - sizeof(*this));
 
         this->Retain();

--- a/src/system/SystemObject.h
+++ b/src/system/SystemObject.h
@@ -211,14 +211,14 @@ inline size_t ObjectPool<T, N>::Size(void)
 template <class T, unsigned int N>
 inline T * ObjectPool<T, N>::Get(const Layer & aLayer, size_t aIndex)
 {
-    T * lReturn = NULL;
+    T * lReturn = nullptr;
 
     if (aIndex < N)
         lReturn = &reinterpret_cast<T *>(mArena.uMemory)[aIndex];
 
     (void) static_cast<Object *>(lReturn); /* In C++-11, this would be a static_assert that T inherits Object. */
 
-    return (lReturn != NULL) && lReturn->IsRetained(aLayer) ? lReturn : NULL;
+    return (lReturn != nullptr) && lReturn->IsRetained(aLayer) ? lReturn : nullptr;
 }
 
 /**
@@ -228,7 +228,7 @@ inline T * ObjectPool<T, N>::Get(const Layer & aLayer, size_t aIndex)
 template <class T, unsigned int N>
 inline T * ObjectPool<T, N>::TryCreate(Layer & aLayer)
 {
-    T * lReturn = NULL;
+    T * lReturn = nullptr;
     unsigned int lIndex;
 #if CHIP_SYSTEM_CONFIG_PROVIDE_STATISTICS
     unsigned int lNumInUse = 0;
@@ -246,7 +246,7 @@ inline T * ObjectPool<T, N>::TryCreate(Layer & aLayer)
     }
 
 #if CHIP_SYSTEM_CONFIG_PROVIDE_STATISTICS
-    if (lReturn != NULL)
+    if (lReturn != nullptr)
     {
         lIndex++;
         lNumInUse = lIndex;
@@ -293,7 +293,7 @@ inline void ObjectPool<T, N>::GetNumObjectsInUse(unsigned int aStartIndex, unsig
     {
         T & lObject = reinterpret_cast<T *>(mArena.uMemory)[lIndex];
 
-        if (lObject.mSystemLayer != NULL)
+        if (lObject.mSystemLayer != nullptr)
         {
             count++;
         }

--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -173,7 +173,7 @@ void PacketBuffer::SetDataLength(uint16_t aNewLen, PacketBuffer * aChainHead)
     this->len     = aNewLen;
     this->tot_len = (uint16_t)(this->tot_len + lDelta);
 
-    while (aChainHead != NULL && aChainHead != this)
+    while (aChainHead != nullptr && aChainHead != this)
     {
         aChainHead->tot_len = static_cast<uint16_t>(aChainHead->tot_len + lDelta);
         aChainHead          = static_cast<PacketBuffer *>(aChainHead->next);
@@ -242,7 +242,7 @@ void PacketBuffer::AddToEnd(PacketBuffer * aPacket)
     while (true)
     {
         lCursor->tot_len += aPacket->tot_len;
-        if (lCursor->next == NULL)
+        if (lCursor->next == nullptr)
         {
             lCursor->next = aPacket;
             break;
@@ -263,7 +263,7 @@ PacketBuffer * PacketBuffer::DetachTail()
 {
     PacketBuffer & lReturn = *static_cast<PacketBuffer *>(this->next);
 
-    this->next    = NULL;
+    this->next    = nullptr;
     this->tot_len = this->len;
 
     return &lReturn;
@@ -289,7 +289,7 @@ void PacketBuffer::CompactHead()
 
     uint16_t lAvailLength = this->AvailableDataLength();
 
-    while (lAvailLength > 0 && this->next != NULL)
+    while (lAvailLength > 0 && this->next != nullptr)
     {
         PacketBuffer & lNextPacket = *static_cast<PacketBuffer *>(this->next);
         VerifyOrDieWithMsg(lNextPacket.ref == 1, chipSystemLayer, "next buffer %p is not exclusive to this chain", &lNextPacket);
@@ -343,7 +343,7 @@ PacketBuffer * PacketBuffer::Consume(uint16_t aConsumeLength)
 {
     PacketBuffer * lPacket = this;
 
-    while (lPacket != NULL && aConsumeLength > 0)
+    while (lPacket != nullptr && aConsumeLength > 0)
     {
         const uint16_t kLength = lPacket->DataLength();
 
@@ -452,12 +452,12 @@ PacketBuffer * PacketBuffer::NewWithAvailableSize(uint16_t aReservedSize, size_t
     const size_t lBlockSize    = CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE + lAllocSize;
     PacketBuffer * lPacket;
 
-    CHIP_SYSTEM_FAULT_INJECT(FaultInjection::kFault_PacketBufferNew, return NULL);
+    CHIP_SYSTEM_FAULT_INJECT(FaultInjection::kFault_PacketBufferNew, return nullptr);
 
     if (lAllocSize > CHIP_SYSTEM_CONFIG_PACKETBUFFER_CAPACITY_MAX)
     {
         ChipLogError(chipSystemLayer, "PacketBuffer: allocation too large.");
-        return NULL;
+        return nullptr;
     }
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
@@ -474,7 +474,7 @@ PacketBuffer * PacketBuffer::NewWithAvailableSize(uint16_t aReservedSize, size_t
     LOCK_BUF_POOL();
 
     lPacket = sFreeList;
-    if (lPacket != NULL)
+    if (lPacket != nullptr)
     {
         sFreeList = static_cast<PacketBuffer *>(lPacket->next);
         SYSTEM_STATS_INCREMENT(chip::System::Stats::kSystemLayer_NumPacketBufs);
@@ -490,15 +490,15 @@ PacketBuffer * PacketBuffer::NewWithAvailableSize(uint16_t aReservedSize, size_t
 #endif // !CHIP_SYSTEM_CONFIG_PACKETBUFFER_MAXALLOC
 #endif // !CHIP_SYSTEM_CONFIG_USE_LWIP
 
-    if (lPacket == NULL)
+    if (lPacket == nullptr)
     {
         ChipLogError(chipSystemLayer, "PacketBuffer: pool EMPTY.");
-        return NULL;
+        return nullptr;
     }
 
     lPacket->payload = reinterpret_cast<uint8_t *>(lPacket) + CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE + lReservedSize;
     lPacket->len = lPacket->tot_len = 0;
-    lPacket->next                   = NULL;
+    lPacket->next                   = nullptr;
     lPacket->ref                    = 1;
 #if CHIP_SYSTEM_CONFIG_PACKETBUFFER_MAXALLOC == 0
     lPacket->alloc_size = lAllocSize;
@@ -585,7 +585,7 @@ void PacketBuffer::Free(PacketBuffer * aPacket)
 
     LOCK_BUF_POOL();
 
-    while (aPacket != NULL)
+    while (aPacket != nullptr)
     {
         PacketBuffer * lNextPacket = static_cast<PacketBuffer *>(aPacket->next);
 
@@ -606,7 +606,7 @@ void PacketBuffer::Free(PacketBuffer * aPacket)
         }
         else
         {
-            aPacket = NULL;
+            aPacket = nullptr;
         }
     }
 
@@ -642,7 +642,7 @@ void PacketBuffer::Clear(void)
 PacketBuffer * PacketBuffer::FreeHead(PacketBuffer * aPacket)
 {
     PacketBuffer * lNextPacket = static_cast<PacketBuffer *>(aPacket->next);
-    aPacket->next              = NULL;
+    aPacket->next              = nullptr;
     PacketBuffer::Free(aPacket);
     return lNextPacket;
 }
@@ -674,7 +674,7 @@ PacketBuffer * PacketBuffer::RightSize(PacketBuffer * aPacket)
 
 PacketBuffer * PacketBuffer::BuildFreeList()
 {
-    PacketBuffer * lHead = NULL;
+    PacketBuffer * lHead = nullptr;
 
     for (int i = 0; i < CHIP_SYSTEM_CONFIG_PACKETBUFFER_MAXALLOC; i++)
     {

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -99,7 +99,7 @@ public:
     void SetStart(uint8_t * aNewStart);
 
     uint16_t DataLength(void) const;
-    void SetDataLength(uint16_t aNewLen, PacketBuffer * aChainHead = NULL);
+    void SetDataLength(uint16_t aNewLen, PacketBuffer * aChainHead = nullptr);
 
     uint16_t TotalLength(void) const;
 

--- a/src/system/SystemTimer.cpp
+++ b/src/system/SystemTimer.cpp
@@ -130,7 +130,7 @@ Error Timer::Start(uint32_t aDelayMilliseconds, OnCompleteFunct aOnComplete, voi
 
     this->AppState     = aAppState;
     this->mAwakenEpoch = Timer::GetCurrentEpoch() + static_cast<Epoch>(aDelayMilliseconds);
-    if (!__sync_bool_compare_and_swap(&this->OnComplete, NULL, aOnComplete))
+    if (!__sync_bool_compare_and_swap(&this->OnComplete, nullptr, aOnComplete))
     {
         chipDie();
     }
@@ -183,7 +183,7 @@ Error Timer::ScheduleWork(OnCompleteFunct aOnComplete, void * aAppState)
 
     this->AppState     = aAppState;
     this->mAwakenEpoch = Timer::GetCurrentEpoch();
-    if (!__sync_bool_compare_and_swap(&this->OnComplete, NULL, aOnComplete))
+    if (!__sync_bool_compare_and_swap(&this->OnComplete, nullptr, aOnComplete))
     {
         chipDie();
     }
@@ -211,12 +211,12 @@ Error Timer::Cancel()
     OnCompleteFunct lOnComplete = this->OnComplete;
 
     // Check if the timer is armed
-    VerifyOrExit(lOnComplete != NULL, );
+    VerifyOrExit(lOnComplete != nullptr, );
     // Atomically disarm if the value has not changed
-    VerifyOrExit(__sync_bool_compare_and_swap(&this->OnComplete, lOnComplete, NULL), );
+    VerifyOrExit(__sync_bool_compare_and_swap(&this->OnComplete, lOnComplete, nullptr), );
 
     // Since this thread changed the state of OnComplete, release the timer.
-    this->AppState = NULL;
+    this->AppState = nullptr;
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     if (lLayer.mTimerList)
@@ -261,16 +261,16 @@ void Timer::HandleComplete()
     void * lAppState                  = this->AppState;
 
     // Check if timer is armed
-    VerifyOrExit(lOnComplete != NULL, );
+    VerifyOrExit(lOnComplete != nullptr, );
     // Atomically disarm if the value has not changed.
-    VerifyOrExit(__sync_bool_compare_and_swap(&this->OnComplete, lOnComplete, NULL), );
+    VerifyOrExit(__sync_bool_compare_and_swap(&this->OnComplete, lOnComplete, nullptr), );
 
     // Since this thread changed the state of OnComplete, release the timer.
-    AppState = NULL;
+    AppState = nullptr;
     this->Release();
 
     // Invoke the app's callback, if it's still valid.
-    if (lOnComplete != NULL)
+    if (lOnComplete != nullptr)
         lOnComplete(&lLayer, lAppState, CHIP_SYSTEM_NO_ERROR);
 
 exit:

--- a/src/system/tests/TestSystemErrorStr.cpp
+++ b/src/system/tests/TestSystemErrorStr.cpp
@@ -80,12 +80,12 @@ static void CheckSystemErrorStr(nlTestSuite * inSuite, void * inContext)
 
         // Assert that the error string contains the error number in hex.
         snprintf(expectedText, sizeof(expectedText), "%08" PRIX32, err);
-        NL_TEST_ASSERT(inSuite, (strstr(errStr, expectedText) != NULL));
+        NL_TEST_ASSERT(inSuite, (strstr(errStr, expectedText) != nullptr));
 
 #if !CHIP_CONFIG_SHORT_ERROR_STR
         // Assert that the error string contains a description, which is signaled
         // by a presence of a colon proceeding the description.
-        NL_TEST_ASSERT(inSuite, (strchr(errStr, ':') != NULL));
+        NL_TEST_ASSERT(inSuite, (strchr(errStr, ':') != nullptr));
 #endif // !CHIP_CONFIG_SHORT_ERROR_STR
     }
 }
@@ -110,8 +110,8 @@ int TestSystemErrorStr(void)
 	{
         "System-Error-Strings",
         &sTests[0],
-        NULL,
-        NULL
+        nullptr,
+        nullptr
     };
     // clang-format on
 

--- a/src/system/tests/TestSystemObject.cpp
+++ b/src/system/tests/TestSystemObject.cpp
@@ -150,8 +150,8 @@ void TestObject::CheckRetention(nlTestSuite * inSuite, void * aContext)
     {
         TestObject * lCreated = sPool.TryCreate(lLayer);
 
-        NL_TEST_ASSERT(lContext.mTestSuite, lCreated != NULL);
-        if (lCreated == NULL)
+        NL_TEST_ASSERT(lContext.mTestSuite, lCreated != nullptr);
+        if (lCreated == nullptr)
             continue;
         NL_TEST_ASSERT(lContext.mTestSuite, lCreated->IsRetained(lLayer));
         NL_TEST_ASSERT(lContext.mTestSuite, &(lCreated->SystemLayer()) == &lLayer);
@@ -164,11 +164,11 @@ void TestObject::CheckRetention(nlTestSuite * inSuite, void * aContext)
 
             if (j > i)
             {
-                NL_TEST_ASSERT(lContext.mTestSuite, lGotten == NULL);
+                NL_TEST_ASSERT(lContext.mTestSuite, lGotten == nullptr);
             }
             else
             {
-                NL_TEST_ASSERT(lContext.mTestSuite, lGotten != NULL);
+                NL_TEST_ASSERT(lContext.mTestSuite, lGotten != nullptr);
                 lGotten->Retain();
             }
         }
@@ -178,7 +178,7 @@ void TestObject::CheckRetention(nlTestSuite * inSuite, void * aContext)
     {
         TestObject * lGotten = sPool.Get(lLayer, i);
 
-        NL_TEST_ASSERT(lContext.mTestSuite, lGotten != NULL);
+        NL_TEST_ASSERT(lContext.mTestSuite, lGotten != nullptr);
 
         for (j = kPoolSize; j > i; --j)
         {
@@ -195,7 +195,7 @@ void TestObject::CheckRetention(nlTestSuite * inSuite, void * aContext)
     {
         TestObject * lGotten = sPool.Get(lLayer, i);
 
-        NL_TEST_ASSERT(lContext.mTestSuite, lGotten == NULL);
+        NL_TEST_ASSERT(lContext.mTestSuite, lGotten == nullptr);
     }
 
     lLayer.Shutdown();
@@ -224,7 +224,7 @@ void TestObject::Delay(volatile unsigned int & aAccumulator)
 void * TestObject::CheckConcurrencyThread(void * aContext)
 {
     const unsigned int kNumObjects = kPoolSize / kNumThreads;
-    TestObject * lObject           = NULL;
+    TestObject * lObject           = nullptr;
     TestContext & lContext         = *static_cast<TestContext *>(aContext);
     Layer lLayer;
     unsigned int i;
@@ -235,7 +235,7 @@ void * TestObject::CheckConcurrencyThread(void * aContext)
 
     for (i = 0; i < kNumObjects; ++i)
     {
-        while (lObject == NULL)
+        while (lObject == nullptr)
         {
             lObject = sPool.TryCreate(lLayer);
         }
@@ -252,7 +252,7 @@ void * TestObject::CheckConcurrencyThread(void * aContext)
 
     lObject = sPool.Get(lLayer, kPoolSize - 1);
 
-    if (lObject != NULL)
+    if (lObject != nullptr)
     {
         lObject->Release();
         NL_TEST_ASSERT(lContext.mTestSuite, !lObject->IsRetained(lLayer));
@@ -265,8 +265,8 @@ void * TestObject::CheckConcurrencyThread(void * aContext)
     {
         unsigned int j;
 
-        lObject = NULL;
-        while (lObject == NULL)
+        lObject = nullptr;
+        while (lObject == nullptr)
         {
             lObject = sPool.TryCreate(lLayer);
         }
@@ -278,12 +278,12 @@ void * TestObject::CheckConcurrencyThread(void * aContext)
         lObject->Delay(lContext.mAccumulator);
 
         j       = kPoolSize;
-        lObject = NULL;
+        lObject = nullptr;
         while (j-- > 0)
         {
             lObject = sPool.Get(lLayer, j);
 
-            if (lObject == NULL)
+            if (lObject == nullptr)
                 continue;
 
             lObject->Release();
@@ -291,7 +291,7 @@ void * TestObject::CheckConcurrencyThread(void * aContext)
             break;
         }
 
-        NL_TEST_ASSERT(lContext.mTestSuite, lObject != NULL);
+        NL_TEST_ASSERT(lContext.mTestSuite, lObject != nullptr);
     }
 
     // Cleanup
@@ -300,7 +300,7 @@ void * TestObject::CheckConcurrencyThread(void * aContext)
     {
         lObject = sPool.Get(lLayer, i);
 
-        if (lObject == NULL)
+        if (lObject == nullptr)
             continue;
 
         lObject->Release();
@@ -343,14 +343,14 @@ void TestObject::MultithreadedTest(nlTestSuite * inSuite, void * aContext, void 
 
     for (unsigned int i = 0; i < kNumThreads; ++i)
     {
-        int lError = pthread_create(&lThread[i], NULL, aStartRoutine, &lContext);
+        int lError = pthread_create(&lThread[i], nullptr, aStartRoutine, &lContext);
 
         NL_TEST_ASSERT(lContext.mTestSuite, lError == 0);
     }
 
     for (unsigned int i = 0; i < kNumThreads; ++i)
     {
-        int lError = pthread_join(lThread[i], NULL);
+        int lError = pthread_join(lThread[i], nullptr);
 
         NL_TEST_ASSERT(lContext.mTestSuite, lError == 0);
     }
@@ -379,7 +379,7 @@ void TestObject::CheckHighWatermark(nlTestSuite * inSuite, void * aContext)
     memset(&sPool, 0, sizeof(sPool));
 
     const int kNumObjects  = kPoolSize;
-    TestObject * lObject   = NULL;
+    TestObject * lObject   = nullptr;
     TestContext & lContext = *static_cast<TestContext *>(aContext);
     Layer lLayer;
     chip::System::Stats::count_t lNumInUse;
@@ -407,7 +407,7 @@ void TestObject::CheckHighWatermark(nlTestSuite * inSuite, void * aContext)
     // Fail an allocation and check that both stats don't change
 
     lObject = sPool.TryCreate(lLayer);
-    NL_TEST_ASSERT(lContext.mTestSuite, lObject == NULL);
+    NL_TEST_ASSERT(lContext.mTestSuite, lObject == nullptr);
 
     sPool.GetStatistics(lNumInUse, lHighWatermark);
     NL_TEST_ASSERT(lContext.mTestSuite, lNumInUse == kNumObjects);
@@ -420,7 +420,7 @@ void TestObject::CheckHighWatermark(nlTestSuite * inSuite, void * aContext)
     {
         lObject = sPool.Get(lLayer, i);
 
-        NL_TEST_ASSERT(lContext.mTestSuite, lObject != NULL);
+        NL_TEST_ASSERT(lContext.mTestSuite, lObject != nullptr);
 
         lObject->Release();
         NL_TEST_ASSERT(lContext.mTestSuite, !lObject->IsRetained(lLayer));
@@ -453,7 +453,7 @@ void TestObject::CheckHighWatermark(nlTestSuite * inSuite, void * aContext)
     {
         lObject = sPool.Get(lLayer, i);
 
-        if (lObject == NULL)
+        if (lObject == nullptr)
             continue;
 
         lObject->Release();
@@ -493,7 +493,7 @@ static nlTestSuite sTestSuite =
 static int Initialize(void * aContext)
 {
     TestContext & lContext = *reinterpret_cast<TestContext *>(aContext);
-    void * lLayerContext   = NULL;
+    void * lLayerContext   = nullptr;
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP && LWIP_VERSION_MAJOR <= 2 && LWIP_VERSION_MINOR < 1
     static sys_mbox_t * sLwIPEventQueue = NULL;
@@ -520,7 +520,7 @@ static int Finalize(void * aContext)
 {
     TestContext & lContext = *reinterpret_cast<TestContext *>(aContext);
 
-    lContext.mTestSuite = NULL;
+    lContext.mTestSuite = nullptr;
 
     return SUCCESS;
 }

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -78,11 +78,11 @@ struct TestContext
 // clang-format off
 struct TestContext sContext[] =
 {
-      { 0,      0,                               NULL, NULL, NULL, NULL },
-      { 0,      10,                              NULL, NULL, NULL, NULL },
-      { 0,      128,                             NULL, NULL, NULL, NULL },
-      { 0,      1536,                            NULL, NULL, NULL, NULL },
-      { 0,      CHIP_SYSTEM_PACKETBUFFER_SIZE,   NULL, NULL, NULL, NULL }
+      { 0,      0,                               nullptr, nullptr, nullptr, nullptr },
+      { 0,      10,                              nullptr, nullptr, nullptr, nullptr },
+      { 0,      128,                             nullptr, nullptr, nullptr, nullptr },
+      { 0,      1536,                            nullptr, nullptr, nullptr, nullptr },
+      { 0,      CHIP_SYSTEM_PACKETBUFFER_SIZE,   nullptr, nullptr, nullptr, nullptr }
 };
 // clang-format on
 
@@ -102,10 +102,10 @@ const size_t kTestLengths  = sizeof(sLengths) / sizeof(uint16_t);
  */
 void BufferFree(struct TestContext * theContext)
 {
-    if (theContext->buf != NULL)
+    if (theContext->buf != nullptr)
     {
         PacketBuffer::Free(OF_LWIP_PBUF(theContext->buf));
-        theContext->buf = NULL;
+        theContext->buf = nullptr;
     }
 }
 
@@ -124,12 +124,12 @@ void BufferAlloc(struct TestContext * theContext)
 #endif // LWIP_PBUF_FROM_CUSTOM_POOLS
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
-    if (theContext->buf == NULL)
+    if (theContext->buf == nullptr)
     {
         theContext->buf = TO_LWIP_PBUF(PacketBuffer::New(0));
     }
 
-    if (theContext->buf == NULL)
+    if (theContext->buf == nullptr)
     {
         fprintf(stderr, "Failed to allocate %zuB memory: %s\n", lAllocSize, strerror(errno));
         exit(EXIT_FAILURE);
@@ -174,7 +174,7 @@ PacketBuffer * PrepareTestBuffer(struct TestContext * theContext)
 {
     BufferAlloc(theContext);
 
-    theContext->buf->next    = NULL;
+    theContext->buf->next    = nullptr;
     theContext->buf->payload = theContext->payload_ptr;
     theContext->buf->ref     = 1;
     theContext->buf->len     = theContext->init_len;
@@ -318,7 +318,7 @@ void CheckSetDataLength(nlTestSuite * inSuite, void * inContext)
                 if (theFirstContext == theSecondContext)
                 {
                     // headOfChain (the second arg) is NULL
-                    buffer_2->SetDataLength(sLengths[n], NULL);
+                    buffer_2->SetDataLength(sLengths[n], nullptr);
 
                     if (sLengths[n] > (theSecondContext->end_buffer - theSecondContext->payload_ptr))
                     {
@@ -327,13 +327,13 @@ void CheckSetDataLength(nlTestSuite * inSuite, void * inContext)
                         NL_TEST_ASSERT(inSuite,
                                        theSecondContext->buf->tot_len ==
                                            (theSecondContext->end_buffer - theSecondContext->payload_ptr));
-                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->next == NULL);
+                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->next == nullptr);
                     }
                     else
                     {
                         NL_TEST_ASSERT(inSuite, theSecondContext->buf->len == sLengths[n]);
                         NL_TEST_ASSERT(inSuite, theSecondContext->buf->tot_len == sLengths[n]);
-                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->next == NULL);
+                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->next == nullptr);
                     }
                 }
                 else
@@ -348,7 +348,7 @@ void CheckSetDataLength(nlTestSuite * inSuite, void * inContext)
                         NL_TEST_ASSERT(inSuite,
                                        theSecondContext->buf->tot_len ==
                                            (theSecondContext->end_buffer - theSecondContext->payload_ptr));
-                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->next == NULL);
+                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->next == nullptr);
 
                         NL_TEST_ASSERT(inSuite,
                                        theFirstContext->buf->tot_len ==
@@ -360,7 +360,7 @@ void CheckSetDataLength(nlTestSuite * inSuite, void * inContext)
                     {
                         NL_TEST_ASSERT(inSuite, theSecondContext->buf->len == sLengths[n]);
                         NL_TEST_ASSERT(inSuite, theSecondContext->buf->tot_len == sLengths[n]);
-                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->next == NULL);
+                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->next == nullptr);
 
                         NL_TEST_ASSERT(inSuite,
                                        theFirstContext->buf->tot_len ==
@@ -479,9 +479,9 @@ void CheckAddToEnd(nlTestSuite * inSuite, void * inContext)
 
             for (size_t kth = 0; kth < kTestElements; kth++)
             {
-                PacketBuffer * buffer_1 = NULL;
-                PacketBuffer * buffer_2 = NULL;
-                PacketBuffer * buffer_3 = NULL;
+                PacketBuffer * buffer_1 = nullptr;
+                PacketBuffer * buffer_2 = nullptr;
+                PacketBuffer * buffer_3 = nullptr;
 
                 if (theFirstContext == theSecondContext || theFirstContext == theThirdContext ||
                     theSecondContext == theThirdContext)
@@ -498,9 +498,9 @@ void CheckAddToEnd(nlTestSuite * inSuite, void * inContext)
 
                 NL_TEST_ASSERT(inSuite, theFirstContext->buf->tot_len == (theFirstContext->init_len + theSecondContext->init_len));
                 NL_TEST_ASSERT(inSuite, theFirstContext->buf->next == theSecondContext->buf);
-                NL_TEST_ASSERT(inSuite, theSecondContext->buf->next == NULL);
+                NL_TEST_ASSERT(inSuite, theSecondContext->buf->next == nullptr);
 
-                NL_TEST_ASSERT(inSuite, theThirdContext->buf->next == NULL);
+                NL_TEST_ASSERT(inSuite, theThirdContext->buf->next == nullptr);
 
                 buffer_1->AddToEnd(buffer_3);
 
@@ -509,7 +509,7 @@ void CheckAddToEnd(nlTestSuite * inSuite, void * inContext)
                                    (theFirstContext->init_len + theSecondContext->init_len + theThirdContext->init_len));
                 NL_TEST_ASSERT(inSuite, theFirstContext->buf->next == theSecondContext->buf);
                 NL_TEST_ASSERT(inSuite, theSecondContext->buf->next == theThirdContext->buf);
-                NL_TEST_ASSERT(inSuite, theThirdContext->buf->next == NULL);
+                NL_TEST_ASSERT(inSuite, theThirdContext->buf->next == nullptr);
 
                 theThirdContext++;
             }
@@ -543,7 +543,7 @@ void CheckDetachTail(nlTestSuite * inSuite, void * inContext)
         {
             PacketBuffer * buffer_1 = PrepareTestBuffer(theFirstContext);
             PacketBuffer * buffer_2 = PrepareTestBuffer(theSecondContext);
-            PacketBuffer * returned = NULL;
+            PacketBuffer * returned = nullptr;
 
             if (theFirstContext != theSecondContext)
             {
@@ -553,7 +553,7 @@ void CheckDetachTail(nlTestSuite * inSuite, void * inContext)
 
             returned = buffer_1->DetachTail();
 
-            NL_TEST_ASSERT(inSuite, theFirstContext->buf->next == NULL);
+            NL_TEST_ASSERT(inSuite, theFirstContext->buf->next == nullptr);
             NL_TEST_ASSERT(inSuite, theFirstContext->buf->tot_len == theFirstContext->init_len);
 
             if (theFirstContext != theSecondContext)
@@ -640,8 +640,8 @@ void CheckCompactHead(nlTestSuite * inSuite, void * inContext)
                         else
                         {
                             /* make sure the second buffer is freed */
-                            NL_TEST_ASSERT(inSuite, theFirstContext->buf->next == NULL);
-                            theSecondContext->buf = NULL;
+                            NL_TEST_ASSERT(inSuite, theFirstContext->buf->next == nullptr);
+                            theSecondContext->buf = nullptr;
                         }
                     }
                 }
@@ -690,7 +690,7 @@ void CheckConsumeHead(nlTestSuite * inSuite, void * inContext)
 
             if (theContext->buf->ref == 0)
             {
-                theContext->buf = NULL;
+                theContext->buf = nullptr;
             }
         }
 
@@ -768,13 +768,13 @@ void CheckConsume(nlTestSuite * inSuite, void * inContext)
                                  (sLengths[c] < buf_1_len + buf_2_len || (sLengths[c] == buf_1_len + buf_2_len && buf_2_len == 0)))
                         {
                             NL_TEST_ASSERT(inSuite, returned == buffer_2);
-                            theFirstContext->buf = NULL;
+                            theFirstContext->buf = nullptr;
                         }
                         else if (sLengths[c] >= (buf_1_len + buf_2_len))
                         {
-                            NL_TEST_ASSERT(inSuite, returned == NULL);
-                            theFirstContext->buf  = NULL;
-                            theSecondContext->buf = NULL;
+                            NL_TEST_ASSERT(inSuite, returned == nullptr);
+                            theFirstContext->buf  = nullptr;
+                            theSecondContext->buf = nullptr;
                         }
                     }
                 }
@@ -909,10 +909,10 @@ void CheckNext(nlTestSuite * inSuite, void * inContext)
             }
             else
             {
-                NL_TEST_ASSERT(inSuite, buffer_1->Next() == NULL);
+                NL_TEST_ASSERT(inSuite, buffer_1->Next() == nullptr);
             }
 
-            NL_TEST_ASSERT(inSuite, buffer_2->Next() == NULL);
+            NL_TEST_ASSERT(inSuite, buffer_2->Next() == nullptr);
             theSecondContext++;
         }
 
@@ -955,27 +955,27 @@ void CheckNewWithAvailableSizeAndFree(nlTestSuite * inSuite, void * inContext)
 
     for (size_t ith = 0; ith < kTestElements; ith++)
     {
-        struct pbuf * pb = NULL;
+        struct pbuf * pb = nullptr;
 
         buffer = PacketBuffer::NewWithAvailableSize(theContext->reserved_size, 0);
 
         if (theContext->reserved_size > CHIP_SYSTEM_CONFIG_PACKETBUFFER_CAPACITY_MAX)
         {
-            NL_TEST_ASSERT(inSuite, buffer == NULL);
+            NL_TEST_ASSERT(inSuite, buffer == nullptr);
             theContext++;
             continue;
         }
 
         NL_TEST_ASSERT(inSuite, theContext->reserved_size <= buffer->AllocSize());
-        NL_TEST_ASSERT(inSuite, buffer != NULL);
+        NL_TEST_ASSERT(inSuite, buffer != nullptr);
 
-        if (buffer != NULL)
+        if (buffer != nullptr)
         {
             pb = TO_LWIP_PBUF(buffer);
 
             NL_TEST_ASSERT(inSuite, pb->len == 0);
             NL_TEST_ASSERT(inSuite, pb->tot_len == 0);
-            NL_TEST_ASSERT(inSuite, pb->next == NULL);
+            NL_TEST_ASSERT(inSuite, pb->next == nullptr);
             NL_TEST_ASSERT(inSuite, pb->ref == 1);
         }
 
@@ -988,7 +988,7 @@ void CheckNewWithAvailableSizeAndFree(nlTestSuite * inSuite, void * inContext)
     do
     {
         buffer = PacketBuffer::NewWithAvailableSize(0, 0);
-    } while (buffer != NULL);
+    } while (buffer != nullptr);
 }
 
 /**
@@ -1054,12 +1054,12 @@ void CheckFree(nlTestSuite * inSuite, void * inContext)
 
                 if (theFirstContext->buf->ref == 0)
                 {
-                    theFirstContext->buf = NULL;
+                    theFirstContext->buf = nullptr;
                 }
 
                 if (theSecondContext->buf->ref == 0)
                 {
-                    theSecondContext->buf = NULL;
+                    theSecondContext->buf = nullptr;
                 }
             }
 
@@ -1091,7 +1091,7 @@ void CheckFreeHead(nlTestSuite * inSuite, void * inContext)
         {
             PacketBuffer * buffer_1;
             PacketBuffer * buffer_2;
-            PacketBuffer * returned = NULL;
+            PacketBuffer * returned = nullptr;
 
             if (theFirstContext == theSecondContext)
             {
@@ -1107,7 +1107,7 @@ void CheckFreeHead(nlTestSuite * inSuite, void * inContext)
 
             NL_TEST_ASSERT(inSuite, returned == buffer_2);
 
-            theFirstContext->buf = NULL;
+            theFirstContext->buf = nullptr;
             theSecondContext++;
         }
 

--- a/src/system/tests/TestSystemTimer.cpp
+++ b/src/system/tests/TestSystemTimer.cpp
@@ -244,7 +244,7 @@ static Layer sLayer;
 static int TestSetup(void * aContext)
 {
     TestContext & lContext = *reinterpret_cast<TestContext *>(aContext);
-    void * lLayerContext   = NULL;
+    void * lLayerContext   = nullptr;
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 #if LWIP_VERSION_MAJOR <= 2 && LWIP_VERSION_MINOR < 1

--- a/src/system/tests/TestTimeSource.cpp
+++ b/src/system/tests/TestTimeSource.cpp
@@ -83,11 +83,11 @@ static const nlTest sTests[] =
 int TestTimeSource(void)
 {
     nlTestSuite theSuite = {
-        "chip-timesource", &sTests[0], NULL /* setup */, NULL /* teardown */
+        "chip-timesource", &sTests[0], nullptr /* setup */, nullptr /* teardown */
     };
 
     // Run test suit againt one context.
-    nlTestRunner(&theSuite, NULL /* context */);
+    nlTestRunner(&theSuite, nullptr /* context */);
 
     return (nlTestRunnerStats(&theSuite));
 }

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -49,16 +49,16 @@ CHIP_ERROR SecureSession::InitFromSecret(const uint8_t * secret, const size_t se
     CHIP_ERROR error = CHIP_NO_ERROR;
 
     VerifyOrExit(mKeyAvailable == false, error = CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrExit(secret != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(secret != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(secret_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     if (salt_length > 0)
     {
-        VerifyOrExit(salt != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrExit(salt != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     }
 
     VerifyOrExit(info_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(info != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(info != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     error = HKDF_SHA256(secret, secret_length, salt, salt_length, info, info_length, mKey, sizeof(mKey));
     SuccessOrExit(error);
@@ -78,11 +78,11 @@ CHIP_ERROR SecureSession::Init(const Crypto::P256Keypair & local_keypair, const 
     VerifyOrExit(mKeyAvailable == false, error = CHIP_ERROR_INCORRECT_STATE);
     if (salt_length > 0)
     {
-        VerifyOrExit(salt != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrExit(salt != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     }
 
     VerifyOrExit(info_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(info != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(info != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     error = local_keypair.ECDH_derive_secret(remote_public_key, secret);
     SuccessOrExit(error);
@@ -153,9 +153,9 @@ CHIP_ERROR SecureSession::Encrypt(const uint8_t * input, size_t input_length, ui
     uint8_t tag[taglen];
 
     VerifyOrExit(mKeyAvailable, error = CHIP_ERROR_INVALID_USE_OF_SESSION_KEY);
-    VerifyOrExit(input != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(input != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(input_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(output != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(output != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     error = GetIV(header, IV, sizeof(IV));
     SuccessOrExit(error);
@@ -182,9 +182,9 @@ CHIP_ERROR SecureSession::Decrypt(const uint8_t * input, size_t input_length, ui
     size_t aadLen = sizeof(AAD);
 
     VerifyOrExit(mKeyAvailable, error = CHIP_ERROR_INVALID_USE_OF_SESSION_KEY);
-    VerifyOrExit(input != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(input != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(input_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(output != NULL, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(output != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     error = GetIV(header, IV, sizeof(IV));
     SuccessOrExit(error);

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -93,8 +93,8 @@ CHIP_ERROR SecureSessionMgrBase::SendMessage(NodeId peerNodeId, System::PacketBu
 
     VerifyOrExit(mState == State::kInitialized, err = CHIP_ERROR_INCORRECT_STATE);
 
-    VerifyOrExit(msgBuf != NULL, err = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(msgBuf->Next() == NULL, err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
+    VerifyOrExit(msgBuf != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(msgBuf->Next() == nullptr, err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
     VerifyOrExit(msgBuf->TotalLength() < kMax_SecureSDU_Length, err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
 
     // Find an active connection to the specified peer node
@@ -133,18 +133,18 @@ CHIP_ERROR SecureSessionMgrBase::SendMessage(NodeId peerNodeId, System::PacketBu
         err = header.EncodeMACTag(&data[totalLen], kMaxTagLen, &taglen);
         SuccessOrExit(err);
 
-        msgBuf->SetDataLength(totalLen + taglen, NULL);
+        msgBuf->SetDataLength(totalLen + taglen, nullptr);
 
         ChipLogProgress(Inet, "Secure transport transmitting msg %u after encryption", state->GetSendMessageIndex());
 
         err    = mTransport->SendMessage(header, state->GetPeerAddress(), msgBuf);
-        msgBuf = NULL;
+        msgBuf = nullptr;
     }
     SuccessOrExit(err);
     state->IncrementSendMessageIndex();
 
 exit:
-    if (msgBuf != NULL)
+    if (msgBuf != nullptr)
     {
         const char * errStr = ErrorStr(err);
         if (state == nullptr)
@@ -156,7 +156,7 @@ exit:
             ChipLogProgress(Inet, "Secure transport failed to encrypt msg %u: %s", state->GetSendMessageIndex(), errStr);
         }
         PacketBuffer::Free(msgBuf);
-        msgBuf = NULL;
+        msgBuf = nullptr;
     }
 
     return err;
@@ -256,7 +256,7 @@ void SecureSessionMgrBase::HandleDataReceived(MessageHeader & header, const Peer
         err = header.DecodeMACTag(&data[header.GetPayloadLength()], kMaxTagLen, &taglen);
         VerifyOrExit(err == CHIP_NO_ERROR, ChipLogProgress(Inet, "Secure transport failed to decode MAC Tag: err %d", err));
         len -= taglen;
-        msg->SetDataLength(len, NULL);
+        msg->SetDataLength(len, nullptr);
 
         err = state->GetSecureSession().Decrypt(data, len, plainText, header);
         VerifyOrExit(err == CHIP_NO_ERROR, ChipLogProgress(Inet, "Secure transport failed to decrypt msg: err %d", err));

--- a/src/transport/TCP.cpp
+++ b/src/transport/TCP.cpp
@@ -219,10 +219,10 @@ CHIP_ERROR TCPBase::SendMessage(const MessageHeader & header, const Transport::P
     SuccessOrExit(err);
 
 exit:
-    if (msgBuf != NULL)
+    if (msgBuf != nullptr)
     {
         System::PacketBuffer::Free(msgBuf);
-        msgBuf = NULL;
+        msgBuf = nullptr;
     }
 
     return err;

--- a/src/transport/UDP.cpp
+++ b/src/transport/UDP.cpp
@@ -109,10 +109,10 @@ CHIP_ERROR UDP::SendMessage(const MessageHeader & header, const Transport::PeerA
     SuccessOrExit(err);
 
 exit:
-    if (msgBuf != NULL)
+    if (msgBuf != nullptr)
     {
         System::PacketBuffer::Free(msgBuf);
-        msgBuf = NULL;
+        msgBuf = nullptr;
     }
 
     return err;

--- a/src/transport/tests/NetworkTestHelpers.cpp
+++ b/src/transport/tests/NetworkTestHelpers.cpp
@@ -29,7 +29,7 @@ CHIP_ERROR IOContext::Init(nlTestSuite * suite)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    gSystemLayer.Init(NULL);
+    gSystemLayer.Init(nullptr);
 
     InitNetwork();
 

--- a/src/transport/tests/TestMessageHeader.cpp
+++ b/src/transport/tests/TestMessageHeader.cpp
@@ -198,8 +198,8 @@ static const nlTest sTests[] =
 
 int TestMessageHeader(void)
 {
-    nlTestSuite theSuite = { "Transport-MessageHeader", &sTests[0], NULL, NULL };
-    nlTestRunner(&theSuite, NULL);
+    nlTestSuite theSuite = { "Transport-MessageHeader", &sTests[0], nullptr, nullptr };
+    nlTestRunner(&theSuite, nullptr);
     return nlTestRunnerStats(&theSuite);
 }
 

--- a/src/transport/tests/TestPeerConnections.cpp
+++ b/src/transport/tests/TestPeerConnections.cpp
@@ -282,8 +282,8 @@ static const nlTest sTests[] =
 
 int TestPeerConnectionsFn(void)
 {
-    nlTestSuite theSuite = { "Transport-PeerConnections", &sTests[0], NULL, NULL };
-    nlTestRunner(&theSuite, NULL);
+    nlTestSuite theSuite = { "Transport-PeerConnections", &sTests[0], nullptr, nullptr };
+    nlTestRunner(&theSuite, nullptr);
     return nlTestRunnerStats(&theSuite);
 }
 

--- a/src/transport/tests/TestSecurePairingSession.cpp
+++ b/src/transport/tests/TestSecurePairingSession.cpp
@@ -152,8 +152,8 @@ static nlTestSuite sSuite =
 {
     "Test-CHIP-SecurePairing",
     &sTests[0],
-    NULL,
-    NULL
+    nullptr,
+    nullptr
 };
 // clang-format on
 
@@ -163,7 +163,7 @@ static nlTestSuite sSuite =
 int TestSecurePairingSession()
 {
     // Run test suit against one context
-    nlTestRunner(&sSuite, NULL);
+    nlTestRunner(&sSuite, nullptr);
 
     return (nlTestRunnerStats(&sSuite));
 }

--- a/src/transport/tests/TestSecureSession.cpp
+++ b/src/transport/tests/TestSecureSession.cpp
@@ -47,17 +47,17 @@ void SecureChannelInitTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, keypair2.Initialize() == CHIP_NO_ERROR);
 
     // Test all combinations of invalid parameters
-    NL_TEST_ASSERT(inSuite, channel.Init(keypair, keypair2.Pubkey(), NULL, 0, NULL, 0) == CHIP_ERROR_INVALID_ARGUMENT);
-    NL_TEST_ASSERT(inSuite, channel.Init(keypair, keypair2.Pubkey(), NULL, 10, NULL, 0) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, channel.Init(keypair, keypair2.Pubkey(), nullptr, 0, nullptr, 0) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, channel.Init(keypair, keypair2.Pubkey(), nullptr, 10, nullptr, 0) == CHIP_ERROR_INVALID_ARGUMENT);
 
     // Test the channel is successfully created with valid parameters
     const char * info = "Test Info";
     NL_TEST_ASSERT(inSuite,
-                   channel.Init(keypair, keypair2.Pubkey(), NULL, 0, (const uint8_t *) info, sizeof(info)) == CHIP_NO_ERROR);
+                   channel.Init(keypair, keypair2.Pubkey(), nullptr, 0, (const uint8_t *) info, sizeof(info)) == CHIP_NO_ERROR);
 
     // Test the channel cannot be reinitialized
     NL_TEST_ASSERT(inSuite,
-                   channel.Init(keypair, keypair2.Pubkey(), NULL, 0, (const uint8_t *) info, sizeof(info)) ==
+                   channel.Init(keypair, keypair2.Pubkey(), nullptr, 0, (const uint8_t *) info, sizeof(info)) ==
                        CHIP_ERROR_INCORRECT_STATE);
 
     // Test the channel can be initialized with valid salt
@@ -92,9 +92,9 @@ void SecureChannelEncryptTest(nlTestSuite * inSuite, void * inContext)
                                 sizeof(info)) == CHIP_NO_ERROR);
 
     // Test initialized channel, but invalid arguments
-    NL_TEST_ASSERT(inSuite, channel.Encrypt(NULL, 0, NULL, header) == CHIP_ERROR_INVALID_ARGUMENT);
-    NL_TEST_ASSERT(inSuite, channel.Encrypt(plain_text, 0, NULL, header) == CHIP_ERROR_INVALID_ARGUMENT);
-    NL_TEST_ASSERT(inSuite, channel.Encrypt(plain_text, sizeof(plain_text), NULL, header) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, channel.Encrypt(nullptr, 0, nullptr, header) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, channel.Encrypt(plain_text, 0, nullptr, header) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, channel.Encrypt(plain_text, sizeof(plain_text), nullptr, header) == CHIP_ERROR_INVALID_ARGUMENT);
 
     // Valid arguments
     NL_TEST_ASSERT(inSuite, channel.Encrypt(plain_text, sizeof(plain_text), output, header) == CHIP_NO_ERROR);
@@ -131,9 +131,9 @@ void SecureChannelDecryptTest(nlTestSuite * inSuite, void * inContext)
                                  sizeof(info)) == CHIP_NO_ERROR);
 
     // Channel initialized, but invalid arguments to decrypt
-    NL_TEST_ASSERT(inSuite, channel2.Decrypt(NULL, 0, NULL, header) == CHIP_ERROR_INVALID_ARGUMENT);
-    NL_TEST_ASSERT(inSuite, channel2.Decrypt(encrypted, 0, NULL, header) == CHIP_ERROR_INVALID_ARGUMENT);
-    NL_TEST_ASSERT(inSuite, channel2.Decrypt(encrypted, sizeof(encrypted), NULL, header) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, channel2.Decrypt(nullptr, 0, nullptr, header) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, channel2.Decrypt(encrypted, 0, nullptr, header) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, channel2.Decrypt(encrypted, sizeof(encrypted), nullptr, header) == CHIP_ERROR_INVALID_ARGUMENT);
 
     // Valid arguments
     NL_TEST_ASSERT(inSuite, channel2.Decrypt(encrypted, sizeof(plain_text), output, header) == CHIP_NO_ERROR);
@@ -162,8 +162,8 @@ static nlTestSuite sSuite =
 {
     "Test-CHIP-SecureChannel",
     &sTests[0],
-    NULL,
-    NULL
+    nullptr,
+    nullptr
 };
 // clang-format on
 
@@ -173,7 +173,7 @@ static nlTestSuite sSuite =
 int TestSecureSession()
 {
     // Run test suit against one context
-    nlTestRunner(&sSuite, NULL);
+    nlTestRunner(&sSuite, nullptr);
 
     return (nlTestRunnerStats(&sSuite));
 }

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -96,7 +96,7 @@ void CheckSimpleInitTest(nlTestSuite * inSuite, void * inContext)
     SecureSessionMgr<LoopbackTransport> conn;
     CHIP_ERROR err;
 
-    ctx.GetInetLayer().SystemLayer()->Init(NULL);
+    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
 
     err = conn.Init(kSourceNodeId, ctx.GetInetLayer().SystemLayer(), "LOOPBACK");
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -108,7 +108,7 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
 
     size_t payload_len = sizeof(PAYLOAD);
 
-    ctx.GetInetLayer().SystemLayer()->Init(NULL);
+    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
 
     chip::System::PacketBuffer * buffer = chip::System::PacketBuffer::NewWithAvailableSize(payload_len);
     memmove(buffer->Start(), PAYLOAD, payload_len);


### PR DESCRIPTION
 #### Problem
C++ code should use `nullptr`, not `NULL`.

 #### Summary of Changes
Run `run-clang-tidy.py -header-filter='.*' -checks='-*,modernize-use-nullptr` for Linux clang build.

See also https://github.com/project-chip/connectedhomeip/pull/2769