### PR TITLE
Add support for persisting paired device information on CHIP controller

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -25,6 +25,10 @@
  *
  */
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS
 #endif
@@ -67,8 +71,8 @@ constexpr const char * kDeviceAddressKeyPrefix     = "DeviceAddress";
     do                                                                                                                             \
     {                                                                                                                              \
         const size_t len = strlen(keyPrefix);                                                                                      \
-        char key[len + 2 * sizeof(NodeId) + 1];                                                                                        \
-        snprintf(key, sizeof(key), "%s%" PRIx64, keyPrefix, node);                                                                     \
+        char key[len + 2 * sizeof(NodeId) + 1];                                                                                    \
+        snprintf(key, sizeof(key), "%s%" PRIx64, keyPrefix, node);                                                                 \
         action;                                                                                                                    \
     } while (0)
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -67,8 +67,8 @@ constexpr const char * kDeviceAddressKeyPrefix     = "DeviceAddress";
     do                                                                                                                             \
     {                                                                                                                              \
         const size_t len = strlen(keyPrefix);                                                                                      \
-        char key[len + sizeof(NodeId) + 1];                                                                                        \
-        snprintf(key, sizeof(key), "%s%llx", keyPrefix, node);                                                                     \
+        char key[len + 2 * sizeof(NodeId) + 1];                                                                                        \
+        snprintf(key, sizeof(key), "%s%" PRIx64, keyPrefix, node);                                                                     \
         action;                                                                                                                    \
     } while (0)
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -66,7 +66,7 @@ using namespace chip::Encoding;
 constexpr const char * kDeviceCredentialsKeyPrefix = "DeviceCredentials";
 constexpr const char * kDeviceAddressKeyPrefix     = "DeviceAddress";
 
-// This macro generats a key using node ID an key prefix, and performs the given action
+// This macro generates a key using node ID an key prefix, and performs the given action
 // on that key.
 #define PERSISTENT_KEY_OP(node, keyPrefix, key, action)                                                                            \
     do                                                                                                                             \
