### PR TITLE
Update ChipLog* from examples/chip-tool, src/app/encoder.cpp and src/…

### DIFF
--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -31,7 +31,7 @@ bool Command::InitArguments(int argc, char ** argv)
     size_t argsCount    = mArgs.size();
 
     VerifyOrExit(argsCount == (size_t)(argc),
-                 ChipLogProgress(chipTool, "InitArgs: Wrong arguments number: %zu instead of %zu", argc, argsCount));
+                 ChipLogError(chipTool, "InitArgs: Wrong arguments number: %zu instead of %zu", argc, argsCount));
 
     for (size_t i = 0; i < argsCount; i++)
     {

--- a/examples/chip-tool/commands/common/EchoCommand.cpp
+++ b/examples/chip-tool/commands/common/EchoCommand.cpp
@@ -71,7 +71,7 @@ void EchoCommand::ReceiveEcho(PacketBuffer * buffer) const
     }
     else
     {
-        ChipLogProgress(chipTool, "Echo: (%s): Error \nSend: %s \nRecv: %s", GetNetworkName(), PAYLOAD, msg_buffer);
+        ChipLogError(chipTool, "Echo: (%s): Error \nSend: %s \nRecv: %s", GetNetworkName(), PAYLOAD, msg_buffer);
     }
 }
 

--- a/examples/chip-tool/commands/common/ModelCommand.cpp
+++ b/examples/chip-tool/commands/common/ModelCommand.cpp
@@ -103,7 +103,7 @@ bool ModelCommand::SendCommand(ChipDeviceController * dc)
     }
 
     buffer->SetDataLength(dataLength);
-    ChipLogProgress(chipTool, "Encoded data of length %d", dataLength);
+    ChipLogDetail(chipTool, "Encoded data of length %d", dataLength);
 
 #ifdef DEBUG
     PrintBuffer(buffer);
@@ -129,7 +129,7 @@ void ModelCommand::ReceiveCommandResponse(ChipDeviceController * dc, PacketBuffe
         PacketBuffer::Free(buffer);
         ExitNow();
     }
-    ChipLogProgress(chipTool, "APS frame processing success!");
+    ChipLogDetail(chipTool, "APS frame processing success!");
 
     messageLen = extractMessage(buffer->Start(), buffer->DataLength(), &message);
     CHECK_MESSAGE_LENGTH(messageLen >= 3);
@@ -264,7 +264,7 @@ void ModelCommand::ParseSpecificClusterResponseCommand(uint8_t commandId, uint8_
     ChipLogProgress(chipTool, "Parsing cluster id '0x%04x' response command '0x%02x'", mClusterId, commandId);
     if (!HandleClusterResponse(message, messageLen))
     {
-        ChipLogProgress(chipTool, "Not handling command '0x%02x'", commandId);
+        ChipLogError(chipTool, "Not handling command '0x%02x'", commandId);
     }
 }
 

