### PR TITLE
[cirque] Add requests to py requirements

### DIFF
--- a/scripts/requirements.in
+++ b/scripts/requirements.in
@@ -8,3 +8,6 @@ future>=0.15.2
 cryptography>=2.1.4
 pyparsing>=2.0.3,<2.4.0
 pyelftools>=0.22
+
+# cirque tests
+requests>=2.24.0

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -4,16 +4,21 @@
 #
 #    pip-compile requirements.in
 #
+certifi==2020.6.20        # via requests
 cffi==1.14.3              # via cryptography
+chardet==3.0.4            # via requests
 click==7.1.2              # via -r requirements.in, pip-tools
 cryptography==3.1.1       # via -r requirements.in
 future==0.18.2            # via -r requirements.in
+idna==2.10                # via requests
 pip-tools==5.3.1          # via -r requirements.in
 pycparser==2.20           # via cffi
 pyelftools==0.26          # via -r requirements.in
 pyparsing==2.3.1          # via -r requirements.in
 pyserial==3.4             # via -r requirements.in
+requests==2.24.0          # via -r requirements.in
 six==1.15.0               # via cryptography, pip-tools
+urllib3==1.25.10          # via requests
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
 #### Problem
Cirque test requires requests, which is not installed after #2852 

 #### Summary of Changes
Add requests to requirements.in

fixes #2901
