### PR TITLE
clang-tidy: Apply fixes "modernize-use-equals-delete"

### DIFF
--- a/src/ble/BLEEndPoint.h
+++ b/src/ble/BLEEndPoint.h
@@ -159,8 +159,8 @@ private:
 
 private:
     // Private functions:
-    BLEEndPoint(void);  // not defined
-    ~BLEEndPoint(void); // not defined
+    BLEEndPoint(void)  = delete;
+    ~BLEEndPoint(void) = delete;
 
     BLE_ERROR Init(BleLayer * bleLayer, BLE_CONNECTION_OBJECT connObj, BleRole role, bool autoClose);
     bool IsConnected(uint8_t state) const;

--- a/src/inet/IPEndPointBasis.h
+++ b/src/inet/IPEndPointBasis.h
@@ -176,9 +176,9 @@ protected:
 #endif // CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
 private:
-    IPEndPointBasis(void);                    // not defined
-    IPEndPointBasis(const IPEndPointBasis &); // not defined
-    ~IPEndPointBasis(void);                   // not defined
+    IPEndPointBasis(void)                    = delete;
+    IPEndPointBasis(const IPEndPointBasis &) = delete;
+    ~IPEndPointBasis(void)                   = delete;
 };
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP

--- a/src/inet/RawEndPoint.h
+++ b/src/inet/RawEndPoint.h
@@ -84,9 +84,9 @@ public:
     void Free(void);
 
 private:
-    RawEndPoint(void);                // not defined
-    RawEndPoint(const RawEndPoint &); // not defined
-    ~RawEndPoint(void);               // not defined
+    RawEndPoint(void)                = delete;
+    RawEndPoint(const RawEndPoint &) = delete;
+    ~RawEndPoint(void)               = delete;
 
     static chip::System::ObjectPool<RawEndPoint, INET_CONFIG_NUM_RAW_ENDPOINTS> sPool;
 

--- a/src/inet/UDPEndPoint.h
+++ b/src/inet/UDPEndPoint.h
@@ -65,9 +65,9 @@ public:
     void Free(void);
 
 private:
-    UDPEndPoint(void);                // not defined
-    UDPEndPoint(const UDPEndPoint &); // not defined
-    ~UDPEndPoint(void);               // not defined
+    UDPEndPoint(void)                = delete;
+    UDPEndPoint(const UDPEndPoint &) = delete;
+    ~UDPEndPoint(void)               = delete;
 
     static chip::System::ObjectPool<UDPEndPoint, INET_CONFIG_NUM_UDP_ENDPOINTS> sPool;
 

--- a/src/lib/support/verhoeff/Verhoeff.h
+++ b/src/lib/support/verhoeff/Verhoeff.h
@@ -64,8 +64,8 @@ public:
     static char ValToChar(int val);
 
 private:
-    Verhoeff10(void);  // not defined
-    ~Verhoeff10(void); // not defined
+    Verhoeff10(void)  = delete;
+    ~Verhoeff10(void) = delete;
 
     static uint8_t sMultiplyTable[];
     static uint8_t sPermTable[];
@@ -101,8 +101,8 @@ public:
     static char ValToChar(int val);
 
 private:
-    Verhoeff16(void);  // not defined
-    ~Verhoeff16(void); // not defined
+    Verhoeff16(void)  = delete;
+    ~Verhoeff16(void) = delete;
 
     static uint8_t sMultiplyTable[];
     static uint8_t sPermTable[];
@@ -140,8 +140,8 @@ public:
     static char ValToChar(int val);
 
 private:
-    Verhoeff32(void);  // not defined
-    ~Verhoeff32(void); // not defined
+    Verhoeff32(void)  = delete;
+    ~Verhoeff32(void) = delete;
 
     static uint8_t sMultiplyTable[];
     static uint8_t sPermTable[];
@@ -175,8 +175,8 @@ public:
     static char ValToChar(int val);
 
 private:
-    Verhoeff36(void);  // not defined
-    ~Verhoeff36(void); // not defined
+    Verhoeff36(void)  = delete;
+    ~Verhoeff36(void) = delete;
 
     static uint8_t sMultiplyTable[];
     static uint8_t sPermTable[];

--- a/src/system/SystemLayer.h
+++ b/src/system/SystemLayer.h
@@ -209,8 +209,8 @@ private:
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
     // Copy and assignment NOT DEFINED
-    Layer(const Layer &);
-    Layer & operator=(const Layer &);
+    Layer(const Layer &) = delete;
+    Layer & operator=(const Layer &) = delete;
 
     friend class Timer;
 };

--- a/src/system/SystemMutex.h
+++ b/src/system/SystemMutex.h
@@ -83,8 +83,8 @@ private:
     volatile int mInitialized;
 #endif // CHIP_SYSTEM_CONFIG_FREERTOS_LOCKING
 
-    Mutex(const Mutex &) /* = delete */;
-    Mutex & operator=(const Mutex &) /* = delete */;
+    Mutex(const Mutex &) = delete;
+    Mutex & operator=(const Mutex &) = delete;
 };
 
 inline Mutex::Mutex(void) {}

--- a/src/system/SystemObject.h
+++ b/src/system/SystemObject.h
@@ -99,8 +99,8 @@ protected:
 private:
     Object(void);
     ~Object(void);
-    Object(const Object &) /* = delete */;
-    Object & operator=(const Object &) /* = delete */;
+    Object(const Object &) = delete;
+    Object & operator=(const Object &) = delete;
 
     Layer * volatile mSystemLayer; /**< Pointer to the layer object that owns this object. */
     unsigned int mRefCount;        /**< Count of remaining calls to Release before object is dead. */

--- a/src/system/SystemTimer.h
+++ b/src/system/SystemTimer.h
@@ -90,8 +90,8 @@ private:
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
     // Not defined
-    Timer(const Timer &);
-    Timer & operator=(const Timer &);
+    Timer(const Timer &) = delete;
+    Timer & operator=(const Timer &) = delete;
 };
 
 inline void Timer::GetStatistics(chip::System::Stats::count_t & aNumInUse, chip::System::Stats::count_t & aHighWatermark)

--- a/src/system/tests/TestSystemObject.cpp
+++ b/src/system/tests/TestSystemObject.cpp
@@ -105,8 +105,8 @@ private:
 #endif // CHIP_SYSTEM_CONFIG_POSIX_LOCKING
 
     // Not defined
-    TestObject(const TestObject &);
-    TestObject & operator=(const TestObject &);
+    TestObject(const TestObject &) = delete;
+    TestObject & operator=(const TestObject &) = delete;
 };
 
 ObjectPool<TestObject, TestObject::kPoolSize> TestObject::sPool;


### PR DESCRIPTION
 #### Problem
We build with C++11, and can use `= delete` to remove default overloads.

 #### Summary of Changes
Run `run-clang-tidy.py -header-filter='.*' -checks='-*,modernize-use-equals-delete` for Linux clang build.