### PR TITLE
Use C++11 variadic template for src/app/encoder.cpp

### DIFF
--- a/examples/chip-tool/commands/clusters/Identify/Commands.h
+++ b/examples/chip-tool/commands/clusters/Identify/Commands.h
@@ -25,10 +25,10 @@ class Identify : public ModelCommand
 {
 public:
     Identify(const uint16_t clusterId) : ModelCommand("identify", clusterId) {}
-    size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
+    size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint8_t endpointId, uint16_t clusterId) override
     {
         uint16_t duration = 10;
-        return encodeIdentifyCommand(buffer->Start(), bufferSize, endPointId, duration);
+        return encodeCommand(buffer->Start(), bufferSize, endpointId, clusterId, 0x00, duration);
     }
 };
 
@@ -36,9 +36,9 @@ class IdentifyQuery : public ModelCommand
 {
 public:
     IdentifyQuery(const uint16_t clusterId) : ModelCommand("identify-query", clusterId) {}
-    size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
+    size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint8_t endpointId, uint16_t clusterId) override
     {
-        return encodeIdentifyQueryCommand(buffer->Start(), bufferSize, endPointId);
+        return encodeCommand(buffer->Start(), bufferSize, endpointId, clusterId, 0x01);
     }
 
     bool HandleClusterResponse(uint8_t * message, uint16_t messageLen) const override

--- a/examples/chip-tool/commands/clusters/OnOff/Commands.h
+++ b/examples/chip-tool/commands/clusters/OnOff/Commands.h
@@ -26,9 +26,9 @@ class Off : public ModelCommand
 public:
     Off(const uint16_t clusterId) : ModelCommand("off", clusterId) {}
 
-    size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
+    size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint8_t endpointId, uint16_t clusterId) override
     {
-        return encodeOffCommand(buffer->Start(), bufferSize, endPointId);
+        return encodeCommand(buffer->Start(), bufferSize, endpointId, clusterId, 0x00);
     }
 };
 
@@ -37,9 +37,9 @@ class On : public ModelCommand
 public:
     On(const uint16_t clusterId) : ModelCommand("on", clusterId) {}
 
-    size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
+    size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint8_t endpointId, uint16_t clusterId) override
     {
-        return encodeOnCommand(buffer->Start(), bufferSize, endPointId);
+        return encodeCommand(buffer->Start(), bufferSize, endpointId, clusterId, 0x01);
     }
 };
 
@@ -48,9 +48,10 @@ class ReadOnOff : public ModelCommand
 public:
     ReadOnOff(const uint16_t clusterId) : ModelCommand("read", clusterId) { AddArgument("attr-name", "onoff"); }
 
-    size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
+    size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint8_t endpointId, uint16_t clusterId) override
     {
-        return encodeReadOnOffCommand(buffer->Start(), bufferSize, endPointId);
+        uint16_t attrId = 0x0000; /* OnOff attribute */
+        return encodeGlobalCommand(buffer->Start(), bufferSize, endpointId, clusterId, 0x00, attrId);
     }
 };
 
@@ -59,9 +60,9 @@ class Toggle : public ModelCommand
 public:
     Toggle(const uint16_t clusterId) : ModelCommand("toggle", clusterId) {}
 
-    size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
+    size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint8_t endpointId, uint16_t clusterId) override
     {
-        return encodeToggleCommand(buffer->Start(), bufferSize, endPointId);
+        return encodeCommand(buffer->Start(), bufferSize, endpointId, clusterId, 0x02);
     }
 };
 

--- a/examples/chip-tool/commands/common/ModelCommand.cpp
+++ b/examples/chip-tool/commands/common/ModelCommand.cpp
@@ -83,7 +83,13 @@ void ModelCommand::SendCommand(ChipDeviceController * dc)
     // Make sure our buffer is big enough, but this will need a better setup!
     static const size_t bufferSize = 1024;
     auto * buffer                  = PacketBuffer::NewWithAvailableSize(bufferSize);
-    uint16_t dataLength            = EncodeCommand(buffer, bufferSize, mEndPointId);
+    uint16_t dataLength            = EncodeCommand(buffer, bufferSize, mEndPointId, mClusterId);
+    if (dataLength == 0)
+    {
+        ChipLogError(chipTool, "Error encoding command: %s", GetName());
+        return;
+    }
+
     buffer->SetDataLength(dataLength);
     ChipLogProgress(chipTool, "Encoded data of length %d", dataLength);
 

--- a/examples/chip-tool/commands/common/ModelCommand.h
+++ b/examples/chip-tool/commands/common/ModelCommand.h
@@ -52,7 +52,7 @@ public:
     void OnError(ChipDeviceController * dc, CHIP_ERROR err) override;
     void OnMessage(ChipDeviceController * dc, PacketBuffer * buffer) override;
 
-    virtual size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) = 0;
+    virtual size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint8_t endpointId, uint16_t clusterId) = 0;
     virtual bool HandleClusterResponse(uint8_t * message, uint16_t messageLen) const { return false; }
 
 private:


### PR DESCRIPTION
 #### Problem
Adding a new cluster to src/app/encoder.cpp is a painful process where one needs to add all the definitions in the header file and a method definition for it. All of the methods are extremely similar, the only difference being in the number/types of arguments they used.

 #### Summary of Changes
* Use variadic templates in src/app/ to make it easier to add new commands

I'm keeping it as a draft for now since I believe the current patch breaks the iOS app.