### PR TITLE
[nrfconnect] Disable CodeQL CI check

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -288,10 +288,10 @@ jobs:
             # - name: Perform CodeQL Analysis
             #   if: ${{ github.event_name == 'push' }}
             #   uses: github/codeql-action/analyze@v1
-            - name: Perform CodeQL Analysis
-              if: ${{ github.event_name == 'push' }}
-              uses: github/codeql-action/analyze@v1
-    
+            # - name: Perform CodeQL Analysis
+            #   if: ${{ github.event_name == 'push' }}
+            #   uses: github/codeql-action/analyze@v1
+
     qpg6100:
         name: QPG6100
         env:


### PR DESCRIPTION
#### Problem
nRF Connect platform often fails on CodeQL stage in CI. This is a known problem reported here: #3100. 
By accident with #3130 PR the CI check was enabled.

 #### Summary of Changes
Disable CodeQL temporary to unblock other PRs to be merged.
The correct solution will be introduced later.

Fixes: #3192.