### PR TITLE
Fix possible buffer leak in ChipLinuxStorageIni::GetBinaryBlobValue

### DIFF
--- a/src/platform/Linux/CHIPLinuxStorageIni.cpp
+++ b/src/platform/Linux/CHIPLinuxStorageIni.cpp
@@ -302,11 +302,11 @@ CHIP_ERROR ChipLinuxStorageIni::GetBinaryBlobValue(const char * key, uint8_t * d
         {
             retval = CHIP_ERROR_DECODE_FAILED;
         }
+    }
 
-        if (encodedData)
-        {
-            chip::Platform::MemoryFree(encodedData);
-        }
+    if (encodedData)
+    {
+        chip::Platform::MemoryFree(encodedData);
     }
 
     return retval;


### PR DESCRIPTION
It's possible for us to allocate encodedData but then never reach the
Base64Decode call because of failing buffer length checks (e.g. if the
encodedData buffer is more than 65KB).  So we should make sure we free
encodedData as long as it's not null.

 #### Problem
Can leak memory in error conditions.

 #### Summary of Changes
Don't leak.

fixes #2579
