### PR TITLE
Handle Thread Association Request in rendezvous session

### DIFF
--- a/examples/common/chip-app-server/RendezvousServer.cpp
+++ b/examples/common/chip-app-server/RendezvousServer.cpp
@@ -33,7 +33,7 @@ using namespace ::chip::DeviceLayer;
 
 namespace chip {
 
-void AccesoryNetworkProvisioningDelegate::ProvisionThread(const DeviceLayer::Internal::DeviceNetworkInfo & threadData)
+void AccessoryNetworkProvisioningDelegate::ProvisionThread(const DeviceLayer::Internal::DeviceNetworkInfo & threadData)
 {
 #if CHIP_ENABLE_OPENTHREAD
     ThreadStackMgr().SetThreadEnabled(false);

--- a/examples/common/chip-app-server/RendezvousServer.cpp
+++ b/examples/common/chip-app-server/RendezvousServer.cpp
@@ -33,16 +33,7 @@ using namespace ::chip::DeviceLayer;
 
 namespace chip {
 
-void AccessoryNetworkProvisioningDelegate::ProvisionThread(const DeviceLayer::Internal::DeviceNetworkInfo & threadData)
-{
-#if CHIP_ENABLE_OPENTHREAD
-    ThreadStackMgr().SetThreadEnabled(false);
-    ThreadStackMgr().SetThreadProvision(threadData);
-    ThreadStackMgr().SetThreadEnabled(true);
-#endif // CHIP_ENABLE_OPENTHREAD
-}
-
-RendezvousServer::RendezvousServer() : mRendezvousSession(this, &mNetworkProvisioningDelegate) {}
+RendezvousServer::RendezvousServer() : mRendezvousSession(this, this) {}
 
 CHIP_ERROR RendezvousServer::Init(const RendezvousParameters & params)
 {
@@ -88,6 +79,15 @@ void RendezvousServer::OnRendezvousStatusUpdate(Status status, CHIP_ERROR err)
 
 exit:
     return;
+}
+
+void RendezvousServer::ProvisionThread(const DeviceLayer::Internal::DeviceNetworkInfo & threadData)
+{
+#if CHIP_ENABLE_OPENTHREAD
+    ThreadStackMgr().SetThreadEnabled(false);
+    ThreadStackMgr().SetThreadProvision(threadData);
+    ThreadStackMgr().SetThreadEnabled(true);
+#endif // CHIP_ENABLE_OPENTHREAD
 }
 
 } // namespace chip

--- a/examples/common/chip-app-server/RendezvousServer.cpp
+++ b/examples/common/chip-app-server/RendezvousServer.cpp
@@ -25,7 +25,6 @@
 
 #if CHIP_ENABLE_OPENTHREAD
 #include <platform/ThreadStackManager.h>
-#include <platform/internal/DeviceNetworkInfo.h>
 #endif
 
 using namespace ::chip::Inet;
@@ -34,7 +33,16 @@ using namespace ::chip::DeviceLayer;
 
 namespace chip {
 
-RendezvousServer::RendezvousServer() : mRendezvousSession(this) {}
+void AccesoryNetworkProvisioningDelegate::ProvisionThread(const DeviceLayer::Internal::DeviceNetworkInfo & threadData)
+{
+#if CHIP_ENABLE_OPENTHREAD
+    ThreadStackMgr().SetThreadEnabled(false);
+    ThreadStackMgr().SetThreadProvision(threadData);
+    ThreadStackMgr().SetThreadEnabled(true);
+#endif // CHIP_ENABLE_OPENTHREAD
+}
+
+RendezvousServer::RendezvousServer() : mRendezvousSession(this, &mNetworkProvisioningDelegate) {}
 
 CHIP_ERROR RendezvousServer::Init(const RendezvousParameters & params)
 {
@@ -58,66 +66,6 @@ void RendezvousServer::OnRendezvousConnectionClosed()
 
 void RendezvousServer::OnRendezvousMessageReceived(PacketBuffer * buffer)
 {
-#if CHIP_ENABLE_OPENTHREAD
-    uint16_t bufferLen = buffer->DataLength();
-    uint8_t * data     = buffer->Start();
-    chip::DeviceLayer::Internal::DeviceNetworkInfo networkInfo;
-    ChipLogProgress(AppServer, "Receive BLE message size=%u", bufferLen);
-
-    VerifyOrExit(bufferLen >= sizeof(networkInfo.ThreadNetworkName),
-                 ChipLogProgress(AppServer, "Invalid network provision message"));
-    memcpy(networkInfo.ThreadNetworkName, data, sizeof(networkInfo.ThreadNetworkName));
-    data += sizeof(networkInfo.ThreadNetworkName);
-    bufferLen -= sizeof(networkInfo.ThreadNetworkName);
-
-    VerifyOrExit(bufferLen >= sizeof(networkInfo.ThreadExtendedPANId),
-                 ChipLogProgress(AppServer, "Invalid network provision message"));
-    memcpy(networkInfo.ThreadExtendedPANId, data, sizeof(networkInfo.ThreadExtendedPANId));
-    data += sizeof(networkInfo.ThreadExtendedPANId);
-    bufferLen -= sizeof(networkInfo.ThreadExtendedPANId);
-
-    VerifyOrExit(bufferLen >= sizeof(networkInfo.ThreadMeshPrefix),
-                 ChipLogProgress(AppServer, "Invalid network provision message"));
-    memcpy(networkInfo.ThreadMeshPrefix, data, sizeof(networkInfo.ThreadMeshPrefix));
-    data += sizeof(networkInfo.ThreadMeshPrefix);
-    bufferLen -= sizeof(networkInfo.ThreadMeshPrefix);
-
-    VerifyOrExit(bufferLen >= sizeof(networkInfo.ThreadMasterKey), ChipLogProgress(AppServer, "Invalid network provision message"));
-    memcpy(networkInfo.ThreadMasterKey, data, sizeof(networkInfo.ThreadMasterKey));
-    data += sizeof(networkInfo.ThreadMasterKey);
-    bufferLen -= sizeof(networkInfo.ThreadMasterKey);
-
-    VerifyOrExit(bufferLen >= sizeof(networkInfo.ThreadPSKc), ChipLogProgress(AppServer, "Invalid network provision message"));
-    memcpy(networkInfo.ThreadPSKc, data, sizeof(networkInfo.ThreadPSKc));
-    data += sizeof(networkInfo.ThreadPSKc);
-    bufferLen -= sizeof(networkInfo.ThreadPSKc);
-
-    VerifyOrExit(bufferLen >= sizeof(networkInfo.ThreadPANId), ChipLogProgress(AppServer, "Invalid network provision message"));
-    networkInfo.ThreadPANId = data[0] | (data[1] << 8);
-    data += sizeof(networkInfo.ThreadPANId);
-    bufferLen -= sizeof(networkInfo.ThreadPANId);
-
-    VerifyOrExit(bufferLen >= sizeof(networkInfo.ThreadChannel), ChipLogProgress(AppServer, "Invalid network provision message"));
-    networkInfo.ThreadChannel = data[0];
-    data += sizeof(networkInfo.ThreadChannel);
-    bufferLen -= sizeof(networkInfo.ThreadChannel);
-
-    VerifyOrExit(bufferLen >= 3, ChipLogProgress(AppServer, "Invalid network provision message"));
-    networkInfo.FieldPresent.ThreadExtendedPANId = *data;
-    data++;
-    networkInfo.FieldPresent.ThreadMeshPrefix = *data;
-    data++;
-    networkInfo.FieldPresent.ThreadPSKc = *data;
-    data++;
-    networkInfo.NetworkId              = 0;
-    networkInfo.FieldPresent.NetworkId = true;
-
-    ThreadStackMgr().SetThreadEnabled(false);
-    ThreadStackMgr().SetThreadProvision(networkInfo);
-    ThreadStackMgr().SetThreadEnabled(true);
-
-#endif
-exit:
     chip::System::PacketBuffer::Free(buffer);
 }
 

--- a/examples/common/chip-app-server/include/RendezvousServer.h
+++ b/examples/common/chip-app-server/include/RendezvousServer.h
@@ -22,7 +22,7 @@
 
 namespace chip {
 
-class AccesoryNetworkProvisioningDelegate : public DeviceNetworkProvisioningDelegate
+class AccessoryNetworkProvisioningDelegate : public DeviceNetworkProvisioningDelegate
 {
     void ProvisionThread(const DeviceLayer::Internal::DeviceNetworkInfo & threadData) override;
 };
@@ -41,7 +41,7 @@ public:
     void OnRendezvousStatusUpdate(Status status, CHIP_ERROR err) override;
 
 private:
-    AccesoryNetworkProvisioningDelegate mNetworkProvisioningDelegate;
+    AccessoryNetworkProvisioningDelegate mNetworkProvisioningDelegate;
     RendezvousSession mRendezvousSession;
 };
 

--- a/examples/common/chip-app-server/include/RendezvousServer.h
+++ b/examples/common/chip-app-server/include/RendezvousServer.h
@@ -22,6 +22,11 @@
 
 namespace chip {
 
+class AccesoryNetworkProvisioningDelegate : public DeviceNetworkProvisioningDelegate
+{
+    void ProvisionThread(const DeviceLayer::Internal::DeviceNetworkInfo & threadData) override;
+};
+
 class RendezvousServer : public RendezvousSessionDelegate
 {
 public:
@@ -36,6 +41,7 @@ public:
     void OnRendezvousStatusUpdate(Status status, CHIP_ERROR err) override;
 
 private:
+    AccesoryNetworkProvisioningDelegate mNetworkProvisioningDelegate;
     RendezvousSession mRendezvousSession;
 };
 

--- a/examples/common/chip-app-server/include/RendezvousServer.h
+++ b/examples/common/chip-app-server/include/RendezvousServer.h
@@ -22,17 +22,14 @@
 
 namespace chip {
 
-class AccessoryNetworkProvisioningDelegate : public DeviceNetworkProvisioningDelegate
-{
-    void ProvisionThread(const DeviceLayer::Internal::DeviceNetworkInfo & threadData) override;
-};
-
-class RendezvousServer : public RendezvousSessionDelegate
+class RendezvousServer : public RendezvousSessionDelegate, public DeviceNetworkProvisioningDelegate
 {
 public:
     RendezvousServer();
 
     CHIP_ERROR Init(const RendezvousParameters & params);
+
+    //////////////// RendezvousSessionDelegate Implementation ///////////////////
 
     void OnRendezvousConnectionOpened() override;
     void OnRendezvousConnectionClosed() override;
@@ -40,8 +37,11 @@ public:
     void OnRendezvousMessageReceived(System::PacketBuffer * buffer) override;
     void OnRendezvousStatusUpdate(Status status, CHIP_ERROR err) override;
 
+    //////////// DeviceNetworkProvisioningDelegate Implementation ///////////////
+
+    void ProvisionThread(const DeviceLayer::Internal::DeviceNetworkInfo & threadData) override;
+
 private:
-    AccessoryNetworkProvisioningDelegate mNetworkProvisioningDelegate;
     RendezvousSession mRendezvousSession;
 };
 

--- a/examples/lighting-app/nrfconnect/main/main.cpp
+++ b/examples/lighting-app/nrfconnect/main/main.cpp
@@ -19,6 +19,7 @@
 #include "AppTask.h"
 
 #include <platform/CHIPDeviceLayer.h>
+#include <support/CHIPMem.h>
 
 #include <logging/log.h>
 
@@ -33,6 +34,13 @@ int main(void)
     int ret = 0;
 
     k_thread_priority_set(k_current_get(), K_PRIO_COOP(CONFIG_NUM_COOP_PRIORITIES - 1));
+
+    ret = chip::Platform::MemoryInit();
+    if (ret != CHIP_NO_ERROR)
+    {
+        LOG_ERR("Platform::MemoryInit() failed");
+        goto exit;
+    }
 
     LOG_INF("Init CHIP stack");
     ret = PlatformMgr().InitChipStack();

--- a/examples/lock-app/nrfconnect/main/main.cpp
+++ b/examples/lock-app/nrfconnect/main/main.cpp
@@ -22,6 +22,7 @@
 #include <logging/log.h>
 
 #include <platform/CHIPDeviceLayer.h>
+#include <support/CHIPMem.h>
 
 LOG_MODULE_REGISTER(app);
 
@@ -34,6 +35,13 @@ int main()
     int ret = 0;
 
     k_thread_priority_set(k_current_get(), K_PRIO_COOP(CONFIG_NUM_COOP_PRIORITIES - 1));
+
+    ret = chip::Platform::MemoryInit();
+    if (ret != CHIP_NO_ERROR)
+    {
+        LOG_ERR("Platform::MemoryInit() failed");
+        goto exit;
+    }
 
     LOG_INF("Init CHIP stack");
     ret = PlatformMgr().InitChipStack();

--- a/examples/wifi-echo/server/esp32/main/DeviceNetworkProvisioningDelegate.cpp
+++ b/examples/wifi-echo/server/esp32/main/DeviceNetworkProvisioningDelegate.cpp
@@ -22,7 +22,7 @@
 
 using namespace ::chip;
 
-void ESP32NetworkProvisioningDelegate::ProvisionNetwork(const char * ssid, const char * key)
+void ESP32NetworkProvisioningDelegate::ProvisionWiFi(const char * ssid, const char * key)
 {
     ChipLogProgress(NetworkProvisioning, "ESP32NetworkProvisioningDelegate: SSID: %s, key: %s", ssid, key);
     SetWiFiStationProvisioning(ssid, key);

--- a/examples/wifi-echo/server/esp32/main/include/DeviceNetworkProvisioningDelegate.h
+++ b/examples/wifi-echo/server/esp32/main/include/DeviceNetworkProvisioningDelegate.h
@@ -32,5 +32,5 @@ public:
      * @param ssid WiFi SSID
      * @param passwd WiFi password
      */
-    void ProvisionNetwork(const char * ssid, const char * passwd) override;
+    void ProvisionWiFi(const char * ssid, const char * passwd) override;
 };

--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -76,6 +76,7 @@ public:
     CHIP_ERROR GetAndLogThreadTopologyMinimal();
     CHIP_ERROR GetAndLogThreadTopologyFull();
     CHIP_ERROR GetPrimary802154MACAddress(uint8_t * buf);
+    CHIP_ERROR GetSlaacIPv6Address(chip::Inet::IPAddress & addr);
 
     CHIP_ERROR JoinerStart();
     CHIP_ERROR SetThreadProvision(const Internal::DeviceNetworkInfo & netInfo);
@@ -303,6 +304,11 @@ inline CHIP_ERROR ThreadStackManager::GetAndLogThreadTopologyFull()
 inline CHIP_ERROR ThreadStackManager::GetPrimary802154MACAddress(uint8_t * buf)
 {
     return static_cast<ImplClass *>(this)->_GetPrimary802154MACAddress(buf);
+}
+
+inline CHIP_ERROR ThreadStackManager::GetSlaacIPv6Address(chip::Inet::IPAddress & addr)
+{
+    return static_cast<ImplClass *>(this)->_GetSlaacIPv6Address(addr);
 }
 
 inline CHIP_ERROR ThreadStackManager::JoinerStart()

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -417,6 +417,11 @@ exit:
     return OTBR_TO_CHIP_ERROR(error);
 }
 
+CHIP_ERROR ThreadStackManagerImpl::_GetSlaacIPv6Address(chip::Inet::IPAddress & addr)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 CHIP_ERROR ThreadStackManagerImpl::_JoinerStart()
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -83,6 +83,8 @@ public:
 
     CHIP_ERROR _GetPrimary802154MACAddress(uint8_t * buf);
 
+    CHIP_ERROR _GetSlaacIPv6Address(chip::Inet::IPAddress & addr);
+
     CHIP_ERROR _JoinerStart();
 
     ~ThreadStackManagerImpl() = default;

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -772,6 +772,21 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetPrimary80215
 };
 
 template <class ImplClass>
+CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetSlaacIPv6Address(chip::Inet::IPAddress & addr)
+{
+    for (const otNetifAddress * otAddr = otIp6GetUnicastAddresses(mOTInst); otAddr != nullptr; otAddr = otAddr->mNext)
+    {
+        if (otAddr->mValid && otAddr->mAddressOrigin == OT_ADDRESS_ORIGIN_SLAAC)
+        {
+            addr = ToIPAddress(otAddr->mAddress);
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    return CHIP_ERROR_INCORRECT_STATE;
+}
+
+template <class ImplClass>
 CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::DoInit(otInstance * otInst)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -783,7 +783,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetSlaacIPv6Add
         }
     }
 
-    return CHIP_ERROR_INCORRECT_STATE;
+    return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
 }
 
 template <class ImplClass>

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -80,6 +80,7 @@ protected:
     CHIP_ERROR _GetAndLogThreadTopologyMinimal(void);
     CHIP_ERROR _GetAndLogThreadTopologyFull(void);
     CHIP_ERROR _GetPrimary802154MACAddress(uint8_t * buf);
+    CHIP_ERROR _GetSlaacIPv6Address(chip::Inet::IPAddress & addr);
     void _OnWoBLEAdvertisingStart(void);
     void _OnWoBLEAdvertisingStop(void);
 

--- a/src/transport/NetworkProvisioning.cpp
+++ b/src/transport/NetworkProvisioning.cpp
@@ -242,11 +242,11 @@ CHIP_ERROR NetworkProvisioning::DecodeThreadAssociationRequest(System::PacketBuf
     data += sizeof(networkInfo.ThreadMeshPrefix);
     dataLen -= sizeof(networkInfo.ThreadMeshPrefix);
 
-    VerifyOrExit(dataLen >= sizeof(networkInfo.ThreadNetworkKey),
+    VerifyOrExit(dataLen >= sizeof(networkInfo.ThreadMasterKey),
                  ChipLogProgress(NetworkProvisioning, "Invalid network provision message"));
-    memcpy(networkInfo.ThreadNetworkKey, data, sizeof(networkInfo.ThreadNetworkKey));
-    data += sizeof(networkInfo.ThreadNetworkKey);
-    dataLen -= sizeof(networkInfo.ThreadNetworkKey);
+    memcpy(networkInfo.ThreadMasterKey, data, sizeof(networkInfo.ThreadMasterKey));
+    data += sizeof(networkInfo.ThreadMasterKey);
+    dataLen -= sizeof(networkInfo.ThreadMasterKey);
 
     VerifyOrExit(dataLen >= sizeof(networkInfo.ThreadPSKc),
                  ChipLogProgress(NetworkProvisioning, "Invalid network provision message"));

--- a/src/transport/NetworkProvisioning.h
+++ b/src/transport/NetworkProvisioning.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <core/CHIPCore.h>
+#include <platform/internal/DeviceNetworkInfo.h>
 #include <protocols/CHIPProtocols.h>
 #include <support/BufBound.h>
 #include <system/SystemPacketBuffer.h>
@@ -45,7 +46,15 @@ public:
      * @param ssid WiFi SSID
      * @param passwd WiFi password
      */
-    virtual void ProvisionNetwork(const char * ssid, const char * passwd) {}
+    virtual void ProvisionWiFi(const char * ssid, const char * passwd) {}
+
+    /**
+     * @brief
+     *   Called to provision Thread credentials in a device
+     *
+     * @param threadData Thread settings and credentials
+     */
+    virtual void ProvisionThread(const DeviceLayer::Internal::DeviceNetworkInfo & threadData) {}
 
     virtual ~DeviceNetworkProvisioningDelegate() {}
 };
@@ -89,8 +98,9 @@ class DLL_EXPORT NetworkProvisioning
 public:
     enum MsgTypes : uint8_t
     {
-        kWiFiAssociationRequest = 0,
-        kIPAddressAssigned      = 1,
+        kWiFiAssociationRequest   = 0,
+        kIPAddressAssigned        = 1,
+        kThreadAssociationRequest = 2
     };
 
     void Init(NetworkProvisioningDelegate * delegate, DeviceNetworkProvisioningDelegate * deviceDelegate);
@@ -128,6 +138,8 @@ private:
 
     CHIP_ERROR EncodeString(const char * str, BufBound & bbuf);
     CHIP_ERROR DecodeString(const uint8_t * input, size_t input_len, BufBound & bbuf, size_t & consumed);
+
+    CHIP_ERROR DecodeThreadAssociationRequest(System::PacketBuffer * msgBuf);
 
 #if CONFIG_DEVICE_LAYER
     static void ConnectivityHandler(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg);


### PR DESCRIPTION
 #### Problem
Currently, NetworkProvisioning class, which takes part in Rendezvous over BLE session, only supports WiFi provisioning and Thread provisioning is partially implemented in RendezvousServer (Application layer).

 #### Proposed Solution
- move the Thread provisioning code to the BLE transport layer to process both network types in the same/similar way
- reply on Thread Association request with SLAAC/On-Mesh IPv6 Address once that is assigned so that the controller knows that provisioning completed successfully and how to reach the device
- call MemoryInit() in nrfconnect examples

 Fixes #3302