### PR TITLE
Doxygen ci

### DIFF
--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -1,0 +1,33 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Doxygen
+
+on:
+    push:
+    pull_request:
+
+jobs:
+    build:
+        name: Generate
+
+        runs-on: ubuntu-20.04 
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  submodules: true
+            - name: Generate
+              run: scripts/helpers/doxygen.sh

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -795,7 +795,7 @@ WARN_NO_PARAMDOC       = NO
 # a warning is encountered.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = YES
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -948,7 +948,10 @@ EXCLUDE_PATTERNS       = NetworkProvisioningServer* \
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        = */dbus/*
+EXCLUDE_SYMBOLS        =  VerifyOrExit \
+                          SuccessOrExit \
+                          ExitNow \
+                          */dbus/*
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include
@@ -2186,7 +2189,9 @@ INCLUDE_FILE_PATTERNS  =
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
 PREDEFINED             = DOXYGEN=1 \
+                         DOXYGEN_SHOULD_SKIP_THIS=1 \
                          NO_INLINE= \
+                         CONFIG_NETWORK_LAYER_BLE=1 \
                          CHIP_SYSTEM_CONFIG_USE_SOCKETS=1 \
                          CHIP_SYSTEM_CONFIG_USE_LWIP=1 \
                          INET_CONFIG_ENABLE_IPV4=1 \

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -5,14 +5,15 @@ CHIP documentation lives here:
 -   **GitHub** — All guides and tutorials across the complete
     [Project-CHIP organization](https://github.com/project-chip).
 
-See [CONTRIBUTING.md](../CONTRIBUTING.md) for general information on
-contributing to this project.
+See
+[CONTRIBUTING.md](https://github.com/project-chip/connectedhomeip/blob/master/CONTRIBUTING.md)
+for general information on contributing to this project.
 
 ## Location
 
 Place all documentation contributions in the appropriate location in the
-[`/docs`](./) directory. Most contributions should go into the `/docs/guides`
-subdirectory, which covers conceptual and usage content.
+[`/docs`](../docs) directory. Most contributions should go into the
+`/docs/guides` subdirectory, which covers conceptual and usage content.
 
 Current documentation structure:
 

--- a/scripts/helpers/doxygen.sh
+++ b/scripts/helpers/doxygen.sh
@@ -33,8 +33,8 @@ install_doxygen() {
                 brew install doxygen
                 ;;
             "Linux")
-                apt-get update
-                apt-get install -y doxygen
+                sudo apt-get update
+                sudo apt-get install -y doxygen
                 ;;
             *)
                 die
@@ -51,8 +51,8 @@ install_graphviz() {
                 brew install graphviz
                 ;;
             "Linux")
-                apt-get update
-                apt-get install -y graphviz
+                sudo apt-get update
+                sudo apt-get install -y graphviz
                 ;;
             *)
                 die

--- a/src/platform/Darwin/ConfigurationManagerImpl.h
+++ b/src/platform/Darwin/ConfigurationManagerImpl.h
@@ -44,7 +44,9 @@ class ConfigurationManagerImpl final : public ConfigurationManager,
 
     // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
     // defined on this class.
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
     friend class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
+#endif
 
 private:
     // ===== Members that implement the ConfigurationManager public interface.

--- a/src/platform/Darwin/PlatformManagerImpl.h
+++ b/src/platform/Darwin/PlatformManagerImpl.h
@@ -40,7 +40,9 @@ class PlatformManagerImpl final : public PlatformManager, public Internal::Gener
 
     // Allow the generic implementation base class to call helper methods on
     // this class.
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
     friend Internal::GenericPlatformManagerImpl_POSIX<PlatformManagerImpl>;
+#endif
 
 public:
     // ===== Platform-specific members that may be accessed directly by the application.

--- a/src/platform/EFR32/ConfigurationManagerImpl.h
+++ b/src/platform/EFR32/ConfigurationManagerImpl.h
@@ -49,7 +49,9 @@ class ConfigurationManagerImpl final : public ConfigurationManager,
 
     // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
     // defined on this class.
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
     friend class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
+#endif
 
 private:
     // ===== Members that implement the ConfigurationManager public interface.

--- a/src/platform/EFR32/PlatformManagerImpl.h
+++ b/src/platform/EFR32/PlatformManagerImpl.h
@@ -41,7 +41,9 @@ class PlatformManagerImpl final : public PlatformManager, public Internal::Gener
 
     // Allow the generic implementation base class to call helper methods on
     // this class.
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
     friend Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>;
+#endif
 
 public:
     // ===== Platform-specific members that may be accessed directly by the application.

--- a/src/platform/EFR32/ThreadStackManagerImpl.h
+++ b/src/platform/EFR32/ThreadStackManagerImpl.h
@@ -57,9 +57,11 @@ class ThreadStackManagerImpl final : public ThreadStackManager,
 
     // Allow the generic implementation base classes to call helper methods on
     // this class.
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
     friend Internal::GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>;
     friend Internal::GenericThreadStackManagerImpl_OpenThread_LwIP<ThreadStackManagerImpl>;
     friend Internal::GenericThreadStackManagerImpl_FreeRTOS<ThreadStackManagerImpl>;
+#endif
 
     // Allow glue functions called by OpenThread to call helper methods on this
     // class.

--- a/src/platform/ESP32/ConfigurationManagerImpl.h
+++ b/src/platform/ESP32/ConfigurationManagerImpl.h
@@ -61,7 +61,9 @@ class ConfigurationManagerImpl final : public ConfigurationManager,
 
     // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
     // defined on this class.
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
     friend class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
+#endif
 
 private:
     // ===== Members that implement the ConfigurationManager public interface.

--- a/src/platform/ESP32/PlatformManagerImpl.h
+++ b/src/platform/ESP32/PlatformManagerImpl.h
@@ -42,7 +42,9 @@ class PlatformManagerImpl final : public PlatformManager, public Internal::Gener
 
     // Allow the generic implementation base class to call helper methods on
     // this class.
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
     friend Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>;
+#endif
 
 public:
     // ===== Platform-specific members that may be accessed directly by the application.

--- a/src/platform/K32W/ConfigurationManagerImpl.h
+++ b/src/platform/K32W/ConfigurationManagerImpl.h
@@ -49,7 +49,9 @@ class ConfigurationManagerImpl final : public ConfigurationManager,
 
     // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
     // defined on this class.
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
     friend class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
+#endif
 
 private:
     // ===== Members that implement the ConfigurationManager public interface.

--- a/src/platform/K32W/PlatformManagerImpl.h
+++ b/src/platform/K32W/PlatformManagerImpl.h
@@ -42,7 +42,9 @@ class PlatformManagerImpl final : public PlatformManager, public Internal::Gener
 
     // Allow the generic implementation base class to call helper methods on
     // this class.
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
     friend Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>;
+#endif
 
 public:
     // ===== Platform-specific members that may be accessed directly by the application.

--- a/src/platform/K32W/ThreadStackManagerImpl.h
+++ b/src/platform/K32W/ThreadStackManagerImpl.h
@@ -56,9 +56,11 @@ class ThreadStackManagerImpl final : public ThreadStackManager,
 
     // Allow the generic implementation base classes to call helper methods on
     // this class.
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
     friend Internal::GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>;
     friend Internal::GenericThreadStackManagerImpl_OpenThread_LwIP<ThreadStackManagerImpl>;
     friend Internal::GenericThreadStackManagerImpl_FreeRTOS<ThreadStackManagerImpl>;
+#endif
 
     // Allow glue functions called by OpenThread to call helper methods on this
     // class.

--- a/src/platform/Linux/ConfigurationManagerImpl.h
+++ b/src/platform/Linux/ConfigurationManagerImpl.h
@@ -44,7 +44,9 @@ class ConfigurationManagerImpl final : public ConfigurationManager,
 
     // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
     // defined on this class.
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
     friend class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
+#endif
 
 private:
     // ===== Members that implement the ConfigurationManager public interface.

--- a/src/platform/Linux/PlatformManagerImpl.h
+++ b/src/platform/Linux/PlatformManagerImpl.h
@@ -45,7 +45,9 @@ class PlatformManagerImpl final : public PlatformManager, public Internal::Gener
 
     // Allow the generic implementation base class to call helper methods on
     // this class.
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
     friend Internal::GenericPlatformManagerImpl_POSIX<PlatformManagerImpl>;
+#endif
 
 public:
     // ===== Platform-specific members that may be accessed directly by the application.

--- a/src/platform/nRF5/ConfigurationManagerImpl.h
+++ b/src/platform/nRF5/ConfigurationManagerImpl.h
@@ -44,7 +44,9 @@ class ConfigurationManagerImpl final : public ConfigurationManager,
 
     // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
     // defined on this class.
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
     friend class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
+#endif
 
 private:
     // ===== Members that implement the ConfigurationManager public interface.

--- a/src/platform/nRF5/PlatformManagerImpl.h
+++ b/src/platform/nRF5/PlatformManagerImpl.h
@@ -40,7 +40,9 @@ class PlatformManagerImpl final : public PlatformManager, public Internal::Gener
 
     // Allow the generic implementation base class to call helper methods on
     // this class.
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
     friend Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>;
+#endif
 
 public:
     // ===== Platform-specific members that may be accessed directly by the application.

--- a/src/platform/nRF5/ThreadStackManagerImpl.h
+++ b/src/platform/nRF5/ThreadStackManagerImpl.h
@@ -57,9 +57,11 @@ class ThreadStackManagerImpl final : public ThreadStackManager,
 
     // Allow the generic implementation base classes to call helper methods on
     // this class.
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
     friend Internal::GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>;
     friend Internal::GenericThreadStackManagerImpl_OpenThread_LwIP<ThreadStackManagerImpl>;
     friend Internal::GenericThreadStackManagerImpl_FreeRTOS<ThreadStackManagerImpl>;
+#endif
 
     // Allow glue functions called by OpenThread to call helper methods on this
     // class.

--- a/src/platform/nrfconnect/ConfigurationManagerImpl.h
+++ b/src/platform/nrfconnect/ConfigurationManagerImpl.h
@@ -44,7 +44,9 @@ class ConfigurationManagerImpl final : public ConfigurationManager,
 
     // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
     // defined on this class.
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
     friend class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
+#endif
 
 private:
     // ===== Members that implement the ConfigurationManager public interface.

--- a/src/platform/nrfconnect/PlatformManagerImpl.h
+++ b/src/platform/nrfconnect/PlatformManagerImpl.h
@@ -40,7 +40,9 @@ class PlatformManagerImpl final : public PlatformManager, public Internal::Gener
 
     // Allow the generic implementation base class to call helper methods on
     // this class.
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
     friend Internal::GenericPlatformManagerImpl_Zephyr<PlatformManagerImpl>;
+#endif
 
 public:
     // ===== Platform-specific members that may be accessed directly by the application.

--- a/src/platform/nrfconnect/ThreadStackManagerImpl.h
+++ b/src/platform/nrfconnect/ThreadStackManagerImpl.h
@@ -48,8 +48,10 @@ class ThreadStackManagerImpl final : public ThreadStackManager,
 
     // Allow the generic implementation base classes to call helper methods on
     // this class.
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
     friend Internal::GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>;
     friend Internal::GenericThreadStackManagerImpl_Zephyr<ThreadStackManagerImpl>;
+#endif
 
 private:
     // ===== Members for internal use by the following friends.

--- a/src/system/SystemConfig.h
+++ b/src/system/SystemConfig.h
@@ -163,7 +163,7 @@
  *  @def CHIP_SYSTEM_CONFIG_NO_LOCKING
  *
  *  @brief
- *      Disable the use of locking within the system layer..
+ *      Disable the use of locking within the system layer.
  *
  *      Unless you are simulating an LwIP-based system on a Unix-style host, this value should be left at its default.
  */

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -97,7 +97,9 @@ public:
      * @param input_length Length of the input data
      * @param output Output buffer for decrypted data
      * @param header message header structure
