### PR TITLE
Remove verbose code comments

### DIFF
--- a/examples/lighting-app/efr32/src/main.cpp
+++ b/examples/lighting-app/efr32/src/main.cpp
@@ -133,7 +133,6 @@ int main(void)
         appError(ret);
     }
 
-    // Configure device to operate as a Thread sleepy end-device.
     ret = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_Router);
     if (ret != CHIP_NO_ERROR)
     {

--- a/examples/lock-app/efr32/src/main.cpp
+++ b/examples/lock-app/efr32/src/main.cpp
@@ -133,7 +133,6 @@ int main(void)
         appError(ret);
     }
 
-    // Configure device to operate as a Thread sleepy end-device.
     ret = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_Router);
     if (ret != CHIP_NO_ERROR)
     {

--- a/examples/lock-app/k32w/main/main.cpp
+++ b/examples/lock-app/k32w/main/main.cpp
@@ -100,7 +100,6 @@ extern "C" void main_task(void const * argument)
         goto exit;
     }
 
-    // Configure device to operate as a Thread sleepy end-device.
     ret = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_SleepyEndDevice);
     if (ret != CHIP_NO_ERROR)
     {

--- a/examples/platform/nrf528xx/app/chipinit.cpp
+++ b/examples/platform/nrf528xx/app/chipinit.cpp
@@ -112,7 +112,6 @@ ret_code_t ChipInit()
         APP_ERROR_HANDLER(ret);
     }
 
-    // Configure device to operate as a Thread sleepy end-device.
     ret = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_Router);
     if (ret != CHIP_NO_ERROR)
     {


### PR DESCRIPTION
 #### Problem
Some devices are configured to act as Thread router instead of
sleepy-end device.

 #### Summary of Changes
This PR removes these incorrect or verbose comments.
