### PR TITLE
[GN] ESP32 flashing support

### DIFF
--- a/examples/wifi-echo/server/esp32/Makefile
+++ b/examples/wifi-echo/server/esp32/Makefile
@@ -36,4 +36,31 @@ ifneq ($(CHIP_BUILD_WITH_GN),n)
 CPPFLAGS += -DCHIP_SEPARATE_CONFIG_H
 endif
 export CHIP_BUILD_WITH_GN
+
+top: all flashing_script
+
 include $(IDF_PATH)/make/project.mk
+
+FLASHING_SCRIPT=$(BUILD_DIR_BASE)/$(PROJECT_NAME).flash.py
+
+$(FLASHING_SCRIPT): $(APP_BIN) $(BOOTLOADER_BIN) $(PARTITION_TABLE_BIN) $(PROJECT_PATH)/sdkconfig
+	@third_party/connectedhomeip/scripts/flashing/gen_flashing_script.py esp32 \
+	  --output $(BUILD_DIR_BASE)/$(PROJECT_NAME).flash.py \
+	  --port $(ESPPORT) --baud $(ESPBAUD) --before $(CONFIG_ESPTOOLPY_BEFORE) --after $(CONFIG_ESPTOOLPY_AFTER) \
+	  --application $(subst $(BUILD_DIR_BASE)/,,$(APP_BIN)) \
+	  --bootloader $(subst $(BUILD_DIR_BASE)/,,$(BOOTLOADER_BIN)) \
+	  --partition $(subst $(BUILD_DIR_BASE)/,,$(PARTITION_TABLE_BIN)) \
+	  --use-partition-file $(PARTITION_TABLE_BIN) \
+	  --use-parttool $(IDF_PATH)/components/partition_table/parttool.py \
+	  --use-sdkconfig $(PROJECT_PATH)/sdkconfig
+
+flashing_script: $(FLASHING_SCRIPT) $(BUILD_DIR_BASE)/esp32_firmware_utils.py $(BUILD_DIR_BASE)/firmware_utils.py 
+	@echo To flash $(subst $(CURDIR)/,,$(APP_BIN)), run $(subst $(CURDIR)/,,$(FLASHING_SCRIPT))
+
+$(BUILD_DIR_BASE)/esp32_firmware_utils.py: third_party/connectedhomeip/scripts/flashing/esp32_firmware_utils.py
+	@cp $< $@
+
+$(BUILD_DIR_BASE)/firmware_utils.py: third_party/connectedhomeip/scripts/flashing/firmware_utils.py
+	@cp $< $@
+
+.PHONY: flashing_script

--- a/scripts/flashing/README.md
+++ b/scripts/flashing/README.md
@@ -2,19 +2,18 @@
 
 ## Using
 
-### ${TARGET}.flash.py
+### \${TARGET}.flash.py
 
-When a build target has a corresponding `.flash.py` script,
-that script can be run to flash the target to an attached device.
+When a build target has a corresponding `.flash.py` script, that script can be
+run to flash the target to an attached device.
 
-This is really just a wrapper around `${PLATFORM}_firmware_utils.py`
-with built-in argument defaults, so that it can typically be run
-with no arguments. You can however supply additional command line arguments
-to override or supplement the defaults, for example to select a specific
-connected device. In particular, `${TARGET}.flash.py --help` lists the
-available arguments.
+This is really just a wrapper around `${PLATFORM}_firmware_utils.py` with
+built-in argument defaults, so that it can typically be run with no arguments.
+You can however supply additional command line arguments to override or
+supplement the defaults, for example to select a specific connected device. In
+particular, `${TARGET}.flash.py --help` lists the available arguments.
 
-### ${PLATFORM}_firmware_utils.py
+### \${PLATFORM}\_firmware_utils.py
 
 These scripts invoking flashing tools for the particular platform with a
 more-or-less uniform interface. The core set of command line options is
@@ -24,20 +23,20 @@ more-or-less uniform interface. The core set of command line options is
     --verify_application  Verify the image after flashing
     --reset               Reset device after flashing
 
