### PR TITLE
[samples/nrfconnect] Added updating ZCL cluster state to fit actual light/lock state.

### DIFF
--- a/examples/lighting-app/efr32/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/efr32/src/ZclCallbacks.cpp
@@ -56,3 +56,16 @@ extern "C" void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClus
         LightMgr().InitiateAction(AppEvent::kEventType_Light, LightingManager::OFF_ACTION);
     }
 }
+
+/** @brief On/off Cluster Server Post Init
+ *
+ * Following resolution of the On/Off state at startup for this endpoint,
+ * perform any additional initialization needed; e.g., synchronize hardware
+ * state.
+ *
+ * @param endpoint Endpoint that is being initialized  Ver.: always
+ */
+extern "C" void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint)
+{
+    // TODO: implement any additional On/off Cluster Server post init actions
+}

--- a/examples/lighting-app/lighting-common/gen/callback-stub.c
+++ b/examples/lighting-app/lighting-common/gen/callback-stub.c
@@ -43,16 +43,6 @@
 //#include "hal/hal.h"
 //#include EMBER_AF_API_NETWORK_STEERING
 
-/** @brief On/off Cluster Server Post Init
- *
- * Following resolution of the On/Off state at startup for this endpoint,
- * perform any additional initialization needed; e.g., synchronize hardware
- * state.
- *
- * @param endpoint Endpoint that is being initialized  Ver.: always
- */
-void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint) {}
-
 /** @brief Add To Current App Tasks
  *
  * This function is only useful to sleepy end devices.  This function will note

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -61,6 +61,19 @@ void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clust
         LightingMgr().InitiateAction(LightingManager::OFF_ACTION);
     }
 }
+
+/** @brief On/off Cluster Server Post Init
+ *
+ * Following resolution of the On/Off state at startup for this endpoint,
+ * perform any additional initialization needed; e.g., synchronize hardware
+ * state.
+ *
+ * @param endpoint Endpoint that is being initialized  Ver.: always
+ */
+void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint)
+{
+    // TODO: implement any additional On/off Cluster Server post init actions
+}
 }
 
 int main()

--- a/examples/lighting-app/nrf5/main/ZclCallbacks.cpp
+++ b/examples/lighting-app/nrf5/main/ZclCallbacks.cpp
@@ -53,4 +53,17 @@ void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clust
         LightingMgr().InitiateAction(LightingManager::OFF_ACTION);
     }
 }
+
+/** @brief On/off Cluster Server Post Init
+ *
+ * Following resolution of the On/Off state at startup for this endpoint,
+ * perform any additional initialization needed; e.g., synchronize hardware
+ * state.
+ *
+ * @param endpoint Endpoint that is being initialized  Ver.: always
+ */
+void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint)
+{
+    // TODO: implement any additional On/off Cluster Server post init actions
+}
 }

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -210,7 +210,7 @@ void AppTask::LightingActionEventHandler(AppEvent * aEvent)
     else if (aEvent->Type == AppEvent::kEventType_Button)
     {
         action = LightingMgr().IsTurnedOn() ? LightingManager::OFF_ACTION : LightingManager::ON_ACTION;
-        actor = AppEvent::kEventType_Button;
+        actor  = AppEvent::kEventType_Button;
     }
 
     if (action != LightingManager::INVALID_ACTION && !LightingMgr().InitiateAction(action, actor))

--- a/examples/lighting-app/nrfconnect/main/LightingManager.cpp
+++ b/examples/lighting-app/nrfconnect/main/LightingManager.cpp
@@ -59,7 +59,7 @@ void LightingManager::SetCallbacks(LightingCallback_fn aActionInitiated_CB, Ligh
     mActionCompleted_CB = aActionCompleted_CB;
 }
 
