### PR TITLE
[nRF connect] Fix assert on button push

### DIFF
--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -373,7 +373,7 @@ void AppTask::PostLightingActionRequest(LightingManager::Action_t aAction)
 
 void AppTask::PostEvent(AppEvent * aEvent)
 {
-    if (k_msgq_put(&sAppEventQueue, aEvent, K_TICKS(1)) != 0)
+    if (k_msgq_put(&sAppEventQueue, aEvent, K_NO_WAIT) != 0)
     {
         LOG_INF("Failed to post event to app task event queue");
     }

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -386,7 +386,7 @@ void AppTask::PostLockActionRequest(int32_t aActor, BoltLockManager::Action_t aA
 
 void AppTask::PostEvent(AppEvent * aEvent)
 {
-    if (k_msgq_put(&sAppEventQueue, aEvent, K_TICKS(1)))
+    if (k_msgq_put(&sAppEventQueue, aEvent, K_NO_WAIT))
     {
         LOG_INF("Failed to post event to app task event queue");
     }


### PR DESCRIPTION
 #### Problem
On a recent Zephyr version there's an assert that ISRs don't call a blocking push to a message queue. It caused a problem with handling button pushes in nRF Connect examples.

 #### Summary of Changes
Switch to non-blocking message queue operations.

 Fixes #3114