### PR TITLE
Extends .gitignore with Python related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,9 +35,15 @@ TAGS
 # C-Lion / IDEA files
 .idea/**
 
-# Python bytecodes
-__pycache__
+# Python
 *.pyc
+*.egg/
+*.eggs/
+*.egg-info/
+.cache/
+.mypy_cache/
+__pycache__/
+dist/
 
 # Doxygen outputs
 docs/html


### PR DESCRIPTION
 #### Problem
egg-info directories are not ignored by git

 #### Summary of Changes
Take python related file patterns from Pigweed's .gitignore.