### PR TITLE
Implement missing parts for WiFi station methods in ConnectivityManager

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -58,7 +58,7 @@ CHIP_ERROR ConnectivityManagerImpl::_Init()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    mWiFiStationMode = kWiFiStationMode_Disabled;
+    mWiFiStationMode                = kWiFiStationMode_Disabled;
     mWiFiStationReconnectIntervalMS = CHIP_DEVICE_CONFIG_WIFI_STATION_RECONNECT_INTERVAL;
 
     // Initialize the generic base classes that require it.
@@ -135,6 +135,11 @@ exit:
     return err;
 }
 
+uint32_t ConnectivityManagerImpl::_GetWiFiStationReconnectIntervalMS(void)
+{
+    return mWiFiStationReconnectIntervalMS;
+}
+
 CHIP_ERROR ConnectivityManagerImpl::_SetWiFiStationReconnectIntervalMS(uint32_t val)
 {
     mWiFiStationReconnectIntervalMS = val;
@@ -176,7 +181,7 @@ bool ConnectivityManagerImpl::_IsWiFiStationApplicationControlled()
 
 bool ConnectivityManagerImpl::_IsWiFiStationProvisioned(void)
 {
-    bool ret            = false;
+    bool ret          = false;
     const gchar * bss = nullptr;
 
     if (mWpaSupplicant.state != GDBusWpaSupplicant::WPA_INTERFACE_CONNECTED)
@@ -186,7 +191,7 @@ bool ConnectivityManagerImpl::_IsWiFiStationProvisioned(void)
     }
 
     bss = wpa_fi_w1_wpa_supplicant1_interface_get_current_bss(mWpaSupplicant.iface);
-    if (g_str_match_string ("BSSs", bss, true))
+    if (g_str_match_string("BSSs", bss, true))
     {
         ret = true;
     }
@@ -204,16 +209,13 @@ void ConnectivityManagerImpl::_ClearWiFiStationProvision(void)
 
     if (mWiFiStationMode != kWiFiStationMode_ApplicationControlled)
     {
-        GError * err                            = nullptr;
-        gboolean ret = wpa_fi_w1_wpa_supplicant1_interface_call_remove_all_networks_sync(
-            mWpaSupplicant.iface,
-            nullptr,
-            &err);
+        GError * err = nullptr;
+        gboolean ret = wpa_fi_w1_wpa_supplicant1_interface_call_remove_all_networks_sync(mWpaSupplicant.iface, nullptr, &err);
 
         if (err != nullptr)
         {
             ChipLogProgress(DeviceLayer, "wpa_supplicant: failed to remove all networks with error: %s",
-                err ? err->message : "unknown error");
+                            err ? err->message : "unknown error");
             g_error_free(err);
         }
     }

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -204,7 +204,7 @@ void ConnectivityManagerImpl::_ClearWiFiStationProvision(void)
 
     if (mWiFiStationMode != kWiFiStationMode_ApplicationControlled)
     {
-        GError * err                            = nullptr;    
+        GError * err                            = nullptr;
         gboolean ret = wpa_fi_w1_wpa_supplicant1_interface_call_remove_all_networks_sync(
             mWpaSupplicant.iface,
             nullptr,

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -117,9 +117,13 @@ private:
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
     WiFiStationMode _GetWiFiStationMode();
     CHIP_ERROR _SetWiFiStationMode(ConnectivityManager::WiFiStationMode val);
+    uint32_t _GetWiFiStationReconnectIntervalMS();
+    CHIP_ERROR _SetWiFiStationReconnectIntervalMS(uint32_t val);
     bool _IsWiFiStationEnabled();
     bool _IsWiFiStationConnected();
     bool _IsWiFiStationApplicationControlled();
+    bool _IsWiFiStationProvisioned();
+    void _ClearWiFiStationProvision();    
     bool _CanStartWiFiScan();
     static void _OnWpaProxyReady(GObject * source_object, GAsyncResult * res, gpointer user_data);
     static void _OnWpaInterfaceRemoved(WpaFiW1Wpa_supplicant1 * proxy, const gchar * path, GVariant * properties,
@@ -142,11 +146,17 @@ private:
     // ===== Private members reserved for use by this class only.
 
     ConnectivityManager::WiFiStationMode mWiFiStationMode;
+    uint32_t mWiFiStationReconnectIntervalMS;
 };
 
 inline bool ConnectivityManagerImpl::_HaveServiceConnectivity()
 {
     return _HaveServiceConnectivityViaThread();
+}
+
+inline uint32_t ConnectivityManagerImpl::_GetWiFiStationReconnectIntervalMS(void)
+{
+    return mWiFiStationReconnectIntervalMS;
 }
 
 /**

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -123,7 +123,7 @@ private:
     bool _IsWiFiStationConnected();
     bool _IsWiFiStationApplicationControlled();
     bool _IsWiFiStationProvisioned();
-    void _ClearWiFiStationProvision();    
+    void _ClearWiFiStationProvision();
     bool _CanStartWiFiScan();
     static void _OnWpaProxyReady(GObject * source_object, GAsyncResult * res, gpointer user_data);
     static void _OnWpaInterfaceRemoved(WpaFiW1Wpa_supplicant1 * proxy, const gchar * path, GVariant * properties,

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -154,11 +154,6 @@ inline bool ConnectivityManagerImpl::_HaveServiceConnectivity()
     return _HaveServiceConnectivityViaThread();
 }
 
-inline uint32_t ConnectivityManagerImpl::_GetWiFiStationReconnectIntervalMS(void)
-{
-    return mWiFiStationReconnectIntervalMS;
-}
-
 /**
  * Returns the public interface of the ConnectivityManager singleton object.
  *


### PR DESCRIPTION
 #### Problem
There are few WiFi station methods left un-implemented on Linux platform. 

 #### Summary of Changes
Implement missing parts for WiFi station methods in ConnectivityManager

fixes #2924