-Running `${PLATFORM}_firmware_utils.py --help` will show the complete list
-of available command line options for that platform.
+Running `${PLATFORM}_firmware_utils.py --help` will show the complete list of
+available command line options for that platform.
 
 ## Generating wrappers
 
 Normally this is done automatically for a suitable GN build target.
 
-The script `gen_flashing_script.py` builds a `${TARGET}.flash.py` wrapper
-script to invoke the firmware utils with a particular set of argument defaults.
-Run this as
+The script `gen_flashing_script.py` builds a `${TARGET}.flash.py` wrapper script
+to invoke the firmware utils with a particular set of argument defaults. Run
+this as
 
-> `gen_flashing_script.py ${PLATFORM} --output` *filename* [*argument* ...]
+> `gen_flashing_script.py ${PLATFORM} --output` _filename_ [*argument* ...]
 
-The *arguments* are the same as those of `${PLATFORM}_firmware_utils.py`.
-Some platforms may have additional options, e.g. to obtain additional values
-from a configuration file. Use `gen_flashing_script.py ${PLATFORM} --help`
-to list all options for a particular platform.
+The _arguments_ are the same as those of `${PLATFORM}_firmware_utils.py`. Some
+platforms may have additional options, e.g. to obtain additional values from a
+configuration file. Use `gen_flashing_script.py ${PLATFORM} --help` to list all
+options for a particular platform.

--- a/scripts/flashing/README.md
+++ b/scripts/flashing/README.md
@@ -1,0 +1,43 @@
+# Flashing Scripts
+
+## Using
+
+### ${TARGET}.flash.py
+
+When a build target has a corresponding `.flash.py` script,
+that script can be run to flash the target to an attached device.
+
+This is really just a wrapper around `${PLATFORM}_firmware_utils.py`
+with built-in argument defaults, so that it can typically be run
+with no arguments. You can however supply additional command line arguments
+to override or supplement the defaults, for example to select a specific
+connected device. In particular, `${TARGET}.flash.py --help` lists the
+available arguments.
+
+### ${PLATFORM}_firmware_utils.py
+
+These scripts invoking flashing tools for the particular platform with a
+more-or-less uniform interface. The core set of command line options is
+
+    --erase               Erase device
+    --application FILE    Flash an image
+    --verify_application  Verify the image after flashing
+    --reset               Reset device after flashing
+
+Running `${PLATFORM}_firmware_utils.py --help` will show the complete list
+of available command line options for that platform.
+
+## Generating wrappers
+
+Normally this is done automatically for a suitable GN build target.
+
+The script `gen_flashing_script.py` builds a `${TARGET}.flash.py` wrapper
+script to invoke the firmware utils with a particular set of argument defaults.
+Run this as
+
+> `gen_flashing_script.py ${PLATFORM} --output` *filename* [*argument* ...]
+
+The *arguments* are the same as those of `${PLATFORM}_firmware_utils.py`.
+Some platforms may have additional options, e.g. to obtain additional values
+from a configuration file. Use `gen_flashing_script.py ${PLATFORM} --help`
+to list all options for a particular platform.

--- a/scripts/flashing/efr32_firmware_utils.py
+++ b/scripts/flashing/efr32_firmware_utils.py
@@ -20,24 +20,28 @@ For `Flasher`, see the class documentation. For the parse_command()
 interface or standalone execution:
 
 usage: efr32_firmware_utils.py [-h] [--verbose] [--erase] [--application FILE]
-                               [--verify-application] [--reset] [--skip-reset]
-                               [--commander FILE]
+                               [--verify_application] [--reset] [--skip_reset]
+                               [--commander FILE] [--serialno SERIAL]
 
-Flash device
+Flash EFR32 device
 
 optional arguments:
   -h, --help            show this help message and exit
 
 configuration:
-  --verbose             Report more verbosely
+  --verbose, -v         Report more verbosely
   --commander FILE      File name of the commander executable
