### PR TITLE
Add sdkconfig direct include in PlatformConfig, to depend outside -isystem

### DIFF
--- a/src/platform/ESP32/CHIPPlatformConfig.h
+++ b/src/platform/ESP32/CHIPPlatformConfig.h
@@ -25,6 +25,14 @@
 
 #pragma once
 
+/* Force sdkconfig to be added as a dependecy. That file is also included as a sideffect of
+ * esp_err.h -> assert.h -> sdkconfig.h however since esp_err.h and above are -isystem includes,
+ * they are not added as dependencies by GN build systems.
+ *
+ * This triggers a rebuild of files including CHIPPlatformConfig if sdkconfig.h changes.
+ */
+#include <sdkconfig.h>
+
 #include "esp_err.h"
 
 // ==================== General Platform Adaptations ====================


### PR DESCRIPTION

 #### Problem
sdkconfig.h is user editable (we generally update it with `make menuconfig` for things like wifi or other settings).

Currently this is included as a side-effect of including sys_err, however platform files use those defines. When performing an incremental build, gn assumes system includes never change and does not trigger a rebuild. This forces us to use a clean build every time sdkconfig is updated.

 #### Summary of Changes
Include sdkconfig.h directly instead of through system include sideffects.

Changes that partially fix #3283 (Though this seems awkward - if we get system includes not through this platform include, we still may get mismatches between headers)
