### PR TITLE
Fix selection of Android logging on Android

### DIFF
--- a/src/lib/core/core.gni
+++ b/src/lib/core/core.gni
@@ -52,10 +52,10 @@ if (chip_target_style == "") {
 }
 
 if (chip_logging_style == "") {
-  if (current_os != "freertos") {
-    chip_logging_style = "stdio"
-  } else if (current_os == "android") {
+  if (current_os == "android") {
     chip_logging_style = "android"
+  } else if (current_os != "freertos") {
+    chip_logging_style = "stdio"
   } else {
     chip_logging_style = "external"
   }


### PR DESCRIPTION
We're actually taking the first conditional, since "android" !=
"freertos". Reorder these conditions so that Android logging is used on
Android.

 #### Problem
Android logging is broken since the GN transition.

 #### Summary of Changes
Fix configuration to choose Android logging by default when current_os == "android".