### PR TITLE
clang-tidy: Apply fixes "readability-string-compare"

### DIFF
--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -301,7 +301,7 @@ bool SetupPayload::operator==(SetupPayload & input)
         CHIP_ERROR err = getOptionalVendorData(inputInfo.tag, info);
         VerifyOrExit(err == CHIP_NO_ERROR, isIdentical = false);
         VerifyOrExit(inputInfo.type == info.type, isIdentical = false);
-        VerifyOrExit(inputInfo.data.compare(info.data) == 0, isIdentical = false);
+        VerifyOrExit(inputInfo.data == info.data, isIdentical = false);
         VerifyOrExit(inputInfo.int32 == info.int32, isIdentical = false);
     }
 
@@ -314,7 +314,7 @@ bool SetupPayload::operator==(SetupPayload & input)
         CHIP_ERROR err = getOptionalExtensionData(inputInfo.tag, info);
         VerifyOrExit(err == CHIP_NO_ERROR, isIdentical = false);
         VerifyOrExit(inputInfo.type == info.type, isIdentical = false);
-        VerifyOrExit(inputInfo.data.compare(info.data) == 0, isIdentical = false);
+        VerifyOrExit(inputInfo.data == info.data, isIdentical = false);
         VerifyOrExit(inputInfo.int32 == info.int32, isIdentical = false);
         VerifyOrExit(inputInfo.int64 == info.int64, isIdentical = false);
         VerifyOrExit(inputInfo.uint32 == info.uint32, isIdentical = false);

