### PR TITLE
[linux] Implement BLE discovery

### DIFF
--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -47,6 +47,7 @@ if (chip_build_tests) {
 
     if (chip_device_platform != "esp32") {
       deps += [
+        "${chip_root}/src/ble/tests",
         "${chip_root}/src/lib/core/tests",
         "${chip_root}/src/lib/support/tests",
         "${chip_root}/src/platform/tests",

--- a/src/ble/BUILD.gn
+++ b/src/ble/BUILD.gn
@@ -15,6 +15,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/gn/chip/buildconfig_header.gni")
+import("${chip_root}/gn/chip/tests.gni")
 import("${chip_root}/src/platform/device.gni")
 import("ble.gni")
 

--- a/src/ble/BleUUID.cpp
+++ b/src/ble/BleUUID.cpp
@@ -19,8 +19,9 @@
 
 #if CONFIG_NETWORK_LAYER_BLE
 
-#include <stdint.h>
-#include <string.h>
+#include <cctype>
+#include <cstdint>
+#include <cstring>
 
 #include "BleUUID.h"
 
@@ -31,6 +32,11 @@ const ChipBleUUID CHIP_BLE_SVC_ID = { { // 0000FEAF-0000-1000-8000-00805F9B34FB
                                         0x00, 0x00, 0xFE, 0xAF, 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0x80, 0x5F, 0x9B, 0x34,
                                         0xFB } };
 
+inline static uint8_t HexDigitToInt(const char c)
+{
+    return static_cast<uint8_t>(c >= '0' && c <= '9' ? c - '0' : tolower(c) - 'a' + 10);
+}
+
 bool UUIDsMatch(const ChipBleUUID * idOne, const ChipBleUUID * idTwo)
 {
     if ((idOne == nullptr) || (idTwo == nullptr))
@@ -38,6 +44,35 @@ bool UUIDsMatch(const ChipBleUUID * idOne, const ChipBleUUID * idTwo)
         return false;
     }
     return (memcmp(idOne->bytes, idTwo->bytes, 16) == 0);
+}
+
+// Convert a string like "0000FEAF-0000-1000-8000-00805F9B34FB" to binary UUID
+bool StringToUUID(const char * str, ChipBleUUID & uuid)
+{
+    constexpr size_t NUM_UUID_NIBBLES = sizeof(uuid.bytes) * 2;
+    size_t nibbleId                   = 0;
+
+    for (; *str; ++str)
+    {
+        if (*str == '-') // skip separators
+            continue;
+
+        if (!isxdigit(*str)) // invalid character!
+            return false;
+
+        if (nibbleId >= NUM_UUID_NIBBLES) // too long string!
+            return false;
+
+        if (nibbleId % 2 == 0)
+            uuid.bytes[nibbleId / 2] = static_cast<uint8_t>(HexDigitToInt(*str) << 4);
+        else
+            uuid.bytes[nibbleId / 2] |= HexDigitToInt(*str);
+
+        ++nibbleId;
+    }
+
+    // All bytes were initialized?
+    return nibbleId == NUM_UUID_NIBBLES;
 }
 
 } /* namespace Ble */

--- a/src/ble/BleUUID.h
+++ b/src/ble/BleUUID.h
@@ -27,15 +27,16 @@ namespace Ble {
 // the Bluetooth Base UUID to form full 128-bit UUIDs as described in the
 // Service Discovery Protocol (SDP) definition, part of the Bluetooth Core
 // Specification.
-typedef struct
+struct ChipBleUUID
 {
     uint8_t bytes[16];
-} ChipBleUUID;
+};
 
 // UUID of CHIP BLE service. Exposed for use in scan filter.
 extern const ChipBleUUID CHIP_BLE_SVC_ID;
 
 bool UUIDsMatch(const ChipBleUUID * idOne, const ChipBleUUID * idTwo);
+bool StringToUUID(const char * str, ChipBleUUID & uuid);
 
 } /* namespace Ble */
 } /* namespace chip */

--- a/src/ble/tests/BUILD.gn
+++ b/src/ble/tests/BUILD.gn
@@ -31,5 +31,8 @@ chip_test_suite("tests") {
     "${nlunit_test_root}:nlunit-test",
   ]
 
