### PR TITLE
Process IP address assignment response in Rendezvous Session

### DIFF
--- a/examples/wifi-echo/server/esp32/main/EchoDeviceCallbacks.cpp
+++ b/examples/wifi-echo/server/esp32/main/EchoDeviceCallbacks.cpp
@@ -24,7 +24,6 @@
  **/
 
 #include "EchoDeviceCallbacks.h"
-#include "RendezvousDeviceDelegate.h"
 #include "esp_heap_caps.h"
 #include "esp_log.h"
 #include "esp_netif.h"
@@ -48,7 +47,6 @@ using namespace ::chip::DeviceLayer;
 extern LEDWidget statusLED1;
 extern LEDWidget statusLED2;
 extern WiFiWidget wifiLED;
-extern RendezvousDeviceDelegate * rendezvousDelegate;
 
 void EchoDeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_t arg)
 {
@@ -57,22 +55,7 @@ void EchoDeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, int
         ESP_LOGI(TAG, "Current free heap: %d\n", heap_caps_get_free_size(MALLOC_CAP_8BIT));
         if (event->InternetConnectivityChange.IPv4 == kConnectivity_Established)
         {
-            esp_netif_ip_info_t ipInfo;
-            if (esp_netif_get_ip_info(esp_netif_get_handle_from_ifkey("WIFI_STA_DEF"), &ipInfo) == ESP_OK)
-            {
-                char ipAddrStr[INET_ADDRSTRLEN];
-                esp_ip4addr_ntoa(&ipInfo.ip, ipAddrStr, sizeof(ipAddrStr));
-                ESP_LOGI(TAG, "Server ready at: %s:%d", ipAddrStr, CHIP_PORT);
-
-                // Since the commissioner device does not yet have a mechanism to discover the IP address
-                // of the peripheral, the following code send it over the current Rendezvous session.
-                if (rendezvousDelegate != NULL)
-                {
-                    IPAddress addr;
-                    IPAddress::FromString(ipAddrStr, addr);
-                    rendezvousDelegate->AssignedIPAddress(addr);
-                }
-            }
+            ESP_LOGI(TAG, "Server ready at: %s:%d", event->InternetConnectivityChange.address, CHIP_PORT);
             wifiLED.Set(true);
         }
         else if (event->InternetConnectivityChange.IPv4 == kConnectivity_Lost)

--- a/examples/wifi-echo/server/esp32/main/EchoDeviceCallbacks.cpp
+++ b/examples/wifi-echo/server/esp32/main/EchoDeviceCallbacks.cpp
@@ -68,7 +68,9 @@ void EchoDeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, int
                 // of the peripheral, the following code send it over the current Rendezvous session.
                 if (rendezvousDelegate != NULL)
                 {
-                    rendezvousDelegate->Send(ipAddrStr);
+                    IPAddress addr;
+                    IPAddress::FromString(ipAddrStr, addr);
+                    rendezvousDelegate->AssignedIPAddress(addr);
                 }
             }
             wifiLED.Set(true);

--- a/examples/wifi-echo/server/esp32/main/RendezvousDeviceDelegate.cpp
+++ b/examples/wifi-echo/server/esp32/main/RendezvousDeviceDelegate.cpp
@@ -54,11 +54,6 @@ exit:
     }
 }
 
-CHIP_ERROR RendezvousDeviceDelegate::AssignedIPAddress(IPAddress & deviceAddr)
-{
-    return mRendezvousSession->AssignedIPAddress(deviceAddr);
-}
-
 void RendezvousDeviceDelegate::OnRendezvousError(CHIP_ERROR err)
 {
     ESP_LOGI(TAG, "OnRendezvousError: %s", ErrorStr(err));

--- a/examples/wifi-echo/server/esp32/main/RendezvousDeviceDelegate.cpp
+++ b/examples/wifi-echo/server/esp32/main/RendezvousDeviceDelegate.cpp
@@ -54,22 +54,9 @@ exit:
     }
 }
 
