### PR TITLE
Use 4 bits from discriminator in manual setup code

### DIFF
--- a/src/setup_payload/ManualSetupPayloadGenerator.cpp
+++ b/src/setup_payload/ManualSetupPayloadGenerator.cpp
@@ -34,7 +34,7 @@ static uint32_t shortPayloadRepresentation(const SetupPayload & payload)
 {
     int offset      = 1;
     uint32_t result = payload.requiresCustomFlow ? 1 : 0;
-    result |= payload.discriminator << offset;
+    result |= (payload.discriminator & kManualSetupDiscriminatorFieldBitMask) << offset;
     offset += kManualSetupDiscriminatorFieldLengthInBits;
     result |= payload.setUpPINCode << offset;
     return result;

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -83,7 +83,12 @@ bool SetupPayload::isValidQRCodePayload()
 
 bool SetupPayload::isValidManualCode()
 {
-    if (discriminator >= 1 << kManualSetupDiscriminatorFieldLengthInBits)
+    // The discriminator for manual setup code is 4 least significant bits
+    // in a regular 12 bit discriminator. Let's make sure that the provided
+    // discriminator fits within 12 bits (kPayloadDiscriminatorFieldLengthInBits).
+    // The manual setup code generator will only use 4 least significant bits from
+    // it.
+    if (discriminator >= 1 << kPayloadDiscriminatorFieldLengthInBits)
     {
         return false;
     }

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -40,6 +40,7 @@ const int kCustomFlowRequiredFieldLengthInBits       = 1;
 const int kRendezvousInfoFieldLengthInBits           = 8;
 const int kPayloadDiscriminatorFieldLengthInBits     = 12;
 const int kManualSetupDiscriminatorFieldLengthInBits = 4;
+const int kManualSetupDiscriminatorFieldBitMask      = (1 << kManualSetupDiscriminatorFieldLengthInBits) - 1;
 const int kSetupPINCodeFieldLengthInBits             = 27;
 const int kPaddingFieldLengthInBits                  = 5;
 

--- a/src/setup_payload/tests/TestManualCode.cpp
+++ b/src/setup_payload/tests/TestManualCode.cpp
@@ -167,7 +167,8 @@ void TestGenerateAndParser_ManualSetupCodeWithLongDiscriminator(nlTestSuite * in
 
         SetupPayload outPayload;
         CHIP_ERROR err = ManualSetupPayloadParser(result).populatePayload(outPayload);
-        assertPayloadValues(inSuite, err, CHIP_NO_ERROR, outPayload, payload.setUpPINCode, 0xa, payload.vendorID, payload.productID);
+        assertPayloadValues(inSuite, err, CHIP_NO_ERROR, outPayload, payload.setUpPINCode, 0xa, payload.vendorID,
+                            payload.productID);
     }
 
     payload.vendorID           = 1;
@@ -183,7 +184,8 @@ void TestGenerateAndParser_ManualSetupCodeWithLongDiscriminator(nlTestSuite * in
 
         SetupPayload outPayload;
         CHIP_ERROR err = ManualSetupPayloadParser(result).populatePayload(outPayload);
-        assertPayloadValues(inSuite, err, CHIP_NO_ERROR, outPayload, payload.setUpPINCode, 0xb, payload.vendorID, payload.productID);
+        assertPayloadValues(inSuite, err, CHIP_NO_ERROR, outPayload, payload.setUpPINCode, 0xb, payload.vendorID,
+                            payload.productID);
     }
 }
 

--- a/src/setup_payload/tests/TestManualCode.cpp
+++ b/src/setup_payload/tests/TestManualCode.cpp
@@ -157,7 +157,7 @@ void TestGenerateAndParser_ManualSetupCodeWithLongDiscriminator(nlTestSuite * in
 {
     SetupPayload payload       = GetDefaultPayload();
     payload.requiresCustomFlow = false;
-    payload.discriminator      = 0xf11;
+    payload.discriminator      = 0xf1a;
 
     {
         // Test short 11 digit code
@@ -167,13 +167,13 @@ void TestGenerateAndParser_ManualSetupCodeWithLongDiscriminator(nlTestSuite * in
 
         SetupPayload outPayload;
         CHIP_ERROR err = ManualSetupPayloadParser(result).populatePayload(outPayload);
-        assertPayloadValues(inSuite, err, CHIP_NO_ERROR, outPayload, payload.setUpPINCode, 1, payload.vendorID, payload.productID);
+        assertPayloadValues(inSuite, err, CHIP_NO_ERROR, outPayload, payload.setUpPINCode, 0xa, payload.vendorID, payload.productID);
     }
 
     payload.vendorID           = 1;
     payload.productID          = 1;
     payload.requiresCustomFlow = true;
-    payload.discriminator      = 0xf12;
+    payload.discriminator      = 0xf1b;
 
     {
         // Test long 21 digit code
@@ -183,7 +183,7 @@ void TestGenerateAndParser_ManualSetupCodeWithLongDiscriminator(nlTestSuite * in
 
         SetupPayload outPayload;
         CHIP_ERROR err = ManualSetupPayloadParser(result).populatePayload(outPayload);
-        assertPayloadValues(inSuite, err, CHIP_NO_ERROR, outPayload, payload.setUpPINCode, 2, payload.vendorID, payload.productID);
+        assertPayloadValues(inSuite, err, CHIP_NO_ERROR, outPayload, payload.setUpPINCode, 0xb, payload.vendorID, payload.productID);
     }
 }
 

--- a/src/setup_payload/tests/TestManualCode.cpp
+++ b/src/setup_payload/tests/TestManualCode.cpp
@@ -136,7 +136,7 @@ void TestDecimalRepresentation_AllZeros(nlTestSuite * inSuite, void * inContext)
 void TestDecimalRepresentation_InvalidPayload(nlTestSuite * inSuite, void * inContext)
 {
     SetupPayload payload  = GetDefaultPayload();
-    payload.discriminator = 16;
+    payload.discriminator = 0x1f00;
 
     ManualSetupPayloadGenerator generator(payload);
     string result;
@@ -151,6 +151,42 @@ void assertPayloadValues(nlTestSuite * inSuite, CHIP_ERROR actualError, CHIP_ERR
     NL_TEST_ASSERT(inSuite, payload.discriminator == discriminator);
     NL_TEST_ASSERT(inSuite, payload.vendorID == vendorID);
     NL_TEST_ASSERT(inSuite, payload.productID == productID);
+}
+
+void TestGenerateAndParser_ManualSetupCodeWithLongDiscriminator(nlTestSuite * inSuite, void * inContext)
+{
+    SetupPayload payload       = GetDefaultPayload();
+    payload.requiresCustomFlow = false;
+    payload.discriminator      = 0xf11;
+
+    {
+        // Test short 11 digit code
+        ManualSetupPayloadGenerator generator(payload);
+        string result;
+        NL_TEST_ASSERT(inSuite, generator.payloadDecimalStringRepresentation(result) == CHIP_NO_ERROR);
+
+        SetupPayload outPayload;
+        CHIP_ERROR err = ManualSetupPayloadParser(result).populatePayload(outPayload);
+        assertPayloadValues(inSuite, err, CHIP_NO_ERROR, outPayload, payload.setUpPINCode, 1, payload.vendorID,
+                            payload.productID);
+    }
+
+    payload.vendorID           = 1;
+    payload.productID          = 1;
+    payload.requiresCustomFlow = true;
+    payload.discriminator      = 0xf12;
+
+    {
+        // Test long 21 digit code
+        ManualSetupPayloadGenerator generator(payload);
+        string result;
+        NL_TEST_ASSERT(inSuite, generator.payloadDecimalStringRepresentation(result) == CHIP_NO_ERROR);
+
+        SetupPayload outPayload;
+        CHIP_ERROR err = ManualSetupPayloadParser(result).populatePayload(outPayload);
+        assertPayloadValues(inSuite, err, CHIP_NO_ERROR, outPayload, payload.setUpPINCode, 2, payload.vendorID,
+                            payload.productID);
+    }
 }
 
 void assertEmptyPayloadWithError(nlTestSuite * inSuite, CHIP_ERROR actualError, CHIP_ERROR expectedError,
@@ -507,6 +543,7 @@ const nlTest sTests[] =
     NL_TEST_DEF("Decimal Representation from Full Payload without Zeros",               TestDecimalRepresentation_FullPayloadWithoutZeros_DoesNotRequireCustomFlow),
     NL_TEST_DEF("Decimal Representation from Full Payload without Zeros (Custom Flow)", TestDecimalRepresentation_FullPayloadWithoutZeros),
     NL_TEST_DEF("Test Decimal Representation - Invalid Payload",                        TestDecimalRepresentation_InvalidPayload),
+    NL_TEST_DEF("Test 12 bit discriminator for manual setup code",                      TestGenerateAndParser_ManualSetupCodeWithLongDiscriminator),
     NL_TEST_DEF("Test Decimal Representation - All Zeros",                              TestDecimalRepresentation_AllZeros),
     NL_TEST_DEF("Parse from Partial Payload",                                           TestPayloadParser_PartialPayload),
     NL_TEST_DEF("Parse from Full Payload",                                              TestPayloadParser_FullPayload),

--- a/src/setup_payload/tests/TestManualCode.cpp
+++ b/src/setup_payload/tests/TestManualCode.cpp
@@ -167,8 +167,7 @@ void TestGenerateAndParser_ManualSetupCodeWithLongDiscriminator(nlTestSuite * in
 
         SetupPayload outPayload;
         CHIP_ERROR err = ManualSetupPayloadParser(result).populatePayload(outPayload);
-        assertPayloadValues(inSuite, err, CHIP_NO_ERROR, outPayload, payload.setUpPINCode, 1, payload.vendorID,
-                            payload.productID);
+        assertPayloadValues(inSuite, err, CHIP_NO_ERROR, outPayload, payload.setUpPINCode, 1, payload.vendorID, payload.productID);
     }
 
     payload.vendorID           = 1;
@@ -184,8 +183,7 @@ void TestGenerateAndParser_ManualSetupCodeWithLongDiscriminator(nlTestSuite * in
 
         SetupPayload outPayload;
         CHIP_ERROR err = ManualSetupPayloadParser(result).populatePayload(outPayload);
-        assertPayloadValues(inSuite, err, CHIP_NO_ERROR, outPayload, payload.setUpPINCode, 2, payload.vendorID,
-                            payload.productID);
+        assertPayloadValues(inSuite, err, CHIP_NO_ERROR, outPayload, payload.setUpPINCode, 2, payload.vendorID, payload.productID);
     }
 }
 


### PR DESCRIPTION
#### Problem
As per spec, the manual setup code should use 4 least significant bits from the discriminator. The discriminator itself can be 12 bits long.

The code is checking that the discriminator can actually fit in 4 bits. For example, 0x123 is a valid discriminator, and the manual setup code should use 4 bits (0x3) from it. The current check returns failure for a setup code with this discriminator.

#### Summary of Changes
Use 4 least significant bits from the 12 bit discriminator.
Also added a unit test.

Fixes #3234 