### PR TITLE
Convert operator new and delete to use CHIPMem.h

### DIFF
--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -36,21 +36,29 @@ int Commands::Run(NodeId localId, NodeId remoteId, int argc, char ** argv)
 {
     ConfigureChipLogging();
 
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    ChipDeviceController dc;
+    CHIP_ERROR err = chip::Platform::MemoryInit();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "Init Memory failure: %s", chip::ErrorStr(err));
+    }
+    else
+    {
 
-    err = dc.Init(localId);
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure: %s", chip::ErrorStr(err)));
+        ChipDeviceController dc;
 
-    err = dc.ServiceEvents();
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init Run Loop failure: %s", chip::ErrorStr(err)));
+        err = dc.Init(localId);
+        VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure: %s", chip::ErrorStr(err)));
 
-    err = RunCommand(dc, remoteId, argc, argv);
-    SuccessOrExit(err);
+        err = dc.ServiceEvents();
+        VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init Run Loop failure: %s", chip::ErrorStr(err)));
 
-exit:
-    dc.ServiceEventSignal();
-    dc.Shutdown();
+        err = RunCommand(dc, remoteId, argc, argv);
+        SuccessOrExit(err);
+
+    exit:
+        dc.ServiceEventSignal();
+        dc.Shutdown();
+    }
     return (err == CHIP_NO_ERROR) ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 

--- a/examples/common/screen-framework/ScreenManager.cpp
+++ b/examples/common/screen-framework/ScreenManager.cpp
@@ -27,6 +27,8 @@
 
 #if CONFIG_HAVE_DISPLAY
 
+#include <support/CHIPMem.h>
+
 #include <cassert>
 #include <vector>
 
@@ -260,7 +262,7 @@ void ScreenManager::PopScreen()
     Screen * screen = screens.back();
     screens.pop_back(); // screen is popped immediately before last exit
     screen->Exit(true); // screen is not top when exit/popped
-    delete screen;
+    chip::Platform::Delete(screen);
 
     focusBack = false;
 

--- a/examples/common/screen-framework/include/ListScreen.h
+++ b/examples/common/screen-framework/include/ListScreen.h
@@ -30,6 +30,8 @@
 
 #if CONFIG_HAVE_DISPLAY
 
+#include <support/CHIPMem.h>
+
 #include <functional>
 #include <string>
 #include <tuple>
@@ -56,7 +58,7 @@ private:
 public:
     ListScreen(Model * model) : model(model) {}
 
-    virtual ~ListScreen() { delete model; }
+    virtual ~ListScreen() { chip::Platform::Delete(model); }
 
     virtual std::string GetTitle() { return model->GetTitle(); }
 

--- a/examples/wifi-echo/server/esp32/main/RendezvousDeviceDelegate.cpp
+++ b/examples/wifi-echo/server/esp32/main/RendezvousDeviceDelegate.cpp
@@ -21,6 +21,7 @@
 #include "RendezvousMessageHandler.h"
 #include "esp_log.h"
 #include <platform/ConfigurationManager.h>
+#include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
 #include <support/ErrorStr.h>
 #include <system/SystemPacketBuffer.h>
@@ -46,7 +47,7 @@ RendezvousDeviceDelegate::RendezvousDeviceDelegate()
 
     params.SetSetupPINCode(setupPINCode).SetLocalNodeId(kLocalNodeId).SetBleLayer(DeviceLayer::ConnectivityMgr().GetBleLayer());
 
-    mRendezvousSession = new RendezvousSession(this, &mDeviceNetworkProvisioningDelegate);
+    mRendezvousSession = chip::Platform::New<RendezvousSession>(this, &mDeviceNetworkProvisioningDelegate);
     err                = mRendezvousSession->Init(params);
 
 exit:

--- a/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
@@ -45,6 +45,7 @@
 #include <crypto/CHIPCryptoPAL.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
+#include <support/CHIPMem.h>
 #include <support/ErrorStr.h>
 #include <transport/SecureSessionMgr.h>
 
