### PR TITLE
[EFR apps] Fix issues building and running apps for a EFRMG21 based board

### DIFF
--- a/examples/platform/efr32/init_otSystem.c
+++ b/examples/platform/efr32/init_otSystem.c
@@ -65,7 +65,8 @@ void halInitChipSpecific(void);
 void initOtSysEFR(void)
 {
     sl_status_t status;
-    uint32_t SubPrio = 0;
+    uint32_t PrioGoupPos = 0;
+    uint32_t SubPrio     = 0;
 #if defined(EFR32MG21)
     // FreeRTOS recommends a lower configuration for CortexM3 and asserts
     // in some places if using default PRIGROUP_POSITION.
@@ -77,11 +78,12 @@ void initOtSysEFR(void)
 #undef FIXED_EXCEPTION
 #define FIXED_EXCEPTION(vectorNumber, functionName, deviceIrqn, deviceIrqHandler)
 #define EXCEPTION(vectorNumber, functionName, deviceIrqn, deviceIrqHandler, priorityLevel, subpriority)                            \
-    NVIC_SetPriority(deviceIrqn, NVIC_EncodePriority(PRIGROUP_POSITION - SubPrio, priorityLevel, subpriority));
+    PrioGoupPos = PRIGROUP_POSITION - SubPrio;                                                                                     \
+    NVIC_SetPriority(deviceIrqn, NVIC_EncodePriority(PrioGoupPos, priorityLevel, subpriority));
 #include NVIC_CONFIG
 #undef EXCEPTION
 
-    NVIC_SetPriorityGrouping(PRIGROUP_POSITION - SubPrio);
+    NVIC_SetPriorityGrouping(PrioGoupPos);
     CHIP_Init();
     halInitChipSpecific();
 #if DISPLAY_ENABLED
@@ -94,6 +96,8 @@ void initOtSysEFR(void)
     CMU_ClockEnable(cmuClock_CORELE, true);
 #elif defined(EFR32MG21)
     CMU_OscillatorEnable(cmuOsc_LFRCO, true, true);
+#else
+#error "Enable Clocks for the used board"
 #endif /* EFR32 PLATFORM */
     CMU_ClockEnable(cmuClock_RTCC, true);
     status = sl_sleeptimer_init();
@@ -112,7 +116,7 @@ void initOtSysEFR(void)
     efr32RadioInit();
     efr32AlarmInit();
     efr32MiscInit();
-#if defined(EFR32MG12)
+#ifndef EFR32MG21
     efr32RandomInit();
 #endif /* EFR32 PLATFORM */
     otHeapSetCAllocFree(calloc, free);

--- a/examples/platform/efr32/init_otSystem.c
+++ b/examples/platform/efr32/init_otSystem.c
@@ -65,17 +65,23 @@ void halInitChipSpecific(void);
 void initOtSysEFR(void)
 {
     sl_status_t status;
+    uint32_t SubPrio = 0;
+#if defined(EFR32MG21)
+    // FreeRTOS recommends a lower configuration for CortexM3 and asserts
+    // in some places if using default PRIGROUP_POSITION.
+    SubPrio = 1;
+#endif
 
     __disable_irq();
 
 #undef FIXED_EXCEPTION
 #define FIXED_EXCEPTION(vectorNumber, functionName, deviceIrqn, deviceIrqHandler)
 #define EXCEPTION(vectorNumber, functionName, deviceIrqn, deviceIrqHandler, priorityLevel, subpriority)                            \
-    NVIC_SetPriority(deviceIrqn, NVIC_EncodePriority(PRIGROUP_POSITION, priorityLevel, subpriority));
+    NVIC_SetPriority(deviceIrqn, NVIC_EncodePriority(PRIGROUP_POSITION - SubPrio, priorityLevel, subpriority));
 #include NVIC_CONFIG
 #undef EXCEPTION
 
-    NVIC_SetPriorityGrouping(PRIGROUP_POSITION);
+    NVIC_SetPriorityGrouping(PRIGROUP_POSITION - SubPrio);
     CHIP_Init();
     halInitChipSpecific();
 #if DISPLAY_ENABLED
@@ -83,8 +89,12 @@ void initOtSysEFR(void)
 #endif
     BSP_Init(BSP_INIT_BCC);
 
+#if defined(EFR32MG12)
     CMU_ClockSelectSet(cmuClock_LFE, cmuSelect_LFRCO);
     CMU_ClockEnable(cmuClock_CORELE, true);
+#elif defined(EFR32MG21)
+    CMU_OscillatorEnable(cmuOsc_LFRCO, true, true);
+#endif /* EFR32 PLATFORM */
     CMU_ClockEnable(cmuClock_RTCC, true);
     status = sl_sleeptimer_init();
     assert(status == SL_STATUS_OK);
@@ -102,6 +112,8 @@ void initOtSysEFR(void)
     efr32RadioInit();
     efr32AlarmInit();
     efr32MiscInit();
+#if defined(EFR32MG12)
     efr32RandomInit();
+#endif /* EFR32 PLATFORM */
     otHeapSetCAllocFree(calloc, free);
 }

--- a/third_party/efr32_sdk/efr32_sdk.gni
+++ b/third_party/efr32_sdk/efr32_sdk.gni
@@ -139,6 +139,8 @@ template("efr32_sdk") {
         "${efr32_sdk_root}/platform/emdrv/nvm3/lib/libnvm3_CM4_gcc.a",
         "${efr32_sdk_root}/protocol/bluetooth/lib/EFR32MG12P/GCC/libmbedtls.a",
       ]
+
+      defines += [ "EFR32MG12" ]
     } else if (efr32_family == "efr32mg21") {
       _include_dirs += [
         "${efr32_sdk_root}/hardware/kit/EFR32MG21_${efr32_board}/config",
@@ -154,7 +156,9 @@ template("efr32_sdk") {
         "${efr32_sdk_root}/protocol/bluetooth/lib/efr32mg21/GCC/libmbedtls.a",
       ]
 
-      defines += [ "EFR32_SERIES2_CONFIG1_MICRO" ]
+      defines += [  "EFR32MG21",
+                    "EFR32_SERIES2_CONFIG1_MICRO"
+                 ]
     }
 
     cflags = []

--- a/third_party/efr32_sdk/efr32_sdk.gni
+++ b/third_party/efr32_sdk/efr32_sdk.gni
@@ -156,9 +156,10 @@ template("efr32_sdk") {
         "${efr32_sdk_root}/protocol/bluetooth/lib/efr32mg21/GCC/libmbedtls.a",
       ]
 
-      defines += [  "EFR32MG21",
-                    "EFR32_SERIES2_CONFIG1_MICRO"
-                 ]
+      defines += [
+        "EFR32MG21",
+        "EFR32_SERIES2_CONFIG1_MICRO",
+      ]
     }
 
     cflags = []


### PR DESCRIPTION
 #### Problem
MCUs Hardfault after starting FreeRTOS Scheduler
Building for BOARD4180A fails because of undefined clock name 

 #### Summary of Changes
initOtSysEFR Clock tree was set to MG12 architecture. MG21 has different clock system and names
Add a define for the EFR family in use to if def those tree
Fix a freeRTOS hard fault with MG21 family, needs a different prio_group config for cortex-m3

fixes #2959 
