### PR TITLE
Move WiFi association processing to Rendezvous StateMachine

### DIFF
--- a/examples/wifi-echo/server/esp32/main/DeviceNetworkProvisioningDelegate.cpp
+++ b/examples/wifi-echo/server/esp32/main/DeviceNetworkProvisioningDelegate.cpp
@@ -1,0 +1,26 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "DeviceNetworkProvisioningDelegate.h"
+#include <support/logging/CHIPLogging.h>
+
+using namespace ::chip;
+
+void ESP32NetworkProvisioningDelegate::ProvisionNetwork(const char * ssid, const char * passwd)
+{
+    ChipLogProgress(NetworkProvisioning, "ESP32NetworkProvisioningDelegate: Received SSID and passwd\n");
+}

--- a/examples/wifi-echo/server/esp32/main/RendezvousDeviceDelegate.cpp
+++ b/examples/wifi-echo/server/esp32/main/RendezvousDeviceDelegate.cpp
@@ -87,3 +87,9 @@ void RendezvousDeviceDelegate::OnRendezvousMessageReceived(PacketBuffer * buffer
         mRendezvousSession->SendMessage(buffer);
     }
 }
+
+void RendezvousDeviceDelegate::OnRendezvousProvisionNetwork(const char * ssid, const char * passwd)
+{
+    ESP_LOGI(TAG, "OnRendezvousProvisionNetwork");
+    // Call device network configuration method here.
+}

--- a/examples/wifi-echo/server/esp32/main/RendezvousDeviceDelegate.cpp
+++ b/examples/wifi-echo/server/esp32/main/RendezvousDeviceDelegate.cpp
@@ -56,23 +56,30 @@ exit:
     }
 }
 
-void RendezvousDeviceDelegate::OnRendezvousError(CHIP_ERROR err)
+void RendezvousDeviceDelegate::OnRendezvousStatusUpdate(RendezvousSessionDelegate::Status status, CHIP_ERROR err)
 {
-    ESP_LOGI(TAG, "OnRendezvousError: %s", ErrorStr(err));
-}
+    if (err != CHIP_NO_ERROR)
+    {
+        ESP_LOGI(TAG, "OnRendezvousStatusUpdate: %s", ErrorStr(err));
+    }
 
-void RendezvousDeviceDelegate::OnRendezvousConnectionOpened()
-{
-    ESP_LOGI(TAG, "OnRendezvousConnectionOpened");
+    switch (status)
+    {
+    case RendezvousSessionDelegate::SecurePairingSuccess:
+        ESP_LOGI(TAG, "Device completed SPAKE2+ handshake\n");
+        PairingComplete(&mRendezvousSession->GetPairingSession());
+        bluetoothLED.Set(true);
+        break;
 
-    PairingComplete(&mRendezvousSession->GetPairingSession());
-    bluetoothLED.Set(true);
-}
+    case RendezvousSessionDelegate::NetworkProvisioningSuccess:
 
-void RendezvousDeviceDelegate::OnRendezvousConnectionClosed()
-{
-    ESP_LOGI(TAG, "OnRendezvousConnectionClosed");
-    bluetoothLED.Set(false);
+        ESP_LOGI(TAG, "Device was assigned an ip address\n");
+        bluetoothLED.Set(false);
+        break;
+
+    default:
+        break;
+    };
 }
 
 void RendezvousDeviceDelegate::OnRendezvousMessageReceived(PacketBuffer * buffer)

--- a/examples/wifi-echo/server/esp32/main/RendezvousDeviceDelegate.cpp
+++ b/examples/wifi-echo/server/esp32/main/RendezvousDeviceDelegate.cpp
@@ -46,7 +46,7 @@ RendezvousDeviceDelegate::RendezvousDeviceDelegate()
 
     params.SetSetupPINCode(setupPINCode).SetLocalNodeId(kLocalNodeId).SetBleLayer(DeviceLayer::ConnectivityMgr().GetBleLayer());
 
-    mRendezvousSession = new RendezvousSession(this);
+    mRendezvousSession = new RendezvousSession(this, &mDeviceNetworkProvisioningDelegate);
     err                = mRendezvousSession->Init(params);
 
 exit:
