### PR TITLE
Added ASN1 support macros needed for X509 to CHIP certificate conversion

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -44,6 +44,7 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
       "${chip_root}/src/crypto",
       "${chip_root}/src/inet",
       "${chip_root}/src/lib",
+      "${chip_root}/src/lib/asn1",
       "${chip_root}/src/lib/core",
       "${chip_root}/src/lib/shell",
       "${chip_root}/src/lib/support",

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -48,6 +48,7 @@ if (chip_build_tests) {
 
     if (chip_device_platform != "esp32") {
       deps += [
+        "${chip_root}/src/lib/asn1/tests",
         "${chip_root}/src/lib/core/tests",
         "${chip_root}/src/lib/support/tests",
         "${chip_root}/src/platform/tests",

--- a/src/lib/asn1/ASN1.h
+++ b/src/lib/asn1/ASN1.h
@@ -1,0 +1,220 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines types and objects for reading and writing
+ *      Abstract Syntax Notation One (ASN.1) encoded data.
+ *
+ */
+
+#pragma once
+
+#include <support/DLLUtil.h>
+
+#include <asn1/ASN1Error.h>
+
+namespace chip {
+namespace TLV {
+class TLVReader;
+}
+} // namespace chip
+
+/**
+ *   @namespace chip::ASN1
+ *
+ *   @brief
+ *     This namespace includes all interfaces within CHIP for
+ *     working with Abstract Syntax Notation One (ASN.1).
+ */
+
+namespace chip {
+namespace ASN1 {
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+#include <asn1/ASN1OID.h>
+#endif
+
+enum ASN1TagClasses
+{
+    kASN1TagClass_Universal       = 0x00,
+    kASN1TagClass_Application     = 0x40,
+    kASN1TagClass_ContextSpecific = 0x80,
+    kASN1TagClass_Private         = 0xC0
+};
+
+enum ASN1UniversalTags
+{
+    kASN1UniversalTag_Boolean         = 1,
+    kASN1UniversalTag_Integer         = 2,
+    kASN1UniversalTag_BitString       = 3,
+    kASN1UniversalTag_OctetString     = 4,
+    kASN1UniversalTag_Null            = 5,
+    kASN1UniversalTag_ObjectId        = 6,
+    kASN1UniversalTag_ObjectDesc      = 7,
+    kASN1UniversalTag_External        = 8,
+    kASN1UniversalTag_Real            = 9,
+    kASN1UniversalTag_Enumerated      = 10,
+    kASN1UniversalTag_UTF8String      = 12,
+    kASN1UniversalTag_Sequence        = 16,
+    kASN1UniversalTag_Set             = 17,
+    kASN1UniversalTag_NumericString   = 18,
+    kASN1UniversalTag_PrintableString = 19,
+    kASN1UniversalTag_T61String       = 20,
+    kASN1UniversalTag_VideotexString  = 21,
+    kASN1UniversalTag_IA5String       = 22,
+    kASN1UniversalTag_UTCTime         = 23,
+    kASN1UniversalTag_GeneralizedTime = 24,
+    kASN1UniversalTag_GraphicString   = 25,
+    kASN1UniversalTag_VisibleString   = 26,
+    kASN1UniversalTag_GeneralString   = 27,
+    kASN1UniversalTag_UniversalString = 28
+};
+
+struct ASN1UniversalTime
+{
+    uint16_t Year;
+    uint8_t Month;
+    uint8_t Day;
+    uint8_t Hour;
+    uint8_t Minute;
+    uint8_t Second;
+};
+
+class DLL_EXPORT ASN1Reader
+{
+public:
+    void Init(const uint8_t * buf, uint32_t len);
+
+    uint8_t GetClass(void) const { return Class; };
+    uint32_t GetTag(void) const { return Tag; };
+    const uint8_t * GetValue(void) const { return Value; };
+    uint32_t GetValueLen(void) const { return ValueLen; };
+    bool IsConstructed(void) const { return Constructed; };
+    bool IsIndefiniteLen(void) const { return IndefiniteLen; };
+    bool IsEndOfContents(void) const { return EndOfContents; };
+
+    ASN1_ERROR Next(void);
+    ASN1_ERROR EnterConstructedType(void);
+    ASN1_ERROR ExitConstructedType(void);
+    ASN1_ERROR EnterEncapsulatedType(void);
+    ASN1_ERROR ExitEncapsulatedType(void);
+    bool IsContained(void) const;
+    ASN1_ERROR GetInteger(int64_t & val);
+    ASN1_ERROR GetBoolean(bool & val);
+    ASN1_ERROR GetObjectId(OID & oid);
+    ASN1_ERROR GetUTCTime(ASN1UniversalTime & outTime);
+    ASN1_ERROR GetGeneralizedTime(ASN1UniversalTime & outTime);
+    ASN1_ERROR GetBitString(uint32_t & outVal);
+
+private:
+    static constexpr size_t kMaxContextDepth = 32;
+
+    struct ASN1ParseContext
+    {
+        const uint8_t * ElemStart;
+        uint32_t HeadLen;
+        uint32_t ValueLen;
+        bool IndefiniteLen;
+        const uint8_t * ContainerEnd;
+    };
+
+    uint8_t Class;
+    uint32_t Tag;
+    const uint8_t * Value;
+    uint32_t ValueLen;
+    bool Constructed;
+    bool IndefiniteLen;
+    bool EndOfContents;
+
+    const uint8_t * mBuf;
+    const uint8_t * mBufEnd;
+    const uint8_t * mElemStart;
+    const uint8_t * mContainerEnd;
+    uint32_t mHeadLen;
+    ASN1ParseContext mSavedContexts[kMaxContextDepth];
+    uint32_t mNumSavedContexts;
+
+    ASN1_ERROR DecodeHead(void);
+    void ResetElementState(void);
+    ASN1_ERROR EnterContainer(uint32_t offset);
+    ASN1_ERROR ExitContainer(void);
+};
+
+class DLL_EXPORT ASN1Writer
+{
+public:
+    void Init(uint8_t * buf, uint32_t maxLen);
+    void InitNullWriter(void);
+    ASN1_ERROR Finalize(void);
+    uint16_t GetLengthWritten(void) const;
+
+    ASN1_ERROR PutInteger(int64_t val);
+    ASN1_ERROR PutBoolean(bool val);
+    ASN1_ERROR PutObjectId(const uint8_t * val, uint16_t valLen);
+    ASN1_ERROR PutObjectId(OID oid);
+    ASN1_ERROR PutString(uint32_t tag, const char * val, uint16_t valLen);
+    ASN1_ERROR PutOctetString(const uint8_t * val, uint16_t valLen);
+    ASN1_ERROR PutOctetString(uint8_t cls, uint32_t tag, const uint8_t * val, uint16_t valLen);
+    ASN1_ERROR PutOctetString(uint8_t cls, uint32_t tag, chip::TLV::TLVReader & val);
+    ASN1_ERROR PutBitString(uint32_t val);
+    ASN1_ERROR PutBitString(uint8_t unusedBits, const uint8_t * val, uint16_t valLen);
+    ASN1_ERROR PutBitString(uint8_t unusedBits, chip::TLV::TLVReader & val);
+    ASN1_ERROR PutTime(const ASN1UniversalTime & val);
+    ASN1_ERROR PutNull(void);
+    ASN1_ERROR StartConstructedType(uint8_t cls, uint32_t tag);
+    ASN1_ERROR EndConstructedType(void);
+    ASN1_ERROR StartEncapsulatedType(uint8_t cls, uint32_t tag, bool bitStringEncoding);
+    ASN1_ERROR EndEncapsulatedType(void);
+    ASN1_ERROR PutValue(uint8_t cls, uint32_t tag, bool isConstructed, const uint8_t * val, uint16_t valLen);
+    ASN1_ERROR PutValue(uint8_t cls, uint32_t tag, bool isConstructed, chip::TLV::TLVReader & val);
+
+private:
+    uint8_t * mBuf;
+    uint8_t * mBufEnd;
+    uint8_t * mWritePoint;
+    uint8_t ** mDeferredLengthList;
+
+    ASN1_ERROR EncodeHead(uint8_t cls, uint32_t tag, bool isConstructed, int32_t len);
+    ASN1_ERROR WriteDeferredLength(void);
+    static uint8_t BytesForLength(int32_t len);
+    static void EncodeLength(uint8_t * buf, uint8_t bytesForLen, int32_t lenToEncode);
+};
+
+OID ParseObjectID(const uint8_t * encodedOID, uint16_t encodedOIDLen);
+bool GetEncodedObjectID(OID oid, const uint8_t *& encodedOID, uint16_t & encodedOIDLen);
+
+OIDCategory GetOIDCategory(OID oid);
+
+const char * GetOIDName(OID oid);
+
+ASN1_ERROR DumpASN1(ASN1Reader & reader, const char * prefix, const char * indent);
+
+inline OID GetOID(OIDCategory category, uint8_t id)
+{
+    return (category | id);
+}
+
+inline uint8_t GetOIDEnum(OID oid)
+{
+    return static_cast<uint8_t>(oid & kOID_EnumMask);
+}
+
+} // namespace ASN1
+} // namespace chip

--- a/src/lib/asn1/ASN1Config.h
+++ b/src/lib/asn1/ASN1Config.h
@@ -1,0 +1,92 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2014-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines default compile-time configuration constants
+ *      for the CHIP ASN1 subsystem.
+ *
+ */
+
+#pragma once
+
+#include <core/CHIPConfig.h>
+
+// clang-format off
+
+/**
+ *  @def ASN1_CONFIG_ERROR_TYPE
+ *
+ *  @brief
+ *    This defines the data type used to represent errors for the ASN1
+ *    subsystem.
+ *
+ */
+#ifndef ASN1_CONFIG_ERROR_TYPE
+#include <stdint.h>
+
+#define ASN1_CONFIG_ERROR_TYPE                              int32_t
+#endif // ASN1_CONFIG_ERROR_TYPE
+
+/**
+ *  @def ASN1_CONFIG_NO_ERROR
+ *
+ *  @brief
+ *    This defines the ASN1 error code for no error or success.
+ *
+ */
+#ifndef ASN1_CONFIG_NO_ERROR
+#define ASN1_CONFIG_NO_ERROR                                0
+#endif // ASN1_CONFIG_NO_ERROR
+
+/**
+ *  @def ASN1_CONFIG_ERROR_MIN
+ *
+ *  @brief
+ *    This defines the base or minimum ASN1 error number range.
+ *
+ */
+#ifndef ASN1_CONFIG_ERROR_MIN
+#define ASN1_CONFIG_ERROR_MIN                               5000
+#endif // ASN1_CONFIG_ERROR_MIN
+
+/**
+ *  @def ASN1_CONFIG_ERROR_MAX
+ *
+ *  @brief
+ *    This defines the top or maximum ASN1 error number range.
+ *
+ */
+#ifndef ASN1_CONFIG_ERROR_MAX
+#define ASN1_CONFIG_ERROR_MAX                               5999
+#endif // ASN1_CONFIG_ERROR_MAX
+
+/**
+ *  @def _ASN1_CONFIG_ERROR
+ *
+ *  @brief
+ *    This defines a mapping function for ASN1 errors that allows
+ *    mapping such errors into a platform- or system-specific range.
+ *
+ */
+#ifndef _ASN1_CONFIG_ERROR
+#define _ASN1_CONFIG_ERROR(e)                               (ASN1_ERROR_MIN + (e))
+#endif // _ASN1_CONFIG_ERROR
+
+// clang-format on

--- a/src/lib/asn1/ASN1Error.cpp
+++ b/src/lib/asn1/ASN1Error.cpp
@@ -1,0 +1,99 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2019 Google LLC.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file contains functions for working with ASN1 errors.
+ */
+
+#include <stdlib.h>
+
+#include <asn1/ASN1.h>
+#include <support/ErrorStr.h>
+
+namespace chip {
+namespace ASN1 {
+
+/**
+ * Given an ASN1 error, returns a human-readable NULL-terminated C string
+ * describing the error.
+ *
+ * @param[in] buf                   Buffer into which the error string will be placed.
+ * @param[in] bufSize               Size of the supplied buffer in bytes.
+ * @param[in] err                   The error to be described.
+ *
+ * @return true                     If a description string was written into the supplied buffer.
+ * @return false                    If the supplied error was not an ASN1 error.
+ *
+ */
+bool FormatASN1Error(char * buf, uint16_t bufSize, int32_t err)
+{
+    const char * desc = nullptr;
+
+    if (err < ASN1_ERROR_MIN || err > ASN1_ERROR_MAX)
+    {
+        return false;
+    }
+
+#if !CHIP_CONFIG_SHORT_ERROR_STR
+    switch (err)
+    {
+    case ASN1_END:
+        desc = "End of input";
+        break;
+    case ASN1_ERROR_UNDERRUN:
+        desc = "Reader underrun";
+        break;
+    case ASN1_ERROR_OVERFLOW:
+        desc = "Writer overflow";
+        break;
+    case ASN1_ERROR_INVALID_STATE:
+        desc = "Invalid state";
+        break;
+    case ASN1_ERROR_MAX_DEPTH_EXCEEDED:
+        desc = "Max depth exceeded";
+        break;
+    case ASN1_ERROR_INVALID_ENCODING:
+        desc = "Invalid encoding";
+        break;
+    case ASN1_ERROR_UNSUPPORTED_ENCODING:
+        desc = "Unsupported encoding";
+        break;
+    case ASN1_ERROR_TAG_OVERFLOW:
+        desc = "Tag overflow";
+        break;
+    case ASN1_ERROR_LENGTH_OVERFLOW:
+        desc = "Length overflow";
+        break;
+    case ASN1_ERROR_VALUE_OVERFLOW:
+        desc = "Value overflow";
+        break;
+    case ASN1_ERROR_UNKNOWN_OBJECT_ID:
+        desc = "Unknown object id";
+        break;
+    }
+#endif // !CHIP_CONFIG_SHORT_ERROR_STR
+
+    FormatError(buf, bufSize, "ASN1", err, desc);
+
+    return true;
+}
+
+} // namespace ASN1
+} // namespace chip

--- a/src/lib/asn1/ASN1Error.h
+++ b/src/lib/asn1/ASN1Error.h
@@ -1,0 +1,218 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines constants for the CHIP ASN1 subsystem.
+ *
+ *      Error types, ranges, and mappings overrides may be made by
+ *      defining the appropriate ASN1_CONFIG_* or _ASN1_CONFIG_*
+ *      macros.
+ *
+ */
+
+#pragma once
+
+#include "ASN1Config.h"
+
+namespace chip {
+namespace ASN1 {
+
+// clang-format off
+
+/**
+ *  @def ASN1_NO_ERROR
+ *
+ *  @brief
+ *    This defines the InetLayer error code for success or no
+ *    error. This value may be configured via #ASN1_CONFIG_NO_ERROR.
+ *
+ */
+#define ASN1_NO_ERROR                   ASN1_CONFIG_NO_ERROR
+
+/**
+ *  @def ASN1_ERROR_MIN
+ *
+ *  @brief
+ *    This defines the base or minimum ASN1 error number range.
+ *    This value may be configured via #ASN1_CONFIG_ERROR_MIN.
+ *
+ */
+#define ASN1_ERROR_MIN                  ASN1_CONFIG_ERROR_MIN
+
+/**
+ *  @def ASN1_ERROR_MAX
+ *
+ *  @brief
+ *    This defines the top or maximum ASN1 error number range.
+ *    This value may be configured via #ASN1_CONFIG_ERROR_MAX.
+ *
+ */
+#define ASN1_ERROR_MAX                  ASN1_CONFIG_ERROR_MAX
+
+/**
+ *  @def _ASN1_ERROR(e)
+ *
+ *  @brief
+ *    This defines a mapping function for ASN1 errors that allows
+ *    mapping such errors into a platform- or system-specific
+ *    range. This function may be configured via
+ *    #_ASN1_CONFIG_ERROR(e).
+ *
+ *  @param[in]  e  The ASN1 error to map.
+ *
+ *  @return The mapped ASN1 error.
+ *
+ */
+#define _ASN1_ERROR(e)                  _ASN1_CONFIG_ERROR(e)
+
+/**
+ *  The basic type for all ASN1 subsystem errors.
+ *
+ *  This is defined to a platform- or system-specific type.
+ *
+ */
+typedef ASN1_CONFIG_ERROR_TYPE ASN1_ERROR;
+
+
+/**
+ *  @name Error Definitions
+ *
+ *  @{
+ */
+
+/**
+ *  @def ASN1_END
+ *
+ *  @brief
+ *    An end of ASN1 container or stream condition occurred.
+ *
+ */
+#define ASN1_END                        _ASN1_ERROR(0)
+
+/**
+ *  @def ASN1_ERROR_UNDERRUN
+ *
+ *  @brief
+ *    The ASN.1 encoding ended prematurely.
+ *
+ */
+#define ASN1_ERROR_UNDERRUN             _ASN1_ERROR(1)
+
+/**
+ *  @def ASN1_ERROR_OVERFLOW
+ *
+ *  @brief
+ *    The encoding exceeds the available space required to write it.
+ *
+ */
+#define ASN1_ERROR_OVERFLOW             _ASN1_ERROR(2)
+
+/**
+ *  @def ASN1_ERROR_INVALID_STATE
+ *
+ *  @brief
+ *    An unexpected or invalid state was encountered.
+ *
+ */
+#define ASN1_ERROR_INVALID_STATE        _ASN1_ERROR(3)
+
+/**
+ *  @def ASN1_ERROR_MAX_DEPTH_EXCEEDED
+ *
+ *  @brief
+ *    The maximum number of container reading contexts was exceeded.
+ *
+ */
+#define ASN1_ERROR_MAX_DEPTH_EXCEEDED   _ASN1_ERROR(4)
+
+/**
+ *  @def ASN1_ERROR_INVALID_ENCODING
+ *
+ *  @brief
+ *    The ASN.1 encoding is invalid.
+ *
+ */
+#define ASN1_ERROR_INVALID_ENCODING     _ASN1_ERROR(5)
+
+/**
+ *  @def ASN1_ERROR_UNSUPPORTED_ENCODING
+ *
+ *  @brief
+ *    An unsupported encoding was requested or encountered.
+ *
+ */
+#define ASN1_ERROR_UNSUPPORTED_ENCODING _ASN1_ERROR(6)
+
+/**
+ *  @def ASN1_ERROR_TAG_OVERFLOW
+ *
+ *  @brief
+ *    An encoded tag exceeds the available or allowed space required
+ *    for it.
+ *
+ */
+#define ASN1_ERROR_TAG_OVERFLOW         _ASN1_ERROR(7)
+
+/**
+ *  @def ASN1_ERROR_LENGTH_OVERFLOW
+ *
+ *  @brief
+ *    An encoded length exceeds the available or allowed space
+ *    required for it.
+ *
+ */
+#define ASN1_ERROR_LENGTH_OVERFLOW      _ASN1_ERROR(8)
+
+/**
+ *  @def ASN1_ERROR_VALUE_OVERFLOW
+ *
+ *  @brief
+ *    An encoded value exceeds the available or allowed space
+ *    required for it.
+ *
+ */
+#define ASN1_ERROR_VALUE_OVERFLOW       _ASN1_ERROR(9)
+
+/**
+ *  @def ASN1_ERROR_UNKNOWN_OBJECT_ID
+ *
+ *  @brief
+ *    A requested object identifier does not match the list of
+ *    supported object identifiers.
+ *
+ */
+#define ASN1_ERROR_UNKNOWN_OBJECT_ID    _ASN1_ERROR(10)
+
+//                        !!!!! IMPORTANT !!!!!
+//
+// If you add new ASN1 errors, please update the translation of error
+// codes to strings in ASN1Error.cpp, and add them to unittest
+// in test-apps/TestErrorStr.cpp
+
+/**
+ *  @}
+ */
+
+// clang-format on
+
+bool FormatASN1Error(char * buf, uint16_t bufSize, int32_t err);
+
+} // namespace ASN1
+} // namespace chip

--- a/src/lib/asn1/ASN1Macros.h
+++ b/src/lib/asn1/ASN1Macros.h
@@ -1,0 +1,305 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines convenience macros for dealing with Abstract
+ *      Syntax Notation One (ASN.1) encoded data.
+ *
+ */
+
+#pragma once
+
+#include <support/CodeUtils.h>
+
+// Local variable names used by utility macros.
+
+#define ASN1_READER reader
+#define ASN1_ERR err
+
+// Utility Macros for parsing ASN1
+
+#define ASN1_VERIFY_TAG(CLASS, TAG)                                                                                                \
+    VerifyOrExit(ASN1_READER.GetClass() == (CLASS) && ASN1_READER.GetTag() == (TAG), ASN1_ERR = ASN1_ERROR_INVALID_ENCODING);
+
+#define ASN1_PARSE_ELEMENT(CLASS, TAG)                                                                                             \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ASN1_ERR = ASN1_READER.Next();                                                                                             \
+        SuccessOrExit(ASN1_ERR);                                                                                                   \
+                                                                                                                                   \
+        ASN1_VERIFY_TAG(CLASS, TAG);                                                                                               \
+    } while (0)
+
+#define ASN1_PARSE_ANY                                                                                                             \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ASN1_ERR = ASN1_READER.Next();                                                                                             \
+        SuccessOrExit(ASN1_ERR);                                                                                                   \
+    } while (0)
+
+#define ASN1_ENTER_CONSTRUCTED(CLASS, TAG)                                                                                         \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ASN1_VERIFY_TAG(CLASS, TAG);                                                                                               \
+                                                                                                                                   \
+        ASN1_ERR = ASN1_READER.EnterConstructedType();                                                                             \
+        SuccessOrExit(ASN1_ERR);
+
+#define ASN1_PARSE_ENTER_CONSTRUCTED(CLASS, TAG)                                                                                   \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ASN1_ERR = ASN1_READER.Next();                                                                                             \
+        SuccessOrExit(ASN1_ERR);                                                                                                   \
+                                                                                                                                   \
+        ASN1_VERIFY_TAG(CLASS, TAG);                                                                                               \
+                                                                                                                                   \
+        ASN1_ERR = ASN1_READER.EnterConstructedType();                                                                             \
+        SuccessOrExit(ASN1_ERR);
+
+#define ASN1_EXIT_CONSTRUCTED                                                                                                      \
+    ASN1_ERR = ASN1_READER.Next();                                                                                                 \
+    if (ASN1_ERR == ASN1_NO_ERROR)                                                                                                 \
+        ASN1_ERR = ASN1_ERROR_INVALID_ENCODING;                                                                                    \
+    else if (ASN1_ERR == ASN1_END)                                                                                                 \
+        ASN1_ERR = ASN1_NO_ERROR;                                                                                                  \
+    SuccessOrExit(ASN1_ERR);                                                                                                       \
+                                                                                                                                   \
+    ASN1_ERR = ASN1_READER.ExitConstructedType();                                                                                  \
+    SuccessOrExit(ASN1_ERR);                                                                                                       \
+    }                                                                                                                              \
+    while (0)
+
+#define ASN1_PARSE_ENTER_SEQUENCE ASN1_PARSE_ENTER_CONSTRUCTED(kASN1TagClass_Universal, kASN1UniversalTag_Sequence)
+
+#define ASN1_ENTER_SEQUENCE ASN1_ENTER_CONSTRUCTED(kASN1TagClass_Universal, kASN1UniversalTag_Sequence)
+
+#define ASN1_EXIT_SEQUENCE ASN1_EXIT_CONSTRUCTED
+
+#define ASN1_PARSE_ENTER_SET ASN1_PARSE_ENTER_CONSTRUCTED(kASN1TagClass_Universal, kASN1UniversalTag_Set)
+
+#define ASN1_ENTER_SET ASN1_ENTER_CONSTRUCTED(kASN1TagClass_Universal, kASN1UniversalTag_Set)
+
+#define ASN1_EXIT_SET ASN1_EXIT_CONSTRUCTED
+
+#define ASN1_ENTER_ENCAPSULATED(CLASS, TAG)                                                                                        \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ASN1_VERIFY_TAG(CLASS, TAG);                                                                                               \
+                                                                                                                                   \
+        ASN1_ERR = ASN1_READER.EnterEncapsulatedType();                                                                            \
+        SuccessOrExit(ASN1_ERR);
+
+#define ASN1_PARSE_ENTER_ENCAPSULATED(CLASS, TAG)                                                                                  \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ASN1_ERR = ASN1_READER.Next();                                                                                             \
+        SuccessOrExit(ASN1_ERR);                                                                                                   \
+                                                                                                                                   \
+        ASN1_VERIFY_TAG(CLASS, TAG);                                                                                               \
+                                                                                                                                   \
+        ASN1_ERR = ASN1_READER.EnterEncapsulatedType();                                                                            \
+        SuccessOrExit(ASN1_ERR);
+
+#define ASN1_EXIT_ENCAPSULATED                                                                                                     \
+    ASN1_ERR = ASN1_READER.Next();                                                                                                 \
+    if (ASN1_ERR == ASN1_NO_ERROR)                                                                                                 \
+        ASN1_ERR = ASN1_ERROR_INVALID_ENCODING;                                                                                    \
+    else if (ASN1_ERR == ASN1_END)                                                                                                 \
+        ASN1_ERR = ASN1_NO_ERROR;                                                                                                  \
+    SuccessOrExit(ASN1_ERR);                                                                                                       \
+                                                                                                                                   \
+    ASN1_ERR = ASN1_READER.ExitEncapsulatedType();                                                                                 \
+    SuccessOrExit(ASN1_ERR);                                                                                                       \
+    }                                                                                                                              \
+    while (0)
+
+#define ASN1_PARSE_INTEGER(OUT_VAL)                                                                                                \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ASN1_PARSE_ELEMENT(kASN1TagClass_Universal, kASN1UniversalTag_Integer);                                                    \
+                                                                                                                                   \
+        ASN1_ERR = ASN1_READER.GetInteger(OUT_VAL);                                                                                \
+        SuccessOrExit(ASN1_ERR);                                                                                                   \
+    } while (0)
+
+#define ASN1_GET_INTEGER(OUT_VAL)                                                                                                  \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ASN1_ERR = ASN1_READER.GetInteger(OUT_VAL);                                                                                \
+        SuccessOrExit(ASN1_ERR);                                                                                                   \
+    } while (0)
+
+#define ASN1_PARSE_BOOLEAN(OUT_VAL)                                                                                                \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ASN1_PARSE_ELEMENT(kASN1TagClass_Universal, kASN1UniversalTag_Boolean);                                                    \
+                                                                                                                                   \
+        ASN1_ERR = ASN1_READER.GetBoolean(OUT_VAL);                                                                                \
+        SuccessOrExit(ASN1_ERR);                                                                                                   \
+    } while (0)
+
+#define ASN1_GET_BOOLEAN(OUT_VAL)                                                                                                  \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ASN1_ERR = ASN1_READER.GetBoolean(OUT_VAL);                                                                                \
+        SuccessOrExit(ASN1_ERR);                                                                                                   \
+    } while (0)
+
+#define ASN1_PARSE_OBJECT_ID(OUT_VAL)                                                                                              \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ASN1_PARSE_ELEMENT(kASN1TagClass_Universal, kASN1UniversalTag_ObjectId);                                                   \
+                                                                                                                                   \
+        ASN1_ERR = ASN1_READER.GetObjectId(OUT_VAL);                                                                               \
+        SuccessOrExit(ASN1_ERR);                                                                                                   \
+    } while (0)
+
+#define ASN1_GET_OBJECT_ID(OUT_VAL)                                                                                                \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ASN1_ERR = ASN1_READER.GetObjectId(OUT_VAL);                                                                               \
+        SuccessOrExit(ASN1_ERR);                                                                                                   \
+    } while (0)
+
+#define ASN1_PARSE_NULL ASN1_PARSE_ELEMENT(kASN1TagClass_Universal, kASN1UniversalTag_Null)
+
+#define ASN1_PARSE_TIME(OUT_VAL)                                                                                                   \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ASN1_PARSE_ANY;                                                                                                            \
+                                                                                                                                   \
+        if (ASN1_READER.GetClass() == kASN1TagClass_Universal && ASN1_READER.GetTag() == kASN1UniversalTag_UTCTime)                \
+            ASN1_ERR = ASN1_READER.GetUTCTime(OUT_VAL);                                                                            \
+        else if (ASN1_READER.GetClass() == kASN1TagClass_Universal && ASN1_READER.GetTag() == kASN1UniversalTag_GeneralizedTime)   \
+            ASN1_ERR = ASN1_READER.GetGeneralizedTime(OUT_VAL);                                                                    \
+        else                                                                                                                       \
+            ASN1_ERR = ASN1_ERROR_INVALID_ENCODING;                                                                                \
+        SuccessOrExit(ASN1_ERR);                                                                                                   \
+    } while (0)
+
+#define ASN1_PARSE_BIT_STRING(OUT_VAL)                                                                                             \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ASN1_PARSE_ELEMENT(kASN1TagClass_Universal, kASN1UniversalTag_BitString);                                                  \
+                                                                                                                                   \
+        ASN1_ERR = ASN1_READER.GetBitString(OUT_VAL);                                                                              \
+        SuccessOrExit(ASN1_ERR);                                                                                                   \
+    } while (0)
+
+#define ASN1_GET_BIT_STRING(OUT_VAL)                                                                                               \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ASN1_ERR = ASN1_READER.GetBitString(OUT_VAL);                                                                              \
+        SuccessOrExit(ASN1_ERR);                                                                                                   \
+    } while (0)
+
+// Utility Macros for encoding ASN1
+
+#define ASN1_START_CONSTRUCTED(CLASS, TAG)                                                                                         \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ASN1_ERR = writer.StartConstructedType(CLASS, TAG);                                                                        \
+        SuccessOrExit(ASN1_ERR);
+
+#define ASN1_END_CONSTRUCTED                                                                                                       \
+    ASN1_ERR = writer.EndConstructedType();                                                                                        \
+    SuccessOrExit(ASN1_ERR);                                                                                                       \
+    }                                                                                                                              \
+    while (0)
+
+#define ASN1_START_SEQUENCE ASN1_START_CONSTRUCTED(kASN1TagClass_Universal, kASN1UniversalTag_Sequence)
+
+#define ASN1_END_SEQUENCE ASN1_END_CONSTRUCTED
+
+#define ASN1_START_SET ASN1_START_CONSTRUCTED(kASN1TagClass_Universal, kASN1UniversalTag_Set)
+
+#define ASN1_END_SET ASN1_END_CONSTRUCTED
+
+#define ASN1_ENCODE_INTEGER(VAL)                                                                                                   \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ASN1_ERR = writer.PutInteger(VAL);                                                                                         \
+        SuccessOrExit(ASN1_ERR);                                                                                                   \
+    } while (0);
+
+#define ASN1_ENCODE_BOOLEAN(VAL)                                                                                                   \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ASN1_ERR = writer.PutBoolean(VAL);                                                                                         \
+        SuccessOrExit(ASN1_ERR);                                                                                                   \
+    } while (0);
+
+#define ASN1_ENCODE_BIT_STRING(VAL)                                                                                                \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ASN1_ERR = writer.PutBitString(VAL);                                                                                       \
+        SuccessOrExit(ASN1_ERR);                                                                                                   \
+    } while (0);
+
+#define ASN1_ENCODE_OBJECT_ID(OID)                                                                                                 \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ASN1_ERR = writer.PutObjectId(OID);                                                                                        \
+        SuccessOrExit(ASN1_ERR);                                                                                                   \
+    } while (0);
+
+#define ASN1_ENCODE_STRING(TAG, VAL, LEN)                                                                                          \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ASN1_ERR = writer.PutString(TAG, VAL, LEN);                                                                                \
+        SuccessOrExit(ASN1_ERR);                                                                                                   \
+    } while (0);
+
+#define ASN1_ENCODE_OCTET_STRING(VAL, LEN)                                                                                         \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ASN1_ERR = writer.PutOctetString(VAL, LEN);                                                                                \
+        SuccessOrExit(ASN1_ERR);                                                                                                   \
+    } while (0);
+
+#define ASN1_ENCODE_TIME(VAL)                                                                                                      \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ASN1_ERR = writer.PutTime(VAL);                                                                                            \
+        SuccessOrExit(ASN1_ERR);                                                                                                   \
+    } while (0);
+
+#define ASN1_ENCODE_NULL                                                                                                           \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ASN1_ERR = writer.PutNull();                                                                                               \
+        SuccessOrExit(ASN1_ERR);                                                                                                   \
+    } while (0);
+
+#define ASN1_START_ENCAPSULATED(CLASS, TAG, BIT_STRING_ENCODING)                                                                   \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ASN1_ERR = writer.StartEncapsulatedType(CLASS, TAG, BIT_STRING_ENCODING);                                                  \
+        SuccessOrExit(ASN1_ERR);
+
+#define ASN1_START_OCTET_STRING_ENCAPSULATED ASN1_START_ENCAPSULATED(kASN1TagClass_Universal, kASN1UniversalTag_OctetString, false)
+
+#define ASN1_START_BIT_STRING_ENCAPSULATED ASN1_START_ENCAPSULATED(kASN1TagClass_Universal, kASN1UniversalTag_BitString, true)
+
+#define ASN1_END_ENCAPSULATED                                                                                                      \
+    ASN1_ERR = writer.EndEncapsulatedType();                                                                                       \
+    SuccessOrExit(ASN1_ERR);                                                                                                       \
+    }                                                                                                                              \
+    while (0)

