### PR TITLE
Duplicate Configuration Manager object initialization

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
@@ -55,14 +55,6 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_InitChipStack()
 
     mChipStackLock = PTHREAD_MUTEX_INITIALIZER;
 
-    // Initialize the Configuration Manager object.
-    err = ConfigurationMgr().Init();
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(DeviceLayer, "Configuration Manager initialization failed: %s", ErrorStr(err));
-    }
-    SuccessOrExit(err);
-
     // Call up to the base class _InitChipStack() to perform the bulk of the initialization.
     err = GenericPlatformManagerImpl<ImplClass>::_InitChipStack();
     SuccessOrExit(err);


### PR DESCRIPTION
 #### Problem
Duplicate Configuration Manager object initialization during _InitChipStack()

 #### Summary of Changes
Remove Initializing the Configuration Manager object in GenericPlatformManagerImpl_POSIX.ipp
The Configuration Manager object is initialized in GenericPlatformManagerImpl.ipp