### PR TITLE
GN: Use android logging style for android

### DIFF
--- a/src/lib/core/core.gni
+++ b/src/lib/core/core.gni
@@ -54,6 +54,8 @@ if (chip_target_style == "") {
 if (chip_logging_style == "") {
   if (current_os != "freertos") {
     chip_logging_style = "stdio"
+  } else if (current_os == "android") {
+    chip_logging_style = "android"
   } else {
     chip_logging_style = "external"
   }


### PR DESCRIPTION
 #### Problem
Seems like Android logging style was defined to android by configure.ac but it is not automatically for GN.

@vidhis88 Can you confirm that the patch helps you with logging ? Otherwise there is likely more work to do :)