### PR TITLE
Update the list of supported clusters attributes

### DIFF
--- a/examples/chip-tool/commands/clusters/Commands.h
+++ b/examples/chip-tool/commands/clusters/Commands.h
@@ -567,18 +567,7 @@ public:
 |------------------------------------------------------------------------------|
 | Attributes:                                                         |        |
 | * ZCLVersion                                                        | 0x0000 |
-| * ApplicationVersion                                                | 0x0001 |
-| * StackVersion                                                      | 0x0002 |
-| * HWVersion                                                         | 0x0003 |
-| * ManufacturerName                                                  | 0x0004 |
-| * ModelIdentifier                                                   | 0x0005 |
-| * DateCode                                                          | 0x0006 |
 | * PowerSource                                                       | 0x0007 |
-| * GenericDevice-Class                                               | 0x0008 |
-| * GenericDevice-Type                                                | 0x0009 |
-| * ProductCode                                                       | 0x000A |
-| * ProductURL                                                        | 0x000B |
-| * SWBuildID                                                         | 0x4000 |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -624,132 +613,6 @@ public:
 };
 
 /*
- * Attribute ApplicationVersion
- */
-class ReadBasicApplicationVersion : public ModelCommand
-{
-public:
-    ReadBasicApplicationVersion() : ModelCommand("read", kBasicClusterId, 0x00) { AddArgument("attr-name", "application-version"); }
-
-    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeBasicClusterReadApplicationVersionAttribute(buffer->Start(), bufferSize, endPointId);
-    }
-
-    // Global Response: ReadAttributesResponse
-    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
-    {
-        ReadAttributesResponse response;
-        return response.HandleCommandResponse(commandId, message, messageLen);
-    }
-};
-
-/*
- * Attribute StackVersion
- */
-class ReadBasicStackVersion : public ModelCommand
-{
-public:
-    ReadBasicStackVersion() : ModelCommand("read", kBasicClusterId, 0x00) { AddArgument("attr-name", "stack-version"); }
-
-    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeBasicClusterReadStackVersionAttribute(buffer->Start(), bufferSize, endPointId);
-    }
-
-    // Global Response: ReadAttributesResponse
-    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
-    {
-        ReadAttributesResponse response;
-        return response.HandleCommandResponse(commandId, message, messageLen);
-    }
-};
-
-/*
- * Attribute HWVersion
- */
-class ReadBasicHWVersion : public ModelCommand
-{
-public:
-    ReadBasicHWVersion() : ModelCommand("read", kBasicClusterId, 0x00) { AddArgument("attr-name", "hwversion"); }
-
-    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeBasicClusterReadHWVersionAttribute(buffer->Start(), bufferSize, endPointId);
-    }
-
-    // Global Response: ReadAttributesResponse
-    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
-    {
-        ReadAttributesResponse response;
-        return response.HandleCommandResponse(commandId, message, messageLen);
-    }
-};
-
-/*
- * Attribute ManufacturerName
- */
-class ReadBasicManufacturerName : public ModelCommand
-{
-public:
-    ReadBasicManufacturerName() : ModelCommand("read", kBasicClusterId, 0x00) { AddArgument("attr-name", "manufacturer-name"); }
-
-    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeBasicClusterReadManufacturerNameAttribute(buffer->Start(), bufferSize, endPointId);
-    }
-
-    // Global Response: ReadAttributesResponse
-    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
-    {
-        ReadAttributesResponse response;
-        return response.HandleCommandResponse(commandId, message, messageLen);
-    }
-};
-
-/*
- * Attribute ModelIdentifier
- */
-class ReadBasicModelIdentifier : public ModelCommand
-{
-public:
-    ReadBasicModelIdentifier() : ModelCommand("read", kBasicClusterId, 0x00) { AddArgument("attr-name", "model-identifier"); }
-
-    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeBasicClusterReadModelIdentifierAttribute(buffer->Start(), bufferSize, endPointId);
-    }
-
-    // Global Response: ReadAttributesResponse
-    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
-    {
-        ReadAttributesResponse response;
-        return response.HandleCommandResponse(commandId, message, messageLen);
-    }
-};
-
-/*
- * Attribute DateCode
- */
-class ReadBasicDateCode : public ModelCommand
-{
-public:
-    ReadBasicDateCode() : ModelCommand("read", kBasicClusterId, 0x00) { AddArgument("attr-name", "date-code"); }
-
-    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeBasicClusterReadDateCodeAttribute(buffer->Start(), bufferSize, endPointId);
-    }
-
-    // Global Response: ReadAttributesResponse
-    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
-    {
-        ReadAttributesResponse response;
-        return response.HandleCommandResponse(commandId, message, messageLen);
-    }
-};
-
-/*
  * Attribute PowerSource
  */
 class ReadBasicPowerSource : public ModelCommand
