### PR TITLE
Enable BLE for Darwin platform

### DIFF
--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -40,7 +40,8 @@ declare_args() {
   chip_enable_wifi = chip_device_platform == "linux"
 
   # Enable ble support.
-  chip_enable_ble = chip_device_platform == "linux"
+  chip_enable_ble =
+      chip_device_platform == "linux" || chip_device_platform == "darwin"
 }
 
 _chip_device_layer = "none"


### PR DESCRIPTION
#### Problem
`CHIP Tool iOS` application fails in Rendezvous as BLE layer is not initialized.

#### Summary of Changes
A recent change introduced a build variable `chip_enable_ble` that controls if the BLE layer for a platform is initialized. The variable was not being set for Darwin platform. This change sets the variable for Darwin as well.