### PR TITLE
Fix nondeterminism in python build

### DIFF
--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -28,11 +28,8 @@ config("includes") {
 
 shared_library("ChipDeviceCtrl") {
   output_name = "_ChipDeviceCtrl"
-  output_dir = "$root_out_dir/controller/python/chip"
-  include_dirs = [
-    ".",
-    "${chip_root}/src/controller",
-  ]
+  output_dir = "${target_out_dir}/chip"
+  include_dirs = [ "." ]
 
   sources = [
     "ChipDeviceController-BleApplicationDelegate.cpp",
@@ -54,68 +51,75 @@ shared_library("ChipDeviceCtrl") {
   configs += [ ":controller_wno_deprecate" ]
 }
 
-copy("deviceControllerPyCopy1") {
-  sources = [
-    "chip/ChipBleBase.py",
-    "chip/ChipBleUtility.py",
-    "chip/ChipDeviceCtrl.py",
-    "chip/ChipStack.py",
-    "chip/ChipTLV.py",
-    "chip/ChipUtility.py",
-    "chip/__init__.py",
-  ]
-
-  if (current_os == "linux") {
-    sources += [ "chip/ChipBluezMgr.py" ]
-  }
-
-  if (current_os == "mac") {
-    sources += [ "chip/ChipCoreBluetoothMgr.py" ]
-  }
-
-  outputs = [ "$root_out_dir/controller/python/chip/{{source_file_part}}" ]
-}
-
-copy("deviceControllerPyCopy2") {
-  sources = [
-    "build-chip-wheel.py",
-    "chip-device-ctrl.py",
-  ]
-
-  outputs = [ "$root_out_dir/controller/python/{{source_name_part}}" ]
-}
-
 pw_python_script("python") {
-  script = "$root_out_dir/controller/python/build-chip-wheel"
+  script = "build-chip-wheel.py"
 
-  inputs = [ "${root_out_dir}/controller/python/chip/_ChipDeviceCtrl.so" ]
+  _py_manifest_files = [
+    {
+      src_dir = "."
+      sources = [
+        "chip-device-ctrl.py",
+        "chip/ChipBleBase.py",
+        "chip/ChipBleUtility.py",
+        "chip/ChipBluezMgr.py",
+        "chip/ChipCoreBluetoothMgr.py",
+        "chip/ChipDeviceCtrl.py",
+        "chip/ChipStack.py",
+        "chip/ChipTLV.py",
+        "chip/ChipUtility.py",
+        "chip/__init__.py",
+      ]
+    },
+    {
+      src_dir = target_out_dir
+      sources = [ "${target_out_dir}/chip/_ChipDeviceCtrl.so" ]
+    },
+    {
+      src_dir = "//"
+      sources = [ "//LICENSE" ]
+    },
+  ]
 
-  inputs += get_target_outputs(":deviceControllerPyCopy1")
-  inputs += get_target_outputs(":deviceControllerPyCopy2")
+  _py_manifest_file = "${target_gen_dir}/${target_name}.py_manifest.json"
+
+  inputs = []
+  _py_manifest_files_rebased = []
+  foreach(_manifest_entry, _py_manifest_files) {
+    inputs += _manifest_entry.sources
+    _py_manifest_files_rebased += [
+      {
+        src_dir = rebase_path(_manifest_entry.src_dir,
+                              get_path_info(_py_manifest_file, "dir"))
+        sources = rebase_path(_manifest_entry.sources, _manifest_entry.src_dir)
+      },
+    ]
+  }
+
+  _py_manifest = {
+    files = _py_manifest_files_rebased
+  }
+
+  write_file(_py_manifest_file, _py_manifest, "json")
+
+  _dist_dir = "${root_out_dir}/controller/python"
 
   args = [
     "--package_name",
     "chip",
     "--build_number",
     "0.0",
+    "--build_dir",
+    rebase_path("${target_gen_dir}/${target_name}.py_build", root_build_dir),
+    "--dist_dir",
+    rebase_path(_dist_dir, root_build_dir),
+    "--manifest",
+    rebase_path(_py_manifest_file, root_build_dir),
   ]
 
-  if (current_os == "linux") {
-    inputs += [ "chip/ChipBluezMgr.py" ]
-  }
-
-  if (current_os == "mac") {
-    inputs += [ "chip/ChipCoreBluetoothMgr.py" ]
-  }
-
-  public_deps = [
-    ":ChipDeviceCtrl",
-    ":deviceControllerPyCopy1",
-    ":deviceControllerPyCopy2",
-  ]
+  public_deps = [ ":ChipDeviceCtrl" ]
 
   pythontags = exec_script("//chip/python_gen_tags.py", [], "list lines", [])
   pythontagsStr = string_join("", pythontags)
   output_name = "chip-0.0-$pythontagsStr.whl"
-  outputs = [ "$root_out_dir/controller/python/$output_name" ]
+  outputs = [ "${_dist_dir}/$output_name" ]
 }

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -43,8 +43,7 @@
 #include "ChipDeviceController-BlePlatformDelegate.h"
 #endif /* CONFIG_NETWORK_LAYER_BLE */
 
-#include "CHIPDeviceController.h"
-
+#include <controller/CHIPDeviceController.h>
 #include <support/CodeUtils.h>
 #include <support/DLLUtil.h>
 #include <support/logging/CHIPLogging.h>

--- a/src/controller/python/build-chip-wheel.py
+++ b/src/controller/python/build-chip-wheel.py
@@ -27,12 +27,10 @@ from setuptools import setup
 from wheel.bdist_wheel import bdist_wheel
 
 import argparse
-import getpass
 import json
 import os
 import platform
 import shutil
-import stat
 
 
 parser = argparse.ArgumentParser(description='build the pip package for chip using chip components generated during the build and python source code')

--- a/src/controller/python/build-chip-wheel.py
+++ b/src/controller/python/build-chip-wheel.py
@@ -28,6 +28,7 @@ from wheel.bdist_wheel import bdist_wheel
 
 import argparse
 import getpass
+import json
 import os
 import platform
 import shutil
@@ -37,11 +38,14 @@ import stat
 parser = argparse.ArgumentParser(description='build the pip package for chip using chip components generated during the build and python source code')
 parser.add_argument('--package_name', default='chip', help='configure the python package name')
 parser.add_argument('--build_number', default='0.0', help='configure the chip build number')
+parser.add_argument('--build_dir', help='directory to build in')
+parser.add_argument('--dist_dir', help='directory to place distribution in')
+parser.add_argument('--manifest', help='list of files to package')
 
 args = parser.parse_args()
 
 chipDLLName = '_ChipDeviceCtrl.so'
-deviceManagerShellName = 'chip-device-ctrl'
+deviceManagerShellName = 'chip-device-ctrl.py'
 chipControllerShellInstalledName = os.path.splitext(deviceManagerShellName)[0]
 packageName = args.package_name
 chipPackageVer = args.build_number
@@ -49,12 +53,15 @@ chipPackageVer = args.build_number
 # Record the current directory at the start of execution.
 curDir = os.curdir
 
-# Presume that the current directory is the build directory.
-buildDir = os.path.dirname(os.path.abspath(__file__))
+manifestFile = os.path.abspath(args.manifest)
+buildDir = os.path.abspath(args.build_dir)
+distDir = os.path.abspath(args.dist_dir)
 
 # Use a temporary directory within the build directory to assemble the components
 # for the installable package.
 tmpDir = os.path.join(buildDir, 'chip-wheel-components')
+
+manifest = json.load(open(manifestFile, 'r'))
 
 try:
 
@@ -65,66 +72,30 @@ try:
     # Create the temporary components directory.
     if os.path.isdir(tmpDir):
         shutil.rmtree(tmpDir)
-    os.mkdir(tmpDir)
+    os.makedirs(tmpDir, exist_ok=True)
 
     # Switch to the temporary directory. (Foolishly, setuptools relies on the current directory
     # for many of its features.)
     os.chdir(tmpDir)
 
-    # Make a copy of the chip package in the tmp directory and ensure the copied
-    # directory is writable.
-    chipPackageDir = os.path.join(tmpDir, packageName)
-    if os.path.isdir(chipPackageDir):
-        shutil.rmtree(chipPackageDir)
-    shutil.copytree(os.path.join(buildDir, 'chip'), chipPackageDir)
-    os.chmod(chipPackageDir, os.stat(chipPackageDir).st_mode|stat.S_IWUSR)
-    
-    # Copy the chip wrapper DLL from where libtool places it (.libs) into
-    # the root of the chip package directory.  This is necessary because
-    # setuptools will only add package data files that are relative to the
-    # associated package source root.
-    shutil.copy2(os.path.join(buildDir, 'chip', chipDLLName),
-                 os.path.join(chipPackageDir, chipDLLName))
-    
-    # Make a copy of the Chip Device Controller Shell script in the tmp directory,
-    # but without the .py suffix. This is how we want it to appear when installed
-    # by the wheel.
-    shutil.copy2(os.path.join(buildDir, deviceManagerShellName),
-                 os.path.join(tmpDir, chipControllerShellInstalledName))
-    
-    # Search for the CHIP LICENSE file in the parents of the source
-    # directory and make a copy of the file called LICENSE.txt in the tmp
-    # directory.  
-    def _AllDirsToRoot(dir):
-        dir = os.path.abspath(dir)
-        while True:
-            yield dir
-            parent = os.path.dirname(dir)
-            if parent == '' or parent == dir:
-                break
-            dir = parent
-    for dir in _AllDirsToRoot(buildDir):
-        licFileName = os.path.join(dir, 'LICENSE')
-        if os.path.isfile(licFileName):
-            shutil.copy2(licFileName,
-                         os.path.join(tmpDir, 'LICENSE.txt'))
-            break
-    else:
-        raise FileNotFoundError('Unable to find CHIP LICENSE file')
-    
+    manifestBase = os.path.dirname(manifestFile)
+    for entry in manifest['files']:
+        srcDir = os.path.join(manifestBase, entry['src_dir'])
+        for path in entry['sources']:
+          srcFile = os.path.join(srcDir, path)
+          dstFile = os.path.join(tmpDir, path)
+          os.makedirs(os.path.dirname(dstFile), exist_ok=True)
+          shutil.copyfile(srcFile, dstFile)
+
+    os.rename(os.path.join(tmpDir, deviceManagerShellName),
+              os.path.join(tmpDir, chipControllerShellInstalledName))
+
     # Define a custom version of the bdist_wheel command that configures the
     # resultant wheel as platform-specific (i.e. not "pure"). 
     class bdist_wheel_override(bdist_wheel):
         def finalize_options(self):
             bdist_wheel.finalize_options(self)
             self.root_is_pure = False
-    
-    # Generate a description string with information on how/when the package
-    # was built. 
-
-    buildDescription = 'Build by %s on %s\n' % (
-                            getpass.getuser(),
-                            datetime.now().strftime('%Y/%m/%d %H:%M:%S'))
     
     # Select required packages based on the target system.
     if platform.system() == 'Linux':
@@ -145,7 +116,6 @@ try:
         name=packageName,
         version=chipPackageVer,
         description='Python-base APIs and tools for CHIP.',
-        long_description=buildDescription,
         url='https://github.com/project-chip/connectedhomeip',
         license='Apache',
         classifiers=[
@@ -174,7 +144,7 @@ try:
         options={
             'bdist_wheel':{
                 'universal':False,
-                'dist_dir':buildDir         # Place the generated .whl in the build directory.
+                'dist_dir':distDir         # Place the generated .whl in the dist directory.
             },
             'egg_info':{
                 'egg_base':tmpDir           # Place the .egg-info subdirectory in the tmp directory.


### PR DESCRIPTION




<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

- Deleted files will still be packaged
- LICENSE is used without declaring it as an input
- The build user and date are included in description

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes

- Pass a list of files to package to the packager script so that
unexpected files are not included.
- Add the LICENSE file to inputs.
- Remove the description.
- Remove repeated copying. Just copy inputs once from their
original location into the temporary directory for setuptools.
- Don't package the packaging script as it's not needed.

This should be really be cleaned up further, e.g. define a reusable
py_library() template, however that is not done here.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->
<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
