### PR TITLE
Rename SecureSessionMgrCallback to SecureSessionMgrDelegate to align …

### DIFF
--- a/examples/common/chip-app-server/Server.cpp
+++ b/examples/common/chip-app-server/Server.cpp
@@ -59,7 +59,7 @@ SecureSessionMgrBase & SessionManager()
 
 namespace {
 
-class ServerCallback : public SecureSessionMgrCallback
+class ServerCallback : public SecureSessionMgrDelegate
 {
 public:
     void OnMessageReceived(const PacketHeader & header, Transport::PeerConnectionState * state, System::PacketBuffer * buffer,

--- a/examples/wifi-echo/server/esp32/main/EchoServer.cpp
+++ b/examples/wifi-echo/server/esp32/main/EchoServer.cpp
@@ -120,7 +120,7 @@ static size_t odc(const uint8_t * bytes, size_t bytes_len, char * out, size_t ou
     return required;
 }
 
-class EchoServerCallback : public SecureSessionMgrCallback
+class EchoServerCallback : public SecureSessionMgrDelegate
 {
 public:
     void OnMessageReceived(const PacketHeader & header, Transport::PeerConnectionState * state, System::PacketBuffer * buffer,

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -95,7 +95,7 @@ public:
     virtual void OnPairingDeleted(CHIP_ERROR error) {}
 };
 
-class DLL_EXPORT ChipDeviceController : public SecureSessionMgrCallback, public RendezvousSessionDelegate
+class DLL_EXPORT ChipDeviceController : public SecureSessionMgrDelegate, public RendezvousSessionDelegate
 {
     friend class ChipDeviceControllerCallback;
 

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -50,7 +50,7 @@ class SecureSessionMgrBase;
  *   is interested in receiving these callbacks, they can specialize this class and handle
  *   each trigger in their implementation of this class.
  */
-class DLL_EXPORT SecureSessionMgrCallback : public ReferenceCounted<SecureSessionMgrCallback>
+class DLL_EXPORT SecureSessionMgrDelegate : public ReferenceCounted<SecureSessionMgrDelegate>
 {
 public:
     /**
@@ -86,7 +86,7 @@ public:
      */
     virtual void OnNewConnection(Transport::PeerConnectionState * state, SecureSessionMgrBase * mgr) {}
 
-    ~SecureSessionMgrCallback() override {}
+    ~SecureSessionMgrDelegate() override {}
 };
 
 class DLL_EXPORT SecureSessionMgrBase : public ReferenceCounted<SecureSessionMgrBase>
@@ -112,7 +112,7 @@ public:
      * @details
      *   Release if there was an existing callback object
      */
-    void SetDelegate(SecureSessionMgrCallback * cb)
+    void SetDelegate(SecureSessionMgrDelegate * cb)
     {
         if (mCB != nullptr)
         {
@@ -159,7 +159,7 @@ private:
     Transport::PeerConnections<CHIP_CONFIG_PEER_CONNECTION_POOL_SIZE> mPeerConnections; // < Active connections to other peers
     State mState;                                                                       // < Initialization state of the object
 
-    SecureSessionMgrCallback * mCB = nullptr;
+    SecureSessionMgrDelegate * mCB = nullptr;
 
     /** Schedules a new oneshot timer for checking connection expiry. */
     void ScheduleExpiryTimer();

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -63,7 +63,7 @@ public:
     bool CanSendToPeer(const PeerAddress & address) override { return true; }
 };
 
-class TestSessMgrCallback : public SecureSessionMgrCallback
+class TestSessMgrCallback : public SecureSessionMgrDelegate
 {
 public:
     void OnMessageReceived(const PacketHeader & header, PeerConnectionState * state, System::PacketBuffer * msgBuf,


### PR DESCRIPTION
 #### Problem
CHIP APIs (Controller, SecureSessionMgr, Rendezvous, Pairing etc) are moving towards using delegates pattern, but naming the delegate callback interface differently.

 #### Summary of Changes
 Rename SecureSessionMgrCallback to SecureSessionMgrDelegate to align with other APIs.