### PR TITLE
clang-tidy: Apply fixes "modernize-use-override"

### DIFF
--- a/examples/common/chip-app-server/Server.cpp
+++ b/examples/common/chip-app-server/Server.cpp
@@ -150,8 +150,8 @@ void HandleBLEConnectionOpened(chip::Ble::BLEEndPoint * endPoint)
 class ServerCallback : public SecureSessionMgrCallback
 {
 public:
-    virtual void OnMessageReceived(const MessageHeader & header, Transport::PeerConnectionState * state,
-                                   System::PacketBuffer * buffer, SecureSessionMgrBase * mgr)
+    void OnMessageReceived(const MessageHeader & header, Transport::PeerConnectionState * state, System::PacketBuffer * buffer,
+                           SecureSessionMgrBase * mgr) override
     {
         const size_t data_len = buffer->DataLength();
         char src_addr[PeerAddress::kMaxToStringSize];
@@ -178,7 +178,7 @@ public:
         }
     }
 
-    virtual void OnNewConnection(Transport::PeerConnectionState * state, SecureSessionMgrBase * mgr)
+    void OnNewConnection(Transport::PeerConnectionState * state, SecureSessionMgrBase * mgr) override
     {
         ChipLogProgress(AppServer, "Received a new connection.");
     }

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -776,31 +776,31 @@ public:
         memset(&mSpake2pContext, 0, sizeof(mSpake2pContext));
     }
 
-    virtual ~Spake2p_P256_SHA256_HKDF_HMAC(void) { FreeImpl(); }
+    ~Spake2p_P256_SHA256_HKDF_HMAC(void) override { FreeImpl(); }
 
-    CHIP_ERROR Mac(const uint8_t * key, size_t key_len, const uint8_t * in, size_t in_len, uint8_t * out);
+    CHIP_ERROR Mac(const uint8_t * key, size_t key_len, const uint8_t * in, size_t in_len, uint8_t * out) override;
     CHIP_ERROR MacVerify(const uint8_t * key, size_t key_len, const uint8_t * mac, size_t mac_len, const uint8_t * in,
-                         size_t in_len);
-    CHIP_ERROR FELoad(const uint8_t * in, size_t in_len, void * fe);
-    CHIP_ERROR FEWrite(const void * fe, uint8_t * out, size_t out_len);
-    CHIP_ERROR FEGenerate(void * fe);
-    CHIP_ERROR FEMul(void * fer, const void * fe1, const void * fe2);
+                         size_t in_len) override;
+    CHIP_ERROR FELoad(const uint8_t * in, size_t in_len, void * fe) override;
+    CHIP_ERROR FEWrite(const void * fe, uint8_t * out, size_t out_len) override;
+    CHIP_ERROR FEGenerate(void * fe) override;
+    CHIP_ERROR FEMul(void * fer, const void * fe1, const void * fe2) override;
 
-    CHIP_ERROR PointLoad(const uint8_t * in, size_t in_len, void * R);
-    CHIP_ERROR PointWrite(const void * R, uint8_t * out, size_t out_len);
-    CHIP_ERROR PointMul(void * R, const void * P1, const void * fe1);
-    CHIP_ERROR PointAddMul(void * R, const void * P1, const void * fe1, const void * P2, const void * fe2);
-    CHIP_ERROR PointInvert(void * R);
-    CHIP_ERROR PointCofactorMul(void * R);
-    CHIP_ERROR PointIsValid(void * R);
-    CHIP_ERROR ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1in, size_t w1in_len);
+    CHIP_ERROR PointLoad(const uint8_t * in, size_t in_len, void * R) override;
+    CHIP_ERROR PointWrite(const void * R, uint8_t * out, size_t out_len) override;
+    CHIP_ERROR PointMul(void * R, const void * P1, const void * fe1) override;
+    CHIP_ERROR PointAddMul(void * R, const void * P1, const void * fe1, const void * P2, const void * fe2) override;
+    CHIP_ERROR PointInvert(void * R) override;
+    CHIP_ERROR PointCofactorMul(void * R) override;
+    CHIP_ERROR PointIsValid(void * R) override;
+    CHIP_ERROR ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1in, size_t w1in_len) override;
 
 protected:
