### PR TITLE
ChipTool: Remove default values for commands and pass them as paramet…

### DIFF
--- a/examples/chip-tool/commands/clusters/ColorControl/Commands.h
+++ b/examples/chip-tool/commands/clusters/ColorControl/Commands.h
@@ -24,230 +24,353 @@
 class MoveToHue : public ModelCommand
 {
 public:
-    MoveToHue(const uint16_t clusterId) : ModelCommand("move-to-hue", clusterId) {}
+    MoveToHue(const uint16_t clusterId) : ModelCommand("move-to-hue", clusterId)
+    {
+        AddArgument("hue", 0, UINT8_MAX, &mHue);
+        AddArgument("direction", 0, UINT16_MAX, &mDirection);
+        AddArgument("time", 0, UINT16_MAX, &mTransitionTime);
+        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+    }
 
     size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
     {
-        uint8_t hue             = 30;
-        uint8_t direction       = 2;
-        uint16_t transitionTime = 10;
-        uint8_t optionsMask     = 0;
-        uint8_t optionsOverride = 0;
-        return encodeMoveToHueCommand(buffer->Start(), bufferSize, endPointId, hue, direction, transitionTime, optionsMask,
-                                      optionsOverride);
+        return encodeMoveToHueCommand(buffer->Start(), bufferSize, endPointId, mHue, mDirection, mTransitionTime, mOptionsMask,
+                                      mOptionsOverride);
     }
+
+private:
+    uint8_t mHue;
+    uint16_t mDirection;
+    uint16_t mTransitionTime;
+    uint8_t mOptionsMask;
+    uint8_t mOptionsOverride;
 };
 
 class MoveHue : public ModelCommand
 {
 public:
-    MoveHue(const uint16_t clusterId) : ModelCommand("move-hue", clusterId) {}
+    MoveHue(const uint16_t clusterId) : ModelCommand("move-hue", clusterId)
+    {
+        AddArgument("mode", 0, UINT8_MAX, &mMoveMode);
+        AddArgument("rate", 0, UINT8_MAX, &mRate);
+        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+    }
 
     size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
     {
-        uint8_t moveMode        = 2;
-        uint8_t rate            = 127;
-        uint8_t optionsMask     = 0;
-        uint8_t optionsOverride = 0;
-        return encodeMoveHueCommand(buffer->Start(), bufferSize, endPointId, moveMode, rate, optionsMask, optionsOverride);
+        return encodeMoveHueCommand(buffer->Start(), bufferSize, endPointId, mMoveMode, mRate, mOptionsMask, mOptionsOverride);
     }
+
+private:
+    uint8_t mMoveMode;
+    uint8_t mRate;
+    uint8_t mOptionsMask;
+    uint8_t mOptionsOverride;
 };
 
 class StepHue : public ModelCommand
 {
 public:
-    StepHue(const uint16_t clusterId) : ModelCommand("step-hue", clusterId) {}
+    StepHue(const uint16_t clusterId) : ModelCommand("step-hue", clusterId)
+    {
+        AddArgument("mode", 0, UINT8_MAX, &mStepMode);
+        AddArgument("size", 0, UINT8_MAX, &mStepSize);
+        AddArgument("time", 0, UINT16_MAX, &mTransitionTime);
+        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+    }
 
     size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
     {
-        uint8_t stepMode        = 2;
-        uint8_t stepSize        = 127;
-        uint16_t transitionTime = 10;
-        uint8_t optionsMask     = 0;
-        uint8_t optionsOverride = 0;
-        return encodeStepHueCommand(buffer->Start(), bufferSize, endPointId, stepMode, stepSize, transitionTime, optionsMask,
-                                    optionsOverride);
+        return encodeStepHueCommand(buffer->Start(), bufferSize, endPointId, mStepMode, mStepSize, mTransitionTime, mOptionsMask,
+                                    mOptionsOverride);
     }
+
+private:
+    uint8_t mStepMode;
+    uint8_t mStepSize;
+    uint16_t mTransitionTime;
+    uint8_t mOptionsMask;
+    uint8_t mOptionsOverride;
 };
 
 class MoveToSaturation : public ModelCommand
 {
 public:
-    MoveToSaturation(const uint16_t clusterId) : ModelCommand("move-to-saturation", clusterId) {}
+    MoveToSaturation(const uint16_t clusterId) : ModelCommand("move-to-saturation", clusterId)
+    {
+        AddArgument("saturation", 0, UINT8_MAX, &mSaturation);
+        AddArgument("time", 0, UINT16_MAX, &mTransitionTime);
+        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+    }
 
     size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
     {
-        uint8_t saturation      = 30;
-        uint16_t transitionTime = 10;
-        uint8_t optionsMask     = 0;
-        uint8_t optionsOverride = 0;
-        return encodeMoveToSaturationCommand(buffer->Start(), bufferSize, endPointId, saturation, transitionTime, optionsMask,
-                                             optionsOverride);
+        return encodeMoveToSaturationCommand(buffer->Start(), bufferSize, endPointId, mSaturation, mTransitionTime, mOptionsMask,
+                                             mOptionsOverride);
     }
+
+private:
+    uint8_t mSaturation;
+    uint16_t mTransitionTime;
+    uint8_t mOptionsMask;
+    uint8_t mOptionsOverride;
 };
 
 class MoveSaturation : public ModelCommand
 {
 public:
-    MoveSaturation(const uint16_t clusterId) : ModelCommand("move-saturation", clusterId) {}
+    MoveSaturation(const uint16_t clusterId) : ModelCommand("move-saturation", clusterId)
+    {
+        AddArgument("mode", 0, UINT8_MAX, &mMoveMode);
+        AddArgument("rate", 0, UINT8_MAX, &mRate);
+        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+    }
 
     size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
     {
-        uint8_t moveMode        = 30;
-        uint8_t rate            = 100;
-        uint8_t optionsMask     = 0;
-        uint8_t optionsOverride = 0;
-        return encodeMoveSaturationCommand(buffer->Start(), bufferSize, endPointId, moveMode, rate, optionsMask, optionsOverride);
+        return encodeMoveSaturationCommand(buffer->Start(), bufferSize, endPointId, mMoveMode, mRate, mOptionsMask,
+                                           mOptionsOverride);
     }
+
+private:
+    uint8_t mMoveMode;
+    uint8_t mRate;
+    uint8_t mOptionsMask;
+    uint8_t mOptionsOverride;
 };
 
 class StepSaturation : public ModelCommand
 {
 public:
-    StepSaturation(const uint16_t clusterId) : ModelCommand("step-saturation", clusterId) {}
+    StepSaturation(const uint16_t clusterId) : ModelCommand("step-saturation", clusterId)
+    {
+        AddArgument("mode", 0, UINT8_MAX, &mStepMode);
+        AddArgument("size", 0, UINT8_MAX, &mStepSize);
+        AddArgument("time", 0, UINT16_MAX, &mTransitionTime);
+        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+    }
 
     size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
     {
-        uint8_t stepMode        = 30;
-        uint8_t stepSize        = 100;
-        uint16_t transitionTime = 10;
-        uint8_t optionsMask     = 0;
-        uint8_t optionsOverride = 0;
-        return encodeStepSaturationCommand(buffer->Start(), bufferSize, endPointId, stepMode, stepSize, transitionTime, optionsMask,
-                                           optionsOverride);
+        return encodeStepSaturationCommand(buffer->Start(), bufferSize, endPointId, mStepMode, mStepSize, mTransitionTime,
+                                           mOptionsMask, mOptionsOverride);
     }
+
+private:
+    uint8_t mStepMode;
+    uint8_t mStepSize;
+    uint16_t mTransitionTime;
+    uint8_t mOptionsMask;
+    uint8_t mOptionsOverride;
 };
 
 class MoveToHueSaturation : public ModelCommand
 {
 public:
-    MoveToHueSaturation(const uint16_t clusterId) : ModelCommand("move-to-hue-saturation", clusterId) {}
+    MoveToHueSaturation(const uint16_t clusterId) : ModelCommand("move-to-hue-saturation", clusterId)
+    {
+        AddArgument("hue", 0, UINT8_MAX, &mHue);
+        AddArgument("saturation", 0, UINT8_MAX, &mSaturation);
+        AddArgument("time", 0, UINT16_MAX, &mTransitionTime);
+        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+    }
 
     size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
     {
-        uint8_t hue             = 30;
-        uint8_t saturation      = 100;
-        uint16_t transitionTime = 10;
-        uint8_t optionsMask     = 0;
-        uint8_t optionsOverride = 0;
-        return encodeMoveToHueSaturationCommand(buffer->Start(), bufferSize, endPointId, hue, saturation, transitionTime,
-                                                optionsMask, optionsOverride);
+        return encodeMoveToHueSaturationCommand(buffer->Start(), bufferSize, endPointId, mHue, mSaturation, mTransitionTime,
+                                                mOptionsMask, mOptionsOverride);
     }
+
+private:
+    uint8_t mHue;
+    uint8_t mSaturation;
+    uint16_t mTransitionTime;
+    uint8_t mOptionsMask;
+    uint8_t mOptionsOverride;
 };
 
 class MoveToColor : public ModelCommand
 {
 public:
-    MoveToColor(const uint16_t clusterId) : ModelCommand("move-to-color", clusterId) {}
+    MoveToColor(const uint16_t clusterId) : ModelCommand("move-to-color", clusterId)
+    {
+        AddArgument("x", 0, UINT16_MAX, &mColorX);
+        AddArgument("y", 0, UINT16_MAX, &mColorY);
+        AddArgument("time", 0, UINT16_MAX, &mTransitionTime);
+        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+    }
 
     size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
     {
-        uint16_t colorX         = 30;
-        uint16_t colorY         = 30;
-        uint16_t transitionTime = 10;
-        uint8_t optionsMask     = 0;
-        uint8_t optionsOverride = 0;
-        return encodeMoveToColorCommand(buffer->Start(), bufferSize, endPointId, colorX, colorY, transitionTime, optionsMask,
-                                        optionsOverride);
+        return encodeMoveToColorCommand(buffer->Start(), bufferSize, endPointId, mColorX, mColorY, mTransitionTime, mOptionsMask,
+                                        mOptionsOverride);
     }
+
+private:
+    uint16_t mColorX;
+    uint16_t mColorY;
+    uint16_t mTransitionTime;
+    uint8_t mOptionsMask;
+    uint8_t mOptionsOverride;
 };
 
 class MoveColor : public ModelCommand
 {
 public:
-    MoveColor(const uint16_t clusterId) : ModelCommand("move-color", clusterId) {}
+    MoveColor(const uint16_t clusterId) : ModelCommand("move-color", clusterId)
+    {
+        AddArgument("x", 0, UINT16_MAX, &mRateX);
+        AddArgument("y", 0, UINT16_MAX, &mRateY);
+        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+    }
 
     size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
     {
-        uint16_t rateX          = 30;
-        uint16_t rateY          = 30;
-        uint8_t optionsMask     = 0;
-        uint8_t optionsOverride = 0;
-        return encodeMoveColorCommand(buffer->Start(), bufferSize, endPointId, rateX, rateY, optionsMask, optionsOverride);
+        return encodeMoveColorCommand(buffer->Start(), bufferSize, endPointId, mRateX, mRateY, mOptionsMask, mOptionsOverride);
     }
+
+private:
+    uint16_t mRateX;
+    uint16_t mRateY;
+    uint8_t mOptionsMask;
+    uint8_t mOptionsOverride;
 };
 
 class StepColor : public ModelCommand
 {
 public:
-    StepColor(const uint16_t clusterId) : ModelCommand("step-color", clusterId) {}
+    StepColor(const uint16_t clusterId) : ModelCommand("step-color", clusterId)
+    {
+        AddArgument("x", 0, UINT16_MAX, &mStepX);
+        AddArgument("y", 0, UINT16_MAX, &mStepY);
+        AddArgument("time", 0, UINT16_MAX, &mTransitionTime);
+        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+    }
 
     size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
     {
-        uint16_t stepX          = 30;
-        uint16_t stepY          = 30;
-        uint16_t transitionTime = 10;
-        uint8_t optionsMask     = 0;
-        uint8_t optionsOverride = 0;
-        return encodeStepColorCommand(buffer->Start(), bufferSize, endPointId, stepX, stepY, transitionTime, optionsMask,
-                                      optionsOverride);
+        return encodeStepColorCommand(buffer->Start(), bufferSize, endPointId, mStepX, mStepY, mTransitionTime, mOptionsMask,
+                                      mOptionsOverride);
     }
+
+private:
+    uint16_t mStepX;
+    uint16_t mStepY;
+    uint16_t mTransitionTime;
+    uint8_t mOptionsMask;
+    uint8_t mOptionsOverride;
 };
 
 class MoveToColorTemperature : public ModelCommand
 {
 public:
-    MoveToColorTemperature(const uint16_t clusterId) : ModelCommand("move-to-color-temperature", clusterId) {}
+    MoveToColorTemperature(const uint16_t clusterId) : ModelCommand("move-to-color-temperature", clusterId)
+    {
+        AddArgument("temperature", 0, UINT16_MAX, &mColorTemperature);
+        AddArgument("time", 0, UINT16_MAX, &mTransitionTime);
+        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+    }
 
     size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
     {
-        uint16_t colorTemperature = 50000;
-        uint16_t transitionTime   = 50;
-        uint8_t optionsMask       = 0;
-        uint8_t optionsOverride   = 0;
-        return encodeMoveToColorTemperatureCommand(buffer->Start(), bufferSize, endPointId, colorTemperature, transitionTime,
-                                                   optionsMask, optionsOverride);
+        return encodeMoveToColorTemperatureCommand(buffer->Start(), bufferSize, endPointId, mColorTemperature, mTransitionTime,
+                                                   mOptionsMask, mOptionsOverride);
     }
+
+private:
+    uint16_t mColorTemperature;
+    uint16_t mTransitionTime;
+    uint8_t mOptionsMask;
+    uint8_t mOptionsOverride;
 };
 
 class MoveColorTemperature : public ModelCommand
 {
 public:
-    MoveColorTemperature(const uint16_t clusterId) : ModelCommand("move-color-temperature", clusterId) {}
+    MoveColorTemperature(const uint16_t clusterId) : ModelCommand("move-color-temperature", clusterId)
+    {
+        AddArgument("mode", 0, UINT8_MAX, &mMoveMode);
+        AddArgument("rate", 0, UINT16_MAX, &mRate);
+        AddArgument("min", 0, UINT16_MAX, &mColorTemperatureMin);
+        AddArgument("max", 0, UINT16_MAX, &mColorTemperatureMax);
+        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+    }
 
     size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
     {
-        uint8_t moveMode             = 4;
-        uint16_t rate                = 100;
-        uint16_t colorTemperatureMin = 1000;
-        uint16_t colorTemperatureMax = 5000;
-        uint8_t optionsMask          = 0;
-        uint8_t optionsOverride      = 0;
-        return encodeMoveColorTemperatureCommand(buffer->Start(), bufferSize, endPointId, moveMode, rate, colorTemperatureMin,
-                                                 colorTemperatureMax, optionsMask, optionsOverride);
+        return encodeMoveColorTemperatureCommand(buffer->Start(), bufferSize, endPointId, mMoveMode, mRate, mColorTemperatureMin,
+                                                 mColorTemperatureMax, mOptionsMask, mOptionsOverride);
     }
+
+private:
+    uint8_t mMoveMode;
+    uint16_t mRate;
+    uint16_t mColorTemperatureMin;
+    uint16_t mColorTemperatureMax;
+    uint8_t mOptionsMask;
+    uint8_t mOptionsOverride;
 };
 
 class StepColorTemperature : public ModelCommand
 {
 public:
-    StepColorTemperature(const uint16_t clusterId) : ModelCommand("step-color-temperature", clusterId) {}
+    StepColorTemperature(const uint16_t clusterId) : ModelCommand("step-color-temperature", clusterId)
+    {
+        AddArgument("mode", 0, UINT8_MAX, &mStepMode);
+        AddArgument("size", 0, UINT8_MAX, &mStepSize);
+        AddArgument("time", 0, UINT16_MAX, &mTransitionTime);
+        AddArgument("min", 0, UINT16_MAX, &mColorTemperatureMin);
+        AddArgument("max", 0, UINT16_MAX, &mColorTemperatureMax);
+        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+    }
 
     size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
     {
-        uint8_t stepMode             = 4;
-        uint16_t stepSize            = 100;
-        uint16_t transitionTime      = 10;
-        uint16_t colorTemperatureMin = 1000;
-        uint16_t colorTemperatureMax = 5000;
-        uint8_t optionsMask          = 0;
-        uint8_t optionsOverride      = 0;
-        return encodeStepColorTemperatureCommand(buffer->Start(), bufferSize, endPointId, stepMode, stepSize, colorTemperatureMin,
-                                                 colorTemperatureMax, transitionTime, optionsMask, optionsOverride);
+        return encodeStepColorTemperatureCommand(buffer->Start(), bufferSize, endPointId, mStepMode, mStepSize,
+                                                 mColorTemperatureMin, mColorTemperatureMax, mTransitionTime, mOptionsMask,
+                                                 mOptionsOverride);
     }
+
+private:
+    uint8_t mStepMode;
+    uint8_t mStepSize;
+    uint16_t mTransitionTime;
+    uint16_t mColorTemperatureMin;
+    uint16_t mColorTemperatureMax;
+    uint8_t mOptionsMask;
+    uint8_t mOptionsOverride;
 };
 
 class StopMoveStep : public ModelCommand
 {
 public:
-    StopMoveStep(const uint16_t clusterId) : ModelCommand("stop-move-step", clusterId) {}
+    StopMoveStep(const uint16_t clusterId) : ModelCommand("stop-move-step", clusterId)
+    {
+        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+    }
 
     size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
     {
-        uint8_t optionsMask     = 0;
-        uint8_t optionsOverride = 0;
-        return encodeStopMoveStepCommand(buffer->Start(), bufferSize, endPointId, optionsMask, optionsOverride);
+        return encodeStopMoveStepCommand(buffer->Start(), bufferSize, endPointId, mOptionsMask, mOptionsOverride);
     }
+
+private:
+    uint8_t mOptionsMask;
+    uint8_t mOptionsOverride;
 };
 
 void registerClusterColorControl(Commands & commands)