-bool LightingManager::InitiateAction(Action_t aAction)
+bool LightingManager::InitiateAction(Action_t aAction, int32_t aActor)
 {
     // TODO: this function is called InitiateAction because we want to implement some features such as ramping up here.
     bool action_initiated = false;
@@ -81,14 +81,14 @@ bool LightingManager::InitiateAction(Action_t aAction)
     {
         if (mActionInitiated_CB)
         {
-            mActionInitiated_CB(aAction);
+            mActionInitiated_CB(aAction, aActor);
         }
 
         Set(new_state == kState_On);
 
         if (mActionCompleted_CB)
         {
-            mActionCompleted_CB(aAction);
+            mActionCompleted_CB(aAction, aActor);
         }
     }
 

--- a/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
@@ -23,8 +23,8 @@
 #include "gen/znet-bookkeeping.h"
 #include <app/util/af-types.h>
 
-#include "LightingManager.h"
 #include "AppTask.h"
+#include "LightingManager.h"
 
 extern "C" {
 void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,

--- a/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
@@ -24,6 +24,7 @@
 #include <app/util/af-types.h>
 
 #include "LightingManager.h"
+#include "AppTask.h"
 
 extern "C" {
 void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,
@@ -41,6 +42,19 @@ void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clust
         return;
     }
 
-    LightingMgr().InitiateAction(*value ? LightingManager::ON_ACTION : LightingManager::OFF_ACTION);
+    LightingMgr().InitiateAction(*value ? LightingManager::ON_ACTION : LightingManager::OFF_ACTION, AppEvent::kEventType_Lighting);
+}
+
+/** @brief On/off Cluster Server Post Init
+ *
+ * Following resolution of the On/Off state at startup for this endpoint,
+ * perform any additional initialization needed; e.g., synchronize hardware
+ * state.
+ *
+ * @param endpoint Endpoint that is being initialized  Ver.: always
+ */
+void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint)
+{
+    GetAppTask().UpdateClusterState();
 }
 }

--- a/examples/lighting-app/nrfconnect/main/include/AppEvent.h
+++ b/examples/lighting-app/nrfconnect/main/include/AppEvent.h
@@ -49,6 +49,7 @@ struct AppEvent
         struct
         {
             uint8_t Action;
+            int32_t Actor;
         } LightingEvent;
     };
 

--- a/examples/lighting-app/nrfconnect/main/include/AppTask.h
+++ b/examples/lighting-app/nrfconnect/main/include/AppTask.h
@@ -32,14 +32,15 @@ public:
 
     void PostLightingActionRequest(LightingManager::Action_t aAction);
     void PostEvent(AppEvent * event);
+    void UpdateClusterState();
 
 private:
     friend AppTask & GetAppTask(void);
 
     int Init();
 
-    static void ActionInitiated(LightingManager::Action_t aAction);
-    static void ActionCompleted(LightingManager::Action_t aAction);
+    static void ActionInitiated(LightingManager::Action_t aAction, int32_t aActor);
+    static void ActionCompleted(LightingManager::Action_t aAction, int32_t aActor);
 
     void CancelTimer(void);
 
@@ -66,7 +67,6 @@ private:
 
     Function_t mFunction;
     bool mFunctionTimerActive;
-
     static AppTask sAppTask;
 };
 

--- a/examples/lighting-app/nrfconnect/main/include/LightingManager.h
+++ b/examples/lighting-app/nrfconnect/main/include/LightingManager.h
@@ -40,11 +40,11 @@ public:
         kState_Off,
     };
 
-    using LightingCallback_fn = void (*)(Action_t);
+    using LightingCallback_fn = void (*)(Action_t, int32_t);
 
     int Init(const char * gpioDeviceName, gpio_pin_t gpioPin);
     bool IsTurnedOn() const { return mState == kState_On; }
-    bool InitiateAction(Action_t aAction);
+    bool InitiateAction(Action_t aAction, int32_t aActor);
     void SetCallbacks(LightingCallback_fn aActionInitiated_CB, LightingCallback_fn aActionCompleted_CB);
 
 private:

