### PR TITLE
[example/nrfconnect] Added support for sending UDP broadcast messages.

### DIFF
--- a/examples/lighting-app/nrfconnect/CMakeLists.txt
+++ b/examples/lighting-app/nrfconnect/CMakeLists.txt
@@ -26,7 +26,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CHIP_ROOT}/config/nrfconnect/)
 include(nrfconnect-app)
 
 project(chip-nrf52840-lighting-example)
-target_include_directories(app PRIVATE main/include ${LIGHTING_COMMON} ${NRFCONNECT_COMMON}/util/include ${CHIP_APP_SERVER}/include)
+target_include_directories(app PRIVATE main/include ${LIGHTING_COMMON} ${NRFCONNECT_COMMON}/util/include ${NRFCONNECT_COMMON}/app/include ${CHIP_APP_SERVER}/include)
 target_sources(app PRIVATE
                main/AppTask.cpp
                main/LightingManager.cpp
@@ -37,6 +37,7 @@ target_sources(app PRIVATE
                ${LIGHTING_COMMON}/gen/znet-bookkeeping.c
                ${NRFCONNECT_COMMON}/util/LEDWidget.cpp
                ${NRFCONNECT_COMMON}/util/ThreadUtil.cpp
+               ${NRFCONNECT_COMMON}/app/Service.cpp
                ${CHIP_APP_SERVER}/DataModelHandler.cpp
                ${CHIP_APP_SERVER}/Server.cpp
                ${CHIP_APP_SERVER}/QRCodeUtil.cpp

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -106,7 +106,7 @@ int AppTask::Init()
 
 int AppTask::StartApp()
 {
-    int ret = Init();
+    int ret                            = Init();
     uint64_t mLastPublishServiceTimeUS = 0;
 
     if (ret)

--- a/examples/lock-app/nrfconnect/CMakeLists.txt
+++ b/examples/lock-app/nrfconnect/CMakeLists.txt
@@ -26,7 +26,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CHIP_ROOT}/config/nrfconnect/)
 include(nrfconnect-app)
 
 project(chip-nrf52840-lock-example)
-target_include_directories(app PRIVATE main/include ${LOCK_COMMON} ${NRFCONNECT_COMMON}/util/include ${CHIP_APP_SERVER}/include)
+target_include_directories(app PRIVATE main/include ${LOCK_COMMON} ${NRFCONNECT_COMMON}/util/include ${NRFCONNECT_COMMON}/app/include ${CHIP_APP_SERVER}/include)
 target_sources(app PRIVATE
                main/AppTask.cpp
                main/BoltLockManager.cpp
@@ -37,6 +37,7 @@ target_sources(app PRIVATE
                ${LOCK_COMMON}/gen/znet-bookkeeping.c
                ${NRFCONNECT_COMMON}/util/LEDWidget.cpp
                ${NRFCONNECT_COMMON}/util/ThreadUtil.cpp
+               ${NRFCONNECT_COMMON}/app/Service.cpp
                ${CHIP_APP_SERVER}/DataModelHandler.cpp
                ${CHIP_APP_SERVER}/Server.cpp
                ${CHIP_APP_SERVER}/QRCodeUtil.cpp

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -98,7 +98,7 @@ int AppTask::Init()
 
 int AppTask::StartApp()
 {
-    int ret = Init();
+    int ret                            = Init();
     uint64_t mLastPublishServiceTimeUS = 0;
 
     if (ret)

--- a/examples/platform/nrfconnect/app/Service.cpp
+++ b/examples/platform/nrfconnect/app/Service.cpp
@@ -1,0 +1,93 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @file
+ *   This file implements the service publishing code for example usage.
+ */
+
+#include "Service.h"
+
+#include <string.h>
+
+#include <platform/CHIPDeviceLayer.h>
+#include <logging/log.h>
+#include <zephyr.h>
+
+#if CHIP_ENABLE_OPENTHREAD
+#include <openthread/message.h>
+#include <openthread/udp.h>
+#include <platform/OpenThread/OpenThreadUtils.h>
+#include <platform/ThreadStackManager.h>
+#include <platform/nrfconnect/ThreadStackManagerImpl.h>
+#endif
+
+LOG_MODULE_DECLARE(serv);
+
+// Transport Callbacks
+namespace {
+
+char deviceName[CONFIG_BT_DEVICE_NAME_MAX];
+constexpr uint16_t kUDPBroadcastPort = 23367;
+
+} // namespace
+
+void PublishService()
+{
+    chip::Inet::IPAddress addr;
+    if (!chip::DeviceLayer::ConnectivityMgrImpl().IsThreadAttached())
+    {
+        return;
+    }
+    chip::DeviceLayer::ThreadStackMgrImpl().LockThreadStack();
+    otError error = OT_ERROR_NONE;
+    otMessageInfo messageInfo;
+    otUdpSocket mSocket;
+    otMessage * message = nullptr;
+
+    memset(&mSocket, 0, sizeof(mSocket));
+    memset(&messageInfo, 0, sizeof(messageInfo));
+
+    // Use mesh local EID by default, if we have GUA, use that IP address.
+    memcpy(&messageInfo.mSockAddr, otThreadGetMeshLocalEid(chip::DeviceLayer::ThreadStackMgrImpl().OTInstance()), sizeof(messageInfo.mSockAddr));
+
+    // Select a address to send
+    const otNetifAddress * otAddrs = otIp6GetUnicastAddresses(chip::DeviceLayer::ThreadStackMgrImpl().OTInstance());
+    for (const otNetifAddress * otAddr = otAddrs; otAddr != NULL; otAddr = otAddr->mNext)
+    {
+        addr = chip::DeviceLayer::Internal::ToIPAddress(otAddr->mAddress);
+        if (otAddr->mValid && addr.IsIPv6GlobalUnicast())
+        {
+            memcpy(&messageInfo.mSockAddr, &(otAddr->mAddress), sizeof(otAddr->mAddress));
+            break;
+        }
+    }
+
+    message = otUdpNewMessage(chip::DeviceLayer::ThreadStackMgrImpl().OTInstance(), nullptr);
+    otIp6AddressFromString("ff03::1", &messageInfo.mPeerAddr);
+    messageInfo.mPeerPort = kUDPBroadcastPort;
+    otMessageAppend(message, deviceName, static_cast<uint16_t>(strlen(deviceName)));
+
+    error = otUdpSend(chip::DeviceLayer::ThreadStackMgrImpl().OTInstance(), &mSocket, message, &messageInfo);
+
+    if (error != OT_ERROR_NONE && message != nullptr)
+    {
+        otMessageFree(message);
+        LOG_INF("Failed to otUdpSend: %d", error);
+    }
+    chip::DeviceLayer::ThreadStackMgrImpl().UnlockThreadStack();
+}

--- a/examples/platform/nrfconnect/app/Service.cpp
+++ b/examples/platform/nrfconnect/app/Service.cpp
@@ -24,8 +24,8 @@
 
 #include <string.h>
 
-#include <platform/CHIPDeviceLayer.h>
 #include <logging/log.h>
+#include <platform/CHIPDeviceLayer.h>
 #include <zephyr.h>
 
 #if CHIP_ENABLE_OPENTHREAD
@@ -63,7 +63,8 @@ void PublishService()
     memset(&messageInfo, 0, sizeof(messageInfo));
 
     // Use mesh local EID by default, if we have GUA, use that IP address.
-    memcpy(&messageInfo.mSockAddr, otThreadGetMeshLocalEid(chip::DeviceLayer::ThreadStackMgrImpl().OTInstance()), sizeof(messageInfo.mSockAddr));
+    memcpy(&messageInfo.mSockAddr, otThreadGetMeshLocalEid(chip::DeviceLayer::ThreadStackMgrImpl().OTInstance()),
+           sizeof(messageInfo.mSockAddr));
 
     // Select a address to send
     const otNetifAddress * otAddrs = otIp6GetUnicastAddresses(chip::DeviceLayer::ThreadStackMgrImpl().OTInstance());

--- a/examples/platform/nrfconnect/app/include/Service.h
+++ b/examples/platform/nrfconnect/app/include/Service.h
@@ -1,0 +1,23 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef NRFCONNECT_COMMON_SERVICE_H
+#define NRFCONNECT_COMMON_SERVICE_H
+
+void PublishService();
+
+#endif // NRFCONNECT_COMMON_SERVICE_H


### PR DESCRIPTION

 #### Problem
nrfconnect platform doesn't support sending UDP broadcast messages
periodically by PublishService as other platforms do (e.g. nrf5)

 #### Summary of Changes
* Added Service component with PublishService implementation
to support sending UDP broadcast messages.

 Fixes https://github.com/project-chip/connectedhomeip/issues/3088
