### PR TITLE
make class ReferenceCounted use a deletor instead of virtual destruction

### DIFF
--- a/src/lib/core/ReferenceCounted.h
+++ b/src/lib/core/ReferenceCounted.h
@@ -30,16 +30,21 @@
 
 namespace chip {
 
+template <class T>
+class DeleteDeletor
+{
+public:
+    static void Release(T * obj) { chip::Platform::Delete(obj); }
+};
+
 /**
  * A reference counted object maintains a count of usages and when the usage
  * count drops to 0, it deletes itself.
  */
-template <class SUBCLASS>
+template <class SUBCLASS, class DELETOR = DeleteDeletor<SUBCLASS>>
 class ReferenceCounted
 {
 public:
-    virtual ~ReferenceCounted() {}
-
     typedef uint32_t count_type;
 
     /** Adds one to the usage count of this class */
@@ -51,7 +56,7 @@ public:
         }
         ++mRefCount;
 
-        return reinterpret_cast<SUBCLASS *>(this);
+        return static_cast<SUBCLASS *>(this);
     }
 
     /** Release usage of this class */
@@ -64,7 +69,7 @@ public:
 
         if (--mRefCount == 0)
         {
-            chip::Platform::Delete(this);
+            DELETOR::Release(static_cast<SUBCLASS *>(this));
         }
     }
 

--- a/src/lib/core/tests/TestReferenceCounted.cpp
+++ b/src/lib/core/tests/TestReferenceCounted.cpp
@@ -36,14 +36,54 @@
 
 using namespace chip;
 
+class TestClass : public ReferenceCounted<TestClass>
+{
+};
+
 static void TestRetainRelease(nlTestSuite * inSuite, void * inContext)
 {
-    ReferenceCounted<int> testObj;
+    TestClass * testObj = chip::Platform::New<TestClass>();
+    NL_TEST_ASSERT(inSuite, testObj->GetReferenceCount() == 1);
+    testObj->Retain();
+    NL_TEST_ASSERT(inSuite, testObj->GetReferenceCount() == 2);
+    testObj->Release();
+    NL_TEST_ASSERT(inSuite, testObj->GetReferenceCount() == 1);
+    testObj->Release();
+}
+
+class TestClassNonHeap;
+class Deletor
+{
+public:
+    static void Release(TestClassNonHeap * obj);
+};
+
+class TestClassNonHeap : public ReferenceCounted<TestClassNonHeap, Deletor>
+{
+public:
+    bool deleted;
+};
+
+void Deletor::Release(TestClassNonHeap * obj)
+{
+    obj->deleted = true;
+}
+
+static void TestRetainReleaseNonHeap(nlTestSuite * inSuite, void * inContext)
+{
+    TestClassNonHeap testObj;
+    testObj.deleted = false;
     NL_TEST_ASSERT(inSuite, testObj.GetReferenceCount() == 1);
+    NL_TEST_ASSERT(inSuite, testObj.deleted == false);
     testObj.Retain();
     NL_TEST_ASSERT(inSuite, testObj.GetReferenceCount() == 2);
+    NL_TEST_ASSERT(inSuite, testObj.deleted == false);
     testObj.Release();
     NL_TEST_ASSERT(inSuite, testObj.GetReferenceCount() == 1);
+    NL_TEST_ASSERT(inSuite, testObj.deleted == false);
+    testObj.Release();
+    NL_TEST_ASSERT(inSuite, testObj.GetReferenceCount() == 0);
+    NL_TEST_ASSERT(inSuite, testObj.deleted == true);
 }
 
 /**
@@ -54,20 +94,35 @@ static void TestRetainRelease(nlTestSuite * inSuite, void * inContext)
 static const nlTest sTests[] =
 {
     NL_TEST_DEF("ReferenceCountedRetain", TestRetainRelease),
+    NL_TEST_DEF("ReferenceCountedRetainNonHeap", TestRetainReleaseNonHeap),
 
     NL_TEST_SENTINEL()
 };
 // clang-format on
 
+int TestReferenceCounted_Setup(void * inContext)
+{
+    CHIP_ERROR error = chip::Platform::MemoryInit();
+    if (error != CHIP_NO_ERROR)
+        return FAILURE;
+    return SUCCESS;
+}
+
+int TestReferenceCounted_Teardown(void * inContext)
+{
+    chip::Platform::MemoryShutdown();
+    return SUCCESS;
+}
+
 int TestReferenceCounted(void)
 {
     // clang-format off
     nlTestSuite theSuite =
-	{
+    {
         "Reference-Counted",
         &sTests[0],
-        nullptr,
-        nullptr
+        TestReferenceCounted_Setup,
+        TestReferenceCounted_Teardown
     };
     // clang-format on
 

--- a/src/transport/NetworkProvisioning.h
+++ b/src/transport/NetworkProvisioning.h
@@ -48,7 +48,7 @@ public:
      */
     virtual void ProvisionNetwork(const char * ssid, const char * passwd) {}
 
-    ~DeviceNetworkProvisioningDelegate() override {}
+    virtual ~DeviceNetworkProvisioningDelegate() {}
 };
 
 class DLL_EXPORT NetworkProvisioningDelegate : public ReferenceCounted<NetworkProvisioningDelegate>
@@ -82,7 +82,7 @@ public:
      */
     virtual void OnNetworkProvisioningComplete() {}
 
-    ~NetworkProvisioningDelegate() override {}
+    virtual ~NetworkProvisioningDelegate() {}
 };
 
 class DLL_EXPORT NetworkProvisioning

--- a/src/transport/SecurePairingSession.h
+++ b/src/transport/SecurePairingSession.h
@@ -64,7 +64,7 @@ public:
      */
     virtual void OnPairingComplete() {}
 
-    ~SecurePairingSessionDelegate() override {}
+    virtual ~SecurePairingSessionDelegate() {}
 };
 
 class DLL_EXPORT SecurePairingSession

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -86,7 +86,7 @@ public:
      */
     virtual void OnNewConnection(Transport::PeerConnectionState * state, SecureSessionMgrBase * mgr) {}
 
-    ~SecureSessionMgrDelegate() override {}
+    virtual ~SecureSessionMgrDelegate() {}
 };
 
 class DLL_EXPORT SecureSessionMgrBase : public ReferenceCounted<SecureSessionMgrBase>
@@ -103,7 +103,7 @@ public:
     CHIP_ERROR SendMessage(NodeId peerNodeId, System::PacketBuffer * msgBuf);
 
     SecureSessionMgrBase();
-    ~SecureSessionMgrBase() override;
+    virtual ~SecureSessionMgrBase();
 
     /**
      * @brief

--- a/src/transport/raw/Base.h
+++ b/src/transport/raw/Base.h
@@ -42,7 +42,7 @@ namespace Transport {
 class Base : public ReferenceCounted<Base>
 {
 public:
-    ~Base() override {}
+    virtual ~Base() {}
 
     /**
      * Sets the message receive handler and associated argument


### PR DESCRIPTION
 #### Problem

class ReferenceCounted can't be used to manage life-cycle of objects which are not allocated in the heap (using new)

 #### Summary of Changes

make class ReferenceCounted use a deletor instead of virtual destruction
    
There are a few benefits to use a deletor.
 1. it may save memory if SUBCLASS is not virtual class
 2. allow use of custom deletor

