### PR TITLE
ChipTool: Make the ShowUsage output grouped by clusters

### DIFF
--- a/examples/chip-tool/commands/clusters/Identify/Commands.h
+++ b/examples/chip-tool/commands/clusters/Identify/Commands.h
@@ -58,10 +58,15 @@ public:
 
 void registerClusterIdentify(Commands & commands)
 {
+    const char * clusterName = "Identify";
     const uint16_t clusterId = 0x0003;
 
-    commands.Register(make_unique<Identify>(clusterId));
-    commands.Register(make_unique<IdentifyQuery>(clusterId));
+    commands_list clusterCommands = {
+        make_unique<Identify>(clusterId),
+        make_unique<IdentifyQuery>(clusterId),
+    };
+
+    commands.Register(clusterName, clusterCommands);
 }
 
 #endif // __CHIPTOOL_IDENTIFY_COMMANDS_H__

--- a/examples/chip-tool/commands/clusters/OnOff/Commands.h
+++ b/examples/chip-tool/commands/clusters/OnOff/Commands.h
@@ -67,12 +67,17 @@ public:
 
 void registerClusterOnOff(Commands & commands)
 {
+    const char * clusterName = "OnOff";
     const uint16_t clusterId = 0x0006;
 
-    commands.Register(make_unique<Off>(clusterId));
-    commands.Register(make_unique<On>(clusterId));
-    commands.Register(make_unique<ReadOnOff>(clusterId));
-    commands.Register(make_unique<Toggle>(clusterId));
+    commands_list clusterCommands = {
+        make_unique<Off>(clusterId),
+        make_unique<On>(clusterId),
+        make_unique<ReadOnOff>(clusterId),
+        make_unique<Toggle>(clusterId),
+    };
+
+    commands.Register(clusterName, clusterCommands);
 }
 
 #endif // __CHIPTOOL_ONOFF_COMMANDS_H__

--- a/examples/chip-tool/commands/clusters/TemperatureMeasurement/Commands.h
+++ b/examples/chip-tool/commands/clusters/TemperatureMeasurement/Commands.h
@@ -37,9 +37,14 @@ public:
 
 void registerClusterTemperatureMeasurement(Commands & commands)
 {
+    const char * clusterName = "Temperature Measurement";
     const uint16_t clusterId = 0x0402;
 
-    commands.Register(make_unique<ReadCurrentTemperature>(clusterId));
+    commands_list clusterCommands = {
+        make_unique<ReadCurrentTemperature>(clusterId),
+    };
+
+    commands.Register(clusterName, clusterCommands);
 }
 
 #endif // __CHIPTOOL_TEMPERATURE_MEASUREMENT_COMMANDS_H__

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -19,12 +19,29 @@
 #ifndef __CHIPTOOL_COMMAND_H__
 #define __CHIPTOOL_COMMAND_H__
 
-#include "Commands.h"
-#include <vector>
-
 #include <controller/CHIPDeviceController.h>
 #include <inet/InetInterface.h>
 #include <support/CHIPLogging.h>
+
+#include <memory>
+#include <vector>
+
+class Command;
+
+template <typename T, typename... Args>
+std::unique_ptr<Command> make_unique(Args &&... args)
+{
+    return std::unique_ptr<Command>(new T(std::forward<Args>(args)...));
+}
+
+struct movable_initializer_list
+{
+    movable_initializer_list(std::unique_ptr<Command> && in) : item(std::move(in)) {}
+    operator std::unique_ptr<Command>() const && { return std::move(item); }
+    mutable std::unique_ptr<Command> item;
+};
+
+typedef std::initializer_list<movable_initializer_list> commands_list;
 
 enum ArgumentType
 {
@@ -41,12 +58,6 @@ struct Argument
     uint32_t max;
     void * value;
 };
