### PR TITLE
Redefine the sepcial NodeID address to align with convention

### DIFF
--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -35,8 +35,9 @@ namespace chip {
 /// Convenience type to make it clear a number represents a node id.
 typedef uint64_t NodeId;
 
-constexpr NodeId kUndefinedNodeId = 0xFFFFFFFFFFFFFFFFll;
-constexpr size_t kMaxTagLen       = 16;
+static constexpr NodeId kUndefinedNodeId = 0ULL;
+static constexpr NodeId kAnyNodeId       = 0xFFFFFFFFFFFFFFFFULL;
+static constexpr size_t kMaxTagLen       = 16;
 
 typedef int PacketHeaderFlags;
 


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Currently, 0xFFFFFFFFFFFFFFFFULL is defined as the undefined Node ID and for all initialization. But this value is used as the broadcast Node address in the ExchangeManger implementation.

After discussion, we propose to use 0xFFFFFFFFFFFFFFFFULL as the broadcast address, and 0 for UnSpecified NodeId since it is a chosen convention to use all FFs for AnyNodeId and 0s for UnSpecified NodeId, using all Fs for broadcast is a typical convention used everywhere.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes

Use 0 as the undefined Node address and FFs as the broadcast Node address.
static constexpr NodeId kUndefinedNodeId = 0ULL;
static constexpr NodeId kAnyNodeId       = 0xFFFFFFFFFFFFFFFFULL;