### PR TITLE
Remove remaining Linux C-style casts & fix const correctness

### DIFF
--- a/examples/shell/shell_common/cmd_device.cpp
+++ b/examples/shell/shell_common/cmd_device.cpp
@@ -177,7 +177,7 @@ static CHIP_ERROR ConfigGetDeviceCert(bool printHeader)
         streamer_printf(sout, "DeviceCert:      ");
     }
     // Determine the length of the device certificate.
-    error = ConfigurationMgr().GetDeviceCertificate((uint8_t *) nullptr, 0, certLen);
+    error = ConfigurationMgr().GetDeviceCertificate(nullptr, 0, certLen);
     SuccessOrExit(error);
 
     // Fail if no certificate has been configured.
@@ -213,7 +213,7 @@ static CHIP_ERROR ConfigGetDeviceCaCerts(bool printHeader)
         streamer_printf(sout, "DeviceCaCerts:   ");
     }
     // Determine the length of the device certificate.
-    error = ConfigurationMgr().GetDeviceIntermediateCACerts((uint8_t *) nullptr, 0, certLen);
+    error = ConfigurationMgr().GetDeviceIntermediateCACerts(nullptr, 0, certLen);
     SuccessOrExit(error);
 
     // Fail if no certificate has been configured.
@@ -266,7 +266,7 @@ static CHIP_ERROR ConfigGetManufacturerDeviceCert(bool printHeader)
         streamer_printf(sout, "MfrDeviceCert:   ");
     }
     // Determine the length of the device certificate.
-    error = ConfigurationMgr().GetManufacturerDeviceCertificate((uint8_t *) nullptr, 0, certLen);
+    error = ConfigurationMgr().GetManufacturerDeviceCertificate(nullptr, 0, certLen);
     SuccessOrExit(error);
 
     // Fail if no certificate has been configured.
@@ -302,7 +302,7 @@ static CHIP_ERROR ConfigGetManufacturerDeviceCaCerts(bool printHeader)
         streamer_printf(sout, "MfgDeviceCaCerts:");
     }
     // Determine the length of the device certificate.
-    error = ConfigurationMgr().GetManufacturerDeviceIntermediateCACerts((uint8_t *) nullptr, 0, certLen);
+    error = ConfigurationMgr().GetManufacturerDeviceIntermediateCACerts(nullptr, 0, certLen);
     SuccessOrExit(error);
 
     // Fail if no certificate has been configured.

