### PR TITLE
Safety changes after malloc to CHIPMem conversions

### DIFF
--- a/src/inet/tests/TestInetCommon.cpp
+++ b/src/inet/tests/TestInetCommon.cpp
@@ -290,8 +290,8 @@ void InitNetwork()
         {
             uint64_t iid    = gNetworkOptions.LocalIPv6Addr[j].InterfaceId();
             char * tap_name = (char *) chip::Platform::MemoryAlloc(sizeof(gDefaultTapDeviceName));
+            assert(tap_name);
             snprintf(tap_name, sizeof(gDefaultTapDeviceName), "chip-dev-%" PRIx64, iid & 0xFFFF);
-            tap_name[sizeof(gDefaultTapDeviceName) - 1] = 0;
             gNetworkOptions.TapDeviceName.push_back(tap_name);
         }
     }

--- a/src/lib/core/CHIPTLVReader.cpp
+++ b/src/lib/core/CHIPTLVReader.cpp
@@ -695,6 +695,7 @@ CHIP_ERROR TLVReader::DupBytes(uint8_t *& buf, uint32_t & dataLen)
     if (err != CHIP_NO_ERROR)
     {
         chip::Platform::MemoryFree(buf);
+        buf = nullptr;
         return err;
     }
 
@@ -739,6 +740,7 @@ CHIP_ERROR TLVReader::DupString(char *& buf)
     if (err != CHIP_NO_ERROR)
     {
         chip::Platform::MemoryFree(buf);
+        buf = nullptr;
         return err;
     }
 


### PR DESCRIPTION
#### Problem

As part of heap memory management, a recent change (#3143) replaced
malloc()-family calls one-for-one with their "CHIPMem.h" equivalents.
Reviewers proposed some related small safety changes.

#### Summary of Changes

- added an assert()
- null out two dead pointers
