### PR TITLE
Force scripts to run with python3

### DIFF
--- a/.gn
+++ b/.gn
@@ -23,6 +23,8 @@ secondary_source = "//gn/"
 
 import("//gn/build_overrides/pigweed.gni")
 
+script_executable = "python3"
+
 default_args = {
   pw_unit_test_AUTOMATIC_RUNNER = "$dir_pigweed/targets/host/run_test"
 }

--- a/gn/chip/python_gen_tags.py
+++ b/gn/chip/python_gen_tags.py
@@ -15,5 +15,15 @@
 
 # Utility script to genertae the python tag + the abi tag + platform tag for a Python
 
-from setuptools.pep425tags import get_abbr_impl, get_impl_ver, get_abi_tag, get_platform
-print(get_abbr_impl() + get_impl_ver() + "-" + get_abi_tag() + "-" + get_platform())
+try:
+  from setuptools import pep425tags
+except ImportError:
+  from wheel import pep425tags
+
+try:
+  platform_tag = pep425tags.get_platform(None)
+except TypeError:
+  platform_tag = pep425tags.get_platform()
+
+print(pep425tags.get_abbr_impl() + pep425tags.get_impl_ver() + "-" +
+      pep425tags.get_abi_tag() + "-" + platform_tag)


### PR DESCRIPTION
If the environmental python is python2, scripts with type hints will
fail to parse. Force python to python3 until "python" is version 3 on
more systems.

This makes the default build work without bootstrapping on common Linux
environments and Mac (except that gn & ninja must be provided by other
means).