--- a/src/ble/BLEEndPoint.cpp
+++ b/src/ble/BLEEndPoint.cpp
@@ -551,7 +551,7 @@ BLE_ERROR BLEEndPoint::Init(BleLayer * bleLayer, BLE_CONNECTION_OBJECT connObj, 
     //
     // Beware this line should we ever use virtuals in this class or its
     // super(s). See similar lines in chip::System::Layer end points.
-    memset((void *) this, 0, sizeof(*this));
+    memset(this, 0, sizeof(*this));
 
     // If end point plays peripheral role, expect ack for indication sent as last step of BTP handshake.
     // If central, periperal's handshake indication 'ack's write sent by central to kick off the BTP handshake.

--- a/src/ble/BtpEngine.h
+++ b/src/ble/BtpEngine.h
@@ -92,9 +92,6 @@ public:
 
 public:
     // Public functions:
-    BtpEngine() {}
-    ~BtpEngine() {}
-
     BLE_ERROR Init(void * an_app_state, bool expect_first_ack);
 
     inline void SetTxFragmentSize(uint8_t size) { mTxFragmentSize = size; }

--- a/src/controller/python/ChipDeviceController-BlePlatformDelegate.cpp
+++ b/src/controller/python/ChipDeviceController-BlePlatformDelegate.cpp
@@ -38,7 +38,7 @@ bool DeviceController_BlePlatformDelegate::SubscribeCharacteristic(BLE_CONNECTIO
 
     if (subscribeCB && svcId && charId)
     {
-        return subscribeCB(connObj, (void *) svcId->bytes, (void *) charId->bytes, subscribe);
+        return subscribeCB(connObj, static_cast<const void *>(svcId->bytes), static_cast<const void *>(charId->bytes), subscribe);
     }
 
     return false;
@@ -52,7 +52,7 @@ bool DeviceController_BlePlatformDelegate::UnsubscribeCharacteristic(BLE_CONNECT
 
     if (subscribeCB && svcId && charId)
     {
-        return subscribeCB(connObj, (void *) svcId->bytes, (void *) charId->bytes, !subscribe);
+        return subscribeCB(connObj, static_cast<const void *>(svcId->bytes), static_cast<const void *>(charId->bytes), !subscribe);
     }
 
     return false;
@@ -94,7 +94,8 @@ bool DeviceController_BlePlatformDelegate::SendWriteRequest(BLE_CONNECTION_OBJEC
 
     if (writeCB && svcId && charId && pBuf)
     {
-        ret = writeCB(connObj, (void *) svcId->bytes, (void *) charId->bytes, (void *) pBuf->Start(), pBuf->DataLength());
+        ret = writeCB(connObj, static_cast<const void *>(svcId->bytes), static_cast<const void *>(charId->bytes),
+                      static_cast<void *>(pBuf->Start()), pBuf->DataLength());
     }
 
     // Release delegate's reference to pBuf. pBuf will be freed when both platform delegate and Chip stack free their references to

--- a/src/controller/python/ChipDeviceController-BlePlatformDelegate.h
+++ b/src/controller/python/ChipDeviceController-BlePlatformDelegate.h
@@ -23,8 +23,9 @@
 #include <ble/BleLayer.h>
 #include <ble/BlePlatformDelegate.h>
 
-typedef bool (*WriteBleCharacteristicCBFunct)(void * connObj, void * svcId, void * charId, void * buffer, uint16_t length);
-typedef bool (*SubscribeBleCharacteristicCBFunct)(void * connObj, void * svcId, void * charId, bool subscribe);
+typedef bool (*WriteBleCharacteristicCBFunct)(void * connObj, const void * svcId, const void * charId, const void * buffer,
+                                              uint16_t length);
+typedef bool (*SubscribeBleCharacteristicCBFunct)(void * connObj, const void * svcId, const void * charId, bool subscribe);
 typedef bool (*CloseBleCBFunct)(void * connObj);
 
 class DeviceController_BlePlatformDelegate : public chip::Ble::BlePlatformDelegate

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -108,7 +108,8 @@ class ECPKey
 public:
     virtual SupportedECPKeyTypes Type() const = 0;
     virtual size_t Length() const             = 0;
-    virtual operator uint8_t *() const        = 0;
+    virtual operator const uint8_t *() const  = 0;
+    virtual operator uint8_t *()              = 0;
 
     virtual CHIP_ERROR ECDSA_validate_msg_signature(const uint8_t * msg, const size_t msg_length, const Sig & signature) const
     {
@@ -143,7 +144,8 @@ public:
 
     /** @brief Returns buffer pointer
      **/
-    operator uint8_t *() const { return (uint8_t *) bytes; }
+    operator uint8_t *() { return bytes; }
+    operator const uint8_t *() const { return bytes; }
 
 private:
     uint8_t bytes[Cap];
@@ -159,7 +161,8 @@ class P256PublicKey : public ECPKey<P256ECDSASignature>
 public:
     SupportedECPKeyTypes Type() const override { return SupportedECPKeyTypes::ECP256R1; }
     size_t Length() const override { return kP256_PublicKey_Length; }
-    operator uint8_t *() const override { return (uint8_t *) bytes; }
+    operator uint8_t *() override { return bytes; }
+    operator const uint8_t *() const override { return bytes; }
 
     CHIP_ERROR ECDSA_validate_msg_signature(const uint8_t * msg, const size_t msg_length,
                                             const P256ECDSASignature & signature) const override;

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -649,7 +649,7 @@ public:
 
     void * M;
     void * N;
-    void * G;
+    const void * G;
     void * X;
     void * Y;
     void * L;

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -238,9 +238,11 @@ CHIP_ERROR AES_CCM_decrypt(const uint8_t * ciphertext, size_t ciphertext_length,
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
     // Pass in expected tag
+    // Removing "const" from |tag| here should hopefully be safe as
+    // we're writing the tag, not reading.
     VerifyOrExit(CanCastTo<int>(tag_length), error = CHIP_ERROR_INVALID_ARGUMENT);
     result = EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_CCM_SET_TAG, static_cast<int>(tag_length),
-                                 const_cast<void *>(reinterpret_cast<const void *>(tag)));
+                                 const_cast<void *>(static_cast<const void *>(tag)));
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
     // Pass in key + iv

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -1103,7 +1103,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal()
     context->curve = EC_GROUP_new_by_curve_name(NID_X9_62_prime256v1);
     VerifyOrExit(context->curve != nullptr, error = CHIP_ERROR_INTERNAL);
 
-    G = const_cast<void *>(reinterpret_cast<const void *>(EC_GROUP_get0_generator(context->curve)));
+    G = EC_GROUP_get0_generator(context->curve);
     VerifyOrExit(G != nullptr, error = CHIP_ERROR_INTERNAL);
 
     context->bn_ctx = BN_CTX_secure_new();

--- a/src/include/platform/internal/BLEManager.h
+++ b/src/include/platform/internal/BLEManager.h
@@ -65,7 +65,7 @@ public:
     CHIP_ERROR SetDeviceName(const char * deviceName);
     uint16_t NumConnections();
     void OnPlatformEvent(const ChipDeviceEvent * event);
-    chip::Ble::BleLayer * GetBleLayer() const;
+    chip::Ble::BleLayer * GetBleLayer();
 
 protected:
     // Construction/destruction limited to subclasses.
@@ -171,9 +171,9 @@ inline void BLEManager::OnPlatformEvent(const ChipDeviceEvent * event)
     return static_cast<ImplClass *>(this)->_OnPlatformEvent(event);
 }
 
-inline chip::Ble::BleLayer * BLEManager::GetBleLayer() const
+inline chip::Ble::BleLayer * BLEManager::GetBleLayer()
 {
-    return static_cast<const ImplClass *>(this)->_GetBleLayer();
+    return static_cast<ImplClass *>(this)->_GetBleLayer();
 }
 
 } // namespace Internal

--- a/src/inet/IPAddress-StringFuncts.cpp
+++ b/src/inet/IPAddress-StringFuncts.cpp
@@ -69,13 +69,16 @@ char * IPAddress::ToString(char * buf, uint32_t bufSize) const
 #if INET_CONFIG_ENABLE_IPV4
     if (IsIPv4())
     {
-        buf =
-            const_cast<char *>(inet_ntop(AF_INET, reinterpret_cast<const void *>(&Addr[3]), buf, static_cast<socklen_t>(bufSize)));
+        const void *addr = &Addr[3];
+        const char *s = inet_ntop(AF_INET, addr, buf, static_cast<socklen_t>(bufSize));
+        buf = buf + (s - buf);
     }
     else
 #endif // INET_CONFIG_ENABLE_IPV4
     {
-        buf = const_cast<char *>(inet_ntop(AF_INET6, reinterpret_cast<const void *>(Addr), buf, static_cast<socklen_t>(bufSize)));
+        const void *addr = &Addr[0];
+        const char *s = inet_ntop(AF_INET6, addr, buf, static_cast<socklen_t>(bufSize));
+        buf = buf + (s - buf);
     }
 #endif // !CHIP_SYSTEM_CONFIG_USE_LWIP
 

--- a/src/inet/IPAddress-StringFuncts.cpp
+++ b/src/inet/IPAddress-StringFuncts.cpp
@@ -69,16 +69,16 @@ char * IPAddress::ToString(char * buf, uint32_t bufSize) const
 #if INET_CONFIG_ENABLE_IPV4
     if (IsIPv4())
     {
-        const void *addr = &Addr[3];
-        const char *s = inet_ntop(AF_INET, addr, buf, static_cast<socklen_t>(bufSize));
+        const void * addr = &Addr[3];
+        const char * s    = inet_ntop(AF_INET, addr, buf, static_cast<socklen_t>(bufSize));
         // This cast is safe because |s| points into |buf| which is not const.
         buf = const_cast<char *>(s);
     }
     else
 #endif // INET_CONFIG_ENABLE_IPV4
     {
-        const void *addr = &Addr[0];
-        const char *s = inet_ntop(AF_INET6, addr, buf, static_cast<socklen_t>(bufSize));
+        const void * addr = &Addr[0];
+        const char * s    = inet_ntop(AF_INET6, addr, buf, static_cast<socklen_t>(bufSize));
         // This cast is safe because |s| points into |buf| which is not const.
         buf = const_cast<char *>(s);
     }

--- a/src/inet/IPAddress-StringFuncts.cpp
+++ b/src/inet/IPAddress-StringFuncts.cpp
@@ -71,14 +71,16 @@ char * IPAddress::ToString(char * buf, uint32_t bufSize) const
     {
         const void *addr = &Addr[3];
         const char *s = inet_ntop(AF_INET, addr, buf, static_cast<socklen_t>(bufSize));
-        buf = buf + (s - buf);
+        // This cast is safe because |s| points into |buf| which is not const.
+        buf = const_cast<char *>(s);
     }
     else
 #endif // INET_CONFIG_ENABLE_IPV4
     {
         const void *addr = &Addr[0];
         const char *s = inet_ntop(AF_INET6, addr, buf, static_cast<socklen_t>(bufSize));
-        buf = buf + (s - buf);
+        // This cast is safe because |s| points into |buf| which is not const.
+        buf = const_cast<char *>(s);
     }
 #endif // !CHIP_SYSTEM_CONFIG_USE_LWIP
 

--- a/src/inet/IPAddress-StringFuncts.cpp
+++ b/src/inet/IPAddress-StringFuncts.cpp
@@ -69,12 +69,13 @@ char * IPAddress::ToString(char * buf, uint32_t bufSize) const
 #if INET_CONFIG_ENABLE_IPV4
     if (IsIPv4())
     {
-        buf = const_cast<char *>(inet_ntop(AF_INET, (const void *) &Addr[3], buf, static_cast<socklen_t>(bufSize)));
+        buf =
+            const_cast<char *>(inet_ntop(AF_INET, reinterpret_cast<const void *>(&Addr[3]), buf, static_cast<socklen_t>(bufSize)));
     }
     else
 #endif // INET_CONFIG_ENABLE_IPV4
     {
-        buf = const_cast<char *>(inet_ntop(AF_INET6, (const void *) Addr, buf, static_cast<socklen_t>(bufSize)));
+        buf = const_cast<char *>(inet_ntop(AF_INET6, reinterpret_cast<const void *>(Addr), buf, static_cast<socklen_t>(bufSize)));
     }
 #endif // !CHIP_SYSTEM_CONFIG_USE_LWIP
 

--- a/src/inet/IPAddress.cpp
+++ b/src/inet/IPAddress.cpp
@@ -149,7 +149,7 @@ lwip_ip_addr_type IPAddress::ToLwIPAddrType(IPAddressType typ)
 #if INET_CONFIG_ENABLE_IPV4
 ip4_addr_t IPAddress::ToIPv4() const
 {
-    return *(ip4_addr_t *) &Addr[3];
+    return *reinterpret_cast<const ip4_addr_t *>(&Addr[3]);
 }
 
 IPAddress IPAddress::FromIPv4(const ip4_addr_t & ipv4Addr)
@@ -203,7 +203,10 @@ IPAddress IPAddress::FromIPv4(const struct in_addr & ipv4Addr)
 
 struct in6_addr IPAddress::ToIPv6() const
 {
-    return *(struct in6_addr *) &Addr;
+    in6_addr addr;
+    static_assert(sizeof(addr) == sizeof(Addr), "in6_addr size mismatch");
+    memcpy(&addr, Addr, sizeof(addr));
+    return addr;
 }
 
 IPAddress IPAddress::FromIPv6(const struct in6_addr & ipv6Addr)
@@ -225,10 +228,10 @@ IPAddress IPAddress::FromSockAddr(const struct sockaddr & sockaddr)
 {
 #if INET_CONFIG_ENABLE_IPV4
     if (sockaddr.sa_family == AF_INET)
-        return FromIPv4(((sockaddr_in *) &sockaddr)->sin_addr);
+        return FromIPv4(reinterpret_cast<const sockaddr_in *>(&sockaddr)->sin_addr);
 #endif // INET_CONFIG_ENABLE_IPV4
     if (sockaddr.sa_family == AF_INET6)
-        return FromIPv6(((sockaddr_in6 *) &sockaddr)->sin6_addr);
+        return FromIPv6(reinterpret_cast<const sockaddr_in6 *>(&sockaddr)->sin6_addr);
     return Any;
 }
 

--- a/src/inet/IPAddress.cpp
+++ b/src/inet/IPAddress.cpp
@@ -150,8 +150,7 @@ lwip_ip_addr_type IPAddress::ToLwIPAddrType(IPAddressType typ)
 ip4_addr_t IPAddress::ToIPv4() const
 {
     ip4_addr_t addr;
-    static_assert(sizeof(addr) == sizeof(mAddr), "ip4_addr_t size mismatch")
-    memcpy(&addr, mAddr, sizeof(addr));
+    static_assert(sizeof(addr) == sizeof(mAddr), "ip4_addr_t size mismatch") memcpy(&addr, mAddr, sizeof(addr));
     return addr;
 }
 

--- a/src/inet/IPAddress.cpp
+++ b/src/inet/IPAddress.cpp
@@ -149,7 +149,10 @@ lwip_ip_addr_type IPAddress::ToLwIPAddrType(IPAddressType typ)
 #if INET_CONFIG_ENABLE_IPV4
 ip4_addr_t IPAddress::ToIPv4() const
 {
-    return *reinterpret_cast<const ip4_addr_t *>(&Addr[3]);
+    ip4_addr_t addr;
+    static_assert(sizeof(addr) == sizeof(mAddr), "ip4_addr_t size mismatch")
+    memcpy(&addr, mAddr, sizeof(addr));
+    return addr;
 }
 
 IPAddress IPAddress::FromIPv4(const ip4_addr_t & ipv4Addr)
@@ -165,16 +168,17 @@ IPAddress IPAddress::FromIPv4(const ip4_addr_t & ipv4Addr)
 
 ip6_addr_t IPAddress::ToIPv6() const
 {
-    return *(ip6_addr_t *) Addr;
+    ip6_addr_t addr;
+    static_assert(sizeof(addr) == sizeof(Addr), "ip6_addr_t size mismatch");
+    memcpy(&addr, Addr, sizeof(addr));
+    return addr;
 }
 
 IPAddress IPAddress::FromIPv6(const ip6_addr_t & ipv6Addr)
 {
     IPAddress ipAddr;
-    ipAddr.Addr[0] = ipv6Addr.addr[0];
-    ipAddr.Addr[1] = ipv6Addr.addr[1];
-    ipAddr.Addr[2] = ipv6Addr.addr[2];
-    ipAddr.Addr[3] = ipv6Addr.addr[3];
+    static_assert(sizeof(ipAddr) == sizeof(Addr), "ip6_addr_t size mismatch");
+    memcpy(ipAddr.Addr, &ipv6Addr, sizeof(ipv6Addr));
     return ipAddr;
 }
 
@@ -203,24 +207,17 @@ IPAddress IPAddress::FromIPv4(const struct in_addr & ipv4Addr)
 
 struct in6_addr IPAddress::ToIPv6() const
 {
-    in6_addr addr;
-    static_assert(sizeof(addr) == sizeof(Addr), "in6_addr size mismatch");
-    memcpy(&addr, Addr, sizeof(addr));
-    return addr;
+    in6_addr ipAddr;
+    static_assert(sizeof(ipAddr) == sizeof(Addr), "in6_addr size mismatch");
+    memcpy(&ipAddr, Addr, sizeof(ipAddr));
+    return ipAddr;
 }
 
 IPAddress IPAddress::FromIPv6(const struct in6_addr & ipv6Addr)
 {
     IPAddress ipAddr;
-    ipAddr.Addr[0] = htonl((static_cast<uint32_t>(ipv6Addr.s6_addr[0])) << 24 | (static_cast<uint32_t>(ipv6Addr.s6_addr[1])) << 16 |
-                           (static_cast<uint32_t>(ipv6Addr.s6_addr[2])) << 8 | (static_cast<uint32_t>(ipv6Addr.s6_addr[3])));
-    ipAddr.Addr[1] = htonl((static_cast<uint32_t>(ipv6Addr.s6_addr[4])) << 24 | (static_cast<uint32_t>(ipv6Addr.s6_addr[5])) << 16 |
-                           (static_cast<uint32_t>(ipv6Addr.s6_addr[6])) << 8 | (static_cast<uint32_t>(ipv6Addr.s6_addr[7])));
-    ipAddr.Addr[2] = htonl((static_cast<uint32_t>(ipv6Addr.s6_addr[8])) << 24 | (static_cast<uint32_t>(ipv6Addr.s6_addr[9])) << 16 |
-                           (static_cast<uint32_t>(ipv6Addr.s6_addr[10])) << 8 | (static_cast<uint32_t>(ipv6Addr.s6_addr[11])));
-    ipAddr.Addr[3] =
-        htonl((static_cast<uint32_t>(ipv6Addr.s6_addr[12])) << 24 | (static_cast<uint32_t>(ipv6Addr.s6_addr[13])) << 16 |
-              (static_cast<uint32_t>(ipv6Addr.s6_addr[14])) << 8 | (static_cast<uint32_t>(ipv6Addr.s6_addr[15])));
+    static_assert(sizeof(ipAddr) == sizeof(ipv6Addr), "in6_addr size mismatch");
+    memcpy(ipAddr.Addr, &ipv6Addr, sizeof(ipv6Addr));
     return ipAddr;
 }
 

--- a/src/inet/IPAddress.cpp
+++ b/src/inet/IPAddress.cpp
@@ -150,7 +150,8 @@ lwip_ip_addr_type IPAddress::ToLwIPAddrType(IPAddressType typ)
 ip4_addr_t IPAddress::ToIPv4() const
 {
     ip4_addr_t addr;
-    static_assert(sizeof(addr) == sizeof(mAddr), "ip4_addr_t size mismatch") memcpy(&addr, mAddr, sizeof(addr));
+    static_assert(sizeof(addr) == sizeof(mAddr), "ip4_addr_t size mismatch");
+    memcpy(&addr, mAddr, sizeof(addr));
     return addr;
 }
 

--- a/src/inet/IPAddress.cpp
+++ b/src/inet/IPAddress.cpp
@@ -149,10 +149,9 @@ lwip_ip_addr_type IPAddress::ToLwIPAddrType(IPAddressType typ)
 #if INET_CONFIG_ENABLE_IPV4
 ip4_addr_t IPAddress::ToIPv4() const
 {
-    ip4_addr_t addr;
-    static_assert(sizeof(addr) == sizeof(mAddr), "ip4_addr_t size mismatch");
-    memcpy(&addr, mAddr, sizeof(addr));
-    return addr;
+    ip4_addr_t ipAddr;
+    memcpy(&ipAddr, &Addr[3], sizeof(ipAddr));
+    return ipAddr;
 }
 
 IPAddress IPAddress::FromIPv4(const ip4_addr_t & ipv4Addr)
@@ -168,10 +167,10 @@ IPAddress IPAddress::FromIPv4(const ip4_addr_t & ipv4Addr)
 
 ip6_addr_t IPAddress::ToIPv6() const
 {
-    ip6_addr_t addr;
-    static_assert(sizeof(addr) == sizeof(Addr), "ip6_addr_t size mismatch");
-    memcpy(&addr, Addr, sizeof(addr));
-    return addr;
+    ip6_addr_t ipAddr;
+    static_assert(sizeof(ipAddr) == sizeof(Addr), "ip6_addr_t size mismatch");
+    memcpy(&ipAddr, Addr, sizeof(ipAddr));
+    return ipAddr;
 }
 
 IPAddress IPAddress::FromIPv6(const ip6_addr_t & ipv6Addr)

--- a/src/inet/IPEndPointBasis.cpp
+++ b/src/inet/IPEndPointBasis.cpp
@@ -969,11 +969,11 @@ INET_ERROR IPEndPointBasis::GetSocket(IPAddressType aAddressType, int aType, int
         // logic up to check for implementations of these options and
         // to provide appropriate HAVE_xxxxx definitions accordingly.
 
-        res = setsockopt(mSocket, SOL_SOCKET, SO_REUSEADDR, (void *) &one, sizeof(one));
+        res = setsockopt(mSocket, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const void *>(&one), sizeof(one));
         static_cast<void>(res);
 
 #ifdef SO_REUSEPORT
-        res = setsockopt(mSocket, SOL_SOCKET, SO_REUSEPORT, (void *) &one, sizeof(one));
+        res = setsockopt(mSocket, SOL_SOCKET, SO_REUSEPORT, reinterpret_cast<const void *>(&one), sizeof(one));
         if (res != 0)
         {
             ChipLogError(Inet, "SO_REUSEPORT failed: %d", errno);
@@ -987,7 +987,7 @@ INET_ERROR IPEndPointBasis::GetSocket(IPAddressType aAddressType, int aType, int
 #ifdef IPV6_V6ONLY
         if (aAddressType == kIPAddressType_IPv6)
         {
-            res = setsockopt(mSocket, IPPROTO_IPV6, IPV6_V6ONLY, (void *) &one, sizeof(one));
+            res = setsockopt(mSocket, IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<const void *>(&one), sizeof(one));
             if (res != 0)
             {
                 ChipLogError(Inet, "IPV6_V6ONLY failed: %d", errno);
@@ -999,7 +999,7 @@ INET_ERROR IPEndPointBasis::GetSocket(IPAddressType aAddressType, int aType, int
 #ifdef IP_PKTINFO
         if (aAddressType == kIPAddressType_IPv4)
         {
-            res = setsockopt(mSocket, IPPROTO_IP, IP_PKTINFO, (void *) &one, sizeof(one));
+            res = setsockopt(mSocket, IPPROTO_IP, IP_PKTINFO, reinterpret_cast<const void *>(&one), sizeof(one));
             if (res != 0)
             {
                 ChipLogError(Inet, "IP_PKTINFO failed: %d", errno);
@@ -1011,7 +1011,7 @@ INET_ERROR IPEndPointBasis::GetSocket(IPAddressType aAddressType, int aType, int
 #ifdef IPV6_RECVPKTINFO
         if (aAddressType == kIPAddressType_IPv6)
         {
-            res = setsockopt(mSocket, IPPROTO_IPV6, IPV6_RECVPKTINFO, (void *) &one, sizeof(one));
+            res = setsockopt(mSocket, IPPROTO_IPV6, IPV6_RECVPKTINFO, reinterpret_cast<const void *>(&one), sizeof(one));
             if (res != 0)
             {
                 ChipLogError(Inet, "IPV6_PKTINFO failed: %d", errno);

--- a/src/inet/IPEndPointBasis.cpp
+++ b/src/inet/IPEndPointBasis.cpp
@@ -969,11 +969,11 @@ INET_ERROR IPEndPointBasis::GetSocket(IPAddressType aAddressType, int aType, int
         // logic up to check for implementations of these options and
         // to provide appropriate HAVE_xxxxx definitions accordingly.
 
-        res = setsockopt(mSocket, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const void *>(&one), sizeof(one));
+        res = setsockopt(mSocket, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
         static_cast<void>(res);
 
 #ifdef SO_REUSEPORT
-        res = setsockopt(mSocket, SOL_SOCKET, SO_REUSEPORT, reinterpret_cast<const void *>(&one), sizeof(one));
+        res = setsockopt(mSocket, SOL_SOCKET, SO_REUSEPORT, &one, sizeof(one));
         if (res != 0)
         {
             ChipLogError(Inet, "SO_REUSEPORT failed: %d", errno);
@@ -987,7 +987,7 @@ INET_ERROR IPEndPointBasis::GetSocket(IPAddressType aAddressType, int aType, int
 #ifdef IPV6_V6ONLY
         if (aAddressType == kIPAddressType_IPv6)
         {
-            res = setsockopt(mSocket, IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<const void *>(&one), sizeof(one));
+            res = setsockopt(mSocket, IPPROTO_IPV6, IPV6_V6ONLY, &one, sizeof(one));
             if (res != 0)
             {
                 ChipLogError(Inet, "IPV6_V6ONLY failed: %d", errno);
@@ -999,7 +999,7 @@ INET_ERROR IPEndPointBasis::GetSocket(IPAddressType aAddressType, int aType, int
 #ifdef IP_PKTINFO
         if (aAddressType == kIPAddressType_IPv4)
         {
-            res = setsockopt(mSocket, IPPROTO_IP, IP_PKTINFO, reinterpret_cast<const void *>(&one), sizeof(one));
+            res = setsockopt(mSocket, IPPROTO_IP, IP_PKTINFO, &one, sizeof(one));
             if (res != 0)
             {
                 ChipLogError(Inet, "IP_PKTINFO failed: %d", errno);
@@ -1011,7 +1011,7 @@ INET_ERROR IPEndPointBasis::GetSocket(IPAddressType aAddressType, int aType, int
 #ifdef IPV6_RECVPKTINFO
         if (aAddressType == kIPAddressType_IPv6)
         {
-            res = setsockopt(mSocket, IPPROTO_IPV6, IPV6_RECVPKTINFO, reinterpret_cast<const void *>(&one), sizeof(one));
+            res = setsockopt(mSocket, IPPROTO_IPV6, IPV6_RECVPKTINFO, &one, sizeof(one));
             if (res != 0)
             {
                 ChipLogError(Inet, "IPV6_PKTINFO failed: %d", errno);

--- a/src/inet/TCPEndPoint.cpp
+++ b/src/inet/TCPEndPoint.cpp
@@ -413,7 +413,7 @@ INET_ERROR TCPEndPoint::Connect(IPAddress addr, uint16_t port, InterfaceId intfI
             // If the permission is denied(EACCES) because CHIP is running in a context
             // that does not have privileged access, choose a source address on the
             // interface to bind the connetion to.
-            int r = setsockopt(mSocket, SOL_SOCKET, SO_BINDTODEVICE, (void *) &ifr, sizeof(ifr));
+            int r = setsockopt(mSocket, SOL_SOCKET, SO_BINDTODEVICE, &ifr, sizeof(ifr));
             if (r < 0 && errno != EACCES)
             {
                 return res = chip::System::MapErrorPOSIX(errno);
@@ -2227,7 +2227,7 @@ INET_ERROR TCPEndPoint::GetSocket(IPAddressType addrType)
         if (family == PF_INET6)
         {
             int one = 1;
-            setsockopt(mSocket, IPPROTO_IPV6, IPV6_V6ONLY, (void *) &one, sizeof(one));
+            setsockopt(mSocket, IPPROTO_IPV6, IPV6_V6ONLY, &one, sizeof(one));
         }
 #endif // defined(IPV6_V6ONLY)
 

--- a/src/inet/tests/TestInetAddress.cpp
+++ b/src/inet/tests/TestInetAddress.cpp
@@ -1234,7 +1234,7 @@ void CheckFromSocket(nlTestSuite * inSuite, void * inContext)
             memset(&sock_v4, 0, sizeof(struct sockaddr_in));
             sock_v4.sin_family = AF_INET;
             memcpy(&sock_v4.sin_addr.s_addr, &addr[3], sizeof(struct in_addr));
-            test_addr_2 = IPAddress::FromSockAddr((struct sockaddr &) sock_v4);
+            test_addr_2 = IPAddress::FromSockAddr(reinterpret_cast<struct sockaddr &>(sock_v4));
             break;
 #endif // INET_CONFIG_ENABLE_IPV4
 
@@ -1242,14 +1242,14 @@ void CheckFromSocket(nlTestSuite * inSuite, void * inContext)
             memset(&sock_v6, 0, sizeof(struct sockaddr_in6));
             sock_v6.sin6_family = AF_INET6;
             memcpy(&sock_v6.sin6_addr.s6_addr, addr, sizeof(struct in6_addr));
-            test_addr_2 = IPAddress::FromSockAddr((struct sockaddr &) sock_v6);
+            test_addr_2 = IPAddress::FromSockAddr(reinterpret_cast<struct sockaddr &>(sock_v6));
             break;
 
         case kIPAddressType_Any:
             memset(&sock_v6, 0, sizeof(struct sockaddr_in6));
             sock_v6.sin6_family = 0;
             memcpy(&sock_v6.sin6_addr.s6_addr, addr, sizeof(struct in6_addr));
-            test_addr_2 = IPAddress::FromSockAddr((struct sockaddr &) sock_v6);
+            test_addr_2 = IPAddress::FromSockAddr(reinterpret_cast<struct sockaddr &>(sock_v6));
             break;
 
         default:

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -252,7 +252,12 @@ static void TestInetInterface(nlTestSuite * inSuite, void * inContext)
         err = intIterator.GetInterfaceName(intName, sizeof(intName));
         NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
         printf("     interface id: 0x%" PRIxPTR ", interface name: %s, interface state: %s, %s multicast, %s broadcast addr\n",
-               (uintptr_t)(intId), intName, intIterator.IsUp() ? "UP" : "DOWN", intIterator.SupportsMulticast() ? "supports" : "no",
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+               reinterpret_cast<uintptr_t>(intId),
+#else
+               static_cast<uintptr_t>(intId),
+#endif
+               intName, intIterator.IsUp() ? "UP" : "DOWN", intIterator.SupportsMulticast() ? "supports" : "no",
                intIterator.HasBroadcastAddress() ? "has" : "no");
 
         gInet.GetLinkLocalAddr(intId, &addr);
@@ -279,8 +284,14 @@ static void TestInetInterface(nlTestSuite * inSuite, void * inContext)
         NL_TEST_ASSERT(inSuite, intName[0] != '\0' && memchr(intName, '\0', sizeof(intName)) != nullptr);
         printf("     %s/%d, interface id: 0x%" PRIxPTR
                ", interface name: %s, interface state: %s, %s multicast, %s broadcast addr\n",
-               addrStr, addrWithPrefix.Length, (uintptr_t)(intId), intName, addrIterator.IsUp() ? "UP" : "DOWN",
-               addrIterator.SupportsMulticast() ? "supports" : "no", addrIterator.HasBroadcastAddress() ? "has" : "no");
+               addrStr, addrWithPrefix.Length,
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+               reinterpret_cast<uintptr_t>(intId),
+#else
+               static_cast<uintptr_t>(intId),
+#endif
+               intName, addrIterator.IsUp() ? "UP" : "DOWN", addrIterator.SupportsMulticast() ? "supports" : "no",
+               addrIterator.HasBroadcastAddress() ? "has" : "no");
     }
     NL_TEST_ASSERT(inSuite, !addrIterator.Next());
     addrIterator.GetAddressWithPrefix(addrWithPrefix);

--- a/src/inet/tests/TestInetLayerDNS.cpp
+++ b/src/inet/tests/TestInetLayerDNS.cpp
@@ -408,7 +408,7 @@ static void TestDNSResolution_Cancel(nlTestSuite * testSuite, void * inContext)
     if (!testContext.callbackCalled)
     {
         // Cancel the resolution before it completes.
-        gInet.CancelResolveHostAddress(HandleResolutionComplete, (void *) &testContext);
+        gInet.CancelResolveHostAddress(HandleResolutionComplete, &testContext);
 
         // Service the network for awhile to see what happens (should timeout).
         ServiceNetworkUntilDone(DEFAULT_CANCEL_TEST_DURATION_MILLISECS);
@@ -521,7 +521,7 @@ static void StartTestCase(DNSResolutionTestContext & testContext)
 
     printf("Resolving hostname %s\n", testCase.hostName);
     err = gInet.ResolveHostAddress(testCase.hostName, strlen(testCase.hostName), testCase.dnsOptions, testCase.maxResults,
-                                   testContext.resultsBuf, HandleResolutionComplete, (void *) &testContext);
+                                   testContext.resultsBuf, HandleResolutionComplete, &testContext);
 
     if (err != INET_NO_ERROR)
     {

--- a/src/lib/core/CHIPCallback.h
+++ b/src/lib/core/CHIPCallback.h
@@ -187,7 +187,7 @@ public:
     /**
      * @brief dequeue, but don't cancel, all cas that match the by()
      */
-    Cancelable DequeueBy(bool (*by)(void *, const Cancelable *), void * p)
+    Cancelable DequeueBy(bool (*by)(uint64_t, const Cancelable *), uint64_t p)
     {
         Cancelable dequeued;
 

--- a/src/lib/core/CHIPCircularTLVBuffer.cpp
+++ b/src/lib/core/CHIPCircularTLVBuffer.cpp
@@ -329,7 +329,7 @@ CHIP_ERROR CHIPCircularTLVBuffer::GetNewBufferFunct(TLVWriter & ioWriter, uintpt
 
     VerifyOrExit(inBufHandle != 0, err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    buf = static_cast<CHIPCircularTLVBuffer *>((void *) inBufHandle);
+    buf = reinterpret_cast<CHIPCircularTLVBuffer *>(inBufHandle);
 
     err = buf->GetNewBuffer(ioWriter, outBufStart, outBufLen);
 
@@ -361,7 +361,7 @@ CHIP_ERROR CHIPCircularTLVBuffer::FinalizeBufferFunct(TLVWriter & ioWriter, uint
 
     VerifyOrExit(inBufHandle != 0, err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    buf = static_cast<CHIPCircularTLVBuffer *>((void *) inBufHandle);
+    buf = reinterpret_cast<CHIPCircularTLVBuffer *>(inBufHandle);
 
     err = buf->FinalizeBuffer(ioWriter, inBufStart, inBufLen);
 
@@ -394,7 +394,7 @@ CHIP_ERROR CHIPCircularTLVBuffer::GetNextBufferFunct(TLVReader & ioReader, uintp
 
     VerifyOrExit(inBufHandle != 0, err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    buf = static_cast<CHIPCircularTLVBuffer *>((void *) inBufHandle);
+    buf = reinterpret_cast<CHIPCircularTLVBuffer *>(inBufHandle);
 
     err = buf->GetNextBuffer(ioReader, outBufStart, outBufLen);
 
@@ -419,7 +419,7 @@ exit:
  */
 void CircularTLVWriter::Init(CHIPCircularTLVBuffer * buf)
 {
-    mBufHandle     = (uintptr_t) buf;
+    mBufHandle     = reinterpret_cast<uintptr_t>(buf);
     mLenWritten    = 0;
     mMaxLen        = UINT32_MAX;
     mContainerType = kTLVType_NotSpecified;
@@ -450,7 +450,7 @@ void CircularTLVReader::Init(CHIPCircularTLVBuffer * buf)
 {
     uint32_t bufLen = 0;
 
-    mBufHandle    = (uintptr_t) buf;
+    mBufHandle    = reinterpret_cast<uintptr_t>(buf);
     GetNextBuffer = CHIPCircularTLVBuffer::GetNextBufferFunct;
     mLenRead      = 0;
     mReadPoint    = nullptr;

--- a/src/lib/core/CHIPEncoding.h
+++ b/src/lib/core/CHIPEncoding.h
@@ -132,22 +132,6 @@ inline void Put8(uint8_t * p, uint8_t v)
  * from the specified pointer address and increment the pointer by
  * 8-bits (1 byte).
  *
- * @param[in,out] p   A reference to a pointer address, potentially
- *                    unaligned, to read the 8-bit value from and to
- *                    then increment by 8-bits (1 byte).
- *
- * @return The 8-bit value at the specified pointer address.
- */
-inline uint8_t Read8(uint8_t *& p)
-{
-    return nl::IO::Read8(const_cast<const void *&>(reinterpret_cast<void *&>(p)));
-}
-
-/**
- * Perform a, potentially unaligned, memory read of the 8-bit value
- * from the specified pointer address and increment the pointer by
- * 8-bits (1 byte).
- *
  * @param[in,out] p   A reference to a constant pointer address,
  *                    potentially unaligned, to read the 8-bit value
  *                    from and to then increment by 8-bits (1 byte).
@@ -157,6 +141,22 @@ inline uint8_t Read8(uint8_t *& p)
 inline uint8_t Read8(const uint8_t *& p)
 {
     return nl::IO::Read8(reinterpret_cast<const void *&>(p));
+}
+
+/**
+ * Perform a, potentially unaligned, memory read of the 8-bit value
+ * from the specified pointer address and increment the pointer by
+ * 8-bits (1 byte).
+ *
+ * @param[in,out] p   A reference to a pointer address, potentially
+ *                    unaligned, to read the 8-bit value from and to
+ *                    then increment by 8-bits (1 byte).
+ *
+ * @return The 8-bit value at the specified pointer address.
+ */
+inline uint8_t Read8(uint8_t *& p)
+{
+    return Read8(const_cast<const uint8_t *&>(p));
 }
 
 /**
@@ -365,66 +365,6 @@ inline void Put64(uint8_t * p, uint64_t v)
  * the value in target system byte ordering, and increment the pointer
  * by 16-bits (2 bytes).
  *
- * @param[in,out] p   A reference to a pointer address, potentially
- *                    unaligned, to read the 16-bit little endian byte
- *                    ordered value from and to then increment by 16-
- *                    bits (2 bytes).
- *
- * @return The 16-bit value at the specified pointer address, if necessary,
- *         byte order swapped.
- */
-inline uint16_t Read16(uint8_t *& p)
-{
-    return nl::IO::LittleEndian::ReadUnaligned16(const_cast<const void *&>(reinterpret_cast<void *&>(p)));
-}
-
-/**
- * Perform a, potentially unaligned, memory read of the little endian
- * byte ordered 32-bit value from the specified pointer address,
- * perform byte reordering, as necessary, for the target system to put
- * the value in target system byte ordering, and increment the pointer
- * by 32-bits (4 bytes).
- *
- * @param[in,out] p   A reference to a pointer address, potentially
- *                    unaligned, to read the 32-bit little endian byte
- *                    ordered value from and to then increment by 32-
- *                    bits (4 bytes).
- *
- * @return The 32-bit value at the specified pointer address, if necessary,
- *         byte order swapped.
- */
-inline uint32_t Read32(uint8_t *& p)
-{
-    return nl::IO::LittleEndian::ReadUnaligned32(const_cast<const void *&>(reinterpret_cast<void *&>(p)));
-}
-
-/**
- * Perform a, potentially unaligned, memory read of the little endian
- * byte ordered 64-bit value from the specified pointer address,
- * perform byte reordering, as necessary, for the target system to put
- * the value in target system byte ordering, and increment the pointer
- * by 64-bits (8 bytes).
- *
- * @param[in,out] p   A reference to a pointer address, potentially
- *                    unaligned, to read the 64-bit little endian byte
- *                    ordered value from and to then increment by 64-
- *                    bits (8 bytes).
- *
- * @return The 64-bit value at the specified pointer address, if necessary,
- *         byte order swapped.
- */
-inline uint64_t Read64(uint8_t *& p)
-{
-    return nl::IO::LittleEndian::ReadUnaligned64(const_cast<const void *&>(reinterpret_cast<void *&>(p)));
-}
-
-/**
- * Perform a, potentially unaligned, memory read of the little endian
- * byte ordered 16-bit value from the specified pointer address,
- * perform byte reordering, as necessary, for the target system to put
- * the value in target system byte ordering, and increment the pointer
- * by 16-bits (2 bytes).
- *
  * @param[in,out] p   A reference to a constant pointer address, potentially
  *                    unaligned, to read the 16-bit little endian byte
  *                    ordered value from and to then increment by 16-
@@ -436,6 +376,26 @@ inline uint64_t Read64(uint8_t *& p)
 inline uint16_t Read16(const uint8_t *& p)
 {
     return nl::IO::LittleEndian::ReadUnaligned16(reinterpret_cast<const void *&>(p));
+}
+
+/**
+ * Perform a, potentially unaligned, memory read of the big endian
+ * byte ordered 16-bit value from the specified pointer address,
+ * perform byte reordering, as necessary, for the target system to put
+ * the value in target system byte ordering, and increment the pointer
+ * by 16-bits (2 bytes).
+ *
+ * @param[in,out] p   A reference to a pointer address, potentially
+ *                    unaligned, to read the 16-bit big endian byte
+ *                    ordered value from and to then increment by 16-
+ *                    bits (2 bytes).
+ *
+ * @return The 16-bit value at the specified pointer address, if necessary,
+ *         byte order swapped.
+ */
+inline uint16_t Read16(uint8_t *& p)
+{
+    return Read16(const_cast<const uint8_t *&>(p));
 }
 
 /**
@@ -460,6 +420,26 @@ inline uint32_t Read32(const uint8_t *& p)
 
 /**
  * Perform a, potentially unaligned, memory read of the little endian
+ * byte ordered 32-bit value from the specified pointer address,
+ * perform byte reordering, as necessary, for the target system to put
+ * the value in target system byte ordering, and increment the pointer
+ * by 32-bits (4 bytes).
+ *
+ * @param[in,out] p   A reference to a pointer address, potentially
+ *                    unaligned, to read the 32-bit little endian byte
+ *                    ordered value from and to then increment by 32-
+ *                    bits (4 bytes).
+ *
+ * @return The 32-bit value at the specified pointer address, if necessary,
+ *         byte order swapped.
+ */
+inline uint32_t Read32(uint8_t *& p)
+{
+    return Read32(const_cast<const uint8_t *&>(p));
+}
+
+/**
+ * Perform a, potentially unaligned, memory read of the little endian
  * byte ordered 64-bit value from the specified pointer address,
  * perform byte reordering, as necessary, for the target system to put
  * the value in target system byte ordering, and increment the pointer
@@ -476,6 +456,26 @@ inline uint32_t Read32(const uint8_t *& p)
 inline uint64_t Read64(const uint8_t *& p)
 {
     return nl::IO::LittleEndian::ReadUnaligned64(reinterpret_cast<const void *&>(p));
+}
+
+/**
+ * Perform a, potentially unaligned, memory read of the little endian
+ * byte ordered 64-bit value from the specified pointer address,
+ * perform byte reordering, as necessary, for the target system to put
+ * the value in target system byte ordering, and increment the pointer
+ * by 64-bits (8 bytes).
+ *
+ * @param[in,out] p   A reference to a pointer address, potentially
+ *                    unaligned, to read the 64-bit little endian byte
+ *                    ordered value from and to then increment by 64-
+ *                    bits (8 bytes).
+ *
+ * @return The 64-bit value at the specified pointer address, if necessary,
+ *         byte order swapped.
+ */
+inline uint64_t Read64(uint8_t *& p)
+{
+    return Read64(const_cast<const uint8_t *&>(p));
 }
 
 /**
@@ -738,66 +738,6 @@ inline void Put64(uint8_t * p, uint64_t v)
  * the value in target system byte ordering, and increment the pointer
  * by 16-bits (2 bytes).
  *
- * @param[in,out] p   A reference to a pointer address, potentially
- *                    unaligned, to read the 16-bit big endian byte
- *                    ordered value from and to then increment by 16-
- *                    bits (2 bytes).
- *
- * @return The 16-bit value at the specified pointer address, if necessary,
- *         byte order swapped.
- */
-inline uint16_t Read16(uint8_t *& p)
-{
-    return nl::IO::BigEndian::ReadUnaligned16(const_cast<const void *&>(reinterpret_cast<void *&>(p)));
-}
-
-/**
- * Perform a, potentially unaligned, memory read of the big endian
- * byte ordered 32-bit value from the specified pointer address,
- * perform byte reordering, as necessary, for the target system to put
- * the value in target system byte ordering, and increment the pointer
- * by 32-bits (4 bytes).
- *
- * @param[in,out] p   A reference to a pointer address, potentially
- *                    unaligned, to read the 32-bit big endian byte
- *                    ordered value from and to then increment by 32-
- *                    bits (4 bytes).
- *
- * @return The 32-bit value at the specified pointer address, if necessary,
- *         byte order swapped.
- */
-inline uint32_t Read32(uint8_t *& p)
-{
-    return nl::IO::BigEndian::ReadUnaligned32(const_cast<const void *&>(reinterpret_cast<void *&>(p)));
-}
-
-/**
- * Perform a, potentially unaligned, memory read of the big endian
- * byte ordered 64-bit value from the specified pointer address,
- * perform byte reordering, as necessary, for the target system to put
- * the value in target system byte ordering, and increment the pointer
- * by 64-bits (8 bytes).
- *
- * @param[in,out] p   A reference to a pointer address, potentially
- *                    unaligned, to read the 64-bit big endian byte
- *                    ordered value from and to then increment by 64-
- *                    bits (8 bytes).
- *
- * @return The 64-bit value at the specified pointer address, if necessary,
- *         byte order swapped.
- */
-inline uint64_t Read64(uint8_t *& p)
-{
-    return nl::IO::BigEndian::ReadUnaligned64(const_cast<const void *&>(reinterpret_cast<void *&>(p)));
-}
-
-/**
- * Perform a, potentially unaligned, memory read of the big endian
- * byte ordered 16-bit value from the specified pointer address,
- * perform byte reordering, as necessary, for the target system to put
- * the value in target system byte ordering, and increment the pointer
- * by 16-bits (2 bytes).
- *
  * @param[in,out] p   A reference to a constant pointer address, potentially
  *                    unaligned, to read the 16-bit big endian byte
  *                    ordered value from and to then increment by 16-
@@ -809,6 +749,26 @@ inline uint64_t Read64(uint8_t *& p)
 inline uint16_t Read16(const uint8_t *& p)
 {
     return nl::IO::BigEndian::ReadUnaligned16(reinterpret_cast<const void *&>(p));
+}
+
+/**
+ * Perform a, potentially unaligned, memory read of the big endian
+ * byte ordered 16-bit value from the specified pointer address,
+ * perform byte reordering, as necessary, for the target system to put
+ * the value in target system byte ordering, and increment the pointer
+ * by 16-bits (2 bytes).
+ *
+ * @param[in,out] p   A reference to a pointer address, potentially
+ *                    unaligned, to read the 16-bit big endian byte
+ *                    ordered value from and to then increment by 16-
+ *                    bits (2 bytes).
+ *
+ * @return The 16-bit value at the specified pointer address, if necessary,
+ *         byte order swapped.
+ */
+inline uint16_t Read16(uint8_t *& p)
+{
+    return Read16(const_cast<const uint8_t *&>(p));
 }
 
 /**
@@ -833,6 +793,26 @@ inline uint32_t Read32(const uint8_t *& p)
 
 /**
  * Perform a, potentially unaligned, memory read of the big endian
+ * byte ordered 32-bit value from the specified pointer address,
+ * perform byte reordering, as necessary, for the target system to put
+ * the value in target system byte ordering, and increment the pointer
+ * by 32-bits (4 bytes).
+ *
+ * @param[in,out] p   A reference to a pointer address, potentially
+ *                    unaligned, to read the 32-bit big endian byte
+ *                    ordered value from and to then increment by 32-
+ *                    bits (4 bytes).
+ *
+ * @return The 32-bit value at the specified pointer address, if necessary,
+ *         byte order swapped.
+ */
+inline uint32_t Read32(uint8_t *& p)
+{
+    return Read32(const_cast<const uint8_t *&>(p));
+}
+
+/**
+ * Perform a, potentially unaligned, memory read of the big endian
  * byte ordered 64-bit value from the specified pointer address,
  * perform byte reordering, as necessary, for the target system to put
  * the value in target system byte ordering, and increment the pointer
@@ -849,6 +829,26 @@ inline uint32_t Read32(const uint8_t *& p)
 inline uint64_t Read64(const uint8_t *& p)
 {
     return nl::IO::BigEndian::ReadUnaligned64(reinterpret_cast<const void *&>(p));
+}
+
+/**
+ * Perform a, potentially unaligned, memory read of the big endian
+ * byte ordered 64-bit value from the specified pointer address,
+ * perform byte reordering, as necessary, for the target system to put
+ * the value in target system byte ordering, and increment the pointer
+ * by 64-bits (8 bytes).
+ *
+ * @param[in,out] p   A reference to a pointer address, potentially
+ *                    unaligned, to read the 64-bit big endian byte
+ *                    ordered value from and to then increment by 64-
+ *                    bits (8 bytes).
+ *
+ * @return The 64-bit value at the specified pointer address, if necessary,
+ *         byte order swapped.
+ */
+inline uint64_t Read64(uint8_t *& p)
+{
+    return Read64(const_cast<const uint8_t *&>(p));
 }
 
 /**

--- a/src/lib/core/CHIPEncoding.h
+++ b/src/lib/core/CHIPEncoding.h
@@ -140,7 +140,7 @@ inline void Put8(uint8_t * p, uint8_t v)
  */
 inline uint8_t Read8(uint8_t *& p)
 {
-    return nl::IO::Read8((const void *&) p);
+    return nl::IO::Read8(const_cast<const void *&>(reinterpret_cast<void *&>(p)));
 }
 
 /**
@@ -156,7 +156,7 @@ inline uint8_t Read8(uint8_t *& p)
  */
 inline uint8_t Read8(const uint8_t *& p)
 {
-    return nl::IO::Read8((const void *&) p);
+    return nl::IO::Read8(reinterpret_cast<const void *&>(p));
 }
 
 /**
@@ -375,7 +375,7 @@ inline void Put64(uint8_t * p, uint64_t v)
  */
 inline uint16_t Read16(uint8_t *& p)
 {
-    return nl::IO::LittleEndian::ReadUnaligned16((const void *&) p);
+    return nl::IO::LittleEndian::ReadUnaligned16(const_cast<const void *&>(reinterpret_cast<void *&>(p)));
 }
 
 /**
@@ -395,7 +395,7 @@ inline uint16_t Read16(uint8_t *& p)
  */
 inline uint32_t Read32(uint8_t *& p)
 {
-    return nl::IO::LittleEndian::ReadUnaligned32((const void *&) p);
+    return nl::IO::LittleEndian::ReadUnaligned32(const_cast<const void *&>(reinterpret_cast<void *&>(p)));
 }
 
 /**
@@ -415,7 +415,7 @@ inline uint32_t Read32(uint8_t *& p)
  */
 inline uint64_t Read64(uint8_t *& p)
 {
-    return nl::IO::LittleEndian::ReadUnaligned64((const void *&) p);
+    return nl::IO::LittleEndian::ReadUnaligned64(const_cast<const void *&>(reinterpret_cast<void *&>(p)));
 }
 
 /**
@@ -435,7 +435,7 @@ inline uint64_t Read64(uint8_t *& p)
  */
 inline uint16_t Read16(const uint8_t *& p)
 {
-    return nl::IO::LittleEndian::ReadUnaligned16((const void *&) p);
+    return nl::IO::LittleEndian::ReadUnaligned16(reinterpret_cast<const void *&>(p));
 }
 
 /**
@@ -455,7 +455,7 @@ inline uint16_t Read16(const uint8_t *& p)
  */
 inline uint32_t Read32(const uint8_t *& p)
 {
-    return nl::IO::LittleEndian::ReadUnaligned32((const void *&) p);
+    return nl::IO::LittleEndian::ReadUnaligned32(reinterpret_cast<const void *&>(p));
 }
 
 /**
@@ -475,7 +475,7 @@ inline uint32_t Read32(const uint8_t *& p)
  */
 inline uint64_t Read64(const uint8_t *& p)
 {
-    return nl::IO::LittleEndian::ReadUnaligned64((const void *&) p);
+    return nl::IO::LittleEndian::ReadUnaligned64(reinterpret_cast<const void *&>(p));
 }
 
 /**
@@ -748,7 +748,7 @@ inline void Put64(uint8_t * p, uint64_t v)
  */
 inline uint16_t Read16(uint8_t *& p)
 {
-    return nl::IO::BigEndian::ReadUnaligned16((const void *&) p);
+    return nl::IO::BigEndian::ReadUnaligned16(const_cast<const void *&>(reinterpret_cast<void *&>(p)));
 }
 
 /**
@@ -768,7 +768,7 @@ inline uint16_t Read16(uint8_t *& p)
  */
 inline uint32_t Read32(uint8_t *& p)
 {
-    return nl::IO::BigEndian::ReadUnaligned32((const void *&) p);
+    return nl::IO::BigEndian::ReadUnaligned32(const_cast<const void *&>(reinterpret_cast<void *&>(p)));
 }
 
 /**
@@ -788,7 +788,7 @@ inline uint32_t Read32(uint8_t *& p)
  */
 inline uint64_t Read64(uint8_t *& p)
 {
-    return nl::IO::BigEndian::ReadUnaligned64((const void *&) p);
+    return nl::IO::BigEndian::ReadUnaligned64(const_cast<const void *&>(reinterpret_cast<void *&>(p)));
 }
 
 /**
@@ -808,7 +808,7 @@ inline uint64_t Read64(uint8_t *& p)
  */
 inline uint16_t Read16(const uint8_t *& p)
 {
-    return nl::IO::BigEndian::ReadUnaligned16((const void *&) p);
+    return nl::IO::BigEndian::ReadUnaligned16(reinterpret_cast<const void *&>(p));
 }
 
 /**
@@ -828,7 +828,7 @@ inline uint16_t Read16(const uint8_t *& p)
  */
 inline uint32_t Read32(const uint8_t *& p)
 {
-    return nl::IO::BigEndian::ReadUnaligned32((const void *&) p);
+    return nl::IO::BigEndian::ReadUnaligned32(reinterpret_cast<const void *&>(p));
 }
 
 /**
@@ -848,7 +848,7 @@ inline uint32_t Read32(const uint8_t *& p)
  */
 inline uint64_t Read64(const uint8_t *& p)
 {
-    return nl::IO::BigEndian::ReadUnaligned64((const void *&) p);
+    return nl::IO::BigEndian::ReadUnaligned64(reinterpret_cast<const void *&>(p));
 }
 
 /**

--- a/src/lib/core/CHIPEncoding.h
+++ b/src/lib/core/CHIPEncoding.h
@@ -379,14 +379,14 @@ inline uint16_t Read16(const uint8_t *& p)
 }
 
 /**
- * Perform a, potentially unaligned, memory read of the big endian
+ * Perform a, potentially unaligned, memory read of the little endian
  * byte ordered 16-bit value from the specified pointer address,
  * perform byte reordering, as necessary, for the target system to put
  * the value in target system byte ordering, and increment the pointer
  * by 16-bits (2 bytes).
  *
  * @param[in,out] p   A reference to a pointer address, potentially
- *                    unaligned, to read the 16-bit big endian byte
+ *                    unaligned, to read the 16-bit little endian byte
  *                    ordered value from and to then increment by 16-
  *                    bits (2 bytes).
  *

--- a/src/lib/core/CHIPTLVReader.cpp
+++ b/src/lib/core/CHIPTLVReader.cpp
@@ -172,7 +172,7 @@ void TLVReader::Init(const uint8_t * data, uint32_t dataLen)
  */
 void TLVReader::Init(PacketBuffer * buf, uint32_t maxLen)
 {
-    mBufHandle = (uintptr_t) buf;
+    mBufHandle = reinterpret_cast<uintptr_t>(buf);
     mReadPoint = buf->Start();
     mBufEnd    = mReadPoint + buf->DataLength();
     mLenRead   = 0;
@@ -204,7 +204,7 @@ void TLVReader::Init(PacketBuffer * buf, uint32_t maxLen)
  */
 void TLVReader::Init(PacketBuffer * buf, uint32_t maxLen, bool allowDiscontiguousBuffers)
 {
-    mBufHandle = (uintptr_t) buf;
+    mBufHandle = reinterpret_cast<uintptr_t>(buf);
     mReadPoint = buf->Start();
     mBufEnd    = mReadPoint + buf->DataLength();
     mLenRead   = 0;
@@ -1557,7 +1557,7 @@ TLVElementType TLVReader::ElementType() const
 
 CHIP_ERROR TLVReader::GetNextPacketBuffer(TLVReader & reader, uintptr_t & bufHandle, const uint8_t *& bufStart, uint32_t & bufLen)
 {
-    PacketBuffer *& buf = (PacketBuffer *&) bufHandle;
+    PacketBuffer *& buf = reinterpret_cast<PacketBuffer *&>(bufHandle);
 
     if (buf != nullptr)
         buf = buf->Next();

--- a/src/lib/core/CHIPTLVUpdater.cpp
+++ b/src/lib/core/CHIPTLVUpdater.cpp
@@ -172,7 +172,7 @@ CHIP_ERROR TLVUpdater::Init(TLVReader & aReader, uint32_t freeLen)
 
     // Clear the input reader object before returning. The user can no longer
     // use the original TLVReader object anymore.
-    aReader.Init((const uint8_t *) nullptr, 0);
+    aReader.Init(static_cast<const uint8_t *>(nullptr), 0);
 
 exit:
     return err;

--- a/src/lib/core/CHIPTLVWriter.cpp
+++ b/src/lib/core/CHIPTLVWriter.cpp
@@ -198,7 +198,7 @@ NO_INLINE void TLVWriter::Init(uint8_t * buf, uint32_t maxLen)
  */
 void TLVWriter::Init(PacketBuffer * buf, uint32_t maxLen)
 {
-    mBufHandle = (uintptr_t) buf;
+    mBufHandle = reinterpret_cast<uintptr_t>(buf);
     mBufStart = mWritePoint = buf->Start() + buf->DataLength();
     mRemainingLen           = buf->AvailableDataLength();
     if (mRemainingLen > maxLen)
@@ -1279,7 +1279,7 @@ CHIP_ERROR TLVWriter::CloseContainer(TLVWriter & containerWriter)
     SetContainerOpen(false);
 
     // Reset the container writer so that it can't accidentally be used again.
-    containerWriter.Init((uint8_t *) nullptr, 0);
+    containerWriter.Init(static_cast<uint8_t *>(nullptr), 0);
 
     return WriteElementHead(kTLVElementType_EndOfContainer, AnonymousTag, 0);
 }
@@ -1843,7 +1843,7 @@ exit:
  */
 CHIP_ERROR TLVWriter::GetNewPacketBuffer(TLVWriter & writer, uintptr_t & bufHandle, uint8_t *& bufStart, uint32_t & bufLen)
 {
-    PacketBuffer * buf = (PacketBuffer *) bufHandle;
+    PacketBuffer * buf = reinterpret_cast<PacketBuffer *>(bufHandle);
 
     PacketBuffer * newBuf = buf->Next();
     if (newBuf == nullptr)
@@ -1855,7 +1855,7 @@ CHIP_ERROR TLVWriter::GetNewPacketBuffer(TLVWriter & writer, uintptr_t & bufHand
 
     if (newBuf != nullptr)
     {
-        bufHandle = (uintptr_t) newBuf;
+        bufHandle = reinterpret_cast<uintptr_t>(newBuf);
         bufStart  = newBuf->Start();
         bufLen    = newBuf->MaxDataLength();
     }
@@ -1880,7 +1880,7 @@ CHIP_ERROR TLVWriter::GetNewPacketBuffer(TLVWriter & writer, uintptr_t & bufHand
  */
 CHIP_ERROR TLVWriter::FinalizePacketBuffer(TLVWriter & writer, uintptr_t bufHandle, uint8_t * bufStart, uint32_t dataLen)
 {
-    PacketBuffer * buf = (PacketBuffer *) bufHandle;
+    PacketBuffer * buf = reinterpret_cast<PacketBuffer *>(bufHandle);
     uint8_t * endPtr   = bufStart + dataLen;
 
     buf->SetDataLength(endPtr - buf->Start());

--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -3036,7 +3036,7 @@ void TestCHIPTLVReaderErrorHandling(nlTestSuite * inSuite)
     const uint8_t * data = static_cast<uint8_t *>(malloc(16));
     err                  = reader.GetDataPtr(data);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_WRONG_TLV_TYPE);
-    free(const_cast<void *>(reinterpret_cast<const void *>(data)));
+    free(const_cast<uint8_t *>(data));
 }
 /**
  *  Test CHIP TLV Reader in a use case

--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -3036,7 +3036,7 @@ void TestCHIPTLVReaderErrorHandling(nlTestSuite * inSuite)
     const uint8_t * data = static_cast<uint8_t *>(malloc(16));
     err                  = reader.GetDataPtr(data);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_WRONG_TLV_TYPE);
-    free((void *) data);
+    free(const_cast<void *>(reinterpret_cast<const void *>(data)));
 }
 /**
  *  Test CHIP TLV Reader in a use case

--- a/src/lib/message/CHIPExchangeMgr.cpp
+++ b/src/lib/message/CHIPExchangeMgr.cpp
@@ -290,7 +290,7 @@ ExchangeContext * ChipExchangeManager::NewContext(ChipConnection * con, void * a
  */
 ExchangeContext * ChipExchangeManager::FindContext(uint64_t peerNodeId, ChipConnection * con, void * appState, bool isInitiator)
 {
-    ExchangeContext * ec = (ExchangeContext *) ContextPool;
+    ExchangeContext * ec = ContextPool;
     for (int i = 0; i < CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS; i++, ec++)
         if (ec->ExchangeMgr != nullptr && ec->PeerNodeId == peerNodeId && ec->Con == con && ec->AppState == appState &&
             ec->IsInitiator() == isInitiator)
@@ -507,14 +507,14 @@ void ChipExchangeManager::HandleConnectionClosed(ChipConnection * con, CHIP_ERRO
         BindingPool[i].OnConnectionClosed(con, conErr);
     }
 
-    ExchangeContext * ec = (ExchangeContext *) ContextPool;
+    ExchangeContext * ec = ContextPool;
     for (int i = 0; i < CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS; i++, ec++)
         if (ec->ExchangeMgr != nullptr && ec->Con == con)
         {
             ec->HandleConnectionClosed(conErr);
         }
 
-    UnsolicitedMessageHandler * umh = (UnsolicitedMessageHandler *) UMHandlerPool;
+    UnsolicitedMessageHandler * umh = UMHandlerPool;
     for (int i = 0; i < CHIP_CONFIG_MAX_UNSOLICITED_MESSAGE_HANDLERS; i++, umh++)
         if (umh->Handler != nullptr && umh->Con == con)
         {
@@ -533,7 +533,7 @@ void ChipExchangeManager::HandleConnectionClosed(ChipConnection * con, CHIP_ERRO
 size_t ChipExchangeManager::ExpireExchangeTimers()
 {
     size_t retval        = 0;
-    ExchangeContext * ec = (ExchangeContext *) ContextPool;
+    ExchangeContext * ec = ContextPool;
     for (int i = 0; i < CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS; i++, ec++)
     {
         if (ec->ExchangeMgr != nullptr)
@@ -553,7 +553,7 @@ size_t ChipExchangeManager::ExpireExchangeTimers()
 
 ExchangeContext * ChipExchangeManager::AllocContext()
 {
-    ExchangeContext * ec = (ExchangeContext *) ContextPool;
+    ExchangeContext * ec = ContextPool;
 
     CHIP_FAULT_INJECT(FaultInjection::kFault_AllocExchangeContext, return nullptr);
 
@@ -716,7 +716,7 @@ void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffe
     } // If delayed delivery Msg
 
     // Search for an existing exchange that the message applies to. If a match is found...
-    ec = (ExchangeContext *) ContextPool;
+    ec = ContextPool;
     for (int i = 0; i < CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS; i++, ec++)
     {
         if (ec->ExchangeMgr != nullptr && ec->MatchExchange(msgCon, msgInfo, &exchangeHeader))
@@ -748,7 +748,7 @@ void ChipExchangeManager::DispatchMessage(ChipMessageInfo * msgInfo, PacketBuffe
     {
         // Search for an unsolicited message handler that can handle the message. Prefer handlers that can explicitly
         // handle the message type over handlers that handle all messages for a profile.
-        umh = (UnsolicitedMessageHandler *) UMHandlerPool;
+        umh = UMHandlerPool;
 
         matchingUMH = nullptr;
 
@@ -895,7 +895,7 @@ exit:
 CHIP_ERROR ChipExchangeManager::RegisterUMH(uint32_t profileId, int16_t msgType, ChipConnection * con, bool allowDups,
                                             ExchangeContext::MessageReceiveFunct handler, void * appState)
 {
-    UnsolicitedMessageHandler * umh      = (UnsolicitedMessageHandler *) UMHandlerPool;
+    UnsolicitedMessageHandler * umh      = UMHandlerPool;
     UnsolicitedMessageHandler * selected = nullptr;
     for (int i = 0; i < CHIP_CONFIG_MAX_UNSOLICITED_MESSAGE_HANDLERS; i++, umh++)
     {
@@ -929,7 +929,7 @@ CHIP_ERROR ChipExchangeManager::RegisterUMH(uint32_t profileId, int16_t msgType,
 
 CHIP_ERROR ChipExchangeManager::UnregisterUMH(uint32_t profileId, int16_t msgType, ChipConnection * con)
 {
-    UnsolicitedMessageHandler * umh = (UnsolicitedMessageHandler *) UMHandlerPool;
+    UnsolicitedMessageHandler * umh = UMHandlerPool;
     for (int i = 0; i < CHIP_CONFIG_MAX_UNSOLICITED_MESSAGE_HANDLERS; i++, umh++)
     {
         if (umh->Handler != nullptr && umh->ProfileId == profileId && umh->MessageType == msgType && umh->Con == con)
@@ -1078,7 +1078,7 @@ void ChipExchangeManager::AllowUnsolicitedMessages(ChipConnection * con)
  */
 void ChipExchangeManager::NotifyKeyFailed(uint64_t peerNodeId, uint16_t keyId, CHIP_ERROR keyErr)
 {
-    ExchangeContext * ec = (ExchangeContext *) ContextPool;
+    ExchangeContext * ec = ContextPool;
 
     for (int i = 0; i < CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS; i++, ec++)
     {
@@ -1128,7 +1128,7 @@ void ChipExchangeManager::NotifySecurityManagerAvailable()
  */
 void ChipExchangeManager::ClearMsgCounterSyncReq(uint64_t peerNodeId)
 {
-    RetransTableEntry * re = (RetransTableEntry *) RetransTable;
+    RetransTableEntry * re = RetransTable;
 
     // Find all retransmit entries (re) matching peerNodeId and using application group key.
     for (int i = 0; i < CHIP_CONFIG_RMP_RETRANS_TABLE_SIZE; i++, re++)
@@ -1153,7 +1153,7 @@ void ChipExchangeManager::ClearMsgCounterSyncReq(uint64_t peerNodeId)
  */
 void ChipExchangeManager::RetransPendingAppGroupMsgs(uint64_t peerNodeId)
 {
-    RetransTableEntry * re = (RetransTableEntry *) RetransTable;
+    RetransTableEntry * re = RetransTable;
 
     // Find all retransmit entries (re) matching peerNodeId and using application group key.
     for (int i = 0; i < CHIP_CONFIG_RMP_RETRANS_TABLE_SIZE; i++, re++)
@@ -1233,7 +1233,7 @@ void ChipExchangeManager::RMPExecuteActions()
     ExchangeContext * ec = nullptr;
 
     // Process Ack Tables for all ExchangeContexts
-    ec = (ExchangeContext *) ContextPool;
+    ec = ContextPool;
 
 #if defined(RMP_TICKLESS_DEBUG)
     ChipLogProgress(ExchangeManager, "RMPExecuteActions");
@@ -1329,7 +1329,7 @@ void ChipExchangeManager::RMPExpireTicks()
     uint32_t deltaTicks;
 
     // Process Ack Tables for all ExchangeContexts
-    ec = (ExchangeContext *) ContextPool;
+    ec = ContextPool;
 
     now = System::Timer::GetCurrentEpoch();
 
@@ -1666,7 +1666,7 @@ void ChipExchangeManager::RMPStartTimer()
     ExchangeContext * ec  = nullptr;
 
     // When do we need to next wake up to send an ACK?
-    ec = (ExchangeContext *) ContextPool;
+    ec = ContextPool;
 
     for (int i = 0; i < CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS; i++, ec++)
     {

--- a/src/lib/message/CHIPMessageLayer.cpp
+++ b/src/lib/message/CHIPMessageLayer.cpp
@@ -814,7 +814,7 @@ void ChipMessageLayer::GetConnectionPoolStats(chip::System::Stats::count_t & aOu
 {
     aOutInUse = 0;
 
-    const ChipConnection * con = (ChipConnection *) mConPool;
+    const ChipConnection * con = mConPool;
     for (int i = 0; i < CHIP_CONFIG_MAX_CONNECTIONS; i++, con++)
     {
         if (con->mRefCount != 0)
@@ -833,7 +833,7 @@ void ChipMessageLayer::GetConnectionPoolStats(chip::System::Stats::count_t & aOu
  */
 ChipConnection * ChipMessageLayer::NewConnection()
 {
-    ChipConnection * con = (ChipConnection *) mConPool;
+    ChipConnection * con = mConPool;
     for (int i = 0; i < CHIP_CONFIG_MAX_CONNECTIONS; i++, con++)
     {
         if (con->mRefCount == 0)
@@ -852,7 +852,7 @@ void ChipMessageLayer::GetIncomingTCPConCount(const IPAddress & peerAddr, uint16
     count       = 0;
     countFromIP = 0;
 
-    ChipConnection * con = (ChipConnection *) mConPool;
+    ChipConnection * con = mConPool;
     for (int i = 0; i < CHIP_CONFIG_MAX_CONNECTIONS; i++, con++)
     {
         if (con->mRefCount > 0 && con->NetworkType == ChipConnection::kNetworkType_IP && con->IsIncoming())

--- a/src/lib/support/ScopedBuffer.h
+++ b/src/lib/support/ScopedBuffer.h
@@ -28,7 +28,6 @@
 #include <lib/support/CHIPMem.h>
 
 #include <type_traits>
-#include <utility>
 
 namespace chip {
 namespace Platform {
@@ -50,20 +49,6 @@ public:
     ScopedMemoryBufferBase() {}
     ScopedMemoryBufferBase(const ScopedMemoryBufferBase &) = delete;
     ScopedMemoryBufferBase & operator=(const ScopedMemoryBufferBase & other) = delete;
-
-    ScopedMemoryBufferBase(ScopedMemoryBufferBase && other)
-    {
-        if (this == &other)
-            return;
-        *this = std::move(other);
-    }
-
-    ScopedMemoryBufferBase & operator=(ScopedMemoryBufferBase && other)
-    {
-        mBuffer       = other.mBuffer;
-        other.mBuffer = nullptr;
-        return *this;
-    }
 
     ~ScopedMemoryBufferBase() { Free(); }
 

--- a/src/lib/support/ScopedBuffer.h
+++ b/src/lib/support/ScopedBuffer.h
@@ -28,6 +28,7 @@
 #include <lib/support/CHIPMem.h>
 
 #include <type_traits>
+#include <utility>
 
 namespace chip {
 namespace Platform {
@@ -49,6 +50,20 @@ public:
     ScopedMemoryBufferBase() {}
     ScopedMemoryBufferBase(const ScopedMemoryBufferBase &) = delete;
     ScopedMemoryBufferBase & operator=(const ScopedMemoryBufferBase & other) = delete;
+
+    ScopedMemoryBufferBase(ScopedMemoryBufferBase && other)
+    {
+        if (this == &other)
+            return;
+        *this = std::move(other);
+    }
+
+    ScopedMemoryBufferBase & operator=(ScopedMemoryBufferBase && other)
+    {
+        mBuffer       = other.mBuffer;
+        other.mBuffer = nullptr;
+        return *this;
+    }
 
     ~ScopedMemoryBufferBase() { Free(); }
 

--- a/src/lib/support/tests/TestCHIPArgParser.cpp
+++ b/src/lib/support/tests/TestCHIPArgParser.cpp
@@ -188,7 +188,7 @@ static void SimpleParseTest_SingleLongOption()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, (char **) argv, optionSets, HandleNonOptionArgs);
+    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == true, "ParseArgs() returned false");
     VerifyOrQuit(sCallbackRecordCount == 2, "Invalid value returned for sCallbackRecordCount");
     VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", nullptr);
@@ -213,7 +213,7 @@ static void SimpleParseTest_SingleShortOption()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, (char **) argv, optionSets, HandleNonOptionArgs);
+    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == true, "ParseArgs() returned false");
     VerifyOrQuit(sCallbackRecordCount == 2, "Invalid value returned for sCallbackRecordCount");
     VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetB, 's', "-s", nullptr);
@@ -238,7 +238,7 @@ static void SimpleParseTest_SingleLongOptionWithValue()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, (char **) argv, optionSets, HandleNonOptionArgs);
+    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == true, "ParseArgs() returned false");
     VerifyOrQuit(sCallbackRecordCount == 2, "Invalid value returned for sCallbackRecordCount");
     VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetB, 1000, "--run", "run-value");
@@ -263,7 +263,7 @@ static void SimpleParseTest_SingleShortOptionWithValue()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, (char **) argv, optionSets, HandleNonOptionArgs);
+    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == true, "ParseArgs() returned false");
     VerifyOrQuit(sCallbackRecordCount == 2, "Invalid value returned for sCallbackRecordCount");
     VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, 'Z', "-Z", "baz-value");
@@ -297,7 +297,7 @@ static void SimpleParseTest_VariousShortAndLongWithArgs()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, (char **) argv, optionSets, HandleNonOptionArgs);
+    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == true, "ParseArgs() returned false");
     VerifyOrQuit(sCallbackRecordCount == 12, "Invalid value returned for sCallbackRecordCount");
     VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", nullptr);
@@ -336,7 +336,7 @@ static void UnknownOptionTest_UnknownShortOption()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, (char **) argv, optionSets, HandleNonOptionArgs);
+    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 3, "Invalid value returned for sCallbackRecordCount");
     VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", nullptr);
@@ -368,7 +368,7 @@ static void UnknownOptionTest_UnknownLongOption()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, (char **) argv, optionSets, HandleNonOptionArgs);
+    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 3, "Invalid value returned for sCallbackRecordCount");
     VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", nullptr);
@@ -400,7 +400,7 @@ static void UnknownOptionTest_UnknownShortOptionAfterKnown()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, (char **) argv, optionSets, HandleNonOptionArgs);
+    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 4, "Invalid value returned for sCallbackRecordCount");
     VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", nullptr);
@@ -429,7 +429,7 @@ static void UnknownOptionTest_UnknownShortOptionBeforeKnown()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, (char **) argv, optionSets, HandleNonOptionArgs);
+    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 1, "Invalid value returned for sCallbackRecordCount");
     VerifyPrintArgErrorCallback(0);
@@ -457,7 +457,7 @@ static void UnknownOptionTest_UnknownShortOptionAfterArgs()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, (char **) argv, optionSets, HandleNonOptionArgs);
+    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 1, "Invalid value returned for sCallbackRecordCount");
     VerifyPrintArgErrorCallback(0);
@@ -485,7 +485,7 @@ static void UnknownOptionTest_UnknownLongOptionAfterArgs()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, (char **) argv, optionSets, HandleNonOptionArgs);
+    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 1, "Invalid value returned for sCallbackRecordCount");
     VerifyPrintArgErrorCallback(0);
@@ -514,7 +514,7 @@ static void UnknownOptionTest_IgnoreUnknownLongOption()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, (char **) argv, optionSets, HandleNonOptionArgs, true);
+    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs, true);
     VerifyOrQuit(res == true, "ParseArgs() returned false");
 
     VerifyOrQuit(sCallbackRecordCount == 4, "Invalid value returned for sCallbackRecordCount");
@@ -546,7 +546,7 @@ static void UnknownOptionTest_IgnoreUnknownShortOption()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, (char **) argv, optionSets, HandleNonOptionArgs, true);
+    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs, true);
     VerifyOrQuit(res == true, "ParseArgs() returned false");
 
     VerifyOrQuit(sCallbackRecordCount == 5, "Invalid value returned for sCallbackRecordCount");
@@ -576,7 +576,7 @@ static void MissingValueTest_MissingShortOptionValue()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, (char **) argv, optionSets, HandleNonOptionArgs, true);
+    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs, true);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 1, "Invalid value returned for sCallbackRecordCount");
     VerifyPrintArgErrorCallback(0);
@@ -602,7 +602,7 @@ static void MissingValueTest_MissingLongOptionValue()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, (char **) argv, optionSets, HandleNonOptionArgs, true);
+    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs, true);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 1, "Invalid value returned for sCallbackRecordCount");
     VerifyPrintArgErrorCallback(0);

--- a/src/lib/support/tests/TestCHIPArgParser.cpp
+++ b/src/lib/support/tests/TestCHIPArgParser.cpp
@@ -27,6 +27,7 @@
 #include <core/CHIPCore.h>
 
 #include <support/CHIPArgParser.hpp>
+#include <support/ScopedBuffer.h>
 
 #if CHIP_CONFIG_ENABLE_ARG_PARSER
 
@@ -170,6 +171,44 @@ static OptionSet sOptionSetB =
 };
 // clang-format on
 
+namespace {
+
+struct TestArgv
+{
+    chip::Platform::ScopedMemoryBuffer<char> strings;
+    chip::Platform::ScopedMemoryBuffer<char *> argv;
+};
+
+// Duplicate arguments since tests use string constants and argv is not
+// defined const.
+TestArgv DupeArgs(const char * argv[], int argc)
+{
+    TestArgv ret;
+    ret.argv.Alloc(argc + 1);
+
+    size_t len = 0;
+    for (int i = 0; i < argc; ++i)
+    {
+        len += strlen(argv[i]) + 1;
+    }
+
+    ret.strings.Alloc(len);
+
+    size_t offset = 0;
+    for (int i = 0; i < argc; ++i)
+    {
+        ret.argv[i] = &ret.strings[offset];
+        memcpy(ret.argv[i], argv[i], strlen(argv[i]) + 1);
+        offset += strlen(argv[i]) + 1;
+    }
+
+    ret.argv[argc] = nullptr;
+
+    return ret;
+}
+
+} // namespace
+
 static void SimpleParseTest_SingleLongOption()
 {
     bool res;
@@ -188,7 +227,8 @@ static void SimpleParseTest_SingleLongOption()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs);
+    TestArgv argsDup = DupeArgs(argv, argc);
+    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == true, "ParseArgs() returned false");
     VerifyOrQuit(sCallbackRecordCount == 2, "Invalid value returned for sCallbackRecordCount");
     VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", nullptr);
@@ -213,7 +253,8 @@ static void SimpleParseTest_SingleShortOption()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs);
+    TestArgv argsDup = DupeArgs(argv, argc);
+    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == true, "ParseArgs() returned false");
     VerifyOrQuit(sCallbackRecordCount == 2, "Invalid value returned for sCallbackRecordCount");
     VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetB, 's', "-s", nullptr);
@@ -238,7 +279,8 @@ static void SimpleParseTest_SingleLongOptionWithValue()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs);
+    TestArgv argsDup = DupeArgs(argv, argc);
+    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == true, "ParseArgs() returned false");
     VerifyOrQuit(sCallbackRecordCount == 2, "Invalid value returned for sCallbackRecordCount");
     VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetB, 1000, "--run", "run-value");
@@ -263,7 +305,8 @@ static void SimpleParseTest_SingleShortOptionWithValue()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs);
+    TestArgv argsDup = DupeArgs(argv, argc);
+    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == true, "ParseArgs() returned false");
     VerifyOrQuit(sCallbackRecordCount == 2, "Invalid value returned for sCallbackRecordCount");
     VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, 'Z', "-Z", "baz-value");
@@ -297,7 +340,8 @@ static void SimpleParseTest_VariousShortAndLongWithArgs()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs);
+    TestArgv argsDup = DupeArgs(argv, argc);
+    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == true, "ParseArgs() returned false");
     VerifyOrQuit(sCallbackRecordCount == 12, "Invalid value returned for sCallbackRecordCount");
     VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", nullptr);
@@ -336,7 +380,8 @@ static void UnknownOptionTest_UnknownShortOption()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs);
+    TestArgv argsDup = DupeArgs(argv, argc);
+    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 3, "Invalid value returned for sCallbackRecordCount");
     VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", nullptr);
@@ -368,7 +413,8 @@ static void UnknownOptionTest_UnknownLongOption()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs);
+    TestArgv argsDup = DupeArgs(argv, argc);
+    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 3, "Invalid value returned for sCallbackRecordCount");
     VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", nullptr);
@@ -400,7 +446,8 @@ static void UnknownOptionTest_UnknownShortOptionAfterKnown()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs);
+    TestArgv argsDup = DupeArgs(argv, argc);
+    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 4, "Invalid value returned for sCallbackRecordCount");
     VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", nullptr);
@@ -429,7 +476,8 @@ static void UnknownOptionTest_UnknownShortOptionBeforeKnown()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs);
+    TestArgv argsDup = DupeArgs(argv, argc);
+    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 1, "Invalid value returned for sCallbackRecordCount");
     VerifyPrintArgErrorCallback(0);
@@ -457,7 +505,8 @@ static void UnknownOptionTest_UnknownShortOptionAfterArgs()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs);
+    TestArgv argsDup = DupeArgs(argv, argc);
+    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 1, "Invalid value returned for sCallbackRecordCount");
     VerifyPrintArgErrorCallback(0);
@@ -485,7 +534,8 @@ static void UnknownOptionTest_UnknownLongOptionAfterArgs()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs);
+    TestArgv argsDup = DupeArgs(argv, argc);
+    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 1, "Invalid value returned for sCallbackRecordCount");
     VerifyPrintArgErrorCallback(0);
@@ -514,7 +564,8 @@ static void UnknownOptionTest_IgnoreUnknownLongOption()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs, true);
+    TestArgv argsDup = DupeArgs(argv, argc);
+    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs, true);
     VerifyOrQuit(res == true, "ParseArgs() returned false");
 
     VerifyOrQuit(sCallbackRecordCount == 4, "Invalid value returned for sCallbackRecordCount");
@@ -546,7 +597,8 @@ static void UnknownOptionTest_IgnoreUnknownShortOption()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs, true);
+    TestArgv argsDup = DupeArgs(argv, argc);
+    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs, true);
     VerifyOrQuit(res == true, "ParseArgs() returned false");
 
     VerifyOrQuit(sCallbackRecordCount == 5, "Invalid value returned for sCallbackRecordCount");
@@ -576,7 +628,8 @@ static void MissingValueTest_MissingShortOptionValue()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs, true);
+    TestArgv argsDup = DupeArgs(argv, argc);
+    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs, true);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 1, "Invalid value returned for sCallbackRecordCount");
     VerifyPrintArgErrorCallback(0);
@@ -602,7 +655,8 @@ static void MissingValueTest_MissingLongOptionValue()
     ClearCallbackRecords();
     PrintArgError = HandleArgError;
 
-    res = ParseArgs(__FUNCTION__, argc, const_cast<char **>(argv), optionSets, HandleNonOptionArgs, true);
+    TestArgv argsDup = DupeArgs(argv, argc);
+    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs, true);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 1, "Invalid value returned for sCallbackRecordCount");
     VerifyPrintArgErrorCallback(0);

--- a/src/lib/support/tests/TestCHIPArgParser.cpp
+++ b/src/lib/support/tests/TestCHIPArgParser.cpp
@@ -228,7 +228,7 @@ static void SimpleParseTest_SingleLongOption()
     PrintArgError = HandleArgError;
 
     TestArgv argsDup = DupeArgs(argv, argc);
-    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
+    res              = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == true, "ParseArgs() returned false");
     VerifyOrQuit(sCallbackRecordCount == 2, "Invalid value returned for sCallbackRecordCount");
     VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", nullptr);
