### PR TITLE
ChipTool: Add cluster name to the command line parameters

### DIFF
--- a/examples/chip-tool/README.md
+++ b/examples/chip-tool/README.md
@@ -36,14 +36,14 @@ pass it the discriminator and pairing code of the remote device. The command
 below uses the default values hard-coded into the debug versions of the ESP32
 wifi-echo app:
 
-          $ chip-tool echo-ble 3840 12345678
+    $ chip-tool echo ble 3840 12345678
 
 ### Ping a device over IP
 
 To start the Client in echo mode, run the built executable and pass it the IP
 address and port of the server to talk to, as well as the command "echo".
 
-          $ chip-tool 192.168.0.30 8000 echo
+    $ chip-tool echo ip 192.168.0.30 8000
 
 If valid values are supplied, it will begin to periodically send messages to the
 server address provided.
@@ -55,12 +55,39 @@ Stop the Client at any time with `Ctrl + C`.
 
 ## Using the Client to Send CHIP Commands
 
-To use the Client to send a CHIP comands, run the built executable and pass it
-the IP address and port of the server to talk to, the name of the command to
-send, as well as an enpoint id. Right now the "off", "on", and "toggle" commands
-are supported, from the On/Off cluster. The endpoint id must be between 1
+To use the Client to send a CHIP commands, run the built executable and pass it
+the target cluster name, the target command name, an endpoint id as well as the
+IP address and port of the server to talk to. The endpoint id must be between 1
 and 240.
 
-          $ chip-tool 192.168.0.30 8000 on 1
+    $ chip-tool onoff on 1 192.168.0.30 11095
 
 The client will send a single command packet and then exit.
+
+### How to get the list of supported clusters
+
+To get the list of supported clusters, run the built executable without any
+arguments.
+
+    $ chip-tool
+
+### How to get the list of supported commands for a specific cluster
+
+To get the list of commands for a specific cluster, run the built executable
+with the target cluster name.
+
+    $ chip-tool onoff
+
+### How to get the list of supported attributes for a specific cluster
+
+To the the list of attributes for a specific cluster, run the built executable
+with the target cluster name and the `read` command name.
+
+    $ chip-tool onoff read
+
+### How to get the list of parameters for a command
+
+To get the list of parameters for a specific command, run the built executable
+with the target cluster name and the target command name
+
+    $ chip-tool onoff on

--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -128,7 +128,7 @@ size_t Command::AddArgument(const char * name, const char * value)
     arg.name  = name;
     arg.value = const_cast<void *>(reinterpret_cast<const void *>(value));
 
-    mArgs.push_back(arg);
+    mArgs.emplace(mArgs.begin(), arg);
     return mArgs.size();
 }
 
@@ -139,7 +139,7 @@ size_t Command::AddArgument(const char * name, char ** value)
     arg.name  = name;
     arg.value = reinterpret_cast<void *>(value);
 
-    mArgs.push_back(arg);
+    mArgs.emplace(mArgs.begin(), arg);
     return mArgs.size();
 }
 
@@ -150,7 +150,7 @@ size_t Command::AddArgument(const char * name, AddressWithInterface * out)
     arg.name  = name;
     arg.value = reinterpret_cast<void *>(out);
 
-    mArgs.push_back(arg);
+    mArgs.emplace(mArgs.begin(), arg);
     return mArgs.size();
 }
 
@@ -163,7 +163,7 @@ size_t Command::AddArgument(const char * name, int64_t min, int64_t max, void * 
     arg.min   = min;
     arg.max   = max;
 
-    mArgs.push_back(arg);
+    mArgs.emplace(mArgs.begin(), arg);
     return mArgs.size();
 }
 

--- a/examples/chip-tool/commands/common/Commands.h
+++ b/examples/chip-tool/commands/common/Commands.h
@@ -29,19 +29,23 @@ class Commands
 public:
     using ChipDeviceController = ::chip::DeviceController::ChipDeviceController;
     using NodeId               = ::chip::NodeId;
+    using CommandsVector       = ::std::vector<std::unique_ptr<Command>>;
 
     void Register(const char * clusterName, commands_list commandsList);
     int Run(NodeId localId, NodeId remoteId, int argc, char ** argv);
 
 private:
-    CHIP_ERROR RunCommand(ChipDeviceController & dc, NodeId remoteId, int argc, char * argv[]);
+    CHIP_ERROR RunCommand(ChipDeviceController & dc, NodeId remoteId, int argc, char ** argv);
+    std::map<std::string, CommandsVector>::iterator GetCluster(std::string clusterName);
+    Command * GetCommand(CommandsVector & commands, std::string commandName);
+    Command * GetReadCommand(CommandsVector & commands, std::string commandName, std::string attributeName);
 
