### PR TITLE
clang-tidy: Apply fixes "readability-else-after-return"

### DIFF
--- a/src/ble/BLEEndPoint.cpp
+++ b/src/ble/BLEEndPoint.cpp
@@ -968,10 +968,8 @@ BLE_ERROR BLEEndPoint::HandleGattSendConfirmationReceived()
 
         return HandleHandshakeConfirmationReceived();
     }
-    else
-    {
-        return HandleFragmentConfirmationReceived();
-    }
+
+    return HandleFragmentConfirmationReceived();
 }
 
 BLE_ERROR BLEEndPoint::DriveStandAloneAck()
@@ -1302,12 +1300,10 @@ SequenceNumber_t BLEEndPoint::AdjustRemoteReceiveWindow(SequenceNumber_t lastRec
         // New window boundary WOULD wrap, and latest unacked seq num already HAS wrapped, so add offset to difference.
         return (newRemoteWindowBoundary - (newestUnackedSentSeqNum + UINT8_MAX));
     }
-    else
-    {
-        // Neither values would or have wrapped, OR new boundary WOULD wrap but latest unacked seq num does not, so no
-        // offset required.
-        return (newRemoteWindowBoundary - newestUnackedSentSeqNum);
-    }
+
+    // Neither values would or have wrapped, OR new boundary WOULD wrap but latest unacked seq num does not, so no
+    // offset required.
+    return (newRemoteWindowBoundary - newestUnackedSentSeqNum);
 }
 
 BLE_ERROR BLEEndPoint::Receive(PacketBuffer * data)

--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -112,10 +112,8 @@ public:
         {
             return (BLEEndPoint *) (sEndPointPool.Pool + (sizeof(BLEEndPoint) * i));
         }
-        else
-        {
-            return NULL;
-        }
+
+        return NULL;
     }
 
     BLEEndPoint * Find(BLE_CONNECTION_OBJECT c)

--- a/src/ble/BtpEngine.cpp
+++ b/src/ble/BtpEngine.cpp
@@ -183,10 +183,8 @@ bool BtpEngine::IsValidAck(SequenceNumber_t ack_num) const
     {
         return (ack_num <= mTxNewestUnackedSeqNum && ack_num >= mTxOldestUnackedSeqNum);
     }
