### PR TITLE
Add Basic cluster commands to chip-tool and src/app/

### DIFF
--- a/examples/chip-tool/commands/clusters/Basic/Commands.h
+++ b/examples/chip-tool/commands/clusters/Basic/Commands.h
@@ -1,0 +1,47 @@
+/*
+ *   Copyright (c) 2020 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#ifndef __CHIPTOOL_BASIC_COMMANDS_H__
+#define __CHIPTOOL_BASIC_COMMANDS_H__
+
+#include "../../common/ModelCommand.h"
+
+class ResetToFactory : public ModelCommand
+{
+public:
+    ResetToFactory(const uint16_t clusterId) : ModelCommand("reset-to-factory", clusterId) {}
+
+    size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
+    {
+        return encodeResetToFactoryCommand(buffer->Start(), bufferSize, endPointId);
+    }
+};
+
+void registerClusterBasic(Commands & commands)
+{
+    const char * clusterName = "Basic";
+    const uint16_t clusterId = 0x0000;
+
+    commands_list clusterCommands = {
+        make_unique<ResetToFactory>(clusterId),
+    };
+
+    commands.Register(clusterName, clusterCommands);
+}
+
+#endif // __CHIPTOOL_BASIC_COMMANDS_H__

--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -18,6 +18,7 @@
 
 #include "commands/common/Commands.h"
 
+#include "commands/clusters/Basic/Commands.h"
 #include "commands/clusters/ColorControl/Commands.h"
 #include "commands/clusters/Identify/Commands.h"
 #include "commands/clusters/OnOff/Commands.h"
@@ -38,6 +39,7 @@ int main(int argc, char * argv[])
     Commands commands;
 
     registerCommandsEcho(commands);
+    registerClusterBasic(commands);
     registerClusterColorControl(commands);
     registerClusterIdentify(commands);
     registerClusterOnOff(commands);

--- a/src/app/chip-zcl-zpro-codec.h
+++ b/src/app/chip-zcl-zpro-codec.h
@@ -340,6 +340,18 @@ uint16_t encodeStepColorTemperatureCommand(uint8_t * buffer, uint16_t buf_length
 uint16_t encodeStopMoveStepCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint8_t optionMask,
                                    uint8_t optionOverride);
 
+/**
+ * Basic cluster commands
+ */
+
+/**
+ * @brief Encode a reset-to-factory command for the Basic cluster
+ * @param buffer                Buffer to encode into
+ * @param buf_length            Length of buffer
+ * @param destination_endpoint  Destination endpoint
+ * */
+uint16_t encodeResetToFactoryCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/app/encoder.cpp
+++ b/src/app/encoder.cpp
@@ -166,6 +166,7 @@ uint16_t encodeReadAttributesCommand(uint8_t * buffer, uint16_t buf_length, uint
     COMMAND_HEADER(name, cluster_id, command_id);                                                                                  \
     COMMAND_FOOTER(name);
 
+#define BASIC_CLUSTER_ID 0x0000
 #define ONOFF_CLUSTER_ID 0x0006
 #define IDENTIFY_CLUSTER_ID 0x0003
 #define TEMP_MEASUREMENT_CLUSTER_ID 0x0402
@@ -389,6 +390,15 @@ uint16_t encodeStopMoveStepCommand(uint8_t * buffer, uint16_t buf_length, uint8_
     buf.Put(optionMask);
     buf.Put(optionOverride);
     COMMAND_FOOTER("StopMoveStep");
+}
+
+/*
+ * Basic Cluster commands
+ */
+
+uint16_t encodeResetToFactoryCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+{
+    COMMAND("ResetToFactory", BASIC_CLUSTER_ID, 0x00);
 }
 
 } // extern "C"


### PR DESCRIPTION
 #### Problem

This PR add Basic cluster commands to chip-tool and to src/app.

 #### Summary of Changes
* Add a command to chip-tool for the Basic cluster
* Add a command inside src/app for the Basic cluster