### PR TITLE
Replace raw arrays in method declarations of Command.h and Commands.h…

### DIFF
--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -25,7 +25,7 @@
 
 #include <support/CHIPLogging.h>
 
-bool Command::InitArguments(int argc, char * argv[])
+bool Command::InitArguments(int argc, char ** argv)
 {
     bool isValidCommand = false;
     size_t argsCount    = mArgs.size();

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -82,7 +82,7 @@ public:
     const char * GetArgumentName(size_t index) const;
     size_t GetArgumentsCount(void) const { return mArgs.size(); }
 
-    bool InitArguments(int argc, char * argv[]);
+    bool InitArguments(int argc, char ** argv);
     template <class T>
     size_t AddArgument(const char * name, int64_t min, int64_t max, T * out)
     {

--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -29,7 +29,7 @@ void Commands::Register(const char * clusterName, commands_list commandsList)
     }
 }
 
-int Commands::Run(NodeId localId, NodeId remoteId, int argc, char * argv[])
+int Commands::Run(NodeId localId, NodeId remoteId, int argc, char ** argv)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     ChipDeviceController dc;

--- a/examples/chip-tool/commands/common/Commands.h
+++ b/examples/chip-tool/commands/common/Commands.h
@@ -31,7 +31,7 @@ public:
     using NodeId               = ::chip::NodeId;
 
     void Register(const char * clusterName, commands_list commandsList);
-    int Run(NodeId localId, NodeId remoteId, int argc, char * argv[]);
+    int Run(NodeId localId, NodeId remoteId, int argc, char ** argv);
 
 private:
     CHIP_ERROR RunCommand(ChipDeviceController & dc, NodeId remoteId, int argc, char * argv[]);


### PR DESCRIPTION
… in chip-tool

It seems like CodeQL does not like `char * argv[]` in method declaration and would rather prefer `char ** argv`.

I don't think it matters much in this case but I just want to shutdown the CodeQL warnings:
https://github.com/project-chip/connectedhomeip/security/code-scanning/51?query=ref%3Arefs%2Fheads%2Fmaster
https://github.com/project-chip/connectedhomeip/security/code-scanning/54?query=ref%3Arefs%2Fheads%2Fmaster
 #### Problem
  * Replace `char * argv[]` by `char ** argv`