### PR TITLE
Add missing symbols to Temperature Measurement Server

### DIFF
--- a/src/app/clusters/temperature-measurement-server/temperature-measurement-server.c
+++ b/src/app/clusters/temperature-measurement-server/temperature-measurement-server.c
@@ -43,6 +43,10 @@
 #include <app/util/af-event.h>
 #include <app/util/attribute-storage.h>
 
+EmberEventControl emberAfPluginTemperatureMeasurementServerReadEventControl;
+
+void emberAfPluginTemperatureMeasurementServerReadEventHandler() {}
+
 // -------------------------------------------------------------------------
 // ****** callback section *******
 


### PR DESCRIPTION
The current build is broken because of missing symbols. This is a collision between 2 patches that have landed affecting clusters.