### PR TITLE
Add -Wl,-z,-defs to ldflags on Linux & Android

### DIFF
--- a/gn/build/config/compiler/BUILD.gn
+++ b/gn/build/config/compiler/BUILD.gn
@@ -171,6 +171,10 @@ config("strict_warnings") {
   if (is_clang) {
     cflags += [ "-Wimplicit-fallthrough" ]
   }
+
+  if (current_os == "linux" || current_os == "android") {
+    ldflags += [ "-Wl,-z,defs" ]
+  }
 }
 
 config("warnings_default") {


### PR DESCRIPTION
This ensures there are no undefined symbols at link time. After this PR,
problems like #2916 will be caught at compile time.

 #### Problem
Undefined symbols aren't caught until runtime.

 #### Summary of Changes
Fail linking if there are undefined symbols in shared libraries.