### PR TITLE
Log decimal setup payload in the esp example

### DIFF
--- a/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
@@ -44,6 +44,7 @@
 
 #include <crypto/CHIPCryptoPAL.h>
 #include <platform/CHIPDeviceLayer.h>
+#include <setup_payload/ManualSetupPayloadGenerator.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <support/ErrorStr.h>
 #include <transport/SecureSessionMgr.h>
@@ -412,6 +413,20 @@ std::string createSetupPayload()
     {
         QRCodeSetupPayloadGenerator generator(payload);
         err = generator.payloadBase41Representation(result);
+    }
+
+    {
+        ManualSetupPayloadGenerator generator(payload);
+        std::string outCode;
+
+        if (generator.payloadDecimalStringRepresentation(outCode) == CHIP_NO_ERROR)
+        {
+            ESP_LOGI(TAG, "DECIMAL PAYLOAD: %s", outCode.c_str());
+        }
+        else
+        {
+            ESP_LOGE(TAG, "Failed to get decimal QR code");
+        }
     }
 
     if (err != CHIP_NO_ERROR)

--- a/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
@@ -421,7 +421,7 @@ std::string createSetupPayload()
 
         if (generator.payloadDecimalStringRepresentation(outCode) == CHIP_NO_ERROR)
         {
-            ESP_LOGI(TAG, "DECIMAL PAYLOAD: %s", outCode.c_str());
+            ESP_LOGI(TAG, "Manual(decimal) setup code: %s", outCode.c_str());
         }
         else
         {

--- a/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
@@ -425,7 +425,7 @@ std::string createSetupPayload()
         }
         else
         {
-            ESP_LOGE(TAG, "Failed to get decimal QR code");
+            ESP_LOGE(TAG, "Failed to get decimal setup code");
         }
     }
 


### PR DESCRIPTION
 #### Problem
ESP example only displays QR code. We would like to be able to test both QR and manual code paths.

 #### Summary of Changes

Logs out the manual payload code. tested that iOS manual code parser reads it correctly.
