### PR TITLE
[zephyr] Update BLE advertising data

### DIFF
--- a/examples/common/chip-app-server/QRCodeUtil.cpp
+++ b/examples/common/chip-app-server/QRCodeUtil.cpp
@@ -1,0 +1,73 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "QRCodeUtil.h"
+
+#include <platform/CHIPDeviceLayer.h>
+
+#include <setup_payload/QRCodeSetupPayloadGenerator.h>
+#include <support/CodeUtils.h>
+#include <support/logging/CHIPLogging.h>
+
+void PrintQRCode(chip::RendezvousInformationFlags rendezvousFlags)
+{
+    using namespace ::chip::DeviceLayer;
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    chip::SetupPayload payload;
+    payload.version               = 1;
+    payload.rendezvousInformation = rendezvousFlags;
+
+    err = ConfigurationMgr().GetSetupPinCode(payload.setUpPINCode);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogProgress(AppServer, "ConfigurationMgr().GetSetupPinCode() failed: %s", chip::ErrorStr(err));
+    }
+
+    err = ConfigurationMgr().GetSetupDiscriminator(payload.discriminator);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogProgress(AppServer, "ConfigurationMgr().GetSetupDiscriminator() failed: %s", chip::ErrorStr(err));
+    }
+
+    err = ConfigurationMgr().GetVendorId(payload.vendorID);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogProgress(AppServer, "ConfigurationMgr().GetVendorId() failed: %s", chip::ErrorStr(err));
+    }
+
+    err = ConfigurationMgr().GetProductId(payload.productID);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogProgress(AppServer, "ConfigurationMgr().GetProductId() failed: %s", chip::ErrorStr(err));
+    }
+
+    // TODO: Usage of STL will significantly increase the image size, this should be changed to more efficient method for
+    // generating payload
+    std::string result;
+    err = chip::QRCodeSetupPayloadGenerator(payload).payloadBase41Representation(result);
+    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(AppServer, "Failed to generate QR Code"));
+
+    ChipLogProgress(AppServer, "SetupPINCode: [%" PRIu32 "]", payload.setUpPINCode);
+    // There might be whitespace in setup QRCode, add brackets to make it clearer.
+    ChipLogProgress(AppServer, "SetupQRCode:  [%s]", result.c_str());
+
+exit:
+    return;
+}