--- a/src/lib/asn1/ASN1OID.cpp
+++ b/src/lib/asn1/ASN1OID.cpp
@@ -1,0 +1,111 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements methods for manipulating for writing
+ *      Abstract Syntax Notation One (ASN.1) Object Identifiers
+ *      (OIDs).
+ *
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <support/DLLUtil.h>
+
+#define ASN1_DEFINE_OID_TABLE
+#define ASN1_DEFINE_OID_NAME_TABLE
+#include <asn1/ASN1.h>
+
+namespace chip {
+namespace ASN1 {
+
+DLL_EXPORT OID ParseObjectID(const uint8_t * encodedOID, uint16_t encodedOIDLen)
+{
+    if (encodedOID == nullptr or encodedOIDLen == 0)
+        return kOID_NotSpecified;
+
+    for (uint32_t i = 0; i < sOIDTableSize; i++)
+        if (encodedOIDLen == sOIDTable[i].EncodedOIDLen && memcmp(encodedOID, sOIDTable[i].EncodedOID, encodedOIDLen) == 0)
+            return sOIDTable[i].EnumVal;
+
+    return kOID_Unknown;
+}
+
+bool GetEncodedObjectID(OID oid, const uint8_t *& encodedOID, uint16_t & encodedOIDLen)
+{
+    for (uint32_t i = 0; i < sOIDTableSize; i++)
+        if (oid == sOIDTable[i].EnumVal)
+        {
+            encodedOID    = sOIDTable[i].EncodedOID;
+            encodedOIDLen = sOIDTable[i].EncodedOIDLen;
+            return true;
+        }
+
+    return false;
+}
+
+OIDCategory GetOIDCategory(OID oid)
+{
+    if (oid == kOID_Unknown)
+        return kOIDCategory_Unknown;
+    if (oid == kOID_NotSpecified)
+        return kOIDCategory_NotSpecified;
+    return (OIDCategory)(oid & kOIDCategory_Mask);
+}
+
+const char * GetOIDName(OID oid)
+{
+    if (oid == kOID_Unknown)
+        return "Unknown";
+    if (oid == kOID_NotSpecified)
+        return "NotSpecified";
+    for (uint32_t i = 0; i < sOIDTableSize; i++)
+        if (oid == sOIDNameTable[i].EnumVal)
+            return sOIDNameTable[i].Name;
+    return "Unknown";
+}
+
+ASN1_ERROR ASN1Reader::GetObjectId(OID & oid)
+{
+    if (Value == nullptr)
+        return ASN1_ERROR_INVALID_STATE;
+    if (ValueLen < 1)
+        return ASN1_ERROR_INVALID_ENCODING;
+    if (mElemStart + mHeadLen + ValueLen > mContainerEnd)
+        return ASN1_ERROR_UNDERRUN;
+    oid = ParseObjectID(Value, ValueLen);
+    return ASN1_NO_ERROR;
+}
+
+ASN1_ERROR ASN1Writer::PutObjectId(OID oid)
+{
+    const uint8_t * encodedOID;
+    uint16_t encodedOIDLen;
+
+    if (!GetEncodedObjectID(oid, encodedOID, encodedOIDLen))
+        return ASN1_ERROR_UNKNOWN_OBJECT_ID;
+
+    return PutObjectId(encodedOID, encodedOIDLen);
+}
+
+} // namespace ASN1
+} // namespace chip