-    void ShowUsage(const char * executable);
-    void PrintMiscCommands();
-    void PrintClustersCommands();
-    void PrintClustersAttributes();
+    void ShowClusters(std::string executable);
+    void ShowCluster(std::string executable, std::string clusterName, CommandsVector & commands);
+    void ShowClusterAttributes(std::string executable, std::string clusterName, CommandsVector & commands);
+    void ShowCommand(std::string executable, std::string clusterName, Command * command);
 
-    std::map<const char *, std::vector<std::unique_ptr<Command>>> clusters;
+    std::map<std::string, CommandsVector> mClusters;
 };
 
 #endif // __CHIPTOOL_COMMANDS_H__

--- a/examples/chip-tool/commands/common/NetworkCommand.h
+++ b/examples/chip-tool/commands/common/NetworkCommand.h
@@ -35,14 +35,14 @@ public:
     {
         if (type == NetworkType::UDP || type == NetworkType::ALL)
         {
+            AddArgument("device-remote-port", 0, UINT16_MAX, &mRemotePort);
             AddArgument("device-remote-ip", &mRemoteAddr);
-            AddArgument("device-remote-port", 0, 65536, &mRemotePort);
         }
 
         if (type == NetworkType::BLE || type == NetworkType::ALL)
         {
-            AddArgument("discriminator", 0, 4096, &mDiscriminator);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
+            AddArgument("discriminator", 0, 4096, &mDiscriminator);
         }
     }
 

--- a/examples/chip-tool/commands/echo/Commands.h
+++ b/examples/chip-tool/commands/echo/Commands.h
@@ -24,18 +24,18 @@
 class Echo : public EchoCommand
 {
 public:
-    Echo() : EchoCommand("echo", NetworkType::UDP) {}
+    Echo() : EchoCommand("ip", NetworkType::UDP) {}
 };
 
 class EchoBle : public EchoCommand
 {
 public:
-    EchoBle() : EchoCommand("echo-ble", NetworkType::BLE) {}
+    EchoBle() : EchoCommand("ble", NetworkType::BLE) {}
 };
 
 void registerCommandsEcho(Commands & commands)
 {
-    const char * clusterName = "";
+    const char * clusterName = "Echo";
 
     commands_list clusterCommands = {
         make_unique<Echo>(),

--- a/examples/lighting-app/efr32/README.md
+++ b/examples/lighting-app/efr32/README.md
@@ -156,7 +156,7 @@ combination with JLinkRTTClient as follows:
     `router table` using a serial terminal (screen / minicom etc.) on the board
     running the lighting-app example)
 -   Using chip-tool you can now control the light status with on/off command
-    such as `chip-tool on <ipv6 address of the node> 11095 1`
+    such as `chip-tool onoff on 1 <ipv6 address of the node> 11095`
 
 ### Notes
 

--- a/examples/lock-app/efr32/README.md
+++ b/examples/lock-app/efr32/README.md
@@ -156,7 +156,7 @@ combination with JLinkRTTClient as follows:
     `router table` using a serial terminal (screen / minicom etc.) on the board
     running the lock-app example)
 -   Using chip-tool you can now control the lock status with on/off command such
-    as `chip-tool on <ipv6 address of the node> 11095 1`
+    as `chip-tool onoff on 1 <ipv6 address of the node> 11095`
 
 ### Notes
 

--- a/src/test_driver/linux-cirque/test-on-off-cluster.py
+++ b/src/test_driver/linux-cirque/test-on-off-cluster.py
@@ -79,7 +79,7 @@ class TestOnOffCluster(CHIPVirtualHome):
 
         for ip in server_ip_address:
             output = self.execute_device_cmd(
-                tool_device_id, "chip-tool on {} {} 1".format(ip, CHIP_PORT))
+                tool_device_id, "chip-tool onoff on 1 {} {}".format(ip, CHIP_PORT))
             self.logger.info(
                 'checking output does not contain "No response from device"')
             self.assertFalse(self.sequenceMatch(
@@ -87,7 +87,7 @@ class TestOnOffCluster(CHIPVirtualHome):
         time.sleep(1)
         for ip in server_ip_address:
             output = self.execute_device_cmd(
-                tool_device_id, "chip-tool off {} {} 1".format(ip, CHIP_PORT))
+                tool_device_id, "chip-tool onoff off 1 {} {}".format(ip, CHIP_PORT))
             self.logger.info(
                 'checking output does not contain "No response from device"')
             self.assertFalse(self.sequenceMatch(


### PR DESCRIPTION
 #### Problem

Since the addition of a bunch of commands to chip-tool, there are some collisions over attributes (e.g name-support).
At the moment one can only read the `name-support`attribute of the first register cluster

 #### Summary of Changes
 * Add a new mandatory argument to chip-tool: `cluster_name`
 * Update `ShowUsage` to make it easier to list clusters, commands and attributes
 * Update examples/chip-tool/README.md