### PR TITLE
Use C++11 when compiling Objective C++ files

### DIFF
--- a/gn/build/config/compiler/BUILD.gn
+++ b/gn/build/config/compiler/BUILD.gn
@@ -190,7 +190,9 @@ config("symbols_default") {
 
 config("gnu11") {
   cflags_c = [ "-std=gnu11" ]
+  cflags_objc = [ "-std=gnu11" ]
   cflags_cc = [ "-std=gnu++11" ]
+  cflags_objcc = [ "-std=gnu++11" ]
 }
 
 config("std_default") {


### PR DESCRIPTION
 #### Problem
We're not ending up in C++11 mode when compiling `.mm` files, so the Mac build breaks.

 #### Summary of Changes
Use the right build flags.

fixes https://github.com/project-chip/connectedhomeip/issues/2812
