### PR TITLE
Add missing header guards in src/app

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -38,6 +38,9 @@
  *******************************************************************************
  ******************************************************************************/
 
+#ifndef SILABS_DOOR_LOCK_SERVER_H
+#define SILABS_DOOR_LOCK_SERVER_H
+
 // ------------------------------------------------------------------------------
 // Core
 
@@ -247,3 +250,5 @@ bool emAfPluginDoorLockServerCheckForSufficientSpace(uint8_t spaceReq, uint8_t s
 
 #define EmberAfDoorLockScheduleEntry EmberAfPluginDoorLockServerWeekdayScheduleEntry
 #define EmberAfDoorLockUser EmberAfPluginDoorLockServerUser
+
+#endif // SILABS_DOOR_LOCK_SERVER_H

--- a/src/app/clusters/scenes/scenes.h
+++ b/src/app/clusters/scenes/scenes.h
@@ -37,6 +37,9 @@
  *******************************************************************************
  ******************************************************************************/
 
+#ifndef SILABS_SCENES_PLUGIN_H
+#define SILABS_SCENES_PLUGIN_H
+
 #include <app/util/af-types.h>
 #include <stdint.h>
 
@@ -80,3 +83,5 @@ extern EmberAfSceneTableEntry emberAfPluginScenesServerSceneTable[];
 bool emberAfPluginScenesServerParseAddScene(const EmberAfClusterCommand * cmd, uint16_t groupId, uint8_t sceneId,
                                             uint16_t transitionTime, uint8_t * sceneName, uint8_t * extensionFieldSets);
 bool emberAfPluginScenesServerParseViewScene(const EmberAfClusterCommand * cmd, uint16_t groupId, uint8_t sceneId);
+
+#endif // SILABS_SCENES_PLUGIN_H

--- a/src/app/util/esi-management.h
+++ b/src/app/util/esi-management.h
@@ -39,6 +39,9 @@
  *******************************************************************************
  ******************************************************************************/
 
+#ifndef SILABS_ESI_MANAGEMENT_H
+#define SILABS_ESI_MANAGEMENT_H
+
 #include "af.h"
 
 #ifndef EMBER_AF_PLUGIN_ESI_MANAGEMENT_ESI_TABLE_SIZE
@@ -169,3 +172,5 @@ bool emberAfPluginEsiManagementSubscribeToDeletionAnnouncements(EmberAfEsiManage
  *  entry could not be added since the table was full.
  **/
 uint8_t emberAfPluginEsiManagementUpdateEsiAndGetIndex(const EmberAfClusterCommand * cmd);
+
+#endif // SILABS_ESI_MANAGEMENT_H


### PR DESCRIPTION
 #### Problem

CodeQL complains about some missing header guards in src/app.

https://github.com/project-chip/connectedhomeip/security/code-scanning/1436?query=ref%3Arefs%2Fheads%2Fmaster
https://github.com/project-chip/connectedhomeip/security/code-scanning/1435?query=ref%3Arefs%2Fheads%2Fmaster
https://github.com/project-chip/connectedhomeip/security/code-scanning/1434?query=ref%3Arefs%2Fheads%2Fmaster

 #### Summary of Changes
 * Add the missing header guards...