-    else // Else, if current unacked interval DOES wrap...
-    {
-        return (ack_num <= mTxNewestUnackedSeqNum || ack_num >= mTxOldestUnackedSeqNum);
-    }
+    // Else, if current unacked interval DOES wrap...
+    return (ack_num <= mTxNewestUnackedSeqNum || ack_num >= mTxOldestUnackedSeqNum);
 }
 
 BLE_ERROR BtpEngine::HandleAckReceived(SequenceNumber_t ack_num)

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -245,10 +245,9 @@ inline ConnectivityChange GetConnectivityChange(bool prevState, bool newState)
 {
     if (prevState == newState)
         return kConnectivity_NoChange;
-    else if (newState)
+    if (newState)
         return kConnectivity_Established;
-    else
-        return kConnectivity_Lost;
+    return kConnectivity_Lost;
 }
 
 /**

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -134,12 +134,10 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetFirmwareRevision(char
         memcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION, outLen);
         return CHIP_NO_ERROR;
     }
-    else
 #endif // CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION
-    {
-        outLen = 0;
-        return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
-    }
+
+    outLen = 0;
+    return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
 }
 
 template <class ImplClass>

--- a/src/inet/IPAddress.cpp
+++ b/src/inet/IPAddress.cpp
@@ -292,8 +292,7 @@ uint64_t IPAddress::InterfaceId() const
 {
     if (IsIPv6ULA())
         return (((uint64_t) ntohl(Addr[2])) << 32) | ((uint64_t) ntohl(Addr[3]));
-    else
-        return 0;
+    return 0;
 }
 
 // Extract the subnet id from a IPv6 ULA address.  Returns 0 if the address
@@ -302,8 +301,7 @@ uint16_t IPAddress::Subnet() const
 {
     if (IsIPv6ULA())
         return (uint16_t) ntohl(Addr[1]);
-    else
-        return 0;
+    return 0;
 }
 
 // Extract the global id from a IPv6 ULA address.  Returns 0 if the address
@@ -312,8 +310,7 @@ uint64_t IPAddress::GlobalId() const
 {
     if (IsIPv6ULA())
         return (((uint64_t)(ntohl(Addr[0]) & 0xFFFFFF)) << 16) | ((uint64_t)(ntohl(Addr[1])) & 0xFFFF0000) >> 16;
-    else
-        return 0;
+    return 0;
 }
 
 IPAddressType IPAddress::Type() const

--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -117,13 +117,12 @@ DLL_EXPORT INET_ERROR GetInterfaceName(InterfaceId intfId, char * nameBuf, size_
 
 #endif // CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
     }
-    else
-    {
-        if (nameBufSize < 1)
-            return INET_ERROR_NO_MEMORY;
-        nameBuf[0] = 0;
-        return INET_NO_ERROR;
-    }
+
+    if (nameBufSize < 1)
+        return INET_ERROR_NO_MEMORY;
+
+    nameBuf[0] = 0;
+    return INET_NO_ERROR;
 }
 
 /**

--- a/src/inet/RawEndPoint.cpp
+++ b/src/inet/RawEndPoint.cpp
@@ -613,7 +613,7 @@ INET_ERROR RawEndPoint::SendMsg(const IPPacketInfo * pktInfo, chip::System::Pack
         return INET_ERROR_WRONG_ADDRESS_TYPE;
     }
 #if INET_CONFIG_ENABLE_IPV4
-    else if (IPVer == kIPVersion_4 && addr.Type() != kIPAddressType_IPv4)
+    if (IPVer == kIPVersion_4 && addr.Type() != kIPAddressType_IPv4)
     {
         return INET_ERROR_WRONG_ADDRESS_TYPE;
     }

--- a/src/inet/TCPEndPoint.cpp
+++ b/src/inet/TCPEndPoint.cpp
@@ -1038,16 +1038,14 @@ uint32_t TCPEndPoint::PendingSendLength()
 {
     if (mSendQueue != NULL)
         return mSendQueue->TotalLength();
-    else
-        return 0;
+    return 0;
 }
 
 uint32_t TCPEndPoint::PendingReceiveLength()
 {
     if (mRcvQueue != NULL)
         return mRcvQueue->TotalLength();
-    else
-        return 0;
+    return 0;
 }
 
 INET_ERROR TCPEndPoint::Shutdown()

--- a/src/lib/core/CHIPTLVReader.cpp
+++ b/src/lib/core/CHIPTLVReader.cpp
@@ -328,8 +328,7 @@ uint32_t TLVReader::GetLength() const
 {
     if (TLVTypeHasLength(ElementType()))
         return (uint32_t) mElemLenOrVal;
-    else
-        return 0;
+    return 0;
 }
 
 /**
@@ -1553,8 +1552,7 @@ TLVElementType TLVReader::ElementType() const
 {
     if (mControlByte == (uint16_t) kTLVControlByte_NotSpecified)
         return kTLVElementType_NotSpecified;
-    else
-        return (TLVElementType)(mControlByte & kTLVTypeMask);
+    return (TLVElementType)(mControlByte & kTLVTypeMask);
 }
 
 CHIP_ERROR TLVReader::GetNextPacketBuffer(TLVReader & reader, uintptr_t & bufHandle, const uint8_t *& bufStart, uint32_t & bufLen)

--- a/src/lib/core/CHIPTLVTypes.h
+++ b/src/lib/core/CHIPTLVTypes.h
@@ -152,8 +152,7 @@ inline TLVFieldSize GetTLVFieldSize(uint8_t type)
 {
     if (TLVTypeHasValue(type))
         return (TLVFieldSize)(type & kTLVTypeSizeMask);
-    else
-        return kTLVFieldSize_0Byte;
+    return kTLVFieldSize_0Byte;
 }
 
 // TODO: move to private namespace

--- a/src/lib/core/CHIPTLVWriter.cpp
+++ b/src/lib/core/CHIPTLVWriter.cpp
@@ -380,8 +380,7 @@ CHIP_ERROR TLVWriter::Put(uint64_t tag, uint8_t v, bool preserveSize)
 {
     if (preserveSize)
         return WriteElementHead(kTLVElementType_UInt8, tag, v);
-    else
-        return Put(tag, v);
+    return Put(tag, v);
 }
 
 /**
@@ -399,8 +398,7 @@ CHIP_ERROR TLVWriter::Put(uint64_t tag, uint16_t v, bool preserveSize)
 {
     if (preserveSize)
         return WriteElementHead(kTLVElementType_UInt16, tag, v);
-    else
-        return Put(tag, v);
+    return Put(tag, v);
 }
 
 /**
@@ -418,8 +416,7 @@ CHIP_ERROR TLVWriter::Put(uint64_t tag, uint32_t v, bool preserveSize)
 {
     if (preserveSize)
         return WriteElementHead(kTLVElementType_UInt32, tag, v);
-    else
-        return Put(tag, v);
+    return Put(tag, v);
 }
 
 /**
@@ -446,8 +443,7 @@ CHIP_ERROR TLVWriter::Put(uint64_t tag, uint64_t v, bool preserveSize)
 {
     if (preserveSize)
         return WriteElementHead(kTLVElementType_UInt64, tag, v);
-    else
-        return Put(tag, v);
+    return Put(tag, v);
 }
 
 /**
@@ -515,8 +511,7 @@ CHIP_ERROR TLVWriter::Put(uint64_t tag, int8_t v, bool preserveSize)
 {
     if (preserveSize)
         return WriteElementHead(kTLVElementType_Int8, tag, v);
-    else
-        return Put(tag, v);
+    return Put(tag, v);
 }
 
 /**
@@ -534,8 +529,7 @@ CHIP_ERROR TLVWriter::Put(uint64_t tag, int16_t v, bool preserveSize)
 {
     if (preserveSize)
         return WriteElementHead(kTLVElementType_Int16, tag, v);
-    else
-        return Put(tag, v);
+    return Put(tag, v);
 }
 
 /**
@@ -553,8 +547,7 @@ CHIP_ERROR TLVWriter::Put(uint64_t tag, int32_t v, bool preserveSize)
 {
     if (preserveSize)
         return WriteElementHead(kTLVElementType_Int32, tag, v);
-    else
-        return Put(tag, v);
+    return Put(tag, v);
 }
 
 /**
@@ -581,8 +574,7 @@ CHIP_ERROR TLVWriter::Put(uint64_t tag, int64_t v, bool preserveSize)
 {
     if (preserveSize)
         return WriteElementHead(kTLVElementType_Int64, tag, v);
-    else
-        return Put(tag, v);
+    return Put(tag, v);
 }
 
 /**
@@ -1772,8 +1764,7 @@ CHIP_ERROR TLVWriter::WriteElementHead(TLVElementType elemType, uint64_t tag, ui
         mLenWritten += len;
         return CHIP_NO_ERROR;
     }
-    else
-        return WriteData(stagingBuf, p - stagingBuf);
+    return WriteData(stagingBuf, p - stagingBuf);
 }
 
 CHIP_ERROR TLVWriter::WriteElementWithData(TLVType type, uint64_t tag, const uint8_t * data, uint32_t dataLen)

--- a/src/lib/message/CHIPFabricState.cpp
+++ b/src/lib/message/CHIPFabricState.cpp
@@ -1002,10 +1002,8 @@ IPAddress ChipFabricState::SelectNodeAddress(uint64_t nodeId, uint16_t subnetId)
     {
         return IPAddress::MakeIPv6WellKnownMulticast(kIPv6MulticastScope_Link, kIPV6MulticastGroup_AllNodes);
     }
-    else
-    {
-        return IPAddress::MakeULA(FabricId, subnetId, ChipNodeIdToIPv6InterfaceId(nodeId));
-    }
+
+    return IPAddress::MakeULA(FabricId, subnetId, ChipNodeIdToIPv6InterfaceId(nodeId));
 }
 
 /**
@@ -2091,7 +2089,8 @@ ChipMsgEncryptionKey * ChipMsgEncryptionKeyCache::FindOrAllocateKeyEntry(uint16_
             retKeyEntryIndex = i;
             break;
         }
-        else if (retKeyEntryIndex == CHIP_CONFIG_MAX_CACHED_MSG_ENC_APP_KEYS && keyEntry->KeyId == ChipKeyId::kNone)
+
+        if (retKeyEntryIndex == CHIP_CONFIG_MAX_CACHED_MSG_ENC_APP_KEYS && keyEntry->KeyId == ChipKeyId::kNone)
         {
             retKeyEntryIndex = i;
         }

--- a/src/lib/message/CHIPSecurityMgr.cpp
+++ b/src/lib/message/CHIPSecurityMgr.cpp
@@ -974,10 +974,8 @@ CHIP_ERROR ChipSecurityManager::CancelSessionEstablishment(void * reqState)
     }
 
     // Otherwise, tell the caller there was no match.
-    else
-    {
-        return CHIP_ERROR_INCORRECT_STATE;
-    }
+
+    return CHIP_ERROR_INCORRECT_STATE;
 }
 
 /**

--- a/src/lib/message/ExchangeContext.cpp
+++ b/src/lib/message/ExchangeContext.cpp
@@ -1034,10 +1034,8 @@ bool ExchangeContext::RMPCheckAndRemRetransTable(uint32_t ackMsgId, void ** rCtx
             res = true;
             break;
         }
-        else
-        {
-            continue;
-        }
+
+        continue;
     }
 
     return res;

--- a/src/lib/support/TimeUtils.cpp
+++ b/src/lib/support/TimeUtils.cpp
@@ -56,8 +56,7 @@ static inline uint8_t DaysToMarch1(uint16_t year)
 {
     if (IsLeapYear(year))
         return 60;
-    else
-        return 59;
+    return 59;
 }
 
 /* Converts a March-based month number (0=March, 1=April, etc.) to a March-1st based day of year (0=March 1st, 1=March 2nd, etc.).
@@ -112,10 +111,9 @@ uint8_t DaysInMonth(uint16_t year, uint8_t month)
 
     if (month == kFebruary && IsLeapYear(year))
         return 29;
-    else if (month >= kJanuary && month <= kDecember)
+    if (month >= kJanuary && month <= kDecember)
         return daysInMonth[month - 1];
-    else
-        return 0;
+    return 0;
 }
 
 /**

--- a/src/lib/support/verhoeff/Verhoeff.cpp
+++ b/src/lib/support/verhoeff/Verhoeff.cpp
@@ -35,24 +35,21 @@ int Verhoeff::DihedralMultiply(int x, int y, int n)
     {
         if (y < n)
             return (x + y) % n;
-        else
-            return ((x + (y - n)) % n) + n;
+
+        return ((x + (y - n)) % n) + n;
     }
-    else
-    {
-        if (y < n)
-            return ((n + (x - n) - y) % n) + n;
-        else
-            return (n + (x - n) - (y - n)) % n;
-    }
+
+    if (y < n)
+        return ((n + (x - n) - y) % n) + n;
+
+    return (n + (x - n) - (y - n)) % n;
 }
 
 int Verhoeff::DihedralInvert(int val, int n)
 {
     if (val > 0 && val < n)
         return n - val;
-    else
-        return val;
+    return val;
 }
 
 int Verhoeff::Permute(int val, uint8_t * permTable, int permTableLen, int iterCount)
@@ -60,6 +57,5 @@ int Verhoeff::Permute(int val, uint8_t * permTable, int permTableLen, int iterCo
     val = val % permTableLen;
     if (iterCount <= 0)
         return val;
-    else
-        return Permute(permTable[val], permTable, permTableLen, iterCount - 1);
+    return Permute(permTable[val], permTable, permTableLen, iterCount - 1);
 }

--- a/src/lib/support/verhoeff/Verhoeff10.cpp
+++ b/src/lib/support/verhoeff/Verhoeff10.cpp
@@ -97,14 +97,12 @@ int Verhoeff10::CharToVal(char ch)
 {
     if (ch >= '0' && ch <= '9')
         return ch - '0';
-    else
-        return -1;
+    return -1;
 }
 
 char Verhoeff10::ValToChar(int val)
 {
     if (val >= 0 && val <= Base)
         return '0' + val;
-    else
-        return 0;
+    return 0;
 }

--- a/src/lib/support/verhoeff/Verhoeff16.cpp
+++ b/src/lib/support/verhoeff/Verhoeff16.cpp
@@ -101,20 +101,23 @@ int Verhoeff16::CharToVal(char ch)
 {
     if (ch >= '0' && ch <= '9')
         return ch - '0';
-    else if (ch >= 'A' && ch <= 'F')
+
+    if (ch >= 'A' && ch <= 'F')
         return (ch - 'A') + 10;
-    else if (ch >= 'a' && ch <= 'f')
+
+    if (ch >= 'a' && ch <= 'f')
         return (ch - 'a') + 10;
-    else
-        return -1;
+
+    return -1;
 }
 
 char Verhoeff16::ValToChar(int val)
 {
     if (val >= 0 && val < 10)
         return '0' + val;
-    else if (val >= 10 && val < Base)
+
+    if (val >= 10 && val < Base)
         return 'A' + (val - 10);
-    else
-        return 0;
+
+    return 0;
 }

--- a/src/lib/support/verhoeff/Verhoeff32.cpp
+++ b/src/lib/support/verhoeff/Verhoeff32.cpp
@@ -140,14 +140,12 @@ int Verhoeff32::CharToVal(char ch)
 {
     if (ch >= '0' && ch <= 'y')
         return sCharToValTable[(int) ch - '0'];
-    else
-        return -1;
+    return -1;
 }
 
 char Verhoeff32::ValToChar(int val)
 {
     if (val >= 0 && val < Base)
         return sValToCharTable[val];
-    else
-        return 0;
+    return 0;
 }

--- a/src/lib/support/verhoeff/Verhoeff36.cpp
+++ b/src/lib/support/verhoeff/Verhoeff36.cpp
@@ -146,14 +146,12 @@ int Verhoeff36::CharToVal(char ch)
 {
     if (ch >= '0' && ch <= 'z')
         return sCharToValTable[(int) ch - '0'];
-    else
-        return -1;
+    return -1;
 }
 
 char Verhoeff36::ValToChar(int val)
 {
     if (val >= 0 && val < Base)
         return sValToCharTable[val];
-    else
-        return 0;
+    return 0;
 }

--- a/src/lwip/standalone/sys_arch.c
+++ b/src/lwip/standalone/sys_arch.c
@@ -217,10 +217,8 @@ err_t sys_thread_finish(sys_thread_t t)
         finish_thread(t);
         return ERR_OK;
     }
-    else
-    {
-        return ERR_VAL;
-    }
+
+    return ERR_VAL;
 }
 /*-----------------------------------------------------------------------------------*/
 err_t sys_mbox_new_extra(void * pool, struct sys_mbox ** mb, int size)