-CHIP_ERROR RendezvousDeviceDelegate::Send(const char * msg)
+CHIP_ERROR RendezvousDeviceDelegate::AssignedIPAddress(IPAddress & deviceAddr)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    System::PacketBuffer * buffer;
-    const size_t msgLen = strlen(msg);
-
-    VerifyOrExit(mRendezvousSession, err = CHIP_ERROR_INCORRECT_STATE);
-
-    buffer = System::PacketBuffer::NewWithAvailableSize(msgLen);
-    memcpy(buffer->Start(), msg, msgLen);
-    buffer->SetDataLength(msgLen);
-
-    err = mRendezvousSession->SendMessage(buffer);
-
-exit:
-    return err;
+    return mRendezvousSession->AssignedIPAddress(deviceAddr);
 }
 
 void RendezvousDeviceDelegate::OnRendezvousError(CHIP_ERROR err)

--- a/examples/wifi-echo/server/esp32/main/include/RendezvousDeviceDelegate.h
+++ b/examples/wifi-echo/server/esp32/main/include/RendezvousDeviceDelegate.h
@@ -27,7 +27,7 @@ class RendezvousDeviceDelegate : public RendezvousSessionDelegate
 {
 public:
     RendezvousDeviceDelegate();
-    CHIP_ERROR Send(const char * msg);
+    CHIP_ERROR AssignedIPAddress(IPAddress & deviceAddr);
 
     //////////// RendezvousSession callback Implementation ///////////////
     void OnRendezvousConnectionOpened() override;

--- a/examples/wifi-echo/server/esp32/main/include/RendezvousDeviceDelegate.h
+++ b/examples/wifi-echo/server/esp32/main/include/RendezvousDeviceDelegate.h
@@ -27,7 +27,6 @@ class RendezvousDeviceDelegate : public RendezvousSessionDelegate
 {
 public:
     RendezvousDeviceDelegate();
-    CHIP_ERROR AssignedIPAddress(IPAddress & deviceAddr);
 
     //////////// RendezvousSession callback Implementation ///////////////
     void OnRendezvousConnectionOpened() override;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -189,7 +189,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR ChipDeviceController::ConnectDeviceUsingPairing(NodeId remoteDeviceId, IPAddress deviceAddr, void * appReqState,
+CHIP_ERROR ChipDeviceController::ConnectDeviceUsingPairing(NodeId remoteDeviceId, void * appReqState,
                                                            NewConnectionHandler onConnected,
                                                            MessageReceiveHandler onMessageReceived, ErrorHandler onError,
                                                            uint16_t devicePort, Inet::InterfaceId interfaceId,
@@ -203,7 +203,6 @@ CHIP_ERROR ChipDeviceController::ConnectDeviceUsingPairing(NodeId remoteDeviceId
     }
 
     mRemoteDeviceId  = Optional<NodeId>::Value(remoteDeviceId);
-    mDeviceAddr      = deviceAddr;
     mDevicePort      = devicePort;
     mAppReqState     = appReqState;
     mOnNewConnection = onConnected;
@@ -211,7 +210,7 @@ CHIP_ERROR ChipDeviceController::ConnectDeviceUsingPairing(NodeId remoteDeviceId
     mSessionManager = new SecureSessionMgr<Transport::UDP>();
 
     err = mSessionManager->Init(mLocalDeviceId, mSystemLayer,
-                                Transport::UdpListenParameters(mInetLayer).SetAddressType(deviceAddr.Type()));
+                                Transport::UdpListenParameters(mInetLayer).SetAddressType(mDeviceAddr.Type()));
     SuccessOrExit(err);
 
     mSessionManager->SetDelegate(this);
@@ -222,7 +221,7 @@ CHIP_ERROR ChipDeviceController::ConnectDeviceUsingPairing(NodeId remoteDeviceId
     mOnError             = onError;
 
     err = mSessionManager->NewPairing(
-        Optional<Transport::PeerAddress>::Value(Transport::PeerAddress::UDP(deviceAddr, devicePort, interfaceId)), pairing);
+        Optional<Transport::PeerAddress>::Value(Transport::PeerAddress::UDP(mDeviceAddr, devicePort, interfaceId)), pairing);
     SuccessOrExit(err);
 
     mMessageNumber = 1;
@@ -250,8 +249,8 @@ CHIP_ERROR ChipDeviceController::ConnectDevice(NodeId remoteDeviceId, IPAddress 
                                                NewConnectionHandler onConnected, MessageReceiveHandler onMessageReceived,
                                                ErrorHandler onError, uint16_t devicePort, Inet::InterfaceId interfaceId)
 {
-    return ConnectDeviceUsingPairing(remoteDeviceId, deviceAddr, appReqState, onConnected, onMessageReceived, onError, devicePort,
-                                     interfaceId, &mPairingSession);
+    return ConnectDeviceUsingPairing(remoteDeviceId, appReqState, onConnected, onMessageReceived, onError, devicePort, interfaceId,
+                                     &mPairingSession);
 }
 
 CHIP_ERROR ChipDeviceController::ConnectDeviceWithoutSecurePairing(NodeId remoteDeviceId, IPAddress deviceAddr, void * appReqState,
@@ -260,8 +259,9 @@ CHIP_ERROR ChipDeviceController::ConnectDeviceWithoutSecurePairing(NodeId remote
                                                                    uint16_t devicePort, Inet::InterfaceId interfaceId)
 {
     SecurePairingUsingTestSecret pairing(Optional<NodeId>::Value(remoteDeviceId), 0, 0);
-    return ConnectDeviceUsingPairing(remoteDeviceId, deviceAddr, appReqState, onConnected, onMessageReceived, onError, devicePort,
-                                     interfaceId, &pairing);
+    mDeviceAddr = deviceAddr;
+    return ConnectDeviceUsingPairing(remoteDeviceId, appReqState, onConnected, onMessageReceived, onError, devicePort, interfaceId,
+                                     &pairing);
 }
 
 CHIP_ERROR ChipDeviceController::PopulatePeerAddress(Transport::PeerAddress & peerAddress)
@@ -424,6 +424,15 @@ void ChipDeviceController::OnRendezvousMessageReceived(PacketBuffer * buffer)
     if (mOnComplete.Response)
     {
         mOnComplete.Response(this, mAppReqState, buffer);
+    }
+}
+
+void ChipDeviceController::OnRendezvousStatusUpdate(RendezvousSessionDelegate::Status status)
+{
+    if (status == RendezvousSessionDelegate::NetworkProvisioningSuccess && mRendezvousSession->HasIPAddress())
+    {
+        ChipLogProgress(Controller, "Device was assigned an ip address\n");
+        mDeviceAddr = mRendezvousSession->GetIPAddress();
     }
 }
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -429,9 +429,9 @@ void ChipDeviceController::OnRendezvousMessageReceived(PacketBuffer * buffer)
 
 void ChipDeviceController::OnRendezvousStatusUpdate(RendezvousSessionDelegate::Status status)
 {
-    if (status == RendezvousSessionDelegate::NetworkProvisioningSuccess && mRendezvousSession->HasIPAddress())
+    if (status == RendezvousSessionDelegate::NetworkProvisioningSuccess)
     {
-        ChipLogProgress(Controller, "Device was assigned an ip address\n");
+        ChipLogProgress(Controller, "Remote device was assigned an ip address\n");
         mDeviceAddr = mRendezvousSession->GetIPAddress();
     }
 }

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -196,6 +196,7 @@ public:
     void OnRendezvousConnectionClosed() override;
     void OnRendezvousError(CHIP_ERROR err) override;
     void OnRendezvousMessageReceived(PacketBuffer * buffer) override;
+    void OnRendezvousStatusUpdate(RendezvousSessionDelegate::Status status) override;
 
 private:
     enum
@@ -241,10 +242,9 @@ private:
     void ClearRequestState();
     void ClearOpState();
 
-    CHIP_ERROR ConnectDeviceUsingPairing(NodeId remoteDeviceId, IPAddress deviceAddr, void * appReqState,
-                                         NewConnectionHandler onConnected, MessageReceiveHandler onMessageReceived,
-                                         ErrorHandler onError, uint16_t devicePort, Inet::InterfaceId interfaceId,
-                                         SecurePairingSession * pairing);
+    CHIP_ERROR ConnectDeviceUsingPairing(NodeId remoteDeviceId, void * appReqState, NewConnectionHandler onConnected,
+                                         MessageReceiveHandler onMessageReceived, ErrorHandler onError, uint16_t devicePort,
+                                         Inet::InterfaceId interfaceId, SecurePairingSession * pairing);
 };
 
 } // namespace DeviceController

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -305,6 +305,7 @@ struct ChipDeviceEvent final
         {
             ConnectivityChange IPv4;
             ConnectivityChange IPv6;
+            char address[INET6_ADDRSTRLEN];
         } InternetConnectivityChange;
         struct
         {

--- a/src/lib/protocols/CHIPProtocols.h
+++ b/src/lib/protocols/CHIPProtocols.h
@@ -50,6 +50,7 @@ enum CHIPProtocolId
 
     kChipProtocol_Common              = (kChipVendor_Common << 16) | 0x0000, // Common Protocol
     kChipProtocol_Echo                = (kChipVendor_Common << 16) | 0x0001, // Echo Protocol
+    kChipProtocol_SecurePairing       = (kChipVendor_Common << 16) | 0x0002, // SPAKE2+ handshake Protocol
     kChipProtocol_NetworkProvisioning = (kChipVendor_Common << 16) | 0x0003, // Network Provisioning Protocol
     kChipProtocol_Security            = (kChipVendor_Common << 16) | 0x0004, // Network Security Protocol
     kChipProtocol_FabricProvisioning  = (kChipVendor_Common << 16) | 0x0005, // Fabric Provisioning Protocol

--- a/src/platform/ESP32/ConnectivityManagerImpl.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl.cpp
@@ -929,6 +929,7 @@ void ConnectivityManagerImpl::UpdateInternetConnectivityState(void)
                     if (esp_netif_get_ip_info(esp_netif_get_handle_from_ifkey("WIFI_STA_DEF"), &ipInfo) == ESP_OK)
                     {
                         char addrStr[INET_ADDRSTRLEN];
+                        // ToDo: change the code to using IPv6 address
                         esp_ip4addr_ntoa(&ipInfo.ip, addrStr, sizeof(addrStr));
                         IPAddress::FromString(addrStr, addr);
                     }

--- a/src/platform/ESP32/ConnectivityManagerImpl.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl.cpp
@@ -903,6 +903,7 @@ void ConnectivityManagerImpl::UpdateInternetConnectivityState(void)
     bool haveIPv6Conn = false;
     bool hadIPv4Conn  = GetFlag(mFlags, kFlag_HaveIPv4InternetConnectivity);
     bool hadIPv6Conn  = GetFlag(mFlags, kFlag_HaveIPv6InternetConnectivity);
+    IPAddress addr;
 
     // If the WiFi station is currently in the connected state...
     if (mWiFiStationState == kWiFiStationState_Connected)
@@ -923,6 +924,14 @@ void ConnectivityManagerImpl::UpdateInternetConnectivityState(void)
                 if (!ip4_addr_isany_val(*netif_ip4_addr(netif)) && !ip4_addr_isany_val(*netif_ip4_gw(netif)))
                 {
                     haveIPv4Conn = true;
+
+                    esp_netif_ip_info_t ipInfo;
+                    if (esp_netif_get_ip_info(esp_netif_get_handle_from_ifkey("WIFI_STA_DEF"), &ipInfo) == ESP_OK)
+                    {
+                        char addrStr[INET_ADDRSTRLEN];
+                        esp_ip4addr_ntoa(&ipInfo.ip, addrStr, sizeof(addrStr));
+                        IPAddress::FromString(addrStr, addr);
+                    }
                 }
 
                 // Search among the IPv6 addresses assigned to the interface for a Global Unicast
@@ -957,6 +966,7 @@ void ConnectivityManagerImpl::UpdateInternetConnectivityState(void)
         event.Type                            = DeviceEventType::kInternetConnectivityChange;
         event.InternetConnectivityChange.IPv4 = GetConnectivityChange(hadIPv4Conn, haveIPv4Conn);
         event.InternetConnectivityChange.IPv6 = GetConnectivityChange(hadIPv6Conn, haveIPv6Conn);
+        addr.ToString(event.InternetConnectivityChange.address, sizeof(event.InternetConnectivityChange.address));
         PlatformMgr().PostEvent(&event);
 
         if (haveIPv4Conn != hadIPv4Conn)

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -339,7 +339,7 @@ CHIP_ERROR RendezvousSession::HandleSecureMessage(PacketBuffer * msgBuf)
 
         mDelegate->OnRendezvousStatusUpdate(RendezvousSessionDelegate::NetworkProvisioningSuccess);
     }
-    // else .. TBD once application dependency on this message has been removed, enable the else condition 
+    // else .. TBD once application dependency on this message has been removed, enable the else condition
     {
         mDelegate->OnRendezvousMessageReceived(msgBuf);
     }

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -142,7 +142,7 @@ CHIP_ERROR RendezvousSession::SendSecureMessage(Protocols::CHIPProtocolId protoc
         .SetEncryptionKeyID(mPairingSession.GetLocalKeyId()) //
         .SetPayloadLength(static_cast<uint16_t>(headerSize + msgBuf->TotalLength()));
 
-    payloadHeader.SetProtocolID(protocol).SetMessageType(msgType);
+    payloadHeader.SetProtocolID(static_cast<uint16_t>(protocol)).SetMessageType(msgType);
 
     VerifyOrExit(msgBuf->EnsureReservedSize(headerSize), err = CHIP_ERROR_NO_MEMORY);
 
@@ -350,11 +350,15 @@ void RendezvousSession::SendIPAddress(const IPAddress & addr)
     CHIP_ERROR err                = CHIP_NO_ERROR;
     System::PacketBuffer * buffer = System::PacketBuffer::New();
     char * addrStr                = addr.ToString(Uint8::to_char(buffer->Start()), buffer->AvailableDataLength());
+    size_t addrLen                = 0;
 
     VerifyOrExit(addrStr != nullptr, err = CHIP_ERROR_INVALID_ADDRESS);
     VerifyOrExit(mPairingInProgress == false, err = CHIP_ERROR_INCORRECT_STATE);
 
-    buffer->SetDataLength(strlen(addrStr) + 1);
+    addrLen = strlen(addrStr) + 1;
+
+    VerifyOrExit(CanCastTo<uint16_t>(addrLen), err = CHIP_ERROR_INVALID_ARGUMENT);
+    buffer->SetDataLength(static_cast<uint16_t>(addrLen));
 
     err = SendSecureMessage(Protocols::kChipProtocol_NetworkProvisioning, NetworkProvisioningMsgTypes::kIPAddressAssigned, buffer);
     SuccessOrExit(err);

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -41,7 +41,7 @@ enum NetworkProvisioningMsgTypes : uint8_t
     kIPAddressAssigned      = 1,
 };
 
-CHIP_ERROR RendezvousSession::Init()
+CHIP_ERROR RendezvousSession::Init(const RendezvousParameters & params)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -345,7 +345,7 @@ CHIP_ERROR RendezvousSession::Pair(Optional<NodeId> nodeId, uint32_t setupPINCod
                                 strlen(kSpake2pKeyExchangeSalt), nodeId, mNextKeyId++, this);
 }
 
-void RendezvousSession::SendIPAddress(IPAddress & addr)
+void RendezvousSession::SendIPAddress(const IPAddress & addr)
 {
     CHIP_ERROR err                = CHIP_NO_ERROR;
     System::PacketBuffer * buffer = System::PacketBuffer::New();

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+#include <core/CHIPSafeCasts.h>
 #include <support/CodeUtils.h>
 #include <support/ErrorStr.h>
 #include <support/SafeInt.h>
@@ -30,7 +31,13 @@ static const char * kSpake2pKeyExchangeSalt        = "SPAKE2P Key Exchange Salt"
 
 namespace chip {
 
-CHIP_ERROR RendezvousSession::Init(const RendezvousParameters & params)
+enum NetworkProvisioningMsgTypes : uint8_t
+{
+    kWiFiAssociationRequest = 0,
+    kIPAddressAssigned      = 1,
+};
+
+CHIP_ERROR RendezvousSession::Init()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -73,7 +80,9 @@ RendezvousSession::~RendezvousSession()
 
 CHIP_ERROR RendezvousSession::SendMessage(System::PacketBuffer * msgBuf)
 {
-    CHIP_ERROR err = mPairingInProgress ? SendPairingMessage(msgBuf) : SendSecureMessage(msgBuf);
+    CHIP_ERROR err = mPairingInProgress ? SendPairingMessage(msgBuf)
+                                        : SendSecureMessage(Protocols::kChipProtocol_NetworkProvisioning,
+                                                            NetworkProvisioningMsgTypes::kWiFiAssociationRequest, msgBuf);
     SuccessOrExit(err);
 
 exit:
@@ -81,6 +90,27 @@ exit:
     {
         mPairingInProgress ? OnPairingError(err) : OnRendezvousError(err);
     }
+    return err;
+}
+
+CHIP_ERROR RendezvousSession::AssignedIPAddress(IPAddress & deviceAddr)
+{
+    CHIP_ERROR err                = CHIP_NO_ERROR;
+    System::PacketBuffer * buffer = System::PacketBuffer::New();
+
+    char * addrStr = deviceAddr.ToString(Uint8::to_char(buffer->Start()), buffer->AvailableDataLength());
+    VerifyOrExit(addrStr != nullptr, err = CHIP_ERROR_INVALID_ADDRESS);
+
+    buffer->SetDataLength(strlen(addrStr) + 1);
+
+    err = SendSecureMessage(Protocols::kChipProtocol_NetworkProvisioning, NetworkProvisioningMsgTypes::kIPAddressAssigned, buffer);
+    SuccessOrExit(err);
+
+    mDeviceAddress = deviceAddr;
+    return err;
+
+exit:
+    OnRendezvousError(err);
     return err;
 }
 
@@ -104,7 +134,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR RendezvousSession::SendSecureMessage(System::PacketBuffer * msgBuf)
+CHIP_ERROR RendezvousSession::SendSecureMessage(Protocols::CHIPProtocolId protocol, uint8_t msgType, System::PacketBuffer * msgBuf)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     PacketHeader packetHeader;
@@ -126,6 +156,8 @@ CHIP_ERROR RendezvousSession::SendSecureMessage(System::PacketBuffer * msgBuf)
         .SetMessageId(mSecureMessageIndex)                   //
         .SetEncryptionKeyID(mPairingSession.GetLocalKeyId()) //
         .SetPayloadLength(static_cast<uint16_t>(headerSize + msgBuf->TotalLength()));
+
+    payloadHeader.SetProtocolID(protocol).SetMessageType(msgType);
 
     VerifyOrExit(msgBuf->EnsureReservedSize(headerSize), err = CHIP_ERROR_NO_MEMORY);
 
@@ -159,6 +191,7 @@ void RendezvousSession::OnPairingError(CHIP_ERROR err)
 {
     mPairingInProgress = false;
     mDelegate->OnRendezvousError(err);
+    mDelegate->OnRendezvousStatusUpdate(RendezvousSessionDelegate::SecurePairingFailed);
 }
 
 void RendezvousSession::OnPairingComplete()
@@ -169,6 +202,7 @@ void RendezvousSession::OnPairingComplete()
                                                          strlen(kSpake2pI2RSessionInfo), mSecureSession);
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Ble, "Failed to initialize a secure session: %s", ErrorStr(err)));
 
