### PR TITLE
ESP32/boards: Add support of ESP32 Wrover Kit in wifi-echo demo

### DIFF
--- a/examples/common/screen-framework/Display.cpp
+++ b/examples/common/screen-framework/Display.cpp
@@ -131,8 +131,7 @@ esp_err_t InitDisplay()
 
     ESP_LOGI(TAG, "Display initialized (height %u, width %u)", DisplayHeight, DisplayWidth);
 
-    // for some reason this is backwards (turns out this is because of a 2019 update to the m5stack hw)
-    TFT_invertDisplay(INVERT_ON);
+    TFT_invertDisplay(INVERT_DISPLAY);
 
     // prepare the display for brightness control
     SetupBrightnessControl();

--- a/examples/common/screen-framework/include/Display.h
+++ b/examples/common/screen-framework/include/Display.h
@@ -31,13 +31,19 @@
 #if CONFIG_DEVICE_TYPE_M5STACK
 
 #define CONFIG_HAVE_DISPLAY 1
-#define CONFIG_TFT_PREDEFINED_DISPLAY_TYPE 3
+// for some reason this is backwards (turns out this is because of a 2019 update to the m5stack hw)
+#define INVERT_DISPLAY INVERT_ON
 
-#else // !CONFIG_DEVICE_TYPE_M5STACK
+#elif CONFIG_DEVICE_TYPE_ESP32_WROVER_KIT
+
+#define CONFIG_HAVE_DISPLAY 1
+#define INVERT_DISPLAY INVERT_OFF
+
+#else
 
 #define CONFIG_HAVE_DISPLAY 0
 
-#endif // !CONFIG_DEVICE_TYPE_M5STACK
+#endif
 
 #if CONFIG_HAVE_DISPLAY
 

--- a/examples/wifi-echo/server/esp32/main/Kconfig.projbuild
+++ b/examples/wifi-echo/server/esp32/main/Kconfig.projbuild
@@ -31,6 +31,8 @@ menu "WiFi Echo Demo"
 
         config DEVICE_TYPE_ESP32_DEVKITC
             bool "ESP32-DevKitC"
+        config DEVICE_TYPE_ESP32_WROVER_KIT
+            bool "ESP32-WROVER-KIT_V4.1"
         config DEVICE_TYPE_M5STACK
             bool "M5Stack"
     endchoice
@@ -66,8 +68,9 @@ menu "WiFi Echo Demo"
     config TFT_PREDEFINED_DISPLAY_TYPE
         int
         range 0 5
-        default 3 if DEVICE_TYPE_M5STACK
         default 0 if DEVICE_TYPE_ESP32_DEVKITC
+        default 3 if DEVICE_TYPE_M5STACK
+        default 4 if DEVICE_TYPE_ESP32_WROVER_KIT
 
     config RENDEZVOUS_MODE
        int

--- a/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
@@ -62,11 +62,12 @@ extern void startServer();
 #define BUTTON_3_GPIO_NUM GPIO_NUM_37    // Right button on M5Stack
 #define STATUS_LED_GPIO_NUM GPIO_NUM_MAX // No status LED on M5Stack
 
+#elif CONFIG_DEVICE_TYPE_ESP32_WROVER_KIT
+
+#define STATUS_LED_GPIO_NUM GPIO_NUM_26
+
 #elif CONFIG_DEVICE_TYPE_ESP32_DEVKITC
 
-#define BUTTON_1_GPIO_NUM GPIO_NUM_34  // Button 1 on DevKitC
-#define BUTTON_2_GPIO_NUM GPIO_NUM_35  // Button 2 on DevKitC
-#define BUTTON_3_GPIO_NUM GPIO_NUM_0   // Button 3 on DevKitC
 #define STATUS_LED_GPIO_NUM GPIO_NUM_2 // Use LED1 (blue LED) as status LED on DevKitC
 
 #else // !CONFIG_DEVICE_TYPE_ESP32_DEVKITC
@@ -77,15 +78,6 @@ extern void startServer();
 
 // Used to indicate that an IP address has been added to the QRCode
 #define EXAMPLE_VENDOR_TAG_IP 1
-
-#if CONFIG_HAVE_DISPLAY
-
-// Where to draw the connection status message
-#define CONNECTION_MESSAGE 75
-// Where to draw the IPv6 information
-#define IPV6_INFO 85
-
-#endif // CONFIG_HAVE_DISPLAY
 
 LEDWidget statusLED1;
 LEDWidget statusLED2;
