### PR TITLE
[android/CHIPTool] Use ATT Write Request instead of ATT Write Command

### DIFF
--- a/src/controller/java/src/chip/devicecontroller/AndroidChipStack.java
+++ b/src/controller/java/src/chip/devicecontroller/AndroidChipStack.java
@@ -264,6 +264,9 @@ public final class AndroidChipStack {
       return false;
     }
 
+    // Request acknowledgement (use ATT Write Request).
+    sendChar.setWriteType(BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT);
+
     if (!bluetoothGatt.writeCharacteristic(sendChar)) {
       Log.e(TAG, "Failed writing char");
       return false;


### PR DESCRIPTION
 #### Problem

Whenever CHIP Tool for Android writes to the characteristic it does not request acknowledgement on ATT layer.
This violates the current CHIPoBLE specification (section 4.7.3.2, visualization in figure 5).

 #### Summary of Changes

- Force using ATT Write Request (with ATT Write Response) instead of default ATT Write Command without response.

Wireshark capture from the current master:
![android_before](https://user-images.githubusercontent.com/5144764/95516643-dad92700-09bf-11eb-8ed2-c49be31d2cff.png)

Wireshark capture after applying the fix:
![android_after](https://user-images.githubusercontent.com/5144764/95516655-ddd41780-09bf-11eb-9ce0-7397b1b3cbe9.png)

Checked with #3135.

Fixes #3160