### PR TITLE
[examples] Update session manager after successful rendezvous

### DIFF
--- a/examples/common/chip-app-server/RendezvousServer.cpp
+++ b/examples/common/chip-app-server/RendezvousServer.cpp
@@ -16,6 +16,11 @@
  */
 
 #include "RendezvousServer.h"
+
+#include <core/CHIPError.h>
+#include <support/CodeUtils.h>
+#include <transport/SecureSessionMgr.h>
+
 #if CHIP_ENABLE_OPENTHREAD
 #include <platform/ThreadStackManager.h>
 #include <platform/internal/DeviceNetworkInfo.h>
@@ -26,6 +31,8 @@ using namespace ::chip::Transport;
 using namespace ::chip::DeviceLayer;
 
 namespace chip {
+
+extern SecureSessionMgrBase & SessionManager();
 
 RendezvousServer::RendezvousServer() : mRendezvousSession(this) {}
 
@@ -113,6 +120,27 @@ void RendezvousServer::OnRendezvousMessageReceived(PacketBuffer * buffer)
 #endif
 exit:
     chip::System::PacketBuffer::Free(buffer);
+}
+
+void RendezvousServer::OnRendezvousStatusUpdate(Status status, CHIP_ERROR err)
+{
+    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(AppServer, "OnRendezvousStatusUpdate: %s", chip::ErrorStr(err)));
+
+    switch (status)
+    {
+    case RendezvousSessionDelegate::SecurePairingSuccess:
+        ChipLogProgress(AppServer, "Device completed SPAKE2+ handshake");
+        SessionManager().NewPairing(Optional<Transport::PeerAddress>{}, &mRendezvousSession.GetPairingSession());
+        break;
+    case RendezvousSessionDelegate::NetworkProvisioningSuccess:
+        ChipLogProgress(AppServer, "Device was assigned network credentials");
+        break;
+    default:
+        break;
+    };
+
+exit:
+    return;
 }
 
 } // namespace chip

--- a/examples/common/chip-app-server/RendezvousServer.cpp
+++ b/examples/common/chip-app-server/RendezvousServer.cpp
@@ -17,6 +17,8 @@
 
 #include "RendezvousServer.h"
 
+#include "SessionManager.h"
+
 #include <core/CHIPError.h>
 #include <support/CodeUtils.h>
 #include <transport/SecureSessionMgr.h>
@@ -31,8 +33,6 @@ using namespace ::chip::Transport;
 using namespace ::chip::DeviceLayer;
 
 namespace chip {
-
-extern SecureSessionMgrBase & SessionManager();
 
 RendezvousServer::RendezvousServer() : mRendezvousSession(this) {}
 

--- a/examples/common/chip-app-server/include/RendezvousServer.h
+++ b/examples/common/chip-app-server/include/RendezvousServer.h
@@ -33,6 +33,7 @@ public:
     void OnRendezvousConnectionClosed() override;
     void OnRendezvousError(CHIP_ERROR err) override;
     void OnRendezvousMessageReceived(System::PacketBuffer * buffer) override;
+    void OnRendezvousStatusUpdate(Status status, CHIP_ERROR err) override;
 
 private:
     RendezvousSession mRendezvousSession;

--- a/examples/common/chip-app-server/include/SessionManager.h
+++ b/examples/common/chip-app-server/include/SessionManager.h
@@ -17,15 +17,9 @@
 
 #pragma once
 
-#include <transport/SecureSessionMgr.h>
-#include <transport/raw/UDP.h>
+namespace chip {
 
-using DemoSessionManager = chip::SecureSessionMgr<chip::Transport::UDP>;
+class SecureSessionMgrBase;
+SecureSessionMgrBase & SessionManager();
 
-/**
- * Initialize DataModelHandler and start CHIP datamodel server, the server
- * assumes the platform's networking has been setup already.
- *
- * @param [in] sessions The demo's session manager.
- */
-void InitServer();
+} // namespace chip

--- a/examples/common/chip-app-server/include/SessionManager.h
+++ b/examples/common/chip-app-server/include/SessionManager.h
@@ -17,9 +17,8 @@
 
 #pragma once
 
+#include <transport/SecureSessionMgr.h>
+
 namespace chip {
-
-class SecureSessionMgrBase;
 SecureSessionMgrBase & SessionManager();
-
 } // namespace chip


### PR DESCRIPTION
 #### Problem
Encryption keys exchanged during SPAKE2+ handshake are not added to the session manager on the accessory side (CHIPDeviceController adds the keys at the first message dispatch after successful rendezvous).

 #### Summary of Changes
Implement OnRendezvousStatusUpdate callback in RendezvousServer to update the session manager on SPAKE2+ handshake completion.
