### PR TITLE
Check if the result of EncodeCommand is successful before trying to s…

### DIFF
--- a/examples/chip-tool/commands/common/EchoCommand.cpp
+++ b/examples/chip-tool/commands/common/EchoCommand.cpp
@@ -43,11 +43,11 @@ void EchoCommand::SendEcho() const
     CHIP_ERROR err = mController->SendMessage(NULL, buffer);
     if (err == CHIP_NO_ERROR)
     {
-        ChipLogProgress(chipTool, "Echo (%s): Message sent to server", GetName());
+        ChipLogProgress(chipTool, "Echo (%s): Message sent to server", GetNetworkName());
     }
     else
     {
-        ChipLogError(chipTool, "Echo (%s): %s", GetName(), ErrorStr(err));
+        ChipLogError(chipTool, "Echo (%s): %s", GetNetworkName(), ErrorStr(err));
     }
 }
 
@@ -62,11 +62,11 @@ void EchoCommand::ReceiveEcho(PacketBuffer * buffer) const
     bool isEchoIdenticalToMessage = strncmp(msg_buffer, PAYLOAD, data_len) == 0;
     if (isEchoIdenticalToMessage)
     {
-        ChipLogProgress(chipTool, "Echo (%s): Received expected message !", GetName());
+        ChipLogProgress(chipTool, "Echo (%s): Received expected message !", GetNetworkName());
     }
     else
     {
-        ChipLogProgress(chipTool, "Echo: (%s): Error \nSend: %s \nRecv: %s", GetName(), PAYLOAD, msg_buffer);
+        ChipLogProgress(chipTool, "Echo: (%s): Error \nSend: %s \nRecv: %s", GetNetworkName(), PAYLOAD, msg_buffer);
     }
 }
 

--- a/examples/chip-tool/commands/common/ModelCommand.h
+++ b/examples/chip-tool/commands/common/ModelCommand.h
@@ -56,7 +56,7 @@ public:
     virtual bool HandleClusterResponse(uint8_t * message, uint16_t messageLen) const { return false; }
 
 private:
-    void SendCommand(ChipDeviceController * dc);
+    bool SendCommand(ChipDeviceController * dc);
     void ReceiveCommandResponse(ChipDeviceController * dc, chip::System::PacketBuffer * buffer) const;
 
     void ParseGlobalResponseCommand(uint8_t commandId, uint8_t * message, uint16_t messageLen) const;

--- a/examples/chip-tool/commands/common/NetworkCommand.h
+++ b/examples/chip-tool/commands/common/NetworkCommand.h
@@ -46,7 +46,7 @@ public:
         }
     }
 
-    const char * GetName(void) const { return mName; }
+    const char * GetNetworkName(void) const { return mName; }
 
     virtual void OnConnect(ChipDeviceController * dc)                                      = 0;
     virtual void OnError(ChipDeviceController * dc, CHIP_ERROR err)                        = 0;


### PR DESCRIPTION
…end the command

 #### Problem
When a command encoding failed in chip-tool, the current ignore it and still try to send it.

#### Changes
 * Add a check to prevent it