### PR TITLE
[nRF5 examples] Make lighting/lock app work again

### DIFF
--- a/src/platform/nRF5/BLEManagerImpl.cpp
+++ b/src/platform/nRF5/BLEManagerImpl.cpp
@@ -685,11 +685,7 @@ CHIP_ERROR BLEManagerImpl::EncodeAdvertisingData(ble_gap_adv_data_t & gapAdvData
 
     // Initialize the CHIP BLE Device Identification Information block that will be sent as payload
     // within the BLE service advertisement data.
-    // TODO: retrive device configuration from the ConfigurationMgr()
-    // err = ConfigurationMgr().GetBLEDeviceIdentificationInfo(deviceIdInfo);
-    deviceIdInfo.Init();
-    deviceIdInfo.SetVendorId(0xDEAD);
-    deviceIdInfo.SetProductId(0xBEEF);
+    err = ConfigurationMgr().GetBLEDeviceIdentificationInfo(deviceIdInfo);
     SuccessOrExit(err);
 
     // Form the contents of the scan response packet.

--- a/src/platform/nRF5/ThreadStackManagerImpl.cpp
+++ b/src/platform/nRF5/ThreadStackManagerImpl.cpp
@@ -54,9 +54,8 @@ CHIP_ERROR ThreadStackManagerImpl::InitThreadStack(otInstance * otInst)
     // Initialize the generic implementation base classes.
     err = GenericThreadStackManagerImpl_FreeRTOS<ThreadStackManagerImpl>::DoInit();
     SuccessOrExit(err);
-    // TODO: resolve an issue with hanging the IC in next function
-    // err = GenericThreadStackManagerImpl_OpenThread_LwIP<ThreadStackManagerImpl>::DoInit(otInst);
-    // SuccessOrExit(err);
+    err = GenericThreadStackManagerImpl_OpenThread_LwIP<ThreadStackManagerImpl>::DoInit(otInst);
+    SuccessOrExit(err);
 
 exit:
     return err;


### PR DESCRIPTION
 #### Problem
After #2010 is merged, the lighting app does not work.

 #### Summary of Changes
Uncomment the code that is commented out in #2010 

#### Testing
build the image, flash the image on nrf52840dk, verify that chip-tool can control the device.

fixes #2727