-
-template <typename T, typename... Args>
-std::unique_ptr<T> make_unique(Args &&... args)
-{
-    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-}
 
 class Command
 {

--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -21,9 +21,12 @@
 #include "Command.h"
 #include <string>
 
-void Commands::Register(std::unique_ptr<Command> command)
+void Commands::Register(const char * clusterName, commands_list commandsList)
 {
-    commands.push_back(std::move(command));
+    for (auto & command : commandsList)
+    {
+        clusters[clusterName].push_back(std::move(command));
+    }
 }
 
 int Commands::Run(NodeId localId, NodeId remoteId, int argc, char * argv[])
@@ -52,23 +55,25 @@ CHIP_ERROR Commands::RunCommand(ChipDeviceController & dc, NodeId remoteId, int 
 
     VerifyOrExit(argc > 1, err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    for (size_t i = 0; i < commands.size(); i++)
+    for (auto & cluster : clusters)
     {
-        Command * cmd = commands.at(i).get();
-        if (strcmp(cmd->GetName(), argv[1]) == 0)
+        for (auto & command : cluster.second)
         {
-            // If the command is a read command, ensure the target attribute value matches with the last argument
-            if (strcmp(cmd->GetName(), "read") == 0 && strcmp(cmd->GetAttribute(), argv[argc - 1]) != 0)
+            if (strcmp(command->GetName(), argv[1]) == 0)
             {
-                continue;
+                // If the command is a read command, ensure the target attribute value matches with the last argument
+                if (strcmp(command->GetName(), "read") == 0 && strcmp(command->GetAttribute(), argv[argc - 1]) != 0)
+                {
+                    continue;
+                }
+
+                VerifyOrExit(command->InitArguments(argc - 2, &argv[2]), err = CHIP_ERROR_INVALID_ARGUMENT);
+
+                err = command->Run(&dc, remoteId);
+                SuccessOrExit(err);
+
+                return err;
             }
-
-            VerifyOrExit(cmd->InitArguments(argc - 2, &argv[2]), err = CHIP_ERROR_INVALID_ARGUMENT);
-
-            err = cmd->Run(&dc, remoteId);
-            SuccessOrExit(err);
-
-            return err;
         }
     }
 
@@ -89,36 +94,130 @@ exit:
 
 void Commands::ShowUsage(const char * executable)
 {
-    std::string arguments  = "";
-    std::string attributes = "";
-    size_t commandsCount   = commands.size();
+    fprintf(stderr, "Usage:\n");
+    fprintf(stderr, "  %s command [params]\n\n", executable);
+    fprintf(stderr, "  Supported commands and their parameters:\n");
+    fprintf(stderr, "\n");
+    fprintf(stderr, "  +-------------------------------------------------------------------------------------+\n");
+    fprintf(stderr, "  | Misc. Commands:                                                                     |\n");
+    fprintf(stderr, "  +-------------------------------------------------------------------------------------+\n");
+    PrintMiscCommands();
+    fprintf(stderr, "  +-------------------------------------------------------------------------------------+\n");
+    fprintf(stderr, "\n");
+    fprintf(stderr, "\n");
+    fprintf(stderr, "  +-------------------------------------------------------------------------------------+\n");
+    fprintf(stderr, "  | Clusters:                                                                           |\n");
+    fprintf(stderr, "  |                                                                                     |\n");
+    fprintf(stderr, "  |   Usage:                                                                            |\n");
+    fprintf(stderr, "  |    command_name remote-ip remote-port endpoint-id                                   |\n");
+    fprintf(stderr, "  |                                                                                     |\n");
+    fprintf(stderr, "  | Available command names:                                                            |\n");
+    fprintf(stderr, "  +-------------------------------------------------------------------------------------+\n");
+    PrintClustersCommands();
+    fprintf(stderr, "\n");
+    fprintf(stderr, "  +-------------------------------------------------------------------------------------+\n");
+    fprintf(stderr, "  | Read Attributes:                                                                    |\n");
+    fprintf(stderr, "  |                                                                                     |\n");
+    fprintf(stderr, "  |   Usage:                                                                            |\n");
+    fprintf(stderr, "  |    read remote-ip remote-port endpoint-id attribute-name                            |\n");
+    fprintf(stderr, "  |                                                                                     |\n");
+    fprintf(stderr, "  | Available attribute names:                                                          |\n");
+    fprintf(stderr, "  +-------------------------------------------------------------------------------------+\n");
+    PrintClustersAttributes();
+}
 
-    for (size_t i = 0; i < commandsCount; i++)
+void Commands::PrintMiscCommands()
+{
+    for (auto & cluster : clusters)
     {
-        const Command * command = commands.at(i).get();
-
-        arguments += "    ";
-        arguments += command->GetName();
-
-        size_t argumentsCount = command->GetArgumentsCount();
-        for (size_t j = 0; j < argumentsCount; j++)
+        if (cluster.first[0] == '\0')
         {
-            arguments += " ";
-            arguments += command->GetArgumentName(j);
-        }
+            for (auto & command : cluster.second)
+            {
+                std::string arguments = "";
+                arguments += command->GetName();
 
-        arguments += "\n";
+                size_t argumentsCount = command->GetArgumentsCount();
+                for (size_t j = 0; j < argumentsCount; j++)
+                {
+                    arguments += " ";
+                    arguments += command->GetArgumentName(j);
+                }
 
-        if (strcmp("read", command->GetName()) == 0)
-        {
-            attributes += "    " + std::string(command->GetAttribute()) + "\n";
+                fprintf(stderr, "  | %-84s|\n", arguments.c_str());
+            }
         }
     }
+}
 
-    fprintf(stderr,
-            "Usage: \n"
-            "  %s command [params]\n\n"
-            "  Supported commands and their parameters:\n%s\n"
-            "  Supported attribute names for the 'read' command:\n%s",
-            executable, arguments.c_str(), attributes.c_str());
+void PrintClusterHeader(const char * name)
+{
+    fprintf(stderr, "  | * Cluster: %-73s|\n", name);
+    fprintf(stderr, "  +-------------------------------------------------------------------------------------+\n");
+}
+
+void PrintClusterFooter()
+{
+    fprintf(stderr, "  | %-84s|\n", "");
+    fprintf(stderr, "  +-------------------------------------------------------------------------------------+\n");
+}
+
+void Commands::PrintClustersCommands()
+{
+    for (auto & cluster : clusters)
+    {
+        bool hasCommands = false;
+
+        if (cluster.first[0] != '\0')
+        {
+            for (auto & command : cluster.second)
+            {
+                if (strcmp("read", command->GetName()) != 0)
+                {
+                    if (!hasCommands)
+                    {
+                        PrintClusterHeader(cluster.first);
+                        hasCommands = true;
+                    }
+
+                    fprintf(stderr, "  | %-84s|\n", command->GetName());
+                }
+            }
+        }
+
+        if (hasCommands)
+        {
+            PrintClusterFooter();
+        }
+    }
+}
+
+void Commands::PrintClustersAttributes()
+{
+    for (auto & cluster : clusters)
+    {
+        bool hasAttributes = false;
+
+        if (cluster.first[0] != '\0')
+        {
+            for (auto & command : cluster.second)
+            {
+                if (strcmp("read", command->GetName()) == 0)
+                {
+                    if (!hasAttributes)
+                    {
+                        PrintClusterHeader(cluster.first);
+                        hasAttributes = true;
+                    }
+
+                    fprintf(stderr, "  | %-84s|\n", command->GetAttribute());
+                }
+            }
+        }
+
+        if (hasAttributes)
+        {
+            PrintClusterFooter();
+        }
+    }
 }

--- a/examples/chip-tool/commands/common/Commands.h
+++ b/examples/chip-tool/commands/common/Commands.h
@@ -19,11 +19,10 @@
 #ifndef __CHIPTOOL_COMMANDS_H__
 #define __CHIPTOOL_COMMANDS_H__
 
-#include <controller/CHIPDeviceController.h>
-#include <memory>
-#include <vector>
+#include "Command.h"
+#include <map>
 
-class Command;
+#include <controller/CHIPDeviceController.h>
 
 class Commands
 {
@@ -31,13 +30,18 @@ public:
     using ChipDeviceController = ::chip::DeviceController::ChipDeviceController;
     using NodeId               = ::chip::NodeId;
 
-    void Register(std::unique_ptr<Command> command);
+    void Register(const char * clusterName, commands_list commandsList);
     int Run(NodeId localId, NodeId remoteId, int argc, char * argv[]);
 
 private:
     CHIP_ERROR RunCommand(ChipDeviceController & dc, NodeId remoteId, int argc, char * argv[]);
+
     void ShowUsage(const char * executable);
-    std::vector<std::unique_ptr<Command>> commands;
+    void PrintMiscCommands();
+    void PrintClustersCommands();
+    void PrintClustersAttributes();
+
+    std::map<const char *, std::vector<std::unique_ptr<Command>>> clusters;
 };
 
 #endif // __CHIPTOOL_COMMANDS_H__

--- a/examples/chip-tool/commands/echo/Commands.h
+++ b/examples/chip-tool/commands/echo/Commands.h
@@ -35,8 +35,14 @@ public:
 
 void registerCommandsEcho(Commands & commands)
 {
-    commands.Register(make_unique<Echo>());
-    commands.Register(make_unique<EchoBle>());
+    const char * clusterName = "";
+
+    commands_list clusterCommands = {
+        make_unique<Echo>(),
+        make_unique<EchoBle>(),
+    };
+
+    commands.Register(clusterName, clusterCommands);
 }
 
 #endif // __CHIPTOOL_ECHO_COMMANDS_H__

--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -16,6 +16,8 @@
  *
  */
 
+#include "commands/common/Commands.h"
+
 #include "commands/clusters/Identify/Commands.h"
 #include "commands/clusters/OnOff/Commands.h"
 #include "commands/clusters/TemperatureMeasurement/Commands.h"


### PR DESCRIPTION
#### Problem

ChipTool help is hard to read, and it will be harder and harder when adding more commands.

 #### Summary of Changes
* Prettify the output by making per cluster commands group