+  --serialno SERIAL, -s SERIAL
+                        Serial number of device to flash
 
 operations:
   --erase               Erase device
   --application FILE    Flash an image
-  --verify-application  Verify the image after flashing
+  --verify_application, --verify-application
+                        Verify the image after flashing
   --reset               Reset device after flashing
-  --skip-reset          Do not reset device after flashing
+  --skip_reset, --skip-reset
+                        Do not reset device after flashing
 """
 
 import sys
@@ -53,21 +57,27 @@ EFR32_OPTIONS = {
         'commander': {
             'help': 'File name of the commander executable',
             'default': 'commander',
-            'argument': {
+            'argparse': {
                 'metavar': 'FILE'
             },
-            'tool': {
-                'verify': ['{commander}', '--version'],
-                'error':
-                    """\
-                    Unable to execute {commander}.
+            'verify': ['{commander}', '--version'],
+            'error':
+                """\
+                Unable to execute {commander}.
 
-                    Please ensure that this tool is installed and
-                    available. See the EFR32 example README for
-                    installation instructions.
+                Please ensure that this tool is installed and
+                available. See the EFR32 example README for
+                installation instructions.
 
-                    """,
-            }
+                """,
+        },
+        'serialno': {
+            'help': 'Serial number of device to flash',
+            'default': None,
+            'alias': ['-s'],
+            'argparse': {
+                'metavar': 'SERIAL'
+            },
         },
     },
 }
@@ -76,49 +86,62 @@ EFR32_OPTIONS = {
 class Flasher(firmware_utils.Flasher):
     """Manage efr32 flashing."""
 
-    def __init__(self, options=None):
-        super().__init__(options, 'EFR32')
+    def __init__(self, **options):
+        super().__init__(platform='EFR32', module=__name__, **options)
         self.define_options(EFR32_OPTIONS)
-        self.module = __name__
+
+    # Common command line arguments for commander device subcommands.
+    DEVICE_ARGUMENTS = [{'optional': 'serialno'}]
 
     def erase(self):
         """Perform `commander device masserase`."""
-        return self.run_tool_logging('commander', ['device', 'masserase'],
-                                     'Erase device')
+        return self.run_tool(
+            'commander', ['device', 'masserase', self.DEVICE_ARGUMENTS],
+            name='Erase device')
 
     def verify(self, image):
         """Verify image."""
-        return self.run_tool_logging('commander', ['verify', image], 'Verify',
-                                     'Verified', 'Not verified', 2)
+        return self.run_tool(
+            'commander',
+            ['verify', self.DEVICE_ARGUMENTS, image],
+            name='Verify',
+            pass_message='Verified',
+            fail_message='Not verified',
+            fail_level=2)
 
     def flash(self, image):
         """Flash image."""
-        return self.run_tool_logging('commander', ['flash', image], 'Flash',
-                                     'Flashed')
+        return self.run_tool(
+            'commander',
+            ['flash', self.DEVICE_ARGUMENTS, image],
+            name='Flash')
 
     def reset(self):
         """Reset the device."""
-        return self.run_tool_logging('commander', ['device', 'reset'], 'Reset')
+        return self.run_tool(
+                'commander',
+                ['device', 'reset', self.DEVICE_ARGUMENTS],
+                name='Reset')
 
     def actions(self):
-        """Perform actions on the device according to self.options."""
-        self.log(3, 'OPTIONS:', self.options)
+        """Perform actions on the device according to self.option."""
+        self.log(3, 'Options:', self.option)
 
-        if self.options['erase']:
+        if self.option.erase:
             if self.erase().err:
                 return self
 
-        application = self.optional_file(self.options['application'])
+        application = self.optional_file(self.option.application)
         if application:
             if self.flash(application).err:
                 return self
-            if self.options['verify-application']:
+            if self.option.verify_application:
                 if self.verify(application).err:
                     return self
-            if self.options['reset'] is None:
-                self.options['reset'] = True
+            if self.option.reset is None:
+                self.option.reset = True
 
-        if self.options['reset']:
+        if self.option.reset:
             if self.reset().err:
                 return self
 

--- a/scripts/flashing/esp32_firmware_utils.py
+++ b/scripts/flashing/esp32_firmware_utils.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Flash an ESP32 device.
+
+This is layered so that a caller can perform individual operations
+through an `Flasher` instance, or operations according to a command line.
+For `Flasher`, see the class documentation. For the parse_command()
+interface or standalone execution:
+
+usage: esp32_firmware_utils.py [-h] [--verbose] [--erase] [--application FILE]
+                               [--verify_application] [--reset] [--skip_reset]
+                               [--esptool FILE] [--parttool FILE]
+                               [--sdkconfig FILE] [--chip CHIP] [--port PORT]
+                               [--baud BAUD] [--before ACTION]
+                               [--after ACTION] [--flash_mode MODE]
+                               [--flash_freq FREQ] [--flash_size SIZE]
+                               [--compress] [--bootloader FILE]
+                               [--bootloader_offset OFFSET] [--partition FILE]
+                               [--partition_offset OFFSET]
+                               [--application_offset OFFSET]
+
+Flash ESP32 device
+
+optional arguments:
+  -h, --help            show this help message and exit
+
+configuration:
+  --verbose, -v         Report more verbosely
+  --esptool FILE        File name of the esptool executable
+  --parttool FILE       File name of the parttool executable
+  --sdkconfig FILE      File containing option defaults
+  --chip CHIP           Target chip type
+  --port PORT           Serial port device
+  --baud BAUD           Serial port baud rate
+  --before ACTION       What to do before connecting
+  --after ACTION        What to do when finished
+  --flash_mode MODE, --flash-mode MODE
+                        Flash mode
+  --flash_freq FREQ, --flash-freq FREQ
+                        Flash frequency
+  --flash_size SIZE, --flash-size SIZE
+                        Flash size
+  --compress, -z        Compress data in transfer
+  --bootloader FILE     Bootloader image
+  --bootloader_offset OFFSET, --bootloader-offset OFFSET
+                        Bootloader offset
+  --partition FILE      Partition table image
+  --partition_offset OFFSET, --partition-offset OFFSET
+                        Partition table offset
+  --application_offset OFFSET, --application-offset OFFSET
+                        Application offset
+
+operations:
+  --erase               Erase device
+  --application FILE    Flash an image
+  --verify_application, --verify-application
+                        Verify the image after flashing
+  --reset               Reset device after flashing
+  --skip_reset, --skip-reset
+                        Do not reset device after flashing
+"""
+
+import os
+import sys
+
+import firmware_utils
+
+# Additional options that can be use to configure an `Flasher`
+# object (as dictionary keys) and/or passed as command line options.
+ESP32_OPTIONS = {
+    # Configuration options define properties used in flashing operations.
+    'configuration': {
+        # Tool configuration options.
+        'esptool': {
+            'help': 'File name of the esptool executable',
+            'default': None,
+            'argparse': {
+                'metavar': 'FILE',
+            },
+            'command': [
+                {'option': 'esptool'},
+                {'optional': 'port'},
+                {'optional': 'baud'},
+                {'optional': 'before'},
+                {'optional': 'after'},
+                ()
+            ],
+            'verify': ['{esptool}', 'version'],
+            'error':
+                """\
+                Unable to execute {esptool}.
+
+                Please ensure that this tool is installed and
+                that $IDF_PATH is set. See the ESP32 example
+                README for installation instructions.
+                """,
+        },
+        'parttool': {
+            'help': 'File name of the parttool executable',
+            'default': None,
+            'argparse': {
+                'metavar': 'FILE'
+            },
+            'command': [
+                {'option': 'parttool'},
+                {'optional': 'port'},
+                {'optional': 'baud'},
+                {
+                    'option': 'partition',
+                    'result': ['--partition-table-file', '{partition}'],
+                    'expand': True
+                },
+                ()
+            ],
+            'verify': ['{parttool}', '--quiet'],
+            'error':
+                """\
+                Unable to execute {parttool}.
+
+                Please ensure that this tool is installed and
+                that $IDF_PATH is set. See the ESP32 example
+                README for installation instructions.
+                """,
+        },
+        'sdkconfig': {
+            'help': 'File containing option defaults',
+            'default': None,
+            'argparse': {
+                'metavar': 'FILE'
+            },
+        },
+
+        # Device configuration options.
+        'chip': {
+            'help': 'Target chip type',
+            'default': 'esp32',
+            'argparse': {
+                'metavar': 'CHIP'
+            },
+            'sdkconfig': 'CONFIG_IDF_TARGET',
+        },
+        'port': {
+            'help': 'Serial port device',
+            'default': None,
+            'argparse': {
+                'metavar': 'PORT',
+            },
+            'sdkconfig': 'CONFIG_ESPTOOLPY_PORT',
+        },
+        'baud': {
+            'help': 'Serial port baud rate',
+            'default': None,
+            'argparse': {
+                'metavar': 'BAUD',
+            },
+            'sdkconfig': 'CONFIG_ESPTOOLPY_BAUD',
+        },
+        'before': {
+            'help': 'What to do before connecting',
+            'default': None,
+            'argparse': {
+                'metavar': 'ACTION',
+            },
+            'sdkconfig': 'CONFIG_ESPTOOLPY_BEFORE',
+        },
+        'after': {
+            'help': 'What to do when finished',
+            'default': None,
+            'argparse': {
+                'metavar': 'ACTION',
+            },
+            'sdkconfig': 'CONFIG_ESPTOOLPY_AFTER',
+        },
+        'flash_mode': {
+            'help': 'Flash mode',
+            'default': None,
+            'argparse': {
+                'metavar': 'MODE',
+            },
+            'sdkconfig': 'CONFIG_ESPTOOLPY_FLASHMODE',
+        },
+        'flash_freq': {
+            'help': 'Flash frequency',
+            'default': None,
+            'argparse': {
+                'metavar': 'FREQ',
+            },
+            'sdkconfig': 'CONFIG_ESPTOOLPY_FLASHFREQ',
+        },
+        'flash_size': {
+            'help': 'Flash size',
+            'default': None,
+            'argparse': {
+                'metavar': 'SIZE',
+            },
+            'sdkconfig': 'CONFIG_ESPTOOLPY_FLASHSIZE',
+        },
+        'compress': {
+            'help': 'Compress data in transfer',
+            'default': None,
+            'alias': ['-z'],
+            'argparse': {
+                'action': 'store_true'
+            },
+            'sdkconfig': 'CONFIG_ESPTOOLPY_COMPRESSED',
+        },
+
+        # Flashing things.
+        'bootloader': {
+            'help': 'Bootloader image',
+            'default': None,
+            'argparse': {
+                'metavar': 'FILE'
+            },
+        },
+        'bootloader_offset': {
+            'help': 'Bootloader offset',
+            'default': '0x1000',
+            'argparse': {
+                'metavar': 'OFFSET'
+            },
+        },
+        'partition': {
+            'help': 'Partition table image',
+            'default': None,
+            'argparse': {
+                'metavar': 'FILE'
+            },
+        },
+        'partition_offset': {
+            'help': 'Partition table offset',
+            'default': None,
+            'argparse': {
+                'metavar': 'OFFSET'
+            },
+            'sdkconfig': 'CONFIG_PARTITION_TABLE_OFFSET',
+        },
+        'application_offset': {
+            'help': 'Application offset',
+            'default': None,
+            'argparse': {
+                'metavar': 'OFFSET'
+            },
+        },
+    },
+}
+
+
+def namespace_defaults(dst, src):
+    for key, value in src.items():
+        if key not in dst or getattr(dst, key) is None:
+            setattr(dst, key, value)
+
+
+class Flasher(firmware_utils.Flasher):
+    """Manage esp32 flashing."""
+
+    def __init__(self, **options):
+        super().__init__(platform='ESP32', module=__name__, **options)
+        self.define_options(ESP32_OPTIONS)
+
+    def _postprocess_argv(self):
+        if self.option.sdkconfig:
+            namespace_defaults(self.option,
+                               self.read_sdkconfig(self.option.sdkconfig))
+#       idf = os.environ.get('IDF_PATH')
+#       if idf:
+#           if self.option.esptool is None:
+#               self.option.esptool = os.path.join(
+#                   idf,
+#                   'components/esptool_py/esptool/esptool.py')
+#           if self.option.parttool is None:
+#               self.option.parttool = os.path.join(
+#                   idf,
+#                   'components/partition_table/parttool.py')
+
+    def read_sdkconfig(self, filename):
+        """Given an ESP32 sdkconfig file, read it for values of options
+           not otherwise set.
+        """
+        config_map = {}
+        for key, info in vars(self.info).items():
+            config_key = info.get('sdkconfig')
+            if config_key:
+                config_map[config_key] = key
+        result = {}
+        with open(filename) as f:
+            for line in f:
+                k, eq, v = line.strip().partition('=')
+                if eq == '=' and k in config_map:
+                    result[config_map[k]] = v.strip('"')
+        return result
+
+    IDF_PATH_TOOLS = {
+        'esptool': 'components/esptool_py/esptool/esptool.py',
+        'parttool': 'components/partition_table/parttool.py',
+    }
+
+    def locate_tool(self, tool):
+        if tool in self.IDF_PATH_TOOLS:
+            idf_path = os.environ.get('IDF_PATH')
+            if idf_path:
+                return os.path.join(idf_path, self.IDF_PATH_TOOLS[tool])
+        return super().locate_tool(tool)
+
+    # Common command line arguments for esptool flashing subcommands.
+    FLASH_ARGUMENTS = [
+        {'optional': 'flash_mode'},
+        {'optional': 'flash_freq'},
+        {'optional': 'flash_size'},
+        {
+            'match': '{compress}',
+            'test': [(True, '-z'), ('y', '-z')],
+            'default': '-u'
+        },
+    ]
+
+    def erase(self):
+        """Perform `commander device masserase`."""
+        return self.run_tool('esptool', ['erase_flash'], {}, 'Erase device')
+
+    def verify(self, image, address=0):
+        """Verify image(s)."""
+        if not isinstance(image, list):
+            image = [address, image]
+        return self.run_tool(
+            'esptool',
+            ['verify_flash', self.FLASH_ARGUMENTS, image],
+            name='Verify',
+            pass_message='Verified',
+            fail_message='Not verified',
+            fail_level=2)
+
+    def flash(self, image, address=0):
+        """Flash image(s)."""
+        if not isinstance(image, list):
+            image = [address, image]
+        return self.run_tool(
+            'esptool',
+            ['write_flash', self.FLASH_ARGUMENTS, image],
+            name='Flash')
+
+    PARTITION_INFO = {
+        'phy': ['--partition-type', 'data', '--partition-subtype', 'phy'],
+        'application': ['--partition-boot-default'],
+        'ota': ['--partition-type', 'data', '--partition-subtype', 'ota'],
+        'factory': [
+            '--partition-type', 'app', '--partition-subtype', 'factory'
+        ],
+    }
+
+    def get_partition_info(self, item, info, options=None):
+        """Run parttool to get partition information."""
+        return self.run_tool(
+            'parttool',
+            ['get_partition_info', self.PARTITION_INFO[item], '--info', info],
+            options or {},
+            capture_output=True).stdout.strip()
+
+    def make_wrapper(self, argv):
+        self.parser.add_argument(
+            '--use-parttool',
+            metavar='FILENAME',
+            help='partition tool to configure flashing script')
+        self.parser.add_argument(
+            '--use-partition-file',
+            metavar='FILENAME',
+            help='partition file to configure flashing script')
+        self.parser.add_argument(
+            '--use-sdkconfig',
+            metavar='FILENAME',
+            help='sdkconfig to configure flashing script')
+        super().make_wrapper(argv)
+
+    def _platform_wrapper_args(self, args):
+        if args.use_sdkconfig:
+            # Include values from sdkconfig so that it isn't needed at
+            # flashing time.
+            namespace_defaults(args, self.read_sdkconfig(args.use_sdkconfig))
+        parttool = args.use_parttool or args.parttool
+        partfile = args.use_partition_file or args.partition
+        if parttool and partfile:
+            # Get unspecified offsets from the partition file now,
+            # so that parttool isn't needed at flashing time.
+            if args.application and args.application_offset is None:
+                args.application_offset = self.get_partition_info(
+                    'application', 'offset',
+                    {'parttool': parttool, 'partition': partfile})
+
+    def actions(self):
+        """Perform actions on the device according to self.option."""
+        self.log(3, 'Options:', self.option)
+
+        if self.option.erase:
+            if self.erase().err:
+                return self
+
+        bootloader = self.optional_file(self.option.bootloader)
+        application = self.optional_file(self.option.application)
+        partition = self.optional_file(self.option.partition)
+
+        if bootloader or application or partition:
+            # Collect the flashable items.
+            flash = []
+            if bootloader:
+                flash += [self.option.bootloader_offset, bootloader]
+            if application:
+                offset = self.option.application_offset
+                if offset is None:
+                    offset = self.get_partition_info('application', 'offset')
+                flash += [offset, application]
+            if partition:
+                flash += [self.option.partition_offset, partition]
+
+            # esptool.py doesn't have an independent reset command, so we add
+            # an `--after` option to the final operation, which may be either
+            # flash or verify.
+            if self.option.after is None:
+                if self.option.reset or self.option.reset is None:
+                    self.option.after = 'hard_reset'
+                else:
+                    self.option.after = 'no_reset'
+            if self.option.verify_application:
+                verify_after = self.option.after
+                self.option.after = 'no_reset'
+
+            if self.flash(flash).err:
+                return self
+            if self.option.verify_application:
+                self.option.after = verify_after
+                if self.verify(flash).err:
+                    return self
+
+        return self
+
+
+if __name__ == '__main__':
+    sys.exit(Flasher().flash_command(sys.argv))

