### PR TITLE
Extraneous break in src/platform/ESP32/nimble/BLEManagerImpl.cpp

### DIFF
--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -866,7 +866,6 @@ CHIP_ERROR BLEManagerImpl::SetSubscribed(uint16_t conId)
         else if (mSubscribedConIds[i] == BLE_CONNECTION_UNINITIALIZED && i < freeIndex)
         {
             freeIndex = i;
-            break;
         }
     }
 


### PR DESCRIPTION
 #### Problem
 The code of the SetSubscribed method in src/platform/ESP32/nimble/BLEManagerImpl.cpp seems largely inspired from the code of other platforms for this method.
 The only difference is that the code has added an extra `break` statement. The statement defeats the purpose of the loop which (I believe) is to iterate over all the possible subscribers and if the current connection id is not found to return the first free slot of the `mSubscribedConIds`

 #### Summary of Changes
 * Remove the extra `break` statement