### PR TITLE
Missing argument for emberAfCorePrint in src/app/clusters/scenes/scen…

### DIFF
--- a/src/app/clusters/scenes/scenes.c
+++ b/src/app/clusters/scenes/scenes.c
@@ -177,7 +177,7 @@ void emAfPluginScenesServerPrintInfo(void)
 #endif
 #ifdef ZCL_USING_COLOR_CONTROL_CLUSTER_SERVER
             emberAfCorePrint(" color %2x %2x", entry.currentXValue, entry.currentYValue);
-            emberAfCorePrint(" %2x %x %x %x %2x", entry.enhancedCurrentHueValue, entry.currentSaturationValue,
+            emberAfCorePrint(" %2x %x %x %x %2x %2x", entry.enhancedCurrentHueValue, entry.currentSaturationValue,
                              entry.colorLoopActiveValue, entry.colorLoopDirectionValue, entry.colorLoopTimeValue,
                              entry.colorTemperatureMiredsValue);
             emberAfCoreFlush();


### PR DESCRIPTION
…es.c
 #### Problem
 
 Seems like a formatting argument is missing in the printf-like method.

https://github.com/project-chip/connectedhomeip/security/code-scanning/1396?query=ref%3Arefs%2Fheads%2Fmaster

 #### Summary of Changes
 * Add an extra formatting argument