### PR TITLE
Integrate Mobly

### DIFF
--- a/examples/pigweed-app/nrf5/BUILD.gn
+++ b/examples/pigweed-app/nrf5/BUILD.gn
@@ -57,8 +57,19 @@ nrf5_executable("pigweed_app") {
   ldflags = [ "-T" + rebase_path(ldscript, root_build_dir) ]
 }
 
+copy("mobly_tests") {
+  sources = [
+    "mobly_tests/pigweed_mobly_config.yml",
+    "mobly_tests/pigweed_mobly_test.py",
+  ]
+  outputs = [ "$root_out_dir/{{source_file_part}}" ]
+}
+
 group("nrf5") {
-  deps = [ ":pigweed_app" ]
+  deps = [
+    ":mobly_tests",
+    ":pigweed_app",
+  ]
 }
 
 group("default") {

--- a/examples/pigweed-app/nrf5/mobly_tests/pigweed_mobly_config.yml
+++ b/examples/pigweed-app/nrf5/mobly_tests/pigweed_mobly_config.yml
@@ -1,26 +1,25 @@
-#!/usr/bin/env bash
-
-#
 # Copyright (c) 2020 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
-set -e
-
-# Bootstrap script for GN build GitHub workflow.
-
-# This is used to account bootstrap time in a dedicated workflow step; there's
-# no need to use this script locally.
-
-source "$(dirname "$0")/../../scripts/activate.sh"
+TestBeds:
+    # A test bed where pw_rpc will find a CHIP device
+    - Name: SampleTestBed
+      Controllers:
+          PigweedDevice:
+              - device_tty: /dev/ttyACM0
+                baud: 115200
+                platform_module: nrf5_firmware_utils
+                platform_args:
+                    - application: chip-nrf52840-pigweed-example.hex
+                      softdevice: s140_nrf52_7.0.1_softdevice.hex

--- a/examples/pigweed-app/nrf5/mobly_tests/pigweed_mobly_test.py
+++ b/examples/pigweed-app/nrf5/mobly_tests/pigweed_mobly_test.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from chip_mobly import pigweed_device
+from mobly import asserts
+from mobly import base_test
+from mobly import test_runner
+
+
+class PigweedMoblyTest(base_test.BaseTestClass):
+    def setup_class(self):
+        # Registering pigweed_device controller module declares the test's
+        # dependency on CHIP/Pigweed device hardware. By default, we expect at least one
+        # object is created from this.
+        # Flashes the image passed in the configuration yml.
+        self.ads = self.register_controller(pigweed_device)
+        self.dut = self.ads[0]
+        self.dut.platform.flash()
+
+    def test_hello(self):
+        expected = "hello!"
+        status, payload = self.dut.rpcs().EchoService.Echo(msg=expected)
+        asserts.assert_true(status.ok(), "Status is %s" % status)
+        asserts.assert_equal(
+            payload.msg,
+            expected,
+            'Returned payload is "%s" expected "%s"' % (payload.msg, expected),
+        )
+
+
+if __name__ == "__main__":
+    test_runner.main()

--- a/integrations/docker/images/chip-build/Dockerfile
+++ b/integrations/docker/images/chip-build/Dockerfile
@@ -68,7 +68,8 @@ RUN set -x \
     && : # last line
 
 RUN set -x \
-    && pip3 install circleci attrs coloredlogs PyGithub pygit \
+    && pip3 install circleci attrs coloredlogs PyGithub pygit future \
+    portpicker mobly                                                 \
     && : # last line
 
 # build and install gn

--- a/integrations/mobly/chip_mobly/__init__.py
+++ b/integrations/mobly/chip_mobly/__init__.py
@@ -1,26 +1,13 @@
-#!/usr/bin/env bash
-
-#
 # Copyright (c) 2020 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-
-set -e
-
-# Bootstrap script for GN build GitHub workflow.
-
-# This is used to account bootstrap time in a dedicated workflow step; there's
-# no need to use this script locally.
-
-source "$(dirname "$0")/../../scripts/activate.sh"

--- a/integrations/mobly/chip_mobly/pigweed_device.py
+++ b/integrations/mobly/chip_mobly/pigweed_device.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from pathlib import Path
+import serial
+import importlib
+
+from pw_hdlc_lite.rpc import HdlcRpcClient
+
+# Point the script to the .proto file with our RPC services.
+PROTO = Path(os.environ["PW_ROOT"], "pw_rpc/pw_rpc_protos/echo.proto")
+
+MOBLY_CONTROLLER_CONFIG_NAME = "PigweedDevice"
+
+
+class Error(Exception):
+    """This is the Exception class defined for all errors."""
+
+
+class PigweedDevice:
+    def __init__(self, device_tty, baud, platform_module=None, platform_args=None):
+        self.pw_rpc_client = HdlcRpcClient(serial.Serial(device_tty, baud), [PROTO])
+        self._platform = None
+        print("Platform args: %s" % platform_args)
+        print("Platform module: %s" % platform_module)
+        if platform_module:
+            m = importlib.import_module(platform_module)
+            create_platform_method = getattr(m, "create_platform")
+            self._platform = create_platform_method(platform_args)
+
+    def rpcs(self):
+        return self.pw_rpc_client.rpcs().pw.rpc
+
+    @property
+    def platform(self):
+        return self._platform
+
+
+def create(configs):
+    """Initializes the CHIP devices based on the testbed configuration.
+
+    Args:
+      configs: a list of testbed configs.
+
+    Returns:
+      a list of device objects
+    """
+    objs = []
+    for config in configs:
+        _validate_config(config)
+        device = PigweedDevice(**config)
+        objs.append(device)
+    return objs
+
+
+def destroy(unused_objs):
+    """Destroys the wearable objects.
+
+    Args:
+      unused_objs: a list of device objects.
+    """
+    pass
+
+
+def _validate_config(config):
+    """Verifies that a config dict for a CHIP device is valid.
+
+    Args:
+      config: A dict that is the configuration for a CHIP device.
+
+    Raises:
+      chip_device.Error: Config file is not valid.
+    """
+    required_keys = ["device_tty", "baud"]  # A placeholder.
+    for key in required_keys:
+        if key not in config:
+            raise Error("Required key %s missing from config %s" % (key, config))

--- a/integrations/mobly/hello_world_config.yml
+++ b/integrations/mobly/hello_world_config.yml
@@ -1,26 +1,21 @@
-#!/usr/bin/env bash
-
-#
 # Copyright (c) 2020 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
-set -e
-
-# Bootstrap script for GN build GitHub workflow.
-
-# This is used to account bootstrap time in a dedicated workflow step; there's
-# no need to use this script locally.
-
-source "$(dirname "$0")/../../scripts/activate.sh"
+TestBeds:
+    # A test bed where pw_rpc will find a CHIP device
+    - Name: SampleTestBed
+      Controllers:
+          PigweedDevice:
+              - device_tty: /dev/ttyACM0
+                baud: 115200

--- a/integrations/mobly/hello_world_test.py
+++ b/integrations/mobly/hello_world_test.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from chip_mobly import pigweed_device
+from mobly import asserts
+from mobly import base_test
+from mobly import test_runner
+
+
+class HelloWorldTest(base_test.BaseTestClass):
+    def setup_class(self):
+        # Registering pigweed_device controller module declares the test's
+        # dependency on CHIP/Pigweed device hardware. By default, we expect at least one
+        # object is created from this.
+        # Assumes correct image is already flashed.
+        self.ads = self.register_controller(pigweed_device)
+        self.dut = self.ads[0]
+
+    def test_hello(self):
+        expected = "hello!"
+        status, payload = self.dut.rpcs().EchoService.Echo(msg=expected)
+        asserts.assert_true(status.ok(), "Status is %s" % status)
+        asserts.assert_equal(
+            payload.msg,
+            expected,
+            'Returned payload is "%s" expected "%s"' % (payload.msg, expected),
+        )
+
+
+if __name__ == "__main__":
+    test_runner.main()

--- a/integrations/mobly/setup.py
+++ b/integrations/mobly/setup.py
@@ -1,26 +1,30 @@
-#!/usr/bin/env bash
-
-#
 # Copyright (c) 2020 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
-set -e
+"""chip_mobly"""
 
-# Bootstrap script for GN build GitHub workflow.
+import setuptools
 
-# This is used to account bootstrap time in a dedicated workflow step; there's
-# no need to use this script locally.
-
-source "$(dirname "$0")/../../scripts/activate.sh"
+setuptools.setup(
+    name='chip_mobly',
+    version='0.0.1',
+    author='CHIP Authors',
+#    author_email='?',
+    description='Integration of Mobly with CHIP devices',
+    packages=setuptools.find_packages(),
+#TODO - uncomment this once native python building is solved for
+#       psutil (one of mobly's dependencies which CHIP does
+#       not actually need)
+#     install_requires=['mobly'],
+)

--- a/scripts/activate.sh
+++ b/scripts/activate.sh
@@ -25,5 +25,12 @@ export PW_BRANDING_BANNER="$CHIP_ROOT/.chip-banner.txt"
 export PW_BRANDING_BANNER_COLOR="bold_white"
 export PW_VIRTUALENV_REQUIREMENTS="$CHIP_ROOT/scripts/requirements.txt"
 
+export PW_VIRTUALENV_SETUP_PY_ROOTS="$CHIP_ROOT/integrations/mobly"
+
 # shellcheck source=/dev/null
 source "$CHIP_ROOT/third_party/pigweed/repo/activate.sh"
+
+#TODO - remove this once native python building is solved for
+#       psutil (one of mobly's dependencies which CHIP does
+#       not actually need, so --no-deps is OK)
+pip install --no-deps portpicker mobly

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -32,5 +32,12 @@ fi
 
 git submodule update --init
 
+export PW_VIRTUALENV_SETUP_PY_ROOTS="$CHIP_ROOT/integrations/mobly"
+
 # shellcheck source=/dev/null
 source "$CHIP_ROOT/third_party/pigweed/repo/bootstrap.sh"
+
+#TODO - remove this once native python building is solved for
+#       psutil (one of mobly's dependencies which CHIP does
+#       not actually need, so --no-deps is OK)
+pip install --no-deps portpicker mobly

--- a/scripts/examples/gn_build_example.sh
+++ b/scripts/examples/gn_build_example.sh
@@ -20,9 +20,7 @@ set -e
 
 # Build script for GN examples GitHub workflow.
 
-CHIP_ROOT="$(dirname "$0")/../.."
-
-source "$CHIP_ROOT/scripts/activate.sh"
+source "$(dirname "$0")/../../scripts/activate.sh"
 
 GN_ARGS=()
 

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -20,9 +20,7 @@ set -e
 
 # Build script for GN EFT32 examples GitHub workflow.
 
-CHIP_ROOT="$(dirname "$0")/../.."
-
-source "$CHIP_ROOT/scripts/activate.sh"
+source "$(dirname "$0")/../../scripts/activate.sh"
 
 set -x
 env

--- a/scripts/flashing/nrf5_firmware_utils.py
+++ b/scripts/flashing/nrf5_firmware_utils.py
@@ -51,6 +51,7 @@ operations:
 """
 
 import errno
+import os
 import sys
 
 import firmware_utils
@@ -189,6 +190,25 @@ class Flasher(firmware_utils.Flasher):
 
         return self
 
+### Mobly integration
+class Nrf5Platform:
+  def __init__(self, flasher_args):
+      self.flasher = Flasher(**flasher_args)
+
+  def flash(self):
+      self.flasher.flash_command([os.getcwd()])
+
+def verify_platform_args(platform_args):
+    required_args = ['application', 'softdevice']
+    for r in required_args:
+        if not r in platform_args:
+            raise ValueError("Required argument %s missing" % r)
+
+def create_platform(platform_args):
+    verify_platform_args(platform_args[0])
+    return Nrf5Platform(platform_args[0])
+
+### End of Mobly integration
 
 if __name__ == '__main__':
     sys.exit(Flasher().flash_command(sys.argv))


### PR DESCRIPTION
 #### Problem
Described as Pillar 1 in
https://github.com/project-chip/connectedhomeip/blob/master/docs/api/device_runner.md

"A test framework provides a testing structure that developers can follow and potentially reduces some of the burden of test setup and teardown (less boilerplate). Support for state-oriented and asynchronous structuring of tests would be beneficial. Many test frameworks leverage scripting languages such as Python to simplify the quick development of tests and to leverage rich sets of libraries for device/systems access and results generation."

 #### Summary of Changes
Mobly (https://github.com/google/mobly) is a host side
on-device test orchestration framework. This change
integrates Mobly through a ChipDevice controller
class and provides an example test that requires
an EchoService Pigweed RPC server be present on the DUT.

This change adds integrations/mobly with a python module
called 'chip_mobly'. It has a mobly-conformant pigweed
device implementation.
Adds a mobly test to pigweed-app which can be executed
in the output directory as follows:
    
```
python pigweed_mobly_test.py -c pigweed_mobly_config.yml
```
    
The test will use nrf5_firmware_utils to flash the
pigweed-app on an nRF52840 device and run a simple
Echo RPC.


fixes #2966
