### PR TITLE
* Fix error range assertion lwip

### DIFF
--- a/src/platform/qpg6100/SystemPlatformConfig.h
+++ b/src/platform/qpg6100/SystemPlatformConfig.h
@@ -49,7 +49,7 @@ struct ChipDeviceEvent;
 #define CHIP_SYSTEM_CONFIG_ERROR_MAX 7000999
 #define _CHIP_SYSTEM_CONFIG_ERROR(e) (CHIP_SYSTEM_CONFIG_ERROR_MIN + (e))
 #define CHIP_SYSTEM_LWIP_ERROR_MIN 3000000
-#define CHIP_SYSTEM_LWIP_ERROR_MAX 3000999
+#define CHIP_SYSTEM_LWIP_ERROR_MAX 3000128
 
 // ========== Platform-specific Configuration Overrides =========
 


### PR DESCRIPTION
 #### Problem
QPG6100 build broken due to static_assert on lwip error range

 #### Summary of Changes
Limited error range to correct type