@@ -490,24 +488,22 @@ static u32_t cond_wait(pthread_cond_t * cond, pthread_mutex_t * mutex, u32_t tim
         {
             return SYS_ARCH_TIMEOUT;
         }
-        else
-        {
-            /* Calculate for how long we waited for the cond. */
-            gettimeofday(&rtime2, NULL);
-            tdiff = (rtime2.tv_sec - rtime1.tv_sec) * 1000 + (rtime2.tv_usec - rtime1.tv_usec) / 1000;
 
-            if (tdiff <= 0)
-            {
-                return 0;
-            }
-            return (u32_t) tdiff;
+        /* Calculate for how long we waited for the cond. */
+        gettimeofday(&rtime2, NULL);
+        tdiff = (rtime2.tv_sec - rtime1.tv_sec) * 1000 + (rtime2.tv_usec - rtime1.tv_usec) / 1000;
+
+        if (tdiff <= 0)
+        {
+            return 0;
         }
+
+        return (u32_t) tdiff;
     }
-    else
-    {
-        pthread_cond_wait(cond, mutex);
-        return 0;
-    }
+
+    pthread_cond_wait(cond, mutex);
+
+    return 0;
 }
 /*-----------------------------------------------------------------------------------*/
 u32_t sys_arch_sem_wait(struct sys_sem ** s, u32_t timeout)