@@ -254,7 +254,7 @@ static void SimpleParseTest_SingleShortOption()
     PrintArgError = HandleArgError;
 
     TestArgv argsDup = DupeArgs(argv, argc);
-    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
+    res              = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == true, "ParseArgs() returned false");
     VerifyOrQuit(sCallbackRecordCount == 2, "Invalid value returned for sCallbackRecordCount");
     VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetB, 's', "-s", nullptr);
@@ -280,7 +280,7 @@ static void SimpleParseTest_SingleLongOptionWithValue()
     PrintArgError = HandleArgError;
 
     TestArgv argsDup = DupeArgs(argv, argc);
-    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
+    res              = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == true, "ParseArgs() returned false");
     VerifyOrQuit(sCallbackRecordCount == 2, "Invalid value returned for sCallbackRecordCount");
     VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetB, 1000, "--run", "run-value");
@@ -306,7 +306,7 @@ static void SimpleParseTest_SingleShortOptionWithValue()
     PrintArgError = HandleArgError;
 
     TestArgv argsDup = DupeArgs(argv, argc);
-    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
+    res              = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == true, "ParseArgs() returned false");
     VerifyOrQuit(sCallbackRecordCount == 2, "Invalid value returned for sCallbackRecordCount");
     VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, 'Z', "-Z", "baz-value");