-    CHIP_ERROR InitImpl();
-    CHIP_ERROR Hash(const uint8_t * in, size_t in_len);
-    CHIP_ERROR HashFinalize(uint8_t * out);
+    CHIP_ERROR InitImpl() override;
+    CHIP_ERROR Hash(const uint8_t * in, size_t in_len) override;
+    CHIP_ERROR HashFinalize(uint8_t * out) override;
     CHIP_ERROR KDF(const uint8_t * secret, const size_t secret_length, const uint8_t * salt, const size_t salt_length,
-                   const uint8_t * info, const size_t info_length, uint8_t * out, size_t out_length);
+                   const uint8_t * info, const size_t info_length, uint8_t * out, size_t out_length) override;
 
 private:
     /**

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -1057,7 +1057,7 @@ public:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR FEGenerate(void * feout) { return FELoad(fe, fe_len, feout); }
+    CHIP_ERROR FEGenerate(void * feout) override { return FELoad(fe, fe_len, feout); }
 
 private:
     uint8_t fe[kMAX_FE_Length];

--- a/src/inet/tests/TestInetCommonOptions.h
+++ b/src/inet/tests/TestInetCommonOptions.h
@@ -73,7 +73,7 @@ public:
 
     NetworkOptions();
 
-    virtual bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg);
+    bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg) override;
 };
 
 extern NetworkOptions gNetworkOptions;
@@ -91,7 +91,7 @@ public:
 
     FaultInjectionOptions();
 
-    virtual bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg);
+    bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg) override;
 };
 
 extern FaultInjectionOptions gFaultInjectionOptions;

--- a/src/lib/protocols/fabric-provisioning/FabricProvisioning.h
+++ b/src/lib/protocols/fabric-provisioning/FabricProvisioning.h
@@ -161,8 +161,8 @@ public:
      *                          is expected to represent the final assessment of access control policy for the
      *                          message.
      */
