### PR TITLE
Add Identify support to the darwin Framework

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -48,6 +48,7 @@ typedef void (^ControllerOnErrorBlock)(NSError * error);
 - (BOOL)sendOnCommand;
 - (BOOL)sendOffCommand;
 - (BOOL)sendToggleCommand;
+- (BOOL)sendIdentifyCommandWithDuration:(NSTimeInterval)duration;
 - (BOOL)disconnect:(NSError * __autoreleasing *)error;
 - (BOOL)isConnected;
 

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -349,6 +349,18 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
     }];
 }
 
+- (BOOL)sendIdentifyCommandWithDuration:(NSTimeInterval)duration
+{
+    if (duration > UINT16_MAX) {
+        duration = UINT16_MAX;
+    }
+
+    return [self sendCHIPCommand:^uint32_t(chip::System::PacketBuffer * buffer, uint16_t bufferSize) {
+        // Hardcode endpoint to 1 for now
+        return encodeIdentifyCommand(buffer->Start(), bufferSize, 1, duration);
+    }];
+}
+
 - (BOOL)disconnect:(NSError * __autoreleasing *)error
 {
     CHIP_ERROR err = CHIP_NO_ERROR;

--- a/src/transport/SecurePairingSession.h
+++ b/src/transport/SecurePairingSession.h
@@ -130,7 +130,7 @@ public:
      * @brief
      *   Handler for peer's messages, exchanged during pairing handshake.
      *
-     * @param header      Message header for the received message
+     * @param packetHeader      Message header for the received message
      * @param msg         Message sent by the peer
      * @return CHIP_ERROR The result of message processing
      */


### PR DESCRIPTION
 #### Problem
There's currently no way to trigger the Identify cluster from the Darwin Framework
 #### Summary of Changes
Add an API to the DeviceController to trigger Identify on an accessory