+     * @param payloadFlags extra flags for packet header decryption
      * @return CHIP_ERROR The result of decryption
+     * @param mac Input mac
      */
     CHIP_ERROR Decrypt(const uint8_t * input, size_t input_length, uint8_t * output, const PacketHeader & header,
                        Header::Flags payloadFlags, const MessageAuthenticationCode & mac);

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -61,10 +61,10 @@ public:
      *   Called when a new message is received. The function must internally release the
      *   msgBuf after processing it.
      *
-     * @param header  messageheader
-     * @param state   connection state
-     * @param msgBuf  received message
-     * @param mgr     A pointer to the SecureSessionMgr
+     * @param packetHeader  The message header
+     * @param state         The connection state
+     * @param msgBuf        The received message
+     * @param mgr           A pointer to the SecureSessionMgr
      */
     virtual void OnMessageReceived(const PacketHeader & packetHeader, Transport::PeerConnectionState * state,
                                    System::PacketBuffer * msgBuf, SecureSessionMgrBase * mgr)

--- a/src/transport/raw/MessageHeader.cpp
+++ b/src/transport/raw/MessageHeader.cpp
@@ -16,8 +16,9 @@
  */
 
 /**
- * @file This file contains the implementation the chip message header
- *       encode/decode classes.
+ * @file
+ *   This file contains the implementation the chip message header
+ *   encode/decode classes.
  */
 
 #include "MessageHeader.h"

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -16,7 +16,8 @@
  */
 
 /**
- * @file  This file defines CHIP binary header encode/decode.
+ * @file
+ * This file defines CHIP binary header encode/decode.
  */
 
 #ifndef MESSAGEHEADER_H_
@@ -245,6 +246,7 @@ public:
      * @param data - the buffer to write to
      * @param size - space available in the buffer (in bytes)
      * @param encode_size - number of bytes written to the buffer.
+     * @param payloadFlags extra flags for packet header encoding
      *
      * @return CHIP_NO_ERROR on success.
      *


### PR DESCRIPTION
 #### Problem

The code use doxygen format but there is no CI to enforce it.

 #### Summary of Changes
* Enforce with by adding a new CI rule
* Turn warnings as fatal for doxygen
* Get doxygen to not output any warning and/or do some workarounds for doxygen parsing issues