### PR TITLE
CodeQL: Too few arguments to formatting function in door-lock-server-…

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server-schedule.c
+++ b/src/app/clusters/door-lock-server/door-lock-server-schedule.c
@@ -57,7 +57,7 @@ static void printWeekdayScheduleTable(void)
         if (entry->inUse)
         {
             emberAfDoorLockClusterPrintln("%x %2x  %x %4x   %4x   %4x  %4x", i, entry->userId, entry->daysMask, entry->startHour,
-                                          entry->stopHour, entry->stopMinute);
+                                          entry->startMinute, entry->stopHour, entry->stopMinute);
         }
     }
 }


### PR DESCRIPTION
…schedule.c
 #### Problem

Seems like someone forgot to add the `entry->startMinute` parameter for the printf-like method of ember.

Seen in https://github.com/project-chip/connectedhomeip/security/code-scanning/1311?query=ref%3Arefs%2Fheads%2Fmaster

 #### Summary of Changes
* Add the missing parameter