@@ -101,8 +93,12 @@ RendezvousDeviceDelegate * rendezvousDelegate = nullptr;
 
 namespace {
 
+#if CONFIG_DEVICE_TYPE_M5STACK
+
 std::vector<Button> buttons          = { Button(), Button(), Button() };
 std::vector<gpio_num_t> button_gpios = { BUTTON_1_GPIO_NUM, BUTTON_2_GPIO_NUM, BUTTON_3_GPIO_NUM };
+
+#endif
 
 // Pretend these are devices with endpoints with clusters with attributes
 typedef std::tuple<std::string, std::string> Attribute;
@@ -139,7 +135,7 @@ void AddDevice(std::string name)
     devices.emplace_back(std::move(device));
 }
 
-#if CONFIG_HAVE_DISPLAY
+#if CONFIG_DEVICE_TYPE_M5STACK
 
 class EditAttributeListModel : public ListScreen::Model
 {
@@ -291,7 +287,7 @@ public:
     }
 };
 
-#endif // CONFIG_HAVE_DISPLAY
+#endif // CONFIG_DEVICE_TYPE_M5STACK
 
 void SetupPretendDevices()
 {
@@ -493,6 +489,18 @@ extern "C" void app_main()
     ESP_LOGI(TAG, "QR CODE: '%s'", qrCodeText.c_str());
 
 #if CONFIG_HAVE_DISPLAY
+    // Initialize the display device.
+    err = InitDisplay();
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "InitDisplay() failed: %s", ErrorStr(err));
+        return;
+    }
+
+    // Initialize the screen manager
+    ScreenManager::Init();
+
+#if CONFIG_DEVICE_TYPE_M5STACK
     // Initialize the buttons.
     for (int i = 0; i < buttons.size(); ++i)
     {
@@ -504,16 +512,7 @@ extern "C" void app_main()
         }
     }
 
-    // Initialize the display device.
-    err = InitDisplay();
-    if (err != ESP_OK)
-    {
-        ESP_LOGE(TAG, "InitDisplay() failed: %s", ErrorStr(err));
-        return;
-    }
-
-    // Initialize the screen manager and push a rudimentary user interface.
-    ScreenManager::Init();
+    // Push a rudimentary user interface.
     ScreenManager::PushScreen(chip::Platform::New<ListScreen>(
         (chip::Platform::New<SimpleListModel>())
             ->Title("CHIP")
@@ -543,6 +542,14 @@ extern "C" void app_main()
             ->Item("For")
             ->Item("Demo")));
 
+#elif CONFIG_DEVICE_TYPE_ESP32_WROVER_KIT
+
+    // Display the QR Code
+    QRCodeScreen qrCodeScreen(qrCodeText);
+    qrCodeScreen.Display();
+
+#endif
+
     // Connect the status LED to VLEDs.
     {
         int vled1 = ScreenManager::AddVLED(TFT_GREEN);
@@ -562,7 +569,7 @@ extern "C" void app_main()
     // Run the UI Loop
     while (true)
     {
-#if CONFIG_HAVE_DISPLAY
+#if CONFIG_DEVICE_TYPE_M5STACK
         // TODO consider refactoring this example to use FreeRTOS tasks
 
         bool woken = false;
@@ -587,7 +594,7 @@ extern "C" void app_main()
             }
         }
 
-#endif // CONFIG_HAVE_DISPLAY
+#endif // CONFIG_DEVICE_TYPE_M5STACK
 
         vTaskDelay(50 / portTICK_PERIOD_MS);
     }


### PR DESCRIPTION
 #### Problem
ESP32: Need to add the support of ESP32 Wrover Kit in wifi-echo demo

 #### Summary of Changes
1. Added a config option for Wrover Kit in the example Kconfig.
2. As the Wrover Kit does not have 3 buttons, only using the QR code screen to display the QR code.
3. Used the Screen Manager framework to display VLEDs on the Wrover display.
4. Inverting colors is not required for Wrover, so managed it according to the device type.
5. CONFIG_TFT_PREDEFINED_DISPLAY_TYPE need not be explicitly defined as it is taken from the menuconfig.
6. Replaced CONFIG_HAVE_DISPLAY with CONFIG_DEVICE_TYPE_M5STACK at a few places in wifi-echo.cpp (for e.g. Not all displays would be having physical buttons)
7. Remove unused code.

Tested this code with both M5Stack and Wrover Kit and the functionality seems to work as expected.
