### PR TITLE
Cluster: Add Temperature Measurement commands to chip-tool and src/app

### DIFF
--- a/examples/chip-tool/commands/clusters/TemperatureMeasurement/Commands.h
+++ b/examples/chip-tool/commands/clusters/TemperatureMeasurement/Commands.h
@@ -1,0 +1,45 @@
+/*
+ *   Copyright (c) 2020 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#ifndef __CHIPTOOL_TEMPERATURE_MEASUREMENT_COMMANDS_H__
+#define __CHIPTOOL_TEMPERATURE_MEASUREMENT_COMMANDS_H__
+
+#include "../../common/ModelCommand.h"
+
+class ReadCurrentTemperature : public ModelCommand
+{
+public:
+    ReadCurrentTemperature(const uint16_t clusterId) : ModelCommand("read", clusterId)
+    {
+        AddArgument("attr-name", "current-temperature");
+    }
+
+    size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
+    {
+        return encodeReadCurrentTemperatureCommand(buffer->Start(), bufferSize, endPointId);
+    }
+};
+
+void registerClusterTemperatureMeasurement(Commands & commands)
+{
+    const uint16_t clusterId = 0x0402;
+
+    commands.Register(make_unique<ReadCurrentTemperature>(clusterId));
+}
+
+#endif // __CHIPTOOL_TEMPERATURE_MEASUREMENT_COMMANDS_H__

--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -57,6 +57,12 @@ CHIP_ERROR Commands::RunCommand(ChipDeviceController & dc, NodeId remoteId, int 
         Command * cmd = commands.at(i).get();
         if (strcmp(cmd->GetName(), argv[1]) == 0)
         {
+            // If the command is a read command, ensure the target attribute value matches with the last argument
+            if (strcmp(cmd->GetName(), "read") == 0 && strcmp(cmd->GetAttribute(), argv[argc - 1]) != 0)
+            {
+                continue;
+            }
+
             VerifyOrExit(cmd->InitArguments(argc - 2, &argv[2]), err = CHIP_ERROR_INVALID_ARGUMENT);
 
             err = cmd->Run(&dc, remoteId);

--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -18,6 +18,7 @@
 
 #include "commands/clusters/Identify/Commands.h"
 #include "commands/clusters/OnOff/Commands.h"
+#include "commands/clusters/TemperatureMeasurement/Commands.h"
 #include "commands/echo/Commands.h"
 
 // NOTE: Remote device ID is in sync with the echo server device id
@@ -36,6 +37,7 @@ int main(int argc, char * argv[])
     registerCommandsEcho(commands);
     registerClusterIdentify(commands);
     registerClusterOnOff(commands);
+    registerClusterTemperatureMeasurement(commands);
 
     return commands.Run(kLocalDeviceId, kRemoteDeviceId, argc, argv);
 }

--- a/src/app/chip-zcl-zpro-codec.h
+++ b/src/app/chip-zcl-zpro-codec.h
@@ -67,7 +67,7 @@ uint16_t encodeToggleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t dest
  * @brief Encode a Read Attributes command for the given cluster and the given
  * list of attributes.
  */
-uint16_t encodeReadAttributesCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint8_t cluster_id,
+uint16_t encodeReadAttributesCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint16_t cluster_id,
                                      uint16_t * attr_ids, uint16_t attr_id_count);
 
 /**
@@ -135,6 +135,12 @@ uint16_t encodeIdentifyQueryCommand(uint8_t * buffer, uint16_t buf_length, uint8
  * @param duration The duration for which the device will identify itself
  * */
 uint16_t encodeIdentifyCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint16_t duration);
+
+/**
+ * @brief Encode a command to read the current temperature attribute from the Temperature Measurement
+ * cluster.
+ */
+uint16_t encodeReadCurrentTemperatureCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
 
 #ifdef __cplusplus
 }

--- a/src/app/encoder.cpp
+++ b/src/app/encoder.cpp
@@ -118,7 +118,7 @@ uint16_t _encodeGlobalCommand(BufBound & buf, uint8_t destination_endpoint, uint
     return _encodeCommand(buf, destination_endpoint, cluster_id, command, frame_control);
 }
 
-uint16_t encodeReadAttributesCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint8_t cluster_id,
+uint16_t encodeReadAttributesCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint16_t cluster_id,
                                      uint16_t * attr_ids, uint16_t attr_id_count)
 {
     BufBound buf = BufBound(buffer, buf_length);
@@ -134,14 +134,14 @@ uint16_t encodeReadAttributesCommand(uint8_t * buffer, uint16_t buf_length, uint
     return buf.Fit() && CanCastTo<uint16_t>(buf.Written()) ? static_cast<uint16_t>(buf.Written()) : 0;
 }
 
-#define READ_ATTRIBUTES(name, cluster_id)                                                                                            \
-    uint16_t attr_id_count = sizeof(attr_ids) / sizeof(attr_ids[0]);                                                                 \
-    uint16_t result        = encodeReadAttributesCommand(buffer, buf_length, destination_endpoint, 0x0006, attr_ids, attr_id_count); \
-    if (result == 0)                                                                                                                 \
-    {                                                                                                                                \
-        ChipLogError(Zcl, "Error encoding %s command", name);                                                                        \
-        return 0;                                                                                                                    \
-    }                                                                                                                                \
+#define READ_ATTRIBUTES(name, cluster_id)                                                                                          \
+    uint16_t attr_id_count = sizeof(attr_ids) / sizeof(attr_ids[0]);                                                               \
+    uint16_t result = encodeReadAttributesCommand(buffer, buf_length, destination_endpoint, cluster_id, attr_ids, attr_id_count);  \
+    if (result == 0)                                                                                                               \
+    {                                                                                                                              \
+        ChipLogError(Zcl, "Error encoding %s command", name);                                                                      \
+        return 0;                                                                                                                  \
+    }                                                                                                                              \
     return result;
 
 #define COMMAND_HEADER(name, cluster_id, command_id)                                                                               \
@@ -168,6 +168,7 @@ uint16_t encodeReadAttributesCommand(uint8_t * buffer, uint16_t buf_length, uint
 
 #define ONOFF_CLUSTER_ID 0x0006
 #define IDENTIFY_CLUSTER_ID 0x0003
+#define TEMP_MEASUREMENT_CLUSTER_ID 0x0402
 
 /*
  * On/Off Cluster commands
@@ -204,6 +205,15 @@ uint16_t encodeIdentifyCommand(uint8_t * buffer, uint16_t buf_length, uint8_t de
 uint16_t encodeIdentifyQueryCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
 {
     COMMAND("IdentifyQuery", IDENTIFY_CLUSTER_ID, 0x01);
+}
+
+/*
+ * Temperature Measurement Cluster commands
+ */
+uint16_t encodeReadCurrentTemperatureCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+{
+    uint16_t attr_ids[] = { 0x0000 }; /* Current Temperature attribute */
+    READ_ATTRIBUTES("ReadCurrentTemperature", TEMP_MEASUREMENT_CLUSTER_ID);
 }
 
 } // extern "C"


### PR DESCRIPTION
 #### Problem

In order to have an minimal example application that would serve as a baseline for memory consumption, it would be nice to use a simple cluster that has only attributes.
The current PR add a command in chip-tool and the corresponding method on src/app to read the current temperature from the Temperature Measurement server.

 #### Summary of Changes
* Add a new command in chip-tool
* Add the corresponding command in src/app
* Fix attributes matching for chip-tool as previously only the first attribute of the list of commands was checked
* Fix attribute read command in src/app/encoder.cpp. It was using an uint8_t for attribute id while it is really an uint16_t

 Fixes #2982, #2981