@@ -203,7 +204,7 @@ public:
     virtual void ItemAction(int i)
     {
         ESP_LOGI(TAG, "Opening attribute %d", i);
-        ScreenManager::PushScreen(new ListScreen(new EditAttributeListModel(d, e, c, i)));
+        ScreenManager::PushScreen(chip::Platform::New<ListScreen>(chip::Platform::New<EditAttributeListModel>(d, e, c, i)));
     }
 };
 
@@ -220,7 +221,7 @@ public:
     virtual void ItemAction(int i)
     {
         ESP_LOGI(TAG, "Opening cluster %d", i);
-        ScreenManager::PushScreen(new ListScreen(new AttributeListModel(d, e, i)));
+        ScreenManager::PushScreen(chip::Platform::New<ListScreen>(chip::Platform::New<AttributeListModel>(d, e, i)));
     }
 };
 
@@ -236,7 +237,7 @@ public:
     virtual void ItemAction(int i)
     {
         ESP_LOGI(TAG, "Opening endpoint %d", i);
-        ScreenManager::PushScreen(new ListScreen(new ClusterListModel(d, i)));
+        ScreenManager::PushScreen(chip::Platform::New<ListScreen>(chip::Platform::New<ClusterListModel>(d, i)));
     }
 };
 
@@ -249,7 +250,7 @@ public:
     virtual void ItemAction(int i)
     {
         ESP_LOGI(TAG, "Opening device %d", i);
-        ScreenManager::PushScreen(new ListScreen(new EndpointListModel(i)));
+        ScreenManager::PushScreen(chip::Platform::New<ListScreen>(chip::Platform::New<EndpointListModel>(i)));
     }
 };
 