@@ -60,7 +60,7 @@ void RendezvousDeviceDelegate::OnRendezvousStatusUpdate(RendezvousSessionDelegat
 {
     if (err != CHIP_NO_ERROR)
     {
-        ESP_LOGI(TAG, "OnRendezvousStatusUpdate: %s", ErrorStr(err));
+        ESP_LOGE(TAG, "OnRendezvousStatusUpdate: %s, status %d", ErrorStr(err), status);
     }
 
     switch (status)
@@ -93,10 +93,4 @@ void RendezvousDeviceDelegate::OnRendezvousMessageReceived(PacketBuffer * buffer
         // If the handler did not recognize the message, treat it as an echo request.
         mRendezvousSession->SendMessage(buffer);
     }
-}
-
-void RendezvousDeviceDelegate::OnRendezvousProvisionNetwork(const char * ssid, const char * passwd)
-{
-    ESP_LOGI(TAG, "OnRendezvousProvisionNetwork");
-    // Call device network configuration method here.
 }

--- a/examples/wifi-echo/server/esp32/main/include/DeviceNetworkProvisioningDelegate.h
+++ b/examples/wifi-echo/server/esp32/main/include/DeviceNetworkProvisioningDelegate.h
@@ -1,0 +1,39 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef _DEVICE_NETWORK_PROVISIONING_DELEGATE_H_
+#define _DEVICE_NETWORK_PROVISIONING_DELEGATE_H_
+
+#include <core/CHIPError.h>
+#include <transport/NetworkProvisioning.h>
+
+using namespace ::chip;
+
+class ESP32NetworkProvisioningDelegate : public DeviceNetworkProvisioningDelegate
+{
+public:
+    /**
+     * @brief
+     *   Called to provision WiFi credentials in a device
+     *
+     * @param ssid WiFi SSID
+     * @param passwd WiFi password
+     */
+    void ProvisionNetwork(const char * ssid, const char * passwd) override;
+};
+
+#endif // _DEVICE_NETWORK_PROVISIONING_DELEGATE_H_

--- a/examples/wifi-echo/server/esp32/main/include/RendezvousDeviceDelegate.h
+++ b/examples/wifi-echo/server/esp32/main/include/RendezvousDeviceDelegate.h
@@ -27,11 +27,9 @@ public:
     RendezvousDeviceDelegate();
 
     //////////// RendezvousSession callback Implementation ///////////////
-    void OnRendezvousConnectionOpened() override;
-    void OnRendezvousConnectionClosed() override;
-    void OnRendezvousError(CHIP_ERROR err) override;
     void OnRendezvousMessageReceived(chip::System::PacketBuffer * buffer) override;
-
+    void OnRendezvousStatusUpdate(RendezvousSessionDelegate::Status status, CHIP_ERROR err) override;
+ 
     void OnRendezvousProvisionNetwork(const char * ssid, const char * passwd) override;
 
 private:

--- a/examples/wifi-echo/server/esp32/main/include/RendezvousDeviceDelegate.h
+++ b/examples/wifi-echo/server/esp32/main/include/RendezvousDeviceDelegate.h
@@ -18,6 +18,8 @@
 #ifndef __RENDEZVOUSDEVICEDELEGATE_H__
 #define __RENDEZVOUSDEVICEDELEGATE_H__
 
+#include "DeviceNetworkProvisioningDelegate.h"
+
 #include <platform/CHIPDeviceLayer.h>
 #include <transport/RendezvousSession.h>
 
@@ -29,11 +31,10 @@ public:
     //////////// RendezvousSession callback Implementation ///////////////
     void OnRendezvousMessageReceived(chip::System::PacketBuffer * buffer) override;
     void OnRendezvousStatusUpdate(RendezvousSessionDelegate::Status status, CHIP_ERROR err) override;
- 
-    void OnRendezvousProvisionNetwork(const char * ssid, const char * passwd) override;
 
 private:
     chip::RendezvousSession * mRendezvousSession;
-};
+    ESP32NetworkProvisioningDelegate mDeviceNetworkProvisioningDelegate;
+ };
 
 #endif // __RENDEZVOUSDEVICEDELEGATE_H__

--- a/examples/wifi-echo/server/esp32/main/include/RendezvousDeviceDelegate.h
+++ b/examples/wifi-echo/server/esp32/main/include/RendezvousDeviceDelegate.h
@@ -32,6 +32,8 @@ public:
     void OnRendezvousError(CHIP_ERROR err) override;
     void OnRendezvousMessageReceived(chip::System::PacketBuffer * buffer) override;
 
