### PR TITLE
Revert "[cirque] Fix cirque test (#2662)"

### DIFF
--- a/src/test_driver/linux-cirque/helper/CHIPTestBase.py
+++ b/src/test_driver/linux-cirque/helper/CHIPTestBase.py
@@ -119,7 +119,7 @@ class CHIPVirtualHome:
         roles = set()
         for device in self.non_ap_devices:
             reply = self.execute_device_cmd(device['id'], 'ot-ctl state')
-            roles.add(reply['output'].split()[1])
+            roles.add(reply['output'].split()[0])
         self.assertTrue('leader' in roles)
         self.assertTrue('router' in roles or 'child' in roles)
         self.logger.info("Thread network formed")


### PR DESCRIPTION
This reverts commit 7aa6f5390632a7942901a17a89d817055a972699.

 #### Problem
Cirque build failed again since the issue is resolved in openthread. Revert #2662 now.

 #### Summary of Changes
Revert #2662 