@@ -480,7 +481,7 @@ extern "C" void app_main()
 
     if (isRendezvousBLE())
     {
-        rendezvousDelegate = new RendezvousDeviceDelegate();
+        rendezvousDelegate = chip::Platform::New<RendezvousDeviceDelegate>();
     }
     else if (isRendezvousBypassed())
     {
@@ -513,33 +514,34 @@ extern "C" void app_main()
 
     // Initialize the screen manager and push a rudimentary user interface.
     ScreenManager::Init();
-    ScreenManager::PushScreen(new ListScreen((new SimpleListModel())
-                                                 ->Title("CHIP")
-                                                 ->Action([](int i) { ESP_LOGI(TAG, "action on item %d", i); })
-                                                 ->Item("Devices",
-                                                        []() {
-                                                            ESP_LOGI(TAG, "Opening device list");
-                                                            ScreenManager::PushScreen(new ListScreen(new DeviceListModel()));
-                                                        })
-                                                 ->Item("Custom",
-                                                        []() {
-                                                            ESP_LOGI(TAG, "Opening custom screen");
-                                                            ScreenManager::PushScreen(new CustomScreen());
-                                                        })
-                                                 ->Item("QR Code",
-                                                        [=]() {
-                                                            ESP_LOGI(TAG, "Opening QR code screen");
-                                                            ScreenManager::PushScreen(new QRCodeScreen(qrCodeText));
-                                                        })
-                                                 ->Item("Setup",
-                                                        [=]() {
-                                                            ESP_LOGI(TAG, "Opening Setup list");
-                                                            ScreenManager::PushScreen(new ListScreen(new SetupListModel()));
-                                                        })
-                                                 ->Item("More")
-                                                 ->Item("Items")
-                                                 ->Item("For")
-                                                 ->Item("Demo")));
+    ScreenManager::PushScreen(chip::Platform::New<ListScreen>(
+        (chip::Platform::New<SimpleListModel>())
+            ->Title("CHIP")
+            ->Action([](int i) { ESP_LOGI(TAG, "action on item %d", i); })
+            ->Item("Devices",
+                   []() {
+                       ESP_LOGI(TAG, "Opening device list");
+                       ScreenManager::PushScreen(chip::Platform::New<ListScreen>(chip::Platform::New<DeviceListModel>()));
+                   })
+            ->Item("Custom",
+                   []() {
+                       ESP_LOGI(TAG, "Opening custom screen");
+                       ScreenManager::PushScreen(chip::Platform::New<CustomScreen>());
+                   })
+            ->Item("QR Code",
+                   [=]() {
+                       ESP_LOGI(TAG, "Opening QR code screen");
+                       ScreenManager::PushScreen(chip::Platform::New<QRCodeScreen>(qrCodeText));
+                   })
+            ->Item("Setup",
+                   [=]() {
+                       ESP_LOGI(TAG, "Opening Setup list");
+                       ScreenManager::PushScreen(chip::Platform::New<ListScreen>(chip::Platform::New<SetupListModel>()));
+                   })
+            ->Item("More")
+            ->Item("Items")
+            ->Item("For")
+            ->Item("Demo")));
 
     // Connect the status LED to VLEDs.
     {

--- a/src/inet/tests/TapAddrAutoconf.h
+++ b/src/inet/tests/TapAddrAutoconf.h
@@ -23,7 +23,6 @@
  *   from the corresponding configuration on the tap interface.
  */
 
-#include <new>
 #include <vector>
 
 int CollectTapAddresses(std::vector<char *> & addresses, const char * ifName);

--- a/src/inet/tests/TestInetCommon.cpp
+++ b/src/inet/tests/TestInetCommon.cpp
@@ -36,7 +36,6 @@
 
 #include "TestInetCommon.h"
 
-#include <new>
 #include <vector>
 
 #include <inttypes.h>

--- a/src/lib/core/ReferenceCounted.h
+++ b/src/lib/core/ReferenceCounted.h
@@ -26,6 +26,8 @@
 #include <limits>
 #include <stdlib.h>
 
+#include <support/CHIPMem.h>
+
 namespace chip {
 
 /**
@@ -62,7 +64,7 @@ public:
 
         if (--mRefCount == 0)
         {
-            delete this;
+            chip::Platform::Delete(this);
         }
     }
 

--- a/src/lib/core/tests/TestCHIPCallback.cpp
+++ b/src/lib/core/tests/TestCHIPCallback.cpp
@@ -25,6 +25,7 @@
 #include "TestCore.h"
 
 #include <core/CHIPCallback.h>
+#include <support/CHIPMem.h>
 #include <support/TestUtils.h>
 
 #include <nlunit-test.h>
@@ -136,7 +137,7 @@ static void ResumerTest(nlTestSuite * inSuite, void * inContext)
     resumer.Dispatch();
     NL_TEST_ASSERT(inSuite, n == 3);
 
-    Callback<> * pcb = new Callback<>(reinterpret_cast<CallFn>(increment), &n);
+    Callback<> * pcb = chip::Platform::New<Callback<>>(reinterpret_cast<CallFn>(increment), &n);
 
     n = 1;
     // cancel on destruct
@@ -145,7 +146,7 @@ static void ResumerTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, n == 2);
 
     resumer.Resume(pcb);
-    delete pcb;
+    chip::Platform::Delete(pcb);
     resumer.Dispatch();
     NL_TEST_ASSERT(inSuite, n == 2);
 }
@@ -218,6 +219,26 @@ static void NotifierTest(nlTestSuite * inSuite, void * inContext)
 }
 
 /**
+ *  Set up the test suite.
+ */
+int TestCHIPCallback_Setup(void * inContext)
+{
+    CHIP_ERROR error = chip::Platform::MemoryInit();
+    if (error != CHIP_NO_ERROR)
+        return FAILURE;
+    return SUCCESS;
+}
+
+/**
+ *  Tear down the test suite.
+ */
+int TestCHIPCallback_Teardown(void * inContext)
+{
+    chip::Platform::MemoryShutdown();
+    return SUCCESS;
+}
+
+/**
  *   Test Suite. It lists all the test functions.
  */
 
@@ -238,8 +259,8 @@ int TestCHIPCallback(void)
 	{
         "CHIPCallback",
         &sTests[0],
-        nullptr,
-        nullptr
+        TestCHIPCallback_Setup,
+        TestCHIPCallback_Teardown
     };
     // clang-format on
 

--- a/src/lib/message/CHIPFabricState.cpp
+++ b/src/lib/message/CHIPFabricState.cpp
@@ -46,23 +46,11 @@
 #include <protocols/fabric-provisioning/FabricProvisioning.h>
 #include <protocols/security/CHIPDummyGroupKeyStore.h>
 #include <protocols/security/CHIPSecurity.h>
+#include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
 #include <support/RandUtils.h>
 #include <support/crypto/CHIPRNG.h>
 #include <support/logging/CHIPLogging.h>
-
-#if HAVE_NEW
-#include <new>
-#else
-inline void * operator new(size_t, void * p) throw()
-{
-    return p;
-}
-inline void * operator new[](size_t, void * p) throw()
-{
-    return p;
-}
-#endif
 
 using namespace chip::Crypto;
 using namespace chip::Encoding;
@@ -220,9 +208,7 @@ ChipFabricState::ChipFabricState()
 
 CHIP_ERROR ChipFabricState::Init()
 {
-    static nlDEFINE_ALIGNED_VAR(sDummyGroupKeyStore, sizeof(DummyGroupKeyStore), void *);
-
-    return Init(new (&sDummyGroupKeyStore) DummyGroupKeyStore());
+    return Init(chip::Platform::New<DummyGroupKeyStore>());
 }
 
 CHIP_ERROR ChipFabricState::Init(GroupKeyStoreBase * groupKeyStore)

--- a/src/lib/support/tests/TestPersistedCounter.cpp
+++ b/src/lib/support/tests/TestPersistedCounter.cpp
@@ -27,7 +27,6 @@
 #define __STDC_FORMAT_MACROS
 #endif
 
-#include <new>
 #include <stdint.h>
 #include <string.h>
 #include <unistd.h>

--- a/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
@@ -43,8 +43,6 @@
 #include "esp_gatts_api.h"
 #include "esp_log.h"
 
-#include <new>
-
 #define MAX_ADV_DATA_LEN 31
 #define CHIP_ADV_DATA_TYPE_FLAGS 0x01
 #define CHIP_ADV_DATA_FLAGS 0x06

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -45,8 +45,6 @@
 #include "services/gap/ble_svc_gap.h"
 #include "services/gatt/ble_svc_gatt.h"
 
-#include <new>
-
 #define MAX_ADV_DATA_LEN 31
 #define CHIP_ADV_DATA_TYPE_FLAGS 0x01
 #define CHIP_ADV_DATA_FLAGS 0x06

--- a/src/platform/nrfconnect/ConnectivityManagerImpl.cpp
+++ b/src/platform/nrfconnect/ConnectivityManagerImpl.cpp
@@ -20,8 +20,6 @@
 #include <platform/ConnectivityManager.h>
 #include <platform/internal/BLEManager.h>
 
-#include <new>
-
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
 

--- a/src/setup_payload/tests/TestQRCodeTLV.cpp
+++ b/src/setup_payload/tests/TestQRCodeTLV.cpp
@@ -283,6 +283,26 @@ struct TestContext
 } // namespace
 
 /**
+ *  Set up the test suite.
+ */
+int TestQRCodeTLV_Setup(void * inContext)
+{
+    CHIP_ERROR error = chip::Platform::MemoryInit();
+    if (error != CHIP_NO_ERROR)
+        return FAILURE;
+    return SUCCESS;
+}
+
+/**
+ *  Tear down the test suite.
+ */
+int TestQRCodeTLV_Teardown(void * inContext)
+{
+    chip::Platform::MemoryShutdown();
+    return SUCCESS;
+}
+
+/**
  *  Main
  */
 int TestQRCodeTLV()
@@ -292,8 +312,8 @@ int TestQRCodeTLV()
     {
         "chip-qrcode-optional-info-tests",
         &sTests[0],
-        nullptr,
-        nullptr
+        TestQRCodeTLV_Setup,
+        TestQRCodeTLV_Teardown
     };
     // clang-format on
     TestContext context;

--- a/src/setup_payload/tests/TestQRCodeTLV.cpp
+++ b/src/setup_payload/tests/TestQRCodeTLV.cpp
@@ -280,8 +280,6 @@ struct TestContext
     nlTestSuite * mSuite;
 };
 
-} // namespace
-
 /**
  *  Set up the test suite.
  */
