### PR TITLE
Fix build with chip_config_network_layer_ble=false

### DIFF
--- a/examples/shell/shell_common/cmd_btp.cpp
+++ b/examples/shell/shell_common/cmd_btp.cpp
@@ -15,6 +15,8 @@
  *    limitations under the License.
  */
 
+#include "ChipShellCollection.h"
+
 #include <core/CHIPCore.h>
 
 #if CONFIG_NETWORK_LAYER_BLE
@@ -27,8 +29,6 @@
 #include <support/CHIPArgParser.hpp>
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
-
-#include <ChipShellCollection.h>
 
 using namespace chip;
 using namespace chip::Shell;

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -56,9 +56,7 @@ if (chip_build_tests) {
     }
 
     if (chip_config_network_layer_ble && chip_device_platform != "esp32") {
-      deps += [
-        "${chip_root}/src/ble/tests",
-      ]
+      deps += [ "${chip_root}/src/ble/tests" ]
     }
 
     if (chip_with_lwip && chip_device_platform != "esp32") {

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -15,6 +15,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/build/chip/tests.gni")
+import("${chip_root}/src/ble/ble.gni")
 import("${chip_root}/src/lwip/lwip.gni")
 import("${chip_root}/src/platform/device.gni")
 
@@ -47,11 +48,16 @@ if (chip_build_tests) {
 
     if (chip_device_platform != "esp32") {
       deps += [
-        "${chip_root}/src/ble/tests",
         "${chip_root}/src/lib/core/tests",
         "${chip_root}/src/lib/support/tests",
         "${chip_root}/src/platform/tests",
         "${chip_root}/src/setup_payload/tests",
+      ]
+    }
+
+    if (chip_config_network_layer_ble && chip_device_platform != "esp32") {
+      deps += [
+        "${chip_root}/src/ble/tests",
       ]
     }
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -183,12 +183,12 @@ CHIP_ERROR ChipDeviceController::ConnectDevice(NodeId remoteDeviceId, Rendezvous
     VerifyOrExit(mState == kState_Initialized, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mConState == kConnectionState_NotConnected, err = CHIP_ERROR_INCORRECT_STATE);
 
-#if CONFIG_DEVICE_LAYER
+#if CONFIG_DEVICE_LAYER && CONFIG_NETWORK_LAYER_BLE
     if (!params.HasBleLayer())
     {
         params.SetBleLayer(DeviceLayer::ConnectivityMgr().GetBleLayer());
     }
-#endif // CONFIG_DEVICE_LAYER
+#endif // CONFIG_DEVICE_LAYER && CONFIG_NETWORK_LAYER_BLE
 
     mRendezvousSession = new RendezvousSession(this);
     err                = mRendezvousSession->Init(params.SetLocalNodeId(mLocalDeviceId));

--- a/src/lib/message/CHIPConnection.cpp
+++ b/src/lib/message/CHIPConnection.cpp
@@ -44,7 +44,9 @@
 #include <inet/InetLayer.h>
 #include <system/SystemStats.h>
 
+#if CONFIG_NETWORK_LAYER_BLE
 using namespace chip::Ble;
+#endif // CONFIG_NETWORK_LAYER_BLE
 using namespace chip::Inet;
 using namespace chip::System;
 

--- a/src/lib/message/CHIPMessageLayer.cpp
+++ b/src/lib/message/CHIPMessageLayer.cpp
@@ -54,7 +54,9 @@
 #include <support/crypto/HashAlgos.h>
 #include <support/logging/CHIPLogging.h>
 
+#if CONFIG_NETWORK_LAYER_BLE
 using namespace chip::Ble;
+#endif // CONFIG_NETWORK_LAYER_BLE
 using namespace chip::Crypto;
 using namespace chip::Encoding;
 using namespace chip::Inet;


### PR DESCRIPTION
 #### Problem
Resolving #3179 fixed compilation with chip_enable_ble=false (which disables BLE in CHIP platform layer), but there are still a few build errors when chip_config_network_layer_ble is false.

 #### Summary of Changes
* Surround some code pieces with `#if CONFIG_NETWORK_LAYER_BLE/#endif`
* Don't build BLE tests when BLE layer is disabled

 Fixes #3246
