### PR TITLE
Add missing liblog for Android logging

### DIFF
--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -115,6 +115,11 @@ static_library("support") {
     public += [ "CHIPFaultInjection.h" ]
     public_deps += [ "${nlfaultinjection_root}:nlfaultinjection" ]
   }
+
+  libs = []
+  if (chip_logging_style == "android") {
+    libs += [ "log" ]
+  }
 }
 
 copy("support_headers") {


### PR DESCRIPTION
 #### Problem
We need to link with liblog for Android logging.

 #### Summary of Changes
Add liblog to libs.