### PR TITLE
[nrfconnect] Fixed building issues that appeared after last NCS update.

### DIFF
--- a/config/nrfconnect/chip-lib.cmake
+++ b/config/nrfconnect/chip-lib.cmake
@@ -81,7 +81,8 @@ function(chip_configure TARGET_NAME)
     convert_list_of_flags_to_string_of_flags(CHIP_CFLAGS CHIP_CFLAGS)
 
     zephyr_get_compile_flags(CHIP_CXXFLAGS CXX)
-    list(FILTER CHIP_CXXFLAGS EXCLUDE REGEX -std.*) # CHIP adds gnu++11 anyway...
+    list(FILTER CHIP_CXXFLAGS EXCLUDE REGEX -std.*)
+    list(APPEND CHIP_CXXFLAGS "-std=gnu++11")
     convert_list_of_flags_to_string_of_flags(CHIP_CXXFLAGS CHIP_CXXFLAGS)
 
     set(GN_ARGS "")

--- a/config/nrfconnect/nrfconnect-app.cmake
+++ b/config/nrfconnect/nrfconnect-app.cmake
@@ -53,6 +53,9 @@ endif()
 # ==================================================
 find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
+# This is temporary solution and should be removed after merging including fix in Zephyr
+zephyr_include_directories("${ZEPHYR_BASE}/../nrfxlib/crypto/nrf_cc310_platform/include")
+
 # ==================================================
 # General settings
 # ==================================================

--- a/examples/lighting-app/nrfconnect/main/LightingManager.cpp
+++ b/examples/lighting-app/nrfconnect/main/LightingManager.cpp
@@ -34,7 +34,7 @@ int LightingManager::Init(const char * gpioDeviceName, gpio_pin_t gpioPin)
 
     mState      = kState_On;
     mGPIOPin    = gpioPin;
-    mGPIODevice = device_get_binding(gpioDeviceName);
+    mGPIODevice = const_cast<device *>(device_get_binding(gpioDeviceName));
 
     if (!mGPIODevice)
     {

--- a/src/lib/support/CHIPArgParser.cpp
+++ b/src/lib/support/CHIPArgParser.cpp
@@ -83,7 +83,7 @@ static bool HelpTextContainsShortOption(char optChar, const char * helpText);
 
 static inline bool IsShortOptionChar(int ch)
 {
-    return isascii(ch) && isgraph(ch);
+    return isgraph(ch);
 }
 
 /**


### PR DESCRIPTION
 #### Problem
There are few building issues in the nrfconnect samples, which appeared after last NCS upmerge:
* No such file or directory when including "nrf_cc3xx_platform_mutex.h".
* 'isascii' was not declared in this scope in CHIPArgParses.cpp file.
* 'strcasecmp' was not declared in this scope in CHIPArgeParses.cpp file.
* Invalid conversion from 'const device*' to 'device*' in LightingManager.cpp file, when calling device_get_binding() method.

 #### Summary of Changes
* Temporarly added include path to the missing file in the nrfconnect-app.cmake file, what will be removed after fixing 
and merging PR with fix in the nrfxlib.
* Removed deprecated isascii method, as isgraph check is enough for this use case.
* Added -std=gnu++11 option to the compiler flags, as strcasecmp is not present in c++11 sources.
* Performed const_cast to fit into the new device_get_binding() method API.

 Fixes #3181 