### PR TITLE
Fix Android release build after enabling -Wl,-z,defs

### DIFF
--- a/src/lwip/BUILD.gn
+++ b/src/lwip/BUILD.gn
@@ -50,8 +50,10 @@ buildconfig_header("lwip_buildconfig") {
 
   defines = [ "HAVE_LWIP_UDP_BIND_NETIF=1" ]
   if (lwip_platform != "external") {
-    # Automatically enable LWIP_DEBUG for internal is_debug builds.
-    defines += [ "LWIP_DEBUG=${is_debug}" ]
+    if (is_debug) {
+      # Automatically enable LWIP_DEBUG for internal is_debug builds.
+      defines += [ "LWIP_DEBUG=1" ]
+    }
 
     if (current_os == "android") {
       defines += [ "LWIP_NO_STDINT_H=1" ]

--- a/src/lwip/standalone/sys_arch.c
+++ b/src/lwip/standalone/sys_arch.c
@@ -687,7 +687,7 @@ void ppp_trace(int level, const char * format, ...)
 }
 #endif
 
-#if LWIP_DEBUG
+#ifdef LWIP_DEBUG
 
 unsigned char gLwIP_DebugFlags = 0;
 


### PR DESCRIPTION
The LWIP_DEBUG option is not applied consistently, LwIP itself uses
 #ifdef LWIP_DEBUG but one location in CHIP uses #if LWIP_DEBUG.

```
/home/spang/sdk/android-ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi24-clang++ -march=armv7-a -mfpu=vfpv3-d16 -mfloat-abi=softfp -mthumb -Wl,-O2 -Wl,--gc-sections -Os -fPIC -Wl,--fatal-warnings -Werror -Wl,-z,defs -fdiagnostics-color -Wl,-Map,android_arm/lib/jni/armeabi-v7a/libSetupPayloadParser.map -Wl,--gc-sections -Wl,--start-group android_arm/obj/src/setup_payload/java/libSetupPayloadParser.SetupPayloadParser-JNI.cpp.o android_arm/obj/src/lwip/standalone/lwip.sys_arch.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/lwip.def.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/lwip.dns.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/lwip.inet_chksum.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/lwip.init.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/lwip.ip.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/lwip.mem.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/lwip.memp.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/lwip.netif.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/lwip.pbuf.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/lwip.raw.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/lwip.stats.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/lwip.sys.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/lwip.tcp.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/lwip.tcp_in.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/lwip.tcp_out.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/lwip.timeouts.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/lwip.udp.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/ipv4/lwip.autoip.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/ipv4/lwip.dhcp.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/ipv4/lwip.etharp.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/ipv4/lwip.icmp.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/ipv4/lwip.igmp.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/ipv4/lwip.ip4.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/ipv4/lwip.ip4_addr.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/ipv4/lwip.ip4_frag.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/ipv6/lwip.dhcp6.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/ipv6/lwip.ethip6.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/ipv6/lwip.icmp6.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/ipv6/lwip.inet6.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/ipv6/lwip.ip6.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/ipv6/lwip.ip6_addr.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/ipv6/lwip.ip6_frag.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/ipv6/lwip.ip6_route_table.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/ipv6/lwip.mld6.c.o android_arm/obj/third_party/lwip/repo/lwip/src/core/ipv6/lwip.nd6.c.o android_arm/obj/third_party/lwip/repo/lwip/src/api/lwip.api_lib.c.o android_arm/obj/third_party/lwip/repo/lwip/src/api/lwip.api_msg.c.o android_arm/obj/third_party/lwip/repo/lwip/src/api/lwip.err.c.o android_arm/obj/third_party/lwip/repo/lwip/src/api/lwip.if.c.o android_arm/obj/third_party/lwip/repo/lwip/src/api/lwip.netbuf.c.o android_arm/obj/third_party/lwip/repo/lwip/src/api/lwip.netdb.c.o android_arm/obj/third_party/lwip/repo/lwip/src/api/lwip.netifapi.c.o android_arm/obj/third_party/lwip/repo/lwip/src/api/lwip.sockets.c.o android_arm/obj/third_party/lwip/repo/lwip/src/api/lwip.tcpip.c.o android_arm/obj/third_party/lwip/repo/lwip/src/netif/lwip.ethernet.c.o android_arm/obj/third_party/lwip/repo/lwip/src/netif/lwip.lowpan6.c.o android_arm/lib/libCHIP.a android_arm/obj/src/setup_payload/lib/libSetupPayload.a android_arm/obj/src/lib/core/lib/libChipCore.a android_arm/obj/src/app/lib/libCHIPDataModel.a android_arm/obj/src/lib/support/lib/libSupportLayer.a android_arm/lib/libnlfaultinjection.a android_arm/obj/src/system/lib/libSystemLayer.a android_arm/obj/src/ble/lib/libBleLayer.a android_arm/obj/src/inet/lib/libInetLayer.a  -llog -Wl,--end-group -o android_arm/lib/jni/armeabi-v7a/libSetupPayloadParser.so -shared
../../third_party/lwip/repo/lwip/src/core/netif.c:0: error: undefined reference to 'gLwIP_DebugFlags'
../../third_party/lwip/repo/lwip/src/core/netif.c:0: error: undefined reference to 'gLwIP_DebugFlags'
../../third_party/lwip/repo/lwip/src/core/netif.c:0: error: undefined reference to 'gLwIP_DebugFlags'
../../third_party/lwip/repo/lwip/src/core/netif.c:0: error: undefined reference to 'gLwIP_DebugFlags'
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

Release builds are broken on Android.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes

Use #ifdef consistently to check for LWIP_DEBUG.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->