--- a/src/platform/GeneralUtils.cpp
+++ b/src/platform/GeneralUtils.cpp
@@ -131,14 +131,17 @@ const char * CharacterizeIPv6Address(const IPAddress & ipAddr)
     {
         return "IPv6 link-local address";
     }
-    else if (ipAddr.IsIPv6ULA())
+
+    if (ipAddr.IsIPv6ULA())
     {
         return "IPv6 unique local address";
     }
-    else if (ipAddr.IsIPv6GlobalUnicast())
+
+    if (ipAddr.IsIPv6GlobalUnicast())
     {
         return "IPv6 global unicast address";
     }
+
     return "IPv6 address";
 }
 

--- a/src/platform/Linux/CHIPLinuxStorageIni.cpp
+++ b/src/platform/Linux/CHIPLinuxStorageIni.cpp
@@ -318,10 +318,8 @@ bool ChipLinuxStorageIni::HasValue(const char * key)
     {
         return true;
     }
-    else
-    {
-        return false;
-    }
+
+    return false;
 }
 
 CHIP_ERROR ChipLinuxStorageIni::AddEntry(const char * key, const char * value)

--- a/src/qrcodetool/qrcodetool.cpp
+++ b/src/qrcodetool/qrcodetool.cpp
@@ -71,10 +71,8 @@ static int execute_command(int argc, char ** argv)
         ChipLogDetail(chipTool, "Executing cmd %s\n", command_to_execute->c_name);
         return command_to_execute->c_func(argc, argv);
     }
