### PR TITLE
Disable happy testing locally by default

### DIFF
--- a/.github/workflows/unit_integration_test.yaml
+++ b/.github/workflows/unit_integration_test.yaml
@@ -68,7 +68,7 @@ jobs:
                      *) ;;
                   esac
 
-                  scripts/build/gn_gen.sh --args="$GN_ARGS"
+                  scripts/build/gn_gen.sh --args="$GN_ARGS chip_enable_happy_tests=true"
             - name: Run Build
               run: scripts/build/gn_build.sh
             - name: Run Tests

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -92,9 +92,11 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
   }
 
   # We don't always want to run happy tests, make them a seperate group.
-  group("happy_tests") {
-    if (chip_link_tests) {
-      deps = [ "//src:happy_tests" ]
+  if (chip_enable_happy_tests) {
+    group("happy_tests") {
+      if (chip_link_tests) {
+        deps = [ "//src:happy_tests" ]
+      }
     }
   }
 } else {

--- a/build/chip/happy_test.gni
+++ b/build/chip/happy_test.gni
@@ -17,6 +17,7 @@ import("//build_overrides/chip.gni")
 import("${chip_root}/build/chip/tests.gni")
 
 assert(chip_build_tests)
+assert(chip_enable_happy_tests)
 
 template("happy_test") {
   _suite_name = target_name

--- a/build/chip/tests.gni
+++ b/build/chip/tests.gni
@@ -19,6 +19,9 @@ import("${chip_root}/src/platform/device.gni")
 declare_args() {
   # Enable building tests.
   chip_build_tests = current_os != "freertos"
+
+  # Enable happy tests.
+  chip_enable_happy_tests = false
 }
 
 declare_args() {

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -64,7 +64,7 @@ if (chip_build_tests) {
     }
   }
 
-  if (current_os == "linux") {
+  if (chip_enable_happy_tests) {
     group("happy_tests") {
       deps = [
         "${chip_root}/src/test_driver/happy/tests/standalone/inet:inet_tests",

--- a/src/inet/tests/BUILD.gn
+++ b/src/inet/tests/BUILD.gn
@@ -16,6 +16,7 @@ import("//build_overrides/chip.gni")
 import("//build_overrides/nlunit_test.gni")
 
 import("${chip_root}/build/chip/chip_test_suite.gni")
+import("${chip_root}/build/chip/tests.gni")
 import("${chip_root}/src/lwip/lwip.gni")
 import("${chip_root}/src/platform/device.gni")
 
@@ -69,20 +70,22 @@ chip_test_suite("tests") {
   }
 }
 
-# The following binaries should be executed by happy.
-chip_test_suite("happy_tests") {
-  output_name = "libHappyTestInetCommon"
+if (chip_enable_happy_tests) {
+  # The following binaries should be executed by happy.
+  chip_test_suite("happy_tests") {
+    output_name = "libHappyTestInetCommon"
 
-  sources = [ "TestInetLayerMulticast.cpp" ]
+    sources = [ "TestInetLayerMulticast.cpp" ]
 
-  public_configs = [ ":tests_config" ]
+    public_configs = [ ":tests_config" ]
 
-  public_deps = [
-    ":tests_common",
-    "${chip_root}/src/inet",
-    "${chip_root}/src/lib/core",
-    "${nlunit_test_root}:nlunit-test",
-  ]
+    public_deps = [
+      ":tests_common",
+      "${chip_root}/src/inet",
+      "${chip_root}/src/lib/core",
+      "${nlunit_test_root}:nlunit-test",
+    ]
 
-  tests = [ "TestInetLayerMulticast" ]
+    tests = [ "TestInetLayerMulticast" ]
+  }
 }


### PR DESCRIPTION
These make the "all" build fail except in happy's special userns
environment, and the build stays persistently dirty because happy
doesn't track inputs & outputs.

Disable it by default until these issues are fixed.

See #3214.