--- a/examples/common/chip-app-server/include/QRCodeUtil.h
+++ b/examples/common/chip-app-server/include/QRCodeUtil.h
@@ -1,0 +1,25 @@
+/*
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef QR_CODE_UTIL_H
+#define QR_CODE_UTIL_H
+
+#include <setup_payload/SetupPayload.h>
+
+void PrintQRCode(chip::RendezvousInformationFlags rendezvousFlags);
+
+#endif // QR_CODE_UTIL_H

--- a/examples/lighting-app/nrfconnect/CMakeLists.txt
+++ b/examples/lighting-app/nrfconnect/CMakeLists.txt
@@ -36,6 +36,7 @@ target_sources(app PRIVATE
                ${NRFCONNECT_COMMON}/util/LEDWidget.cpp
                ${CHIP_APP_SERVER}/DataModelHandler.cpp
                ${CHIP_APP_SERVER}/Server.cpp
+               ${CHIP_APP_SERVER}/QRCodeUtil.cpp
                ${CHIP_ROOT}/src/app/util/af-event.cpp
                ${CHIP_ROOT}/src/app/util/attribute-size.c
                ${CHIP_ROOT}/src/app/util/attribute-storage.c

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -22,6 +22,7 @@
 #include "AppEvent.h"
 #include "LEDWidget.h"
 #include "LightingManager.h"
+#include "QRCodeUtil.h"
 #include "Server.h"
 
 #include <platform/CHIPDeviceLayer.h>
@@ -95,49 +96,9 @@ int AppTask::Init()
 
     // Init ZCL Data Model and start server
     InitServer();
-    PrintQRCode();
+    PrintQRCode(chip::RendezvousInformationFlags::kBLE);
 
     return 0;
-}
-
-void AppTask::PrintQRCode() const
-{
-    CHIP_ERROR err              = CHIP_NO_ERROR;
-    uint32_t setUpPINCode       = 0;
-    uint16_t setUpDiscriminator = 0;
-
-    err = ConfigurationMgr().GetSetupPinCode(setUpPINCode);
-    if (err != CHIP_NO_ERROR)
-    {
-        LOG_INF("ConfigurationMgr().GetSetupPinCode() failed: %s", log_strdup(chip::ErrorStr(err)));
-    }
-
-    err = ConfigurationMgr().GetSetupDiscriminator(setUpDiscriminator);
-    if (err != CHIP_NO_ERROR)
-    {
-        LOG_INF("ConfigurationMgr().GetSetupDiscriminator() failed: %s", log_strdup(chip::ErrorStr(err)));
-    }
-
-    chip::SetupPayload payload;
-    payload.version       = 1;
-    payload.vendorID      = kExampleVendorID;
-    payload.productID     = 1;
-    payload.setUpPINCode  = setUpPINCode;
-    payload.discriminator = setUpDiscriminator;
-    chip::QRCodeSetupPayloadGenerator generator(payload);
-
-    // TODO: Usage of STL will significantly increase the image size, this should be changed to more efficient method for
-    // generating payload
-    std::string result;
-    err = generator.payloadBase41Representation(result);
-    if (err != CHIP_NO_ERROR)
-    {
-        LOG_ERR("Failed to generate QR Code");
-    }
-
-    LOG_INF("SetupPINCode: [%" PRIu32 "]", setUpPINCode);
-    // There might be whitespace in setup QRCode, add brackets to make it clearer.
-    LOG_INF("SetupQRCode:  [%s]", log_strdup(result.c_str()));
 }
 
 int AppTask::StartApp()

--- a/examples/lighting-app/nrfconnect/main/include/AppTask.h
+++ b/examples/lighting-app/nrfconnect/main/include/AppTask.h
@@ -38,7 +38,6 @@ private:
     friend AppTask & GetAppTask(void);
 
     int Init();
-    void PrintQRCode() const;
 
     static void ActionInitiated(LightingManager::Action_t aAction);
     static void ActionCompleted(LightingManager::Action_t aAction);

--- a/examples/lock-app/nrfconnect/CMakeLists.txt
+++ b/examples/lock-app/nrfconnect/CMakeLists.txt
@@ -37,6 +37,7 @@ target_sources(app PRIVATE
                ${NRFCONNECT_COMMON}/util/LEDWidget.cpp
                ${CHIP_APP_SERVER}/DataModelHandler.cpp
                ${CHIP_APP_SERVER}/Server.cpp
+               ${CHIP_APP_SERVER}/QRCodeUtil.cpp
                ${CHIP_ROOT}/src/app/util/af-event.cpp
                ${CHIP_ROOT}/src/app/util/attribute-size.c
                ${CHIP_ROOT}/src/app/util/attribute-storage.c

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -20,6 +20,7 @@
 #include "AppConfig.h"
 #include "BoltLockManager.h"
 #include "LEDWidget.h"
+#include "QRCodeUtil.h"
 #include "Server.h"
 
 #include <platform/CHIPDeviceLayer.h>
@@ -86,63 +87,9 @@ int AppTask::Init()
 
     // Init ZCL Data Model and start server
     InitServer();
-    PrintQRCode();
+    PrintQRCode(chip::RendezvousInformationFlags::kBLE);
 
     return 0;
-}
-
-void AppTask::PrintQRCode() const
-{
-    CHIP_ERROR err              = CHIP_NO_ERROR;
-    uint32_t setUpPINCode       = 0;
-    uint16_t setUpDiscriminator = 0;
-    uint16_t vendorId           = 0;
-    uint16_t productId          = 0;
-
-    err = ConfigurationMgr().GetSetupPinCode(setUpPINCode);
-    if (err != CHIP_NO_ERROR)
-    {
-        LOG_INF("ConfigurationMgr().GetSetupPinCode() failed: %s", log_strdup(chip::ErrorStr(err)));
-    }
-
-    err = ConfigurationMgr().GetSetupDiscriminator(setUpDiscriminator);
-    if (err != CHIP_NO_ERROR)
-    {
-        LOG_INF("ConfigurationMgr().GetSetupDiscriminator() failed: %s", log_strdup(chip::ErrorStr(err)));
-    }
-
-    err = ConfigurationMgr().GetVendorId(vendorId);
-    if (err != CHIP_NO_ERROR)
-    {
-        LOG_INF("ConfigurationMgr().GetVendorId() failed: %s", log_strdup(chip::ErrorStr(err)));
-    }
-
-    err = ConfigurationMgr().GetProductId(productId);
-    if (err != CHIP_NO_ERROR)
-    {
-        LOG_INF("ConfigurationMgr().GetProductId() failed: %s", log_strdup(chip::ErrorStr(err)));
-    }
-
-    chip::SetupPayload payload;
-    payload.version       = 1;
-    payload.vendorID      = vendorId;
-    payload.productID     = productId;
-    payload.setUpPINCode  = setUpPINCode;
-    payload.discriminator = setUpDiscriminator;
-    chip::QRCodeSetupPayloadGenerator generator(payload);
-
-    // TODO: Usage of STL will significantly increase the image size, this should be changed to more efficient method for
-    // generating payload
-    std::string result;
-    err = generator.payloadBase41Representation(result);
-    if (err != CHIP_NO_ERROR)
-    {
-        LOG_ERR("Failed to generate QR Code");
-    }
-
-    LOG_INF("SetupPINCode: [%" PRIu32 "]", setUpPINCode);
-    // There might be whitespace in setup QRCode, add brackets to make it clearer.
-    LOG_INF("SetupQRCode:  [%s]", log_strdup(result.c_str()));
 }
 
 int AppTask::StartApp()

--- a/examples/lock-app/nrfconnect/main/include/AppTask.h
+++ b/examples/lock-app/nrfconnect/main/include/AppTask.h
@@ -37,7 +37,6 @@ private:
     friend AppTask & GetAppTask(void);
 
     int Init();
-    void PrintQRCode() const;
 
     static void ActionInitiated(BoltLockManager::Action_t aAction, int32_t aActor);
     static void ActionCompleted(BoltLockManager::Action_t aAction);

--- a/src/platform/Zephyr/GenericBLEManagerImpl_Zephyr.h
+++ b/src/platform/Zephyr/GenericBLEManagerImpl_Zephyr.h
@@ -94,6 +94,8 @@ private:
             0x0010, /**< The advertising state/configuration has changed, but the SoftDevice has yet to be updated. */
     };
 
+    struct ServiceData;
+
     uint16_t mFlags;
     uint16_t mGAPConns;
     CHIPoBLEServiceMode mServiceMode;
@@ -113,6 +115,7 @@ private:
     bool IsSubscribed(bt_conn * conn);
     bool SetSubscribed(bt_conn * conn);
     bool UnsetSubscribed(bt_conn * conn);
+    uint32_t GetAdvertisingInterval();
 
     static void DriveBLEState(intptr_t arg);
 


### PR DESCRIPTION
 #### Problem
BLE advertising data on Zephyr was not aligned with the spec and other implementations like iOS & ESP32

 #### Summary of Changes
Put all device identification data in the advertising payload (instead of scan response payload)
Set "Rendezvous over BLE" flag in QR Code in nRF Connect examples
By the way, deduplicate code for logging QR Code payload