### PR TITLE
Remove {#mainpage} from the main README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Connected Home over IP {#mainpage}
+# Connected Home over IP
 
 ![Main](https://github.com/project-chip/connectedhomeip/workflows/Builds/badge.svg)
 ![Examples](https://github.com/project-chip/connectedhomeip/workflows/Examples/badge.svg)


### PR DESCRIPTION
 #### Problem
The main README.md shows the {#mainpage} tag from Doxygen. It should not be visible and I'm not sure that Github has not changed something in their templating code. Until I found a good way to fix that, I think it would makes sense to just remove it since it makes a bad looks on the GitHub landing page of the repo.

 #### Summary of Changes
 * Remove the {#mainpage} Doxygen tag

 Fixes #3022 
