### PR TITLE
Remove extra chip typo in python BUILD.gn

### DIFF
--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -108,5 +108,5 @@ action("python") {
   pythontags = exec_script("//chip/python_gen_tags.py", [], "list lines", [])
   pythontagsStr = string_join("", pythontags)
   output_name = "chip-0.0-$pythontagsStr.whl"
-  outputs = [ "$root_out_dir/controller/python/chip/$output_name" ]
+  outputs = [ "$root_out_dir/controller/python/$output_name" ]
 }


### PR DESCRIPTION
Problem:
There exists typo in output path in python BUILD.gn for controller.

Summary of Changes:
Remove extra typo

fixes #2995