### PR TITLE
Add a null check for the EchoCommand in chip-tool

### DIFF
--- a/examples/chip-tool/commands/common/EchoCommand.cpp
+++ b/examples/chip-tool/commands/common/EchoCommand.cpp
@@ -31,6 +31,12 @@ void EchoCommand::SendEcho() const
     // Reallocate buffer on each run, as the secure transport encrypts and
     // overwrites the buffer from previous iteration.
     auto * buffer = PacketBuffer::NewWithAvailableSize(payload_len);
+    if (buffer == nullptr)
+    {
+        ChipLogError(chipTool, "Failed to allocate memory for packet data.");
+        return;
+    }
+
     memcpy(buffer->Start(), PAYLOAD, payload_len);
     buffer->SetDataLength(payload_len);
 


### PR DESCRIPTION
 #### Problem

Seen in https://github.com/project-chip/connectedhomeip/security/code-scanning/104?query=ref%3Arefs%2Fheads%2Fmaster

The current code does not check if the buffer allocation has failed.

 #### Summary of Changes
* Check if the buffer allocation has failed