--- a/examples/chip-tool/commands/clusters/Identify/Commands.h
+++ b/examples/chip-tool/commands/clusters/Identify/Commands.h
@@ -24,12 +24,18 @@
 class Identify : public ModelCommand
 {
 public:
-    Identify(const uint16_t clusterId) : ModelCommand("identify", clusterId) {}
+    Identify(const uint16_t clusterId) : ModelCommand("identify", clusterId)
+    {
+        AddArgument("identifyTime", 0, UINT16_MAX, &mIdentifyTime);
+    }
+
     size_t EncodeCommand(chip::System::PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
     {
-        uint16_t duration = 10;
-        return encodeIdentifyCommand(buffer->Start(), bufferSize, endPointId, duration);
+        return encodeIdentifyCommand(buffer->Start(), bufferSize, endPointId, mIdentifyTime);
     }
+
+private:
+    uint16_t mIdentifyTime;
 };
 
 class IdentifyQuery : public ModelCommand

--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -136,12 +136,12 @@ size_t Command::AddArgument(const char * name, AddressWithInterface * out)
     return mArgs.size();
 }
 
-size_t Command::AddArgument(const char * name, uint32_t min, uint32_t max, uint32_t * out)
+size_t Command::AddArgument(const char * name, int64_t min, int64_t max, void * out)
 {
     Argument arg;
     arg.type  = ArgumentType::Number;
     arg.name  = name;
-    arg.value = reinterpret_cast<void *>(out);
+    arg.value = out;
     arg.min   = min;
     arg.max   = max;
 

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -82,14 +82,19 @@ public:
     size_t GetArgumentsCount(void) const { return mArgs.size(); }
 
     bool InitArguments(int argc, char * argv[]);
+    template <class T>
+    size_t AddArgument(const char * name, int64_t min, int64_t max, T * out)
+    {
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out));
+    }
     size_t AddArgument(const char * name, const char * value);
