### PR TITLE
Remove unnecessary complexity in the const char* overload of BufBound::Put

### DIFF
--- a/src/lib/support/BufBound.h
+++ b/src/lib/support/BufBound.h
@@ -27,7 +27,6 @@
 #include <climits>
 #include <stdint.h>
 #include <string.h>
-#include <support/SafeInt.h>
 
 namespace chip {
 
@@ -66,16 +65,7 @@ public:
         static_assert(CHAR_BIT == 8, "We're assuming char and uint8_t are the same size");
         while (*s != 0)
         {
-            if (!CanCastTo<uint8_t>(*s))
-            {
-                // This means char is signed and our value is negative.
-                Put(static_cast<uint8_t>(0xff + *s));
-            }
-            else
-            {
-                Put(static_cast<uint8_t>(*s));
-            }
-            ++s;
+            Put(static_cast<uint8_t>(*s++));
         }
         return mWritten;
     }

--- a/src/transport/SecurePairingSession.cpp
+++ b/src/transport/SecurePairingSession.cpp
@@ -32,6 +32,7 @@
 #include <protocols/CHIPProtocols.h>
 #include <support/BufBound.h>
 #include <support/CodeUtils.h>
+#include <support/SafeInt.h>
 #include <transport/SecurePairingSession.h>
 
 namespace chip {


### PR DESCRIPTION
Casting to unsigned types is well-defined, so just doing that directly
will do the right thing.  This also fixes a bug in the code: it should
have been adding 0x100, not 0xff, to handle the negative case correctly.

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
The code has extra branches and handles the "negative char" case wrong.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Remove the extra branching.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
