### PR TITLE
Consistently use uint16_t for key ids.

### DIFF
--- a/src/transport/PeerConnectionState.h
+++ b/src/transport/PeerConnectionState.h
@@ -64,11 +64,11 @@ public:
     uint32_t GetSendMessageIndex() const { return mSendMessageIndex; }
     void IncrementSendMessageIndex() { mSendMessageIndex++; }
 
-    uint32_t GetPeerKeyID() const { return mPeerKeyID; }
-    void SetPeerKeyID(uint32_t id) { mPeerKeyID = id; }
+    uint16_t GetPeerKeyID() const { return mPeerKeyID; }
+    void SetPeerKeyID(uint16_t id) { mPeerKeyID = id; }
 
-    uint32_t GetLocalKeyID() const { return mLocalKeyID; }
-    void SetLocalKeyID(uint32_t id) { mLocalKeyID = id; }
+    uint16_t GetLocalKeyID() const { return mLocalKeyID; }
+    void SetLocalKeyID(uint16_t id) { mLocalKeyID = id; }
 
     uint64_t GetLastActivityTimeMs() const { return mLastActityTimeMs; }
     void SetLastActivityTimeMs(uint64_t value) { mLastActityTimeMs = value; }
@@ -78,8 +78,8 @@ public:
 
     bool IsInitialized()
     {
-        return (mPeerAddress.IsInitialized() || mPeerNodeId != kUndefinedNodeId || mPeerKeyID != UINT32_MAX ||
-                mLocalKeyID != UINT32_MAX);
+        return (mPeerAddress.IsInitialized() || mPeerNodeId != kUndefinedNodeId || mPeerKeyID != UINT16_MAX ||
+                mLocalKeyID != UINT16_MAX);
     }
 
     /**
@@ -98,8 +98,8 @@ private:
     PeerAddress mPeerAddress;
     NodeId mPeerNodeId         = kUndefinedNodeId;
     uint32_t mSendMessageIndex = 0;
-    uint32_t mPeerKeyID        = UINT32_MAX;
-    uint32_t mLocalKeyID       = UINT32_MAX;
+    uint16_t mPeerKeyID        = UINT16_MAX;
+    uint16_t mLocalKeyID       = UINT16_MAX;
     uint64_t mLastActityTimeMs = 0;
     SecureSession mSecureSession;
 };


### PR DESCRIPTION
This prevents -Wconversion warnings when shuffling key ids around.

 #### Problem
We're inconsistent about whether key ids are 16-bit or 32-bit.

 #### Summary of Changes
Consistently use `uint16_t` for key ids.

fixes https://github.com/project-chip/connectedhomeip/issues/2824