-    size_t AddArgument(const char * name, uint32_t min, uint32_t max, uint32_t * out);
     size_t AddArgument(const char * name, AddressWithInterface * out);
 
     virtual CHIP_ERROR Run(ChipDeviceController * dc, NodeId remoteId) = 0;
 
 private:
     bool InitArgument(size_t argIndex, const char * argValue);
+    size_t AddArgument(const char * name, int64_t min, int64_t max, void * out);
 
     const char * mName = nullptr;
     std::vector<Argument> mArgs;

--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -109,11 +109,12 @@ void Commands::ShowUsage(const char * executable)
     fprintf(stderr, "  | Clusters:                                                                           |\n");
     fprintf(stderr, "  |                                                                                     |\n");
     fprintf(stderr, "  |   Usage:                                                                            |\n");
-    fprintf(stderr, "  |    command_name remote-ip remote-port endpoint-id                                   |\n");
+    fprintf(stderr, "  |    command_name remote-ip remote-port endpoint-id [param1 param2 ...]               |\n");
     fprintf(stderr, "  |                                                                                     |\n");
-    fprintf(stderr, "  | Available command names:                                                            |\n");
+    fprintf(stderr, "  | Available command names and command specific parameters:                            |\n");
     fprintf(stderr, "  +-------------------------------------------------------------------------------------+\n");
     PrintClustersCommands();
