### PR TITLE
clang-tidy: Apply fixes "misc-unused-using-decls"

### DIFF
--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -32,9 +32,7 @@
 using chip::DeviceLayer::Internal::DeviceNetworkInfo;
 using otbr::DBus::ClientError;
 using otbr::DBus::DeviceRole;
-using otbr::DBus::IpCounters;
 using otbr::DBus::LinkModeConfig;
-using otbr::DBus::MacCounters;
 using otbr::DBus::NeighborInfo;
 
 #ifndef CHIP_CONFIG_OTBR_CLIENT_ERROR_MIN

--- a/src/system/tests/TestSystemObject.cpp
+++ b/src/system/tests/TestSystemObject.cpp
@@ -66,8 +66,6 @@ using namespace chip::System;
 namespace chip {
 namespace System {
 
-using chip::ErrorStr;
-
 static int Initialize(void * aContext);
 static int Finalize(void * aContext);
 

--- a/src/system/tests/TestSystemWakeEvent.cpp
+++ b/src/system/tests/TestSystemWakeEvent.cpp
@@ -42,7 +42,6 @@
 #include <pthread.h>
 #endif // CHIP_SYSTEM_CONFIG_POSIX_LOCKING
 
-using chip::ErrorStr;
 using namespace chip::System;
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS


### PR DESCRIPTION
 #### Problem
There are unused "using" declarations.

 #### Summary of Changes
Remove them.