-    virtual void EnforceAccessControl(ExchangeContext * ec, uint32_t msgProfileId, uint8_t msgType, const ChipMessageInfo * msgInfo,
-                                      AccessControlResult & result);
+    void EnforceAccessControl(ExchangeContext * ec, uint32_t msgProfileId, uint8_t msgType, const ChipMessageInfo * msgInfo,
+                              AccessControlResult & result) override;
 
     /**
      * Called to determine if the device is currently paired to an account.

--- a/src/lib/protocols/security/CHIPDummyGroupKeyStore.h
+++ b/src/lib/protocols/security/CHIPDummyGroupKeyStore.h
@@ -47,20 +47,20 @@ public:
     DummyGroupKeyStore(void);
 
     // Manage application group key material storage.
-    virtual CHIP_ERROR RetrieveGroupKey(uint32_t keyId, ChipGroupKey & key);
-    virtual CHIP_ERROR StoreGroupKey(const ChipGroupKey & key);
-    virtual CHIP_ERROR DeleteGroupKey(uint32_t keyId);
-    virtual CHIP_ERROR DeleteGroupKeysOfAType(uint32_t keyType);
-    virtual CHIP_ERROR EnumerateGroupKeys(uint32_t keyType, uint32_t * keyIds, uint8_t keyIdsArraySize, uint8_t & keyCount);
-    virtual CHIP_ERROR Clear(void);
+    CHIP_ERROR RetrieveGroupKey(uint32_t keyId, ChipGroupKey & key) override;
+    CHIP_ERROR StoreGroupKey(const ChipGroupKey & key) override;
+    CHIP_ERROR DeleteGroupKey(uint32_t keyId) override;
+    CHIP_ERROR DeleteGroupKeysOfAType(uint32_t keyType) override;
+    CHIP_ERROR EnumerateGroupKeys(uint32_t keyType, uint32_t * keyIds, uint8_t keyIdsArraySize, uint8_t & keyCount) override;
+    CHIP_ERROR Clear(void) override;
 
 private:
     // Retrieve and Store LastUsedEpochKeyId value.
-    virtual CHIP_ERROR RetrieveLastUsedEpochKeyId(void);
-    virtual CHIP_ERROR StoreLastUsedEpochKeyId(void);
+    CHIP_ERROR RetrieveLastUsedEpochKeyId(void) override;
+    CHIP_ERROR StoreLastUsedEpochKeyId(void) override;
 
     // Get current platform UTC time in seconds.
-    virtual CHIP_ERROR GetCurrentUTCTime(uint32_t & utcTime);
+    CHIP_ERROR GetCurrentUTCTime(uint32_t & utcTime) override;
 };
 
 } // namespace AppKeys

--- a/src/lib/support/CHIPArgParser.hpp
+++ b/src/lib/support/CHIPArgParser.hpp
@@ -152,7 +152,7 @@ public:
     void PrintLongUsage(OptionSet * optSets[], FILE * s);
     void PrintVersion(FILE * s);
 
-    virtual bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg);
+    bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg) override;
 };
 
 } // namespace ArgParser

--- a/src/lib/support/CHIPCounter.h
+++ b/src/lib/support/CHIPCounter.h
@@ -72,7 +72,7 @@ class MonotonicallyIncreasingCounter : public Counter
 {
 public:
     MonotonicallyIncreasingCounter(void);
-    virtual ~MonotonicallyIncreasingCounter(void);
+    ~MonotonicallyIncreasingCounter(void) override;
 
     /**
      *  @brief

--- a/src/lib/support/PersistedCounter.h
+++ b/src/lib/support/PersistedCounter.h
@@ -58,7 +58,7 @@ class PersistedCounter : public MonotonicallyIncreasingCounter
 {
 public:
     PersistedCounter(void);
-    virtual ~PersistedCounter(void);
+    ~PersistedCounter(void) override;
 
     /**
      *  @brief

--- a/src/transport/BLE.h
+++ b/src/transport/BLE.h
@@ -59,7 +59,7 @@ class DLL_EXPORT BLE : public Base
     };
 
 public:
-    virtual ~BLE();
+    ~BLE() override;
 
     /**
      * Initialize a BLE transport to a given peripheral or a given device name.

--- a/src/transport/Base.h
+++ b/src/transport/Base.h
@@ -43,7 +43,7 @@ namespace Transport {
 class Base : public ReferenceCounted<Base>
 {
 public:
-    virtual ~Base() {}
+    ~Base() override {}
 
     /**
      * Sets the message receive handler and associated argument

--- a/src/transport/RendezvousSession.h
+++ b/src/transport/RendezvousSession.h
@@ -59,7 +59,7 @@ public:
     RendezvousSession(RendezvousSessionDelegate * delegate, const RendezvousParameters & params) :
         mDelegate(delegate), mParams(params)
     {}
-    virtual ~RendezvousSession();
+    ~RendezvousSession() override;
 
     /**
      * @brief
@@ -78,9 +78,9 @@ public:
     SecurePairingSession & GetPairingSession() { return mPairingSession; }
 
     //////////// SecurePairingSessionDelegate Implementation ///////////////
-    virtual CHIP_ERROR SendMessage(System::PacketBuffer * msgBuf) override;
-    virtual void OnPairingError(CHIP_ERROR err) override;
-    virtual void OnPairingComplete() override;
+    CHIP_ERROR SendMessage(System::PacketBuffer * msgBuf) override;
+    void OnPairingError(CHIP_ERROR err) override;
+    void OnPairingComplete() override;
 
     //////////// RendezvousSessionDelegate Implementation ///////////////
     void OnRendezvousConnectionOpened() override;

--- a/src/transport/SecurePairingSession.h
+++ b/src/transport/SecurePairingSession.h
@@ -65,7 +65,7 @@ public:
      */
     virtual void OnPairingComplete() {}
 
-    virtual ~SecurePairingSessionDelegate() {}
+    ~SecurePairingSessionDelegate() override {}
 };
 
 class DLL_EXPORT SecurePairingSession
@@ -225,7 +225,7 @@ public:
         mLocalKeyId = localKeyId;
     }
 
-    ~SecurePairingUsingTestSecret(void) {}
+    ~SecurePairingUsingTestSecret(void) override {}
 
     CHIP_ERROR WaitForPairing(uint32_t mySetUpPINCode, uint32_t pbkdf2IterCount, const uint8_t * salt, size_t saltLen,
                               Optional<NodeId> myNodeId, uint16_t myKeyId, SecurePairingSessionDelegate * delegate)