+    fprintf(stderr, "\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "  +-------------------------------------------------------------------------------------+\n");
     fprintf(stderr, "  | Read Attributes:                                                                    |\n");
@@ -180,7 +181,27 @@ void Commands::PrintClustersCommands()
                         hasCommands = true;
                     }
 
-                    fprintf(stderr, "  | %-84s|\n", command->GetName());
+                    std::string arguments = "";
+                    arguments += command->GetName();
+
+                    size_t argumentsCount = command->GetArgumentsCount();
+
+                    // Skip the first 3 arguments since those are the common arguments for ModelCommands.
+                    if (argumentsCount > 3)
+                    {
+                        arguments += " [";
+                        for (size_t i = 3; i < argumentsCount; i++)
+                        {
+                            if (i != 3)
+                            {
+                                arguments += " ";
+                            }
+                            arguments += command->GetArgumentName(i);
+                        }
+                        arguments += "]";
+                    }
+
+                    fprintf(stderr, "  | %-84s|\n", arguments.c_str());
                 }
             }
         }


### PR DESCRIPTION
…ers of chip-tool instead

 #### Problem

Currently the various parameters of the clusters commands uses default values randomly chosen.
Also, using random values makes it harder to use chip-tool in a CI environment in order check if the stack works correctly.

 #### Summary of Changes
 * Remove default parameters from chip-tool for cluster commands
 * Allow the user to specify those values from the command line