+    mDelegate->OnRendezvousStatusUpdate(RendezvousSessionDelegate::SecurePairingSuccess);
     mDelegate->OnRendezvousConnectionOpened();
 
 exit:
@@ -239,6 +273,17 @@ exit:
     return err;
 }
 
+CHIP_ERROR RendezvousSession::HandleIPAddressAssignment(System::PacketBuffer * buffer)
+{
+    if (IPAddress::FromString(Uint8::to_const_char(buffer->Start()), buffer->DataLength(), mDeviceAddress))
+    {
+        return CHIP_NO_ERROR;
+    }
+
+    mDelegate->OnRendezvousStatusUpdate(RendezvousSessionDelegate::NetworkProvisioningFailed);
+    return CHIP_ERROR_INVALID_ADDRESS;
+}
+
 CHIP_ERROR RendezvousSession::HandleSecureMessage(PacketBuffer * msgBuf)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -286,7 +331,19 @@ CHIP_ERROR RendezvousSession::HandleSecureMessage(PacketBuffer * msgBuf)
 
     msgBuf->ConsumeHead(headerSize);
 
-    mDelegate->OnRendezvousMessageReceived(msgBuf);
+    if (payloadHeader.GetProtocolID() == Protocols::kChipProtocol_NetworkProvisioning &&
+        payloadHeader.GetMessageType() == NetworkProvisioningMsgTypes::kIPAddressAssigned)
+    {
+        err = HandleIPAddressAssignment(msgBuf);
+        SuccessOrExit(err);
+
+        mDelegate->OnRendezvousStatusUpdate(RendezvousSessionDelegate::NetworkProvisioningSuccess);
+    }
+    // else .. TBD once application dependency on this message has been removed, enable the else condition 
+    {
+        mDelegate->OnRendezvousMessageReceived(msgBuf);
+    }
+
     msgBuf = nullptr;
 
 exit:

--- a/src/transport/RendezvousSession.h
+++ b/src/transport/RendezvousSession.h
@@ -25,6 +25,7 @@
 #define __TRANSPORT_RENDEZVOUSSESSION_H__
 
 #include <core/CHIPCore.h>
+#include <protocols/CHIPProtocols.h>
 #include <transport/RendezvousParameters.h>
 #include <transport/RendezvousSessionDelegate.h>
 #include <transport/SecurePairingSession.h>
@@ -86,14 +87,20 @@ public:
     void OnRendezvousError(CHIP_ERROR err) override;
     void OnRendezvousMessageReceived(PacketBuffer * buffer) override;
 
+    CHIP_ERROR AssignedIPAddress(IPAddress & deviceAddr);
+
+    bool HasIPAddress() const { return mDeviceAddress != IPAddress::Any; }
+    const IPAddress & GetIPAddress() const { return mDeviceAddress; }
+
 private:
     CHIP_ERROR SendPairingMessage(System::PacketBuffer * msgBug);
     CHIP_ERROR HandlePairingMessage(System::PacketBuffer * msgBug);
     CHIP_ERROR Pair(Optional<NodeId> nodeId, uint32_t setupPINCode);
     CHIP_ERROR WaitForPairing(Optional<NodeId> nodeId, uint32_t setupPINCode);
 