@@ -239,7 +239,7 @@ public:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR DeriveSecureSession(const uint8_t * info, size_t info_len, SecureSession & session)
+    CHIP_ERROR DeriveSecureSession(const uint8_t * info, size_t info_len, SecureSession & session) override
     {
         const char * secret = "Test secret for key derivation";
         size_t secretLen    = strlen(secret);

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -89,7 +89,7 @@ public:
      */
     virtual void OnNewConnection(Transport::PeerConnectionState * state, SecureSessionMgrBase * mgr) {}
 
-    virtual ~SecureSessionMgrCallback() {}
+    ~SecureSessionMgrCallback() override {}
 };
 
 class DLL_EXPORT SecureSessionMgrBase : public ReferenceCounted<SecureSessionMgrBase>
@@ -106,7 +106,7 @@ public:
     CHIP_ERROR SendMessage(NodeId peerNodeId, System::PacketBuffer * msgBuf);
 
     SecureSessionMgrBase();
-    virtual ~SecureSessionMgrBase();
+    ~SecureSessionMgrBase() override;
 
     /**
      * @brief

--- a/src/transport/TCP.h
+++ b/src/transport/TCP.h
@@ -114,7 +114,7 @@ public:
         std::fill(mActiveConnections, mActiveConnections + mActiveConnectionsSize, nullptr);
         std::fill(mPendingPackets, mPendingPackets + mPendingPacketsSize, emptyPending);
     }
-    virtual ~TCPBase();
+    ~TCPBase() override;
 
     /**
      * Initialize a TCP transport on a given port.

--- a/src/transport/UDP.h
+++ b/src/transport/UDP.h
@@ -92,7 +92,7 @@ class DLL_EXPORT UDP : public Base
     };
 
 public:
-    virtual ~UDP();
+    ~UDP() override;
 
     /**
      * Initialize a UDP transport on a given port.

--- a/src/transport/tests/TestSecurePairingSession.cpp
+++ b/src/transport/tests/TestSecurePairingSession.cpp
@@ -38,7 +38,7 @@ using namespace chip;
 class TestSecurePairingDelegate : public SecurePairingSessionDelegate
 {
 public:
-    virtual CHIP_ERROR SendMessage(System::PacketBuffer * msgBuf)
+    CHIP_ERROR SendMessage(System::PacketBuffer * msgBuf) override
     {
         mNumMessageSend++;
         if (peer != nullptr)
@@ -54,9 +54,9 @@ public:
         return mMessageSendError;
     }
 
-    virtual void OnPairingError(CHIP_ERROR error) { mNumPairingErrors++; }
+    void OnPairingError(CHIP_ERROR error) override { mNumPairingErrors++; }
 
-    virtual void OnPairingComplete() { mNumPairingComplete++; }
+    void OnPairingComplete() override { mNumPairingComplete++; }
 
     uint32_t mNumMessageSend     = 0;
     uint32_t mNumPairingErrors   = 0;

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -65,8 +65,8 @@ public:
 class TestSessMgrCallback : public SecureSessionMgrCallback
 {
 public:
-    virtual void OnMessageReceived(const MessageHeader & header, PeerConnectionState * state, System::PacketBuffer * msgBuf,
-                                   SecureSessionMgrBase * mgr)
+    void OnMessageReceived(const MessageHeader & header, PeerConnectionState * state, System::PacketBuffer * msgBuf,
+                           SecureSessionMgrBase * mgr) override
     {
         NL_TEST_ASSERT(mSuite, header.GetSourceNodeId() == Optional<NodeId>::Value(kSourceNodeId));
         NL_TEST_ASSERT(mSuite, header.GetDestinationNodeId() == Optional<NodeId>::Value(kDestinationNodeId));
@@ -80,7 +80,7 @@ public:
         ReceiveHandlerCallCount++;
     }
 
-    virtual void OnNewConnection(PeerConnectionState * state, SecureSessionMgrBase * mgr) { NewConnectionHandlerCallCount++; }
+    void OnNewConnection(PeerConnectionState * state, SecureSessionMgrBase * mgr) override { NewConnectionHandlerCallCount++; }
 
     nlTestSuite * mSuite              = nullptr;
     int ReceiveHandlerCallCount       = 0;


### PR DESCRIPTION
 #### Problem
Virtual function overrides should be marked as such.

 #### Summary of Changes
Run `run-clang-tidy.py -header-filter='.*' -checks='-*,modernize-use-override` for Linux clang build.