### PR TITLE
Make all src/transport headers use pragma once

### DIFF
--- a/src/transport/BLE.h
+++ b/src/transport/BLE.h
@@ -22,8 +22,7 @@
  *
  */
 
-#ifndef __TRANSPORT_BLE_H__
-#define __TRANSPORT_BLE_H__
+#pragma once
 
 #include <ble/BleConfig.h>
 
@@ -111,5 +110,3 @@ private:
 
 } // namespace Transport
 } // namespace chip
-
-#endif // __TRANSPORT_BLE_H__

--- a/src/transport/NetworkProvisioning.h
+++ b/src/transport/NetworkProvisioning.h
@@ -21,8 +21,7 @@
  *
  */
 
-#ifndef __CHIP_NETWORK_PROVISIONING_H__
-#define __CHIP_NETWORK_PROVISIONING_H__
+#pragma once
 
 #include <core/CHIPCore.h>
 #include <core/ReferenceCounted.h>
@@ -137,4 +136,3 @@ private:
 };
 
 } // namespace chip
-#endif // __CHIP_NETWORK_PROVISIONING_H__

--- a/src/transport/PeerConnectionState.h
+++ b/src/transport/PeerConnectionState.h
@@ -19,8 +19,7 @@
  * @brief Defines state relevant for an active connection to a peer.
  */
 
-#ifndef PEER_CONNCTION_STATE_H_
-#define PEER_CONNCTION_STATE_H_
+#pragma once
 
 #include <transport/SecureSession.h>
 #include <transport/raw/MessageHeader.h>
@@ -106,5 +105,3 @@ private:
 
 } // namespace Transport
 } // namespace chip
-
-#endif // PEER_CONNCTION_STATE_H_

--- a/src/transport/RendezvousParameters.h
+++ b/src/transport/RendezvousParameters.h
@@ -15,8 +15,7 @@
  *    limitations under the License.
  */
 
-#ifndef __TRANSPORT_RENDEZVOUSPARAMETERS_H__
-#define __TRANSPORT_RENDEZVOUSPARAMETERS_H__
+#pragma once
 
 #include <transport/raw/Base.h>
 
@@ -87,5 +86,3 @@ private:
 };
 
 } // namespace chip
-
-#endif // __TRANSPORT_RENDEZVOUSPARAMETERS_H__

--- a/src/transport/RendezvousSession.h
+++ b/src/transport/RendezvousSession.h
@@ -20,9 +20,7 @@
  *      This file defines the CHIP RendezvousSession object that maintains a Rendezvous session.
  *
  */
-
-#ifndef __TRANSPORT_RENDEZVOUSSESSION_H__
-#define __TRANSPORT_RENDEZVOUSSESSION_H__
+#pragma once
 
 #include <core/CHIPCore.h>
 #include <protocols/CHIPProtocols.h>
@@ -147,4 +145,3 @@ private:
 };
 
 } // namespace chip
-#endif // __TRANSPORT_RENDEZVOUSSESSION_H__

--- a/src/transport/RendezvousSessionDelegate.h
+++ b/src/transport/RendezvousSessionDelegate.h
@@ -15,8 +15,7 @@
  *    limitations under the License.
  */
 
-#ifndef __TRANSPORT_RENDEZVOUSSESSIONCALLBACK_H__
-#define __TRANSPORT_RENDEZVOUSSESSIONCALLBACK_H__
+#pragma once
 
 #include <core/CHIPCore.h>
 
@@ -51,5 +50,3 @@ public:
 };
 
 } // namespace chip
-
-#endif // __TRANSPORT_RENDEZVOUSSESSIONCALLBACK_H__

--- a/src/transport/SecurePairingSession.h
+++ b/src/transport/SecurePairingSession.h
@@ -24,8 +24,7 @@
  *
  */
 
-#ifndef __SECUREPAIRINGSESSION_H__
-#define __SECUREPAIRINGSESSION_H__
+#pragma once
 
 #include <core/ReferenceCounted.h>
 #include <crypto/CHIPCryptoPAL.h>
@@ -250,5 +249,3 @@ public:
 };
 
 } // namespace chip
-
-#endif // __SECUREPAIRINGSESSION_H__

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -23,8 +23,7 @@
  *
  */
 