--- a/examples/lock-app/efr32/src/ZclCallbacks.cpp
+++ b/examples/lock-app/efr32/src/ZclCallbacks.cpp
@@ -57,3 +57,16 @@ extern "C" void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClus
         BoltLockMgr().InitiateAction(AppEvent::kEventType_Lock, BoltLockManager::UNLOCK_ACTION);
     }
 }
+
+/** @brief On/off Cluster Server Post Init
+ *
+ * Following resolution of the On/Off state at startup for this endpoint,
+ * perform any additional initialization needed; e.g., synchronize hardware
+ * state.
+ *
+ * @param endpoint Endpoint that is being initialized  Ver.: always
+ */
+extern "C" void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint)
+{
+    // TODO: implement any additional On/off Cluster Server post init actions
+}

--- a/examples/lock-app/k32w/main/ZclCallbacks.cpp
+++ b/examples/lock-app/k32w/main/ZclCallbacks.cpp
@@ -45,4 +45,17 @@ void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clust
 
     BoltLockMgr().InitiateAction(0, *value ? BoltLockManager::LOCK_ACTION : BoltLockManager::UNLOCK_ACTION);
 }
+
+/** @brief On/off Cluster Server Post Init
+ *
+ * Following resolution of the On/Off state at startup for this endpoint,
+ * perform any additional initialization needed; e.g., synchronize hardware
+ * state.
+ *
+ * @param endpoint Endpoint that is being initialized  Ver.: always
+ */
+void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint)
+{
+    // TODO: implement any additional On/off Cluster Server post init actions
+}
 }

--- a/examples/lock-app/lock-common/gen/callback-stub.c
+++ b/examples/lock-app/lock-common/gen/callback-stub.c
@@ -44,16 +44,6 @@
 //#include "hal/hal.h"
 //#include EMBER_AF_API_NETWORK_STEERING
 
-/** @brief On/off Cluster Server Post Init
- *
- * Following resolution of the On/Off state at startup for this endpoint,
- * perform any additional initialization needed; e.g., synchronize hardware
- * state.
- *
- * @param endpoint Endpoint that is being initialized  Ver.: always
- */
-void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint) {}
-
 /** @brief Add To Current App Tasks
  *
  * This function is only useful to sleepy end devices.  This function will note

--- a/examples/lock-app/nrf5/main/ZclCallbacks.cpp
+++ b/examples/lock-app/nrf5/main/ZclCallbacks.cpp
@@ -55,4 +55,17 @@ void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clust
         BoltLockMgr().InitiateAction(0, BoltLockManager::UNLOCK_ACTION);
     }
 }
+
+/** @brief On/off Cluster Server Post Init
+ *
+ * Following resolution of the On/Off state at startup for this endpoint,
+ * perform any additional initialization needed; e.g., synchronize hardware
+ * state.
+ *
+ * @param endpoint Endpoint that is being initialized  Ver.: always
+ */
+void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint)
+{
+    // TODO: implement any additional On/off Cluster Server post init actions
+}
 }

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -203,7 +203,7 @@ void AppTask::LockActionEventHandler(AppEvent * aEvent)
     else if (aEvent->Type == AppEvent::kEventType_Button)
     {
         action = BoltLockMgr().IsUnlocked() ? BoltLockManager::LOCK_ACTION : BoltLockManager::UNLOCK_ACTION;
-        actor = AppEvent::kEventType_Button;
+        actor  = AppEvent::kEventType_Button;
     }
 
     if (action != BoltLockManager::INVALID_ACTION && !BoltLockMgr().InitiateAction(actor, action))

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -25,6 +25,9 @@
 #include "Service.h"
 #include "ThreadUtil.h"
 
+#include "attribute-storage.h"
+#include "gen/cluster-id.h"
+
 #include <platform/CHIPDeviceLayer.h>
 
 #include <dk_buttons_and_leds.h>
