### PR TITLE
Refactor scopedbuffer for more typesafety

### DIFF
--- a/src/platform/Linux/CHIPLinuxStorage.cpp
+++ b/src/platform/Linux/CHIPLinuxStorage.cpp
@@ -200,7 +200,7 @@ CHIP_ERROR ChipLinuxStorage::WriteValueBin(const char * key, const uint8_t * dat
     static const size_t kMaxBlobSize = 5 * 1024;
 
     CHIP_ERROR retval = CHIP_NO_ERROR;
-    chip::Platform::ScopedMemoryBuffer encodedData;
+    chip::Platform::ScopedMemoryBuffer<char> encodedData;
     size_t encodedDataLen     = 0;
     size_t expectedEncodedLen = ((dataLen + 3) * 4) / 3;
 
@@ -225,14 +225,14 @@ CHIP_ERROR ChipLinuxStorage::WriteValueBin(const char * key, const uint8_t * dat
     {
         // We tested above that dataLen is no more than kMaxBlobSize.
         static_assert(kMaxBlobSize < UINT16_MAX, "dataLen won't fit");
-        encodedDataLen                          = Base64Encode(data, static_cast<uint16_t>(dataLen), encodedData.Ptr<char>());
-        encodedData.Ptr<char>()[encodedDataLen] = 0;
+        encodedDataLen                    = Base64Encode(data, static_cast<uint16_t>(dataLen), encodedData.Ptr());
+        encodedData.Ptr()[encodedDataLen] = 0;
     }
 
     // Store it
     if (retval == CHIP_NO_ERROR)
     {
-        WriteValueStr(key, encodedData.Ptr<char>());
+        WriteValueStr(key, encodedData.Ptr());
     }
 
     return retval;

--- a/src/platform/Linux/CHIPLinuxStorageIni.cpp
+++ b/src/platform/Linux/CHIPLinuxStorageIni.cpp
@@ -219,7 +219,8 @@ CHIP_ERROR ChipLinuxStorageIni::GetStringValue(const char * key, char * buf, siz
     return retval;
 }
 
-CHIP_ERROR ChipLinuxStorageIni::GetBinaryBlobDataAndLengths(const char * key, chip::Platform::ScopedMemoryBuffer & encodedData,
+CHIP_ERROR ChipLinuxStorageIni::GetBinaryBlobDataAndLengths(const char * key,
+                                                            chip::Platform::ScopedMemoryBuffer<char> & encodedData,
                                                             size_t & encodedDataLen, size_t & decodedDataLen)
 {
     size_t encodedDataPaddingLen = 0;
@@ -249,14 +250,14 @@ CHIP_ERROR ChipLinuxStorageIni::GetBinaryBlobDataAndLengths(const char * key, ch
     {
         return CHIP_ERROR_NO_MEMORY;
     }
-    encodedDataLen                          = value.copy(encodedData.Ptr<char>(), len);
-    encodedData.Ptr<char>()[encodedDataLen] = '\0';
+    encodedDataLen                    = value.copy(encodedData.Ptr(), len);
+    encodedData.Ptr()[encodedDataLen] = '\0';
 
     // Check if encoded data was padded. Only "=" or "==" padding combinations are allowed.
-    if ((encodedDataLen > 0) && (encodedData.Ptr<char>()[encodedDataLen - 1] == '='))
+    if ((encodedDataLen > 0) && (encodedData.Ptr()[encodedDataLen - 1] == '='))
     {
         encodedDataPaddingLen++;
-        if ((encodedDataLen > 1) && (encodedData.Ptr<char>()[encodedDataLen - 2] == '='))
+        if ((encodedDataLen > 1) && (encodedData.Ptr()[encodedDataLen - 2] == '='))
             encodedDataPaddingLen++;
     }
 
@@ -268,7 +269,7 @@ CHIP_ERROR ChipLinuxStorageIni::GetBinaryBlobDataAndLengths(const char * key, ch
 CHIP_ERROR ChipLinuxStorageIni::GetBinaryBlobValue(const char * key, uint8_t * decodedData, size_t bufSize, size_t & decodedDataLen)
 {
     CHIP_ERROR retval = CHIP_NO_ERROR;
-    chip::Platform::ScopedMemoryBuffer encodedData;
+    chip::Platform::ScopedMemoryBuffer<char> encodedData;
     size_t encodedDataLen;
     size_t expectedDecodedLen = 0;
 
@@ -294,7 +295,7 @@ CHIP_ERROR ChipLinuxStorageIni::GetBinaryBlobValue(const char * key, uint8_t * d
 
     // Decode it
     // Cast is safe because we checked encodedDataLen above.
-    decodedDataLen = Base64Decode(encodedData.Ptr<char>(), static_cast<uint16_t>(encodedDataLen), (uint8_t *) decodedData);
+    decodedDataLen = Base64Decode(encodedData.Ptr(), static_cast<uint16_t>(encodedDataLen), (uint8_t *) decodedData);
     if (decodedDataLen == UINT16_MAX || decodedDataLen > expectedDecodedLen)
     {
         return CHIP_ERROR_DECODE_FAILED;

--- a/src/platform/Linux/CHIPLinuxStorageIni.h
+++ b/src/platform/Linux/CHIPLinuxStorageIni.h
@@ -53,7 +53,7 @@ protected:
 
 private:
     CHIP_ERROR GetDefaultSection(std::map<std::string, std::string> & section);
-    CHIP_ERROR GetBinaryBlobDataAndLengths(const char * key, chip::Platform::ScopedMemoryBuffer & encodedData,
+    CHIP_ERROR GetBinaryBlobDataAndLengths(const char * key, chip::Platform::ScopedMemoryBuffer<char> & encodedData,
                                            size_t & encodedDataLen, size_t & decodedDataLen);
     inipp::Ini<char> mConfigStore;
 };


### PR DESCRIPTION
#### Problem
Address some typesafety suggestions from the original PR

 #### Summary of Changes
Separate buffer type and memory management into separate classes.

Confirmed with godbolt:

```
size_t test() {
    ScopedMemoryBuffer<char> b;

    if (!b.Alloc(256))
    {
        return 0;
    }
    strcpy(b.Ptr(), "this is a test");

    return strlen(b.Ptr());
}
```

translates into

```
.LC0:
        .ascii  "this is a test\000"
test():
        push    {r4, r5, r6, lr}
        mov     r0, #256
        bl      malloc
        subs    r4, r0, #0
        moveq   r5, r4
        beq     .L1
        ldr     r1, .L5
        bl      strcpy
        mov     r0, r4
        bl      strlen
        mov     r5, r0
        mov     r0, r4
        bl      free
.L1:
        mov     r0, r5
        pop     {r4, r5, r6, lr}
        bx      lr
.L5:
        .word   .LC0
```
fixes #3025 ?