### PR TITLE
[linux] Improve type safety in BLE component

### DIFF
--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -180,7 +180,6 @@ CHIP_ERROR BLEManagerImpl::ConfigureBle(uint32_t aNodeId, bool aIsCentral)
     mBLEAdvConfig.mType             = ChipAdvType::BLUEZ_ADV_TYPE_UNDIRECTED_CONNECTABLE_SCANNABLE;
     mBLEAdvConfig.mpAdvertisingUUID = "0xFEAF";
 
-    mpBleAddr  = nullptr;
     mIsCentral = aIsCentral;
 
     return err;
@@ -316,8 +315,7 @@ exit:
 
 uint16_t BLEManagerImpl::GetMTU(BLE_CONNECTION_OBJECT conId) const
 {
-    BluezConnection * con = static_cast<BluezConnection *>(conId);
-    return (con != nullptr) ? con->mMtu : 0;
+    return conId != nullptr ? conId->mMtu : 0;
 }
 
 bool BLEManagerImpl::SubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, const ChipBleUUID * svcId, const ChipBleUUID * charId)
@@ -334,15 +332,14 @@ bool BLEManagerImpl::UnsubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, cons
 
 bool BLEManagerImpl::CloseConnection(BLE_CONNECTION_OBJECT conId)
 {
-    BluezConnection * con = static_cast<BluezConnection *>(conId);
-    ChipLogProgress(DeviceLayer, "Closing BLE GATT connection (con %u)", conId);
-    return CloseBluezConnection(con);
+    ChipLogProgress(DeviceLayer, "Closing BLE GATT connection (con %p)", conId);
+    return CloseBluezConnection(conId);
 }
 
 bool BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const ChipBleUUID * svcId, const Ble::ChipBleUUID * charId,
                                     chip::System::PacketBuffer * pBuf)
 {
-    return SendBluezIndication((void *) conId, pBuf);
+    return SendBluezIndication(conId, pBuf);
 }
 
 bool BLEManagerImpl::SendWriteRequest(BLE_CONNECTION_OBJECT conId, const Ble::ChipBleUUID * svcId, const Ble::ChipBleUUID * charId,
@@ -366,12 +363,12 @@ bool BLEManagerImpl::SendReadResponse(BLE_CONNECTION_OBJECT conId, BLE_READ_REQU
     return true;
 }
 
-void BLEManagerImpl::CHIPoBluez_NewConnection(void * data)
+void BLEManagerImpl::CHIPoBluez_NewConnection(BLE_CONNECTION_OBJECT conId)
 {
-    ChipLogProgress(Ble, "CHIPoBluez_NewConnection: %p", data);
+    ChipLogProgress(Ble, "CHIPoBluez_NewConnection: %p", conId);
 }
 
-void BLEManagerImpl::HandleRXCharWrite(void * data, const uint8_t * value, size_t len)
+void BLEManagerImpl::HandleRXCharWrite(BLE_CONNECTION_OBJECT conId, const uint8_t * value, size_t len)
 {
     CHIP_ERROR err     = CHIP_NO_ERROR;
     PacketBuffer * buf = nullptr;
@@ -390,8 +387,8 @@ void BLEManagerImpl::HandleRXCharWrite(void * data, const uint8_t * value, size_
     {
         ChipDeviceEvent event;
         event.Type = DeviceEventType::kCHIPoBLEWriteReceived;
-        ChipLogProgress(Ble, "Write request received debug %p", data);
-        event.CHIPoBLEWriteReceived.ConId = data;
+        ChipLogProgress(Ble, "Write request received debug %p", conId);
+        event.CHIPoBLEWriteReceived.ConId = conId;
         event.CHIPoBLEWriteReceived.Data  = buf;
         PlatformMgr().PostEvent(&event);
         buf = nullptr;
@@ -409,7 +406,7 @@ exit:
     }
 }
 
-void BLEManagerImpl::CHIPoBluez_ConnectionClosed(void * data)
+void BLEManagerImpl::CHIPoBluez_ConnectionClosed(BLE_CONNECTION_OBJECT conId)
 {
     ChipLogProgress(DeviceLayer, "Bluez notify CHIPoBluez connection disconnected");
 
@@ -417,30 +414,29 @@ void BLEManagerImpl::CHIPoBluez_ConnectionClosed(void * data)
     {
         ChipDeviceEvent event;
         event.Type                           = DeviceEventType::kCHIPoBLEConnectionError;
-        event.CHIPoBLEConnectionError.ConId  = data;
+        event.CHIPoBLEConnectionError.ConId  = conId;
         event.CHIPoBLEConnectionError.Reason = BLE_ERROR_REMOTE_DEVICE_DISCONNECTED;
         PlatformMgr().PostEvent(&event);
     }
 }
 
-void BLEManagerImpl::HandleTXCharCCCDWrite(void * data)
+void BLEManagerImpl::HandleTXCharCCCDWrite(BLE_CONNECTION_OBJECT conId)
 {
-    CHIP_ERROR err               = CHIP_NO_ERROR;
-    BluezConnection * connection = static_cast<BluezConnection *>(data);
+    CHIP_ERROR err = CHIP_NO_ERROR;
 
-    VerifyOrExit(connection != nullptr, ChipLogProgress(DeviceLayer, "Connection is NULL in HandleTXCharCCCDWrite"));
-    VerifyOrExit(connection->mpC2 != nullptr, ChipLogProgress(DeviceLayer, "C2 is NULL in HandleTXCharCCCDWrite"));
+    VerifyOrExit(conId != nullptr, ChipLogProgress(DeviceLayer, "Connection is NULL in HandleTXCharCCCDWrite"));
+    VerifyOrExit(conId->mpC2 != nullptr, ChipLogProgress(DeviceLayer, "C2 is NULL in HandleTXCharCCCDWrite"));
 
     // Post an event to the Chip queue to process either a CHIPoBLE Subscribe or Unsubscribe based on
     // whether the client is enabling or disabling indications.
     {
         ChipDeviceEvent event;
-        event.Type = (connection->mIsNotify) ? DeviceEventType::kCHIPoBLESubscribe : DeviceEventType::kCHIPoBLEUnsubscribe;
-        event.CHIPoBLESubscribe.ConId = data;
+        event.Type = conId->mIsNotify ? DeviceEventType::kCHIPoBLESubscribe : DeviceEventType::kCHIPoBLEUnsubscribe;
+        event.CHIPoBLESubscribe.ConId = conId;
         PlatformMgr().PostEvent(&event);
     }
 
-    ChipLogProgress(DeviceLayer, "CHIPoBLE %s received", (connection->mIsNotify) ? "subscribe" : "unsubscribe");
+    ChipLogProgress(DeviceLayer, "CHIPoBLE %s received", conId->mIsNotify ? "subscribe" : "unsubscribe");
 
 exit:
     if (err != CHIP_NO_ERROR)
@@ -450,12 +446,12 @@ exit:
     }
 }
 
-void BLEManagerImpl::HandleTXComplete(void * data)
+void BLEManagerImpl::HandleTXComplete(BLE_CONNECTION_OBJECT conId)
 {
     // Post an event to the Chip queue to process the indicate confirmation.
     ChipDeviceEvent event;
     event.Type                          = DeviceEventType::kCHIPoBLEIndicateConfirm;
-    event.CHIPoBLEIndicateConfirm.ConId = data;
+    event.CHIPoBLEIndicateConfirm.ConId = conId;
     PlatformMgr().PostEvent(&event);
 }
 

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -35,6 +35,8 @@ namespace Internal {
 using namespace chip::Ble;
 using namespace chip::Ble;
 
+struct BluezEndpoint;
+
 void HandleIncomingBleConnection(BLEEndPoint * bleEP);
 
 enum ChipAdvType
@@ -82,12 +84,11 @@ public:
     CHIP_ERROR ConfigureBle(uint32_t aNodeId, bool aIsCentral);
 
     // Driven by BlueZ IO
-    static void CHIPoBluez_NewConnection(void * user_data);
-    static void HandleRXCharWrite(void * user_data, const uint8_t * value, size_t len);
-    static void CHIPoBluez_ConnectionClosed(void * user_data);
-    static void HandleTXCharCCCDWrite(void * user_data);
-    static void HandleTXComplete(void * user_data);
-    static bool WoBLEz_TimerCb(void * user_data);
+    static void CHIPoBluez_NewConnection(BLE_CONNECTION_OBJECT conId);
+    static void HandleRXCharWrite(BLE_CONNECTION_OBJECT conId, const uint8_t * value, size_t len);
+    static void CHIPoBluez_ConnectionClosed(BLE_CONNECTION_OBJECT conId);
+    static void HandleTXCharCCCDWrite(BLE_CONNECTION_OBJECT conId);
+    static void HandleTXComplete(BLE_CONNECTION_OBJECT conId);
 
     static void NotifyBLEPeripheralRegisterAppComplete(bool aIsSuccess, void * apAppstate);
     static void NotifyBLEPeripheralAdvConfiguredComplete(bool aIsSuccess, void * apAppstate);
@@ -172,8 +173,7 @@ private:
     uint16_t mFlags;
     char mDeviceName[kMaxDeviceNameLength + 1];
     bool mIsCentral;
-    char * mpBleAddr;
-    void * mpAppState;
+    BluezEndpoint * mpAppState;
 };
 
 /**

--- a/src/platform/Linux/BlePlatformConfig.h
+++ b/src/platform/Linux/BlePlatformConfig.h
@@ -25,7 +25,18 @@
 #ifndef BLE_PLATFORM_CONFIG_H
 #define BLE_PLATFORM_CONFIG_H
 
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+struct BluezConnection;
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip
+
 // ==================== Platform Adaptations ====================
+
+#define BLE_CONNECTION_OBJECT chip::DeviceLayer::Internal::BluezConnection *
+#define BLE_CONNECTION_UNINITIALIZED nullptr
 
 // ========== Platform-specific Configuration Overrides =========
 

--- a/src/platform/Linux/CHIPBluezHelper.cpp
+++ b/src/platform/Linux/CHIPBluezHelper.cpp
@@ -235,13 +235,13 @@ exit:
     return G_SOURCE_REMOVE;
 }
 
-static gboolean BluezAdvStart(void * apClosure)
+static gboolean BluezAdvStart(void * apEndpoint)
 {
     GDBusObject * adapter;
     BluezLEAdvertisingManager1 * advMgr = nullptr;
     GVariantBuilder optionsBuilder;
     GVariant * options;
-    BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apClosure);
+    BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apEndpoint);
 
     VerifyOrExit(endpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
     VerifyOrExit(!endpoint->mIsAdvertising,
@@ -258,16 +258,16 @@ static gboolean BluezAdvStart(void * apClosure)
     options = g_variant_builder_end(&optionsBuilder);
 
     bluez_leadvertising_manager1_call_register_advertisement(advMgr, endpoint->mpAdvPath, options, nullptr, BluezAdvStartDone,
-                                                             apClosure);
+                                                             apEndpoint);
 
 exit:
     return G_SOURCE_REMOVE;
 }
 
-static gboolean BluezAdvStop(void * apClosure)
+static gboolean BluezAdvStop(void * apEndpoint)
 {
     GDBusObject * adapter;
-    BluezEndpoint * endpoint            = static_cast<BluezEndpoint *>(apClosure);
+    BluezEndpoint * endpoint            = static_cast<BluezEndpoint *>(apEndpoint);
     BluezLEAdvertisingManager1 * advMgr = nullptr;
 
     VerifyOrExit(endpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
@@ -281,7 +281,7 @@ static gboolean BluezAdvStop(void * apClosure)
     advMgr = bluez_object_get_leadvertising_manager1(BLUEZ_OBJECT(adapter));
     VerifyOrExit(advMgr != nullptr, ChipLogProgress(DeviceLayer, "FAIL: NULL advMgr in %s", __func__));
 
-    bluez_leadvertising_manager1_call_unregister_advertisement(advMgr, endpoint->mpAdvPath, nullptr, BluezAdvStopDone, apClosure);
+    bluez_leadvertising_manager1_call_unregister_advertisement(advMgr, endpoint->mpAdvPath, nullptr, BluezAdvStopDone, apEndpoint);
 
 exit:
     return G_SOURCE_REMOVE;
@@ -299,7 +299,7 @@ static gboolean BluezCharacteristicReadValue(BluezGattCharacteristic1 * aChar, G
 
 #if CHIP_BLUEZ_CHAR_WRITE_VALUE
 static gboolean BluezCharacteristicWriteValue(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation,
-                                              GVariant * aValue, GVariant * aOptions, gpointer apClosure)
+                                              GVariant * aValue, GVariant * aOptions, gpointer apEndpoint)
 {
     const uint8_t * tmpBuf;
     uint8_t * buf;
@@ -307,7 +307,7 @@ static gboolean BluezCharacteristicWriteValue(BluezGattCharacteristic1 * aChar, 
     bool isSuccess         = false;
     BluezConnection * conn = NULL;
 
-    BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apClosure);
+    BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apEndpoint);
     VerifyOrExit(endpoint != NULL, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
 
     VerifyOrExit(aValue != NULL, ChipLogProgress(DeviceLayer, "aValue is NULL in %s", __func__));
@@ -339,7 +339,7 @@ static gboolean BluezCharacteristicWriteValueError(BluezGattCharacteristic1 * aC
     return TRUE;
 }
 
-static gboolean BluezCharacteristicWriteFD(GIOChannel * aChannel, GIOCondition aCond, gpointer apClosure)
+static gboolean BluezCharacteristicWriteFD(GIOChannel * aChannel, GIOCondition aCond, gpointer apEndpoint)
 {
     GVariant * newVal;
     gchar * buf;
@@ -347,7 +347,7 @@ static gboolean BluezCharacteristicWriteFD(GIOChannel * aChannel, GIOCondition a
     int fd;
     bool isSuccess = false;
 
-    BluezConnection * conn = static_cast<BluezConnection *>(apClosure);
+    BluezConnection * conn = static_cast<BluezConnection *>(apEndpoint);
 
     VerifyOrExit(conn != nullptr, ChipLogProgress(DeviceLayer, "No CHIP Bluez connection in %s", __func__));
 
@@ -392,7 +392,7 @@ static gboolean bluezCharacteristicDestroyFD(GIOChannel * aChannel, GIOCondition
 }
 
 static gboolean BluezCharacteristicAcquireWrite(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation,
-                                                GVariant * aOptions, gpointer apClosure)
+                                                GVariant * aOptions, gpointer apEndpoint)
 {
     int fds[2] = { -1, -1 };
     GIOChannel * channel;
@@ -401,7 +401,7 @@ static gboolean BluezCharacteristicAcquireWrite(BluezGattCharacteristic1 * aChar
     bool isSuccess         = false;
     BluezConnection * conn = nullptr;
 
-    BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apClosure);
+    BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apEndpoint);
     VerifyOrExit(endpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
 
     conn = GetBluezConnectionViaDevice(endpoint);
@@ -460,7 +460,7 @@ static gboolean BluezCharacteristicAcquireWriteError(BluezGattCharacteristic1 * 
 }
 
 static gboolean BluezCharacteristicAcquireNotify(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation,
-                                                 GVariant * aOptions, gpointer apClosure)
+                                                 GVariant * aOptions, gpointer apEndpoint)
 {
     int fds[2] = { -1, -1 };
     GIOChannel * channel;
@@ -469,7 +469,7 @@ static gboolean BluezCharacteristicAcquireNotify(BluezGattCharacteristic1 * aCha
     BluezConnection * conn = nullptr;
     bool isSuccess         = false;
 
-    BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apClosure);
+    BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apEndpoint);
     VerifyOrExit(endpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
 
     conn = GetBluezConnectionViaDevice(endpoint);
@@ -509,7 +509,7 @@ static gboolean BluezCharacteristicAcquireNotify(BluezGattCharacteristic1 * aCha
     close(fds[1]);
 
     conn->mIsNotify = true;
-    BLEManagerImpl::HandleTXCharCCCDWrite((void *) conn);
+    BLEManagerImpl::HandleTXCharCCCDWrite(conn);
     isSuccess = true;
 
 exit:
@@ -526,12 +526,12 @@ static gboolean BluezCharacteristicAcquireNotifyError(BluezGattCharacteristic1 *
 }
 
 static gboolean BluezCharacteristicStartNotify(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation,
-                                               gpointer apClosure)
+                                               gpointer apEndpoint)
 {
     bool isSuccess         = false;
     BluezConnection * conn = nullptr;
 
-    BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apClosure);
+    BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apEndpoint);
     VerifyOrExit(endpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
 
     conn = GetBluezConnectionViaDevice(endpoint);
@@ -563,12 +563,12 @@ static gboolean BluezCharacteristicStartNotifyError(BluezGattCharacteristic1 * a
 }
 
 static gboolean BluezCharacteristicStopNotify(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation,
-                                              gpointer apClosure)
+                                              gpointer apEndpoint)
 {
     bool isSuccess         = false;
     BluezConnection * conn = nullptr;
 
-    BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apClosure);
+    BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apEndpoint);
     VerifyOrExit(endpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
 
     conn = GetBluezConnectionViaDevice(endpoint);
@@ -999,12 +999,12 @@ static void BluezSignalInterfacePropertiesChanged(GDBusObjectManagerClient * aMa
                         }
                         // for central, we do not call BluezConnectionInit until the services have been resolved
 
-                        BLEManagerImpl::CHIPoBluez_NewConnection(endpoint);
+                        BLEManagerImpl::CHIPoBluez_NewConnection(conn);
                     }
                     else
                     {
                         ChipLogProgress(DeviceLayer, "Bluez disconnected");
-                        BLEManagerImpl::CHIPoBluez_ConnectionClosed(endpoint);
+                        BLEManagerImpl::CHIPoBluez_ConnectionClosed(conn);
                         BluezOTConnectionDestroy(conn);
                         g_hash_table_remove(endpoint->mpConnMap, g_dbus_proxy_get_object_path(aInterface));
                     }
@@ -1516,7 +1516,7 @@ exit:
     return G_SOURCE_REMOVE;
 }
 
-bool SendBluezIndication(void * apConn, chip::System::PacketBuffer * apBuf)
+bool SendBluezIndication(BluezConnection * apConn, chip::System::PacketBuffer * apBuf)
 {
     ConnectionDataBundle * closure;
     const char * msg = nullptr;
@@ -1529,7 +1529,7 @@ bool SendBluezIndication(void * apConn, chip::System::PacketBuffer * apBuf)
     len    = apBuf->DataLength();
 
     closure         = g_new(ConnectionDataBundle, 1);
-    closure->mpConn = static_cast<BluezConnection *>(apConn);
+    closure->mpConn = apConn;
 
     closure->mpVal = g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, buffer, len * sizeof(uint8_t), sizeof(uint8_t));
 
@@ -1575,15 +1575,15 @@ static int CloseBleconnectionCB(void * apAppState)
     return G_SOURCE_REMOVE;
 }
 
-bool CloseBluezConnection(void * apAppState)
+bool CloseBluezConnection(BluezConnection * apConn)
 {
-    return BluezRunOnBluezThread(CloseBleconnectionCB, apAppState);
+    return BluezRunOnBluezThread(CloseBleconnectionCB, apConn);
 }
 
-CHIP_ERROR StartBluezAdv(void * apAppState)
+CHIP_ERROR StartBluezAdv(BluezEndpoint * apEndpoint)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    if (!BluezRunOnBluezThread(BluezAdvStart, apAppState))
+    if (!BluezRunOnBluezThread(BluezAdvStart, apEndpoint))
     {
         err = CHIP_ERROR_INCORRECT_STATE;
         ChipLogError(Ble, "Failed to schedule BluezAdvStart() on CHIPoBluez thread");
@@ -1591,10 +1591,10 @@ CHIP_ERROR StartBluezAdv(void * apAppState)
     return err;
 }
 
-CHIP_ERROR StopBluezAdv(void * apAppState)
+CHIP_ERROR StopBluezAdv(BluezEndpoint * apEndpoint)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    if (!BluezRunOnBluezThread(BluezAdvStop, apAppState))
+    if (!BluezRunOnBluezThread(BluezAdvStop, apEndpoint))
     {
         err = CHIP_ERROR_INCORRECT_STATE;
         ChipLogError(Ble, "Failed to schedule BluezAdvStop() on CHIPoBluez thread");
@@ -1602,10 +1602,10 @@ CHIP_ERROR StopBluezAdv(void * apAppState)
     return err;
 }
 
-CHIP_ERROR BluezAdvertisementSetup(void * apAppState)
+CHIP_ERROR BluezAdvertisementSetup(BluezEndpoint * apEndpoint)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    if (!BluezRunOnBluezThread(BluezAdvSetup, apAppState))
+    if (!BluezRunOnBluezThread(BluezAdvSetup, apEndpoint))
     {
         err = CHIP_ERROR_INCORRECT_STATE;
         ChipLogError(Ble, "Failed to schedule BluezAdvertisementSetup() on CHIPoBluez thread");
@@ -1613,10 +1613,10 @@ CHIP_ERROR BluezAdvertisementSetup(void * apAppState)
     return err;
 }
 
-CHIP_ERROR BluezGattsAppRegister(void * apAppState)
+CHIP_ERROR BluezGattsAppRegister(BluezEndpoint * apEndpoint)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    if (!BluezRunOnBluezThread(BluezPeripheralRegisterApp, apAppState))
+    if (!BluezRunOnBluezThread(BluezPeripheralRegisterApp, apEndpoint))
     {
         err = CHIP_ERROR_INCORRECT_STATE;
         ChipLogError(Ble, "Failed to schedule BluezPeripheralRegisterApp() on CHIPoBluez thread");
@@ -1661,7 +1661,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR InitBluezBleLayer(bool aIsCentral, char * apBleAddr, BLEAdvConfig & aBleAdvConfig, void *& apEndpoint)
+CHIP_ERROR InitBluezBleLayer(bool aIsCentral, char * apBleAddr, BLEAdvConfig & aBleAdvConfig, BluezEndpoint *& apEndpoint)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     bool retval    = false;

--- a/src/platform/Linux/CHIPBluezHelper.h
+++ b/src/platform/Linux/CHIPBluezHelper.h
@@ -189,14 +189,14 @@ struct ConnectionDataBundle
     GVariant * mpVal;
 };
 
-CHIP_ERROR InitBluezBleLayer(bool aIsCentral, char * apBleAddr, BLEAdvConfig & aBleAdvConfig, void *& apEndpoint);
+CHIP_ERROR InitBluezBleLayer(bool aIsCentral, char * apBleAddr, BLEAdvConfig & aBleAdvConfig, BluezEndpoint *& apEndpoint);
 bool BluezRunOnBluezThread(int (*aCallback)(void *), void * apClosure);
-bool SendBluezIndication(void * apConn, chip::System::PacketBuffer * apBuf);
-bool CloseBluezConnection(void * apAppState);
-CHIP_ERROR StartBluezAdv(void * apAppState);
-CHIP_ERROR StopBluezAdv(void * apAppState);
-CHIP_ERROR BluezGattsAppRegister(void * apAppState);
-CHIP_ERROR BluezAdvertisementSetup(void * apAppState);
+bool SendBluezIndication(BluezConnection * apConn, chip::System::PacketBuffer * apBuf);
+bool CloseBluezConnection(BluezConnection * apConn);
+CHIP_ERROR StartBluezAdv(BluezEndpoint * apEndpoint);
+CHIP_ERROR StopBluezAdv(BluezEndpoint * apEndpoint);
+CHIP_ERROR BluezGattsAppRegister(BluezEndpoint * apEndpoint);
+CHIP_ERROR BluezAdvertisementSetup(BluezEndpoint * apEndpoint);
 
 } // namespace Internal
 } // namespace DeviceLayer


### PR DESCRIPTION
 #### Problem
Linux BLE implementation uses more void* parameters and static_casts than necessary which is quite error-prone and may lead to passing a wrong object to a function.

 #### Summary of Changes
* Use more specific types than void*
* Try to avoid static_casts to/from void*
* Where void* is unavoidable, use more descriptive parameter names than "apAppState" etc.
* Remove unused member of BLEManagerImpl