### PR TITLE
Exclude nanopb from restyling

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -65,6 +65,7 @@ exclude:
     - "third_party/bluez/repo/**/*"
     - "third_party/ot-commissioner/repo/**/*"
     - "third_party/cirque/repo/**/*"
+    - "third_party/nanopb/repo/**/*"
 
 
 changed_paths:


### PR DESCRIPTION
 #### Problem
scripts/helpers/restyle-diff.sh would modify third_party/nanopb
which is a third party repository, no need to restyle it.

 #### Summary of Changes
Added third_party/nanopb/repo to exclude list in
.restyled.yaml
