### PR TITLE
Fix build on Linux arm host

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -27,7 +27,8 @@ import("${chip_root}/build/chip/tools.gni")
 
 if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
   declare_args() {
-    chip_enable_python_modules = true
+    chip_enable_python_modules =
+        (current_os == "mac" || current_os == "linux") && host_cpu == "x64"
   }
 
   # This is a real toolchain. Build CHIP.

--- a/build/config/arm.gni
+++ b/build/config/arm.gni
@@ -39,7 +39,8 @@ if (current_cpu == "arm" || current_cpu == "arm64") {
     arm_fpu = ""
     arm_float_abi = ""
     arm_abi = ""
-    arm_use_thumb = current_os != "android" || current_cpu != "arm64"
+    arm_use_thumb = current_os != "linux" &&
+                    (current_os != "android" || current_cpu != "arm64")
 
     # Update defaults with platform values, if any.
     if (arm_platform_config != "") {

--- a/src/lwip/standalone/arch/cc.h
+++ b/src/lwip/standalone/arch/cc.h
@@ -57,6 +57,7 @@
 #endif
 
 /* Include some files for defining library routines */
+#include <inttypes.h>
 #include <limits.h>
 #include <string.h>
 #include <sys/time.h>
@@ -76,7 +77,7 @@ typedef signed short s16_t;
 typedef unsigned int u32_t;
 typedef signed int s32_t;
 
-typedef unsigned long mem_ptr_t;
+typedef uintptr_t mem_ptr_t;
 
 /* Define (sn)printf formatters for these lwIP types */
 #define X8_F "02x"


### PR DESCRIPTION
In particular, the raspberry Pi. This fixes the following errors:

```
../../src/lib/core/CHIPCallback.h: In constructor ‘chip::Callback::Cancelable::Cancelable()’:
../../src/lib/core/CHIPCallback.h:65:5: sorry, unimplemented: Thumb-1 hard-float VFP ABI
     {
     ^
```

```
In file included from ../../third_party/lwip/repo/lwip/src/include/lwip/debug.h:40,
                 from ../../src/lwip/standalone/sys_arch.c:67:
../../third_party/lwip/repo/lwip/src/include/lwip/arch.h: At top level:
../../third_party/lwip/repo/lwip/src/include/lwip/arch.h:129:19: error: conflicting types for ‘mem_ptr_t’
 typedef uintptr_t mem_ptr_t;
                   ^~~~~~~~~
```