### PR TITLE
Fix CSR creation using mbedTLS

### DIFF
--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -668,9 +668,8 @@ CHIP_ERROR P256Keypair::NewCertificateSigningRequest(uint8_t * out_csr, size_t &
     mbedtls_x509write_csr_set_md_alg(&csr, MBEDTLS_MD_SHA256);
 
     result = mbedtls_x509write_csr_pem(&csr, out_csr, length, CryptoRNG, nullptr);
-    VerifyOrExit(result >= 0, error = CHIP_ERROR_INTERNAL);
-    csr_length = static_cast<unsigned int>(result);
-    result     = 0;
+    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
+    csr_length = strlen(Uint8::to_const_char(out_csr));
 
 exit:
     keypair = nullptr;

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -795,6 +795,7 @@ static void TestCSR_Gen(nlTestSuite * inSuite, void * inContext)
     P256Keypair keypair;
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, keypair.NewCertificateSigningRequest(csr, length) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, length > 0);
 }
 
 static void TestKeypair_Serialize(nlTestSuite * inSuite, void * inContext)


### PR DESCRIPTION
 #### Problem
Incorrect length for CSR generated using `mbedTLS` library

 #### Summary of Changes
The return value for `mbedtls_x509write_csr_pem` was being used to set the length, whereas this is 0, or error code. 

fixes #2910
