### PR TITLE
Disable DNS tests on Raspberry Pi

### DIFF
--- a/src/inet/tests/BUILD.gn
+++ b/src/inet/tests/BUILD.gn
@@ -61,7 +61,8 @@ chip_test_suite("tests") {
     "TestInetEndPoint",
   ]
 
-  if (current_os != "mac" && chip_device_platform != "esp32") {
+  if (current_os != "mac" && chip_device_platform != "esp32" &&
+      current_cpu == "x64") {
     sources += [
       "TestInetLayerDNS.cpp",
       "TestLwIPDNS.cpp",

--- a/src/inet/tests/BUILD.gn
+++ b/src/inet/tests/BUILD.gn
@@ -61,6 +61,8 @@ chip_test_suite("tests") {
     "TestInetEndPoint",
   ]
 
+  # This fails on Raspberry Pi (Linux arm64), so only enable on Linux
+  # x64.
   if (current_os != "mac" && chip_device_platform != "esp32" &&
       current_cpu == "x64") {
     sources += [


### PR DESCRIPTION
These tests don't work on the Pi currently, needs investigation.

See #3312