### PR TITLE
Make ScopedMemoryBuffer a bit easier/safer to use.

### DIFF
--- a/src/lib/support/ScopedBuffer.h
+++ b/src/lib/support/ScopedBuffer.h
@@ -27,6 +27,8 @@
 
 #include <lib/support/CHIPMem.h>
 
+#include <type_traits>
+
 namespace chip {
 namespace Platform {
 
@@ -130,9 +132,13 @@ class ScopedMemoryBuffer : public Impl::ScopedMemoryBufferBase<MemoryManagement>
 public:
     using Base = Impl::ScopedMemoryBufferBase<MemoryManagement>;
 
-    inline T * Ptr() { return static_cast<T *>(Base::Ptr()); }
+    static_assert(std::is_trivial<T>::value, "Constructors won't get run");
 
-    inline const T * Ptr() const { return static_cast<T *>(Base::Ptr()); }
+    inline T * Get() { return static_cast<T *>(Base::Ptr()); }
+    inline T & operator[](size_t index) { return Get()[index]; }
+
+    inline const T * Get() const { return static_cast<T *>(Base::Ptr()); }
+    inline const T & operator[](size_t index) const { return Get()[index]; }
 
     inline T * Release() { return static_cast<T *>(Base::Release()); }
 

--- a/src/lib/support/tests/TestScopedBuffer.cpp
+++ b/src/lib/support/tests/TestScopedBuffer.cpp
@@ -104,11 +104,11 @@ void TestRelease(nlTestSuite * inSuite, void * inContext)
 
         NL_TEST_ASSERT(inSuite, TestCounterMemoryManagement::Counter() == 0);
         NL_TEST_ASSERT(inSuite, buffer.Alloc(128));
-        NL_TEST_ASSERT(inSuite, buffer.Ptr() != nullptr);
+        NL_TEST_ASSERT(inSuite, buffer.Get() != nullptr);
 
         ptr = buffer.Release();
         NL_TEST_ASSERT(inSuite, ptr != nullptr);
-        NL_TEST_ASSERT(inSuite, buffer.Ptr() == nullptr);
+        NL_TEST_ASSERT(inSuite, buffer.Get() == nullptr);
     }
 
     NL_TEST_ASSERT(inSuite, TestCounterMemoryManagement::Counter() == 1);

--- a/src/platform/Linux/CHIPLinuxStorage.cpp
+++ b/src/platform/Linux/CHIPLinuxStorage.cpp
@@ -225,14 +225,14 @@ CHIP_ERROR ChipLinuxStorage::WriteValueBin(const char * key, const uint8_t * dat
     {
         // We tested above that dataLen is no more than kMaxBlobSize.
         static_assert(kMaxBlobSize < UINT16_MAX, "dataLen won't fit");
-        encodedDataLen                    = Base64Encode(data, static_cast<uint16_t>(dataLen), encodedData.Ptr());
-        encodedData.Ptr()[encodedDataLen] = 0;
+        encodedDataLen              = Base64Encode(data, static_cast<uint16_t>(dataLen), encodedData.Get());
+        encodedData[encodedDataLen] = 0;
     }
 
     // Store it
     if (retval == CHIP_NO_ERROR)
     {
-        WriteValueStr(key, encodedData.Ptr());
+        WriteValueStr(key, encodedData.Get());
     }
 
     return retval;

--- a/src/platform/Linux/CHIPLinuxStorageIni.cpp
+++ b/src/platform/Linux/CHIPLinuxStorageIni.cpp
@@ -250,14 +250,14 @@ CHIP_ERROR ChipLinuxStorageIni::GetBinaryBlobDataAndLengths(const char * key,
     {
         return CHIP_ERROR_NO_MEMORY;
     }
-    encodedDataLen                    = value.copy(encodedData.Ptr(), len);
-    encodedData.Ptr()[encodedDataLen] = '\0';
+    encodedDataLen              = value.copy(encodedData.Get(), len);
+    encodedData[encodedDataLen] = '\0';
 
     // Check if encoded data was padded. Only "=" or "==" padding combinations are allowed.
-    if ((encodedDataLen > 0) && (encodedData.Ptr()[encodedDataLen - 1] == '='))
+    if ((encodedDataLen > 0) && (encodedData[encodedDataLen - 1] == '='))
     {
         encodedDataPaddingLen++;
-        if ((encodedDataLen > 1) && (encodedData.Ptr()[encodedDataLen - 2] == '='))
+        if ((encodedDataLen > 1) && (encodedData[encodedDataLen - 2] == '='))
             encodedDataPaddingLen++;
     }
 
@@ -295,7 +295,7 @@ CHIP_ERROR ChipLinuxStorageIni::GetBinaryBlobValue(const char * key, uint8_t * d
 
     // Decode it
     // Cast is safe because we checked encodedDataLen above.
-    decodedDataLen = Base64Decode(encodedData.Ptr(), static_cast<uint16_t>(encodedDataLen), (uint8_t *) decodedData);
+    decodedDataLen = Base64Decode(encodedData.Get(), static_cast<uint16_t>(encodedDataLen), decodedData);
     if (decodedDataLen == UINT16_MAX || decodedDataLen > expectedDecodedLen)
     {
         return CHIP_ERROR_DECODE_FAILED;

--- a/src/platform/nRF5/GroupKeyStoreImpl.cpp
+++ b/src/platform/nRF5/GroupKeyStoreImpl.cpp
@@ -141,7 +141,7 @@ CHIP_ERROR GroupKeyStoreImpl::StoreGroupKey(const ChipGroupKey & key)
 exit:
     if (storedVal != NULL)
     {
-        ClearSecretData(storedVal.Ptr<uint8_t>(), storedValLen);
+        ClearSecretData(storedVal, storedValLen);
         vPortFree(storedVal);
     }
     return err;


### PR DESCRIPTION
* Add conversion and [] operators so you can use it as an array directly.

* Add a static assert that the type being stored doesn't have a
  nontrivial default constructor (which will not get run when the
  buffer is allocated).