-    else
-    {
-        return help(0, NULL);
-    }
+
+    return help(0, NULL);
 }
 
 int main(int argc, char ** argv)

--- a/src/qrcodetool/setup_payload_commands.cpp
+++ b/src/qrcodetool/setup_payload_commands.cpp
@@ -71,10 +71,8 @@ extern int setup_payload_operation_generate_qr_code(int argc, char * const * arg
         ChipLogDetail(chipTool, "QR Code: %s", code.c_str());
         return 0;
     }
-    else
-    {
-        return 2;
-    }
+
+    return 2;
 }
 
 extern int setup_payload_operation_generate_manual_code(int argc, char * const * argv)
@@ -92,8 +90,6 @@ extern int setup_payload_operation_generate_manual_code(int argc, char * const *
         ChipLogDetail(chipTool, "Manual Code: %s", code.c_str());
         return 0;
     }
-    else
-    {
-        return 2;
-    }
+
+    return 2;
 }

--- a/src/setup_payload/ManualSetupPayloadParser.cpp
+++ b/src/setup_payload/ManualSetupPayloadParser.cpp
@@ -100,7 +100,8 @@ static CHIP_ERROR readDigitsFromDecimalString(string decimalString, int & index,
         ChipLogError(SetupPayload, "Failed decoding base10. Input was too short. %zu", decimalString.length());
         return CHIP_ERROR_INVALID_STRING_LENGTH;
     }