--- a/src/lib/asn1/ASN1Reader.cpp
+++ b/src/lib/asn1/ASN1Reader.cpp
@@ -1,0 +1,481 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements an object for reading Abstract Syntax
+ *      Notation One (ASN.1) encoded data.
+ *
+ */
+
+#include <ctype.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <asn1/ASN1.h>
+
+namespace chip {
+namespace ASN1 {
+
+void ASN1Reader::Init(const uint8_t * buf, uint32_t len)
+{
+    ResetElementState();
+    mBuf              = buf;
+    mBufEnd           = buf + len;
+    mElemStart        = buf;
+    mContainerEnd     = mBufEnd;
+    mNumSavedContexts = 0;
+}
+
+ASN1_ERROR ASN1Reader::Next()
+{
+    if (EndOfContents)
+        return ASN1_END;
+
+    if (IndefiniteLen)
+    {
+        return ASN1_ERROR_UNSUPPORTED_ENCODING;
+    }
+    else
+        mElemStart += (mHeadLen + ValueLen);
+
+    ResetElementState();
+
+    if (mElemStart == mContainerEnd)
+        return ASN1_END;
+
+    return DecodeHead();
+}
+
+ASN1_ERROR ASN1Reader::EnterConstructedType()
+{
+    if (!Constructed)
+        return ASN1_ERROR_INVALID_STATE;
+
+    return EnterContainer(0);
+}
+
+ASN1_ERROR ASN1Reader::ExitConstructedType()
+{
+    return ExitContainer();
+}
+
+ASN1_ERROR ASN1Reader::EnterEncapsulatedType()
+{
+    if (Class != kASN1TagClass_Universal || (Tag != kASN1UniversalTag_OctetString && Tag != kASN1UniversalTag_BitString))
+        return ASN1_ERROR_INVALID_STATE;
+
+    if (Constructed)
+        return ASN1_ERROR_UNSUPPORTED_ENCODING;
+
+    return EnterContainer((Tag == kASN1UniversalTag_BitString) ? 1 : 0);
+}
+
+ASN1_ERROR ASN1Reader::ExitEncapsulatedType()
+{
+    return ExitContainer();
+}
+
+ASN1_ERROR ASN1Reader::EnterContainer(uint32_t offset)
+{
+    if (mNumSavedContexts == kMaxContextDepth)
+        return ASN1_ERROR_MAX_DEPTH_EXCEEDED;
+
+    mSavedContexts[mNumSavedContexts].ElemStart     = mElemStart;
+    mSavedContexts[mNumSavedContexts].HeadLen       = mHeadLen;
+    mSavedContexts[mNumSavedContexts].ValueLen      = ValueLen;
+    mSavedContexts[mNumSavedContexts].IndefiniteLen = IndefiniteLen;
+    mSavedContexts[mNumSavedContexts].ContainerEnd  = mContainerEnd;
+    mNumSavedContexts++;
+
+    mElemStart = Value + offset;
+    if (!IndefiniteLen)
+        mContainerEnd = Value + ValueLen;
+
+    ResetElementState();
+
+    return ASN1_NO_ERROR;
+}
+
+ASN1_ERROR ASN1Reader::ExitContainer()
+{
+    if (mNumSavedContexts == 0)
+        return ASN1_ERROR_INVALID_STATE;
+
+    ASN1ParseContext & prevContext = mSavedContexts[--mNumSavedContexts];
+
+    if (prevContext.IndefiniteLen)
+    {
+        return ASN1_ERROR_UNSUPPORTED_ENCODING;
+    }
+    else
+        mElemStart = prevContext.ElemStart + prevContext.HeadLen + prevContext.ValueLen;
+
+    mContainerEnd = prevContext.ContainerEnd;
+
+    ResetElementState();
+
+    return ASN1_NO_ERROR;
+}
+
+bool ASN1Reader::IsContained() const
+{
+    return mNumSavedContexts > 0;
+}
+
+ASN1_ERROR ASN1Reader::GetInteger(int64_t & val)
+{
+    if (Value == nullptr)
+        return ASN1_ERROR_INVALID_STATE;
+    if (ValueLen < 1)
+        return ASN1_ERROR_INVALID_ENCODING;
+    if (ValueLen > sizeof(int64_t))
+        return ASN1_ERROR_VALUE_OVERFLOW;
+    if (mElemStart + mHeadLen + ValueLen > mContainerEnd)
+        return ASN1_ERROR_UNDERRUN;
+    const uint8_t * p = Value;
+    val               = ((*p & 0x80) == 0) ? 0 : -1;
+    for (uint32_t i = ValueLen; i > 0; i--, p++)
+        val = (val << 8) | *p;
+    return ASN1_NO_ERROR;
+}
+
+ASN1_ERROR ASN1Reader::GetBoolean(bool & val)
+{
+    if (Value == nullptr)
+        return ASN1_ERROR_INVALID_STATE;
+    if (ValueLen != 1)
+        return ASN1_ERROR_INVALID_ENCODING;
+    if (mElemStart + mHeadLen + ValueLen > mContainerEnd)
+        return ASN1_ERROR_UNDERRUN;
+    if (*Value == 0)
+        val = false;
+    else if (*Value == 0xFF)
+        val = true;
+    else
+        return ASN1_ERROR_INVALID_ENCODING;
+    return ASN1_NO_ERROR;
+}
+
+ASN1_ERROR ASN1Reader::GetUTCTime(ASN1UniversalTime & outTime)
+{
+    // Supported Encoding: YYMMDDHHMMSSZ
+
+    if (Value == nullptr)
+        return ASN1_ERROR_INVALID_STATE;
+    if (ValueLen < 1)
+        return ASN1_ERROR_INVALID_ENCODING;
+    if (mElemStart + mHeadLen + ValueLen > mContainerEnd)
+        return ASN1_ERROR_UNDERRUN;
+
+    if (ValueLen != 13 || Value[12] != 'Z')
+        return ASN1_ERROR_UNSUPPORTED_ENCODING;
+
+    for (int i = 0; i < 12; i++)
+        if (!isdigit(Value[i]))
+            return ASN1_ERROR_INVALID_ENCODING;
+
+    outTime.Year   = (Value[0] - '0') * 10 + (Value[1] - '0');
+    outTime.Month  = (Value[2] - '0') * 10 + (Value[3] - '0');
+    outTime.Day    = (Value[4] - '0') * 10 + (Value[5] - '0');
+    outTime.Hour   = (Value[6] - '0') * 10 + (Value[7] - '0');
+    outTime.Minute = (Value[8] - '0') * 10 + (Value[9] - '0');
+    outTime.Second = (Value[10] - '0') * 10 + (Value[11] - '0');
+
+    if (outTime.Year >= 50)
+        outTime.Year += 1900;
+    else
+        outTime.Year += 2000;
+
+    return ASN1_NO_ERROR;
+}
+
+ASN1_ERROR ASN1Reader::GetGeneralizedTime(ASN1UniversalTime & outTime)
+{
+    // Supported Encoding: YYYYMMDDHHMMSSZ
+
+    if (Value == nullptr)
+        return ASN1_ERROR_INVALID_STATE;
+    if (ValueLen < 1)
+        return ASN1_ERROR_INVALID_ENCODING;
+    if (mElemStart + mHeadLen + ValueLen > mContainerEnd)
+        return ASN1_ERROR_UNDERRUN;
+
+    if (ValueLen != 15 || Value[14] != 'Z')
+        return ASN1_ERROR_UNSUPPORTED_ENCODING;
+
+    for (int i = 0; i < 14; i++)
+        if (!isdigit(Value[i]))
+            return ASN1_ERROR_INVALID_ENCODING;
+
+    outTime.Year   = (Value[0] - '0') * 1000 + (Value[1] - '0') * 100 + (Value[2] - '0') * 10 + (Value[3] - '0');
+    outTime.Month  = (Value[4] - '0') * 10 + (Value[5] - '0');
+    outTime.Day    = (Value[6] - '0') * 10 + (Value[7] - '0');
+    outTime.Hour   = (Value[8] - '0') * 10 + (Value[9] - '0');
+    outTime.Minute = (Value[10] - '0') * 10 + (Value[11] - '0');
+    outTime.Second = (Value[12] - '0') * 10 + (Value[13] - '0');
+
+    return ASN1_NO_ERROR;
+}
+
+static uint8_t ReverseBits(uint8_t v)
+{
+    // swap adjacent bits
+    v = ((v >> 1) & 0x55) | ((v & 0x55) << 1);
+    // swap adjacent bit pairs
+    v = ((v >> 2) & 0x33) | ((v & 0x33) << 2);
+    // swap nibbles
+    v = (v >> 4) | (v << 4);
+    return v;
+}
+
+ASN1_ERROR ASN1Reader::GetBitString(uint32_t & outVal)
+{
+    // NOTE: only supports DER encoding.
+
+    if (Value == nullptr)
+        return ASN1_ERROR_INVALID_STATE;
+    if (ValueLen < 1)
+        return ASN1_ERROR_INVALID_ENCODING;
+    if (ValueLen > 5)
+        return ASN1_ERROR_UNSUPPORTED_ENCODING;
+    if (mElemStart + mHeadLen + ValueLen > mContainerEnd)
+        return ASN1_ERROR_UNDERRUN;
+
+    if (ValueLen == 1)
+        outVal = 0;
+    else
+    {
+        outVal    = ReverseBits(Value[1]);
+        int shift = 8;
+        for (uint32_t i = 2; i < ValueLen; i++, shift += 8)
+            outVal |= (ReverseBits(Value[i]) << shift);
+    }
+
+    return ASN1_NO_ERROR;
+}
+
+ASN1_ERROR ASN1Reader::DecodeHead()
+{
+    const uint8_t * p = mElemStart;
+
+    if (p >= mBufEnd)
+        return ASN1_ERROR_UNDERRUN;
+
+    Class       = *p & 0xC0;
+    Constructed = (*p & 0x20) != 0;
+
+    Tag = *p & 0x1F;
+    p++;
+    if (Tag == 0x1F)
+    {
+        Tag = 0;
+        do
+        {
+            if (p >= mBufEnd)
+                return ASN1_ERROR_UNDERRUN;
+            if ((Tag & 0xFE000000) != 0)
+                return ASN1_ERROR_TAG_OVERFLOW;
+            Tag = (Tag << 7) | (*p & 0x7F);
+            p++;
+        } while ((*p & 0x80) != 0);
+    }
+
+    if (p >= mBufEnd)
+        return ASN1_ERROR_UNDERRUN;
+
+    if ((*p & 0x80) == 0)
+    {
+        ValueLen      = *p & 0x7F;
+        IndefiniteLen = false;
+        p++;
+    }
+    else if (*p == 0x80)
+    {
+        ValueLen      = 0;
+        IndefiniteLen = true;
+        p++;
+    }
+    else
+    {
+        ValueLen       = 0;
+        uint8_t lenLen = *p & 0x7F;
+        p++;
+        for (; lenLen > 0; lenLen--, p++)
+        {
+            if (p >= mBufEnd)
+                return ASN1_ERROR_UNDERRUN;
+            if ((ValueLen & 0xFF000000) != 0)
+                return ASN1_ERROR_LENGTH_OVERFLOW;
+            ValueLen = (ValueLen << 8) | *p;
+        }
+        IndefiniteLen = false;
+    }
+
+    mHeadLen = p - mElemStart;
+
+    EndOfContents = (Class == kASN1TagClass_Universal && Tag == 0 && Constructed == false && ValueLen == 0);
+
+    Value = p;
+
+    return ASN1_NO_ERROR;
+}
+
+void ASN1Reader::ResetElementState()
+{
+    Class         = 0;
+    Tag           = 0;
+    Value         = nullptr;
+    ValueLen      = 0;
+    Constructed   = false;
+    IndefiniteLen = false;
+    EndOfContents = false;
+    mHeadLen      = 0;
+}
+
+ASN1_ERROR DumpASN1(ASN1Reader & asn1Parser, const char * prefix, const char * indent)
+{
+    ASN1_ERROR err = ASN1_NO_ERROR;
+
+    if (indent == nullptr)
+        indent = "  ";
+
+    int nestLevel = 0;
+    while (true)
+    {
+        err = asn1Parser.Next();
+        if (err != ASN1_NO_ERROR)
+        {
+            if (err == ASN1_END)
+            {
+                if (asn1Parser.IsContained())
+                {
+                    err = asn1Parser.ExitConstructedType();
+                    if (err != ASN1_NO_ERROR)
+                    {
+                        printf("ASN1Reader::ExitConstructedType() failed: %ld\n", (long) err);
+                        return err;
+                    }
+                    nestLevel--;
+                    continue;
+                }
+                else
+                    break;
+            }
+            printf("ASN1Reader::Next() failed: %ld\n", (long) err);
+            return err;
+        }
+        if (prefix != nullptr)
+            printf("%s", prefix);
+        for (int i = nestLevel; i; i--)
+            printf("%s", indent);
+        if (asn1Parser.IsEndOfContents())
+            printf("END-OF-CONTENTS ");
+        else if (asn1Parser.GetClass() == kASN1TagClass_Universal)
+            switch (asn1Parser.GetTag())
+            {
+            case kASN1UniversalTag_Boolean:
+                printf("BOOLEAN ");
+                break;
+            case kASN1UniversalTag_Integer:
+                printf("INTEGER ");
+                break;
+            case kASN1UniversalTag_BitString:
+                printf("BIT STRING ");
+                break;
+            case kASN1UniversalTag_OctetString:
+                printf("OCTET STRING ");
+                break;
+            case kASN1UniversalTag_Null:
+                printf("NULL ");
+                break;
+            case kASN1UniversalTag_ObjectId:
+                printf("OBJECT IDENTIFIER ");
+                break;
+            case kASN1UniversalTag_ObjectDesc:
+                printf("OBJECT DESCRIPTOR ");
+                break;
+            case kASN1UniversalTag_External:
+                printf("EXTERNAL ");
+                break;
+            case kASN1UniversalTag_Real:
+                printf("REAL ");
+                break;
+            case kASN1UniversalTag_Enumerated:
+                printf("ENUMERATED ");
+                break;
+            case kASN1UniversalTag_Sequence:
+                printf("SEQUENCE ");
+                break;
+            case kASN1UniversalTag_Set:
+                printf("SET ");
+                break;
+            case kASN1UniversalTag_UTF8String:
+            case kASN1UniversalTag_NumericString:
+            case kASN1UniversalTag_PrintableString:
+            case kASN1UniversalTag_T61String:
+            case kASN1UniversalTag_VideotexString:
+            case kASN1UniversalTag_IA5String:
+            case kASN1UniversalTag_GraphicString:
+            case kASN1UniversalTag_VisibleString:
+            case kASN1UniversalTag_GeneralString:
+            case kASN1UniversalTag_UniversalString:
+                printf("STRING ");
+                break;
+            case kASN1UniversalTag_UTCTime:
+            case kASN1UniversalTag_GeneralizedTime:
+                printf("TIME ");
+                break;
+            default:
+                printf("[UNIVERSAL %lu] ", static_cast<unsigned long>(asn1Parser.GetTag()));
+                break;
+            }
+        else if (asn1Parser.GetClass() == kASN1TagClass_Application)
+            printf("[APPLICATION %lu] ", static_cast<unsigned long>(asn1Parser.GetTag()));
+        else if (asn1Parser.GetClass() == kASN1TagClass_ContextSpecific)
+            printf("[%lu] ", static_cast<unsigned long>(asn1Parser.GetTag()));
+        else if (asn1Parser.GetClass() == kASN1TagClass_Private)
+            printf("[PRIVATE %lu] ", static_cast<unsigned long>(asn1Parser.GetTag()));
+
+        if (asn1Parser.IsConstructed())
+            printf("(constructed) ");
+
+        if (asn1Parser.IsIndefiniteLen())
+            printf("Length = indefinite\n");
+        else
+            printf("Length = %ld\n", static_cast<long>(asn1Parser.GetValueLen()));
+
+        if (asn1Parser.IsConstructed())
+        {
+            err = asn1Parser.EnterConstructedType();
+            if (err != ASN1_NO_ERROR)
+            {
+                printf("ASN1Reader::EnterConstructedType() failed: %ld\n", (long) err);
+                return err;
+            }
+            nestLevel++;
+        }
+    }
+
+    return err;
+}
+
+} // namespace ASN1
+} // namespace chip