@@ -301,6 +299,8 @@ int TestQRCodeTLV_Teardown(void * inContext)
     chip::Platform::MemoryShutdown();
     return SUCCESS;
 }
+
+} // namespace
 
 /**
  *  Main

--- a/src/system/SystemLayer.cpp
+++ b/src/system/SystemLayer.cpp
@@ -33,6 +33,7 @@
 #include <system/SystemTimer.h>
 
 // Include additional CHIP headers
+#include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
 #include <support/DLLUtil.h>
 #include <support/logging/CHIPLogging.h>
@@ -1097,15 +1098,15 @@ DLL_EXPORT Error PostEvent(Layer & aLayer, void * aContext, Object & aTarget, Ev
     VerifyOrExit(aContext != NULL, lReturn = CHIP_SYSTEM_ERROR_BAD_ARGS);
     lSysMbox = reinterpret_cast<sys_mbox_t>(aContext);
 
-    ev = new LwIPEvent;
-    VerifyOrExit(ev != NULL, lReturn = CHIP_SYSTEM_ERROR_NO_MEMORY);
+    ev = chip::Platform::New<LwIPEvent>();
+    VerifyOrExit(ev != nullptr, lReturn = CHIP_SYSTEM_ERROR_NO_MEMORY);
 
     ev->Type     = aType;
     ev->Target   = &aTarget;
     ev->Argument = aArgument;
 
     lLwIPError = sys_mbox_trypost(&lSysMbox, ev);
-    VerifyOrExit(lLwIPError == ERR_OK, delete ev; lReturn = chip::System::MapErrorLwIP(lLwIPError));
+    VerifyOrExit(lLwIPError == ERR_OK, chip::Platform::Delete(ev); lReturn = chip::System::MapErrorLwIP(lLwIPError));
 
 exit:
     return lReturn;
@@ -1151,7 +1152,7 @@ DLL_EXPORT Error DispatchEvents(Layer & aLayer, void * aContext)
         VerifyOrExit(lEvent != NULL && lEvent->Target != NULL, lReturn = CHIP_SYSTEM_ERROR_UNEXPECTED_EVENT);
 
         lReturn = aLayer.HandleEvent(*lEvent->Target, lEvent->Type, lEvent->Argument);
-        delete lEvent;
+        chip::Platform::Delete(lEvent);
 
         SuccessOrExit(lReturn);
     }

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -18,6 +18,7 @@
 #include <core/CHIPEncoding.h>
 #include <core/CHIPSafeCasts.h>
 #include <platform/internal/DeviceNetworkInfo.h>
+#include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
 #include <support/ErrorStr.h>
 #include <support/SafeInt.h>
@@ -48,7 +49,7 @@ CHIP_ERROR RendezvousSession::Init(const RendezvousParameters & params)
     err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 #if CONFIG_NETWORK_LAYER_BLE
     {
-        Transport::BLE * transport = new Transport::BLE();
+        Transport::BLE * transport = chip::Platform::New<Transport::BLE>();
         err                        = transport->Init(this, mParams);
         mTransport                 = transport;
         mTransport->Retain();


### PR DESCRIPTION
#### Problem

Embedded device-side code should only use heap through CHIPMem.h.
In particular it should not use the C++ new and delete operators for
heap allocation without explicit placement using Platform::MemoryAlloc().

#### Summary of Changes

- Added Platform::New<>() and Delete<>().
- Convert uses of operator new and delete.

Fixes #3232 Remove explicit use of `new` from first-party embedded-device code
