### PR TITLE
ChipTool: Use an env variable to filters ChipLog* messages if needed

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -23,6 +23,7 @@ executable("chip-tool") {
     "commands/common/Command.cpp",
     "commands/common/Commands.cpp",
     "commands/common/EchoCommand.cpp",
+    "commands/common/Logging.cpp",
     "commands/common/ModelCommand.cpp",
     "commands/common/NetworkCommand.cpp",
     "main.cpp",

--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -19,6 +19,7 @@
 #include "Commands.h"
 
 #include "Command.h"
+#include "Logging.h"
 
 #include <algorithm>
 #include <string>
@@ -33,6 +34,8 @@ void Commands::Register(const char * clusterName, commands_list commandsList)
 
 int Commands::Run(NodeId localId, NodeId remoteId, int argc, char ** argv)
 {
+    ConfigureChipLogging();
+
     CHIP_ERROR err = CHIP_NO_ERROR;
     ChipDeviceController dc;
 

--- a/examples/chip-tool/commands/common/Logging.cpp
+++ b/examples/chip-tool/commands/common/Logging.cpp
@@ -1,0 +1,59 @@
+/*
+ *   Copyright (c) 2020 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include <support/CHIPLogging.h>
+#include <support/CodeUtils.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+using namespace ::chip::Logging;
+
+constexpr LogCategory kDefaultLoggingLevel = kLogCategory_Detail;
+
+void ConfigureChipLogging()
+{
+    LogCategory chipLogLevel = kDefaultLoggingLevel;
+
+    const char * level = getenv("CHIP_LOG_LEVEL");
+    VerifyOrExit(level != NULL, /**/);
+
+    if (strcasecmp(level, "none") == 0)
+    {
+        chipLogLevel = kLogCategory_None;
+    }
+    else if (strcasecmp(level, "error") == 0)
+    {
+        chipLogLevel = kLogCategory_Error;
+    }
+    else if (strcasecmp(level, "progress") == 0)
+    {
+        chipLogLevel = kLogCategory_Progress;
+    }
+    else if (strcasecmp(level, "detail") == 0)
+    {
+        chipLogLevel = kLogCategory_Detail;
+    }
+    else if (strcasecmp(level, "retain") == 0)
+    {
+        chipLogLevel = kLogCategory_Retain;
+    }
+
+exit:
+    SetLogFilter(chipLogLevel);
+}

--- a/examples/chip-tool/commands/common/Logging.h
+++ b/examples/chip-tool/commands/common/Logging.h
@@ -1,0 +1,21 @@
+/*
+ *   Copyright (c) 2020 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+void ConfigureChipLogging();


### PR DESCRIPTION
 #### Problem
 
This PR allows to specify `CHIP_LOG_LEVEL` as an env var to chip-tool. By default it still keeps the same level that it currently uses.

 #### Summary of Changes
 * Uses the `CHIP_LOG_LEVEL` env var for chip-tool to configure chip log filtering