--- a/src/lib/asn1/ASN1Writer.cpp
+++ b/src/lib/asn1/ASN1Writer.cpp
@@ -1,0 +1,575 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements an object for writing Abstract Syntax
+ *      Notation One (ASN.1) encoded data.
+ *
+ */
+
+#ifndef __STDC_LIMIT_MACROS
+#define __STDC_LIMIT_MACROS
+#endif
+#include <ctype.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <asn1/ASN1.h>
+#include <core/CHIPCore.h>
+#include <core/CHIPEncoding.h>
+#include <core/CHIPTLV.h>
+#include <support/CodeUtils.h>
+
+namespace chip {
+namespace ASN1 {
+
+using namespace chip::Encoding;
+
+enum
+{
+    kLengthFieldReserveSize = 5,
+    kMaxElementLength       = INT32_MAX,
+    kUnkownLength           = -1,
+    kUnknownLengthMarker    = 0xFF
+};
+
+void ASN1Writer::Init(uint8_t * buf, uint32_t maxLen)
+{
+    mBuf                = buf;
+    mWritePoint         = buf;
+    mBufEnd             = buf + maxLen;
+    mBufEnd             = reinterpret_cast<uint8_t *>(reinterpret_cast<uintptr_t>(mBufEnd) & ~3); // align on 32bit boundary
+    mDeferredLengthList = reinterpret_cast<uint8_t **>(mBufEnd);
+}
+
+void ASN1Writer::InitNullWriter(void)
+{
+    mBuf                = nullptr;
+    mWritePoint         = nullptr;
+    mBufEnd             = nullptr;
+    mDeferredLengthList = nullptr;
+}
+
+ASN1_ERROR ASN1Writer::Finalize()
+{
+    if (mBuf != nullptr)
+    {
+        uint8_t * compactPoint = mBuf;
+        uint8_t * spanStart    = mBuf;
+
+        for (uint8_t ** listEntry = reinterpret_cast<uint8_t **>(mBufEnd); listEntry > mDeferredLengthList;)
+        {
+            uint8_t * lenField        = *--listEntry;
+            uint8_t lenFieldFirstByte = *lenField;
+
+            if (lenFieldFirstByte == kUnknownLengthMarker)
+                return ASN1_ERROR_INVALID_STATE;
+
+            uint8_t lenOfLen = (lenFieldFirstByte < 128) ? 1 : (lenFieldFirstByte & 0x7f) + 1;
+
+            uint8_t * spanEnd = lenField + lenOfLen;
+
+            if (spanStart == compactPoint)
+                compactPoint = spanEnd;
+            else
+            {
+                uint32_t spanLen = spanEnd - spanStart;
+                memmove(compactPoint, spanStart, spanLen);
+                compactPoint += spanLen;
+            }
+
+            spanStart = lenField + kLengthFieldReserveSize;
+        }
+
+        if (spanStart > compactPoint)
+        {
+            uint32_t spanLen = mWritePoint - spanStart;
+            memmove(compactPoint, spanStart, spanLen);
+            compactPoint += spanLen;
+        }
+
+        mWritePoint = compactPoint;
+    }
+
+    return ASN1_NO_ERROR;
+}
+
+uint16_t ASN1Writer::GetLengthWritten() const
+{
+    return (mBuf != nullptr) ? mWritePoint - mBuf : 0;
+}
+
+ASN1_ERROR ASN1Writer::PutInteger(int64_t val)
+{
+    uint8_t encodedVal[8];
+    uint8_t valStart, valLen;
+
+    BigEndian::Put64(encodedVal, static_cast<uint64_t>(val));
+
+    for (valStart = 0; valStart < 7; valStart++)
+    {
+        if (encodedVal[valStart] == 0x00 && (encodedVal[valStart + 1] & 0x80) == 0)
+            continue;
+        if (encodedVal[valStart] == 0xFF && (encodedVal[valStart + 1] & 0x80) == 0x80)
+            continue;
+        break;
+    }
+    valLen = 8 - valStart;
+
+    return PutValue(kASN1TagClass_Universal, kASN1UniversalTag_Integer, false, encodedVal + valStart, valLen);
+}
+
+ASN1_ERROR ASN1Writer::PutBoolean(bool val)
+{
+    ASN1_ERROR err;
+
+    // Do nothing for a null writer.
+    VerifyOrExit(mBuf != nullptr, err = ASN1_NO_ERROR);
+
+    err = EncodeHead(kASN1TagClass_Universal, kASN1UniversalTag_Boolean, false, 1);
+    SuccessOrExit(err);
+
+    *mWritePoint++ = (val) ? 0xFF : 0;
+
+exit:
+    return err;
+}
+
+ASN1_ERROR ASN1Writer::PutObjectId(const uint8_t * val, uint16_t valLen)
+{
+    return PutValue(kASN1TagClass_Universal, kASN1UniversalTag_ObjectId, false, val, valLen);
+}
+
+ASN1_ERROR ASN1Writer::PutString(uint32_t tag, const char * val, uint16_t valLen)
+{
+    return PutValue(kASN1TagClass_Universal, tag, false, (const uint8_t *) val, valLen);
+}
+
+ASN1_ERROR ASN1Writer::PutOctetString(const uint8_t * val, uint16_t valLen)
+{
+    return PutValue(kASN1TagClass_Universal, kASN1UniversalTag_OctetString, false, val, valLen);
+}
+
+ASN1_ERROR ASN1Writer::PutOctetString(uint8_t cls, uint32_t tag, const uint8_t * val, uint16_t valLen)
+{
+    return PutValue(cls, tag, false, val, valLen);
+}
+
+ASN1_ERROR ASN1Writer::PutOctetString(uint8_t cls, uint32_t tag, chip::TLV::TLVReader & val)
+{
+    return PutValue(cls, tag, false, val);
+}
+
+static uint8_t ReverseBits(uint8_t v)
+{
+    // swap adjacent bits
+    v = ((v >> 1) & 0x55) | ((v & 0x55) << 1);
+    // swap adjacent bit pairs
+    v = ((v >> 2) & 0x33) | ((v & 0x33) << 2);
+    // swap nibbles
+    v = (v >> 4) | (v << 4);
+    return v;
+}
+
+static uint8_t HighestBit(uint32_t v)
+{
+    uint32_t highestBit = 0;
+
+    if (v > 0xFFFF)
+    {
+        highestBit = 16;
+        v >>= 16;
+    }
+    if (v > 0xFF)
+    {
+        highestBit |= 8;
+        v >>= 8;
+    }
+    if (v > 0xF)
+    {
+        highestBit |= 4;
+        v >>= 4;
+    }
+    if (v > 0x3)
+    {
+        highestBit |= 2;
+        v >>= 2;
+    }
+    highestBit |= (v >> 1);
+
+    return highestBit;
+}
+
+ASN1_ERROR ASN1Writer::PutBitString(uint32_t val)
+{
+    ASN1_ERROR err;
+    uint8_t len;
+
+    // Do nothing for a null writer.
+    VerifyOrExit(mBuf != nullptr, err = ASN1_NO_ERROR);
+
+    if (val == 0)
+        len = 1;
+    else if (val < 256)
+        len = 2;
+    else if (val < 65536)
+        len = 3;
+    else if (val < (1 << 24))
+        len = 4;
+    else
+        len = 5;
+
+    err = EncodeHead(kASN1TagClass_Universal, kASN1UniversalTag_BitString, false, len);
+    SuccessOrExit(err);
+
+    if (val == 0)
+        mWritePoint[0] = 0;
+    else
+    {
+        mWritePoint[1] = ReverseBits(static_cast<uint8_t>(val));
+        if (len >= 3)
+        {
+            val >>= 8;
+            mWritePoint[2] = ReverseBits(static_cast<uint8_t>(val));
+            if (len >= 4)
+            {
+                val >>= 8;
+                mWritePoint[3] = ReverseBits(static_cast<uint8_t>(val));
+                if (len == 5)
+                {
+                    val >>= 8;
+                    mWritePoint[4] = ReverseBits(static_cast<uint8_t>(val));
+                }
+            }
+        }
+        mWritePoint[0] = 7 - HighestBit(val);
+    }
+
+    mWritePoint += len;
+
+exit:
+    return err;
+}
+
+ASN1_ERROR ASN1Writer::PutBitString(uint8_t unusedBitCount, const uint8_t * encodedBits, uint16_t encodedBitsLen)
+{
+    ASN1_ERROR err;
+
+    // Do nothing for a null writer.
+    VerifyOrExit(mBuf != nullptr, err = ASN1_NO_ERROR);
+
+    err = EncodeHead(kASN1TagClass_Universal, kASN1UniversalTag_BitString, false, encodedBitsLen + 1);
+    SuccessOrExit(err);
+
+    *mWritePoint++ = unusedBitCount;
+
+    memcpy(mWritePoint, encodedBits, encodedBitsLen);
+    mWritePoint += encodedBitsLen;
+
+exit:
+    return err;
+}
+
+ASN1_ERROR ASN1Writer::PutBitString(uint8_t unusedBitCount, chip::TLV::TLVReader & encodedBits)
+{
+    ASN1_ERROR err;
+    uint32_t encodedBitsLen;
+
+    // Do nothing for a null writer.
+    VerifyOrExit(mBuf != nullptr, err = ASN1_NO_ERROR);
+
+    encodedBitsLen = encodedBits.GetLength();
+
+    err = EncodeHead(kASN1TagClass_Universal, kASN1UniversalTag_BitString, false, encodedBitsLen + 1);
+    SuccessOrExit(err);
+
+    *mWritePoint++ = unusedBitCount;
+
+    encodedBits.GetBytes(mWritePoint, encodedBitsLen);
+    mWritePoint += encodedBitsLen;
+
+exit:
+    return err;
+}
+
+static void itoa2(uint32_t val, uint8_t * buf)
+{
+    buf[1] = '0' + (val % 10);
+    val /= 10;
+    buf[0] = '0' + (val % 10);
+}
+
+ASN1_ERROR ASN1Writer::PutTime(const ASN1UniversalTime & val)
+{
+    uint8_t buf[15];
+
+    itoa2(val.Year / 100, buf);
+    itoa2(val.Year, buf + 2);
+    itoa2(val.Month, buf + 4);
+    itoa2(val.Day, buf + 6);
+    itoa2(val.Hour, buf + 8);
+    itoa2(val.Minute, buf + 10);
+    itoa2(val.Second, buf + 12);
+    buf[14] = 'Z';
+
+    // X.509/RFC5280 mandates that times before 2050 UTC must be encoded as ASN.1 UTCTime values, while
+    // times equal or greater than 2050 must be encoded as GeneralizedTime values.  The only difference
+    // (in the context of X.509 DER) is that GeneralizedTimes are encoded with a 4 digit year, while
+    // UTCTimes are encoded with a two-digit year.
+    //
+    if (val.Year >= 2050)
+        return PutValue(kASN1TagClass_Universal, kASN1UniversalTag_GeneralizedTime, false, buf, 15);
+    else
+        return PutValue(kASN1TagClass_Universal, kASN1UniversalTag_UTCTime, false, buf + 2, 13);
+}
+
+ASN1_ERROR ASN1Writer::PutNull()
+{
+    return EncodeHead(kASN1TagClass_Universal, kASN1UniversalTag_Null, false, 0);
+}
+
+ASN1_ERROR ASN1Writer::StartConstructedType(uint8_t cls, uint32_t tag)
+{
+    return EncodeHead(cls, tag, true, kUnkownLength);
+}
+
+ASN1_ERROR ASN1Writer::EndConstructedType()
+{
+    return WriteDeferredLength();
+}
+
+ASN1_ERROR ASN1Writer::StartEncapsulatedType(uint8_t cls, uint32_t tag, bool bitStringEncoding)
+{
+    ASN1_ERROR err;
+
+    // Do nothing for a null writer.
+    VerifyOrExit(mBuf != nullptr, err = ASN1_NO_ERROR);
+
+    err = EncodeHead(cls, tag, false, kUnkownLength);
+    SuccessOrExit(err);
+
+    // If the encapsulating type is BIT STRING, encode the unused bit count field.  Since the BIT
+    // STRING contains an ASN.1 DER encoding, and ASN.1 DER encodings are always multiples of 8 bits,
+    // the unused bit count is always 0.
+    if (bitStringEncoding)
+    {
+        if (mWritePoint == reinterpret_cast<uint8_t *>(mDeferredLengthList))
+            return ASN1_ERROR_OVERFLOW;
+        *mWritePoint++ = 0;
+    }
+
+exit:
+    return err;
+}
+
+ASN1_ERROR ASN1Writer::EndEncapsulatedType()
+{
+    return WriteDeferredLength();
+}
+
+ASN1_ERROR ASN1Writer::PutValue(uint8_t cls, uint32_t tag, bool isConstructed, const uint8_t * val, uint16_t valLen)
+{
+    ASN1_ERROR err;
+
+    // Do nothing for a null writer.
+    VerifyOrExit(mBuf != nullptr, err = ASN1_NO_ERROR);
+
+    err = EncodeHead(cls, tag, isConstructed, valLen);
+    SuccessOrExit(err);
+
+    memcpy(mWritePoint, val, valLen);
+    mWritePoint += valLen;
+
+exit:
+    return err;
+}
+
+ASN1_ERROR ASN1Writer::PutValue(uint8_t cls, uint32_t tag, bool isConstructed, chip::TLV::TLVReader & val)
+{
+    ASN1_ERROR err;
+    uint32_t valLen;
+
+    // Do nothing for a null writer.
+    VerifyOrExit(mBuf != nullptr, err = ASN1_NO_ERROR);
+
+    valLen = val.GetLength();
+
+    err = EncodeHead(cls, tag, isConstructed, valLen);
+    SuccessOrExit(err);
+
+    val.GetBytes(mWritePoint, valLen);
+    mWritePoint += valLen;
+
+exit:
+    return err;
+}
+
+ASN1_ERROR ASN1Writer::EncodeHead(uint8_t cls, uint32_t tag, bool isConstructed, int32_t len)
+{
+    ASN1_ERROR err = ASN1_NO_ERROR;
+    uint8_t bytesForLen;
+    uint32_t totalLen;
+
+    // Do nothing for a null writer.
+    VerifyOrExit(mBuf != nullptr, err = ASN1_NO_ERROR);
+
+    // Only tags <= 31 supported. The implication of this is that encoded tags are exactly 1 byte long.
+    VerifyOrExit(tag <= 0x1F, err = ASN1_ERROR_UNSUPPORTED_ENCODING);
+
+    // Only positive and kUnkownLength values are supported for len input.
+    VerifyOrExit(len >= 0 || len == kUnkownLength, err = ASN1_ERROR_UNSUPPORTED_ENCODING);
+
+    // Compute the number of bytes required to encode the length.
+    bytesForLen = BytesForLength(len);
+
+    // If the element length is unknown, allocate a new entry in the deferred-length list.
+    //
+    // The deferred-length list is a list of "pointers" (represented as offsets into mBuf)
+    // to length fields for which the length of the element was unknown at the time the element
+    // head was written. Examples include constructed types such as SEQUENCE and SET, as well
+    // non-constructed types that encapsulate other ASN.1 types (e.g. OCTET STRINGS that contain
+    // BER/DER encodings). The final lengths are filled in later, at the time the encoding is
+    // complete (e.g. when EndConstructed() is called).
+    //
+    if (len == kUnkownLength)
+        mDeferredLengthList--;
+
+    // Make sure there's enough space to encode the entire value without bumping into the deferred length
+    // list at the end of the buffer.
+    totalLen = 1 + bytesForLen + (len != kUnkownLength ? len : 0);
+    VerifyOrExit((mWritePoint + totalLen) <= reinterpret_cast<uint8_t *>(mDeferredLengthList), err = ASN1_ERROR_OVERFLOW);
+
+    // Write the tag byte.
+    *mWritePoint++ = cls | (isConstructed ? 0x20 : 0) | tag;
+
+    // Encode the length if it is known.
+    if (len != kUnkownLength)
+        EncodeLength(mWritePoint, bytesForLen, len);
+
+    // ... otherwise place a marker in the first byte of the length to indicate that the length is unknown
+    // and save a pointer to the length field in the deferred-length list.
+    else
+    {
+        *mWritePoint         = kUnknownLengthMarker;
+        *mDeferredLengthList = mWritePoint;
+    }
+
+    mWritePoint += bytesForLen;
+
+exit:
+    return err;
+}
+
+ASN1_ERROR ASN1Writer::WriteDeferredLength()
+{
+    ASN1_ERROR err = ASN1_NO_ERROR;
+    uint8_t ** listEntry;
+    uint32_t lenAdj;
+
+    // Do nothing for a null writer.
+    VerifyOrExit(mBuf != nullptr, err = ASN1_NO_ERROR);
+
+    lenAdj = kLengthFieldReserveSize;
+
+    // Scan the deferred-length list in reverse order looking for the most recent entry where
+    // the length is still unknown. This entry represents the "container" element whose encoding
+    // is now complete.
+    for (listEntry = mDeferredLengthList; listEntry < reinterpret_cast<uint8_t **>(mBufEnd); listEntry++)
+    {
+        // Get a pointer to the deferred-length field.
+        uint8_t * lenField = *listEntry;
+
+        // Get the first byte of the length field.
+        uint8_t lenFieldFirstByte = *lenField;
+
+        // If the length is marked as unknown...
+        if (lenFieldFirstByte == kUnknownLengthMarker)
+        {
+            // Compute the final length of the element's value (3 = bytes reserved for length).
+            uint32_t elemLen = (mWritePoint - lenField) - lenAdj;
+
+            // Return an error if the length exceeds the maximum value that can be encoded in the
+            // space reserved for the length.
+            VerifyOrExit(elemLen <= kMaxElementLength, err = ASN1_ERROR_LENGTH_OVERFLOW);
+
+            // Encode the final length of the element, overwriting the unknown length marker
+            // in the process.  Note that the number of bytes consumed by the final length field
+            // may be smaller than the space that was reserved for the field.  This will be fixed
+            // up when the Finalize() method is called.
+            uint8_t bytesForLen = BytesForLength(static_cast<int32_t>(elemLen));
+            EncodeLength(lenField, bytesForLen, elemLen);
+
+            ExitNow(err = ASN1_NO_ERROR);
+        }
+        else
+        {
+            uint8_t bytesForLen = (lenFieldFirstByte < 128) ? 1 : (lenFieldFirstByte & 0x7f) + 1;
+            lenAdj += (kLengthFieldReserveSize - bytesForLen);
+        }
+    }
+
+    err = ASN1_ERROR_INVALID_STATE;
+
+exit:
+    return err;
+}
+
+/**
+ * Returns the number of bytes required to encode the length value.
+ *
+ * @param[in]   len     Parameter, which encoding length to be calculated.
+ *
+ * @return number of bytes required to encode the length value.
+ */
+uint8_t ASN1Writer::BytesForLength(int32_t len)
+{
+    if (len == kUnkownLength)
+        return kLengthFieldReserveSize;
+    if (len < 128)
+        return 1;
+    if (len < 256)
+        return 2;
+    if (len < 65536)
+        return 3;
+    if (len < (1 << 24))
+        return 4;
+    return 5;
+}
+
+void ASN1Writer::EncodeLength(uint8_t * buf, uint8_t bytesForLen, int32_t lenToEncode)
+{
+    if (bytesForLen == 1)
+        buf[0] = static_cast<uint8_t>(lenToEncode);
+    else
+    {
+        --bytesForLen;
+        buf[0] = 0x80 | bytesForLen;
+        do
+        {
+            buf[bytesForLen] = static_cast<uint8_t>(lenToEncode);
+            lenToEncode >>= 8;
+        } while (--bytesForLen);
+    }
+}
+
+} // namespace ASN1
+} // namespace chip

