### PR TITLE
Make cirque artifacts be named -logs so that bloat checker does not delete them

### DIFF
--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -65,6 +65,5 @@ jobs:
               if: ${{ always() }}
               with:
                   name:
-                      cirque_log-${{
-                        steps.outsuffix.outputs.value }}
+                      cirque_log-${{steps.outsuffix.outputs.value}}-logs
                   path: /tmp/cirque_test_output/


### PR DESCRIPTION
 #### Problem
Bloat checker logic is '-logs' is logs, everything else is 'binary comparison'. This makes cirque data be a binary comparison and artifacts get deleted.

 #### Summary of Changes
Rename artifacts for cirque to end in -logs.