--- a/examples/chip-tool/commands/common/NetworkCommand.cpp
+++ b/examples/chip-tool/commands/common/NetworkCommand.cpp
@@ -24,7 +24,7 @@ using namespace ::chip::System;
 
 static void onConnect(ChipDeviceController * dc, Transport::PeerConnectionState * state, void * appReqState)
 {
-    ChipLogProgress(chipTool, "OnConnect");
+    ChipLogDetail(chipTool, "OnConnect");
 
     NetworkCommand * command = reinterpret_cast<NetworkCommand *>(dc->AppState);
     command->OnConnect(dc);
@@ -40,7 +40,7 @@ static void onError(ChipDeviceController * dc, void * appReqState, CHIP_ERROR er
 
 static void onMessage(ChipDeviceController * dc, void * appReqState, PacketBuffer * buffer)
 {
-    ChipLogProgress(chipTool, "OnMessage: Received %zu bytes", buffer->DataLength());
+    ChipLogDetail(chipTool, "OnMessage: Received %zu bytes", buffer->DataLength());
 
     NetworkCommand * command = reinterpret_cast<NetworkCommand *>(dc->AppState);
     command->OnMessage(dc, buffer);

--- a/src/app/encoder.cpp
+++ b/src/app/encoder.cpp
@@ -122,17 +122,17 @@ static uint16_t doEncodeApsFrame(BufBound & buf, uint16_t profileID, uint16_t cl
     if (isMeasuring)
     {
         result = buf.Written();
-        ChipLogProgress(Zcl, "Measured APS frame size %d", result);
+        ChipLogDetail(Zcl, "Measured APS frame size %d", result);
     }
     else
     {
         result = buf.Fit() ? buf.Written() : 0;
         CHECK_FRAME_LENGTH(result, "Buffer too small");
-        ChipLogProgress(Zcl, "Successfully encoded %d bytes", result);
+        ChipLogDetail(Zcl, "Successfully encoded %d bytes", result);
     }
     if (!CanCastTo<uint16_t>(result))
     {
-        ChipLogProgress(Zcl, "Can't fit our measured size in uint16_t");
+        ChipLogError(Zcl, "Can't fit our measured size in uint16_t");
         result = 0;
     }
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -131,7 +131,7 @@ CHIP_ERROR ChipDeviceController::Shutdown()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    ChipLogProgress(Controller, "Shutting down the controller\n");
+    ChipLogDetail(Controller, "Shutting down the controller");
 
     VerifyOrExit(mState == kState_Initialized, err = CHIP_ERROR_INCORRECT_STATE);
 
@@ -387,7 +387,7 @@ CHIP_ERROR ChipDeviceController::SendMessage(void * appReqState, PacketBuffer * 
         buffer->AddRef();
 
         err = mSessionManager->SendMessage(mRemoteDeviceId.Value(), buffer);
-        ChipLogProgress(Controller, "SendMessage returned %d\n", err);
+        ChipLogDetail(Controller, "SendMessage returned %d", err);
 
         // The send could fail due to network timeouts (e.g. broken pipe)
         // Try sesion resumption if needed
@@ -461,7 +461,7 @@ void ChipDeviceController::OnMessageReceived(const PacketHeader & header, Transp
     {
         if (!mRemoteDeviceId.HasValue())
         {
-            ChipLogProgress(Controller, "Learned remote device id");
+            ChipLogDetail(Controller, "Learned remote device id");
             mRemoteDeviceId = header.GetSourceNodeId();
         }
         else if (mRemoteDeviceId != header.GetSourceNodeId())
@@ -507,7 +507,7 @@ void ChipDeviceController::OnRendezvousStatusUpdate(RendezvousSessionDelegate::S
     switch (status)
     {
     case RendezvousSessionDelegate::SecurePairingSuccess:
-        ChipLogProgress(Controller, "Remote device completed SPAKE2+ handshake\n");
+        ChipLogDetail(Controller, "Remote device completed SPAKE2+ handshake\n");
         mPairingSession       = mRendezvousSession->GetPairingSession();
         mSecurePairingSession = &mPairingSession;
 
@@ -524,7 +524,7 @@ void ChipDeviceController::OnRendezvousStatusUpdate(RendezvousSessionDelegate::S
 
     case RendezvousSessionDelegate::NetworkProvisioningSuccess:
 
-        ChipLogProgress(Controller, "Remote device was assigned an ip address\n");
+        ChipLogDetail(Controller, "Remote device was assigned an ip address\n");
         mDeviceAddr = mRendezvousSession->GetIPAddress();
         break;
 


### PR DESCRIPTION
…controller/CHIPDeviceController.cpp to better represent what they log

 #### Problem

Some of the ChipLog* methods are not logging what they represents: `ChipLogProgress`used for errors or `ChipLogProgress` uses for details...
It makes some errors hard to see, and some details too visible in the log output.

 #### Summary of Changes
 * Update the ChipLog* calls