-#ifndef __SECURESESSION_H__
-#define __SECURESESSION_H__
+#pragma once
 
 #include <core/CHIPCore.h>
 #include <crypto/CHIPCryptoPAL.h>
@@ -134,5 +133,3 @@ private:
 };
 
 } // namespace chip
-
-#endif // __SECURESESSION_H__

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -23,8 +23,7 @@
  *
  */
 
-#ifndef __SECURESESSIONMGR_H__
-#define __SECURESESSIONMGR_H__
+#pragma once
 
 #include <utility>
 
@@ -217,5 +216,3 @@ private:
 };
 
 } // namespace chip
-
-#endif // __SECURESESSIONMGR_H__

--- a/src/transport/raw/Base.h
+++ b/src/transport/raw/Base.h
@@ -21,8 +21,7 @@
  *    classes (UDP, TCP, BLE, ....)
  */
 
-#ifndef TRANSPORT_BASE_H_
-#define TRANSPORT_BASE_H_
+#pragma once
 
 #include <core/CHIPError.h>
 #include <core/ReferenceCounted.h>
@@ -118,5 +117,3 @@ protected:
 
 } // namespace Transport
 } // namespace chip
-
-#endif // TRANSPORT_BASE_H_

--- a/src/transport/raw/PeerAddress.h
+++ b/src/transport/raw/PeerAddress.h
@@ -21,8 +21,7 @@
  *
  */
 
-#ifndef PEER_ADDRESS_H_
-#define PEER_ADDRESS_H_
+#pragma once
 
 #include <stdio.h>
 
@@ -171,5 +170,3 @@ private:
 
 } // namespace Transport
 } // namespace chip
-
-#endif // PEER_ADDRESS_H_

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -22,8 +22,7 @@
  *      It binds to any available local addr and port and begins listening.
  */
 
-#ifndef __TCPTRANSPORT_H__
-#define __TCPTRANSPORT_H__
+#pragma once
 
 #include <algorithm>
 #include <utility>
@@ -247,5 +246,3 @@ private:
 
 } // namespace Transport
 } // namespace chip
-
-#endif // __TCPTRANSPORT_H__

--- a/src/transport/raw/Tuple.h
+++ b/src/transport/raw/Tuple.h
@@ -21,8 +21,7 @@
  * Defines a compound transport type (tuple) that can merge several transports
  * to look like a single one.
  */
-#ifndef TRANSPORT_TUPLE_H_
-#define TRANSPORT_TUPLE_H_
+#pragma once
 
 #include <tuple>
 #include <type_traits>
@@ -238,5 +237,3 @@ private:
 
 } // namespace Transport
 } // namespace chip
-
-#endif // TRANSPORT_TUPLE_H_

--- a/src/transport/raw/UDP.h
+++ b/src/transport/raw/UDP.h
@@ -23,8 +23,7 @@
  *
  */
 
-#ifndef __UDPTRANSPORT_H__
-#define __UDPTRANSPORT_H__
+#pragma once
 
 #include <utility>
 
@@ -126,5 +125,3 @@ private:
 
 } // namespace Transport
 } // namespace chip
-
-#endif // __UDPTRANSPORT_H__

--- a/src/transport/retransmit/Cache.h
+++ b/src/transport/retransmit/Cache.h
@@ -14,8 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#ifndef RETRANSIMIT_CACHE_H_
-#define RETRANSIMIT_CACHE_H_
+#pragma once
 
 #include <bitset>
 #include <cstddef>
@@ -177,5 +176,3 @@ private:
 
 } // namespace Retransmit
 } // namespace chip
-
-#endif // RETRANSIMIT_CACHE_H_

--- a/src/transport/tests/TestTransportLayer.h
+++ b/src/transport/tests/TestTransportLayer.h
@@ -22,8 +22,7 @@
  *
  */
 
-#ifndef TESTTRANSPORTLAYER_H
-#define TESTTRANSPORTLAYER_H
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -40,5 +39,3 @@ int TestUDP(void);
 #ifdef __cplusplus
 }
 #endif
-
-#endif // TESTTRANSPORTLAYER_H


### PR DESCRIPTION
 #### Problem
Include header guards are more typing, pollute the global define space, have a chance to mistmatch ending comments (if we ever rename and copy&paste).

`#pragma once` is supported most compilers already, let's use it.

 #### Summary of Changes
Use pragma one.

Part of #3138 
