### PR TITLE
Suppress build-chip-wheel log

### DIFF
--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
+import("//build_overrides/pigweed.gni")
+
 import("${chip_root}/gn/chip/tools.gni")
+import("${dir_pw_unit_test}/test.gni")
 
 config("controller_wno_deprecate") {
   cflags = [ "-Wno-deprecated-declarations" ]
@@ -86,7 +89,7 @@ copy("deviceControllerPyCopy2") {
   outputs = [ "$root_out_dir/controller/python/{{source_name_part}}" ]
 }
 
-action("python") {
+pw_python_script("python") {
   script = "$root_out_dir/controller/python/build-chip-wheel"
 
   inputs = [


### PR DESCRIPTION
Problem:
python build spams the log from build-chip-wheel.

Summary of Changes:
Use pw_python_script to run build-chip-wheel script, which can suppress
the log when it succeeds, and show log when it fails.

fixes #2994 