--- a/src/lib/asn1/BUILD.gn
+++ b/src/lib/asn1/BUILD.gn
@@ -28,24 +28,19 @@ source_set("asn1oid_header") {
   deps = [ ":gen_asn1oid" ]
 }
 
-asn1_headers = [
-  "ASN1Config.h",
-  "ASN1Error.h",
-  "ASN1.h",
-  "ASN1Macros.h",
-]
-
 static_library("asn1") {
   output_name = "libASN1"
 
   sources = [
+    "ASN1.h",
+    "ASN1Config.h",
     "ASN1Error.cpp",
+    "ASN1Error.h",
+    "ASN1Macros.h",
     "ASN1OID.cpp",
     "ASN1Reader.cpp",
     "ASN1Writer.cpp",
   ]
-
-  public = asn1_headers
 
   public_deps = [
     ":asn1oid_header",
@@ -59,10 +54,4 @@ static_library("asn1") {
     "${chip_root}/src/lib:includes",
     "${chip_root}/src/system:system_config",
   ]
-}
-
-copy("asn1_headers") {
-  sources = asn1_headers
-
-  outputs = [ "${root_gen_dir}/include/asn1/{{source_file_part}}" ]
 }

--- a/src/lib/asn1/BUILD.gn
+++ b/src/lib/asn1/BUILD.gn
@@ -1,0 +1,68 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+import("//build_overrides/nlassert.gni")
+
+action("gen_asn1oid") {
+  script = "gen_asn1oid.py"
+  asn1oid_file = "${root_gen_dir}/include/asn1/ASN1OID.h"
+  outputs = [ asn1oid_file ]
+  args = [ "--output_file=" + rebase_path(asn1oid_file, root_build_dir) ]
+}
+
+source_set("asn1oid_header") {
+  sources = get_target_outputs(":gen_asn1oid")
+
+  deps = [ ":gen_asn1oid" ]
+}
+
+asn1_headers = [
+  "ASN1Config.h",
+  "ASN1Error.h",
+  "ASN1.h",
+  "ASN1Macros.h",
+]
+
+static_library("asn1") {
+  output_name = "libASN1"
+
+  sources = [
+    "ASN1Error.cpp",
+    "ASN1OID.cpp",
+    "ASN1Reader.cpp",
+    "ASN1Writer.cpp",
+  ]
+
+  public = asn1_headers
+
+  public_deps = [
+    ":asn1oid_header",
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/support",
+    "${nlassert_root}:nlassert",
+  ]
+
+  public_configs = [
+    "${chip_root}/src:includes",
+    "${chip_root}/src/lib:includes",
+    "${chip_root}/src/system:system_config",
+  ]
+}
+
+copy("asn1_headers") {
+  sources = asn1_headers
+
+  outputs = [ "${root_gen_dir}/include/asn1/{{source_file_part}}" ]
+}

--- a/src/lib/asn1/gen_asn1oid.py
+++ b/src/lib/asn1/gen_asn1oid.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python
+
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#    Copyright (c) 2019 Google LLC.
+#    Copyright (c) 2013-2017 Nest Labs, Inc.
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+#
+#    @file
+#      This file implements a Python script to generate a C/C++ header
+#      for individual ASN1 Object IDs (OIDs) that are used in CHIP
+#      TLV encodings (notably the CHIP Certificate object).
+#
+
+from __future__ import absolute_import
+from __future__ import print_function
+import optparse
+import sys
+
+def identity(n):
+    return n
+
+
+# OID labels
+ansi_X9_62              = identity
+certicom                = identity
+characteristicTwo       = identity
+chip                    = identity
+curve                   = identity
+curves                  = identity
+digest_algorithm        = identity
+dod                     = identity
+ds                      = identity
+enterprise              = identity
+organization            = identity
+internet                = identity
+iso                     = identity
+itu_t                   = identity
+joint_iso_ccitt         = identity
+keyType                 = identity
+mechanisms              = identity
+member_body             = identity
+pkcs1                   = identity
+pkcs                    = identity
+pkix                    = identity
+prime                   = identity
+private                 = identity
+rsadsi                  = identity
+schemes                 = identity
+security                = identity
+signatures              = identity
+us                      = identity
+zigbee                  = identity
+
+# OID Categories
+oidCategories = [
+    ( "PubKeyAlgo",         0x0100 ),
+    ( "SigAlgo",            0x0200 ),
+    ( "AttributeType",      0x0300 ),
+    ( "EllipticCurve",      0x0400 ),
+    ( "Extension",          0x0500 ),
+    ( "KeyPurpose",         0x0600 )
+]
+
+# Table of well-known ASN.1 object IDs
+#
+oids = [
+
+    # !!! WARNING !!!
+    #
+    # The enumerated values associated with individual object IDs are used in CHIP TLV encodings (notably the CHIP Certificate object).
+    # Because of this, the Enum Values assigned to object IDs in this table MUST NOT BE CHANGED once in use.
+
+
+    #                                              Enum
+    # Category          Name                       Value    Object ID
+    # ----------------- -------------------------- -------- ------------------------------------------------------------------------------------------------
+
+    # Public Key Algorithms
+    ( "PubKeyAlgo",     "ECPublicKey",             1,       [ iso(1), member_body(2), us(840), ansi_X9_62(10045), keyType(2), 1 ]                           ),
+
+    # Signature Algorithms
+    # RFC 3279
+    ( "SigAlgo",        "ECDSAWithSHA256",         1,       [ iso(1), member_body(2), us(840), ansi_X9_62(10045), signatures(4), 3, 2 ]                     ),
+
+    # X.509 Distinguished Name Attribute Types
+    #   WARNING -- Assign no values higher than 127.
+    ( "AttributeType",  "CommonName",              1,       [ joint_iso_ccitt(2), ds(5), 4, 3 ]                                                             ),
+    ( "AttributeType",  "Surname",                 2,       [ joint_iso_ccitt(2), ds(5), 4, 4 ]                                                             ),
+    ( "AttributeType",  "SerialNumber",            3,       [ joint_iso_ccitt(2), ds(5), 4, 5 ]                                                             ),
+    ( "AttributeType",  "CountryName",             4,       [ joint_iso_ccitt(2), ds(5), 4, 6 ]                                                             ),
+    ( "AttributeType",  "LocalityName",            5,       [ joint_iso_ccitt(2), ds(5), 4, 7 ]                                                             ),
+    ( "AttributeType",  "StateOrProvinceName",     6,       [ joint_iso_ccitt(2), ds(5), 4, 8 ]                                                             ),
+    ( "AttributeType",  "OrganizationName",        7,       [ joint_iso_ccitt(2), ds(5), 4, 10 ]                                                            ),
+    ( "AttributeType",  "OrganizationalUnitName",  8,       [ joint_iso_ccitt(2), ds(5), 4, 11 ]                                                            ),
+    ( "AttributeType",  "Title",                   9,       [ joint_iso_ccitt(2), ds(5), 4, 12 ]                                                            ),
+    ( "AttributeType",  "Name",                    10,      [ joint_iso_ccitt(2), ds(5), 4, 41 ]                                                            ),
+    ( "AttributeType",  "GivenName",               11,      [ joint_iso_ccitt(2), ds(5), 4, 42 ]                                                            ),
+    ( "AttributeType",  "Initials",                12,      [ joint_iso_ccitt(2), ds(5), 4, 43 ]                                                            ),
+    ( "AttributeType",  "GenerationQualifier",     13,      [ joint_iso_ccitt(2), ds(5), 4, 44 ]                                                            ),
+    ( "AttributeType",  "DNQualifier",             14,      [ joint_iso_ccitt(2), ds(5), 4, 46 ]                                                            ),
+    ( "AttributeType",  "Pseudonym",               15,      [ joint_iso_ccitt(2), ds(5), 4, 65 ]                                                            ),
+    ( "AttributeType",  "DomainComponent",         16,      [ itu_t(0), 9, 2342, 19200300, 100, 1, 25 ]                                                     ),
+    ( "AttributeType",  "ChipNodeId",              17,      [ iso(1), organization(3), dod(6), internet(1), private(4), enterprise(1), zigbee(37244), chip(1), 1 ] ),
+    ( "AttributeType",  "ChipCAId",                18,      [ iso(1), organization(3), dod(6), internet(1), private(4), enterprise(1), zigbee(37244), chip(1), 2 ] ),
+    ( "AttributeType",  "ChipSoftwarePublisherId", 19,      [ iso(1), organization(3), dod(6), internet(1), private(4), enterprise(1), zigbee(37244), chip(1), 3 ] ),
+
+    # Elliptic Curves
+    ( "EllipticCurve",  "prime256v1",              1,       [ iso(1), member_body(2), us(840), ansi_X9_62(10045), curves(3), prime(1), 7 ]                  ),
+
+    # Certificate Extensions
+    ( "Extension",      "AuthorityKeyIdentifier",  1,       [ joint_iso_ccitt(2), ds(5), 29, 35 ]                                                           ),
+    ( "Extension",      "SubjectKeyIdentifier",    2,       [ joint_iso_ccitt(2), ds(5), 29, 14 ]                                                           ),
+    ( "Extension",      "KeyUsage",                3,       [ joint_iso_ccitt(2), ds(5), 29, 15 ]                                                           ),
+    ( "Extension",      "BasicConstraints",        4,       [ joint_iso_ccitt(2), ds(5), 29, 19 ]                                                           ),
+    ( "Extension",      "ExtendedKeyUsage",        5,       [ joint_iso_ccitt(2), ds(5), 29, 37 ]                                                           ),
+
+    # Key Purposes
+    ( "KeyPurpose",     "ServerAuth",              1,       [ iso(1), organization(3), dod(6), internet(1), security(5), mechanisms(5), pkix(7), 3, 1 ]     ),
+    ( "KeyPurpose",     "ClientAuth",              2,       [ iso(1), organization(3), dod(6), internet(1), security(5), mechanisms(5), pkix(7), 3, 2 ]     ),
+    ( "KeyPurpose",     "CodeSigning",             3,       [ iso(1), organization(3), dod(6), internet(1), security(5), mechanisms(5), pkix(7), 3, 3 ]     ),
+    ( "KeyPurpose",     "EmailProtection",         4,       [ iso(1), organization(3), dod(6), internet(1), security(5), mechanisms(5), pkix(7), 3, 4 ]     ),
+    ( "KeyPurpose",     "TimeStamping",            5,       [ iso(1), organization(3), dod(6), internet(1), security(5), mechanisms(5), pkix(7), 3, 8 ]     ),
+    ( "KeyPurpose",     "OCSPSigning",             6,       [ iso(1), organization(3), dod(6), internet(1), security(5), mechanisms(5), pkix(7), 3, 9 ]     ),
+]
+
+
+def encodeOID(oid):
+
+    assert len(oid) >= 2
+
+    oid = [ (oid[0]*40 + oid[1]) ] + oid[2:]
+
+    encodedOID = []
+    for val in oid:
+        val, byte = divmod(val, 128)
+        seg = [ byte ]
+        while val > 0:
+            val, byte = divmod(val, 128)
+            seg.insert(0, byte + 0x80)
+        encodedOID += (seg)
+
+    return encodedOID
+
+
+TEMPLATE = '''/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2019 Google LLC.
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the \"License\");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an \"AS IS\" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+/**
+ *    @file
+ *      ASN.1 Object ID Definitions
+ *
+ *      !!! WARNING !!! WARNING !!! WARNING !!!
+ *
+ *      DO NOT EDIT THIS FILE! This file is generated by the
+ *      gen-oid-table.py script.
+ *
+ *      To make changes, edit the script and re-run it to generate
+ *      this file.
+ *
+ */
+
+#pragma once
+
+enum OIDCategory
+%(oid_category_enums)s
+
+typedef uint16_t OID;
+
+enum
+%(oid_enums)s
+
+struct OIDTableEntry
+{
+    OID EnumVal;
+    const uint8_t *EncodedOID;
+    uint16_t EncodedOIDLen;
+};
+
+struct OIDNameTableEntry
+{
+    OID EnumVal;
+    const char *Name;
+};
+
+extern const OIDTableEntry sOIDTable[];
+extern const OIDNameTableEntry sOIDNameTable[];
+extern const size_t sOIDTableSize;
+
+#ifdef ASN1_DEFINE_OID_TABLE
+%(oid_utf8_strings)s
+
+const OIDTableEntry sOIDTable[] =
+%(oid_table)s
+
+const size_t sOIDTableSize = sizeof(sOIDTable) / sizeof(OIDTableEntry);
+
+#endif // ASN1_DEFINE_OID_TABLE
+
+#ifdef ASN1_DEFINE_OID_NAME_TABLE
+
+const OIDNameTableEntry sOIDNameTable[] =
+%(oid_name_table)s
+
+#endif // ASN1_DEFINE_OID_NAME_TABLE
+'''
+
+oid_category_enums ="{\n"
+for (catName, catEnum) in oidCategories:
+    oid_category_enums +="    kOIDCategory_%s = 0x%04X,\n" % (catName, catEnum)
+oid_category_enums +='''
+    kOIDCategory_NotSpecified = 0,
+    kOIDCategory_Unknown = 0x0F00,
+    kOIDCategory_Mask = 0x0F00
+};'''
+
+oid_enums ="{\n"
+for (catName, catEnum) in oidCategories:
+    for (oidCatName, oidName, oidEnum, oid) in oids:
+        if (oidCatName == catName):
+            oid_enums +="    kOID_%s_%s = 0x%04X,\n" % (catName, oidName, catEnum + oidEnum)
+    oid_enums +="\n"
+oid_enums +='''    kOID_NotSpecified = 0,
+    kOID_Unknown = 0xFFFF,
+    kOID_EnumMask = 0x00FF
+};'''
+
+oid_utf8_strings ="\n"
+for (catName, oidName, oidEnum, oid) in oids:
+    oid_utf8_strings +="static const uint8_t sOID_%s_%s[] = { %s };\n" % (catName, oidName, ", ".join([ "0x%02X" % (x) for x in encodeOID(oid) ]))
+
+oid_table ="{\n"
+for (catName, oidName, oidEnum, oid) in oids:
+    oid_table +="    { kOID_%s_%s, sOID_%s_%s, sizeof(sOID_%s_%s) },\n" % (catName, oidName, catName, oidName, catName, oidName)
+oid_table +="    { kOID_NotSpecified, NULL, 0 }\n};"
+
+oid_name_table ="{\n"
+for (catName, oidName, oidEnum, oid) in oids:
+    oid_name_table +="    { kOID_%s_%s, \"%s\" },\n" % (catName, oidName, oidName)
+oid_name_table +="    { kOID_NotSpecified, NULL }\n};"
+
+
+def main(argv):
+  parser = optparse.OptionParser()
+
+  parser.add_option('--output_file')
+
+  options, _ = parser.parse_args(argv)
+
+  template_args = {
+          'oid_category_enums': oid_category_enums,
+          'oid_enums': oid_enums,
+          'oid_utf8_strings': oid_utf8_strings,
+          'oid_table': oid_table,
+          'oid_name_table': oid_name_table,
+  }
+
+  with open(options.output_file, 'w') as asn1oid_file:
+      asn1oid_file.write(TEMPLATE % template_args)
+
+  return 0
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/src/lib/asn1/tests/BUILD.gn
+++ b/src/lib/asn1/tests/BUILD.gn
@@ -1,0 +1,33 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+import("//build_overrides/nlunit_test.gni")
+
+import("${chip_root}/build/chip/chip_test_suite.gni")
+
+chip_test_suite("tests") {
+  output_name = "libASN1Tests"
+
+  sources = [ "TestASN1.cpp" ]
+
+  public_deps = [
+    "${chip_root}/src/lib/asn1",
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/platform",
+    "${nlunit_test_root}:nlunit-test",
+  ]
+
+  tests = [ "TestASN1" ]
+}

--- a/src/lib/asn1/tests/TestASN1.cpp
+++ b/src/lib/asn1/tests/TestASN1.cpp
@@ -1,0 +1,397 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a process to effect a functional test for
+ *      the CHIP Abstract Syntax Notifcation One (ASN1) encode and
+ *      decode interfaces.
+ *
+ */
+
+#include "TestASN1.h"
+
+#include <nlunit-test.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <asn1/ASN1.h>
+#include <asn1/ASN1Macros.h>
+#include <asn1/ASN1OID.h>
+
+using namespace chip;
+using namespace chip::ASN1;
+
+enum
+{
+    kTestVal_01_Bool      = false,
+    kTestVal_02_Bool      = true,
+    kTestVal_03_BitString = 0x0,
+    kTestVal_04_BitString = 0x1,
+    kTestVal_05_BitString = 0x3,
+    kTestVal_06_BitString = 0x17,
+    kTestVal_07_BitString = 0x37,
+    kTestVal_08_BitString = 0x187,
+    kTestVal_09_BitString = 0x3E7,
+    kTestVal_10_Int       = 0,
+    kTestVal_11_Int       = 1,
+    kTestVal_12_Int       = -1,
+    kTestVal_13_Int       = 0xFF00FF,
+    kTestVal_14_Int       = -0xFF00FF,
+    kTestVal_15_Int       = INT32_MAX,
+    kTestVal_16_Int       = INT32_MIN,
+    kTestVal_17_Int       = INT64_MAX,
+    kTestVal_18_Int       = INT64_MIN,
+    kTestVal_19_OID       = kOID_AttributeType_OrganizationName,
+    kTestVal_23_OID       = kOID_AttributeType_CommonName,
+    kTestVal_24_Int       = 42,
+};
+
+// clang-format off
+static uint8_t kTestVal_20_OctetString[]        = { 0x01, 0x03, 0x05, 0x07, 0x10, 0x30, 0x50, 0x70, 0x00 };
+static const char * kTestVal_21_PrintableString = "Sudden death in Venice";
+static const char * kTestVal_22_UTFString       = "Ond bra\xCC\x8A""d do\xCC\x88""d i Venedig";
+// clang-format on
+
+// Manually copied from ASN1OID.h for testing.
+static const uint8_t sOID_AttributeType_ChipNodeId[]         = { 0x2B, 0x06, 0x01, 0x04, 0x01, 0x82, 0xA2, 0x7C, 0x01, 0x01 };
+static const uint8_t sOID_SigAlgo_ECDSAWithSHA256[]          = { 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x04, 0x03, 0x02 };
+static const uint8_t sOID_EllipticCurve_prime256v1[]         = { 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07 };
+static const uint8_t sOID_Extension_AuthorityKeyIdentifier[] = { 0x55, 0x1D, 0x23 };
+static const uint8_t sOID_Extension_BasicConstraints[]       = { 0x55, 0x1D, 0x13 };
+static const uint8_t sOID_KeyPurpose_ServerAuth[]            = { 0x2B, 0x06, 0x01, 0x05, 0x05, 0x07, 0x03, 0x01 };
+
+uint8_t TestASN1_EncodedData[] = {
+    0x30, 0x81, 0xBA, 0x01, 0x01, 0x00, 0x01, 0x01, 0xFF, 0x31, 0x00, 0x03, 0x01, 0x00, 0x03, 0x02, 0x07, 0x80, 0x03, 0x02, 0x06,
+    0xC0, 0x30, 0x16, 0x30, 0x0F, 0x30, 0x08, 0x03, 0x02, 0x03, 0xE8, 0x03, 0x02, 0x02, 0xEC, 0x03, 0x03, 0x07, 0xE1, 0x80, 0x03,
+    0x03, 0x06, 0xE7, 0xC0, 0x02, 0x01, 0x00, 0x02, 0x01, 0x01, 0x02, 0x01, 0xFF, 0x02, 0x04, 0x00, 0xFF, 0x00, 0xFF, 0x02, 0x04,
+    0xFF, 0x00, 0xFF, 0x01, 0x02, 0x04, 0x7F, 0xFF, 0xFF, 0xFF, 0x02, 0x04, 0x80, 0x00, 0x00, 0x00, 0x02, 0x08, 0x7F, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x02, 0x08, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x06, 0x03, 0x55, 0x04, 0x0A, 0x04,
+    0x09, 0x01, 0x03, 0x05, 0x07, 0x10, 0x30, 0x50, 0x70, 0x00, 0x04, 0x01, 0x01, 0x04, 0x00, 0x1B, 0x00, 0x13, 0x16, 0x53, 0x75,
+    0x64, 0x64, 0x65, 0x6E, 0x20, 0x64, 0x65, 0x61, 0x74, 0x68, 0x20, 0x69, 0x6E, 0x20, 0x56, 0x65, 0x6E, 0x69, 0x63, 0x65, 0x0C,
+    0x1A, 0x4F, 0x6E, 0x64, 0x20, 0x62, 0x72, 0x61, 0xCC, 0x8A, 0x64, 0x20, 0x64, 0x6F, 0xCC, 0x88, 0x64, 0x20, 0x69, 0x20, 0x56,
+    0x65, 0x6E, 0x65, 0x64, 0x69, 0x67, 0x04, 0x0D, 0x30, 0x0B, 0x06, 0x03, 0x55, 0x04, 0x03, 0x03, 0x04, 0x00, 0x02, 0x01, 0x2A
+};
+
+static ASN1_ERROR EncodeASN1TestData(ASN1Writer & writer)
+{
+    ASN1_ERROR err = ASN1_NO_ERROR;
+
+    ASN1_START_SEQUENCE
+    {
+        ASN1_ENCODE_BOOLEAN(kTestVal_01_Bool);
+        ASN1_ENCODE_BOOLEAN(kTestVal_02_Bool);
+        ASN1_START_SET {}
+        ASN1_END_SET;
+        ASN1_ENCODE_BIT_STRING(kTestVal_03_BitString);
+        ASN1_ENCODE_BIT_STRING(kTestVal_04_BitString);
+        ASN1_ENCODE_BIT_STRING(kTestVal_05_BitString);
+        ASN1_START_SEQUENCE
+        {
+            ASN1_START_SEQUENCE
+            {
+                ASN1_START_SEQUENCE
+                {
+                    ASN1_ENCODE_BIT_STRING(kTestVal_06_BitString);
+                    ASN1_ENCODE_BIT_STRING(kTestVal_07_BitString);
+                }
+                ASN1_END_SEQUENCE;
+                ASN1_ENCODE_BIT_STRING(kTestVal_08_BitString);
+            }
+            ASN1_END_SEQUENCE;
+            ASN1_ENCODE_BIT_STRING(kTestVal_09_BitString);
+        }
+        ASN1_END_SEQUENCE;
+        ASN1_ENCODE_INTEGER(kTestVal_10_Int);
+        ASN1_ENCODE_INTEGER(kTestVal_11_Int);
+        ASN1_ENCODE_INTEGER(kTestVal_12_Int);
+        ASN1_ENCODE_INTEGER(kTestVal_13_Int);
+        ASN1_ENCODE_INTEGER(kTestVal_14_Int);
+        ASN1_ENCODE_INTEGER(kTestVal_15_Int);
+        ASN1_ENCODE_INTEGER(kTestVal_16_Int);
+        ASN1_ENCODE_INTEGER(kTestVal_17_Int);
+        ASN1_ENCODE_INTEGER(kTestVal_18_Int);
+        ASN1_ENCODE_OBJECT_ID(kTestVal_19_OID);
+        ASN1_ENCODE_OCTET_STRING(kTestVal_20_OctetString, sizeof(kTestVal_20_OctetString));
+        ASN1_ENCODE_OCTET_STRING(kTestVal_20_OctetString, 1);
+        ASN1_ENCODE_OCTET_STRING(kTestVal_20_OctetString, 0);
+        ASN1_ENCODE_STRING(kASN1UniversalTag_GeneralString, "", 0);
+        ASN1_ENCODE_STRING(kASN1UniversalTag_PrintableString, kTestVal_21_PrintableString, strlen(kTestVal_21_PrintableString));
+        ASN1_ENCODE_STRING(kASN1UniversalTag_UTF8String, kTestVal_22_UTFString, strlen(kTestVal_22_UTFString));
+        ASN1_START_OCTET_STRING_ENCAPSULATED
+        {
+            ASN1_START_SEQUENCE
+            {
+                ASN1_ENCODE_OBJECT_ID(kTestVal_23_OID);
+                ASN1_START_BIT_STRING_ENCAPSULATED { ASN1_ENCODE_INTEGER(kTestVal_24_Int); }
+                ASN1_END_ENCAPSULATED;
+            }
+            ASN1_END_SEQUENCE;
+        }
+        ASN1_END_ENCAPSULATED;
+    }
+    ASN1_END_SEQUENCE;
+
+exit:
+    return err;
+}
+
+static void TestASN1_Encode(nlTestSuite * inSuite, void * inContext)
+{
+    ASN1_ERROR err;
+    uint8_t buf[2048];
+    ASN1Writer writer;
+    uint16_t encodedLen;
+
+    writer.Init(buf, sizeof(buf));
+
+    err = EncodeASN1TestData(writer);
+    NL_TEST_ASSERT(inSuite, err == ASN1_NO_ERROR);
+
+    err = writer.Finalize();
+    NL_TEST_ASSERT(inSuite, err == ASN1_NO_ERROR);
+
+    encodedLen = writer.GetLengthWritten();
+    NL_TEST_ASSERT(inSuite, encodedLen == sizeof(TestASN1_EncodedData));
+    NL_TEST_ASSERT(inSuite, memcmp(buf, TestASN1_EncodedData, sizeof(TestASN1_EncodedData)) == 0);
+
+#define DUMP_HEX 0
+#if DUMP_HEX
+    for (uint16_t i = 0; i < encodedLen; i++)
+    {
+        if (i != 0 && i % 16 == 0)
+            printf("\n");
+        printf("0x%02X, ", buf[i]);
+    }
+    printf("\n");
+#endif
+}
+
+static void TestASN1_Decode(nlTestSuite * inSuite, void * inContext)
+{
+    ASN1_ERROR err = ASN1_NO_ERROR;
+    ASN1Reader reader;
+    bool boolVal;
+    uint32_t bitStringVal;
+    int64_t intVal;
+    OID oidVal;
+
+    reader.Init(TestASN1_EncodedData, sizeof(TestASN1_EncodedData));
+
+    ASN1_PARSE_ENTER_SEQUENCE
+    {
+        ASN1_PARSE_BOOLEAN(boolVal);
+        NL_TEST_ASSERT(inSuite, boolVal == kTestVal_01_Bool);
+        ASN1_PARSE_BOOLEAN(boolVal);
+        NL_TEST_ASSERT(inSuite, boolVal == kTestVal_02_Bool);
+        ASN1_PARSE_ENTER_SET {}
+        ASN1_EXIT_SET;
+        ASN1_PARSE_BIT_STRING(bitStringVal);
+        NL_TEST_ASSERT(inSuite, bitStringVal == kTestVal_03_BitString);
+        ASN1_PARSE_BIT_STRING(bitStringVal);
+        NL_TEST_ASSERT(inSuite, bitStringVal == kTestVal_04_BitString);
+        ASN1_PARSE_BIT_STRING(bitStringVal);
+        NL_TEST_ASSERT(inSuite, bitStringVal == kTestVal_05_BitString);
+        ASN1_PARSE_ENTER_SEQUENCE
+        {
+            ASN1_PARSE_ENTER_SEQUENCE
+            {
+                ASN1_PARSE_ENTER_SEQUENCE
+                {
+                    ASN1_PARSE_BIT_STRING(bitStringVal);
+                    NL_TEST_ASSERT(inSuite, bitStringVal == kTestVal_06_BitString);
+                    ASN1_PARSE_BIT_STRING(bitStringVal);
+                    NL_TEST_ASSERT(inSuite, bitStringVal == kTestVal_07_BitString);
+                }
+                ASN1_EXIT_SEQUENCE;
+                ASN1_PARSE_BIT_STRING(bitStringVal);
+                NL_TEST_ASSERT(inSuite, bitStringVal == kTestVal_08_BitString);
+            }
+            ASN1_EXIT_SEQUENCE;
+            ASN1_PARSE_BIT_STRING(bitStringVal);
+            NL_TEST_ASSERT(inSuite, bitStringVal == kTestVal_09_BitString);
+        }
+        ASN1_EXIT_SEQUENCE;
+        ASN1_PARSE_INTEGER(intVal);
+        NL_TEST_ASSERT(inSuite, intVal == kTestVal_10_Int);
+        ASN1_PARSE_INTEGER(intVal);
+        NL_TEST_ASSERT(inSuite, intVal == kTestVal_11_Int);
+        ASN1_PARSE_INTEGER(intVal);
+        NL_TEST_ASSERT(inSuite, intVal == kTestVal_12_Int);
+        ASN1_PARSE_INTEGER(intVal);
+        NL_TEST_ASSERT(inSuite, intVal == kTestVal_13_Int);
+        ASN1_PARSE_INTEGER(intVal);
+        NL_TEST_ASSERT(inSuite, intVal == kTestVal_14_Int);
+        ASN1_PARSE_INTEGER(intVal);
+        NL_TEST_ASSERT(inSuite, intVal == kTestVal_15_Int);
+        ASN1_PARSE_INTEGER(intVal);
+        NL_TEST_ASSERT(inSuite, intVal == kTestVal_16_Int);
+        ASN1_PARSE_INTEGER(intVal);
+        NL_TEST_ASSERT(inSuite, intVal == kTestVal_17_Int);
+        ASN1_PARSE_INTEGER(intVal);
+        NL_TEST_ASSERT(inSuite, intVal == kTestVal_18_Int);
+        ASN1_PARSE_OBJECT_ID(oidVal);
+        NL_TEST_ASSERT(inSuite, oidVal == kTestVal_19_OID);
+        ASN1_PARSE_ELEMENT(kASN1TagClass_Universal, kASN1UniversalTag_OctetString);
+        NL_TEST_ASSERT(inSuite, reader.GetValueLen() == sizeof(kTestVal_20_OctetString));
+        NL_TEST_ASSERT(inSuite, memcmp(reader.GetValue(), kTestVal_20_OctetString, sizeof(kTestVal_20_OctetString)) == 0);
+        ASN1_PARSE_ELEMENT(kASN1TagClass_Universal, kASN1UniversalTag_OctetString);
+        NL_TEST_ASSERT(inSuite, reader.GetValueLen() == 1);
+        NL_TEST_ASSERT(inSuite, reader.GetValue()[0] == kTestVal_20_OctetString[0]);
+        ASN1_PARSE_ELEMENT(kASN1TagClass_Universal, kASN1UniversalTag_OctetString);
+        NL_TEST_ASSERT(inSuite, reader.GetValueLen() == 0);
+        ASN1_PARSE_ELEMENT(kASN1TagClass_Universal, kASN1UniversalTag_GeneralString);
+        NL_TEST_ASSERT(inSuite, reader.GetValueLen() == 0);
+        ASN1_PARSE_ELEMENT(kASN1TagClass_Universal, kASN1UniversalTag_PrintableString);
+        NL_TEST_ASSERT(inSuite, reader.GetValueLen() == strlen(kTestVal_21_PrintableString));
+        NL_TEST_ASSERT(inSuite, memcmp(reader.GetValue(), kTestVal_21_PrintableString, strlen(kTestVal_21_PrintableString)) == 0);
+        ASN1_PARSE_ELEMENT(kASN1TagClass_Universal, kASN1UniversalTag_UTF8String);
+        NL_TEST_ASSERT(inSuite, reader.GetValueLen() == strlen(kTestVal_22_UTFString));
+        NL_TEST_ASSERT(inSuite, memcmp(reader.GetValue(), kTestVal_22_UTFString, strlen(kTestVal_22_UTFString)) == 0);
+        ASN1_PARSE_ENTER_ENCAPSULATED(kASN1TagClass_Universal, kASN1UniversalTag_OctetString)
+        {
+            ASN1_PARSE_ENTER_SEQUENCE
+            {
+                ASN1_PARSE_OBJECT_ID(oidVal);
+                NL_TEST_ASSERT(inSuite, oidVal == kTestVal_23_OID);
+                ASN1_PARSE_ENTER_ENCAPSULATED(kASN1TagClass_Universal, kASN1UniversalTag_BitString)
+                {
+                    ASN1_PARSE_INTEGER(intVal);
+                    NL_TEST_ASSERT(inSuite, intVal == kTestVal_24_Int);
+                }
+                ASN1_EXIT_ENCAPSULATED;
+            }
+            ASN1_EXIT_SEQUENCE;
+        }
+        ASN1_EXIT_ENCAPSULATED;
+    }
+    ASN1_EXIT_SEQUENCE;
+
+exit:
+    NL_TEST_ASSERT(inSuite, err == ASN1_NO_ERROR);
+}
+
+static void TestASN1_NullWriter(nlTestSuite * inSuite, void * inContext)
+{
+    ASN1_ERROR err;
+    ASN1Writer writer;
+    uint16_t encodedLen;
+
+    writer.InitNullWriter();
+
+    err = EncodeASN1TestData(writer);
+    NL_TEST_ASSERT(inSuite, err == ASN1_NO_ERROR);
+
+    err = writer.Finalize();
+    NL_TEST_ASSERT(inSuite, err == ASN1_NO_ERROR);
+
+    encodedLen = writer.GetLengthWritten();
+    NL_TEST_ASSERT(inSuite, encodedLen == 0);
+}
+
+static void TestASN1_ObjectID(nlTestSuite * inSuite, void * inContext)
+{
+    ASN1_ERROR err;
+    uint8_t buf[2048];
+    ASN1Writer writer;
+    ASN1Reader reader;
+    uint16_t encodedLen;
+
+    writer.Init(buf, sizeof(buf));
+
+    ASN1_START_SEQUENCE
+    {
+        ASN1_ENCODE_OBJECT_ID(kOID_AttributeType_ChipNodeId);
+        ASN1_ENCODE_OBJECT_ID(kOID_SigAlgo_ECDSAWithSHA256);
+        ASN1_ENCODE_OBJECT_ID(kOID_EllipticCurve_prime256v1);
+        ASN1_ENCODE_OBJECT_ID(kOID_Extension_AuthorityKeyIdentifier);
+        ASN1_ENCODE_OBJECT_ID(kOID_Extension_BasicConstraints);
+        ASN1_ENCODE_OBJECT_ID(kOID_KeyPurpose_ServerAuth);
+    }
+    ASN1_END_SEQUENCE;
+
+    err = writer.Finalize();
+    NL_TEST_ASSERT(inSuite, err == ASN1_NO_ERROR);
+
+    encodedLen = writer.GetLengthWritten();
+    NL_TEST_ASSERT(inSuite, encodedLen > 0);
+
+    reader.Init(buf, encodedLen);
+
+    // Parse and check OIDs as actual ASN1 encoded values.
+    ASN1_PARSE_ENTER_SEQUENCE
+    {
+        ASN1_PARSE_ELEMENT(kASN1TagClass_Universal, kASN1UniversalTag_ObjectId);
+        NL_TEST_ASSERT(inSuite, reader.GetValueLen() == sizeof(sOID_AttributeType_ChipNodeId));
+        NL_TEST_ASSERT(inSuite,
+                       memcmp(reader.GetValue(), sOID_AttributeType_ChipNodeId, sizeof(sOID_AttributeType_ChipNodeId)) == 0);
+
+        ASN1_PARSE_ELEMENT(kASN1TagClass_Universal, kASN1UniversalTag_ObjectId);
+        NL_TEST_ASSERT(inSuite, reader.GetValueLen() == sizeof(sOID_SigAlgo_ECDSAWithSHA256));
+        NL_TEST_ASSERT(inSuite, memcmp(reader.GetValue(), sOID_SigAlgo_ECDSAWithSHA256, sizeof(sOID_SigAlgo_ECDSAWithSHA256)) == 0);
+
+        ASN1_PARSE_ELEMENT(kASN1TagClass_Universal, kASN1UniversalTag_ObjectId);
+        NL_TEST_ASSERT(inSuite, reader.GetValueLen() == sizeof(sOID_EllipticCurve_prime256v1));
+        NL_TEST_ASSERT(inSuite,
+                       memcmp(reader.GetValue(), sOID_EllipticCurve_prime256v1, sizeof(sOID_EllipticCurve_prime256v1)) == 0);
+
+        ASN1_PARSE_ELEMENT(kASN1TagClass_Universal, kASN1UniversalTag_ObjectId);
+        NL_TEST_ASSERT(inSuite, reader.GetValueLen() == sizeof(sOID_Extension_AuthorityKeyIdentifier));
+        NL_TEST_ASSERT(
+            inSuite,
+            memcmp(reader.GetValue(), sOID_Extension_AuthorityKeyIdentifier, sizeof(sOID_Extension_AuthorityKeyIdentifier)) == 0);
+
+        ASN1_PARSE_ELEMENT(kASN1TagClass_Universal, kASN1UniversalTag_ObjectId);
+        NL_TEST_ASSERT(inSuite, reader.GetValueLen() == sizeof(sOID_Extension_BasicConstraints));
+        NL_TEST_ASSERT(inSuite,
+                       memcmp(reader.GetValue(), sOID_Extension_BasicConstraints, sizeof(sOID_Extension_BasicConstraints)) == 0);
+
+        ASN1_PARSE_ELEMENT(kASN1TagClass_Universal, kASN1UniversalTag_ObjectId);
+        NL_TEST_ASSERT(inSuite, reader.GetValueLen() == sizeof(sOID_KeyPurpose_ServerAuth));
+        NL_TEST_ASSERT(inSuite, memcmp(reader.GetValue(), sOID_KeyPurpose_ServerAuth, sizeof(sOID_KeyPurpose_ServerAuth)) == 0);
+    }
+    ASN1_EXIT_SEQUENCE;
+
+exit:
+    NL_TEST_ASSERT(inSuite, err == ASN1_NO_ERROR);
+}
+
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+
+// clang-format off
+static const nlTest sTests[] =
+{
+    NL_TEST_DEF("Test ASN1 encoding macros", TestASN1_Encode),
+    NL_TEST_DEF("Test ASN1 decoding macros", TestASN1_Decode),
+    NL_TEST_DEF("Test ASN1 NULL writer", TestASN1_NullWriter),
+    NL_TEST_DEF("Test ASN1 Object IDs", TestASN1_ObjectID),
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+int TestASN1(void)
+{
+    nlTestSuite theSuite = { "Support-ASN1", &sTests[0], nullptr, nullptr };
+    nlTestRunner(&theSuite, nullptr);
+    return (nlTestRunnerStats(&theSuite));
+}

--- a/src/lib/asn1/tests/TestASN1.h
+++ b/src/lib/asn1/tests/TestASN1.h
@@ -1,0 +1,35 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file declares test entry points for CHIP ASN1 library
+ *      unit tests.
+ *
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int TestASN1(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/lib/asn1/tests/TestASN1Driver.cpp
+++ b/src/lib/asn1/tests/TestASN1Driver.cpp
@@ -1,0 +1,30 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a standalone/native program executable
+ *      test driver for the ASN1 library unit tests.
+ *
+ */
+
+#include "TestASN1.h"
+
+int main(void)
+{
+    return (TestASN1());
+}


### PR DESCRIPTION
Added ASN1 support macros needed for X509 to CHIP certificate conversion.

 #### Problem
To be able to process and operate with CHIP certificates basic ASN.1 encoding/decoding functions are needed.

 #### Summary of Changes
      * Implements ASN1Writer and ASN1Reader parsers
      * Implements mactors to operate with ASN1Writer/ASN1Reader classes
      * Implements gen_asn1oid.py python script for automatic generation of OID values
      * Added ZigBee specific attributes for CHIP Certificates:
        - ChipNodeId
        - ChipCAId
        - ChipSoftwarePublisherId