+    void OnRendezvousProvisionNetwork(const char * ssid, const char * passwd) override;
+
 private:
     chip::RendezvousSession * mRendezvousSession;
 };

--- a/examples/wifi-echo/server/esp32/main/include/RendezvousDeviceDelegate.h
+++ b/examples/wifi-echo/server/esp32/main/include/RendezvousDeviceDelegate.h
@@ -35,6 +35,6 @@ public:
 private:
     chip::RendezvousSession * mRendezvousSession;
     ESP32NetworkProvisioningDelegate mDeviceNetworkProvisioningDelegate;
- };
+};
 
 #endif // __RENDEZVOUSDEVICEDELEGATE_H__

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -241,7 +241,7 @@ public:
     //////////// RendezvousSessionDelegate Implementation ///////////////
     void OnRendezvousMessageReceived(System::PacketBuffer * buffer) override;
     void OnRendezvousStatusUpdate(RendezvousSessionDelegate::Status status, CHIP_ERROR err) override;
- 
+
 private:
     enum
     {

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -239,12 +239,9 @@ public:
     void OnNewConnection(Transport::PeerConnectionState * state, SecureSessionMgrBase * mgr) override;
 
     //////////// RendezvousSessionDelegate Implementation ///////////////
-    void OnRendezvousConnectionOpened() override;
-    void OnRendezvousConnectionClosed() override;
-    void OnRendezvousError(CHIP_ERROR err) override;
     void OnRendezvousMessageReceived(System::PacketBuffer * buffer) override;
-    void OnRendezvousStatusUpdate(RendezvousSessionDelegate::Status status) override;
-
+    void OnRendezvousStatusUpdate(RendezvousSessionDelegate::Status status, CHIP_ERROR err) override;
+ 
 private:
     enum
     {

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -137,7 +137,7 @@ static void onMessageReceived(
 }
 
 static void onInternalError(chip::DeviceController::ChipDeviceController * deviceController, void * appReqState, CHIP_ERROR error,
-    const chip::IPPacketInfo * pi)
+    const chip::Inet::IPPacketInfo * pi)
 {
     CHIPDeviceController * controller = (__bridge CHIPDeviceController *) appReqState;
     [controller _dispatchAsyncErrorBlock:[CHIPError errorForCHIPErrorCode:error]];
@@ -264,7 +264,7 @@ static void onInternalError(chip::DeviceController::ChipDeviceController * devic
     [self.lock lock];
     err = self.cppController->PopulatePeerAddress(peerAddr);
     [self.lock unlock];
-    chip::IPAddress ipAddr = peerAddr.GetIPAddress();
+    chip::Inet::IPAddress ipAddr = peerAddr.GetIPAddress();
     uint16_t port = peerAddr.GetPort();
 
     if (err != CHIP_NO_ERROR) {

--- a/src/platform/Darwin/BleApplicationDelegate.h
+++ b/src/platform/Darwin/BleApplicationDelegate.h
@@ -24,7 +24,7 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-class BleApplicationDelegateImpl : public BleApplicationDelegate
+class BleApplicationDelegateImpl : public Ble::BleApplicationDelegate
 {
 public:
     virtual void NotifyChipConnectionClosed(BLE_CONNECTION_OBJECT connObj);

--- a/src/transport/BUILD.gn
+++ b/src/transport/BUILD.gn
@@ -19,6 +19,8 @@ static_library("transport") {
   output_name = "libTransportLayer"
 
   sources = [
+    "NetworkProvisioning.cpp",
+    "NetworkProvisioning.h",
     "PeerConnectionState.h",
     "PeerConnections.h",
     "RendezvousParameters.h",

--- a/src/transport/NetworkProvisioning.cpp
+++ b/src/transport/NetworkProvisioning.cpp
@@ -1,0 +1,195 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <core/CHIPEncoding.h>
+#include <core/CHIPSafeCasts.h>
+#include <platform/internal/DeviceNetworkInfo.h>
+#include <protocols/CHIPProtocols.h>
+#include <support/CodeUtils.h>
+#include <support/ErrorStr.h>
+#include <support/SafeInt.h>
+#include <transport/NetworkProvisioning.h>
+
+#if CONFIG_DEVICE_LAYER
+#include <platform/CHIPDeviceLayer.h>
+#endif
+
+namespace chip {
+
+CHIP_ERROR NetworkProvisioning::HandleNetworkProvisioningMessage(uint8_t msgType, PacketBuffer * msgBuf,
+                                                                 RendezvousSessionDelegate * delegate)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    VerifyOrExit(delegate != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+
+    switch (msgType)
+    {
+    case NetworkProvisioning::MsgTypes::kWiFiAssociationRequest: {
+        char SSID[chip::DeviceLayer::Internal::kMaxWiFiSSIDLength];
+        char passwd[chip::DeviceLayer::Internal::kMaxWiFiKeyLength];
+        BufBound bbufSSID(Uint8::from_char(SSID), chip::DeviceLayer::Internal::kMaxWiFiSSIDLength);
+        BufBound bbufPW(Uint8::from_char(passwd), chip::DeviceLayer::Internal::kMaxWiFiKeyLength);
+
+        const uint8_t * buffer = msgBuf->Start();
+        size_t len             = msgBuf->DataLength();
+        size_t offset          = 0;
+
+        err = DecodeString(&buffer[offset], len - offset, bbufSSID, offset);
+        SuccessOrExit(err);
+
+        err = DecodeString(&buffer[offset], len - offset, bbufPW, offset);
+        SuccessOrExit(err);
+
+        delegate->OnRendezvousProvisionNetwork(SSID, passwd);
+    }
+    break;
+
+    case NetworkProvisioning::MsgTypes::kIPAddressAssigned: {
+        if (!IPAddress::FromString(Uint8::to_const_char(msgBuf->Start()), msgBuf->DataLength(), mDeviceAddress))
+        {
+            ExitNow(err = CHIP_ERROR_INVALID_ADDRESS);
+        }
+    }
+    break;
+
+    default:
+        ExitNow(err = CHIP_ERROR_INVALID_MESSAGE_TYPE);
+        break;
+    };
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        mDelegate->OnNetworkProvisioningError(err);
+    }
+    else
+    {
+        // Network provisioning handshake requires only one message exchange in either direction.
+        // If the current message handling did not result in an error, network provisioning is
+        // complete.
+        mDelegate->OnNetworkProvisioningComplete();
+    }
+    return err;
+}
+
+CHIP_ERROR NetworkProvisioning::EncodeString(const char * str, BufBound & bbuf)
+{
+    CHIP_ERROR err  = CHIP_NO_ERROR;
+    size_t length   = strlen(str);
+    uint16_t u16len = static_cast<uint16_t>(length);
+    VerifyOrExit(CanCastTo<uint16_t>(length), err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    bbuf.PutLE16(u16len);
+    bbuf.Put(str);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR NetworkProvisioning::DecodeString(const uint8_t * input, size_t input_len, BufBound & bbuf, size_t & consumed)
+{
+    CHIP_ERROR err  = CHIP_NO_ERROR;
+    uint16_t length = 0;
+
+    VerifyOrExit(input_len >= sizeof(uint16_t), err = CHIP_ERROR_BUFFER_TOO_SMALL);
+    length   = chip::Encoding::LittleEndian::Get16(input);
+    consumed = sizeof(uint16_t);
+
+    VerifyOrExit(input_len - consumed >= length, err = CHIP_ERROR_BUFFER_TOO_SMALL);
+    bbuf.Put(&input[consumed], length);
+
+    consumed += bbuf.Written();
+    bbuf.Put('\0');
+
+    VerifyOrExit(bbuf.Fit(), err = CHIP_ERROR_BUFFER_TOO_SMALL);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR NetworkProvisioning::SendIPAddress(const IPAddress & addr)
+{
+    CHIP_ERROR err                = CHIP_NO_ERROR;
+    System::PacketBuffer * buffer = System::PacketBuffer::New();
+    char * addrStr                = addr.ToString(Uint8::to_char(buffer->Start()), buffer->AvailableDataLength());
+    size_t addrLen                = 0;
+
+    VerifyOrExit(mDelegate != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(addrStr != nullptr, err = CHIP_ERROR_INVALID_ADDRESS);
+
+    addrLen = strlen(addrStr) + 1;
+
+    VerifyOrExit(CanCastTo<uint16_t>(addrLen), err = CHIP_ERROR_INVALID_ARGUMENT);
+    buffer->SetDataLength(static_cast<uint16_t>(addrLen));
+
+    err = mDelegate->SendSecureMessage(Protocols::kChipProtocol_NetworkProvisioning,
+                                       NetworkProvisioning::MsgTypes::kIPAddressAssigned, buffer);
+    SuccessOrExit(err);
+
+exit:
+    if (CHIP_NO_ERROR != err)
+    {
+        PacketBuffer::Free(buffer);
+    }
+    return err;
+}
+
+CHIP_ERROR NetworkProvisioning::SendNetworkCredentials(const char * ssid, const char * passwd)
+{
+    CHIP_ERROR err                = CHIP_NO_ERROR;
+    System::PacketBuffer * buffer = System::PacketBuffer::New();
+    BufBound bbuf(buffer->Start(), buffer->TotalLength());
+
+    VerifyOrExit(mDelegate != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    SuccessOrExit(EncodeString(ssid, bbuf));
+    SuccessOrExit(EncodeString(passwd, bbuf));
+    VerifyOrExit(bbuf.Fit(), err = CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    VerifyOrExit(CanCastTo<uint16_t>(bbuf.Written()), err = CHIP_ERROR_INVALID_ARGUMENT);
+    buffer->SetDataLength(static_cast<uint16_t>(bbuf.Written()));
+
+    err = mDelegate->SendSecureMessage(Protocols::kChipProtocol_NetworkProvisioning,
+                                       NetworkProvisioning::MsgTypes::kWiFiAssociationRequest, buffer);
+    SuccessOrExit(err);
+
+exit:
+    if (CHIP_NO_ERROR != err)
+    {
+        PacketBuffer::Free(buffer);
+    }
+    return err;
+}
+
+#if CONFIG_DEVICE_LAYER
+void NetworkProvisioning::ConnectivityHandler(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
+{
+    NetworkProvisioning * session = reinterpret_cast<NetworkProvisioning *>(arg);
+
+    VerifyOrExit(session != nullptr, /**/);
+    VerifyOrExit(event->Type == DeviceLayer::DeviceEventType::kInternetConnectivityChange, /**/);
+    VerifyOrExit(event->InternetConnectivityChange.IPv4 == DeviceLayer::kConnectivity_Established, /**/);
+
+    IPAddress addr;
+    IPAddress::FromString(event->InternetConnectivityChange.address, addr);
+    (void) session->SendIPAddress(addr);
+
+exit:
+    return;
+}
+#endif
+
+} // namespace chip

--- a/src/transport/NetworkProvisioning.cpp
+++ b/src/transport/NetworkProvisioning.cpp
@@ -73,7 +73,7 @@ NetworkProvisioning::~NetworkProvisioning()
     }
 }
 
-CHIP_ERROR NetworkProvisioning::HandleNetworkProvisioningMessage(uint8_t msgType, PacketBuffer * msgBuf)
+CHIP_ERROR NetworkProvisioning::HandleNetworkProvisioningMessage(uint8_t msgType, System::PacketBuffer * msgBuf)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -106,7 +106,7 @@ CHIP_ERROR NetworkProvisioning::HandleNetworkProvisioningMessage(uint8_t msgType
 
     case NetworkProvisioning::MsgTypes::kIPAddressAssigned: {
         ChipLogProgress(NetworkProvisioning, "Received kIPAddressAssigned\n");
-        if (!IPAddress::FromString(Uint8::to_const_char(msgBuf->Start()), msgBuf->DataLength(), mDeviceAddress))
+        if (!Inet::IPAddress::FromString(Uint8::to_const_char(msgBuf->Start()), msgBuf->DataLength(), mDeviceAddress))
         {
             ExitNow(err = CHIP_ERROR_INVALID_ADDRESS);
         }
@@ -172,7 +172,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR NetworkProvisioning::SendIPAddress(const IPAddress & addr)
+CHIP_ERROR NetworkProvisioning::SendIPAddress(const Inet::IPAddress & addr)
 {
     CHIP_ERROR err                = CHIP_NO_ERROR;
     System::PacketBuffer * buffer = System::PacketBuffer::New();
@@ -196,7 +196,7 @@ exit:
     if (CHIP_NO_ERROR != err)
     {
         ChipLogError(NetworkProvisioning, "Failed in sending IP address. error %s\n", ErrorStr(err));
-        PacketBuffer::Free(buffer);
+        System::PacketBuffer::Free(buffer);
     }
     return err;
 }
@@ -224,7 +224,7 @@ exit:
     if (CHIP_NO_ERROR != err)
     {
         ChipLogError(NetworkProvisioning, "Failed in sending Network Creds. error %s\n", ErrorStr(err));
-        PacketBuffer::Free(buffer);
+        System::PacketBuffer::Free(buffer);
     }
     return err;
 }
@@ -238,8 +238,8 @@ void NetworkProvisioning::ConnectivityHandler(const DeviceLayer::ChipDeviceEvent
     VerifyOrExit(event->Type == DeviceLayer::DeviceEventType::kInternetConnectivityChange, /**/);
     VerifyOrExit(event->InternetConnectivityChange.IPv4 == DeviceLayer::kConnectivity_Established, /**/);
 
-    IPAddress addr;
-    IPAddress::FromString(event->InternetConnectivityChange.address, addr);
+    Inet::IPAddress addr;
+    Inet::IPAddress::FromString(event->InternetConnectivityChange.address, addr);
     (void) session->SendIPAddress(addr);
 
 exit:

--- a/src/transport/NetworkProvisioning.h
+++ b/src/transport/NetworkProvisioning.h
@@ -1,0 +1,145 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines the CHIP Device Network Provisioning object.
+ *
+ */
+
+#ifndef __CHIP_NETWORK_PROVISIONING_H__
+#define __CHIP_NETWORK_PROVISIONING_H__
+
+#include <core/CHIPCore.h>
+#include <core/ReferenceCounted.h>
+#include <support/BufBound.h>
+#include <system/SystemPacketBuffer.h>
+#include <transport/RendezvousSessionDelegate.h>
+
+#if CONFIG_DEVICE_LAYER
+#include <platform/CHIPDeviceLayer.h>
+#endif
+
+namespace chip {
+
+class DLL_EXPORT NetworkProvisioningDelegate : public ReferenceCounted<NetworkProvisioningDelegate>
+{
+public:
+    /**
+     * @brief
+     *   Called when network provisioning generates a new message that should be sent to peer.
+     *
+     * @param msgBuf the new message that should be sent to the peer
+     * @return CHIP_ERROR Error thrown when sending the message
+     */
+    virtual CHIP_ERROR SendSecureMessage(Protocols::CHIPProtocolId protocol, uint8_t msgType, System::PacketBuffer * msgBuf)
+    {
+        return CHIP_NO_ERROR;
+    }
+
+    /**
+     * @brief
+     *   Called when network provisioning fails with an error
+     *
+     * @param error error code
+     */
+    virtual void OnNetworkProvisioningError(CHIP_ERROR error) {}
+
+    /**
+     * @brief
+     *   Called when the network provisioning is complete
+     */
+    virtual void OnNetworkProvisioningComplete() {}
+
+    ~NetworkProvisioningDelegate() override {}
+};
+
+class DLL_EXPORT NetworkProvisioning
+{
+public:
+    enum MsgTypes : uint8_t
+    {
+        kWiFiAssociationRequest = 0,
+        kIPAddressAssigned      = 1,
+    };
+
+    void Init(NetworkProvisioningDelegate * delegate, bool monitorNetIf)
+    {
+        if (mDelegate != nullptr)
+        {
+            mDelegate->Release();
+        }
+
+        if (delegate != nullptr)
+        {
+            mDelegate = delegate->Retain();
+        }
+
+#if CONFIG_DEVICE_LAYER
+        DeviceLayer::PlatformMgr().AddEventHandler(ConnectivityHandler, reinterpret_cast<intptr_t>(this));
+#endif
+    }
+
+    ~NetworkProvisioning()
+    {
+#if CONFIG_DEVICE_LAYER
+        DeviceLayer::PlatformMgr().RemoveEventHandler(ConnectivityHandler, reinterpret_cast<intptr_t>(this));
+#endif
+        if (mDelegate != nullptr)
+        {
+            mDelegate->Release();
+        }
+    }
+
+    CHIP_ERROR SendNetworkCredentials(const char * ssid, const char * passwd);
+
+    CHIP_ERROR HandleNetworkProvisioningMessage(uint8_t msgType, PacketBuffer * msgBuf, RendezvousSessionDelegate * delegate);
+
+    /**
+     * @brief
+     *  Get the IP address assigned to the device during network provisioning
+     *  process.
+     *
+     * @return The IP address of the device
+     */
+    const IPAddress & GetIPAddress() const { return mDeviceAddress; }
+
+private:
+    NetworkProvisioningDelegate * mDelegate = nullptr;
+
+    IPAddress mDeviceAddress = IPAddress::Any;
+
+    /**
+     * @brief
+     *  The device can use this function to send its IP address to
+     *  commissioner. This would generally be called during network
+     *  provisioning of the device, after the IP address assignment.
+     *
+     * @param addr The IP address of the device
+     */
+    CHIP_ERROR SendIPAddress(const IPAddress & addr);
+
+    CHIP_ERROR EncodeString(const char * str, BufBound & bbuf);
+    CHIP_ERROR DecodeString(const uint8_t * input, size_t input_len, BufBound & bbuf, size_t & consumed);
+
+#if CONFIG_DEVICE_LAYER
+    static void ConnectivityHandler(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
+#endif // CONFIG_DEVICE_LAYER
+};
+
+} // namespace chip
+#endif // __CHIP_NETWORK_PROVISIONING_H__

--- a/src/transport/NetworkProvisioning.h
+++ b/src/transport/NetworkProvisioning.h
@@ -59,6 +59,8 @@ public:
      * @brief
      *   Called when network provisioning generates a new message that should be sent to peer.
      *
+     * @param protocol Protocol ID for the message
+     * @param msgType Message type
      * @param msgBuf the new message that should be sent to the peer
      * @return CHIP_ERROR Error thrown when sending the message
      */

--- a/src/transport/NetworkProvisioning.h
+++ b/src/transport/NetworkProvisioning.h
@@ -99,7 +99,7 @@ public:
 
     CHIP_ERROR SendNetworkCredentials(const char * ssid, const char * passwd);
 
-    CHIP_ERROR HandleNetworkProvisioningMessage(uint8_t msgType, PacketBuffer * msgBuf);
+    CHIP_ERROR HandleNetworkProvisioningMessage(uint8_t msgType, System::PacketBuffer * msgBuf);
 
     /**
      * @brief
@@ -114,7 +114,7 @@ private:
     NetworkProvisioningDelegate * mDelegate             = nullptr;
     DeviceNetworkProvisioningDelegate * mDeviceDelegate = nullptr;
 
-    Inet::IPAddress mDeviceAddress = IPAddress::Any;
+    Inet::IPAddress mDeviceAddress = Inet::IPAddress::Any;
 
     /**
      * @brief

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -61,13 +61,9 @@ CHIP_ERROR RendezvousSession::Init(const RendezvousParameters & params)
     {
         err = WaitForPairing(mParams.GetLocalNodeId(), mParams.GetSetupPINCode());
         SuccessOrExit(err);
+    }
 
-        mNetworkProvision.Init(this, true);
-    }
-    else
-    {
-        mNetworkProvision.Init(this, false);
-    }
+    mNetworkProvision.Init(this, mDeviceNetworkProvisionDelegate);
 
 exit:
     return err;
@@ -254,6 +250,7 @@ void RendezvousSession::OnRendezvousError(CHIP_ERROR err)
         break;
     };
     mDelegate->OnRendezvousError(err);
+    UpdateState(State::kInit);
 }
 
 void RendezvousSession::UpdateState(RendezvousSession::State newState)
@@ -370,10 +367,10 @@ CHIP_ERROR RendezvousSession::HandleSecureMessage(PacketBuffer * msgBuf)
 
     if (payloadHeader.GetProtocolID() == Protocols::kChipProtocol_NetworkProvisioning)
     {
-        err = mNetworkProvision.HandleNetworkProvisioningMessage(payloadHeader.GetMessageType(), msgBuf, mDelegate);
-        // Ignoring error for time being, as the message is getting routed via OnRendezvousMessageReceived()
+        err = mNetworkProvision.HandleNetworkProvisioningMessage(payloadHeader.GetMessageType(), msgBuf);
+        SuccessOrExit(err);
     }
-    // else .. TBD once application dependency on this message has been removed, enable the else condition
+    // else .. TODO once application dependency on this message has been removed, enable the else condition
     {
         mDelegate->OnRendezvousMessageReceived(msgBuf);
     }

--- a/src/transport/RendezvousSession.h
+++ b/src/transport/RendezvousSession.h
@@ -68,13 +68,15 @@ class RendezvousSession : public SecurePairingSessionDelegate,
 public:
     enum State : uint8_t
     {
-        kUnknown = 0,
+        kInit = 0,
         kSecurePairing,
         kNetworkProvisioning,
         kRendezvousComplete,
     };
 
-    RendezvousSession(RendezvousSessionDelegate * delegate) : mDelegate(delegate) {}
+    RendezvousSession(RendezvousSessionDelegate * delegate, DeviceNetworkProvisioningDelegate * networkDelegate = nullptr) :
+        mDelegate(delegate), mDeviceNetworkProvisionDelegate(networkDelegate)
+    {}
     ~RendezvousSession() override;
 
     /**
@@ -135,11 +137,12 @@ private:
 
     SecurePairingSession mPairingSession;
     NetworkProvisioning mNetworkProvision;
+    DeviceNetworkProvisioningDelegate * mDeviceNetworkProvisionDelegate = nullptr;
     SecureSession mSecureSession;
     uint32_t mSecureMessageIndex = 0;
     uint16_t mNextKeyId          = 0;
- 
-    RendezvousSession::State mCurrentState = State::kUnknown;
+
+    RendezvousSession::State mCurrentState = State::kInit;
     void UpdateState(RendezvousSession::State newState);
 };
 

--- a/src/transport/RendezvousSessionDelegate.h
+++ b/src/transport/RendezvousSessionDelegate.h
@@ -35,12 +35,12 @@ public:
         NetworkProvisioningFailed,
     };
 
-    virtual void OnRendezvousConnectionOpened()                             = 0;
-    virtual void OnRendezvousConnectionClosed()                             = 0;
-    virtual void OnRendezvousError(CHIP_ERROR err)                          = 0;
+    virtual void OnRendezvousConnectionOpened() {}
+    virtual void OnRendezvousConnectionClosed() {}
+    virtual void OnRendezvousError(CHIP_ERROR err) {}
     virtual void OnRendezvousMessageReceived(System::PacketBuffer * buffer) = 0;
 
-    virtual void OnRendezvousStatusUpdate(Status status) {}
+    virtual void OnRendezvousStatusUpdate(Status status, CHIP_ERROR err) {}
     virtual void OnRendezvousProvisionNetwork(const char * ssid, const char * passwd) {}
 };
 

--- a/src/transport/RendezvousSessionDelegate.h
+++ b/src/transport/RendezvousSessionDelegate.h
@@ -41,7 +41,6 @@ public:
     virtual void OnRendezvousMessageReceived(System::PacketBuffer * buffer) = 0;
 
     virtual void OnRendezvousStatusUpdate(Status status, CHIP_ERROR err) {}
-    virtual void OnRendezvousProvisionNetwork(const char * ssid, const char * passwd) {}
 };
 
 class DLL_EXPORT RendezvousDeviceCredentialsDelegate

--- a/src/transport/RendezvousSessionDelegate.h
+++ b/src/transport/RendezvousSessionDelegate.h
@@ -39,7 +39,16 @@ public:
     virtual void OnRendezvousConnectionClosed()                             = 0;
     virtual void OnRendezvousError(CHIP_ERROR err)                          = 0;
     virtual void OnRendezvousMessageReceived(System::PacketBuffer * buffer) = 0;
+
     virtual void OnRendezvousStatusUpdate(Status status) {}
+    virtual void OnRendezvousProvisionNetwork(const char * ssid, const char * passwd) {}
+};
+
+class DLL_EXPORT RendezvousDeviceCredentialsDelegate
+{
+public:
+    virtual void SendNetworkCredentials(const char * ssid, const char * passwd) = 0;
+    virtual void SendOperationalCredentials()                                   = 0;
 };
 
 } // namespace chip


### PR DESCRIPTION
 #### Problem
As part of Rendezvous state machine, the controller sends network (e.g. WiFi) credentials to the device. Currently, the controller propagates a Rendezvous message from device to the controller app (e.g. CHIP Tool iOS app), which triggers the app to collect the credentials from the user. The app constructs another Rendezvous message containing the credentials and sends it to the device.

This puts extra burden on the app to understand the Rendezvous message structure. Instead, the Rendezvous state machine should process the message, and call the delegate registered by app to collect the WiFi credentials. Also, the state machine should construct the required Rendezvous message and send it to the device.

 #### Summary of Changes

- Framework to construct and send WiFi association request from Rendezvous Session
- split NetworkProvisioning from RendezvousSession state machine
- split WiFi association from RendezvousSessionDelegate to its own delegate
 
Fixes #2818
