### PR TITLE
Use uint16_t instead of uint32_t for src/app/[encoder|decoder] methods

### DIFF
--- a/src/app/chip-zcl-zpro-codec.h
+++ b/src/app/chip-zcl-zpro-codec.h
@@ -51,17 +51,17 @@ extern "C" {
 
 /** @brief Encode an on command for on-off server into buffer including the APS frame
  */
-uint32_t encodeOnCommand(uint8_t * buffer, uint32_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeOnCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
 
 /** @brief Encode an off command for on-off server into buffer including the APS frame
  */
 
-uint32_t encodeOffCommand(uint8_t * buffer, uint32_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeOffCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
 
 /** @brief Encode a toggle command for on-off server into buffer including the APS frame
  */
 
-uint32_t encodeToggleCommand(uint8_t * buffer, uint32_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeToggleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
 
 /**
  * @brief Encode a Read Attributes command for the given cluster and the given
@@ -82,7 +82,7 @@ uint16_t encodeReadOnOffCommand(uint8_t * buffer, uint16_t buf_length, uint8_t d
  * @param outApsFrame Pointer to EmberApsFrame struct to read into
  * @return returns the number of bytes that were consumed to read out the EmberApsFrame. 0 means an error was encountered
  */
-uint16_t extractApsFrame(uint8_t * buffer, uint32_t buf_length, EmberApsFrame * outApsFrame);
+uint16_t extractApsFrame(uint8_t * buffer, uint16_t buf_length, EmberApsFrame * outApsFrame);
 
 /** @brief Populates msg with address of the zcl message within buffer.
  * @return Returns the length of msg buffer. Returns 0 on error e.g. if buffer is too short.

--- a/src/app/decoder.cpp
+++ b/src/app/decoder.cpp
@@ -47,7 +47,7 @@ struct Reader<2>
 
 extern "C" {
 
-uint16_t extractApsFrame(uint8_t * buffer, uint32_t buf_length, EmberApsFrame * outApsFrame)
+uint16_t extractApsFrame(uint8_t * buffer, uint16_t buf_length, EmberApsFrame * outApsFrame)
 {
     if (buffer == nullptr || buf_length == 0 || outApsFrame == nullptr)
     {

--- a/src/app/encoder.cpp
+++ b/src/app/encoder.cpp
@@ -79,7 +79,7 @@ uint16_t encodeApsFrame(uint8_t * buffer, uint16_t buf_length, EmberApsFrame * a
                             apsFrame->options, apsFrame->groupId, apsFrame->sequence, apsFrame->radius, !buffer);
 }
 
-uint32_t _encodeCommand(BufBound & buf, uint8_t destination_endpoint, uint16_t cluster_id, uint8_t command, uint8_t frame_control)
+uint16_t _encodeCommand(BufBound & buf, uint8_t destination_endpoint, uint16_t cluster_id, uint8_t command, uint8_t frame_control)
 {
     CHECK_FRAME_LENGTH(buf.Size(), "Buffer is empty");
 
@@ -98,7 +98,7 @@ uint32_t _encodeCommand(BufBound & buf, uint8_t destination_endpoint, uint16_t c
     return buf.Fit() ? buf.Written() : 0;
 }
 
-uint32_t _encodeClusterSpecificCommand(BufBound & buf, uint8_t destination_endpoint, uint16_t cluster_id, uint8_t command)
+uint16_t _encodeClusterSpecificCommand(BufBound & buf, uint8_t destination_endpoint, uint16_t cluster_id, uint8_t command)
 {
     // This is a cluster-specific command so low two bits are 0b01.  The command
     // is standard, so does not need a manufacturer code, and we're sending
@@ -108,7 +108,7 @@ uint32_t _encodeClusterSpecificCommand(BufBound & buf, uint8_t destination_endpo
     return _encodeCommand(buf, destination_endpoint, cluster_id, command, frame_control);
 }
 
-uint32_t _encodeGlobalCommand(BufBound & buf, uint8_t destination_endpoint, uint16_t cluster_id, uint8_t command)
+uint16_t _encodeGlobalCommand(BufBound & buf, uint8_t destination_endpoint, uint16_t cluster_id, uint8_t command)
 {
     // This is a global command, so the low bits are 0b00.  The command is
     // standard, so does not need a manufacturer code, and we're sending client
@@ -140,26 +140,26 @@ uint16_t encodeReadAttributesCommand(uint8_t * buffer, uint16_t buf_length, uint
  * Pick cluster id as 0x0006 for now
  */
 
-uint32_t encodeOffCommand(uint8_t * buffer, uint32_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeOffCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
 {
     BufBound buf    = BufBound(buffer, buf_length);
-    uint32_t result = _encodeClusterSpecificCommand(buf, destination_endpoint, 0x0006, 0x00);
+    uint16_t result = _encodeClusterSpecificCommand(buf, destination_endpoint, 0x0006, 0x00);
     CHECK_COMMAND_LENGTH(result, "Off");
     return result;
 };
 
-uint32_t encodeOnCommand(uint8_t * buffer, uint32_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeOnCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
 {
     BufBound buf    = BufBound(buffer, buf_length);
-    uint32_t result = _encodeClusterSpecificCommand(buf, destination_endpoint, 0x0006, 0x01);
+    uint16_t result = _encodeClusterSpecificCommand(buf, destination_endpoint, 0x0006, 0x01);
     CHECK_COMMAND_LENGTH(result, "On");
     return result;
 }
 
-uint32_t encodeToggleCommand(uint8_t * buffer, uint32_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeToggleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
 {
     BufBound buf    = BufBound(buffer, buf_length);
-    uint32_t result = _encodeClusterSpecificCommand(buf, destination_endpoint, 0x0006, 0x02);
+    uint16_t result = _encodeClusterSpecificCommand(buf, destination_endpoint, 0x0006, 0x02);
     CHECK_COMMAND_LENGTH(result, "Toggle");
     return result;
 }


### PR DESCRIPTION
 #### Problem

Methods from src/app/chip-zcl-zpro-codec.h use a mix of uint16_t and uint32_t as return values.
PacketBuffer len is uint16_t, so seems reasonable to use uint16_t all over the places. 

 #### Summary of Changes
* Replace uint32_t by uint16_t from method signatures.