### PR TITLE
Add Door Lock cluster commands to chip-tool and src/app/

### DIFF
--- a/examples/chip-tool/commands/clusters/DoorLock/Commands.h
+++ b/examples/chip-tool/commands/clusters/DoorLock/Commands.h
@@ -1,0 +1,65 @@
+/*
+ *   Copyright (c) 2020 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#ifndef __CHIPTOOL_DOORLOCK_COMMANDS_H__
+#define __CHIPTOOL_DOORLOCK_COMMANDS_H__
+
+#include "../../common/ModelCommand.h"
+
+class LockDoor : public ModelCommand
+{
+public:
+    LockDoor(const uint16_t clusterId) : ModelCommand("lock-door", clusterId) { AddArgument("PIN", &mPIN); }
+
+    size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
+    {
+        return encodeLockDoorCommand(buffer->Start(), bufferSize, endPointId, mPIN);
+    }
+
+private:
+    char * mPIN;
+};
+
+class UnlockDoor : public ModelCommand
+{
+public:
+    UnlockDoor(const uint16_t clusterId) : ModelCommand("unlock-door", clusterId) { AddArgument("PIN", &mPIN); }
+
+    size_t EncodeCommand(PacketBuffer * buffer, size_t bufferSize, uint16_t endPointId) override
+    {
+        return encodeUnlockDoorCommand(buffer->Start(), bufferSize, endPointId, mPIN);
+    }
+
+private:
+    char * mPIN;
+};
+
+void registerClusterDoorLock(Commands & commands)
+{
+    const char * clusterName = "DoorLock";
+    const uint16_t clusterId = 0x0101;
+
+    commands_list clusterCommands = {
+        make_unique<LockDoor>(clusterId),
+        make_unique<UnlockDoor>(clusterId),
+    };
+
+    commands.Register(clusterName, clusterCommands);
+}
+
+#endif // __CHIPTOOL_DOORLOCK_COMMANDS_H__

--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -90,6 +90,13 @@ bool Command::InitArgument(size_t argIndex, const char * argValue)
         break;
     }
 
+    case ArgumentType::String: {
+        const char ** value = reinterpret_cast<const char **>(arg.value);
+        *value              = const_cast<char *>(argValue);
+        isValidArgument     = (strcmp(argValue, *value) == 0);
+        break;
+    }
+
     case ArgumentType::Number: {
         uint32_t * value = reinterpret_cast<uint32_t *>(arg.value);
         // stringstream treats uint8_t as char, which is not what we want here.
@@ -120,6 +127,17 @@ size_t Command::AddArgument(const char * name, const char * value)
     arg.type  = ArgumentType::Attribute;
     arg.name  = name;
     arg.value = const_cast<void *>(reinterpret_cast<const void *>(value));
+
+    mArgs.push_back(arg);
+    return mArgs.size();
+}
+
+size_t Command::AddArgument(const char * name, char ** value)
+{
+    Argument arg;
+    arg.type  = ArgumentType::String;
+    arg.name  = name;
+    arg.value = reinterpret_cast<void *>(value);
 
     mArgs.push_back(arg);
     return mArgs.size();

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -46,6 +46,7 @@ typedef std::initializer_list<movable_initializer_list> commands_list;
 enum ArgumentType
 {
     Number,
+    String,
     Attribute,
     Address
 };
@@ -88,6 +89,15 @@ public:
         return AddArgument(name, min, max, reinterpret_cast<void *>(out));
     }
     size_t AddArgument(const char * name, const char * value);
+    /**
+     * @brief
+     *   Add a string command argument
+     *
+     * @param name  The name that will be displayed in the command help
+     * @param value A pointer to a `char *` where the argv value will be stored
+     * @returns The number of arguments currently added to the command
+     */
+    size_t AddArgument(const char * name, char ** value);
     size_t AddArgument(const char * name, AddressWithInterface * out);
 
     virtual CHIP_ERROR Run(ChipDeviceController * dc, NodeId remoteId) = 0;

--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -20,6 +20,7 @@
 
 #include "commands/clusters/Basic/Commands.h"
 #include "commands/clusters/ColorControl/Commands.h"
+#include "commands/clusters/DoorLock/Commands.h"
 #include "commands/clusters/Identify/Commands.h"
 #include "commands/clusters/OnOff/Commands.h"
 #include "commands/clusters/TemperatureMeasurement/Commands.h"
