### PR TITLE
Make src/system use pragma once in headers

### DIFF
--- a/src/system/SystemAlignSize.h
+++ b/src/system/SystemAlignSize.h
@@ -23,9 +23,6 @@
  *      element with alignment padding.
  */
 
-#ifndef SYSTEMALIGNSIZE_H
-#define SYSTEMALIGNSIZE_H
+#pragma once
 
 #define CHIP_SYSTEM_ALIGN_SIZE(ELEMENT, ALIGNMENT) (((ELEMENT) + (ALIGNMENT) -1) & ~((ALIGNMENT) -1))
-
-#endif // defined(SYSTEMALIGNSIZE_H)

--- a/src/system/SystemClock.h
+++ b/src/system/SystemClock.h
@@ -22,8 +22,7 @@
  *      function for retrieving the current system time.
  */
 
-#ifndef SYSTEMTIME_H
-#define SYSTEMTIME_H
+#pragma once
 
 // Include configuration headers
 #include <system/SystemConfig.h>
@@ -218,5 +217,3 @@ extern Error SetClock_RealTime(uint64_t newCurTime);
 } // namespace Platform
 } // namespace System
 } // namespace chip
-
-#endif // SYSTEMTIME_H

--- a/src/system/SystemConfig.h
+++ b/src/system/SystemConfig.h
@@ -34,8 +34,7 @@
  *      C-language programs.
  */
 
-#ifndef SYSTEMCONFIG_H
-#define SYSTEMCONFIG_H
+#pragma once
 
 /* Platform include headers */
 #if CHIP_SEPARATE_CONFIG_H
@@ -671,5 +670,3 @@ struct LwIPEvent;
 #define CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS 1
 #endif
 #endif // CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
-
-#endif // defined(SYSTEMCONFIG_H)

--- a/src/system/SystemError.h
+++ b/src/system/SystemError.h
@@ -29,8 +29,7 @@
  *      C-language programs.
  */
 
-#ifndef SYSTEMERROR_H
-#define SYSTEMERROR_H
+#pragma once
 
 // Include headers
 #include <system/SystemConfig.h>
@@ -198,4 +197,3 @@ extern bool FormatLwIPError(char * buf, uint16_t bufSize, int32_t err);
 } // namespace chip
 
 #endif // !defined(__cplusplus)
-#endif // defined(SYSTEMERROR_H)

--- a/src/system/SystemEvent.h
+++ b/src/system/SystemEvent.h
@@ -22,8 +22,7 @@
  *      generated at the CHIP System Layer.
  */
 
-#ifndef SYSTEMEVENT_H
-#define SYSTEMEVENT_H
+#pragma once
 
 // Include headers
 #include <system/SystemConfig.h>
@@ -111,5 +110,3 @@ typedef CHIP_SYSTEM_CONFIG_EVENT_OBJECT_TYPE Event;
 
 } // namespace System
 } // namespace chip
-
-#endif // defined(SYSTEMEVENT_H)

--- a/src/system/SystemFaultInjection.h
+++ b/src/system/SystemFaultInjection.h
@@ -21,8 +21,7 @@
  *      Header file for the fault-injection utilities for CHIP System Layer.
  */
 
-#ifndef SYSTEMFAULTINJECTION_H
-#define SYSTEMFAULTINJECTION_H
+#pragma once
 
 #include <system/SystemConfig.h>
 
@@ -127,5 +126,3 @@ DLL_EXPORT void InjectAsyncEvent();
 #define CHIP_SYSTEM_FAULT_INJECT_ASYNC_EVENT()
 
 #endif // CHIP_SYSTEM_CONFIG_TEST
-
-#endif // SYSTEMFAULTINJECTION_H

--- a/src/system/SystemLayer.h
+++ b/src/system/SystemLayer.h
@@ -23,8 +23,7 @@
  *      functions.
  */
 
-#ifndef SYSTEMLAYER_H
-#define SYSTEMLAYER_H
+#pragma once
 
 // Include configuration headers
 #include <system/SystemConfig.h>
@@ -225,5 +224,3 @@ inline LayerState Layer::State() const
 
 } // namespace System
 } // namespace chip
-
-#endif // defined(SYSTEMLAYER_H)

--- a/src/system/SystemLayerPrivate.h
+++ b/src/system/SystemLayerPrivate.h
@@ -20,9 +20,7 @@
  *    @file
  *      This header file includes common private definitions for the CHIP system layer.
  */
-
-#ifndef SYSTEMLAYERPRIVATE_H
-#define SYSTEMLAYERPRIVATE_H
+#pragma once
 
 #include <system/SystemConfig.h>
 
@@ -44,5 +42,3 @@
 #endif // LWIP_VERSION_MAJOR
 
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
-
-#endif // defined(SYSTEMLAYERPRIVATE_H)