@@ -341,7 +341,7 @@ static void SimpleParseTest_VariousShortAndLongWithArgs()
     PrintArgError = HandleArgError;
 
     TestArgv argsDup = DupeArgs(argv, argc);
-    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
+    res              = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == true, "ParseArgs() returned false");
     VerifyOrQuit(sCallbackRecordCount == 12, "Invalid value returned for sCallbackRecordCount");
     VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", nullptr);
@@ -381,7 +381,7 @@ static void UnknownOptionTest_UnknownShortOption()
     PrintArgError = HandleArgError;
 
     TestArgv argsDup = DupeArgs(argv, argc);
-    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
+    res              = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 3, "Invalid value returned for sCallbackRecordCount");
     VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", nullptr);
@@ -414,7 +414,7 @@ static void UnknownOptionTest_UnknownLongOption()
     PrintArgError = HandleArgError;
 
     TestArgv argsDup = DupeArgs(argv, argc);
-    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
+    res              = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 3, "Invalid value returned for sCallbackRecordCount");
     VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", nullptr);
@@ -447,7 +447,7 @@ static void UnknownOptionTest_UnknownShortOptionAfterKnown()
     PrintArgError = HandleArgError;
 
     TestArgv argsDup = DupeArgs(argv, argc);
-    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
+    res              = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 4, "Invalid value returned for sCallbackRecordCount");
     VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", nullptr);
