### PR TITLE
Followup for #3015 - Add Ble namespace for BleApplicationDelegate

### DIFF
--- a/src/platform/Darwin/BleApplicationDelegate.h
+++ b/src/platform/Darwin/BleApplicationDelegate.h
@@ -24,7 +24,7 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-class BleApplicationDelegateImpl : public BleApplicationDelegate
+class BleApplicationDelegateImpl : public Ble::BleApplicationDelegate
 {
 public:
     virtual void NotifyChipConnectionClosed(BLE_CONNECTION_OBJECT connObj);


### PR DESCRIPTION
 #### Problem
#3015 has remove a bunch of using namespace.
It has break Darwin build.

 #### Summary of Changes
* Add the missing Ble:: namespace instructions...