### PR TITLE
clang-tidy: Apply fixes "modernize-loop-convert"

### DIFF
--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -208,9 +208,9 @@ BLE_ERROR BleTransportCapabilitiesRequestMessage::Encode(PacketBuffer * msgBuf) 
     chip::Encoding::Write8(p, CAPABILITIES_MSG_CHECK_BYTE_1);
     chip::Encoding::Write8(p, CAPABILITIES_MSG_CHECK_BYTE_2);
 
-    for (int i = 0; i < CAPABILITIES_REQUEST_SUPPORTED_VERSIONS_LEN; i++)
+    for (uint8_t version : mSupportedProtocolVersions)
     {
-        chip::Encoding::Write8(p, mSupportedProtocolVersions[i]);
+        chip::Encoding::Write8(p, version);
     }
 
     chip::Encoding::LittleEndian::Write16(p, mMtu);

--- a/src/inet/AsyncDNSResolverSockets.cpp
+++ b/src/inet/AsyncDNSResolverSockets.cpp
@@ -98,9 +98,9 @@ INET_ERROR AsyncDNSResolverSockets::Shutdown(void)
     AsyncMutexUnlock();
 
     // Have the CHIP thread join the thread pool for asynchronous DNS resolution.
-    for (int i = 0; i < INET_CONFIG_DNS_ASYNC_MAX_THREAD_COUNT; i++)
+    for (pthread_t thread : mAsyncDNSThreadHandle)
     {
-        pthreadErr = pthread_join(mAsyncDNSThreadHandle[i], nullptr);
+        pthreadErr = pthread_join(thread, nullptr);
         VerifyOrDie(pthreadErr == 0);
     }
 

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -187,26 +187,24 @@ static void TestResolveHostAddress(nlTestSuite * inSuite, void * inContext)
 // Test Inet ParseHostPortAndInterface
 static void TestParseHost(nlTestSuite * inSuite, void * inContext)
 {
-    char correctHostName[7][30] = {
+    char correctHostNames[7][30] = {
         "10.0.0.1", "10.0.0.1:3000", "www.google.com", "www.google.com:3000", "[fd00:0:1:1::1]:3000", "[fd00:0:1:1::1]:300%wpan0",
         "%wpan0"
     };
-    char invalidHostName[4][30] = { "[fd00::1]5", "[fd00:0:1:1::1:3000", "10.0.0.1:1234567", "10.0.0.1:er31" };
+    char invalidHostNames[4][30] = { "[fd00::1]5", "[fd00:0:1:1::1:3000", "10.0.0.1:1234567", "10.0.0.1:er31" };
     const char * host;
     const char * intf;
     uint16_t port, hostlen, intflen;
     INET_ERROR err;
 
-    for (int i = 0; i < 7; i++)
+    for (char * correctHostName : correctHostNames)
     {
-        err =
-            ParseHostPortAndInterface(correctHostName[i], uint16_t(strlen(correctHostName[i])), host, hostlen, port, intf, intflen);
+        err = ParseHostPortAndInterface(correctHostName, uint16_t(strlen(correctHostName)), host, hostlen, port, intf, intflen);
         NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
     }
-    for (int i = 0; i < 4; i++)
+    for (char * invalidHostName : invalidHostNames)
     {
-        err =
-            ParseHostPortAndInterface(invalidHostName[i], uint16_t(strlen(invalidHostName[i])), host, hostlen, port, intf, intflen);
+        err = ParseHostPortAndInterface(invalidHostName, uint16_t(strlen(invalidHostName)), host, hostlen, port, intf, intflen);
         NL_TEST_ASSERT(inSuite, err == INET_ERROR_INVALID_HOST_NAME);
     }
 }

--- a/src/inet/tests/TestInetErrorStr.cpp
+++ b/src/inet/tests/TestInetErrorStr.cpp
@@ -92,9 +92,8 @@ static void CheckInetErrorStr(nlTestSuite * inSuite, void * inContext)
     Inet::RegisterLayerErrorFormatter();
 
     // For each defined error...
-    for (size_t i = 0; i < kTestElements; i++)
+    for (int err : sContext)
     {
-        int32_t err         = sContext[i];
         const char * errStr = ErrorStr(err);
         char expectedText[9];
 

--- a/src/lib/core/tests/TestCHIPErrorStr.cpp
+++ b/src/lib/core/tests/TestCHIPErrorStr.cpp
@@ -232,9 +232,8 @@ static void CheckCoreErrorStr(nlTestSuite * inSuite, void * inContext)
     RegisterCHIPLayerErrorFormatter();
 
     // For each defined error...
-    for (size_t i = 0; i < kTestElements; i++)
+    for (int err : sContext)
     {
-        int32_t err         = sContext[i];
         const char * errStr = ErrorStr(err);
         char expectedText[9];
 

--- a/src/setup_payload/ManualSetupPayloadParser.cpp
+++ b/src/setup_payload/ManualSetupPayloadParser.cpp
@@ -78,15 +78,15 @@ static CHIP_ERROR extractBits(uint32_t number, uint64_t & dest, int index, int n
 static CHIP_ERROR toNumber(string decimalString, uint64_t & dest)
 {
     uint64_t number = 0;
-    for (size_t i = 0; i < decimalString.length(); i++)
+    for (char c : decimalString)
     {
-        if (!isdigit(decimalString[i]))
+        if (!isdigit(c))
         {
-            ChipLogError(SetupPayload, "Failed decoding base10. Character was invalid %c", decimalString[i]);
+            ChipLogError(SetupPayload, "Failed decoding base10. Character was invalid %c", c);
             return CHIP_ERROR_INVALID_INTEGER_VALUE;
         }
         number *= 10;
-        number += decimalString[i] - '0';
+        number += c - '0';
     }
     dest = number;
     return CHIP_NO_ERROR;

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -132,9 +132,9 @@ exit:
 vector<OptionalQRCodeInfo> SetupPayload::getAllOptionalVendorData()
 {
     vector<OptionalQRCodeInfo> returnedOptionalInfo;
-    for (map<uint8_t, OptionalQRCodeInfo>::iterator it = optionalVendorData.begin(); it != optionalVendorData.end(); ++it)
+    for (auto & entry : optionalVendorData)
     {
-        returnedOptionalInfo.push_back(it->second);
+        returnedOptionalInfo.push_back(entry.second);
     }
     return returnedOptionalInfo;
 }
@@ -272,10 +272,9 @@ optionalQRCodeInfoType SetupPayload::getNumericTypeFor(uint8_t tag)
 vector<OptionalQRCodeInfoExtension> SetupPayload::getAllOptionalExtensionData()
 {
     vector<OptionalQRCodeInfoExtension> returnedOptionalInfo;
-    for (map<uint8_t, OptionalQRCodeInfoExtension>::iterator it = optionalExtensionData.begin(); it != optionalExtensionData.end();
-         ++it)
+    for (auto & entry : optionalExtensionData)
     {
-        returnedOptionalInfo.push_back(it->second);
+        returnedOptionalInfo.push_back(entry.second);
     }
     return returnedOptionalInfo;
 }

--- a/src/setup_payload/tests/TestQRCode.cpp
+++ b/src/setup_payload/tests/TestQRCode.cpp
@@ -123,9 +123,9 @@ void TestBase41(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, base41Decode("GHF.KGL+48-G5LGK35", decoded) == CHIP_NO_ERROR);
 
     string hello_world;
-    for (size_t _ = 0; _ < decoded.size(); _++)
+    for (uint8_t b : decoded)
     {
-        hello_world += (char) decoded[_];
+        hello_world += (char) b;
     }
     NL_TEST_ASSERT(inSuite, hello_world == "Hello World!");
 

--- a/src/system/tests/TestSystemErrorStr.cpp
+++ b/src/system/tests/TestSystemErrorStr.cpp
@@ -72,9 +72,8 @@ static void CheckSystemErrorStr(nlTestSuite * inSuite, void * inContext)
     System::RegisterLayerErrorFormatter();
 
     // For each defined error...
-    for (size_t i = 0; i < kTestElements; i++)
+    for (int err : sContext)
     {
-        int32_t err         = sContext[i];
         const char * errStr = ErrorStr(err);
         char expectedText[9];
 

--- a/src/system/tests/TestSystemObject.cpp
+++ b/src/system/tests/TestSystemObject.cpp
@@ -348,9 +348,9 @@ void TestObject::MultithreadedTest(nlTestSuite * inSuite, void * aContext, void 
         NL_TEST_ASSERT(lContext.mTestSuite, lError == 0);
     }
 
-    for (unsigned int i = 0; i < kNumThreads; ++i)
+    for (pthread_t thread : lThread)
     {
-        int lError = pthread_join(lThread[i], nullptr);
+        int lError = pthread_join(thread, nullptr);
 
         NL_TEST_ASSERT(lContext.mTestSuite, lError == 0);
     }

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -232,10 +232,10 @@ void CheckSetStart(nlTestSuite * inSuite, void * inContext)
         };
         // clang-format on
 
-        for (size_t s = 0; s < sizeof(start_offset) / sizeof(start_offset[0]); s++)
+        for (ptrdiff_t offset : start_offset)
         {
             PacketBuffer * buffer  = PrepareTestBuffer(theContext);
-            uint8_t * test_start   = theContext->payload_ptr + start_offset[s];
+            uint8_t * test_start   = theContext->payload_ptr + offset;
             uint8_t * verify_start = test_start;
 
             buffer->SetStart(test_start);
@@ -310,7 +310,7 @@ void CheckSetDataLength(nlTestSuite * inSuite, void * inContext)
 
         for (size_t jth = 0; jth < kTestElements; jth++)
         {
-            for (size_t n = 0; n < kTestLengths; n++)
+            for (uint16_t length : sLengths)
             {
                 PacketBuffer * buffer_1 = PrepareTestBuffer(theFirstContext);
                 PacketBuffer * buffer_2 = PrepareTestBuffer(theSecondContext);
@@ -318,9 +318,9 @@ void CheckSetDataLength(nlTestSuite * inSuite, void * inContext)
                 if (theFirstContext == theSecondContext)
                 {
                     // headOfChain (the second arg) is NULL
-                    buffer_2->SetDataLength(sLengths[n], nullptr);
+                    buffer_2->SetDataLength(length, nullptr);
 
-                    if (sLengths[n] > (theSecondContext->end_buffer - theSecondContext->payload_ptr))
+                    if (length > (theSecondContext->end_buffer - theSecondContext->payload_ptr))
                     {
                         NL_TEST_ASSERT(
                             inSuite, theSecondContext->buf->len == (theSecondContext->end_buffer - theSecondContext->payload_ptr));
@@ -331,17 +331,17 @@ void CheckSetDataLength(nlTestSuite * inSuite, void * inContext)
                     }
                     else
                     {
-                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->len == sLengths[n]);
-                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->tot_len == sLengths[n]);
+                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->len == length);
+                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->tot_len == length);
                         NL_TEST_ASSERT(inSuite, theSecondContext->buf->next == nullptr);
                     }
                 }
                 else
                 {
                     // headOfChain (the second arg) is buffer_1
-                    buffer_2->SetDataLength(sLengths[n], buffer_1);
+                    buffer_2->SetDataLength(length, buffer_1);
 
-                    if (sLengths[n] > (theSecondContext->end_buffer - theSecondContext->payload_ptr))
+                    if (length > (theSecondContext->end_buffer - theSecondContext->payload_ptr))
                     {
                         NL_TEST_ASSERT(
                             inSuite, theSecondContext->buf->len == (theSecondContext->end_buffer - theSecondContext->payload_ptr));
@@ -358,13 +358,13 @@ void CheckSetDataLength(nlTestSuite * inSuite, void * inContext)
                     }
                     else
                     {
-                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->len == sLengths[n]);
-                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->tot_len == sLengths[n]);
+                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->len == length);
+                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->tot_len == length);
                         NL_TEST_ASSERT(inSuite, theSecondContext->buf->next == nullptr);
 
                         NL_TEST_ASSERT(inSuite,
                                        theFirstContext->buf->tot_len ==
-                                           (theFirstContext->init_len + static_cast<int32_t>(sLengths[n]) -
+                                           (theFirstContext->init_len + static_cast<int32_t>(length) -
                                             static_cast<int32_t>(theSecondContext->init_len)));
                     }
                 }
@@ -590,17 +590,17 @@ void CheckCompactHead(nlTestSuite * inSuite, void * inContext)
         for (size_t jth = 0; jth < kTestElements; jth++)
         {
             // start with various initial length for the first buffer
-            for (size_t k = 0; k < kTestLengths; k++)
+            for (uint16_t firstLength : sLengths)
             {
                 // start with various initial length for the second buffer
-                for (size_t l = 0; l < kTestLengths; l++)
+                for (uint16_t secondLength : sLengths)
                 {
                     PacketBuffer * buffer_1 = PrepareTestBuffer(theFirstContext);
                     PacketBuffer * buffer_2 = PrepareTestBuffer(theSecondContext);
                     uint16_t len1           = 0;
                     uint16_t len2           = 0;
 
-                    buffer_1->SetDataLength(sLengths[k], buffer_1);
+                    buffer_1->SetDataLength(firstLength, buffer_1);
                     len1 = buffer_1->DataLength();
 
                     if (theFirstContext != theSecondContext)
@@ -608,7 +608,7 @@ void CheckCompactHead(nlTestSuite * inSuite, void * inContext)
                         theFirstContext->buf->next = theSecondContext->buf;
 
                         // Add various lengths to the second buffer
-                        buffer_2->SetDataLength(sLengths[l], buffer_1);
+                        buffer_2->SetDataLength(secondLength, buffer_1);
                         len2 = buffer_2->DataLength();
                     }
 
@@ -669,13 +669,13 @@ void CheckConsumeHead(nlTestSuite * inSuite, void * inContext)
 
     for (size_t ith = 0; ith < kTestElements; ith++)
     {
-        for (size_t n = 0; n < kTestLengths; n++)
+        for (uint16_t length : sLengths)
         {
             PacketBuffer * buffer = PrepareTestBuffer(theContext);
 
-            buffer->ConsumeHead(sLengths[n]);
+            buffer->ConsumeHead(length);
 
-            if (sLengths[n] > theContext->init_len)
+            if (length > theContext->init_len)
             {
                 NL_TEST_ASSERT(inSuite, theContext->buf->payload == (theContext->payload_ptr + theContext->init_len));
                 NL_TEST_ASSERT(inSuite, theContext->buf->len == 0);
@@ -683,9 +683,9 @@ void CheckConsumeHead(nlTestSuite * inSuite, void * inContext)
             }
             else
             {
-                NL_TEST_ASSERT(inSuite, theContext->buf->payload == (theContext->payload_ptr + sLengths[n]));
-                NL_TEST_ASSERT(inSuite, theContext->buf->len == (theContext->buf->len - sLengths[n]));
-                NL_TEST_ASSERT(inSuite, theContext->buf->tot_len == (theContext->buf->tot_len - sLengths[n]));
+                NL_TEST_ASSERT(inSuite, theContext->buf->payload == (theContext->payload_ptr + length));
+                NL_TEST_ASSERT(inSuite, theContext->buf->len == (theContext->buf->len - length));
+                NL_TEST_ASSERT(inSuite, theContext->buf->tot_len == (theContext->buf->tot_len - length));
             }
 
             if (theContext->buf->ref == 0)
@@ -721,13 +721,13 @@ void CheckConsume(nlTestSuite * inSuite, void * inContext)
         for (size_t jth = 0; jth < kTestElements; jth++)
         {
             // consume various amounts of memory
-            for (size_t c = 0; c < kTestLengths; c++)
+            for (uint16_t consumeLength : sLengths)
             {
                 // start with various initial length for the first buffer
-                for (size_t k = 0; k < kTestLengths; k++)
+                for (uint16_t firstLength : sLengths)
                 {
                     // start with various initial length for the second buffer
-                    for (size_t l = 0; l < kTestLengths; l++)
+                    for (uint16_t secondLength : sLengths)
                     {
                         PacketBuffer * buffer_1;
                         PacketBuffer * buffer_2;
@@ -746,31 +746,32 @@ void CheckConsume(nlTestSuite * inSuite, void * inContext)
                         theFirstContext->buf->next = theSecondContext->buf;
 
                         // Add various lengths to buffers
-                        buffer_1->SetDataLength(sLengths[k], buffer_1);
-                        buffer_2->SetDataLength(sLengths[l], buffer_1);
+                        buffer_1->SetDataLength(firstLength, buffer_1);
+                        buffer_2->SetDataLength(secondLength, buffer_1);
 
                         buf_1_len = theFirstContext->buf->len;
                         buf_2_len = theSecondContext->buf->len;
 
-                        returned = buffer_1->Consume(sLengths[c]);
+                        returned = buffer_1->Consume(consumeLength);
 
-                        if (sLengths[c] == 0)
+                        if (consumeLength == 0)
                         {
                             NL_TEST_ASSERT(inSuite, returned == buffer_1);
                             continue;
                         }
 
-                        if (sLengths[c] < buf_1_len)
+                        if (consumeLength < buf_1_len)
                         {
                             NL_TEST_ASSERT(inSuite, returned == buffer_1);
                         }
-                        else if ((sLengths[c] >= buf_1_len) &&
-                                 (sLengths[c] < buf_1_len + buf_2_len || (sLengths[c] == buf_1_len + buf_2_len && buf_2_len == 0)))
+                        else if ((consumeLength >= buf_1_len) &&
+                                 (consumeLength < buf_1_len + buf_2_len ||
+                                  (consumeLength == buf_1_len + buf_2_len && buf_2_len == 0)))
                         {
                             NL_TEST_ASSERT(inSuite, returned == buffer_2);
                             theFirstContext->buf = nullptr;
                         }
-                        else if (sLengths[c] >= (buf_1_len + buf_2_len))
+                        else if (consumeLength >= (buf_1_len + buf_2_len))
                         {
                             NL_TEST_ASSERT(inSuite, returned == nullptr);
                             theFirstContext->buf  = nullptr;
@@ -802,7 +803,7 @@ void CheckEnsureReservedSize(nlTestSuite * inSuite, void * inContext)
 
     for (size_t ith = 0; ith < kTestElements; ith++)
     {
-        for (size_t n = 0; n < kTestLengths; n++)
+        for (uint16_t length : sLengths)
         {
             PacketBuffer & lBuffer  = *PrepareTestBuffer(theContext);
             const size_t kAllocSize = lBuffer.AllocSize();
@@ -813,20 +814,20 @@ void CheckEnsureReservedSize(nlTestSuite * inSuite, void * inContext)
                 reserved_size = kAllocSize - CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE;
             }
 
-            if (sLengths[n] <= reserved_size)
+            if (length <= reserved_size)
             {
-                NL_TEST_ASSERT(inSuite, lBuffer.EnsureReservedSize(sLengths[n]) == true);
+                NL_TEST_ASSERT(inSuite, lBuffer.EnsureReservedSize(length) == true);
                 continue;
             }
 
-            if ((sLengths[n] + theContext->init_len) > (kAllocSize - CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE))
+            if ((length + theContext->init_len) > (kAllocSize - CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE))
             {
-                NL_TEST_ASSERT(inSuite, lBuffer.EnsureReservedSize(sLengths[n]) == false);
+                NL_TEST_ASSERT(inSuite, lBuffer.EnsureReservedSize(length) == false);
                 continue;
             }
 
-            NL_TEST_ASSERT(inSuite, lBuffer.EnsureReservedSize(sLengths[n]) == true);
-            NL_TEST_ASSERT(inSuite, theContext->buf->payload == (theContext->payload_ptr + sLengths[n] - reserved_size));
+            NL_TEST_ASSERT(inSuite, lBuffer.EnsureReservedSize(length) == true);
+            NL_TEST_ASSERT(inSuite, theContext->buf->payload == (theContext->payload_ptr + length - reserved_size));
         }
 
         theContext++;


### PR DESCRIPTION
 #### Problem
We use C++11, and can use range based for loops.

 #### Summary of Changes
Transform iteration with indexing to range based loops.