@@ -477,7 +477,7 @@ static void UnknownOptionTest_UnknownShortOptionBeforeKnown()
     PrintArgError = HandleArgError;
 
     TestArgv argsDup = DupeArgs(argv, argc);
-    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
+    res              = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 1, "Invalid value returned for sCallbackRecordCount");
     VerifyPrintArgErrorCallback(0);
@@ -506,7 +506,7 @@ static void UnknownOptionTest_UnknownShortOptionAfterArgs()
     PrintArgError = HandleArgError;
 
     TestArgv argsDup = DupeArgs(argv, argc);
-    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
+    res              = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 1, "Invalid value returned for sCallbackRecordCount");
     VerifyPrintArgErrorCallback(0);
@@ -535,7 +535,7 @@ static void UnknownOptionTest_UnknownLongOptionAfterArgs()
     PrintArgError = HandleArgError;
 
     TestArgv argsDup = DupeArgs(argv, argc);
-    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
+    res              = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 1, "Invalid value returned for sCallbackRecordCount");
     VerifyPrintArgErrorCallback(0);
@@ -565,7 +565,7 @@ static void UnknownOptionTest_IgnoreUnknownLongOption()
     PrintArgError = HandleArgError;
 
     TestArgv argsDup = DupeArgs(argv, argc);
