### PR TITLE
Use uint16_t for our various header sizes in bytes

### DIFF
--- a/src/transport/BLE.cpp
+++ b/src/transport/BLE.cpp
@@ -138,7 +138,7 @@ CHIP_ERROR BLE::SendMessage(const PacketHeader & header, Header::Flags payloadFl
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
     const size_t headerSize = header.EncodeSizeBytes();
-    size_t actualEncodedHeaderSize;
+    uint16_t actualEncodedHeaderSize;
 
     VerifyOrExit(address.GetTransportType() == Type::kBle, err = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(mState == State::kInitialized, err = CHIP_ERROR_INCORRECT_STATE);

--- a/src/transport/MessageHeader.h
+++ b/src/transport/MessageHeader.h
@@ -221,7 +221,7 @@ public:
      *
      * @return the number of bytes needed in a buffer to be able to Encode.
      */
-    size_t EncodeSizeBytes() const;
+    uint16_t EncodeSizeBytes() const;
 
     /**
      * Decodes a header from the given buffer.
@@ -237,7 +237,7 @@ public:
      *    CHIP_ERROR_INVALID_ARGUMENT on insufficient buffer size
      *    CHIP_ERROR_VERSION_MISMATCH if header version is not supported.
      */
-    CHIP_ERROR Decode(const uint8_t * data, size_t size, size_t * decode_size);
+    CHIP_ERROR Decode(const uint8_t * const data, size_t size, uint16_t * decode_size);
 
     /**
      * Encodes a header into the given buffer.
@@ -251,7 +251,7 @@ public:
      * Possible failures:
      *    CHIP_ERROR_INVALID_ARGUMENT on insufficient buffer size
      */
-    CHIP_ERROR Encode(uint8_t * data, size_t size, size_t * encode_size, Header::Flags payloadFlags) const;
+    CHIP_ERROR Encode(uint8_t * data, size_t size, uint16_t * encode_size, Header::Flags payloadFlags) const;
 
 private:
     /// Represents the current encode/decode header version
@@ -355,7 +355,7 @@ public:
      *
      * @return the number of bytes needed in a buffer to be able to Encode.
      */
-    size_t EncodeSizeBytes() const;
+    uint16_t EncodeSizeBytes() const;
 
     /**
      * Decodes the encrypted header fields from the given buffer.
@@ -372,7 +372,7 @@ public:
      *    CHIP_ERROR_INVALID_ARGUMENT on insufficient buffer size
      *    CHIP_ERROR_VERSION_MISMATCH if header version is not supported.
      */
-    CHIP_ERROR Decode(Header::Flags flags, const uint8_t * data, size_t size, size_t * decode_size);
+    CHIP_ERROR Decode(Header::Flags flags, const uint8_t * const data, size_t size, uint16_t * decode_size);
 
     /**
      * Encodes the encrypted part of the header into the given buffer.
@@ -386,7 +386,7 @@ public:
      * Possible failures:
      *    CHIP_ERROR_INVALID_ARGUMENT on insufficient buffer size
      */
-    CHIP_ERROR Encode(uint8_t * data, size_t size, size_t * encode_size) const;
+    CHIP_ERROR Encode(uint8_t * data, size_t size, uint16_t * encode_size) const;
 
     /** Flags required for encoding this payload. */
     Header::Flags GetEncodePacketFlags() const;
@@ -443,7 +443,7 @@ public:
      *    CHIP_ERROR_INVALID_ARGUMENT on insufficient buffer size
      *    CHIP_ERROR_VERSION_MISMATCH if header version is not supported.
      */
-    CHIP_ERROR Decode(const PacketHeader & packetHeader, const uint8_t * data, size_t size, size_t * decode_size);
+    CHIP_ERROR Decode(const PacketHeader & packetHeader, const uint8_t * const data, size_t size, uint16_t * decode_size);
 
     /**
      * Encodes the Messae Authentication Tag into the given buffer.
@@ -458,9 +458,9 @@ public:
      * Possible failures:
      *    CHIP_ERROR_INVALID_ARGUMENT on insufficient buffer size
      */
-    CHIP_ERROR Encode(const PacketHeader & packetHeader, uint8_t * data, size_t size, size_t * encode_size) const;
+    CHIP_ERROR Encode(const PacketHeader & packetHeader, uint8_t * data, size_t size, uint16_t * encode_size) const;
 
-    static size_t TagLenForEncryptionType(Header::EncryptionType encType);
+    static uint16_t TagLenForEncryptionType(Header::EncryptionType encType);
 
 private:
     /// Message authentication tag generated at encryption of the message.

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -85,7 +85,7 @@ CHIP_ERROR RendezvousSession::SendPairingMessage(System::PacketBuffer * msgBuf)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     PacketHeader header;
-    size_t headerSize = 0;
+    uint16_t headerSize = 0;
 
     VerifyOrExit(msgBuf != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(msgBuf->Next() == nullptr, err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
@@ -108,10 +108,10 @@ CHIP_ERROR RendezvousSession::SendSecureMessage(System::PacketBuffer * msgBuf)
     PayloadHeader payloadHeader;
     MessageAuthenticationCode mac;
     const size_t headerSize = payloadHeader.EncodeSizeBytes();
-    size_t actualEncodedHeaderSize;
+    uint16_t actualEncodedHeaderSize;
     uint8_t * data  = nullptr;
     size_t totalLen = 0;
-    size_t taglen   = 0;
+    uint16_t taglen = 0;
 
     VerifyOrExit(msgBuf != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(msgBuf->Next() == nullptr, err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
@@ -220,7 +220,7 @@ CHIP_ERROR RendezvousSession::HandlePairingMessage(PacketBuffer * msgBuf)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     PacketHeader packetHeader;
-    size_t headerSize = 0;
+    uint16_t headerSize = 0;
 
     err = packetHeader.Decode(msgBuf->Start(), msgBuf->DataLength(), &headerSize);
     SuccessOrExit(err);
@@ -240,12 +240,12 @@ CHIP_ERROR RendezvousSession::HandleSecureMessage(PacketBuffer * msgBuf)
     PacketHeader packetHeader;
     PayloadHeader payloadHeader;
     MessageAuthenticationCode mac;
-    size_t headerSize              = 0;
+    uint16_t headerSize            = 0;
     uint8_t * data                 = nullptr;
     uint8_t * plainText            = nullptr;
     uint16_t len                   = 0;
-    size_t decodedSize             = 0;
-    size_t taglen                  = 0;
+    uint16_t decodedSize           = 0;
+    uint16_t taglen                = 0;
     System::PacketBuffer * origMsg = nullptr;
 
     err = packetHeader.Decode(msgBuf->Start(), msgBuf->DataLength(), &headerSize);

--- a/src/transport/SecurePairingSession.cpp
+++ b/src/transport/SecurePairingSession.cpp
@@ -116,8 +116,8 @@ CHIP_ERROR SecurePairingSession::AttachHeaderAndSend(uint8_t msgType, System::Pa
         .SetMessageType(msgType) //
         .SetProtocolID(kSecurePairingProtocol);
 
-    size_t headerSize              = payloadHeader.EncodeSizeBytes();
-    size_t actualEncodedHeaderSize = 0;
+    size_t headerSize                = payloadHeader.EncodeSizeBytes();
+    uint16_t actualEncodedHeaderSize = 0;
 
     VerifyOrExit(msgBuf->EnsureReservedSize(headerSize), err = CHIP_ERROR_NO_MEMORY);
 
@@ -363,8 +363,8 @@ exit:
 
 CHIP_ERROR SecurePairingSession::HandlePeerMessage(const PacketHeader & packetHeader, System::PacketBuffer * msg)
 {
-    CHIP_ERROR err    = CHIP_NO_ERROR;
-    size_t headerSize = 0;
+    CHIP_ERROR err      = CHIP_NO_ERROR;
+    uint16_t headerSize = 0;
     PayloadHeader payloadHeader;
 
     VerifyOrExit(msg != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -125,7 +125,7 @@ CHIP_ERROR SecureSession::GetAdditionalAuthData(const PacketHeader & header, con
                                                 size_t & len)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    size_t actualEncodedHeaderSize;
+    uint16_t actualEncodedHeaderSize;
 
     VerifyOrExit(len >= header.EncodeSizeBytes(), err = CHIP_ERROR_INVALID_ARGUMENT);
 

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -110,9 +110,9 @@ CHIP_ERROR SecureSessionMgrBase::SendMessage(NodeId peerNodeId, System::PacketBu
         MessageAuthenticationCode mac;
 
         const size_t headerSize = payloadHeader.EncodeSizeBytes();
-        size_t actualEncodedHeaderSize;
+        uint16_t actualEncodedHeaderSize;
         size_t totalLen = 0;
-        size_t taglen   = 0;
+        uint16_t taglen = 0;
 
         packetHeader
             .SetSourceNodeId(mLocalNodeId)              //
@@ -249,8 +249,8 @@ void SecureSessionMgrBase::HandleDataReceived(const PacketHeader & packetHeader,
         uint8_t * plainText     = nullptr;
         uint16_t len            = msg->TotalLength();
         const size_t headerSize = payloadHeader.EncodeSizeBytes();
-        size_t decodedSize      = 0;
-        size_t taglen           = 0;
+        uint16_t decodedSize    = 0;
+        uint16_t taglen         = 0;
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
         /* This is a workaround for the case where PacketBuffer payload is not

--- a/src/transport/TCP.cpp
+++ b/src/transport/TCP.cpp
@@ -180,7 +180,7 @@ CHIP_ERROR TCPBase::SendMessage(const PacketHeader & header, Header::Flags paylo
     CHIP_ERROR err               = CHIP_NO_ERROR;
     const size_t prefixSize      = header.EncodeSizeBytes() + kPacketSizeBytes;
     Inet::TCPEndPoint * endPoint = nullptr;
-    size_t actualEncodedHeaderSize;
+    uint16_t actualEncodedHeaderSize;
 
     VerifyOrExit(address.GetTransportType() == Type::kTcp, err = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(mState == State::kInitialized, err = CHIP_ERROR_INCORRECT_STATE);
@@ -323,7 +323,7 @@ CHIP_ERROR TCPBase::ProcessSingleMessageFromBufferHead(const PeerAddress & peerA
 
     buffer->SetDataLength(messageSize);
 
-    size_t headerSize = 0;
+    uint16_t headerSize = 0;
 
     PacketHeader header;
     err = header.Decode(buffer->Start(), buffer->DataLength(), &headerSize);

--- a/src/transport/UDP.cpp
+++ b/src/transport/UDP.cpp
@@ -82,7 +82,7 @@ CHIP_ERROR UDP::SendMessage(const PacketHeader & header, Header::Flags payloadFl
                             System::PacketBuffer * msgBuf)
 {
     const size_t headerSize = header.EncodeSizeBytes();
-    size_t actualEncodedHeaderSize;
+    uint16_t actualEncodedHeaderSize;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     VerifyOrExit(address.GetTransportType() == Type::kUdp, err = CHIP_ERROR_INVALID_ARGUMENT);
@@ -123,7 +123,7 @@ void UDP::OnUdpReceive(Inet::IPEndPointBasis * endPoint, System::PacketBuffer * 
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
     UDP * udp               = reinterpret_cast<UDP *>(endPoint->AppState);
-    size_t headerSize       = 0;
+    uint16_t headerSize     = 0;
     PeerAddress peerAddress = PeerAddress::UDP(pktInfo->SrcAddress, pktInfo->SrcPort);
 
     PacketHeader header;

--- a/src/transport/tests/TestSecurePairingSession.cpp
+++ b/src/transport/tests/TestSecurePairingSession.cpp
@@ -44,7 +44,7 @@ public:
         if (peer != nullptr)
         {
             PacketHeader hdr;
-            size_t headerSize = 0;
+            uint16_t headerSize = 0;
 
             hdr.Decode(msgBuf->Start(), msgBuf->DataLength(), &headerSize);
             msgBuf->ConsumeHead(headerSize);


### PR DESCRIPTION
PacketBuffer uses uint16_t for all of its sizes already.  It's easier
to tell that we're not overflowing the buffer if we know our header
sizes also fit in uint16_t.

 #### Problem
Impedance mismatch between header sizes and PacketBuffer.

 #### Summary of Changes
Use uint16_t consistently.

fixes https://github.com/project-chip/connectedhomeip/issues/2835
