### PR TITLE
Returns EXIT_FAILURE is something went wrong inside chip-tool

### DIFF
--- a/examples/chip-tool/commands/clusters/Commands.h
+++ b/examples/chip-tool/commands/clusters/Commands.h
@@ -290,7 +290,10 @@ public:
         {
             ChipLogProgress(chipTool, "  %s: 0x%04x", "attributeId", chip::Encoding::LittleEndian::Read16(message)); // attribId
             ChipLogProgress(chipTool, "  %s: 0x%02x", "status", chip::Encoding::Read8(message));                     // zclStatus
-            ReadAnyType(message);
+            if (!ReadAnyType(message))
+            {
+                return false;
+            }
         } while (message < messageEnd);
 
         return true;
@@ -336,7 +339,10 @@ public:
         do
         {
             ChipLogProgress(chipTool, "  %s: 0x%04x", "attributeId", chip::Encoding::LittleEndian::Read16(message)); // attribId
-            ReadAnyType(message);
+            if (!ReadAnyType(message))
+            {
+                return false;
+            }
         } while (message < messageEnd);
 
         return true;

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -102,10 +102,14 @@ public:
 
     virtual CHIP_ERROR Run(ChipDeviceController * dc, NodeId remoteId) = 0;
 
+    bool GetCommandExitStatus() const { return mCommandExitStatus; }
+    void SetCommandExitStatus(bool status) { mCommandExitStatus = status; }
+
 private:
     bool InitArgument(size_t argIndex, const char * argValue);
     size_t AddArgument(const char * name, int64_t min, int64_t max, void * out);
 
-    const char * mName = nullptr;
+    bool mCommandExitStatus = false;
+    const char * mName      = nullptr;
     std::vector<Argument> mArgs;
 };

--- a/examples/chip-tool/commands/common/ModelCommand.h
+++ b/examples/chip-tool/commands/common/ModelCommand.h
@@ -57,7 +57,7 @@ public:
 
 private:
     bool SendCommand(ChipDeviceController * dc);
-    void ReceiveCommandResponse(ChipDeviceController * dc, chip::System::PacketBuffer * buffer) const;
+    bool ReceiveCommandResponse(ChipDeviceController * dc, chip::System::PacketBuffer * buffer) const;
 
     void UpdateWaitForResponse(bool value);
     void WaitForResponse(void);


### PR DESCRIPTION
 #### Problem

Currently chip-tool returns EXIT_SUCCESS as long as the command has been parsed and sent. It does not use the result of the command to update its status.
It's not very useful to write tests. For example

 #### Summary of Changes
 * Use the status of the response
