### PR TITLE
Fix disappearing device layer code when external headers used

### DIFF
--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -265,6 +265,7 @@ typedef void (*AsyncWorkFunct)(intptr_t arg);
 #elif defined(CHIP_DEVICE_LAYER_TARGET)
 #define CHIPDEVICEPLATFORMEVENT_HEADER <platform/CHIP_DEVICE_LAYER_TARGET/CHIPDevicePlatformEvent.h>
 #include CHIPDEVICEPLATFORMEVENT_HEADER
+#endif // defined(CHIP_DEVICE_LAYER_TARGET)
 
 #include <ble/BleConfig.h>
 #include <system/SystemPacketBuffer.h>
@@ -395,5 +396,4 @@ struct ChipDeviceEvent final
 } // namespace DeviceLayer
 } // namespace chip
 
-#endif // defined(CHIP_DEVICE_LAYER_TARGET)
 #endif // CHIP_DEVICE_EVENT_H

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -197,6 +197,7 @@ extern ConfigurationManagerImpl & ConfigurationMgrImpl();
 #elif defined(CHIP_DEVICE_LAYER_TARGET)
 #define CONFIGURATIONMANAGERIMPL_HEADER <platform/CHIP_DEVICE_LAYER_TARGET/ConfigurationManagerImpl.h>
 #include CONFIGURATIONMANAGERIMPL_HEADER
+#endif // defined(CHIP_DEVICE_LAYER_TARGET)
 
 namespace chip {
 namespace DeviceLayer {
@@ -540,7 +541,5 @@ inline void ConfigurationManager::UseManufacturerCredentialsAsOperational(bool v
 #endif // CHIP_DEVICE_CONFIG_ENABLE_JUST_IN_TIME_PROVISIONING
 } // namespace DeviceLayer
 } // namespace chip
-
-#endif // defined(CHIP_DEVICE_LAYER_TARGET)
 
 #endif // CONFIGURATION_MANAGER_H

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -248,6 +248,7 @@ extern ConnectivityManagerImpl & ConnectivityMgrImpl();
 #elif defined(CHIP_DEVICE_LAYER_TARGET)
 #define CONNECTIVITYMANAGERIMPL_HEADER <platform/CHIP_DEVICE_LAYER_TARGET/ConnectivityManagerImpl.h>
 #include CONNECTIVITYMANAGERIMPL_HEADER
+#endif // defined(CHIP_DEVICE_LAYER_TARGET)
 
 namespace chip {
 namespace DeviceLayer {
@@ -549,5 +550,5 @@ inline void ConnectivityManager::OnWiFiStationProvisionChange()
 
 } // namespace DeviceLayer
 } // namespace chip
-#endif // defined(CHIP_DEVICE_LAYER_TARGET)
+
 #endif // CONNECTIVITY_MANAGER_H

--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -179,6 +179,7 @@ extern PlatformManagerImpl & PlatformMgrImpl();
 #elif defined(CHIP_DEVICE_LAYER_TARGET)
 #define PLATFORMMANAGERIMPL_HEADER <platform/CHIP_DEVICE_LAYER_TARGET/PlatformManagerImpl.h>
 #include PLATFORMMANAGERIMPL_HEADER
+#endif // defined(CHIP_DEVICE_LAYER_TARGET)
 
 namespace chip {
 namespace DeviceLayer {
@@ -251,5 +252,4 @@ inline CHIP_ERROR PlatformManager::Shutdown()
 } // namespace DeviceLayer
 } // namespace chip
 
-#endif // defined(CHIP_DEVICE_LAYER_TARGET)
 #endif // PLATFORM_MANAGER_H

--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -163,6 +163,7 @@ extern ThreadStackManagerImpl & ThreadStackMgrImpl();
 #elif defined(CHIP_DEVICE_LAYER_TARGET)
 #define THREADSTACKMANAGERIMPL_HEADER <platform/CHIP_DEVICE_LAYER_TARGET/ThreadStackManagerImpl.h>
 #include THREADSTACKMANAGERIMPL_HEADER
+#endif // defined(CHIP_DEVICE_LAYER_TARGET)
 
 namespace chip {
 namespace DeviceLayer {
@@ -313,5 +314,4 @@ inline CHIP_ERROR ThreadStackManager::JoinerStart()
 } // namespace DeviceLayer
 } // namespace chip
 
-#endif // defined(CHIP_DEVICE_LAYER_TARGET)
 #endif // THREAD_STACK_MANAGER_H

--- a/src/include/platform/internal/BLEManager.h
+++ b/src/include/platform/internal/BLEManager.h
@@ -106,6 +106,7 @@ extern BLEManagerImpl & BLEMgrImpl();
 #elif defined(CHIP_DEVICE_LAYER_TARGET)
 #define BLEMANAGERIMPL_HEADER <platform/CHIP_DEVICE_LAYER_TARGET/BLEManagerImpl.h>
 #include BLEMANAGERIMPL_HEADER
+#endif // defined(CHIP_DEVICE_LAYER_TARGET)
 
 namespace chip {
 namespace DeviceLayer {
@@ -180,6 +181,5 @@ inline chip::Ble::BleLayer * BLEManager::GetBleLayer()
 } // namespace DeviceLayer
 } // namespace chip
 
-#endif // defined(CHIP_DEVICE_LAYER_TARGET)
 #endif // CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 #endif // BLE_MANAGER_H

--- a/src/include/platform/internal/NetworkProvisioningServer.h
+++ b/src/include/platform/internal/NetworkProvisioningServer.h
@@ -72,10 +72,10 @@ extern NetworkProvisioningServer & NetworkProvisioningSvr();
  */
 #ifdef EXTERNAL_NETWORKPROVISIONINGSERVERIMPL_HEADER
 #include EXTERNAL_NETWORKPROVISIONINGSERVERIMPL_HEADER
-#else
+#elif defined(CHIP_DEVICE_LAYER_TARGET)
 #define NETWORKPROVISIONINGSERVERIMPL_HEADER <platform/CHIP_DEVICE_LAYER_TARGET/NetworkProvisioningServerImpl.h>
 #include NETWORKPROVISIONINGSERVERIMPL_HEADER
-#endif
+#endif // defined(CHIP_DEVICE_LAYER_TARGET)
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/Linux/CHIPBluezHelper.cpp
+++ b/src/platform/Linux/CHIPBluezHelper.cpp
@@ -50,8 +50,7 @@
 
 #include <ble/BleUUID.h>
 #include <ble/CHIPBleServiceData.h>
-#include <platform/internal/BLEManager.h>
-#include <platform/internal/CHIPDeviceLayerInternal.h>
+#include <platform/CHIPDeviceLayer.h>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 #include <errno.h>


### PR DESCRIPTION
As of d8f58a0b ("[GN] add support for external device layer (#2212)")
a bunch of types are removed from device layer when
EXTERNAL_EXTERNAL_*_HEADER is set. This breaks the build if files
that use those types are compiled.

Move the #ifdefs back so that internal end external device layers
work the same way.