-    CHIP_ERROR SendSecureMessage(System::PacketBuffer * msgBug);
+    CHIP_ERROR SendSecureMessage(Protocols::CHIPProtocolId protocol, uint8_t msgType, System::PacketBuffer * msgBug);
     CHIP_ERROR HandleSecureMessage(System::PacketBuffer * msgBuf);
+    CHIP_ERROR HandleIPAddressAssignment(System::PacketBuffer * buffer);
 
     Transport::Base * mTransport          = nullptr; ///< Underlying transport
     RendezvousSessionDelegate * mDelegate = nullptr; ///< Underlying transport events
@@ -104,6 +111,7 @@ private:
     bool mPairingInProgress      = false;
     uint32_t mSecureMessageIndex = 0;
     uint16_t mNextKeyId          = 0;
+    IPAddress mDeviceAddress     = IPAddress::Any;
 };
 
 } // namespace chip

--- a/src/transport/RendezvousSession.h
+++ b/src/transport/RendezvousSession.h
@@ -32,6 +32,10 @@
 
 namespace chip {
 
+namespace DeviceLayer {
+class CHIPDeviceEvent;
+}
+
 /**
  * RendezvousSession establishes and maintains the first connection between
  * a commissioner and a device. This connection is used in order to
@@ -87,10 +91,8 @@ public:
     void OnRendezvousError(CHIP_ERROR err) override;
     void OnRendezvousMessageReceived(PacketBuffer * buffer) override;
 
-    CHIP_ERROR AssignedIPAddress(IPAddress & deviceAddr);
-
-    bool HasIPAddress() const { return mDeviceAddress != IPAddress::Any; }
     const IPAddress & GetIPAddress() const { return mDeviceAddress; }
+    void SendIPAddress(IPAddress & addr);
 
 private:
     CHIP_ERROR SendPairingMessage(System::PacketBuffer * msgBug);
@@ -100,7 +102,6 @@ private:
 
     CHIP_ERROR SendSecureMessage(Protocols::CHIPProtocolId protocol, uint8_t msgType, System::PacketBuffer * msgBug);
     CHIP_ERROR HandleSecureMessage(System::PacketBuffer * msgBuf);
-    CHIP_ERROR HandleIPAddressAssignment(System::PacketBuffer * buffer);
 
     Transport::Base * mTransport          = nullptr; ///< Underlying transport
     RendezvousSessionDelegate * mDelegate = nullptr; ///< Underlying transport events
@@ -112,6 +113,10 @@ private:
     uint32_t mSecureMessageIndex = 0;
     uint16_t mNextKeyId          = 0;
     IPAddress mDeviceAddress     = IPAddress::Any;
+
+#if CONFIG_DEVICE_LAYER
+    static void ConnectivityHandler(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
+#endif // CONFIG_DEVICE_LAYER
 };
 
 } // namespace chip

--- a/src/transport/RendezvousSession.h
+++ b/src/transport/RendezvousSession.h
@@ -92,7 +92,16 @@ public:
     void OnRendezvousMessageReceived(PacketBuffer * buffer) override;
 
     const IPAddress & GetIPAddress() const { return mDeviceAddress; }
-    void SendIPAddress(IPAddress & addr);
+
+    /**
+     * @brief
+     *  The device can use this function to send its IP address to
+     *  commissioner. This would generally be called during network
+     *  provisioning of the device, after the IP address assignment.
+     *
+     * @param addr The IP address of the device
+     */
+    void SendIPAddress(const IPAddress & addr);
 
 private:
     CHIP_ERROR SendPairingMessage(System::PacketBuffer * msgBug);

--- a/src/transport/RendezvousSessionDelegate.h
+++ b/src/transport/RendezvousSessionDelegate.h
@@ -27,10 +27,19 @@ class RendezvousSessionDelegate
 public:
     virtual ~RendezvousSessionDelegate() {}
 
+    enum Status : uint8_t
+    {
+        SecurePairingSuccess = 0,
+        SecurePairingFailed,
+        NetworkProvisioningSuccess,
+        NetworkProvisioningFailed,
+    };
+
     virtual void OnRendezvousConnectionOpened()                             = 0;
     virtual void OnRendezvousConnectionClosed()                             = 0;
     virtual void OnRendezvousError(CHIP_ERROR err)                          = 0;
     virtual void OnRendezvousMessageReceived(System::PacketBuffer * buffer) = 0;
+    virtual void OnRendezvousStatusUpdate(Status status) {}
 };
 
 } // namespace chip