-    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs, true);
+    res              = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs, true);
     VerifyOrQuit(res == true, "ParseArgs() returned false");
 
     VerifyOrQuit(sCallbackRecordCount == 4, "Invalid value returned for sCallbackRecordCount");
@@ -598,7 +598,7 @@ static void UnknownOptionTest_IgnoreUnknownShortOption()
     PrintArgError = HandleArgError;
 
     TestArgv argsDup = DupeArgs(argv, argc);
-    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs, true);
+    res              = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs, true);
     VerifyOrQuit(res == true, "ParseArgs() returned false");
 
     VerifyOrQuit(sCallbackRecordCount == 5, "Invalid value returned for sCallbackRecordCount");
@@ -629,7 +629,7 @@ static void MissingValueTest_MissingShortOptionValue()
     PrintArgError = HandleArgError;
 
     TestArgv argsDup = DupeArgs(argv, argc);
-    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs, true);
+    res              = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs, true);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 1, "Invalid value returned for sCallbackRecordCount");
     VerifyPrintArgErrorCallback(0);
@@ -656,7 +656,7 @@ static void MissingValueTest_MissingLongOptionValue()
     PrintArgError = HandleArgError;
 
     TestArgv argsDup = DupeArgs(argv, argc);
-    res = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs, true);
+    res              = ParseArgs(__FUNCTION__, argc, argsDup.argv.Get(), optionSets, HandleNonOptionArgs, true);
     VerifyOrQuit(res == false, "ParseArgs() returned true");
     VerifyOrQuit(sCallbackRecordCount == 1, "Invalid value returned for sCallbackRecordCount");
     VerifyPrintArgErrorCallback(0);

