### PR TITLE
clang-tidy: Apply fixes "modernize-use-bool-literals"

### DIFF
--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -396,7 +396,7 @@ InterfaceIterator::InterfaceIterator(void)
     mIntfArray       = nullptr;
     mCurIntf         = 0;
     mIntfFlags       = 0;
-    mIntfFlagsCached = 0;
+    mIntfFlagsCached = false;
 }
 
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS && CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS

--- a/src/lib/shell/shell.cpp
+++ b/src/lib/shell/shell.cpp
@@ -211,7 +211,7 @@ void Shell::TaskLoop(void * arg)
 
     theShellRoot.RegisterDefaultCommands();
 
-    while (1)
+    while (true)
     {
         streamer_printf(streamer_get(), CHIP_SHELL_PROMPT);
 


### PR DESCRIPTION
 #### Problem
true should be spelled "true" and false as "false"

 #### Summary of Changes
replace 1 and 0 by true and false