@@ -760,114 +623,6 @@ public:
     uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
     {
         return encodeBasicClusterReadPowerSourceAttribute(buffer->Start(), bufferSize, endPointId);
-    }
-
-    // Global Response: ReadAttributesResponse
-    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
-    {
-        ReadAttributesResponse response;
-        return response.HandleCommandResponse(commandId, message, messageLen);
-    }
-};
-
-/*
- * Attribute GenericDeviceClass
- */
-class ReadBasicGenericDeviceClass : public ModelCommand
-{
-public:
-    ReadBasicGenericDeviceClass() : ModelCommand("read", kBasicClusterId, 0x00)
-    {
-        AddArgument("attr-name", "generic-device-class");
-    }
-
-    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeBasicClusterReadGenericDeviceClassAttribute(buffer->Start(), bufferSize, endPointId);
-    }
-
-    // Global Response: ReadAttributesResponse
-    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
-    {
-        ReadAttributesResponse response;
-        return response.HandleCommandResponse(commandId, message, messageLen);
-    }
-};
-
-/*
- * Attribute GenericDeviceType
- */
-class ReadBasicGenericDeviceType : public ModelCommand
-{
-public:
-    ReadBasicGenericDeviceType() : ModelCommand("read", kBasicClusterId, 0x00) { AddArgument("attr-name", "generic-device-type"); }
-
-    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeBasicClusterReadGenericDeviceTypeAttribute(buffer->Start(), bufferSize, endPointId);
-    }
-
-    // Global Response: ReadAttributesResponse
-    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
-    {
-        ReadAttributesResponse response;
-        return response.HandleCommandResponse(commandId, message, messageLen);
-    }
-};
-
-/*
- * Attribute ProductCode
- */
-class ReadBasicProductCode : public ModelCommand
-{
-public:
-    ReadBasicProductCode() : ModelCommand("read", kBasicClusterId, 0x00) { AddArgument("attr-name", "product-code"); }
-
-    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeBasicClusterReadProductCodeAttribute(buffer->Start(), bufferSize, endPointId);
-    }
-
-    // Global Response: ReadAttributesResponse
-    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
-    {
-        ReadAttributesResponse response;
-        return response.HandleCommandResponse(commandId, message, messageLen);
-    }
-};
-
-/*
- * Attribute ProductURL
- */
-class ReadBasicProductURL : public ModelCommand
-{
-public:
-    ReadBasicProductURL() : ModelCommand("read", kBasicClusterId, 0x00) { AddArgument("attr-name", "product-url"); }
-
-    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeBasicClusterReadProductURLAttribute(buffer->Start(), bufferSize, endPointId);
-    }
-
-    // Global Response: ReadAttributesResponse
-    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
-    {
-        ReadAttributesResponse response;
-        return response.HandleCommandResponse(commandId, message, messageLen);
-    }
-};
-
-/*
- * Attribute SWBuildID
- */
-class ReadBasicSWBuildID : public ModelCommand
-{
-public:
-    ReadBasicSWBuildID() : ModelCommand("read", kBasicClusterId, 0x00) { AddArgument("attr-name", "swbuild-id"); }
-
-    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeBasicClusterReadSWBuildIDAttribute(buffer->Start(), bufferSize, endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -903,6 +658,7 @@ public:
 | Attributes:                                                         |        |
 | * CurrentHue                                                        | 0x0000 |
 | * CurrentSaturation                                                 | 0x0001 |
+| * RemainingTime                                                     | 0x0002 |
 | * CurrentX                                                          | 0x0003 |
 | * CurrentY                                                          | 0x0004 |
 | * ColorTemperatureMireds                                            | 0x0007 |
@@ -1472,6 +1228,30 @@ public:
     uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
     {
         return encodeColorControlClusterReadCurrentSaturationAttribute(buffer->Start(), bufferSize, endPointId);
+    }
+
+    // Global Response: ReadAttributesResponse
+    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
+    {
+        ReadAttributesResponse response;
+        return response.HandleCommandResponse(commandId, message, messageLen);
+    }
+};
+
+/*
+ * Attribute RemainingTime
+ */
+class ReadColorControlRemainingTime : public ModelCommand
+{
+public:
+    ReadColorControlRemainingTime() : ModelCommand("read", kColorControlClusterId, 0x00)
+    {
+        AddArgument("attr-name", "remaining-time");
+    }
+
+    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
+    {
+        return encodeColorControlClusterReadRemainingTimeAttribute(buffer->Start(), bufferSize, endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -4084,8 +3864,6 @@ public:
 |------------------------------------------------------------------------------|
 | Attributes:                                                         |        |
 | * CurrentLevel                                                      | 0x0000 |
-| * RemainingTime                                                     | 0x0001 |
-| * Options                                                           | 0x000F |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -4365,48 +4143,6 @@ public:
     uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
     {
         return encodeLevelClusterReadCurrentLevelAttribute(buffer->Start(), bufferSize, endPointId);
-    }
-
-    // Global Response: ReadAttributesResponse
-    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
-    {
-        ReadAttributesResponse response;
-        return response.HandleCommandResponse(commandId, message, messageLen);
-    }
-};
-
-/*
- * Attribute RemainingTime
- */
-class ReadLevelRemainingTime : public ModelCommand
-{
-public:
-    ReadLevelRemainingTime() : ModelCommand("read", kLevelClusterId, 0x00) { AddArgument("attr-name", "remaining-time"); }
-
-    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeLevelClusterReadRemainingTimeAttribute(buffer->Start(), bufferSize, endPointId);
-    }
-
-    // Global Response: ReadAttributesResponse
-    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
-    {
-        ReadAttributesResponse response;
-        return response.HandleCommandResponse(commandId, message, messageLen);
-    }
-};
-
-/*
- * Attribute Options
- */
-class ReadLevelOptions : public ModelCommand
-{
-public:
-    ReadLevelOptions() : ModelCommand("read", kLevelClusterId, 0x00) { AddArgument("attr-name", "options"); }
-
-    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeLevelClusterReadOptionsAttribute(buffer->Start(), bufferSize, endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -5333,13 +5069,9 @@ void registerClusterBasic(Commands & commands)
     const char * clusterName = "Basic";
 
     commands_list clusterCommands = {
-        make_unique<BasicResetToFactoryDefaults>(), make_unique<ReadBasicZCLVersion>(),
-        make_unique<ReadBasicApplicationVersion>(), make_unique<ReadBasicStackVersion>(),
-        make_unique<ReadBasicHWVersion>(),          make_unique<ReadBasicManufacturerName>(),
-        make_unique<ReadBasicModelIdentifier>(),    make_unique<ReadBasicDateCode>(),
-        make_unique<ReadBasicPowerSource>(),        make_unique<ReadBasicGenericDeviceClass>(),
-        make_unique<ReadBasicGenericDeviceType>(),  make_unique<ReadBasicProductCode>(),
-        make_unique<ReadBasicProductURL>(),         make_unique<ReadBasicSWBuildID>(),
+        make_unique<BasicResetToFactoryDefaults>(),
+        make_unique<ReadBasicZCLVersion>(),
+        make_unique<ReadBasicPowerSource>(),
     };
 
     commands.Register(clusterName, clusterCommands);
@@ -5366,6 +5098,7 @@ void registerClusterColorControl(Commands & commands)
         make_unique<ColorControlStopMoveStep>(),
         make_unique<ReadColorControlCurrentHue>(),
         make_unique<ReadColorControlCurrentSaturation>(),
+        make_unique<ReadColorControlRemainingTime>(),
         make_unique<ReadColorControlCurrentX>(),
         make_unique<ReadColorControlCurrentY>(),
         make_unique<ReadColorControlColorTemperatureMireds>(),
@@ -5474,17 +5207,9 @@ void registerClusterLevel(Commands & commands)
     const char * clusterName = "Level";
 
     commands_list clusterCommands = {
-        make_unique<LevelMove>(),
-        make_unique<LevelMoveToLevel>(),
-        make_unique<LevelMoveToLevelWithOnOff>(),
-        make_unique<LevelMoveWithOnOff>(),
-        make_unique<LevelStep>(),
-        make_unique<LevelStepWithOnOff>(),
-        make_unique<LevelStop>(),
-        make_unique<LevelStopWithOnOff>(),
-        make_unique<ReadLevelCurrentLevel>(),
-        make_unique<ReadLevelRemainingTime>(),
-        make_unique<ReadLevelOptions>(),
+        make_unique<LevelMove>(),          make_unique<LevelMoveToLevel>(),   make_unique<LevelMoveToLevelWithOnOff>(),
+        make_unique<LevelMoveWithOnOff>(), make_unique<LevelStep>(),          make_unique<LevelStepWithOnOff>(),
+        make_unique<LevelStop>(),          make_unique<LevelStopWithOnOff>(), make_unique<ReadLevelCurrentLevel>(),
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/src/app/chip-zcl-zpro-codec-api.h
+++ b/src/app/chip-zcl-zpro-codec-api.h
@@ -45,11 +45,13 @@ extern "C" {
 /*----------------------------------------------------------------------------*\
 | Cluster BarrierControl                                              | 0x0103 |
 |------------------------------------------------------------------------------|
-| Commands:                                                           |        |
-| * GoToPercent                                                       |   0x00 |
+| Responses:                                                          |        |
 |                                                                     |        |
 |------------------------------------------------------------------------------|
-| Attributes::                                                        |        |
+| Commands:                                                           |        |
+| * GoToPercent                                                       |   0x00 |
+|------------------------------------------------------------------------------|
+| Attributes:                                                         |        |
 | * MovingState                                                       | 0x0001 |
 | * SafetyStatus                                                      | 0x0002 |
 | * Capabilities                                                      | 0x0003 |
@@ -91,24 +93,15 @@ uint16_t encodeBarrierControlClusterReadBarrierPositionAttribute(uint8_t * buffe
 /*----------------------------------------------------------------------------*\
 | Cluster Basic                                                       | 0x0000 |
 |------------------------------------------------------------------------------|
-| Commands:                                                           |        |
-| * ResetToFactoryDefaults                                            |   0x00 |
+| Responses:                                                          |        |
 |                                                                     |        |
 |------------------------------------------------------------------------------|
-| Attributes::                                                        |        |
+| Commands:                                                           |        |
+| * ResetToFactoryDefaults                                            |   0x00 |
+|------------------------------------------------------------------------------|
+| Attributes:                                                         |        |
 | * ZCLVersion                                                        | 0x0000 |
-| * ApplicationVersion                                                | 0x0001 |
-| * StackVersion                                                      | 0x0002 |
-| * HWVersion                                                         | 0x0003 |
-| * ManufacturerName                                                  | 0x0004 |
-| * ModelIdentifier                                                   | 0x0005 |
-| * DateCode                                                          | 0x0006 |
 | * PowerSource                                                       | 0x0007 |
-| * GenericDevice-Class                                               | 0x0008 |
-| * GenericDevice-Type                                                | 0x0009 |
-| * ProductCode                                                       | 0x000A |
-| * ProductURL                                                        | 0x000B |
-| * SWBuildID                                                         | 0x4000 |
 \*----------------------------------------------------------------------------*/
 
 /**
@@ -125,78 +118,15 @@ uint16_t encodeBasicClusterReadZCLVersionAttribute(uint8_t * buffer, uint16_t bu
 
 /**
  * @brief
- *    Encode a read command for the application-version attribute for  server into buffer including the APS frame
- */
-uint16_t encodeBasicClusterReadApplicationVersionAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
-
-/**
- * @brief
- *    Encode a read command for the stack-version attribute for  server into buffer including the APS frame
- */
-uint16_t encodeBasicClusterReadStackVersionAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
-
-/**
- * @brief
- *    Encode a read command for the hwversion attribute for  server into buffer including the APS frame
- */
-uint16_t encodeBasicClusterReadHWVersionAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
-
-/**
- * @brief
- *    Encode a read command for the manufacturer-name attribute for  server into buffer including the APS frame
- */
-uint16_t encodeBasicClusterReadManufacturerNameAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
-
-/**
- * @brief
- *    Encode a read command for the model-identifier attribute for  server into buffer including the APS frame
- */
-uint16_t encodeBasicClusterReadModelIdentifierAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
-
-/**
- * @brief
- *    Encode a read command for the date-code attribute for  server into buffer including the APS frame
- */
-uint16_t encodeBasicClusterReadDateCodeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
-
-/**
- * @brief
  *    Encode a read command for the power-source attribute for  server into buffer including the APS frame
  */
 uint16_t encodeBasicClusterReadPowerSourceAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
 
-/**
- * @brief
- *    Encode a read command for the generic-device-class attribute for  server into buffer including the APS frame
- */
-uint16_t encodeBasicClusterReadGenericDeviceClassAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
-
-/**
- * @brief
- *    Encode a read command for the generic-device-type attribute for  server into buffer including the APS frame
- */
-uint16_t encodeBasicClusterReadGenericDeviceTypeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
-
-/**
- * @brief
- *    Encode a read command for the product-code attribute for  server into buffer including the APS frame
- */
-uint16_t encodeBasicClusterReadProductCodeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
-
-/**
- * @brief
- *    Encode a read command for the product-url attribute for  server into buffer including the APS frame
- */
-uint16_t encodeBasicClusterReadProductURLAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
-
-/**
- * @brief
- *    Encode a read command for the swbuild-id attribute for  server into buffer including the APS frame
- */
-uint16_t encodeBasicClusterReadSWBuildIDAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
-
 /*----------------------------------------------------------------------------*\
 | Cluster ColorControl                                                | 0x0300 |
+|------------------------------------------------------------------------------|
+| Responses:                                                          |        |
+|                                                                     |        |
 |------------------------------------------------------------------------------|
 | Commands:                                                           |        |
 | * MoveColor                                                         |   0x08 |
@@ -213,11 +143,11 @@ uint16_t encodeBasicClusterReadSWBuildIDAttribute(uint8_t * buffer, uint16_t buf
 | * StepHue                                                           |   0x02 |
 | * StepSaturation                                                    |   0x05 |
 | * StopMoveStep                                                      |   0x47 |
-|                                                                     |        |
 |------------------------------------------------------------------------------|
-| Attributes::                                                        |        |
+| Attributes:                                                         |        |
 | * CurrentHue                                                        | 0x0000 |
 | * CurrentSaturation                                                 | 0x0001 |
+| * RemainingTime                                                     | 0x0002 |
 | * CurrentX                                                          | 0x0003 |
 | * CurrentY                                                          | 0x0004 |
 | * ColorTemperatureMireds                                            | 0x0007 |
@@ -381,6 +311,12 @@ uint16_t encodeColorControlClusterReadCurrentHueAttribute(uint8_t * buffer, uint
  */
 uint16_t encodeColorControlClusterReadCurrentSaturationAttribute(uint8_t * buffer, uint16_t buf_length,
                                                                  uint8_t destination_endpoint);
+
+/**
+ * @brief
+ *    Encode a read command for the remaining-time attribute for  server into buffer including the APS frame
+ */
+uint16_t encodeColorControlClusterReadRemainingTimeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
 
 /**
  * @brief
@@ -619,6 +555,32 @@ uint16_t encodeColorControlClusterReadStartUpColorTemperatureMiredsAttribute(uin
 /*----------------------------------------------------------------------------*\
 | Cluster DoorLock                                                    | 0x0101 |
 |------------------------------------------------------------------------------|
+| Responses:                                                          |        |
+| * ClearAllPINCodesResponse                                          |   0x08 |
+| * ClearAllRFIDCodesResponse                                         |   0x19 |
+| * ClearHolidayScheduleResponse                                      |   0x13 |
+| * ClearPINCodeResponse                                              |   0x07 |
+| * ClearRFIDCodeResponse                                             |   0x18 |
+| * ClearWeekdayScheduleResponse                                      |   0x0D |
+| * ClearYearDayScheduleResponse                                      |   0x10 |
+| * GetHolidayScheduleResponse                                        |   0x12 |
+| * GetLogRecordResponse                                              |   0x04 |
+| * GetPINCodeResponse                                                |   0x06 |
+| * GetRFIDCodeResponse                                               |   0x17 |
+| * GetUserTypeResponse                                               |   0x15 |
+| * GetWeekdayScheduleResponse                                        |   0x0C |
+| * GetYearDayScheduleResponse                                        |   0x0F |
+| * LockDoorResponse                                                  |   0x00 |
+| * SetHolidayScheduleResponse                                        |   0x11 |
+| * SetPINCodeResponse                                                |   0x05 |
+| * SetRFIDCodeResponse                                               |   0x16 |
+| * SetUserTypeResponse                                               |   0x14 |
+| * SetWeekdayScheduleResponse                                        |   0x0B |
+| * SetYearDayScheduleResponse                                        |   0x0E |
+| * UnlockDoorResponse                                                |   0x01 |
+| * UnlockWithTimeoutResponse                                         |   0x03 |
+|                                                                     |        |
+|------------------------------------------------------------------------------|
 | Commands:                                                           |        |
 | * ClearAllPINCodes                                                  |   0x08 |
 | * ClearAllRFIDCodes                                                 |   0x19 |
@@ -643,9 +605,8 @@ uint16_t encodeColorControlClusterReadStartUpColorTemperatureMiredsAttribute(uin
 | * SetYearDaySchedule                                                |   0x0E |
 | * UnlockDoor                                                        |   0x01 |
 | * UnlockWithTimeout                                                 |   0x03 |
-|                                                                     |        |
 |------------------------------------------------------------------------------|
-| Attributes::                                                        |        |
+| Attributes:                                                         |        |
 | * LockState                                                         | 0x0000 |
 | * LockType                                                          | 0x0001 |
 | * ActuatorEnabled                                                   | 0x0002 |
@@ -834,6 +795,13 @@ uint16_t encodeDoorLockClusterReadActuatorEnabledAttribute(uint8_t * buffer, uin
 /*----------------------------------------------------------------------------*\
 | Cluster Groups                                                      | 0x0004 |
 |------------------------------------------------------------------------------|
+| Responses:                                                          |        |
+| * AddGroupResponse                                                  |   0x00 |
+| * GetGroupMembershipResponse                                        |   0x02 |
+| * RemoveGroupResponse                                               |   0x03 |
+| * ViewGroupResponse                                                 |   0x01 |
+|                                                                     |        |
+|------------------------------------------------------------------------------|
 | Commands:                                                           |        |
 | * AddGroup                                                          |   0x00 |
 | * AddGroupIfIdentifying                                             |   0x05 |
@@ -841,9 +809,8 @@ uint16_t encodeDoorLockClusterReadActuatorEnabledAttribute(uint8_t * buffer, uin
 | * RemoveAllGroups                                                   |   0x04 |
 | * RemoveGroup                                                       |   0x03 |
 | * ViewGroup                                                         |   0x01 |
-|                                                                     |        |
 |------------------------------------------------------------------------------|
-| Attributes::                                                        |        |
+| Attributes:                                                         |        |
 | * NameSupport                                                       | 0x0000 |
 \*----------------------------------------------------------------------------*/
 
@@ -896,12 +863,15 @@ uint16_t encodeGroupsClusterReadNameSupportAttribute(uint8_t * buffer, uint16_t 
 /*----------------------------------------------------------------------------*\
 | Cluster Identify                                                    | 0x0003 |
 |------------------------------------------------------------------------------|
+| Responses:                                                          |        |
+| * IdentifyQueryResponse                                             |   0x00 |
+|                                                                     |        |
+|------------------------------------------------------------------------------|
 | Commands:                                                           |        |
 | * Identify                                                          |   0x00 |
 | * IdentifyQuery                                                     |   0x01 |
-|                                                                     |        |
 |------------------------------------------------------------------------------|
-| Attributes::                                                        |        |
+| Attributes:                                                         |        |
 | * IdentifyTime                                                      | 0x0000 |
 \*----------------------------------------------------------------------------*/
 
@@ -927,6 +897,9 @@ uint16_t encodeIdentifyClusterReadIdentifyTimeAttribute(uint8_t * buffer, uint16
 /*----------------------------------------------------------------------------*\
 | Cluster Level                                                       | 0x0008 |
 |------------------------------------------------------------------------------|
+| Responses:                                                          |        |
+|                                                                     |        |
+|------------------------------------------------------------------------------|
 | Commands:                                                           |        |
 | * Move                                                              |   0x01 |
 | * MoveToLevel                                                       |   0x00 |
@@ -936,12 +909,9 @@ uint16_t encodeIdentifyClusterReadIdentifyTimeAttribute(uint8_t * buffer, uint16
 | * StepWithOnOff                                                     |   0x06 |
 | * Stop                                                              |   0x03 |
 | * StopWithOnOff                                                     |   0x07 |
-|                                                                     |        |
 |------------------------------------------------------------------------------|
-| Attributes::                                                        |        |
+| Attributes:                                                         |        |
 | * CurrentLevel                                                      | 0x0000 |
-| * RemainingTime                                                     | 0x0001 |
-| * Options                                                           | 0x000F |
 \*----------------------------------------------------------------------------*/
 
 /**
@@ -1008,28 +978,18 @@ uint16_t encodeLevelClusterStopWithOnOffCommand(uint8_t * buffer, uint16_t buf_l
  */
 uint16_t encodeLevelClusterReadCurrentLevelAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
 
-/**
- * @brief
- *    Encode a read command for the remaining-time attribute for  server into buffer including the APS frame
- */
-uint16_t encodeLevelClusterReadRemainingTimeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
-
-/**
- * @brief
- *    Encode a read command for the options attribute for  server into buffer including the APS frame
- */
-uint16_t encodeLevelClusterReadOptionsAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
-
 /*----------------------------------------------------------------------------*\
 | Cluster OnOff                                                       | 0x0006 |
+|------------------------------------------------------------------------------|
+| Responses:                                                          |        |
+|                                                                     |        |
 |------------------------------------------------------------------------------|
 | Commands:                                                           |        |
 | * Off                                                               |   0x00 |
 | * On                                                                |   0x01 |
 | * Toggle                                                            |   0x02 |
-|                                                                     |        |
 |------------------------------------------------------------------------------|
-| Attributes::                                                        |        |
+| Attributes:                                                         |        |
 | * OnOff                                                             | 0x0000 |
 \*----------------------------------------------------------------------------*/
 
@@ -1060,6 +1020,18 @@ uint16_t encodeOnOffClusterReadOnOffAttribute(uint8_t * buffer, uint16_t buf_len
 /*----------------------------------------------------------------------------*\
 | Cluster Scenes                                                      | 0x0005 |
 |------------------------------------------------------------------------------|
+| Responses:                                                          |        |
+| * AddSceneResponse                                                  |   0x00 |
+| * CopySceneResponse                                                 |   0x42 |
+| * EnhancedAddSceneResponse                                          |   0x40 |
+| * EnhancedViewSceneResponse                                         |   0x41 |
+| * GetSceneMembershipResponse                                        |   0x06 |
+| * RemoveAllScenesResponse                                           |   0x03 |
+| * RemoveSceneResponse                                               |   0x02 |
+| * StoreSceneResponse                                                |   0x04 |
+| * ViewSceneResponse                                                 |   0x01 |
+|                                                                     |        |
+|------------------------------------------------------------------------------|
 | Commands:                                                           |        |
 | * AddScene                                                          |   0x00 |
 | * CopyScene                                                         |   0x42 |
@@ -1071,9 +1043,8 @@ uint16_t encodeOnOffClusterReadOnOffAttribute(uint8_t * buffer, uint16_t buf_len
 | * RemoveScene                                                       |   0x02 |
 | * StoreScene                                                        |   0x04 |
 | * ViewScene                                                         |   0x01 |
-|                                                                     |        |
 |------------------------------------------------------------------------------|
-| Attributes::                                                        |        |
+| Attributes:                                                         |        |
 | * SceneCount                                                        | 0x0000 |
 | * CurrentScene                                                      | 0x0001 |
 | * CurrentGroup                                                      | 0x0002 |
@@ -1186,10 +1157,12 @@ uint16_t encodeScenesClusterReadNameSupportAttribute(uint8_t * buffer, uint16_t 
 /*----------------------------------------------------------------------------*\
 | Cluster TemperatureMeasurement                                      | 0x0402 |
 |------------------------------------------------------------------------------|
-| Commands:                                                           |        |
+| Responses:                                                          |        |
 |                                                                     |        |
 |------------------------------------------------------------------------------|
-| Attributes::                                                        |        |
+| Commands:                                                           |        |
+|------------------------------------------------------------------------------|
+| Attributes:                                                         |        |
 | * MeasuredValue                                                     | 0x0000 |
 | * MinMeasuredValue                                                  | 0x0001 |
 | * MaxMeasuredValue                                                  | 0x0002 |

--- a/src/app/encoder.cpp
+++ b/src/app/encoder.cpp
@@ -204,11 +204,13 @@ uint16_t encodeReadAttributesCommand(uint8_t * buffer, uint16_t buf_length, uint
 /*----------------------------------------------------------------------------*\
 | Cluster BarrierControl                                              | 0x0103 |
 |------------------------------------------------------------------------------|
-| Commands:                                                           |        |
-| * GoToPercent                                                       |   0x00 |
+| Responses:                                                          |        |
 |                                                                     |        |
 |------------------------------------------------------------------------------|
-| Attributes::                                                        |        |
+| Commands:                                                           |        |
+| * GoToPercent                                                       |   0x00 |
+|------------------------------------------------------------------------------|
+| Attributes:                                                         |        |
 | * MovingState                                                       | 0x0001 |
 | * SafetyStatus                                                      | 0x0002 |
 | * Capabilities                                                      | 0x0003 |
@@ -266,24 +268,15 @@ uint16_t encodeBarrierControlClusterReadBarrierPositionAttribute(uint8_t * buffe
 /*----------------------------------------------------------------------------*\
 | Cluster Basic                                                       | 0x0000 |
 |------------------------------------------------------------------------------|
-| Commands:                                                           |        |
-| * ResetToFactoryDefaults                                            |   0x00 |
+| Responses:                                                          |        |
 |                                                                     |        |
 |------------------------------------------------------------------------------|
-| Attributes::                                                        |        |
+| Commands:                                                           |        |
+| * ResetToFactoryDefaults                                            |   0x00 |
+|------------------------------------------------------------------------------|
+| Attributes:                                                         |        |
 | * ZCLVersion                                                        | 0x0000 |
-| * ApplicationVersion                                                | 0x0001 |
-| * StackVersion                                                      | 0x0002 |
-| * HWVersion                                                         | 0x0003 |
-| * ManufacturerName                                                  | 0x0004 |
-| * ModelIdentifier                                                   | 0x0005 |
-| * DateCode                                                          | 0x0006 |
 | * PowerSource                                                       | 0x0007 |
-| * GenericDevice-Class                                               | 0x0008 |
-| * GenericDevice-Type                                                | 0x0009 |
-| * ProductCode                                                       | 0x000A |
-| * ProductURL                                                        | 0x000B |
-| * SWBuildID                                                         | 0x4000 |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -305,60 +298,6 @@ uint16_t encodeBasicClusterReadZCLVersionAttribute(uint8_t * buffer, uint16_t bu
 }
 
 /*
- * Attribute ApplicationVersion
- */
-uint16_t encodeBasicClusterReadApplicationVersionAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
-{
-    uint16_t attr_ids[] = { 0x0001 };
-    READ_ATTRIBUTES("ReadBasicApplicationVersion", BASIC_CLUSTER_ID);
-}
-
-/*
- * Attribute StackVersion
- */
-uint16_t encodeBasicClusterReadStackVersionAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
-{
-    uint16_t attr_ids[] = { 0x0002 };
-    READ_ATTRIBUTES("ReadBasicStackVersion", BASIC_CLUSTER_ID);
-}
-
-/*
- * Attribute HWVersion
- */
-uint16_t encodeBasicClusterReadHWVersionAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
-{
-    uint16_t attr_ids[] = { 0x0003 };
-    READ_ATTRIBUTES("ReadBasicHWVersion", BASIC_CLUSTER_ID);
-}
-
-/*
- * Attribute ManufacturerName
- */
-uint16_t encodeBasicClusterReadManufacturerNameAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
-{
-    uint16_t attr_ids[] = { 0x0004 };
-    READ_ATTRIBUTES("ReadBasicManufacturerName", BASIC_CLUSTER_ID);
-}
-
-/*
- * Attribute ModelIdentifier
- */
-uint16_t encodeBasicClusterReadModelIdentifierAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
-{
-    uint16_t attr_ids[] = { 0x0005 };
-    READ_ATTRIBUTES("ReadBasicModelIdentifier", BASIC_CLUSTER_ID);
-}
-
-/*
- * Attribute DateCode
- */
-uint16_t encodeBasicClusterReadDateCodeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
-{
-    uint16_t attr_ids[] = { 0x0006 };
-    READ_ATTRIBUTES("ReadBasicDateCode", BASIC_CLUSTER_ID);
-}
-
-/*
  * Attribute PowerSource
  */
 uint16_t encodeBasicClusterReadPowerSourceAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
@@ -367,53 +306,11 @@ uint16_t encodeBasicClusterReadPowerSourceAttribute(uint8_t * buffer, uint16_t b
     READ_ATTRIBUTES("ReadBasicPowerSource", BASIC_CLUSTER_ID);
 }
 
-/*
- * Attribute GenericDeviceClass
- */
-uint16_t encodeBasicClusterReadGenericDeviceClassAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
-{
-    uint16_t attr_ids[] = { 0x0008 };
-    READ_ATTRIBUTES("ReadBasicGenericDeviceClass", BASIC_CLUSTER_ID);
-}
-
-/*
- * Attribute GenericDeviceType
- */
-uint16_t encodeBasicClusterReadGenericDeviceTypeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
-{
-    uint16_t attr_ids[] = { 0x0009 };
-    READ_ATTRIBUTES("ReadBasicGenericDeviceType", BASIC_CLUSTER_ID);
-}
-
-/*
- * Attribute ProductCode
- */
-uint16_t encodeBasicClusterReadProductCodeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
-{
-    uint16_t attr_ids[] = { 0x000A };
-    READ_ATTRIBUTES("ReadBasicProductCode", BASIC_CLUSTER_ID);
-}
-
-/*
- * Attribute ProductURL
- */
-uint16_t encodeBasicClusterReadProductURLAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
-{
-    uint16_t attr_ids[] = { 0x000B };
-    READ_ATTRIBUTES("ReadBasicProductURL", BASIC_CLUSTER_ID);
-}
-
-/*
- * Attribute SWBuildID
- */
-uint16_t encodeBasicClusterReadSWBuildIDAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
-{
-    uint16_t attr_ids[] = { 0x4000 };
-    READ_ATTRIBUTES("ReadBasicSWBuildID", BASIC_CLUSTER_ID);
-}
-
 /*----------------------------------------------------------------------------*\
 | Cluster ColorControl                                                | 0x0300 |
+|------------------------------------------------------------------------------|
+| Responses:                                                          |        |
+|                                                                     |        |
 |------------------------------------------------------------------------------|
 | Commands:                                                           |        |
 | * MoveColor                                                         |   0x08 |
@@ -430,11 +327,11 @@ uint16_t encodeBasicClusterReadSWBuildIDAttribute(uint8_t * buffer, uint16_t buf
 | * StepHue                                                           |   0x02 |
 | * StepSaturation                                                    |   0x05 |
 | * StopMoveStep                                                      |   0x47 |
-|                                                                     |        |
 |------------------------------------------------------------------------------|
-| Attributes::                                                        |        |
+| Attributes:                                                         |        |
 | * CurrentHue                                                        | 0x0000 |
 | * CurrentSaturation                                                 | 0x0001 |
+| * RemainingTime                                                     | 0x0002 |
 | * CurrentX                                                          | 0x0003 |
 | * CurrentY                                                          | 0x0004 |
 | * ColorTemperatureMireds                                            | 0x0007 |
@@ -710,6 +607,15 @@ uint16_t encodeColorControlClusterReadCurrentSaturationAttribute(uint8_t * buffe
 {
     uint16_t attr_ids[] = { 0x0001 };
     READ_ATTRIBUTES("ReadColorControlCurrentSaturation", COLOR_CONTROL_CLUSTER_ID);
+}
+
+/*
+ * Attribute RemainingTime
+ */
+uint16_t encodeColorControlClusterReadRemainingTimeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+{
+    uint16_t attr_ids[] = { 0x0002 };
+    READ_ATTRIBUTES("ReadColorControlRemainingTime", COLOR_CONTROL_CLUSTER_ID);
 }
 
 /*
@@ -1057,6 +963,32 @@ uint16_t encodeColorControlClusterReadStartUpColorTemperatureMiredsAttribute(uin
 /*----------------------------------------------------------------------------*\
 | Cluster DoorLock                                                    | 0x0101 |
 |------------------------------------------------------------------------------|
+| Responses:                                                          |        |
+| * ClearAllPINCodesResponse                                          |   0x08 |
+| * ClearAllRFIDCodesResponse                                         |   0x19 |
+| * ClearHolidayScheduleResponse                                      |   0x13 |
+| * ClearPINCodeResponse                                              |   0x07 |
+| * ClearRFIDCodeResponse                                             |   0x18 |
+| * ClearWeekdayScheduleResponse                                      |   0x0D |
+| * ClearYearDayScheduleResponse                                      |   0x10 |
+| * GetHolidayScheduleResponse                                        |   0x12 |
+| * GetLogRecordResponse                                              |   0x04 |
+| * GetPINCodeResponse                                                |   0x06 |
+| * GetRFIDCodeResponse                                               |   0x17 |
+| * GetUserTypeResponse                                               |   0x15 |
+| * GetWeekdayScheduleResponse                                        |   0x0C |
+| * GetYearDayScheduleResponse                                        |   0x0F |
+| * LockDoorResponse                                                  |   0x00 |
+| * SetHolidayScheduleResponse                                        |   0x11 |
+| * SetPINCodeResponse                                                |   0x05 |
+| * SetRFIDCodeResponse                                               |   0x16 |
+| * SetUserTypeResponse                                               |   0x14 |
+| * SetWeekdayScheduleResponse                                        |   0x0B |
+| * SetYearDayScheduleResponse                                        |   0x0E |
+| * UnlockDoorResponse                                                |   0x01 |
+| * UnlockWithTimeoutResponse                                         |   0x03 |
+|                                                                     |        |
+|------------------------------------------------------------------------------|
 | Commands:                                                           |        |
 | * ClearAllPINCodes                                                  |   0x08 |
 | * ClearAllRFIDCodes                                                 |   0x19 |
@@ -1081,9 +1013,8 @@ uint16_t encodeColorControlClusterReadStartUpColorTemperatureMiredsAttribute(uin
 | * SetYearDaySchedule                                                |   0x0E |
 | * UnlockDoor                                                        |   0x01 |
 | * UnlockWithTimeout                                                 |   0x03 |
-|                                                                     |        |
 |------------------------------------------------------------------------------|
-| Attributes::                                                        |        |
+| Attributes:                                                         |        |
 | * LockState                                                         | 0x0000 |
 | * LockType                                                          | 0x0001 |
 | * ActuatorEnabled                                                   | 0x0002 |
@@ -1391,6 +1322,13 @@ uint16_t encodeDoorLockClusterReadActuatorEnabledAttribute(uint8_t * buffer, uin
 /*----------------------------------------------------------------------------*\
 | Cluster Groups                                                      | 0x0004 |
 |------------------------------------------------------------------------------|
+| Responses:                                                          |        |
+| * AddGroupResponse                                                  |   0x00 |
+| * GetGroupMembershipResponse                                        |   0x02 |
+| * RemoveGroupResponse                                               |   0x03 |
+| * ViewGroupResponse                                                 |   0x01 |
+|                                                                     |        |
+|------------------------------------------------------------------------------|
 | Commands:                                                           |        |
 | * AddGroup                                                          |   0x00 |
 | * AddGroupIfIdentifying                                             |   0x05 |
@@ -1398,9 +1336,8 @@ uint16_t encodeDoorLockClusterReadActuatorEnabledAttribute(uint8_t * buffer, uin
 | * RemoveAllGroups                                                   |   0x04 |
 | * RemoveGroup                                                       |   0x03 |
 | * ViewGroup                                                         |   0x01 |
-|                                                                     |        |
 |------------------------------------------------------------------------------|
-| Attributes::                                                        |        |
+| Attributes:                                                         |        |
 | * NameSupport                                                       | 0x0000 |
 \*----------------------------------------------------------------------------*/
 
@@ -1481,12 +1418,15 @@ uint16_t encodeGroupsClusterReadNameSupportAttribute(uint8_t * buffer, uint16_t 
 /*----------------------------------------------------------------------------*\
 | Cluster Identify                                                    | 0x0003 |
 |------------------------------------------------------------------------------|
+| Responses:                                                          |        |
+| * IdentifyQueryResponse                                             |   0x00 |
+|                                                                     |        |
+|------------------------------------------------------------------------------|
 | Commands:                                                           |        |
 | * Identify                                                          |   0x00 |
 | * IdentifyQuery                                                     |   0x01 |
-|                                                                     |        |
 |------------------------------------------------------------------------------|
-| Attributes::                                                        |        |
+| Attributes:                                                         |        |
 | * IdentifyTime                                                      | 0x0000 |
 \*----------------------------------------------------------------------------*/
 
@@ -1522,6 +1462,9 @@ uint16_t encodeIdentifyClusterReadIdentifyTimeAttribute(uint8_t * buffer, uint16
 /*----------------------------------------------------------------------------*\
 | Cluster Level                                                       | 0x0008 |
 |------------------------------------------------------------------------------|
+| Responses:                                                          |        |
+|                                                                     |        |
+|------------------------------------------------------------------------------|
 | Commands:                                                           |        |
 | * Move                                                              |   0x01 |
 | * MoveToLevel                                                       |   0x00 |
@@ -1531,12 +1474,9 @@ uint16_t encodeIdentifyClusterReadIdentifyTimeAttribute(uint8_t * buffer, uint16
 | * StepWithOnOff                                                     |   0x06 |
 | * Stop                                                              |   0x03 |
 | * StopWithOnOff                                                     |   0x07 |
-|                                                                     |        |
 |------------------------------------------------------------------------------|
-| Attributes::                                                        |        |
+| Attributes:                                                         |        |
 | * CurrentLevel                                                      | 0x0000 |
-| * RemainingTime                                                     | 0x0001 |
-| * Options                                                           | 0x000F |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -1660,34 +1600,18 @@ uint16_t encodeLevelClusterReadCurrentLevelAttribute(uint8_t * buffer, uint16_t 
     READ_ATTRIBUTES("ReadLevelCurrentLevel", LEVEL_CLUSTER_ID);
 }
 
-/*
- * Attribute RemainingTime
- */
-uint16_t encodeLevelClusterReadRemainingTimeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
-{
-    uint16_t attr_ids[] = { 0x0001 };
-    READ_ATTRIBUTES("ReadLevelRemainingTime", LEVEL_CLUSTER_ID);
-}
-
-/*
- * Attribute Options
- */
-uint16_t encodeLevelClusterReadOptionsAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
-{
-    uint16_t attr_ids[] = { 0x000F };
-    READ_ATTRIBUTES("ReadLevelOptions", LEVEL_CLUSTER_ID);
-}
-
 /*----------------------------------------------------------------------------*\
 | Cluster OnOff                                                       | 0x0006 |
+|------------------------------------------------------------------------------|
+| Responses:                                                          |        |
+|                                                                     |        |
 |------------------------------------------------------------------------------|
 | Commands:                                                           |        |
 | * Off                                                               |   0x00 |
 | * On                                                                |   0x01 |
 | * Toggle                                                            |   0x02 |
-|                                                                     |        |
 |------------------------------------------------------------------------------|
-| Attributes::                                                        |        |
+| Attributes:                                                         |        |
 | * OnOff                                                             | 0x0000 |
 \*----------------------------------------------------------------------------*/
 
@@ -1730,6 +1654,18 @@ uint16_t encodeOnOffClusterReadOnOffAttribute(uint8_t * buffer, uint16_t buf_len
 /*----------------------------------------------------------------------------*\
 | Cluster Scenes                                                      | 0x0005 |
 |------------------------------------------------------------------------------|
+| Responses:                                                          |        |
+| * AddSceneResponse                                                  |   0x00 |
+| * CopySceneResponse                                                 |   0x42 |
+| * EnhancedAddSceneResponse                                          |   0x40 |
+| * EnhancedViewSceneResponse                                         |   0x41 |
+| * GetSceneMembershipResponse                                        |   0x06 |
+| * RemoveAllScenesResponse                                           |   0x03 |
+| * RemoveSceneResponse                                               |   0x02 |
+| * StoreSceneResponse                                                |   0x04 |
+| * ViewSceneResponse                                                 |   0x01 |
+|                                                                     |        |
+|------------------------------------------------------------------------------|
 | Commands:                                                           |        |
 | * AddScene                                                          |   0x00 |
 | * CopyScene                                                         |   0x42 |
@@ -1741,9 +1677,8 @@ uint16_t encodeOnOffClusterReadOnOffAttribute(uint8_t * buffer, uint16_t buf_len
 | * RemoveScene                                                       |   0x02 |
 | * StoreScene                                                        |   0x04 |
 | * ViewScene                                                         |   0x01 |
-|                                                                     |        |
 |------------------------------------------------------------------------------|
-| Attributes::                                                        |        |
+| Attributes:                                                         |        |
 | * SceneCount                                                        | 0x0000 |
 | * CurrentScene                                                      | 0x0001 |
 | * CurrentGroup                                                      | 0x0002 |
@@ -1927,10 +1862,12 @@ uint16_t encodeScenesClusterReadNameSupportAttribute(uint8_t * buffer, uint16_t 
 /*----------------------------------------------------------------------------*\
 | Cluster TemperatureMeasurement                                      | 0x0402 |
 |------------------------------------------------------------------------------|
-| Commands:                                                           |        |
+| Responses:                                                          |        |
 |                                                                     |        |
 |------------------------------------------------------------------------------|
-| Attributes::                                                        |        |
+| Commands:                                                           |        |
+|------------------------------------------------------------------------------|
+| Attributes:                                                         |        |
 | * MeasuredValue                                                     | 0x0000 |
 | * MinMeasuredValue                                                  | 0x0001 |
 | * MaxMeasuredValue                                                  | 0x0002 |


### PR DESCRIPTION
 #### Problem

This is an updated version of the supported attribute list in chip-tool. It removes some extra attributes from the `Basic` cluster, but the main goal of this PR is to add `RemainingTime` at the right place. Because of an issue in ZAP, even if `RemainingTime` was selected for the `ColorControl`cluster in the configuration file it was not used at the end.
The root of the issue is because of a ZAP issue with identical attributes name. Fixing it in ZAP results in being able to add it to the list!

 #### Summary of Changes
 * Remove some extra attributes from the `Basic`cluster
* Add missing `RemainingTime` attribute from the `ColorControl` cluster
* Also `Attributes::` -> `Attributes:` 