--- a/src/system/SystemMutex.h
+++ b/src/system/SystemMutex.h
@@ -22,8 +22,7 @@
  *      offered by the target platform.
  */
 
-#ifndef SYSTEMMUTEX_H
-#define SYSTEMMUTEX_H
+#pragma once
 
 // Include configuration headers
 #include <system/SystemConfig.h>
@@ -114,5 +113,3 @@ inline void Mutex::Unlock(void)
 } // namespace chip
 
 #endif // !CHIP_SYSTEM_CONFIG_NO_LOCKING
-
-#endif // defined(SYSTEMMUTEX_H)

--- a/src/system/SystemObject.h
+++ b/src/system/SystemObject.h
@@ -26,8 +26,7 @@
  *        - template<class T, unsigned int N> class chip::System::ObjectPool
  */
 
-#ifndef SYSTEMOBJECT_H
-#define SYSTEMOBJECT_H
+#pragma once
 
 // Include configuration headers
 #include <system/SystemConfig.h>
@@ -333,5 +332,3 @@ inline void ObjectPool<T, N>::GetStatistics(chip::System::Stats::count_t & aNumI
 
 } // namespace System
 } // namespace chip
-
-#endif // defined(SYSTEMOBJECT_H)

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -23,8 +23,7 @@
  *      octet-serialized data.
  */
 
-#ifndef SYSTEMPACKETBUFFER_H
-#define SYSTEMPACKETBUFFER_H
+#pragma once
 
 // Include configuration header
 #include <system/SystemConfig.h>
@@ -231,5 +230,3 @@ inline uint16_t PacketBuffer::AllocSize() const
 
 } // namespace System
 } // namespace chip
-
-#endif // defined(SYSTEMPACKETBUFFER_H)

--- a/src/system/SystemStats.h
+++ b/src/system/SystemStats.h
@@ -22,8 +22,8 @@
  *  on the state of CHIP, Inet and System resources
  */
 
-#ifndef SYSTEMSTATS_H
-#define SYSTEMSTATS_H
+#pragma once
+
 // Include standard C library limit macros
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS
@@ -170,5 +170,3 @@ const Label * GetStrings();
 #define SYSTEM_STATS_UPDATE_LWIP_PBUF_COUNTS()
 
 #endif // CHIP_SYSTEM_CONFIG_PROVIDE_STATISTICS
-
-#endif // defined(SYSTEMSTATS_H)

--- a/src/system/SystemTimer.h
+++ b/src/system/SystemTimer.h
@@ -23,8 +23,7 @@
  *      timer.
  */
 
-#ifndef SYSTEMTIMER_H
-#define SYSTEMTIMER_H
+#pragma once
 
 // Include configuration headers
 #include <system/SystemConfig.h>
@@ -101,5 +100,3 @@ inline void Timer::GetStatistics(chip::System::Stats::count_t & aNumInUse, chip:
 
 } // namespace System
 } // namespace chip
-
-#endif // defined(SYSTEMTIMER_H)

--- a/src/system/SystemWakeEvent.h
+++ b/src/system/SystemWakeEvent.h
@@ -21,8 +21,7 @@
  *      resuming task from select system call.
  */
 
-#ifndef SYSTEMWAKEEVENT_H
-#define SYSTEMWAKEEVENT_H
+#pragma once
 
 // Include configuration headers
 #include <system/SystemConfig.h>
@@ -65,5 +64,3 @@ private:
 
 } // namespace System
 } // namespace chip
-
-#endif // SYSTEMWAKEEVENT_H

--- a/src/system/TimeSource.h
+++ b/src/system/TimeSource.h
@@ -19,8 +19,8 @@
  * @brief defines a generic time source interface that uses a real clock
  *        at runtime but can be substituted by a test one for unit tests.
  */
-#ifndef TIME_SOURCE_H_
-#define TIME_SOURCE_H_
+
+#pragma once
 
 #include <stdlib.h>
 #include <system/SystemClock.h>
@@ -90,5 +90,3 @@ private:
 
 } // namespace Time
 } // namespace chip
-
-#endif // TIME_SOURCE_H_

--- a/src/system/tests/TestSystemLayer.h
+++ b/src/system/tests/TestSystemLayer.h
@@ -22,8 +22,7 @@
  *
  */
 
-#ifndef TESTSYSTEMLAYER_H
-#define TESTSYSTEMLAYER_H
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,5 +38,3 @@ int TestTimeSource(void);
 #ifdef __cplusplus
 }
 #endif
-
-#endif // TESTSYSTEMLAYER_H


### PR DESCRIPTION
 #### Problem
Include header guards are more typing, pollute the global define space, have a chance to mistmatch ending comments (if we ever rename and copy&paste).

#pragma once is supported most compilers already, let's use it.

 #### Summary of Changes
uses `#pragma once` in headers under src/system

parth of #3138