--- a/src/lib/support/tests/TestCHIPArgParserDriver.cpp
+++ b/src/lib/support/tests/TestCHIPArgParserDriver.cpp
@@ -25,7 +25,11 @@
 
 #include "TestSupport.h"
 
+#include <support/CHIPMem.h>
+
 int main()
 {
+    chip::Platform::MemoryInit();
+
     return (TestCHIPArgParser());
 }

--- a/src/lib/support/tests/TestCHIPArgParserDriver.cpp
+++ b/src/lib/support/tests/TestCHIPArgParserDriver.cpp
@@ -25,11 +25,7 @@
 
 #include "TestSupport.h"
 
-#include <support/CHIPMem.h>
-
 int main()
 {
-    chip::Platform::MemoryInit();
-
     return (TestCHIPArgParser());
 }

--- a/src/platform/Darwin/BLEManagerImpl.cpp
+++ b/src/platform/Darwin/BLEManagerImpl.cpp
@@ -110,9 +110,9 @@ CHIP_ERROR BLEManagerImpl::_SetDeviceName(const char * deviceName)
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
-BleLayer * BLEManagerImpl::_GetBleLayer() const
+BleLayer * BLEManagerImpl::_GetBleLayer()
 {
-    return (BleLayer *) (this);
+    return this;
 }
 
 uint16_t BLEManagerImpl::_NumConnections(void)