--- a/src/transport/SecurePairingSession.cpp
+++ b/src/transport/SecurePairingSession.cpp
@@ -29,6 +29,7 @@
  */
 
 #include <core/CHIPSafeCasts.h>
+#include <protocols/CHIPProtocols.h>
 #include <support/BufBound.h>
 #include <support/CodeUtils.h>
 #include <transport/SecurePairingSession.h>
@@ -114,7 +115,7 @@ CHIP_ERROR SecurePairingSession::AttachHeaderAndSend(uint8_t msgType, System::Pa
 
     payloadHeader
         .SetMessageType(msgType) //
-        .SetProtocolID(kSecurePairingProtocol);
+        .SetProtocolID(Protocols::kChipProtocol_SecurePairing);
 
     uint16_t headerSize              = payloadHeader.EncodeSizeBytes();
     uint16_t actualEncodedHeaderSize = 0;
@@ -387,7 +388,7 @@ CHIP_ERROR SecurePairingSession::HandlePeerMessage(const PacketHeader & packetHe
 
     msg->ConsumeHead(headerSize);
 
-    VerifyOrExit(payloadHeader.GetProtocolID() == kSecurePairingProtocol, err = CHIP_ERROR_INVALID_MESSAGE_TYPE);
+    VerifyOrExit(payloadHeader.GetProtocolID() == Protocols::kChipProtocol_SecurePairing, err = CHIP_ERROR_INVALID_MESSAGE_TYPE);
     VerifyOrExit(payloadHeader.GetMessageType() == (uint8_t) mNextExpectedMsg, err = CHIP_ERROR_INVALID_MESSAGE_TYPE);
 
     switch ((Spake2pMsgType) payloadHeader.GetMessageType())

--- a/src/transport/SecurePairingSession.h
+++ b/src/transport/SecurePairingSession.h
@@ -170,8 +170,7 @@ private:
 
     CHIP_ERROR AttachHeaderAndSend(uint8_t msgType, System::PacketBuffer * msgBuf);
 
-    static constexpr uint16_t kSecurePairingProtocol = 1;
-    static constexpr size_t kSpake2p_WS_Length       = kP256_FE_Length + 8;
+    static constexpr size_t kSpake2p_WS_Length = kP256_FE_Length + 8;
 
     enum Spake2pMsgType : uint8_t
     {


### PR DESCRIPTION
 #### Problem
The device sends its IP address back to controller as part of Rendezvous state machine. Currently, controller propagates this message to the application (e.g. CHIP Tool iOS app). The app decodes the IP address and calls controller API to associate the address with the device. This round tripping of IP address via app is not necessary, and requires extra logic in app.

 #### Summary of Changes
Process the IP address association message locally in RendezvousSession state machine.

fixes #2817 