-    else if (index < 0)
+
+    if (index < 0)
     {
         ChipLogError(SetupPayload, "Failed decoding base10. Index was negative. %d", index);
         return CHIP_ERROR_INVALID_ARGUMENT;
@@ -170,7 +171,7 @@ CHIP_ERROR ManualSetupPayloadParser::populatePayload(SetupPayload & outPayload)
     {
         return result;
     }
-    else if (setUpPINCode == 0)
+    if (setUpPINCode == 0)
     {
         ChipLogError(SetupPayload, "Failed decoding base10. SetUpPINCode was 0.");
         return CHIP_ERROR_INVALID_ARGUMENT;

--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -346,10 +346,8 @@ static string extractPayload(string inString)
     {
         return chipSegment.substr(strlen(kQRCodePrefix)); // strip out prefix before returning
     }
-    else
-    {
-        return chipSegment;
-    }
+
+    return chipSegment;
 }
 
 CHIP_ERROR QRCodeSetupPayloadParser::populatePayload(SetupPayload & outPayload)

--- a/src/system/SystemError.cpp
+++ b/src/system/SystemError.cpp
@@ -246,10 +246,8 @@ bool FormatPOSIXError(char * buf, uint16_t bufSize, int32_t err)
         FormatError(buf, bufSize, "OS", err, desc);
         return true;
     }
-    else
-    {
-        return false;
-    }
+
+    return false;
 }
 
 /**


### PR DESCRIPTION
 #### Problem
else after return has no purpose, and increases control flow complexity.

 #### Summary of Changes
Run `run-clang-tidy.py -header-filter='.*' -checks='-*,readability-else-after-return` for Linux clang build.