@@ -41,6 +42,7 @@ int main(int argc, char * argv[])
     registerCommandsEcho(commands);
     registerClusterBasic(commands);
     registerClusterColorControl(commands);
+    registerClusterDoorLock(commands);
     registerClusterIdentify(commands);
     registerClusterOnOff(commands);
     registerClusterTemperatureMeasurement(commands);

--- a/src/app/chip-zcl-zpro-codec.h
+++ b/src/app/chip-zcl-zpro-codec.h
@@ -352,6 +352,28 @@ uint16_t encodeStopMoveStepCommand(uint8_t * buffer, uint16_t buf_length, uint8_
  * */
 uint16_t encodeResetToFactoryCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
 
+/**
+ * DoorLock cluster commands
+ */
+
+/**
+ * @brief Encode a lock-door command for the Door lock cluster
+ * @param buffer                Buffer to encode into
+ * @param buf_length            Length of buffer
+ * @param destination_endpoint  Destination endpoint
+ * @param pin                   A short string with the PIN to lock the door
+ * */
+uint16_t encodeLockDoorCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, const char * pin);
+
+/**
+ * @brief Encode a unlock-door command for the Door lock cluster
+ * @param buffer                Buffer to encode into
+ * @param buf_length            Length of buffer
+ * @param destination_endpoint  Destination endpoint
+ * @param pin                   A short string with the PIN to unlock the door
+ * */
+uint16_t encodeUnlockDoorCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, const char * pin);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/app/encoder.cpp
+++ b/src/app/encoder.cpp
@@ -162,6 +162,17 @@ uint16_t encodeReadAttributesCommand(uint8_t * buffer, uint16_t buf_length, uint
     }                                                                                                                              \
     return result;
 
+#define COMMAND_INSERT_STRING(name, str)                                                                                           \
+    size_t length = strlen(str);                                                                                                   \
+    if (!CanCastTo<uint8_t>(length))                                                                                               \
+    {                                                                                                                              \
+        ChipLogError(Zcl, "Error encoding %s command. String too long: %d", name, length);                                         \
+        return 0;                                                                                                                  \
+    }                                                                                                                              \
+    uint8_t str_length = static_cast<uint8_t>(length);                                                                             \
+    buf.Put(str_length);                                                                                                           \
+    buf.Put(str);
+
 #define COMMAND(name, cluster_id, command_id)                                                                                      \
     COMMAND_HEADER(name, cluster_id, command_id);                                                                                  \
     COMMAND_FOOTER(name);
@@ -171,6 +182,7 @@ uint16_t encodeReadAttributesCommand(uint8_t * buffer, uint16_t buf_length, uint
 #define IDENTIFY_CLUSTER_ID 0x0003
 #define TEMP_MEASUREMENT_CLUSTER_ID 0x0402
 #define COLORCONTROL_CLUSTER_ID 0x0300
+#define DOORLOCK_CLUSTER_ID 0x0101
 
 /*
  * On/Off Cluster commands
@@ -399,6 +411,23 @@ uint16_t encodeStopMoveStepCommand(uint8_t * buffer, uint16_t buf_length, uint8_
 uint16_t encodeResetToFactoryCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
 {
     COMMAND("ResetToFactory", BASIC_CLUSTER_ID, 0x00);
+}
+
+/*
+ * DoorLock Cluster commands
+ */
+uint16_t encodeLockDoorCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, const char * pin)
+{
+    COMMAND_HEADER("LockDoor", DOORLOCK_CLUSTER_ID, 0x00);
+    COMMAND_INSERT_STRING("LockDoor", pin);
+    COMMAND_FOOTER("LockDoor");
+}
+
+uint16_t encodeUnlockDoorCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, const char * pin)
+{
+    COMMAND_HEADER("UnlockDoor", DOORLOCK_CLUSTER_ID, 0x01);
+    COMMAND_INSERT_STRING("UnlockDoor", pin);
+    COMMAND_FOOTER("UnlockDoor");
 }
 
 } // extern "C"


### PR DESCRIPTION
 #### Problem
 This PR add Door Lock cluster commands to chip-tool and to src/app.

This PR does not contain the whole set of commands of DoorLock. The goal for me is more to validate the code that deals with string in src/app/encoder.cpp since this is the first set of command imported into src/app that use such a parameter.

The rest of commands will happens in a separate issue.
 #### Summary of Changes
 * Add some command to chip-tool for the Barrier Control cluster
 * Add some command inside src/app for the Barrier Control cluster