### PR TITLE
Configure python module builds to be optional.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -26,6 +26,10 @@ import("${chip_root}/gn/chip/tests.gni")
 import("${chip_root}/gn/chip/tools.gni")
 
 if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
+  declare_args() {
+    enable_python_build_tools = true
+  }
+
   # This is a real toolchain. Build CHIP.
   group("default") {
     deps = [ ":all" ]
@@ -64,11 +68,10 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
     if (chip_build_tools) {
       deps += [
         "${chip_root}/examples/shell",
-        "${chip_root}/src/controller/python",
         "${chip_root}/src/qrcodetool",
         "${chip_root}/src/setup_payload",
       ]
-      if (current_os == "linux") {
+      if (enable_python_build_tools) {
         deps += [ "${chip_root}/src/controller/python" ]
       }
     }

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -27,7 +27,7 @@ import("${chip_root}/gn/chip/tools.gni")
 
 if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
   declare_args() {
-    enable_python_build_tools = true
+    chip_enable_python_modules = true
   }
 
   # This is a real toolchain. Build CHIP.
@@ -71,7 +71,7 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
         "${chip_root}/src/qrcodetool",
         "${chip_root}/src/setup_payload",
       ]
-      if (enable_python_build_tools) {
+      if (chip_enable_python_modules) {
         deps += [ "${chip_root}/src/controller/python" ]
       }
     }

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -5,7 +5,7 @@ extraction:
                 - wget -O /tmp/gn.zip
                   https://chrome-infra-packages.appspot.com/dl/gn/gn/linux-amd64/+/Z6cz3BKAP2GgVlujo5D6CFdrLE3B1hXFwVwraB6QBnUC
                   && unzip /tmp/gn.zip -d /tmp/gn-bin gn && /tmp/gn-bin/gn gen
-                  out/default --args='enable_python_build_tools=false'
+                  out/default --args='chip_enable_python_modules=false'
         index: # Customizable step used by all languages.
             build_command:
                 - ninja -C out/default

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -5,7 +5,7 @@ extraction:
                 - wget -O /tmp/gn.zip
                   https://chrome-infra-packages.appspot.com/dl/gn/gn/linux-amd64/+/Z6cz3BKAP2GgVlujo5D6CFdrLE3B1hXFwVwraB6QBnUC
                   && unzip /tmp/gn.zip -d /tmp/gn-bin gn && /tmp/gn-bin/gn gen
-                  out/default
+                  out/default --args='enable_python_build_tools=false'
         index: # Customizable step used by all languages.
             build_command:
                 - ninja -C out/default


### PR DESCRIPTION
#### Problem
LGTM.com does not support python3 and there is no benefit of trying to build python packages there (python is statically checked)

 #### Summary of Changes
Adds a 'enable python tool builds' flag for gn and disables it when running on lgtm.com