--- a/src/setup_payload/SetupPayloadHelper.cpp
+++ b/src/setup_payload/SetupPayloadHelper.cpp
@@ -50,32 +50,32 @@ static CHIP_ERROR resolveSetupPayloadParameter(SetupPayloadParameter & parameter
 {
     bool isUnsignedInt   = true;
     bool shouldHaveValue = true;
-    if (key.compare("version") == 0)
+    if (key == "version")
     {
         parameter.key = SetupPayloadKey_Version;
     }
-    else if (key.compare("vendorID") == 0)
+    else if (key == "vendorID")
     {
         parameter.key = SetupPayloadKey_VendorID;
     }
-    else if (key.compare("productID") == 0)
+    else if (key == "productID")
     {
         parameter.key = SetupPayloadKey_ProductID;
     }
-    else if (key.compare("requiresCustomFlowTrue") == 0)
+    else if (key == "requiresCustomFlowTrue")
     {
         parameter.key   = SetupPayloadKey_RequiresCustomFlowTrue;
         shouldHaveValue = false;
     }
-    else if (key.compare("rendezVousInformation") == 0)
+    else if (key == "rendezVousInformation")
     {
         parameter.key = SetupPayloadKey_RendezVousInformation;
     }
-    else if (key.compare("discriminator") == 0)
+    else if (key == "discriminator")
     {
         parameter.key = SetupPayloadKey_Discriminator;
     }
-    else if (key.compare("setUpPINCode") == 0)
+    else if (key == "setUpPINCode")
     {
         parameter.key = SetupPayloadKey_SetupPINCode;
     }

--- a/src/setup_payload/tests/TestManualCode.cpp
+++ b/src/setup_payload/tests/TestManualCode.cpp
@@ -49,7 +49,7 @@ bool CheckGenerator(SetupPayload payload, string expectedResult)
         expectedResult += Verhoeff10::ComputeCheckChar(expectedResult.c_str());
     }
 
-    bool same = result.compare(expectedResult) == 0;
+    bool same = result == expectedResult;
     if (!same)
     {
         printf("Actual result: %s\n", result.c_str());
@@ -374,13 +374,13 @@ void TestCheckDecimalStringValidity(nlTestSuite * inSuite, void * inContext)
     checkDigit                      = Verhoeff10::ComputeCheckChar(representationWithoutCheckDigit.c_str());
     decimalString                   = representationWithoutCheckDigit + checkDigit;
     NL_TEST_ASSERT(inSuite, checkDecimalStringValidity(decimalString, outReprensation) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, outReprensation.compare(representationWithoutCheckDigit) == 0);
+    NL_TEST_ASSERT(inSuite, outReprensation == representationWithoutCheckDigit);
 
     representationWithoutCheckDigit = "0000";
     checkDigit                      = Verhoeff10::ComputeCheckChar(representationWithoutCheckDigit.c_str());
     decimalString                   = representationWithoutCheckDigit + checkDigit;
     NL_TEST_ASSERT(inSuite, checkDecimalStringValidity(decimalString, outReprensation) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, outReprensation.compare(representationWithoutCheckDigit) == 0);
+    NL_TEST_ASSERT(inSuite, outReprensation == representationWithoutCheckDigit);
 }
 
 void TestCheckCodeLengthValidity(nlTestSuite * inSuite, void * inContext)

--- a/src/setup_payload/tests/TestQRCode.cpp
+++ b/src/setup_payload/tests/TestQRCode.cpp
@@ -83,42 +83,41 @@ void TestBase41(nlTestSuite * inSuite, void * inContext)
     uint8_t input[] = { 10, 10, 10 };
 
     // basic stuff
-    NL_TEST_ASSERT(inSuite, base41Encode(input, 0).compare("") == 0);
-    NL_TEST_ASSERT(inSuite, base41Encode(input, 1).compare("A") == 0);
-    NL_TEST_ASSERT(inSuite, base41Encode(input, 2).compare("SL1") == 0);
-    NL_TEST_ASSERT(inSuite, base41Encode(input, 3).compare("SL1A") == 0);
+    NL_TEST_ASSERT(inSuite, base41Encode(input, 0) == "");
+    NL_TEST_ASSERT(inSuite, base41Encode(input, 1) == "A");
+    NL_TEST_ASSERT(inSuite, base41Encode(input, 2) == "SL1");
+    NL_TEST_ASSERT(inSuite, base41Encode(input, 3) == "SL1A");
 
     // test single odd byte corner conditions
     input[2] = 0;
-    NL_TEST_ASSERT(inSuite, base41Encode(input, 3).compare("SL10") == 0);
+    NL_TEST_ASSERT(inSuite, base41Encode(input, 3) == "SL10");
     input[2] = 40;
-    NL_TEST_ASSERT(inSuite, base41Encode(input, 3).compare("SL1.") == 0);
+    NL_TEST_ASSERT(inSuite, base41Encode(input, 3) == "SL1.");
     input[2] = 41;
-    NL_TEST_ASSERT(inSuite, base41Encode(input, 3).compare("SL101") == 0);
+    NL_TEST_ASSERT(inSuite, base41Encode(input, 3) == "SL101");
     input[2] = 255;
-    NL_TEST_ASSERT(inSuite, base41Encode(input, 3).compare("SL196") == 0);
+    NL_TEST_ASSERT(inSuite, base41Encode(input, 3) == "SL196");
 
     // testing optimized encoding
     // verify that we can't optimize a low value, need 3 chars
     input[0] = 255;
     input[1] = 0;
-    NL_TEST_ASSERT(inSuite, base41Encode(input, 2).compare("960") == 0);
+    NL_TEST_ASSERT(inSuite, base41Encode(input, 2) == "960");
     // smallest optimized encoding, 256
     input[0] = 256 % 256;
     input[1] = 256 / 256;
-    NL_TEST_ASSERT(inSuite, base41Encode(input, 2).compare("A6") == 0);
+    NL_TEST_ASSERT(inSuite, base41Encode(input, 2) == "A6");
     // largest optimizated encoding value
     input[0] = ((kRadix * kRadix) - 1) % 256;
     input[1] = ((kRadix * kRadix) - 1) / 256;
-    NL_TEST_ASSERT(inSuite, base41Encode(input, 2).compare("..") == 0);
+    NL_TEST_ASSERT(inSuite, base41Encode(input, 2) == "..");
     // can't optimize
     input[0] = ((kRadix * kRadix)) % 256;
     input[1] = ((kRadix * kRadix)) / 256;
-    NL_TEST_ASSERT(inSuite, base41Encode(input, 2).compare("001") == 0);
+    NL_TEST_ASSERT(inSuite, base41Encode(input, 2) == "001");
 
     // fun with strings
-    NL_TEST_ASSERT(inSuite,
-                   base41Encode((uint8_t *) "Hello World!", sizeof("Hello World!") - 1).compare("GHF.KGL+48-G5LGK35") == 0);
+    NL_TEST_ASSERT(inSuite, base41Encode((uint8_t *) "Hello World!", sizeof("Hello World!") - 1) == "GHF.KGL+48-G5LGK35");
 
     vector<uint8_t> decoded = vector<uint8_t>();
     NL_TEST_ASSERT(inSuite, base41Decode("GHF.KGL+48-G5LGK35", decoded) == CHIP_NO_ERROR);
@@ -128,7 +127,7 @@ void TestBase41(nlTestSuite * inSuite, void * inContext)
     {
         hello_world += (char) decoded[_];
     }
-    NL_TEST_ASSERT(inSuite, hello_world.compare("Hello World!") == 0);
+    NL_TEST_ASSERT(inSuite, hello_world == "Hello World!");
 
     // short input
     NL_TEST_ASSERT(inSuite, base41Decode("A0", decoded) == CHIP_NO_ERROR);
@@ -278,23 +277,23 @@ void TestQRCodeToPayloadGeneration(nlTestSuite * inSuite, void * inContext)
 
 void TestExtractPayload(nlTestSuite * inSuite, void * inContext)
 {
-    NL_TEST_ASSERT(inSuite, extractPayload(string("CH:ABC")).compare(string("ABC")) == 0);
-    NL_TEST_ASSERT(inSuite, extractPayload(string("CH:")).compare(string("")) == 0);
-    NL_TEST_ASSERT(inSuite, extractPayload(string("H:")).compare(string("")) == 0);
-    NL_TEST_ASSERT(inSuite, extractPayload(string("ASCH:")).compare(string("")) == 0);
-    NL_TEST_ASSERT(inSuite, extractPayload(string("Z%CH:ABC%")).compare(string("ABC")) == 0);
-    NL_TEST_ASSERT(inSuite, extractPayload(string("Z%CH:ABC")).compare(string("ABC")) == 0);
-    NL_TEST_ASSERT(inSuite, extractPayload(string("%Z%CH:ABC")).compare(string("ABC")) == 0);
-    NL_TEST_ASSERT(inSuite, extractPayload(string("%Z%CH:ABC%")).compare(string("ABC")) == 0);
-    NL_TEST_ASSERT(inSuite, extractPayload(string("%Z%CH:ABC%DDD")).compare(string("ABC")) == 0);
-    NL_TEST_ASSERT(inSuite, extractPayload(string("CH:ABC%DDD")).compare(string("ABC")) == 0);
-    NL_TEST_ASSERT(inSuite, extractPayload(string("CH:ABC%")).compare(string("ABC")) == 0);
-    NL_TEST_ASSERT(inSuite, extractPayload(string("%CH:")).compare(string("")) == 0);
-    NL_TEST_ASSERT(inSuite, extractPayload(string("%CH:%")).compare(string("")) == 0);
-    NL_TEST_ASSERT(inSuite, extractPayload(string("A%")).compare(string("")) == 0);
-    NL_TEST_ASSERT(inSuite, extractPayload(string("CH:%")).compare(string("")) == 0);
-    NL_TEST_ASSERT(inSuite, extractPayload(string("%CH:ABC")).compare(string("ABC")) == 0);
-    NL_TEST_ASSERT(inSuite, extractPayload(string("ABC")).compare(string("")) == 0);
+    NL_TEST_ASSERT(inSuite, extractPayload(string("CH:ABC")) == string("ABC"));
+    NL_TEST_ASSERT(inSuite, extractPayload(string("CH:")) == string(""));
+    NL_TEST_ASSERT(inSuite, extractPayload(string("H:")) == string(""));
+    NL_TEST_ASSERT(inSuite, extractPayload(string("ASCH:")) == string(""));
+    NL_TEST_ASSERT(inSuite, extractPayload(string("Z%CH:ABC%")) == string("ABC"));
+    NL_TEST_ASSERT(inSuite, extractPayload(string("Z%CH:ABC")) == string("ABC"));
+    NL_TEST_ASSERT(inSuite, extractPayload(string("%Z%CH:ABC")) == string("ABC"));
+    NL_TEST_ASSERT(inSuite, extractPayload(string("%Z%CH:ABC%")) == string("ABC"));
+    NL_TEST_ASSERT(inSuite, extractPayload(string("%Z%CH:ABC%DDD")) == string("ABC"));
+    NL_TEST_ASSERT(inSuite, extractPayload(string("CH:ABC%DDD")) == string("ABC"));
+    NL_TEST_ASSERT(inSuite, extractPayload(string("CH:ABC%")) == string("ABC"));
+    NL_TEST_ASSERT(inSuite, extractPayload(string("%CH:")) == string(""));
+    NL_TEST_ASSERT(inSuite, extractPayload(string("%CH:%")) == string(""));
+    NL_TEST_ASSERT(inSuite, extractPayload(string("A%")) == string(""));
+    NL_TEST_ASSERT(inSuite, extractPayload(string("CH:%")) == string(""));
+    NL_TEST_ASSERT(inSuite, extractPayload(string("%CH:ABC")) == string("ABC"));
+    NL_TEST_ASSERT(inSuite, extractPayload(string("ABC")) == string(""));
 }
 
 // Test Suite

--- a/src/setup_payload/tests/TestQRCodeTLV.cpp
+++ b/src/setup_payload/tests/TestQRCodeTLV.cpp
@@ -129,11 +129,11 @@ void TestSerialNumberAddRemove(nlTestSuite * inSuite, void * inContext)
 
     NL_TEST_ASSERT(inSuite, inPayload.addSerialNumber(kSerialNumberDefaultStringValue) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, inPayload.getSerialNumber(sn) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, sn.compare(kSerialNumberDefaultStringValue) == 0);
+    NL_TEST_ASSERT(inSuite, sn == kSerialNumberDefaultStringValue);
 
     NL_TEST_ASSERT(inSuite, inPayload.addSerialNumber(kSerialNumberDefaultUInt32Value) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, inPayload.getSerialNumber(sn) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, sn.compare(to_string(kSerialNumberDefaultUInt32Value)) == 0);
+    NL_TEST_ASSERT(inSuite, sn == to_string(kSerialNumberDefaultUInt32Value));
 
     NL_TEST_ASSERT(inSuite, inPayload.removeSerialNumber() == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, inPayload.getSerialNumber(sn) == CHIP_ERROR_KEY_NOT_FOUND);


### PR DESCRIPTION
 #### Problem
`s1.compare(s2) == 0` can be simplified to `s1 == s2`

 #### Summary of Changes
Run `run-clang-tidy.py -header-filter='.*' -checks='-*,readability-string-compare` for Linux clang build.
