### PR TITLE
Fix incorrect suppression of compiler errors in cirque tests.

### DIFF
--- a/src/test_driver/linux-cirque/OnOffClusterTest.sh
+++ b/src/test_driver/linux-cirque/OnOffClusterTest.sh
@@ -31,7 +31,7 @@ function build_chip_tool() {
     set -x
     cd "$chip_tool_dir"
     gn gen out/debug >/dev/null
-    ninja -C out/debug >/dev/null
+    run_ninja -C out/debug
     docker build -t chip_tool -f Dockerfile . >/dev/null 2>&1
 }
 
@@ -40,7 +40,7 @@ function build_chip_lighting() {
     set -x
     cd "$chip_light_dir"
     gn gen out/debug --args='bypass_rendezvous=true' >/dev/null
-    ninja -C out/debug >/dev/null
+    run_ninja -C out/debug
     docker build -t chip_server -f Dockerfile . >/dev/null 2>&1
     set +x
 }
@@ -53,4 +53,5 @@ function main() {
     python3 "$SOURCE_DIR/test-on-off-cluster.py"
 }
 
+source "$SOURCE_DIR"/shell-helpers.sh
 main

--- a/src/test_driver/linux-cirque/shell-helpers.sh
+++ b/src/test_driver/linux-cirque/shell-helpers.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# This function is a workaround for the fact that ninja sends all
+# output, including compiler errors, to stdout, not stderr.  We want
+# to suppress the various output from ninja itself, but not compiler
+# errors.  Do that by prefixing the ninja output with a string that is
+# unlikely to appear in compiler errors, then filtering it out.
+function run_ninja() {
+    prefix="|ninja_filter_prefix|"
+    NINJA_STATUS="$prefix[%f/%t] " ninja "$@" | grep -v "^$prefix"
+}


### PR DESCRIPTION
ninja sends all output, including compiler errors, to stdout, not
stderr.  So redirecting to /dev/null was hiding compiler errors and
making it very difficult to debug test failures.

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Compiler errors not shown in cirque log if compile fails.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Start showing the errors by filtering out ninja output only instead of redirecting everything to `/dev/null`.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
