### PR TITLE
Add ResetToFactoryDefaults callback to the examples/wifi-echo applica…

### DIFF
--- a/examples/wifi-echo/server/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/wifi-echo/server/esp32/main/CHIPDeviceManager.cpp
@@ -90,15 +90,25 @@ exit:
 }
 
 extern "C" {
-void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+void emberAfPostAttributeChangeCallback(uint8_t endpointId, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
+                                        uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
 {
     CHIPDeviceManagerCallbacks * cb = CHIPDeviceManager::GetInstance().GetCHIPDeviceManagerCallbacks();
     if (cb != nullptr)
     {
-        cb->PostAttributeChangeCallback(endpoint, clusterId, attributeId, mask, manufacturerCode, type, size, value);
+        cb->PostAttributeChangeCallback(endpointId, clusterId, attributeId, mask, manufacturerCode, type, size, value);
     }
 }
+
+void emberAfPluginBasicResetToFactoryDefaultsCallback(uint8_t endpointId)
+{
+    CHIPDeviceManagerCallbacks * cb = CHIPDeviceManager::GetInstance().GetCHIPDeviceManagerCallbacks();
+    if (cb != nullptr)
+    {
+        cb->PluginBasicResetToFactoryDefaultsCallback(endpointId);
+    }
+}
+
 } // extern "C"
 
 } // namespace DeviceManager

--- a/examples/wifi-echo/server/esp32/main/DeviceCallbacks.cpp
+++ b/examples/wifi-echo/server/esp32/main/DeviceCallbacks.cpp
@@ -163,3 +163,15 @@ void DeviceCallbacks::OnIdentifyPostAttributeChangeCallback(uint8_t endpointId, 
 exit:
     return;
 }
+
+void DeviceCallbacks::PluginBasicResetToFactoryDefaultsCallback(uint8_t endpointId)
+{
+    ESP_LOGI(TAG, "PluginBasicResetToFactoryDefaultsCallback - EndPoint ID: '0x%02x'", endpointId);
+
+    VerifyOrExit(endpointId == 1, ESP_LOGE(TAG, "Unexpected EndPoint ID: `0x%02x'", endpointId));
+
+    ConnectivityMgr().ClearWiFiStationProvision();
+
+exit:
+    return;
+}

--- a/examples/wifi-echo/server/esp32/main/gen/callback-stub.c
+++ b/examples/wifi-echo/server/esp32/main/gen/callback-stub.c
@@ -98,18 +98,6 @@ bool emberAfPluginGroupsServerGroupNamesSupportedCallback(uint8_t endpoint)
  */
 void emberAfPluginGroupsServerSetGroupNameCallback(uint8_t endpoint, uint16_t groupId, uint8_t * groupName) {}
 
-/** @brief Basic Cluster Reset To Factory Defaults
- *
- * This function is called by the Basic server plugin when a request to
- * reset to factory defaults is received. The plugin will reset attributes
- * managed by the framework to their default values.
- * The application should perform any other necessary reset-related operations
- * in this callback, including resetting any externally-stored attributes.
- *
- * @param endpoint Endpoint that is being initialized  Ver.: always
- */
-void emberAfPluginBasicResetToFactoryDefaultsCallback(uint8_t endpoint) {}
-
 /** @brief Add To Current App Tasks
  *
  * This function is only useful to sleepy end devices.  This function will note
@@ -1785,29 +1773,6 @@ int8_t emberAfPluginNetworkSteeringGetPowerForRadioChannelCallback(uint8_t chann
 {
     return emberAfMaxPowerLevel();
 }
-
-// Ifdef out the attribute change callback, since we implement it in
-// DataModelHandler
-#if 0
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
-{}
-#endif
 
 /** @brief Post Em4 Reset
  *

--- a/examples/wifi-echo/server/esp32/main/include/CHIPDeviceManager.h
+++ b/examples/wifi-echo/server/esp32/main/include/CHIPDeviceManager.h
@@ -62,6 +62,14 @@ public:
 
     /**
      * @brief
+     *   Called when the ResetToFactoryDefaults method of the Basic cluster object has been called
+     *
+     * @param endpoint           endpoint id
+     */
+    virtual void PluginBasicResetToFactoryDefaultsCallback(uint8_t endpointId);
+
+    /**
+     * @brief
      *   Called after an attribute has been changed
      *
      * @param endpoint           endpoint id

--- a/examples/wifi-echo/server/esp32/main/include/DeviceCallbacks.h
+++ b/examples/wifi-echo/server/esp32/main/include/DeviceCallbacks.h
@@ -34,6 +34,7 @@ class DeviceCallbacks : public chip::DeviceManager::CHIPDeviceManagerCallbacks
 {
 public:
     virtual void DeviceEventCallback(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
+    virtual void PluginBasicResetToFactoryDefaultsCallback(uint8_t endpointId);
     virtual void PostAttributeChangeCallback(uint8_t endpointId, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
                                              uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value);
 


### PR DESCRIPTION
…tion


 #### Problem
This is the device side of #3049 . 
For now it resets the WiFi credentials on the device. Useful when you have a device that has no screen and you want to reset the WiFi credentials that has been previously set.

At the end of the day I think we may want to have something different for callbacks on the app side, but I do not have a proposal at the moment.

 #### Summary of Changes
* Implement the emberAfPluginBasicResetToFactoryDefaultsCallback function