@@ -200,6 +203,7 @@ void AppTask::LockActionEventHandler(AppEvent * aEvent)
     else if (aEvent->Type == AppEvent::kEventType_Button)
     {
         action = BoltLockMgr().IsUnlocked() ? BoltLockManager::LOCK_ACTION : BoltLockManager::UNLOCK_ACTION;
+        actor = AppEvent::kEventType_Button;
     }
 
     if (action != BoltLockManager::INVALID_ACTION && !BoltLockMgr().InitiateAction(actor, action))
@@ -370,7 +374,7 @@ void AppTask::ActionInitiated(BoltLockManager::Action_t aAction, int32_t aActor)
     sLockLED.Blink(50, 50);
 }
 
-void AppTask::ActionCompleted(BoltLockManager::Action_t aAction)
+void AppTask::ActionCompleted(BoltLockManager::Action_t aAction, int32_t aActor)
 {
     // if the action has been completed by the lock, update the bolt lock trait.
     // Turn on the lock LED if in a LOCKED state OR
@@ -384,6 +388,11 @@ void AppTask::ActionCompleted(BoltLockManager::Action_t aAction)
     {
         LOG_INF("Unlock Action has been completed");
         sLockLED.Set(false);
+    }
+
+    if (aActor == AppEvent::kEventType_Button)
+    {
+        sAppTask.UpdateClusterState();
     }
 }
 
@@ -414,5 +423,18 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
     else
     {
         LOG_INF("Event received with no handler. Dropping event.");
+    }
+}
+
+void AppTask::UpdateClusterState()
+{
+    uint8_t newValue = !BoltLockMgr().IsUnlocked();
+
+    // write the new on/off value
+    EmberAfStatus status = emberAfWriteAttribute(1, ZCL_ON_OFF_CLUSTER_ID, ZCL_ON_OFF_ATTRIBUTE_ID, CLUSTER_MASK_SERVER, &newValue,
+                                                 ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    {
+        LOG_ERR("Updating on/off %x", status);
     }
 }

--- a/examples/lock-app/nrfconnect/main/BoltLockManager.cpp
+++ b/examples/lock-app/nrfconnect/main/BoltLockManager.cpp
@@ -77,14 +77,14 @@ bool BoltLockManager::InitiateAction(int32_t aActor, Action_t aAction)
     if (mState == kState_LockingCompleted && aAction == UNLOCK_ACTION)
     {
         action_initiated = true;
-        mCurrentActor = aActor;
-        new_state = kState_UnlockingInitiated;
+        mCurrentActor    = aActor;
+        new_state        = kState_UnlockingInitiated;
     }
     else if (mState == kState_UnlockingCompleted && aAction == LOCK_ACTION)
     {
         action_initiated = true;
-        mCurrentActor = aActor;
-        new_state = kState_LockingInitiated;
+        mCurrentActor    = aActor;
+        new_state        = kState_LockingInitiated;
     }
 
     if (action_initiated)

--- a/examples/lock-app/nrfconnect/main/BoltLockManager.cpp
+++ b/examples/lock-app/nrfconnect/main/BoltLockManager.cpp
@@ -77,13 +77,13 @@ bool BoltLockManager::InitiateAction(int32_t aActor, Action_t aAction)
     if (mState == kState_LockingCompleted && aAction == UNLOCK_ACTION)
     {
         action_initiated = true;
-
+        mCurrentActor = aActor;
         new_state = kState_UnlockingInitiated;
     }
     else if (mState == kState_UnlockingCompleted && aAction == LOCK_ACTION)
     {
         action_initiated = true;
-
+        mCurrentActor = aActor;
         new_state = kState_LockingInitiated;
     }
 
@@ -173,7 +173,7 @@ void BoltLockManager::ActuatorMovementTimerEventHandler(AppEvent * aEvent)
     {
         if (lock->mActionCompleted_CB)
         {
-            lock->mActionCompleted_CB(actionCompleted);
+            lock->mActionCompleted_CB(actionCompleted, lock->mCurrentActor);
         }
 
         if (lock->mAutoRelock && actionCompleted == UNLOCK_ACTION)

--- a/examples/lock-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lock-app/nrfconnect/main/ZclCallbacks.cpp
@@ -18,8 +18,8 @@
 
 #include <support/logging/CHIPLogging.h>
 
-#include "BoltLockManager.h"
 #include "AppTask.h"
+#include "BoltLockManager.h"
 
 #include "gen/attribute-id.h"
 #include "gen/cluster-id.h"

--- a/examples/lock-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lock-app/nrfconnect/main/ZclCallbacks.cpp
@@ -19,6 +19,7 @@
 #include <support/logging/CHIPLogging.h>
 
 #include "BoltLockManager.h"
+#include "AppTask.h"
 
 #include "gen/attribute-id.h"
 #include "gen/cluster-id.h"
@@ -44,5 +45,18 @@ void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clust
     }
 
     BoltLockMgr().InitiateAction(0, *value ? BoltLockManager::LOCK_ACTION : BoltLockManager::UNLOCK_ACTION);
+}
+
+/** @brief On/off Cluster Server Post Init
+ *
+ * Following resolution of the On/Off state at startup for this endpoint,
+ * perform any additional initialization needed; e.g., synchronize hardware
+ * state.
+ *
+ * @param endpoint Endpoint that is being initialized  Ver.: always
+ */
+void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint)
+{
+    GetAppTask().UpdateClusterState();
 }
 }

