### PR TITLE
Fix missing glib package for cirque presubmit

### DIFF
--- a/examples/chip-tool/Dockerfile
+++ b/examples/chip-tool/Dockerfile
@@ -16,7 +16,7 @@
 #
 
 from generic_node_image
-
+RUN apt-get install -y libglib2.0
 COPY out/debug/chip-tool /usr/bin/
 COPY entrypoint.sh /
 

--- a/examples/lighting-app/linux/Dockerfile
+++ b/examples/lighting-app/linux/Dockerfile
@@ -16,7 +16,7 @@
 #
 
 from generic_node_image
-
+RUN apt-get install -y libglib2.0
 COPY out/debug/chip-tool-server /usr/bin/
 COPY entrypoint.sh /
 


### PR DESCRIPTION
Problem

Cirque uses ot-br-posix as generic docker node basefile, recent
upstream otbr make dockerfile refactor, which seems to make glib package
missing.

Summary of changes:
-- Add missing glib pckage to unblock the presubmit.

fixed #3272 