### PR TITLE
Comparison between i of type uint8_t and emAfAppEventContextLength of…

### DIFF
--- a/src/app/util/af-event.cpp
+++ b/src/app/util/af-event.cpp
@@ -134,7 +134,7 @@ const char * emberAfGetEventString(uint8_t index)
 static EmberAfEventContext * findEventContext(uint8_t endpoint, EmberAfClusterId clusterId, bool isClient)
 {
 #if defined(EMBER_AF_GENERATED_EVENT_CONTEXT)
-    uint8_t i;
+    uint16_t i;
     for (i = 0; i < emAfAppEventContextLength; i++)
     {
         EmberAfEventContext * context = &(emAfAppEventContext[i]);


### PR DESCRIPTION
… wider type uint16_t
  #### Problem
  The findContext method of af-event does a loop comparing a uint8_t with a uint16_t. Seems like we can miss some events.
  Seen in https://github.com/project-chip/connectedhomeip/security/code-scanning/1318?query=ref%3Arefs%2Fheads%2Fmaster

 #### Summary of Changes
 * Change `uint8_t I;` -> `uint16_t i;`