### PR TITLE
Make sure scoped buffer test test calls Platform::MemoryInit

### DIFF
--- a/src/lib/support/tests/TestScopedBuffer.cpp
+++ b/src/lib/support/tests/TestScopedBuffer.cpp
@@ -132,6 +132,12 @@ int Setup(void * inContext)
     return SUCCESS;
 }
 
+int Teardown(void * inContext)
+{
+    chip::Platform::MemoryShutdown();
+    return SUCCESS;
+}
+
 } // namespace
 
 #define NL_TEST_DEF_FN(fn) NL_TEST_DEF("Test " #fn, fn)
@@ -147,7 +153,7 @@ static const nlTest sTests[] = {
 
 int TestScopedBuffer(void)
 {
-    nlTestSuite theSuite = { "CHIP ScopedBuffer tests", &sTests[0], Setup, nullptr };
+    nlTestSuite theSuite = { "CHIP ScopedBuffer tests", &sTests[0], Setup, Teardown };
 
     // Run test suit againt one context.
     nlTestRunner(&theSuite, nullptr);

--- a/src/lib/support/tests/TestScopedBuffer.cpp
+++ b/src/lib/support/tests/TestScopedBuffer.cpp
@@ -124,6 +124,14 @@ void TestRelease(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, TestCounterMemoryManagement::Counter() == 0);
 }
 
+int Setup(void * inContext)
+{
+    CHIP_ERROR error = chip::Platform::MemoryInit();
+    if (error != CHIP_NO_ERROR)
+        return FAILURE;
+    return SUCCESS;
+}
+
 } // namespace
 
 #define NL_TEST_DEF_FN(fn) NL_TEST_DEF("Test " #fn, fn)
@@ -139,7 +147,7 @@ static const nlTest sTests[] = {
 
 int TestScopedBuffer(void)
 {
-    nlTestSuite theSuite = { "CHIP ScopedBuffer tests", &sTests[0], nullptr, nullptr };
+    nlTestSuite theSuite = { "CHIP ScopedBuffer tests", &sTests[0], Setup, nullptr };
 
     // Run test suit againt one context.
     nlTestRunner(&theSuite, nullptr);


### PR DESCRIPTION
 #### Problem
 We now have a check that MemoryInit is called even on systems using malloc.

 #### Summary of Changes
 Add a setup method that initializes the test and a teardown that removes it.