--- a/src/platform/Darwin/BLEManagerImpl.h
+++ b/src/platform/Darwin/BLEManagerImpl.h
@@ -56,7 +56,7 @@ private:
     CHIP_ERROR _SetDeviceName(const char * deviceName);
     uint16_t _NumConnections(void);
     void _OnPlatformEvent(const ChipDeviceEvent * event);
-    BleLayer * _GetBleLayer(void) const;
+    BleLayer * _GetBleLayer(void);
 
     // ===== Members for internal use by the following friends.
 

--- a/src/platform/EFR32/BLEManagerImpl.h
+++ b/src/platform/EFR32/BLEManagerImpl.h
@@ -60,7 +60,7 @@ class BLEManagerImpl final : public BLEManager, private BleLayer, private BlePla
     CHIP_ERROR _SetDeviceName(const char * deviceName);
     uint16_t _NumConnections(void);
     void _OnPlatformEvent(const ChipDeviceEvent * event);
-    BleLayer * _GetBleLayer(void) const;
+    BleLayer * _GetBleLayer(void);
 
     // ===== Members that implement virtual methods on BlePlatformDelegate.
 
@@ -170,9 +170,9 @@ inline BLEManagerImpl & BLEMgrImpl(void)
     return BLEManagerImpl::sInstance;
 }
 
-inline BleLayer * BLEManagerImpl::_GetBleLayer() const
+inline BleLayer * BLEManagerImpl::_GetBleLayer()
 {
-    return (BleLayer *) (this);
+    return this;
 }
 
 inline BLEManager::CHIPoBLEServiceMode BLEManagerImpl::_GetCHIPoBLEServiceMode(void)

--- a/src/platform/ESP32/BLEManagerImpl.h
+++ b/src/platform/ESP32/BLEManagerImpl.h
@@ -86,7 +86,7 @@ class BLEManagerImpl final : public BLEManager,
     CHIP_ERROR _SetDeviceName(const char * deviceName);
     uint16_t _NumConnections(void);
     void _OnPlatformEvent(const ChipDeviceEvent * event);
-    ::chip::Ble::BleLayer * _GetBleLayer(void) const;
+    ::chip::Ble::BleLayer * _GetBleLayer(void);
 
     // ===== Members that implement virtual methods on BlePlatformDelegate.
 
@@ -236,9 +236,9 @@ inline BLEManagerImpl & BLEMgrImpl(void)
     return BLEManagerImpl::sInstance;
 }
 
-inline ::chip::Ble::BleLayer * BLEManagerImpl::_GetBleLayer() const
+inline ::chip::Ble::BleLayer * BLEManagerImpl::_GetBleLayer()
 {
-    return (BleLayer *) (this);
+    return this;
 }
 
 inline BLEManager::CHIPoBLEServiceMode BLEManagerImpl::_GetCHIPoBLEServiceMode(void)

--- a/src/platform/K32W/BLEManagerImpl.h
+++ b/src/platform/K32W/BLEManagerImpl.h
@@ -67,7 +67,7 @@ private:
     CHIP_ERROR _SetDeviceName(const char * deviceName);
     uint16_t _NumConnections(void);
     void _OnPlatformEvent(const ChipDeviceEvent * event);
-    BleLayer * _GetBleLayer(void) const;
+    BleLayer * _GetBleLayer(void);
 
     // ===== Members that implement virtual methods on BlePlatformDelegate.
 
@@ -162,9 +162,9 @@ inline BLEManagerImpl & BLEMgrImpl(void)
     return BLEManagerImpl::sInstance;
 }
 
-inline ::nl::Ble::BleLayer * BLEManagerImpl::_GetBleLayer() const
+inline ::nl::Ble::BleLayer * BLEManagerImpl::_GetBleLayer()
 {
-    return (BleLayer *) (this);
+    return this;
 }
 
 inline BLEManager::CHIPoBLEServiceMode BLEManagerImpl::_GetCHIPoBLEServiceMode(void)

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -124,7 +124,7 @@ private:
 
     void _OnPlatformEvent(const ChipDeviceEvent * event);
     void HandlePlatformSpecificBLEEvent(const ChipDeviceEvent * event);
-    BleLayer * _GetBleLayer() const;
+    BleLayer * _GetBleLayer();
 
     // ===== Members that implement virtual methods on BlePlatformDelegate.
 
@@ -218,9 +218,9 @@ inline BLEManagerImpl & BLEMgrImpl()
     return BLEManagerImpl::sInstance;
 }
 
-inline Ble::BleLayer * BLEManagerImpl::_GetBleLayer() const
+inline Ble::BleLayer * BLEManagerImpl::_GetBleLayer()
 {
-    return (Ble::BleLayer *) (this);
+    return this;
 }
 
 inline BLEManager::CHIPoBLEServiceMode BLEManagerImpl::_GetCHIPoBLEServiceMode()

--- a/src/platform/Zephyr/GenericBLEManagerImpl_Zephyr.h
+++ b/src/platform/Zephyr/GenericBLEManagerImpl_Zephyr.h
@@ -64,7 +64,7 @@ private:
     CHIP_ERROR _SetDeviceName(const char * deviceName);
     uint16_t _NumConnections(void);
     void _OnPlatformEvent(const ChipDeviceEvent * event);
-    BleLayer * _GetBleLayer(void) const;
+    BleLayer * _GetBleLayer(void);
 
     // ===== Members that implement virtual methods on BlePlatformDelegate.
 
@@ -132,9 +132,9 @@ public:
 };
 
 template <class ImplClass>
-inline BleLayer * GenericBLEManagerImpl_Zephyr<ImplClass>::_GetBleLayer() const
+inline BleLayer * GenericBLEManagerImpl_Zephyr<ImplClass>::_GetBleLayer()
 {
-    return (BleLayer *) (this);
+    return this;
 }
 
 template <class ImplClass>

--- a/src/platform/nRF5/BLEManagerImpl.h
+++ b/src/platform/nRF5/BLEManagerImpl.h
@@ -67,7 +67,7 @@ private:
     CHIP_ERROR _SetDeviceName(const char * deviceName);
     uint16_t _NumConnections(void);
     void _OnPlatformEvent(const ChipDeviceEvent * event);
-    BleLayer * _GetBleLayer(void) const;
+    BleLayer * _GetBleLayer(void);
 
     // ===== Members that implement virtual methods on BlePlatformDelegate.
 
@@ -177,9 +177,9 @@ inline void BLEManagerImpl::SetAdvertisingHandle(uint8_t handle)
     mAdvHandle = handle;
 }
 
-inline BleLayer * BLEManagerImpl::_GetBleLayer() const
+inline BleLayer * BLEManagerImpl::_GetBleLayer()
 {
-    return (BleLayer *) (this);
+    return this;
 }
 
 inline BLEManager::CHIPoBLEServiceMode BLEManagerImpl::_GetCHIPoBLEServiceMode(void)

--- a/src/platform/qpg6100/BLEManagerImpl.h
+++ b/src/platform/qpg6100/BLEManagerImpl.h
@@ -58,7 +58,7 @@ private:
     CHIP_ERROR _SetDeviceName(const char * deviceName);
     uint16_t _NumConnections(void);
     void _OnPlatformEvent(const ChipDeviceEvent * event);
-    BleLayer * _GetBleLayer(void) const;
+    BleLayer * _GetBleLayer(void);
 
     // ===== Members that implement virtual methods on BlePlatformDelegate.
 
@@ -150,9 +150,9 @@ inline BLEManagerImpl & BLEMgrImpl(void)
     return BLEManagerImpl::sInstance;
 }
 
-inline BleLayer * BLEManagerImpl::_GetBleLayer() const
+inline BleLayer * BLEManagerImpl::_GetBleLayer()
 {
-    return (BleLayer *) (this);
+    return this;
 }
 
 inline BLEManager::CHIPoBLEServiceMode BLEManagerImpl::_GetCHIPoBLEServiceMode(void)

--- a/src/system/SystemLayer.cpp
+++ b/src/system/SystemLayer.cpp
@@ -216,10 +216,9 @@ Error Layer::NewTimer(Timer *& aTimerPtr)
     return CHIP_SYSTEM_NO_ERROR;
 }
 
-static bool TimerReady(void * p, const Cancelable * timer)
+static bool TimerReady(const Timer::Epoch epoch, const Cancelable * timer)
 {
-    const Timer::Epoch * kCurrentEpoch = static_cast<const Timer::Epoch *>(p);
-    return !Timer::IsEarlierEpoch(*kCurrentEpoch, timer->mInfoScalar);
+    return !Timer::IsEarlierEpoch(epoch, timer->mInfoScalar);
 }
 
 static int TimerCompare(void * p, const Cancelable * a, const Cancelable * b)
@@ -565,7 +564,7 @@ Error Layer::SetClock_RealTime(uint64_t newCurTime)
 void Layer::DispatchTimerCallbacks(const uint64_t kCurrentEpoch)
 {
     // dispatch TimerCallbacks
-    Cancelable ready = mTimerCallbacks.DequeueBy(TimerReady, const_cast<void *>(reinterpret_cast<const void *>(&kCurrentEpoch)));
+    Cancelable ready = mTimerCallbacks.DequeueBy(TimerReady, kCurrentEpoch);
     while (ready.mNext != &ready)
     {
         // one-shot

--- a/src/system/SystemLayer.cpp
+++ b/src/system/SystemLayer.cpp
@@ -565,7 +565,7 @@ Error Layer::SetClock_RealTime(uint64_t newCurTime)
 void Layer::DispatchTimerCallbacks(const uint64_t kCurrentEpoch)
 {
     // dispatch TimerCallbacks
-    Cancelable ready = mTimerCallbacks.DequeueBy(TimerReady, (void *) &kCurrentEpoch);
+    Cancelable ready = mTimerCallbacks.DequeueBy(TimerReady, const_cast<void *>(reinterpret_cast<const void *>(&kCurrentEpoch)));
     while (ready.mNext != &ready)
     {
         // one-shot


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

Many C style casts remain after 181f0760 ("clang-tidy: Apply fixes
"google-readability-casting" (#3034)").

The reason they were not updated is typically because they are casting
away const qualifiers or because no cast is necessary.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes

Fix these cases by adding or removing casts, `const`, or add a const_cast<> if appropriate.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
