### PR TITLE
Build failure with clang: ar: no archive members specified

### DIFF
--- a/src/retransmit/BUILD.gn
+++ b/src/retransmit/BUILD.gn
@@ -14,9 +14,7 @@
 
 import("//build_overrides/chip.gni")
 
-static_library("retransmit") {
-  output_name = "libRetransmit"
-
+source_set("retransmit") {
   cflags = [ "-Wconversion" ]
 
   sources = [ "Cache.h" ]


### PR DESCRIPTION
 #### Problem
#2832 introduce the retransmit folder, but it uses `static_library` while there is no real library produced (since there is no source file). With GCC this is fine since ar does not complain on missing file but clang does not like that and fails.

 #### Summary of Changes
* Use `source_set` instead of `static_library`

fixes #2937 
