### PR TITLE
Move common functions from ESP32 to abstract ConnectivityManager class

### DIFF
--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -84,6 +84,24 @@ public:
         kThreadMode_Enabled               = 3,
     };
 
+    enum WiFiStationState
+    {
+        kWiFiStationState_NotConnected,
+        kWiFiStationState_Connecting,
+        kWiFiStationState_Connecting_Succeeded,
+        kWiFiStationState_Connecting_Failed,
+        kWiFiStationState_Connected,
+        kWiFiStationState_Disconnecting,
+    };
+
+    enum WiFiAPState
+    {
+        kWiFiAPState_NotActive,
+        kWiFiAPState_Activating,
+        kWiFiAPState_Active,
+        kWiFiAPState_Deactivating,
+    };
+
     enum CHIPoBLEServiceMode
     {
         kCHIPoBLEServiceMode_NotSupported = 0,
@@ -171,6 +189,8 @@ public:
     // Support methods
     static const char * WiFiStationModeToStr(WiFiStationMode mode);
     static const char * WiFiAPModeToStr(WiFiAPMode mode);
+    static const char * WiFiStationStateToStr(WiFiStationState state);
+    static const char * WiFiAPStateToStr(WiFiAPState state);
     static const char * CHIPoBLEServiceModeToStr(CHIPoBLEServiceMode mode);
 
 private:
@@ -515,6 +535,16 @@ inline const char * ConnectivityManager::WiFiStationModeToStr(WiFiStationMode mo
 inline const char * ConnectivityManager::WiFiAPModeToStr(WiFiAPMode mode)
 {
     return ImplClass::_WiFiAPModeToStr(mode);
+}
+
+inline const char * ConnectivityManager::WiFiStationStateToStr(WiFiStationState state)
+{
+    return ImplClass::_WiFiStationStateToStr(state);
+}
+
+inline const char * ConnectivityManager::WiFiAPStateToStr(WiFiAPState state)
+{
+    return ImplClass::_WiFiAPStateToStr(state);
 }
 
 inline const char * ConnectivityManager::CHIPoBLEServiceModeToStr(CHIPoBLEServiceMode mode)

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_NoWiFi.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_NoWiFi.h
@@ -78,6 +78,8 @@ public:
     void _OnWiFiStationProvisionChange();
     static const char * _WiFiStationModeToStr(ConnectivityManager::WiFiStationMode mode);
     static const char * _WiFiAPModeToStr(ConnectivityManager::WiFiAPMode mode);
+    static const char * _WiFiStationStateToStr(ConnectivityManager::WiFiStationState state);
+    static const char * _WiFiAPStateToStr(ConnectivityManager::WiFiAPState state);
 
 private:
     ImplClass * Impl() { return static_cast<ImplClass *>(this); }
@@ -216,6 +218,19 @@ GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_WiFiStationModeToStr(Connecti
 
 template <class ImplClass>
 inline const char * GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_WiFiAPModeToStr(ConnectivityManager::WiFiAPMode mode)
+{
+    return NULL;
+}
+
+template <class ImplClass>
+inline const char *
+GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_WiFiStationStateToStr(ConnectivityManager::WiFiStationState state)
+{
+    return NULL;
+}
+
+template <class ImplClass>
+inline const char * GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_WiFiAPStateToStr(ConnectivityManager::WiFiAPState state)
 {
     return NULL;
 }

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.cpp
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.cpp
@@ -54,6 +54,68 @@ const char * GenericConnectivityManagerImpl_WiFi<ImplClass>::_WiFiStationModeToS
 }
 
 template <class ImplClass>
+const char * GenericConnectivityManagerImpl_WiFi<ImplClass>::_WiFiAPModeToStr(ConnectivityManager::WiFiAPMode mode)
+{
+    switch (mode)
+    {
+    case ConnectivityManager::kWiFiAPMode_NotSupported:
+        return "NotSupported";
+    case ConnectivityManager::kWiFiAPMode_ApplicationControlled:
+        return "AppControlled";
+    case ConnectivityManager::kWiFiAPMode_Disabled:
+        return "Disabled";
+    case ConnectivityManager::kWiFiAPMode_Enabled:
+        return "Enabled";
+    case ConnectivityManager::kWiFiAPMode_OnDemand:
+        return "OnDemand";
+    case ConnectivityManager::kWiFiAPMode_OnDemand_NoStationProvision:
+        return "OnDemand_NoStationProvision";
+    default:
+        return "(unknown)";
+    }
+}
+
+template <class ImplClass>
+const char * GenericConnectivityManagerImpl_WiFi<ImplClass>::_WiFiStationStateToStr(ConnectivityManager::WiFiStationState state)
+{
+    switch (state)
+    {
+    case ConnectivityManager::kWiFiStationState_NotConnected:
+        return "NotConnected";
+    case ConnectivityManager::kWiFiStationState_Connecting:
+        return "Connecting";
+    case ConnectivityManager::kWiFiStationState_Connecting_Succeeded:
+        return "Connecting_Succeeded";
+    case ConnectivityManager::kWiFiStationState_Connecting_Failed:
+        return "Connecting_Failed";
+    case ConnectivityManager::kWiFiStationState_Connected:
+        return "Connected";
+    case ConnectivityManager::kWiFiStationState_Disconnecting:
+        return "Disconnecting";
+    default:
+        return "(unknown)";
+    }
+}
+
+template <class ImplClass>
+const char * GenericConnectivityManagerImpl_WiFi<ImplClass>::_WiFiAPStateToStr(ConnectivityManager::WiFiAPState state)
+{
+    switch (state)
+    {
+    case ConnectivityManager::kWiFiAPState_NotActive:
+        return "NotActive";
+    case ConnectivityManager::kWiFiAPState_Activating:
+        return "Activating";
+    case ConnectivityManager::kWiFiAPState_Active:
+        return "Active";
+    case ConnectivityManager::kWiFiAPState_Deactivating:
+        return "Deactivating";
+    default:
+        return "(unknown)";
+    }
+}
+
+template <class ImplClass>
 bool GenericConnectivityManagerImpl_WiFi<ImplClass>::_IsWiFiStationEnabled()
 {
     return Impl()->GetWiFiStationMode() == ConnectivityManager::kWiFiStationMode_Enabled;

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
@@ -78,6 +78,8 @@ public:
     void _OnWiFiStationProvisionChange();
     static const char * _WiFiStationModeToStr(ConnectivityManager::WiFiStationMode mode);
     static const char * _WiFiAPModeToStr(ConnectivityManager::WiFiAPMode mode);
+    static const char * _WiFiStationStateToStr(ConnectivityManager::WiFiStationState state);
+    static const char * _WiFiAPStateToStr(ConnectivityManager::WiFiAPState state);
 
 protected:
     enum Flags
@@ -178,12 +180,6 @@ inline void GenericConnectivityManagerImpl_WiFi<ImplClass>::_OnWiFiScanDone()
 template <class ImplClass>
 inline void GenericConnectivityManagerImpl_WiFi<ImplClass>::_OnWiFiStationProvisionChange()
 {}
-
-template <class ImplClass>
-inline const char * GenericConnectivityManagerImpl_WiFi<ImplClass>::_WiFiAPModeToStr(ConnectivityManager::WiFiAPMode mode)
-{
-    return nullptr;
-}
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/platform/ESP32/ConnectivityManagerImpl.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl.cpp
@@ -19,10 +19,11 @@
 /* this file behaves like a config.h, comes first */
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
+#include <platform/ConnectivityManager.h>
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 #include <platform/internal/GenericConnectivityManagerImpl_BLE.cpp>
 #endif
-#include <platform/ConnectivityManager.h>
+#include <platform/internal/GenericConnectivityManagerImpl_WiFi.cpp>
 
 #include <platform/ESP32/ESP32Utils.h>
 #include <platform/internal/BLEManager.h>
@@ -1020,82 +1021,6 @@ void ConnectivityManagerImpl::OnIPv6AddressAvailable(const ip_event_got_ip6_t & 
     RefreshMessageLayer();
 
     UpdateInternetConnectivityState();
-}
-
-const char * ConnectivityManagerImpl::_WiFiStationModeToStr(WiFiStationMode mode)
-{
-    switch (mode)
-    {
-    case kWiFiStationMode_NotSupported:
-        return "NotSupported";
-    case kWiFiStationMode_ApplicationControlled:
-        return "AppControlled";
-    case kWiFiStationMode_Enabled:
-        return "Enabled";
-    case kWiFiStationMode_Disabled:
-        return "Disabled";
-    default:
-        return "(unknown)";
-    }
-}
-
-const char * ConnectivityManagerImpl::_WiFiAPModeToStr(WiFiAPMode mode)
-{
-    switch (mode)
-    {
-    case kWiFiAPMode_NotSupported:
-        return "NotSupported";
-    case kWiFiAPMode_ApplicationControlled:
-        return "AppControlled";
-    case kWiFiAPMode_Disabled:
-        return "Disabled";
-    case kWiFiAPMode_Enabled:
-        return "Enabled";
-    case kWiFiAPMode_OnDemand:
-        return "OnDemand";
-    case kWiFiAPMode_OnDemand_NoStationProvision:
-        return "OnDemand_NoStationProvision";
-    default:
-        return "(unknown)";
-    }
-}
-
-const char * ConnectivityManagerImpl::WiFiStationStateToStr(WiFiStationState state)
-{
-    switch (state)
-    {
-    case kWiFiStationState_NotConnected:
-        return "NotConnected";
-    case kWiFiStationState_Connecting:
-        return "Connecting";
-    case kWiFiStationState_Connecting_Succeeded:
-        return "Connecting_Succeeded";
-    case kWiFiStationState_Connecting_Failed:
-        return "Connecting_Failed";
-    case kWiFiStationState_Connected:
-        return "Connected";
-    case kWiFiStationState_Disconnecting:
-        return "Disconnecting";
-    default:
-        return "(unknown)";
-    }
-}
-
-const char * ConnectivityManagerImpl::WiFiAPStateToStr(WiFiAPState state)
-{
-    switch (state)
-    {
-    case kWiFiAPState_NotActive:
-        return "NotActive";
-    case kWiFiAPState_Activating:
-        return "Activating";
-    case kWiFiAPState_Active:
-        return "Active";
-    case kWiFiAPState_Deactivating:
-        return "Deactivating";
-    default:
-        return "(unknown)";
-    }
 }
 
 void ConnectivityManagerImpl::RefreshMessageLayer(void) {}

--- a/src/platform/ESP32/ConnectivityManagerImpl.h
+++ b/src/platform/ESP32/ConnectivityManagerImpl.h
@@ -21,6 +21,7 @@
 
 #include <platform/ConnectivityManager.h>
 #include <platform/internal/GenericConnectivityManagerImpl.h>
+#include <platform/internal/GenericConnectivityManagerImpl_WiFi.h>
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 #include <platform/internal/GenericConnectivityManagerImpl_BLE.h>
 #else
@@ -52,6 +53,7 @@ class GenericNetworkProvisioningServerImpl;
  */
 class ConnectivityManagerImpl final : public ConnectivityManager,
                                       public Internal::GenericConnectivityManagerImpl<ConnectivityManagerImpl>,
+                                      public Internal::GenericConnectivityManagerImpl_WiFi<ConnectivityManagerImpl>,
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
                                       public Internal::GenericConnectivityManagerImpl_BLE<ConnectivityManagerImpl>,
 #else
@@ -94,8 +96,6 @@ private:
     bool _CanStartWiFiScan();
     void _OnWiFiScanDone();
     void _OnWiFiStationProvisionChange();
-    static const char * _WiFiStationModeToStr(WiFiStationMode mode);
-    static const char * _WiFiAPModeToStr(WiFiAPMode mode);
 
     // ===== Members for internal use by the following friends.
 
@@ -105,31 +105,6 @@ private:
     static ConnectivityManagerImpl sInstance;
 
     // ===== Private members reserved for use by this class only.
-
-    enum WiFiStationState
-    {
-        kWiFiStationState_NotConnected,
-        kWiFiStationState_Connecting,
-        kWiFiStationState_Connecting_Succeeded,
-        kWiFiStationState_Connecting_Failed,
-        kWiFiStationState_Connected,
-        kWiFiStationState_Disconnecting,
-    };
-
-    enum WiFiAPState
-    {
-        kWiFiAPState_NotActive,
-        kWiFiAPState_Activating,
-        kWiFiAPState_Active,
-        kWiFiAPState_Deactivating,
-    };
-
-    enum Flags
-    {
-        kFlag_HaveIPv4InternetConnectivity = 0x0001,
-        kFlag_HaveIPv6InternetConnectivity = 0x0002,
-        kFlag_AwaitingConnectivity         = 0x0004,
-    };
 
     uint64_t mLastStationConnectFailTime;
     uint64_t mLastAPDemandTime;
@@ -157,8 +132,6 @@ private:
     void OnStationIPv4AddressLost(void);
     void OnIPv6AddressAvailable(const ip_event_got_ip6_t & got_ip);
 
-    static const char * WiFiStationStateToStr(WiFiStationState state);
-    static const char * WiFiAPStateToStr(WiFiAPState state);
     static void RefreshMessageLayer(void);
 };
 


### PR DESCRIPTION
 #### Problem
Right now, some commons functions within ConnectivityManager class are implemented on each supported platforms.

 #### Summary of Changes
Move the following two functions from ESP32 to GenericConnectivityManagerImpl_WiFi class to be shared by all platforms.
    static const char * WiFiAPStateToStr(WiFiAPState state);
    static const char * CHIPoBLEServiceModeToStr(CHIPoBLEServiceMode mode);