@@ -273,7 +273,7 @@ CHIP_ERROR ChipDeviceController::ConnectDeviceWithoutSecurePairing(NodeId remote
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ChipDeviceController::EstablishSecureSession(const NodeId & peer)
+CHIP_ERROR ChipDeviceController::EstablishSecureSession(NodeId peer)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     SecurePairingSession pairing;
@@ -337,7 +337,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR ChipDeviceController::ResumeSecureSession(const NodeId & peer)
+CHIP_ERROR ChipDeviceController::ResumeSecureSession(NodeId peer)
 {
     if (mConState == kConnectionState_SecureConnected)
     {

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -50,6 +50,7 @@
 #include <support/logging/CHIPLogging.h>
 
 #include <errno.h>
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <time.h>

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -58,6 +58,20 @@ namespace DeviceController {
 
 using namespace chip::Encoding;
 
+constexpr const char * kDeviceCredentialsKeyPrefix = "DeviceCredentials";
+constexpr const char * kDeviceAddressKeyPrefix     = "DeviceAddress";
+
+// This macro generats a key using node ID an key prefix, and performs the given action
+// on that key.
+#define PERSISTENT_KEY_OP(node, keyPrefix, key, action)                                                                            \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        const size_t len = strlen(keyPrefix);                                                                                      \
+        char key[len + sizeof(NodeId) + 1];                                                                                        \
+        snprintf(key, sizeof(key), "%s%llx", keyPrefix, node);                                                                     \
+        action;                                                                                                                    \
+    } while (0)
+
 ChipDeviceController::ChipDeviceController()
 {
     mState             = kState_NotInitialized;
@@ -69,6 +83,7 @@ ChipDeviceController::ChipDeviceController()
     mOnError           = nullptr;
     mOnNewConnection   = nullptr;
     mPairingDelegate   = nullptr;
+    mStorageDelegate   = nullptr;
     mDeviceAddr        = IPAddress::Any;
     mDevicePort        = CHIP_PORT;
     mInterface         = INET_NULL_INTERFACEID;
@@ -117,12 +132,14 @@ exit:
     return err;
 }
 
-CHIP_ERROR ChipDeviceController::Init(NodeId localNodeId, DevicePairingDelegate * pairingDelegate)
+CHIP_ERROR ChipDeviceController::Init(NodeId localNodeId, DevicePairingDelegate * pairingDelegate,
+                                      PersistentStorageDelegate * storage)
 {
     CHIP_ERROR err = Init(localNodeId);
     SuccessOrExit(err);
 
     mPairingDelegate = pairingDelegate;
+    mStorageDelegate = storage;
 
 exit:
     return err;
@@ -167,7 +184,6 @@ CHIP_ERROR ChipDeviceController::Shutdown()
     memset(&mOnComplete, 0, sizeof(mOnComplete));
     mOnError         = nullptr;
     mOnNewConnection = nullptr;
-    mMessageNumber   = 0;
     mRemoteDeviceId.ClearValue();
 
 exit:
@@ -250,11 +266,14 @@ CHIP_ERROR ChipDeviceController::ConnectDeviceWithoutSecurePairing(NodeId remote
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ChipDeviceController::EstablishSecureSession()
+CHIP_ERROR ChipDeviceController::EstablishSecureSession(const NodeId & peer)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
+    SecurePairingSession pairing;
+    SecurePairingSession * pairingSession = mSecurePairingSession;
+    Inet::IPAddress peerAddr              = mDeviceAddr;
 
-    if (mState != kState_Initialized || mSessionManager != nullptr || mConState != kConnectionState_Connected)
+    if (mState != kState_Initialized || mSessionManager != nullptr || mConState == kConnectionState_SecureConnected)
     {
         ExitNow(err = CHIP_ERROR_INCORRECT_STATE);
     }
@@ -269,12 +288,32 @@ CHIP_ERROR ChipDeviceController::EstablishSecureSession()
 
     mConState = kConnectionState_SecureConnected;
 
-    err = mSessionManager->NewPairing(
-        Optional<Transport::PeerAddress>::Value(Transport::PeerAddress::UDP(mDeviceAddr, mDevicePort, mInterface)),
-        mSecurePairingSession);
-    SuccessOrExit(err);
+    if (mStorageDelegate != nullptr)
+    {
+        const char * credentials;
+        const char * address;
 
-    mMessageNumber = 1;
+        PERSISTENT_KEY_OP(peer, kDeviceCredentialsKeyPrefix, key, credentials = mStorageDelegate->GetKeyValue(key));
+        PERSISTENT_KEY_OP(peer, kDeviceAddressKeyPrefix, key, address = mStorageDelegate->GetKeyValue(key));
+
+        SecurePairingSessionSerialized serialized;
+
+        VerifyOrExit(credentials != nullptr, err = CHIP_ERROR_KEY_NOT_FOUND_FROM_PEER);
+        strncpy(Uint8::to_char(serialized.inner), credentials, sizeof(serialized.inner));
+
+        err = pairing.Deserialize(serialized);
+        SuccessOrExit(err);
+
+        pairingSession = &pairing;
+
+        VerifyOrExit(address != nullptr, err = CHIP_ERROR_KEY_NOT_FOUND_FROM_PEER);
+
+        VerifyOrExit(IPAddress::FromString(address, peerAddr), err = CHIP_ERROR_INVALID_ADDRESS);
+    }
+
+    err = mSessionManager->NewPairing(
+        Optional<Transport::PeerAddress>::Value(Transport::PeerAddress::UDP(peerAddr, mDevicePort, mInterface)), pairingSession);
+    SuccessOrExit(err);
 
 exit:
 
@@ -290,7 +329,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR ChipDeviceController::ResumeSecureSession()
+CHIP_ERROR ChipDeviceController::ResumeSecureSession(const NodeId & peer)
 {
     if (mConState == kConnectionState_SecureConnected)
     {
@@ -303,12 +342,8 @@ CHIP_ERROR ChipDeviceController::ResumeSecureSession()
         mSessionManager = nullptr;
     }
 
-    uint32_t currentMessageNumber = mMessageNumber;
-
-    CHIP_ERROR err = EstablishSecureSession();
+    CHIP_ERROR err = EstablishSecureSession(peer);
     SuccessOrExit(err);
-
-    mMessageNumber = currentMessageNumber;
 
 exit:
 
@@ -376,8 +411,8 @@ CHIP_ERROR ChipDeviceController::SendMessage(void * appReqState, PacketBuffer * 
         if (!IsSecurelyConnected())
         {
             // For now, it's expected that the device is connected
-            VerifyOrExit(IsConnected(), err = CHIP_ERROR_INCORRECT_STATE);
-            err = EstablishSecureSession();
+            VerifyOrExit(mState == kState_Initialized, err = CHIP_ERROR_INCORRECT_STATE);
+            err = EstablishSecureSession(mRemoteDeviceId.Value());
             SuccessOrExit(err);
 
             trySessionResumption = false;
@@ -393,7 +428,8 @@ CHIP_ERROR ChipDeviceController::SendMessage(void * appReqState, PacketBuffer * 
         // Try sesion resumption if needed
         if (err != CHIP_NO_ERROR && trySessionResumption)
         {
-            err = ResumeSecureSession();
+            // VerifyOrExit(mRemoteDeviceId.HasValue(), err = CHIP_ERROR_INCORRECT_STATE);
+            err = ResumeSecureSession(mRemoteDeviceId.Value());
             // If session resumption failed, let's free the extra reference to
             // the buffer. If not, SendMessage would free it.
             VerifyOrExit(err == CHIP_NO_ERROR, PacketBuffer::Free(buffer));
@@ -520,12 +556,30 @@ void ChipDeviceController::OnRendezvousStatusUpdate(RendezvousSessionDelegate::S
         {
             mPairingDelegate->OnNetworkCredentialsRequested(mRendezvousSession);
         }
+
+        if (mStorageDelegate != nullptr)
+        {
+            SecurePairingSessionSerialized serialized;
+            CHIP_ERROR err = mSecurePairingSession->Serialize(serialized);
+            if (err == CHIP_NO_ERROR)
+            {
+                PERSISTENT_KEY_OP(mSecurePairingSession->GetPeerNodeId(), kDeviceCredentialsKeyPrefix, key,
+                                  mStorageDelegate->SetKeyValue(key, Uint8::to_const_char(serialized.inner)));
+            }
+        }
         break;
 
     case RendezvousSessionDelegate::NetworkProvisioningSuccess:
 
         ChipLogDetail(Controller, "Remote device was assigned an ip address\n");
         mDeviceAddr = mRendezvousSession->GetIPAddress();
+        if (mStorageDelegate != nullptr)
+        {
+            char addrStr[INET6_ADDRSTRLEN];
+            mDeviceAddr.ToString(addrStr, INET6_ADDRSTRLEN);
+            PERSISTENT_KEY_OP(mRendezvousSession->GetPairingSession().GetPeerNodeId(), kDeviceAddressKeyPrefix, key,
+                              mStorageDelegate->SetKeyValue(key, addrStr));
+        }
         break;
 
     default:

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -25,13 +25,13 @@
  *
  */
 
+#ifndef __STDC_LIMIT_MACROS
+#define __STDC_LIMIT_MACROS
+#endif
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
 #endif
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
 // module header, comes first
 #include <controller/CHIPDeviceController.h>
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -272,8 +272,8 @@ private:
     void ClearRequestState();
     void ClearOpState();
 
-    CHIP_ERROR EstablishSecureSession(const NodeId & peer);
-    CHIP_ERROR ResumeSecureSession(const NodeId & peer);
+    CHIP_ERROR EstablishSecureSession(NodeId peer);
+    CHIP_ERROR ResumeSecureSession(NodeId peer);
 };
 
 } // namespace DeviceController

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <controller/CHIPPersistentStorageDelegate.h>
 #include <core/CHIPCore.h>
 #include <core/CHIPTLV.h>
 #include <support/DLLUtil.h>
@@ -47,38 +48,6 @@ typedef void (*CompleteHandler)(ChipDeviceController * deviceController, void * 
 typedef void (*ErrorHandler)(ChipDeviceController * deviceController, void * appReqState, CHIP_ERROR err,
                              const Inet::IPPacketInfo * pktInfo);
 typedef void (*MessageReceiveHandler)(ChipDeviceController * deviceController, void * appReqState, System::PacketBuffer * payload);
-
-class DLL_EXPORT PersistentStorageDelegate
-{
-public:
-    /**
-     * @brief
-     *   Lookup the key and return it's stringified value
-     *
-     * @param[in] key Key to lookup
-     * @return Value or nullptr if not found
-     */
-    virtual const char * GetKeyValue(const char * key) = 0;
-
-    /**
-     * @brief
-     *   Set the value for the key
-     *
-     * @param[in] key Key to be set
-     * @param[in] value Value to be set
-     * @return returns corresponding error if unsuccessful
-     */
-    virtual CHIP_ERROR SetKeyValue(const char * key, const char * value) = 0;
-
-    /**
-     * @brief
-     *   Deletes the value for the key
-     *
-     * @param[in] key Key to be deleted
-     * @return returns corresponding error if unsuccessful
-     */
-    virtual CHIP_ERROR DeleteKeyValue(const char * key) = 0;
-};
 
 class DLL_EXPORT DevicePairingDelegate
 {

--- a/src/controller/CHIPPersistentStorageDelegate.h
+++ b/src/controller/CHIPPersistentStorageDelegate.h
@@ -1,0 +1,64 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <core/CHIPCore.h>
+#include <support/DLLUtil.h>
+
+namespace chip {
+namespace DeviceController {
+
+class DLL_EXPORT PersistentStorageDelegate
+{
+public:
+    virtual ~PersistentStorageDelegate() {}
+
+    /**
+     * @brief
+     *   Lookup the key and return it's stringified value
+     *
+     * @param[in] key Key to lookup
+     * @return Value or nullptr if not found. Lifetime of the returned
+     *         buffer is tied to the delegate object. If the delegate is
+     *         freed, the returned value would be inaccessible.
+     */
+    virtual const char * GetKeyValue(const char * key) = 0;
+
+    /**
+     * @brief
+     *   Set the value for the key
+     *
+     * @param[in] key Key to be set
+     * @param[in] value Value to be set
+     * @return returns corresponding error if unsuccessful
+     */
+    virtual CHIP_ERROR SetKeyValue(const char * key, const char * value) = 0;
+
+    /**
+     * @brief
+     *   Deletes the value for the key
+     *
+     * @param[in] key Key to be deleted
+     * @return returns corresponding error if unsuccessful
+     */
+    virtual CHIP_ERROR DeleteKeyValue(const char * key) = 0;
+};
+
+} // namespace DeviceController
+} // namespace chip

--- a/src/transport/SecurePairingSession.cpp
+++ b/src/transport/SecurePairingSession.cpp
@@ -58,18 +58,6 @@ SecurePairingSession::~SecurePairingSession()
     memset(&mKe[0], 0, sizeof(mKe));
 }
 
-typedef struct
-{
-    uint16_t mKeLen;
-    uint8_t mKe[kMAX_Hash_Length];
-    uint8_t mPairingComplete;
-    uint64_t mLocalNodeId;
-    uint64_t mPeerNodeId;
-    uint16_t mLocalKeyId;
-    uint16_t mPeerKeyId;
-    uint64_t padding;
-} SecurePairingSessionSerializable;
-
 CHIP_ERROR SecurePairingSession::Serialize(SecurePairingSessionSerialized & output)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
@@ -116,7 +104,7 @@ CHIP_ERROR SecurePairingSession::Deserialize(SecurePairingSessionSerialized & in
     size_t len               = strnlen(Uint8::to_char(input.inner), maxlen);
     uint16_t deserializedLen = 0;
 
-    VerifyOrExit(BASE64_MAX_DECODED_LEN(len) <= sizeof(serializable), error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(len < sizeof(SecurePairingSessionSerialized), error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(CanCastTo<uint16_t>(len), error = CHIP_ERROR_INVALID_ARGUMENT);
 
     memset(&serializable, 0, sizeof(serializable));

--- a/src/transport/SecurePairingSession.cpp
+++ b/src/transport/SecurePairingSession.cpp
@@ -82,13 +82,18 @@ CHIP_ERROR SecurePairingSession::Serialize(SecurePairingSessionSerialized & outp
     VerifyOrExit(CanCastTo<uint16_t>(sizeof(SecurePairingSessionSerializable)), error = CHIP_ERROR_INTERNAL);
 
     {
-        uint8_t paired                                = (mPairingComplete) ? 1 : 0;
-        uint16_t keLen                                = static_cast<uint16_t>(mKeLen);
-        uint16_t serializedLen                        = 0;
-        SecurePairingSessionSerializable serializable = {
-            keLen, { 0 }, paired, localNodeId, peerNodeId, mLocalKeyId, mPeerKeyId, 0
-        };
+        SecurePairingSessionSerializable serializable;
+        memset(&serializable, 0, sizeof(serializable));
+        serializable.mKeLen           = static_cast<uint16_t>(mKeLen);
+        serializable.mPairingComplete = (mPairingComplete) ? 1 : 0;
+        serializable.mLocalNodeId     = localNodeId;
+        serializable.mPeerNodeId      = peerNodeId;
+        serializable.mLocalKeyId      = mLocalKeyId;
+        serializable.mPeerKeyId       = mPeerKeyId;
+
         memcpy(serializable.mKe, mKe, kMAX_Hash_Length);
+
+        uint16_t serializedLen = 0;
 
         VerifyOrExit(BASE64_ENCODED_LEN(sizeof(serializable)) <= sizeof(output.inner), error = CHIP_ERROR_INVALID_ARGUMENT);
 

--- a/src/transport/SecurePairingSession.cpp
+++ b/src/transport/SecurePairingSession.cpp
@@ -92,7 +92,7 @@ CHIP_ERROR SecurePairingSession::Serialize(SecurePairingSessionSerialized & outp
 
         VerifyOrExit(BASE64_ENCODED_LEN(sizeof(serializable)) <= sizeof(output.inner), error = CHIP_ERROR_INVALID_ARGUMENT);
 
-        serializedLen = chip::Base64Encode(Uint8::to_const_uchar((uint8_t *) &serializable),
+        serializedLen = chip::Base64Encode(Uint8::to_const_uchar(reinterpret_cast<uint8_t *>(&serializable)),
                                            static_cast<uint16_t>(sizeof(serializable)), Uint8::to_char(output.inner));
         VerifyOrExit(serializedLen > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
         VerifyOrExit(serializedLen < sizeof(output.inner), error = CHIP_ERROR_INVALID_ARGUMENT);
@@ -121,9 +121,7 @@ CHIP_ERROR SecurePairingSession::Deserialize(SecurePairingSessionSerialized & in
     VerifyOrExit(deserializedLen <= sizeof(serializable), error = CHIP_ERROR_INVALID_ARGUMENT);
 
     mPairingComplete = (serializable.mPairingComplete == 1);
-
-    VerifyOrExit(CanCastTo<uint16_t>(serializable.mKeLen), error = CHIP_ERROR_INTERNAL);
-    mKeLen = static_cast<size_t>(serializable.mKeLen);
+    mKeLen           = static_cast<size_t>(serializable.mKeLen);
 
     VerifyOrExit(mKeLen <= sizeof(mKe), error = CHIP_ERROR_INVALID_ARGUMENT);
     memset(mKe, 0, sizeof(mKe));

--- a/src/transport/SecurePairingSession.cpp
+++ b/src/transport/SecurePairingSession.cpp
@@ -28,6 +28,8 @@
  *
  */
 
+#include <inttypes.h>
+
 #include <core/CHIPSafeCasts.h>
 #include <protocols/CHIPProtocols.h>
 #include <support/BufBound.h>
@@ -54,6 +56,87 @@ SecurePairingSession::~SecurePairingSession()
     memset(&mPoint[0], 0, sizeof(mPoint));
     memset(&mWS[0][0], 0, sizeof(mWS));
     memset(&mKe[0], 0, sizeof(mKe));
+}
+
+typedef struct
+{
+    uint16_t mKeLen;
+    uint8_t mKe[kMAX_Hash_Length];
+    uint8_t mPairingComplete;
+    uint64_t mLocalNodeId;
+    uint64_t mPeerNodeId;
+    uint16_t mLocalKeyId;
+    uint16_t mPeerKeyId;
+    uint64_t padding;
+} SecurePairingSessionSerializable;
+
+CHIP_ERROR SecurePairingSession::Serialize(SecurePairingSessionSerialized & output)
+{
+    CHIP_ERROR error = CHIP_NO_ERROR;
+
+    const NodeId localNodeId = (mLocalNodeId.HasValue()) ? mLocalNodeId.Value() : kUndefinedNodeId;
+    const NodeId peerNodeId  = (mPeerNodeId.HasValue()) ? mPeerNodeId.Value() : kUndefinedNodeId;
+    VerifyOrExit(CanCastTo<uint16_t>(mKeLen), error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(CanCastTo<uint64_t>(localNodeId), error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(CanCastTo<uint64_t>(peerNodeId), error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(CanCastTo<uint16_t>(sizeof(SecurePairingSessionSerializable)), error = CHIP_ERROR_INTERNAL);
+
+    {
+        uint8_t paired                                = (mPairingComplete) ? 1 : 0;
+        uint16_t keLen                                = static_cast<uint16_t>(mKeLen);
+        uint16_t serializedLen                        = 0;
+        SecurePairingSessionSerializable serializable = {
+            keLen, { 0 }, paired, localNodeId, peerNodeId, mLocalKeyId, mPeerKeyId, 0
+        };
+        memcpy(serializable.mKe, mKe, kMAX_Hash_Length);
+
+        VerifyOrExit(BASE64_ENCODED_LEN(sizeof(serializable)) <= sizeof(output.inner), error = CHIP_ERROR_INVALID_ARGUMENT);
+
+        serializedLen = chip::Base64Encode(Uint8::to_const_uchar((uint8_t *) &serializable),
+                                           static_cast<uint16_t>(sizeof(serializable)), Uint8::to_char(output.inner));
+        VerifyOrExit(serializedLen > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrExit(serializedLen < sizeof(output.inner), error = CHIP_ERROR_INVALID_ARGUMENT);
+        output.inner[serializedLen] = '\0';
+    }
+
+exit:
+    return error;
+}
+
+CHIP_ERROR SecurePairingSession::Deserialize(SecurePairingSessionSerialized & input)
+{
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    SecurePairingSessionSerializable serializable;
+    size_t maxlen            = BASE64_ENCODED_LEN(sizeof(serializable));
+    size_t len               = strnlen(Uint8::to_char(input.inner), maxlen);
+    uint16_t deserializedLen = 0;
+
+    VerifyOrExit(BASE64_MAX_DECODED_LEN(len) <= sizeof(serializable), error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(CanCastTo<uint16_t>(len), error = CHIP_ERROR_INVALID_ARGUMENT);
+
+    memset(&serializable, 0, sizeof(serializable));
+    deserializedLen =
+        Base64Decode(Uint8::to_const_char(input.inner), static_cast<uint16_t>(len), Uint8::to_uchar((uint8_t *) &serializable));
+    VerifyOrExit(deserializedLen > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(deserializedLen <= sizeof(serializable), error = CHIP_ERROR_INVALID_ARGUMENT);
+
+    mPairingComplete = (serializable.mPairingComplete == 1);
+
+    VerifyOrExit(CanCastTo<uint16_t>(serializable.mKeLen), error = CHIP_ERROR_INTERNAL);
+    mKeLen = static_cast<size_t>(serializable.mKeLen);
+
+    VerifyOrExit(mKeLen <= sizeof(mKe), error = CHIP_ERROR_INVALID_ARGUMENT);
+    memset(mKe, 0, sizeof(mKe));
+    memcpy(mKe, serializable.mKe, mKeLen);
+
+    mLocalNodeId = Optional<NodeId>::Value(serializable.mLocalNodeId);
+    mPeerNodeId  = Optional<NodeId>::Value(serializable.mPeerNodeId);
+
+    mLocalKeyId = serializable.mLocalKeyId;
+    mPeerKeyId  = serializable.mPeerKeyId;
+
+exit:
+    return error;
 }
 
 CHIP_ERROR SecurePairingSession::Init(uint32_t setupCode, uint32_t pbkdf2IterCount, const uint8_t * salt, size_t saltLen,

--- a/src/transport/SecurePairingSession.cpp
+++ b/src/transport/SecurePairingSession.cpp
@@ -91,7 +91,7 @@ CHIP_ERROR SecurePairingSession::Serialize(SecurePairingSessionSerialized & outp
         serializable.mLocalKeyId      = mLocalKeyId;
         serializable.mPeerKeyId       = mPeerKeyId;
 
-        memcpy(serializable.mKe, mKe, kMAX_Hash_Length);
+        memcpy(serializable.mKe, mKe, mKeLen);
 
         uint16_t serializedLen = 0;
 

--- a/src/transport/SecurePairingSession.h
+++ b/src/transport/SecurePairingSession.h
@@ -263,9 +263,21 @@ public:
     CHIP_ERROR HandlePeerMessage(const PacketHeader & packetHeader, System::PacketBuffer * msg) override { return CHIP_NO_ERROR; }
 };
 
+typedef struct SecurePairingSessionSerializable
+{
+    uint16_t mKeLen;
+    uint8_t mKe[kMAX_Hash_Length];
+    uint8_t mPairingComplete;
+    uint64_t mLocalNodeId;
+    uint64_t mPeerNodeId;
+    uint16_t mLocalKeyId;
+    uint16_t mPeerKeyId;
+} SecurePairingSessionSerializable;
+
 typedef struct SecurePairingSessionSerialized
 {
-    uint8_t inner[BASE64_ENCODED_LEN(sizeof(SecurePairingSession))];
+    // Extra uint64_t to account for padding bytes (NULL termination, and some decoding overheads)
+    uint8_t inner[BASE64_ENCODED_LEN(sizeof(SecurePairingSessionSerializable) + sizeof(uint64_t))];
 } SecurePairingSessionSerialized;
 
 } // namespace chip

--- a/src/transport/SecurePairingSession.h
+++ b/src/transport/SecurePairingSession.h
@@ -28,6 +28,7 @@
 
 #include <core/ReferenceCounted.h>
 #include <crypto/CHIPCryptoPAL.h>
+#include <support/Base64.h>
 #include <system/SystemPacketBuffer.h>
 #include <transport/SecureSession.h>
 
@@ -66,6 +67,8 @@ public:
 
     ~SecurePairingSessionDelegate() override {}
 };
+
+struct SecurePairingSessionSerialized;
 
 class DLL_EXPORT SecurePairingSession
 {
@@ -159,6 +162,18 @@ public:
      */
     uint16_t GetLocalKeyId() { return mLocalKeyId; }
 
+    /** @brief Serialize the Pairing Session to a string.
+     *
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR Serialize(SecurePairingSessionSerialized & output);
+
+    /** @brief Deserialize the Pairing Session from the string.
+     *
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR Deserialize(SecurePairingSessionSerialized & input);
+
 private:
     CHIP_ERROR Init(uint32_t setupCode, uint32_t pbkdf2IterCount, const uint8_t * salt, size_t saltLen, Optional<NodeId> myNodeId,
                     uint16_t myKeyId, SecurePairingSessionDelegate * delegate);
@@ -247,5 +262,10 @@ public:
 
     CHIP_ERROR HandlePeerMessage(const PacketHeader & packetHeader, System::PacketBuffer * msg) override { return CHIP_NO_ERROR; }
 };
+
+typedef struct SecurePairingSessionSerialized
+{
+    uint8_t inner[BASE64_ENCODED_LEN(sizeof(SecurePairingSession))];
+} SecurePairingSessionSerialized;
 
 } // namespace chip

--- a/src/transport/tests/TestSecurePairingSession.cpp
+++ b/src/transport/tests/TestSecurePairingSession.cpp
@@ -134,55 +134,69 @@ void SecurePairingHandshakeTest(nlTestSuite * inSuite, void * inContext)
 
 void SecurePairingSerializeTest(nlTestSuite * inSuite, void * inContext)
 {
-    // Test all combinations of invalid parameters
-    TestSecurePairingDelegate delegateAccessory, deleageCommissioner;
-    SecurePairingSession pairingAccessory, pairingCommissioner;
+    SecurePairingSession pairingCommissioner;
 
-    deleageCommissioner.peer = &pairingAccessory;
-    delegateAccessory.peer   = &pairingCommissioner;
+    {
+        TestSecurePairingDelegate delegateAccessory, deleageCommissioner;
+        SecurePairingSession pairingAccessory;
 
-    NL_TEST_ASSERT(inSuite,
-                   pairingAccessory.WaitForPairing(1234, 500, (const uint8_t *) "salt", 4, Optional<NodeId>::Value(1), 0,
-                                                   &delegateAccessory) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite,
-                   pairingCommissioner.Pair(1234, 500, (const uint8_t *) "salt", 4, Optional<NodeId>::Value(2), 0,
-                                            &deleageCommissioner) == CHIP_NO_ERROR);
+        deleageCommissioner.peer = &pairingAccessory;
+        delegateAccessory.peer   = &pairingCommissioner;
 
-    NL_TEST_ASSERT(inSuite, delegateAccessory.mNumMessageSend == 1);
-    NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingComplete == 1);
+        NL_TEST_ASSERT(inSuite,
+                       pairingAccessory.WaitForPairing(1234, 500, (const uint8_t *) "salt", 4, Optional<NodeId>::Value(1), 0,
+                                                       &delegateAccessory) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite,
+                       pairingCommissioner.Pair(1234, 500, (const uint8_t *) "salt", 4, Optional<NodeId>::Value(2), 0,
+                                                &deleageCommissioner) == CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, deleageCommissioner.mNumMessageSend == 2);
-    NL_TEST_ASSERT(inSuite, deleageCommissioner.mNumPairingComplete == 1);
+        NL_TEST_ASSERT(inSuite, delegateAccessory.mNumMessageSend == 1);
+        NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingComplete == 1);
 
-    SecurePairingSessionSerialized serialized;
-    NL_TEST_ASSERT(inSuite, pairingCommissioner.Serialize(serialized) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, deleageCommissioner.mNumMessageSend == 2);
+        NL_TEST_ASSERT(inSuite, deleageCommissioner.mNumPairingComplete == 1);
+    }
 
     SecurePairingSession deserialized;
-    NL_TEST_ASSERT(inSuite, deserialized.Deserialize(serialized) == CHIP_NO_ERROR);
+    {
+        SecurePairingSessionSerialized serialized;
+        NL_TEST_ASSERT(inSuite, pairingCommissioner.Serialize(serialized) == CHIP_NO_ERROR);
 
-    // Serialize from the deserialized session, and check we get the same string back
-    SecurePairingSessionSerialized serialized2;
-    NL_TEST_ASSERT(inSuite, deserialized.Serialize(serialized2) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, deserialized.Deserialize(serialized) == CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, strncmp(Uint8::to_char(serialized.inner), Uint8::to_char(serialized2.inner), sizeof(serialized)) == 0);
+        // Serialize from the deserialized session, and check we get the same string back
+        SecurePairingSessionSerialized serialized2;
+        NL_TEST_ASSERT(inSuite, deserialized.Serialize(serialized2) == CHIP_NO_ERROR);
 
-    // Let's try encrypting using original session, and decrypting using deserialized
-    SecureSession session1, session2;
-
-    NL_TEST_ASSERT(inSuite, pairingCommissioner.DeriveSecureSession(Uint8::from_const_char("abc"), 3, session1) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, deserialized.DeriveSecureSession(Uint8::from_const_char("abc"), 3, session2) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite,
+                       strncmp(Uint8::to_char(serialized.inner), Uint8::to_char(serialized2.inner), sizeof(serialized)) == 0);
+    }
 
     const uint8_t plain_text[] = { 0x86, 0x74, 0x64, 0xe5, 0x0b, 0xd4, 0x0d, 0x90, 0xe1, 0x17, 0xa3, 0x2d, 0x4b, 0xd4, 0xe1, 0xe6 };
-    uint8_t encrypted[128];
+    uint8_t encrypted[64];
     PacketHeader header;
     MessageAuthenticationCode mac;
 
-    NL_TEST_ASSERT(inSuite,
-                   session1.Encrypt(plain_text, sizeof(plain_text), encrypted, header, Header::Flags(), mac) == CHIP_NO_ERROR);
+    // Let's try encrypting using original session, and decrypting using deserialized
+    {
+        SecureSession session1;
 
-    uint8_t decrypted[128];
-    NL_TEST_ASSERT(inSuite,
-                   session2.Decrypt(encrypted, sizeof(plain_text), decrypted, header, Header::Flags(), mac) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite,
+                       pairingCommissioner.DeriveSecureSession(Uint8::from_const_char("abc"), 3, session1) == CHIP_NO_ERROR);
+
+        NL_TEST_ASSERT(inSuite,
+                       session1.Encrypt(plain_text, sizeof(plain_text), encrypted, header, Header::Flags(), mac) == CHIP_NO_ERROR);
+    }
+
+    {
+        SecureSession session2;
+        NL_TEST_ASSERT(inSuite, deserialized.DeriveSecureSession(Uint8::from_const_char("abc"), 3, session2) == CHIP_NO_ERROR);
+
+        uint8_t decrypted[64];
+        NL_TEST_ASSERT(inSuite,
+                       session2.Decrypt(encrypted, sizeof(plain_text), decrypted, header, Header::Flags(), mac) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, memcmp(plain_text, decrypted, sizeof(plain_text)) == 0);
+    }
 }
 
 // Test Suite


### PR DESCRIPTION
#### Problem
CHIP controller applications cannot persist paired device state across reboots. 

#### Summary of Changes
CHIP Controller API did not provide a mechanism to save pairing state of a device/accessory.
This PR adds
- the key value persistent API
- updates CHIPController to use the API to store the state
- and, a mechanism to serialize, deserialize Pairing state.

This PR is one step towards fixing #2797 
