### PR TITLE
Fix Darwin build failure in TestCHIPoBLEStackMgr.cpp

### DIFF
--- a/src/platform/Darwin/BLEManagerImpl.h
+++ b/src/platform/Darwin/BLEManagerImpl.h
@@ -40,6 +40,9 @@ class BLEManagerImpl final : public BLEManager, private BleLayer
     // the implementation methods provided by this class.
     friend BLEManager;
 
+public:
+    CHIP_ERROR ConfigureBle(uint32_t aNodeId, bool aIsCentral) { return CHIP_NO_ERROR; }
+
 private:
     // ===== Members that implement the BLEManager internal interface.
 


### PR DESCRIPTION
#### Problem
PR #3279 is causing a build failure for Darwin targets.

#### Summary of Changes
The build is failing in `TestCHIPoBLEStackMgr.cpp`. It's looking for a function, `ConfigureBle`, which is only implemented for Linux target. Added a no-op function for Darwin platform.