-  tests = [ "TestBleErrorStr", "TestBleUUID" ]
+  tests = [
+    "TestBleErrorStr",
+    "TestBleUUID",
+  ]
 }

--- a/src/ble/tests/BUILD.gn
+++ b/src/ble/tests/BUILD.gn
@@ -23,6 +23,7 @@ chip_test_suite("tests") {
   sources = [
     "TestBleErrorStr.cpp",
     "TestBleLayer.h",
+    "TestBleUUID.cpp",
   ]
 
   public_deps = [
@@ -30,5 +31,5 @@ chip_test_suite("tests") {
     "${nlunit_test_root}:nlunit-test",
   ]
 
-  tests = [ "TestBleErrorStr" ]
+  tests = [ "TestBleErrorStr", "TestBleUUID" ]
 }

--- a/src/ble/tests/TestBleLayer.h
+++ b/src/ble/tests/TestBleLayer.h
@@ -25,14 +25,7 @@
 #ifndef TESTBLELAYER_H
 #define TESTBLELAYER_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-int TestBleErrorStr(void);
-
-#ifdef __cplusplus
-}
-#endif
+int TestBleErrorStr();
+int TestBleUUID();
 
 #endif // TESTBLELAYER_H

--- a/src/ble/tests/TestBleUUID.cpp
+++ b/src/ble/tests/TestBleUUID.cpp
@@ -1,0 +1,106 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2016-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a process to effect a functional test for
+ *      the CHIP BLE layer library error string support interfaces.
+ *
+ */
+
+#include "TestBleLayer.h"
+
+#include <ble/BleUUID.h>
+#include <support/TestUtils.h>
+
+#include <nlunit-test.h>
+
+using namespace chip;
+using namespace chip::Ble;
+
+namespace {
+
+void CheckStringToUUID_ChipUUID(nlTestSuite * inSuite, void * inContext)
+{
+    // Test positive scenario - CHIP Service UUID
+    ChipBleUUID uuid;
+    NL_TEST_ASSERT(inSuite, StringToUUID("0000FEAF-0000-1000-8000-00805F9B34FB", uuid));
+    NL_TEST_ASSERT(inSuite, UUIDsMatch(&uuid, &CHIP_BLE_SVC_ID));
+}
+
+void CheckStringToUUID_ChipUUID_RandomCase(nlTestSuite * inSuite, void * inContext)
+{
+    // Test that letter case doesn't matter
+    ChipBleUUID uuid;
+    NL_TEST_ASSERT(inSuite, StringToUUID("0000FeAf-0000-1000-8000-00805f9B34Fb", uuid));
+    NL_TEST_ASSERT(inSuite, UUIDsMatch(&uuid, &CHIP_BLE_SVC_ID));
+}
+
+void CheckStringToUUID_ChipUUID_NoSeparators(nlTestSuite * inSuite, void * inContext)
+{
+    // Test that separators don't matter
+    ChipBleUUID uuid;
+    NL_TEST_ASSERT(inSuite, StringToUUID("0000FEAF00001000800000805F9B34FB", uuid));
+    NL_TEST_ASSERT(inSuite, UUIDsMatch(&uuid, &CHIP_BLE_SVC_ID));
+}
+
+void CheckStringToUUID_TooLong(nlTestSuite * inSuite, void * inContext)
+{
+    // Test that even one more digit is too much
+    ChipBleUUID uuid;
+    NL_TEST_ASSERT(inSuite, !StringToUUID("0000FEAF00001000800000805F9B34FB0", uuid));
+}
+
+void CheckStringToUUID_TooShort(nlTestSuite * inSuite, void * inContext)
+{
+    // Test that even one less digit is too little
+    ChipBleUUID uuid;
+    NL_TEST_ASSERT(inSuite, !StringToUUID("0000FEAF00001000800000805F9B34F", uuid));
+}
+
+void CheckStringToUUID_InvalidChar(nlTestSuite * inSuite, void * inContext)
+{
+    // Test that non-hex digits don't pass
+    ChipBleUUID uuid;
+    NL_TEST_ASSERT(inSuite, !StringToUUID("0000GEAF-0000-1000-8000-00805F9B34FB0", uuid));
+}
+
+// clang-format off
+const nlTest sTests[] =
+{
+    NL_TEST_DEF("CheckStringToUUID_ChipUUID", CheckStringToUUID_ChipUUID),
+    NL_TEST_DEF("CheckStringToUUID_ChipUUID_RandomCase", CheckStringToUUID_ChipUUID_RandomCase),
+    NL_TEST_DEF("CheckStringToUUID_ChipUUID_NoSeparators", CheckStringToUUID_ChipUUID_NoSeparators),
+    NL_TEST_DEF("CheckStringToUUID_TooLong", CheckStringToUUID_TooLong),
+    NL_TEST_DEF("CheckStringToUUID_TooShort", CheckStringToUUID_TooShort),
+    NL_TEST_DEF("CheckStringToUUID_InvalidChar", CheckStringToUUID_InvalidChar),
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+} // namespace
+
+int TestBleUUID()
+{
+    nlTestSuite theSuite = { "BleUUID", &sTests[0], NULL, NULL };
+    nlTestRunner(&theSuite, nullptr);
+    return nlTestRunnerStats(&theSuite);
+}
+
+CHIP_REGISTER_TEST_SUITE(TestBleUUID)

--- a/src/ble/tests/TestBleUUIDDriver.cpp
+++ b/src/ble/tests/TestBleUUIDDriver.cpp
@@ -1,0 +1,35 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a standalone/native program executable
+ *      test driver for the CHIP Bluetooth Low Energy (BLE) library
+ *      error string library unit tests.
+ *
+ */
+
+#include "TestBleLayer.h"
+
+#include <nlunit-test.h>
+
+int main()
+{
+    // Generate machine-readable, comma-separated value (CSV) output.
+    nlTestSetOutputStyle(OUTPUT_CSV);
+    return TestBleUUID();
+}

--- a/src/lib/support/TestUtils.cpp
+++ b/src/lib/support/TestUtils.cpp
@@ -21,7 +21,7 @@
 
 namespace chip {
 
-const size_t kTestSuitesMax = 32;
+const size_t kTestSuitesMax = 64;
 
 typedef struct
 {

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -84,7 +84,7 @@ struct BLEScanConfig
 class BLEManagerImpl final : public BLEManager,
                              private Ble::BleLayer,
                              private Ble::BlePlatformDelegate,
-                             private Ble::BleApplicationDelegate
+                             private Ble::BleApplicationDelegate,
                              private Ble::BleConnectionDelegate
 {
     // Allow the BLEManager interface class to delegate method calls to

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -24,6 +24,7 @@
 #ifndef BLE_MANAGER_IMPL_H
 #define BLE_MANAGER_IMPL_H
 
+#include <ble/BleLayer.h>
 #include <platform/internal/BLEManager.h>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
@@ -68,6 +69,15 @@ struct BLEAdvConfig
     const char * mpAdvertisingUUID;
 };
 
+struct BLEScanConfig
+{
+    // Discriminator of seeked device (encoded in its BLE advertising payload)
+    uint16_t mDiscriminator = 0;
+
+    // Optional argument to be passed to callback functions provided by the BLE scan/connect requestor
+    void * mAppState = nullptr;
+};
+
 /**
  * Concrete implementation of the BLEManagerImpl singleton object for the Linux platforms.
  */
@@ -75,6 +85,7 @@ class BLEManagerImpl final : public BLEManager,
                              private Ble::BleLayer,
                              private Ble::BlePlatformDelegate,
                              private Ble::BleApplicationDelegate
+                             private Ble::BleConnectionDelegate
 {
     // Allow the BLEManager interface class to delegate method calls to
     // the implementation methods provided by this class.
@@ -136,6 +147,10 @@ private:
 
     void NotifyChipConnectionClosed(BLE_CONNECTION_OBJECT conId) override;
 
+    // ===== Members that implement virtual methods on BleConnectionDelegate.
+
+    void NewConnection(BleLayer * bleLayer, void * appState, const uint16_t connDiscriminator) override;
+
     // ===== Members for internal use by the following friends.
 
     friend BLEManager & BLEMgr();
@@ -155,7 +170,8 @@ private:
         kFlag_AdvertisingEnabled       = 0x0040, /**< The application has enabled CHIPoBLE advertising. */
         kFlag_FastAdvertisingEnabled   = 0x0080, /**< The application has enabled fast advertising. */
         kFlag_UseCustomDeviceName      = 0x0100, /**< The application has configured a custom BLE device name. */
-        kFlag_AdvertisingRefreshNeeded = 0x0200, /**< The advertising configuration/state in ESP BLE layer needs to be updated. */
+        kFlag_AdvertisingRefreshNeeded = 0x0200, /**< The advertising configuration/state in BLE layer needs to be updated. */
+        kFlag_Scanning                 = 0x0400, /**< The system is currently scanning for CHIPoBLE devices */
     };
 
     enum
@@ -173,9 +189,10 @@ private:
 
     CHIPoBLEServiceMode mServiceMode;
     BLEAdvConfig mBLEAdvConfig;
+    BLEScanConfig mBLEScanConfig;
     uint16_t mFlags;
     char mDeviceName[kMaxDeviceNameLength + 1];
-    bool mIsCentral;
+    bool mIsCentral = false;
     void * mpAppState;
 };
 

--- a/src/platform/Linux/CHIPBluezHelper.cpp
+++ b/src/platform/Linux/CHIPBluezHelper.cpp
@@ -858,7 +858,7 @@ static void BluezHandleAdvertisementFromDevice(BluezDevice1 * aDevice, BluezEndp
 
         VerifyOrExit(chip::Ble::StringToUUID(uuidStr, uuid), ChipLogProgress(DeviceLayer, "TRACE: Invalid BLE UUID format"));
 
-        if (!UUIDsMatch(&uuid, &CHIP_BLE_SVC_ID))
+        if (!UUIDsMatch(&uuid, &Ble::CHIP_BLE_SVC_ID))
             continue;
 
         rawData = g_variant_get_fixed_array(g_variant_get_variant(val), &dataLen, sizeof(uint8_t));

--- a/src/platform/Linux/CHIPBluezHelper.cpp
+++ b/src/platform/Linux/CHIPBluezHelper.cpp
@@ -873,8 +873,7 @@ static void BluezHandleAdvertisementFromDevice(BluezDevice1 * aDevice, BluezEndp
     }
 
 exit:
-    if (debugStr)
-        g_free(debugStr);
+    g_free(debugStr);
 }
 
 static void BluezSignalInterfacePropertiesChanged(GDBusObjectManagerClient * aManager, GDBusObjectProxy * aObject,

--- a/src/platform/Linux/CHIPBluezHelper.cpp
+++ b/src/platform/Linux/CHIPBluezHelper.cpp
@@ -48,6 +48,7 @@
  *          Provides Bluez dbus implementatioon for BLE
  */
 
+#include <ble/BleUUID.h>
 #include <ble/CHIPBleServiceData.h>
 #include <platform/internal/BLEManager.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
@@ -59,6 +60,7 @@
 #include <stdarg.h>
 #include <strings.h>
 #include <unistd.h>
+#include <utility>
 
 #include "CHIPBluezHelper.h"
 #include <support/CodeUtils.h>
@@ -617,20 +619,6 @@ static gboolean BluezCharacteristicConfirmError(BluezGattCharacteristic1 * aChar
     return TRUE;
 }
 
-// both arguments allocated, and non-null
-static void BluezStringAddressToCHIPAddress(const char * aAddressString, BluezAddress * apAddress)
-{
-    size_t i, j = 0;
-    for (i = 0; i < BLUEZ_ADDRESS_SIZE; i++)
-    {
-        apAddress->mAddress[i] =
-            static_cast<uint8_t>((CHAR_TO_BLUEZ(aAddressString[j]) << 4) + CHAR_TO_BLUEZ(aAddressString[j + 1]));
-        j += 2;
-        if (aAddressString[j] == ':')
-            j++;
-    }
-}
-
 static gboolean BluezIsDeviceOnAdapter(BluezDevice1 * aDevice, BluezAdapter1 * aAdapter)
 {
     return strcmp(bluez_device1_get_adapter(aDevice), g_dbus_proxy_get_object_path(G_DBUS_PROXY(aAdapter))) == 0 ? TRUE : FALSE;
@@ -648,31 +636,6 @@ static gboolean BluezIsCharOnService(BluezGattCharacteristic1 * aChar, BluezGatt
     ChipLogProgress(DeviceLayer, "Char1 %s", g_dbus_proxy_get_object_path(G_DBUS_PROXY(aService)));
     return strcmp(bluez_gatt_characteristic1_get_service(aChar), g_dbus_proxy_get_object_path(G_DBUS_PROXY(aService))) == 0 ? TRUE
                                                                                                                             : FALSE;
-}
-
-static uint16_t BluezUUIDStringToShortServiceID(const char * aService)
-{
-    uint32_t shortService = 0;
-    size_t i;
-    // check that the service is a short UUID
-
-    if (strncasecmp(CHIP_BLE_BASE_SERVICE_UUID_STRING, aService + CHIP_BLE_SERVICE_PREFIX_LENGTH,
-                    sizeof(CHIP_BLE_BASE_SERVICE_UUID_STRING)) == 0)
-    {
-        for (i = 0; i < 4; i++)
-        {
-            shortService = (shortService << 8) | static_cast<uint32_t>(CHAR_TO_BLUEZ(aService[2 * i]) << 4) |
-                CHAR_TO_BLUEZ(aService[2 * i + 1]);
-        }
-
-        ChipLogProgress(DeviceLayer, "TRACE: full service UUID: %s, short service %08x", aService, shortService);
-
-        if (shortService > UINT16_MAX)
-        {
-            shortService = 0;
-        }
-    }
-    return (uint16_t) shortService;
 }
 
 static void BluezConnectionInit(BluezConnection * apConn)
@@ -864,86 +827,54 @@ exit:
  * GATT Characteristic object
  ***********************************************************************/
 
-static void BluezHandleAdvertisementFromDevice(BluezDevice1 * aDevice)
+static void BluezHandleAdvertisementFromDevice(BluezDevice1 * aDevice, BluezEndpoint * endpoint)
 {
     const char * address   = bluez_device1_get_address(aDevice);
+    const char * flags     = bluez_device1_get_advertising_flags(aDevice);
     GVariant * serviceData = bluez_device1_get_service_data(aDevice);
-    GVariant * entry;
-    GVariantIter iter;
-    BluezAddress * src;
-    const uint8_t * tmpBuf;
-    uint8_t * buf;
-    size_t len, dataLen;
-    size_t i, j;
-    uint16_t serviceId;
-    char * debugStr;
+
+    GVariantIter serviceIterator;
+    GVariant * serviceEntry;
+    chip::Ble::ChipBleUUID uuid;
+    chip::Ble::ChipBLEDeviceIdentificationInfo deviceInfo;
+    char * debugStr = nullptr;
+    size_t dataLen;
 
     // service data is optional and may not be present
-    SuccessOrExit(serviceData != nullptr);
+    VerifyOrExit(serviceData != nullptr, );
 
-    src = g_new0(BluezAddress, 1);
-
-    BluezStringAddressToCHIPAddress(address, src);
-
+    ChipLogProgress(DeviceLayer, "TRACE: Device %s Advertising flags: %s", address, flags);
     debugStr = g_variant_print(serviceData, TRUE);
     ChipLogProgress(DeviceLayer, "TRACE: Device %s Service data: %s", address, debugStr);
-    g_free(debugStr);
-    // advertising flags
-    ChipLogProgress(DeviceLayer, "TRACE: Device %s Advertising flags: %s", address, bluez_device1_get_advertising_flags(aDevice));
 
-    g_variant_iter_init(&iter, serviceData);
+    g_variant_iter_init(&serviceIterator, serviceData);
 
-    len = 0;
-    while ((entry = g_variant_iter_next_value(&iter)) != nullptr)
+    while ((serviceEntry = g_variant_iter_next_value(&serviceIterator)) != nullptr)
     {
-        GVariant * key    = g_variant_get_child_value(entry, 0);
-        GVariant * val    = g_variant_get_child_value(entry, 1);
-        GVariant * rawVal = g_variant_get_variant(val);
+        GVariant * key     = g_variant_get_child_value(serviceEntry, 0);
+        GVariant * val     = g_variant_get_child_value(serviceEntry, 1);
+        const auto uuidStr = g_variant_get_string(key, &dataLen);
+        const void * rawData;
 
-        serviceId = BluezUUIDStringToShortServiceID(g_variant_get_string(key, &dataLen));
+        VerifyOrExit(chip::Ble::StringToUUID(uuidStr, uuid), ChipLogProgress(DeviceLayer, "TRACE: Invalid BLE UUID format"));
 
-        if (serviceId != 0)
-        {
-            len += 1 + sizeof(uint8_t) + sizeof(serviceId) + g_variant_n_children(rawVal);
-        }
-    }
+        if (!UUIDsMatch(&uuid, &CHIP_BLE_SVC_ID))
+            continue;
 
-    if (len != 0)
-    {
-        // we only parsed services, add 3 bytes for flags
-        len      = len + 3;
-        buf      = (uint8_t *) g_malloc(len);
-        i        = 0;
-        buf[i++] = 2; // length of flags
-        buf[i++] = BLUEZ_ADV_TYPE_FLAGS;
-        buf[i++] = BLUEZ_ADV_FLAGS_LE_DISCOVERABLE | BLUEZ_ADV_FLAGS_EDR_UNSUPPORTED;
-        g_variant_iter_init(&iter, serviceData);
-        while ((entry = g_variant_iter_next_value(&iter)) != nullptr)
-        {
-            GVariant * key    = g_variant_get_child_value(entry, 0);
-            GVariant * val    = g_variant_get_child_value(entry, 1);
-            GVariant * rawVal = g_variant_get_variant(val);
-            serviceId         = BluezUUIDStringToShortServiceID(g_variant_get_string(key, &dataLen));
+        rawData = g_variant_get_fixed_array(g_variant_get_variant(val), &dataLen, sizeof(uint8_t));
+        VerifyOrExit(dataLen == sizeof(deviceInfo), ChipLogProgress(DeviceLayer, "TRACE: Invalid BLE Device info"));
 
-            if (serviceId != 0)
-            {
-                // TODO: Sort out whether this cast is safe:
-                // https://github.com/project-chip/connectedhomeip/issues/2576
-                buf[i++] = static_cast<uint8_t>(g_variant_n_children(rawVal) + 2 + 1);
-                buf[i++] = BLUEZ_ADV_TYPE_SERVICE_DATA;
-                buf[i++] = static_cast<uint8_t>(serviceId & 0xff);
-                buf[i++] = static_cast<uint8_t>((serviceId >> 8) & 0xff);
-                tmpBuf   = (const uint8_t *) g_variant_get_fixed_array(rawVal, &dataLen, sizeof(uint8_t));
-                for (j = 0; j < dataLen; j++)
-                {
-                    buf[i++] = tmpBuf[j];
-                }
-            }
-        }
+        memcpy(&deviceInfo, rawData, dataLen);
+        ChipLogProgress(DeviceLayer, "TRACE: Found CHIP BLE Device: %" PRIu16, deviceInfo.GetDeviceDiscriminator());
+
+        // TODO: Connect device
+        // if (endpoint->mDiscoveryRequest.mDiscriminator == deviceInfo.GetDeviceDiscriminator() &&
+        // endpoint->mDiscoveryRequest.mAutoConnect) ...
     }
 
 exit:
-    return;
+    if (debugStr)
+        g_free(debugStr);
 }
 
 static void BluezSignalInterfacePropertiesChanged(GDBusObjectManagerClient * aManager, GDBusObjectProxy * aObject,
@@ -1034,7 +965,7 @@ static void BluezSignalInterfacePropertiesChanged(GDBusObjectManagerClient * aMa
                      */
                     if (endpoint->mIsCentral)
                     {
-                        BluezHandleAdvertisementFromDevice(device);
+                        BluezHandleAdvertisementFromDevice(device, endpoint);
                     }
                 }
 
@@ -1051,7 +982,7 @@ static void BluezHandleNewDevice(BluezDevice1 * device, BluezEndpoint * apEndpoi
     VerifyOrExit(apEndpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
     if (apEndpoint->mIsCentral)
     {
-        BluezHandleAdvertisementFromDevice(device);
+        BluezHandleAdvertisementFromDevice(device, apEndpoint);
     }
     else
     {
@@ -1683,8 +1614,11 @@ CHIP_ERROR InitBluezBleLayer(bool aIsCentral, char * apBleAddr, BLEAdvConfig & a
     endpoint->mpConnMap  = g_hash_table_new(g_str_hash, g_str_equal);
     endpoint->mIsCentral = aIsCentral;
 
-    err = ConfigureBluezAdv(aBleAdvConfig, endpoint);
-    SuccessOrExit(err);
+    if (!aIsCentral)
+    {
+        err = ConfigureBluezAdv(aBleAdvConfig, endpoint);
+        SuccessOrExit(err);
+    }
 
     sBluezMainLoop = g_main_loop_new(nullptr, FALSE);
     VerifyOrExit(sBluezMainLoop != nullptr, ChipLogProgress(DeviceLayer, "FAIL: memory alloc in %s", __func__));
@@ -1708,6 +1642,105 @@ exit:
     }
 
     return err;
+}
+
+// StartDiscovery callbacks
+
+using DiscoveryTaskArg = std::pair<BluezEndpoint *, BluezDiscoveryRequest>;
+
+void StartDiscoveryDone(GObject * aObject, GAsyncResult * aResult, gpointer apEndpoint)
+{
+    BluezAdapter1 * adapter = BLUEZ_ADAPTER1(aObject);
+    GError * error          = nullptr;
+    gboolean success        = bluez_adapter1_call_start_discovery_finish(adapter, aResult, &error);
+
+    VerifyOrExit(success == TRUE, ChipLogProgress(DeviceLayer, "FAIL: StartDiscovery : %s", error->message));
+    ChipLogProgress(DeviceLayer, "StartDiscovery complete");
+
+exit:
+    if (error != nullptr)
+        g_error_free(error);
+}
+
+static gboolean StartDiscoveryImpl(void * apDiscoveryTaskArg)
+{
+    DiscoveryTaskArg * taskArg = static_cast<DiscoveryTaskArg *>(apDiscoveryTaskArg);
+    BluezEndpoint * endpoint;
+
+    VerifyOrExit(taskArg != nullptr, ChipLogProgress(DeviceLayer, "taskArg is NULL in %s", __func__));
+    endpoint = taskArg->first;
+
+    VerifyOrExit(endpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
+    VerifyOrExit(endpoint->mpAdapter != nullptr, ChipLogProgress(DeviceLayer, "mpAdapter is NULL in %s", __func__));
+
+    endpoint->mDiscoveryRequest = taskArg->second;
+    bluez_adapter1_call_start_discovery(endpoint->mpAdapter, nullptr, StartDiscoveryDone, endpoint);
+
+exit:
+    if (taskArg)
+        delete taskArg;
+    return G_SOURCE_REMOVE;
+}
+
+CHIP_ERROR StartDiscovery(BluezEndpoint * apEndpoint, const BluezDiscoveryRequest aRequest)
+{
+    DiscoveryTaskArg * const taskArg = new DiscoveryTaskArg(apEndpoint, aRequest);
+    CHIP_ERROR error                 = CHIP_NO_ERROR;
+
+    if (!BluezRunOnBluezThread(StartDiscoveryImpl, taskArg))
+    {
+        ChipLogError(Ble, "Failed to schedule StartDiscoveryImpl() on CHIPoBluez thread");
+        delete taskArg;
+        error = CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    return error;
+}
+
+// StopDiscovery callbacks
+
+static void StopDiscoveryDone(GObject * aObject, GAsyncResult * aResult, gpointer apEndpoint)
+{
+    BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apEndpoint);
+    BluezAdapter1 * adapter  = BLUEZ_ADAPTER1(aObject);
+    GError * error           = nullptr;
+    gboolean success         = bluez_adapter1_call_stop_discovery_finish(adapter, aResult, &error);
+
+    VerifyOrExit(endpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
+    endpoint->mDiscoveryRequest = {};
+
+    VerifyOrExit(success == TRUE, ChipLogProgress(DeviceLayer, "FAIL: StopDiscovery : %s", error->message));
+    ChipLogProgress(DeviceLayer, "StopDiscovery complete");
+
+exit:
+    if (error != nullptr)
+        g_error_free(error);
+}
+
+static gboolean StopDiscoveryImpl(void * apEndpoint)
+{
+    BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apEndpoint);
+
+    VerifyOrExit(endpoint != nullptr, ChipLogProgress(DeviceLayer, "endpoint is NULL in %s", __func__));
+    VerifyOrExit(endpoint->mpAdapter != nullptr, ChipLogProgress(DeviceLayer, "mpAdapter is NULL in %s", __func__));
+
+    bluez_adapter1_call_stop_discovery(endpoint->mpAdapter, nullptr, StopDiscoveryDone, apEndpoint);
+
+exit:
+    return G_SOURCE_REMOVE;
+}
+
+CHIP_ERROR StopDiscovery(BluezEndpoint * apEndpoint)
+{
+    CHIP_ERROR error = CHIP_NO_ERROR;
+
+    if (!BluezRunOnBluezThread(StopDiscoveryImpl, apEndpoint))
+    {
+        ChipLogError(Ble, "Failed to schedule StopDiscoveryImpl() on CHIPoBluez thread");
+        error = CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    return error;
 }
 
 } // namespace Internal

--- a/src/platform/Linux/CHIPBluezHelper.h
+++ b/src/platform/Linux/CHIPBluezHelper.h
@@ -210,6 +210,8 @@ CHIP_ERROR BluezAdvertisementSetup(BluezEndpoint * apEndpoint);
 CHIP_ERROR StartDiscovery(BluezEndpoint * apEndpoint, BluezDiscoveryRequest aRequest = {});
 CHIP_ERROR StopDiscovery(BluezEndpoint * apEndpoint);
 
+CHIP_ERROR ConnectDevice(BluezDevice1 * apDevice);
+
 } // namespace Internal
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Linux/CHIPBluezHelper.h
+++ b/src/platform/Linux/CHIPBluezHelper.h
@@ -132,6 +132,12 @@ struct CHIPServiceData
     CHIPIdInfo mIdInfo;
 } __attribute__((packed));
 
+struct BluezDiscoveryRequest
+{
+    uint16_t mDiscriminator;
+    bool mAutoConnect;
+};
+
 struct BluezEndpoint
 {
     char * mpOwningName; // Bus owning name
@@ -167,6 +173,9 @@ struct BluezEndpoint
     uint16_t mDuration; ///< Advertisement interval (in ms).
     bool mIsAdvertising;
     char * mpPeerDevicePath;
+
+    // Discovery settings
+    BluezDiscoveryRequest mDiscoveryRequest = {};
 };
 
 struct BluezConnection
@@ -197,6 +206,9 @@ CHIP_ERROR StartBluezAdv(BluezEndpoint * apEndpoint);
 CHIP_ERROR StopBluezAdv(BluezEndpoint * apEndpoint);
 CHIP_ERROR BluezGattsAppRegister(BluezEndpoint * apEndpoint);
 CHIP_ERROR BluezAdvertisementSetup(BluezEndpoint * apEndpoint);
+
+CHIP_ERROR StartDiscovery(BluezEndpoint * apEndpoint, BluezDiscoveryRequest aRequest = {});
+CHIP_ERROR StopDiscovery(BluezEndpoint * apEndpoint);
 
 } // namespace Internal
 } // namespace DeviceLayer


### PR DESCRIPTION
 #### Problem
Currently, BLE scanning and connection establishment code is missing on Linux. Consequently, implementation of the BleConnectionDelegate interface used by RendezvousSession is impossible.

 #### Summary of Changes
Implement functions for BLE device discovery and filtering by CHIP UUID / discriminator
This is the first part needed for #2791. Connection establishment still needs to be implemented.