--- a/scripts/requirements.in
+++ b/scripts/requirements.in
@@ -8,3 +8,6 @@ future>=0.15.2
 cryptography>=2.1.4
 pyparsing>=2.0.3,<2.4.0
 pyelftools>=0.22
+
+# cirque tests
+requests>=2.24.0

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -4,16 +4,21 @@
 #
 #    pip-compile requirements.in
 #
+certifi==2020.6.20        # via requests
 cffi==1.14.3              # via cryptography
+chardet==3.0.4            # via requests
 click==7.1.2              # via -r requirements.in, pip-tools
 cryptography==3.1.1       # via -r requirements.in
 future==0.18.2            # via -r requirements.in
+idna==2.10                # via requests
 pip-tools==5.3.1          # via -r requirements.in
 pycparser==2.20           # via cffi
 pyelftools==0.26          # via -r requirements.in
 pyparsing==2.3.1          # via -r requirements.in
 pyserial==3.4             # via -r requirements.in
+requests==2.24.0          # via -r requirements.in
 six==1.15.0               # via cryptography, pip-tools
+urllib3==1.25.10          # via requests
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
#### Problem

ESP32 is missing .flash.py support equivalent to EFR32 and NRF5.

#### Summary of Changes

- Generate flashing wrapper script from ESP32 wifi-echo Makefile.
- Added esp32_firmware_utils.
- Added subclass hooks for Flasher.make_wrapper() and .parse_argv().
- Added Flasher.format_command() for tool command argument lists.
- Use argparse.Namespace directly instead of converting to a dict.
- Minor text fixes.

Flashing wrapper generation from GN is not included here since there
is no GN binary target yet, but would be easy to add based on one of
the existing //third_party/*_sdk/*_executable.gni.