--- a/examples/lock-app/nrfconnect/main/include/AppTask.h
+++ b/examples/lock-app/nrfconnect/main/include/AppTask.h
@@ -31,6 +31,7 @@ public:
 
     void PostLockActionRequest(int32_t aActor, BoltLockManager::Action_t aAction);
     void PostEvent(AppEvent * event);
+    void UpdateClusterState();
 
 private:
     friend AppTask & GetAppTask(void);
@@ -38,7 +39,7 @@ private:
     int Init();
 
     static void ActionInitiated(BoltLockManager::Action_t aAction, int32_t aActor);
-    static void ActionCompleted(BoltLockManager::Action_t aAction);
+    static void ActionCompleted(BoltLockManager::Action_t aAction, int32_t aActor);
 
     void CancelTimer(void);
 
@@ -65,7 +66,6 @@ private:
 
     Function_t mFunction;
     bool mFunctionTimerActive;
-
     static AppTask sAppTask;
 };
 

--- a/examples/lock-app/nrfconnect/main/include/BoltLockManager.h
+++ b/examples/lock-app/nrfconnect/main/include/BoltLockManager.h
@@ -52,7 +52,7 @@ public:
     bool InitiateAction(int32_t aActor, Action_t aAction);
 
     typedef void (*Callback_fn_initiated)(Action_t, int32_t aActor);
-    typedef void (*Callback_fn_completed)(Action_t);
+    typedef void (*Callback_fn_completed)(Action_t, int32_t aActor);
     void SetCallbacks(Callback_fn_initiated aActionInitiated_CB, Callback_fn_completed aActionCompleted_CB);
 
 private:
@@ -65,6 +65,7 @@ private:
     bool mAutoRelock;
     uint32_t mAutoLockDuration;
     bool mAutoLockTimerArmed;
+    int32_t mCurrentActor;
 
     void CancelTimer(void);
     void StartTimer(uint32_t aTimeoutMs);


### PR DESCRIPTION

 #### Problem
Initial value of ZCL ON/OFF cluster is not defined, while the lock/lighting is initially turned on in nRF Connect examples.

 #### Summary of Changes
* Added UpdateClusterState method called on the init and each completed on/off action.

 Fixes #3131 