### PR TITLE
Update CHIP iOS framework and app to use persistent storage

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -95,7 +95,9 @@ ChipDeviceController::ChipDeviceController()
     mDevicePort        = CHIP_PORT;
     mInterface         = INET_NULL_INTERFACEID;
     mLocalDeviceId     = 0;
+    mNumCachedPackets  = 0;
     memset(&mOnComplete, 0, sizeof(mOnComplete));
+    memset(&mCachedPackets, 0, sizeof(mCachedPackets));
 }
 
 ChipDeviceController::~ChipDeviceController()
@@ -147,6 +149,11 @@ CHIP_ERROR ChipDeviceController::Init(NodeId localNodeId, DevicePairingDelegate 
 
     mPairingDelegate = pairingDelegate;
     mStorageDelegate = storage;
+
+    if (mStorageDelegate != nullptr)
+    {
+        mStorageDelegate->SetDelegate(this);
+    }
 
 exit:
     return err;
@@ -274,17 +281,12 @@ CHIP_ERROR ChipDeviceController::ConnectDeviceWithoutSecurePairing(NodeId remote
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ChipDeviceController::EstablishSecureSession(NodeId peer)
+CHIP_ERROR ChipDeviceController::EstablishSecureSession()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    SecurePairingSession pairing;
-    SecurePairingSession * pairingSession = mSecurePairingSession;
-    Inet::IPAddress peerAddr              = mDeviceAddr;
 
-    if (mState != kState_Initialized || mSessionManager != nullptr || mConState == kConnectionState_SecureConnected)
-    {
-        ExitNow(err = CHIP_ERROR_INCORRECT_STATE);
-    }
+    VerifyOrExit(mSecurePairingSession != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mDeviceAddr != IPAddress::Any, err = CHIP_ERROR_INCORRECT_STATE);
 
     mSessionManager = chip::Platform::New<SecureSessionMgr<Transport::UDP>>();
 
@@ -294,35 +296,14 @@ CHIP_ERROR ChipDeviceController::EstablishSecureSession(NodeId peer)
 
     mSessionManager->SetDelegate(this);
 
+    err = mSessionManager->NewPairing(
+        Optional<Transport::PeerAddress>::Value(Transport::PeerAddress::UDP(mDeviceAddr, mDevicePort, mInterface)),
+        mSecurePairingSession);
+    SuccessOrExit(err);
+
     mConState = kConnectionState_SecureConnected;
 
-    if (mStorageDelegate != nullptr)
-    {
-        const char * credentials;
-        const char * address;
-
-        PERSISTENT_KEY_OP(peer, kDeviceCredentialsKeyPrefix, key, credentials = mStorageDelegate->GetKeyValue(key));
-        PERSISTENT_KEY_OP(peer, kDeviceAddressKeyPrefix, key, address = mStorageDelegate->GetKeyValue(key));
-
-        SecurePairingSessionSerialized serialized;
-
-        VerifyOrExit(credentials != nullptr, err = CHIP_ERROR_KEY_NOT_FOUND_FROM_PEER);
-        VerifyOrExit(strlen(credentials) <= sizeof(serialized.inner), err = CHIP_ERROR_INVALID_STRING_LENGTH);
-        strncpy(Uint8::to_char(serialized.inner), credentials, sizeof(serialized.inner));
-
-        err = pairing.Deserialize(serialized);
-        SuccessOrExit(err);
-
-        pairingSession = &pairing;
-
-        VerifyOrExit(address != nullptr, err = CHIP_ERROR_KEY_NOT_FOUND_FROM_PEER);
-
-        VerifyOrExit(IPAddress::FromString(address, peerAddr), err = CHIP_ERROR_INVALID_ADDRESS);
-    }
-
-    err = mSessionManager->NewPairing(
-        Optional<Transport::PeerAddress>::Value(Transport::PeerAddress::UDP(peerAddr, mDevicePort, mInterface)), pairingSession);
-    SuccessOrExit(err);
+    SendCachedPackets();
 
 exit:
 
@@ -334,6 +315,78 @@ exit:
             mSessionManager = nullptr;
         }
         mConState = kConnectionState_NotConnected;
+    }
+
+    return err;
+}
+
+void ChipDeviceController::OnValue(const char * key, const char * value)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    NodeId peer    = mRemoteDeviceId.Value();
+
+    VerifyOrExit(key != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    PERSISTENT_KEY_OP(
+        peer, kDeviceCredentialsKeyPrefix, expectedKey, if (strcmp(key, expectedKey) == 0) {
+            SecurePairingSessionSerialized serialized;
+
+            VerifyOrExit(value != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
+            VerifyOrExit(strlen(value) <= sizeof(serialized.inner), err = CHIP_ERROR_INVALID_ARGUMENT);
+            strncpy(Uint8::to_char(serialized.inner), value, sizeof(serialized.inner));
+            SuccessOrExit(mPairingSession.Deserialize(serialized));
+
+            mSecurePairingSession = &mPairingSession;
+        });
+
+    PERSISTENT_KEY_OP(
+        peer, kDeviceAddressKeyPrefix, expectedKey, if (strcmp(key, expectedKey) == 0) {
+            VerifyOrExit(value != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
+            VerifyOrExit(IPAddress::FromString(value, mDeviceAddr), err = CHIP_ERROR_INVALID_ADDRESS);
+        });
+
+    if (mSecurePairingSession != nullptr && mDeviceAddr != IPAddress::Any)
+    {
+        SuccessOrExit(EstablishSecureSession());
+    }
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        mConState = kConnectionState_NotConnected;
+        DiscardCachedPackets();
+    }
+}
+
+void ChipDeviceController::OnStatus(const char * key, Operation op, CHIP_ERROR err) {}
+
+CHIP_ERROR ChipDeviceController::TryEstablishingSecureSession(NodeId peer)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    if (mState != kState_Initialized || mSessionManager != nullptr || mConState == kConnectionState_SecureConnected)
+    {
+        ExitNow(err = CHIP_ERROR_INCORRECT_STATE);
+    }
+
+    if (mStorageDelegate != nullptr)
+    {
+        mSecurePairingSession = nullptr;
+        mDeviceAddr           = IPAddress::Any;
+        PERSISTENT_KEY_OP(peer, kDeviceCredentialsKeyPrefix, key, mStorageDelegate->GetKeyValue(key));
+        PERSISTENT_KEY_OP(peer, kDeviceAddressKeyPrefix, key, mStorageDelegate->GetKeyValue(key));
+        mConState = kConnectionState_SecureConnecting;
+    }
+    else
+    {
+        ExitNow(err = EstablishSecureSession());
+    }
+
+exit:
+
+    if (err != CHIP_NO_ERROR)
+    {
+        DiscardCachedPackets();
     }
     return err;
 }
@@ -351,7 +404,7 @@ CHIP_ERROR ChipDeviceController::ResumeSecureSession(NodeId peer)
         mSessionManager = nullptr;
     }
 
-    CHIP_ERROR err = EstablishSecureSession(peer);
+    CHIP_ERROR err = TryEstablishingSecureSession(peer);
     SuccessOrExit(err);
 
 exit:
@@ -399,7 +452,48 @@ CHIP_ERROR ChipDeviceController::DisconnectDevice()
     return err;
 }
 
-CHIP_ERROR ChipDeviceController::SendMessage(void * appReqState, PacketBuffer * buffer)
+CHIP_ERROR ChipDeviceController::CachePacket(System::PacketBuffer * buffer)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    VerifyOrExit(mNumCachedPackets < kPacketCacheMaxSize, err = CHIP_ERROR_INTERNAL);
+    mCachedPackets[mNumCachedPackets++] = buffer;
+
+exit:
+    return err;
+}
+
+CHIP_ERROR ChipDeviceController::SendCachedPackets()
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    VerifyOrExit(IsSecurelyConnected(), err = CHIP_ERROR_INCORRECT_STATE);
+
+    for (uint16_t i = 0; i < mNumCachedPackets; i++)
+    {
+        err = mSessionManager->SendMessage(mRemoteDeviceId.Value(), mCachedPackets[i]);
+        ChipLogDetail(Controller, "SendMessage returned %d", err);
+    }
+
+    mNumCachedPackets = 0;
+    memset(&mCachedPackets, 0, sizeof(mCachedPackets));
+
+exit:
+    return err;
+}
+
+void ChipDeviceController::DiscardCachedPackets()
+{
+    for (uint16_t i = 0; i < mNumCachedPackets; i++)
+    {
+        PacketBuffer::Free(mCachedPackets[i]);
+    }
+
+    mNumCachedPackets = 0;
+    memset(&mCachedPackets, 0, sizeof(mCachedPackets));
+}
+
+CHIP_ERROR ChipDeviceController::SendMessage(void * appReqState, PacketBuffer * buffer, NodeId peerDevice)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -414,6 +508,10 @@ CHIP_ERROR ChipDeviceController::SendMessage(void * appReqState, PacketBuffer * 
     else
     {
         bool trySessionResumption = true;
+        if (peerDevice != kUndefinedNodeId)
+        {
+            mRemoteDeviceId = Optional<NodeId>::Value(peerDevice);
+        }
         VerifyOrExit(mRemoteDeviceId.HasValue(), err = CHIP_ERROR_INCORRECT_STATE);
 
         // If there is no secure connection to the device, try establishing it
@@ -421,10 +519,16 @@ CHIP_ERROR ChipDeviceController::SendMessage(void * appReqState, PacketBuffer * 
         {
             // For now, it's expected that the device is connected
             VerifyOrExit(mState == kState_Initialized, err = CHIP_ERROR_INCORRECT_STATE);
-            err = EstablishSecureSession(mRemoteDeviceId.Value());
+            err = TryEstablishingSecureSession(mRemoteDeviceId.Value());
             SuccessOrExit(err);
 
             trySessionResumption = false;
+
+            if (mConState == kConnectionState_SecureConnecting)
+            {
+                // Cache the packet while connection is being established
+                ExitNow(err = CachePacket(buffer));
+            }
         }
 
         // Hold on to the buffer, in case a session resumption and resend is needed
@@ -442,6 +546,12 @@ CHIP_ERROR ChipDeviceController::SendMessage(void * appReqState, PacketBuffer * 
             // If session resumption failed, let's free the extra reference to
             // the buffer. If not, SendMessage would free it.
             VerifyOrExit(err == CHIP_NO_ERROR, PacketBuffer::Free(buffer));
+
+            if (mConState == kConnectionState_SecureConnecting)
+            {
+                // Cache the packet while connection is being established
+                ExitNow(err = CachePacket(buffer));
+            }
 
             err = mSessionManager->SendMessage(mRemoteDeviceId.Value(), buffer);
             SuccessOrExit(err);

--- a/src/controller/CHIPPersistentStorageDelegate.h
+++ b/src/controller/CHIPPersistentStorageDelegate.h
@@ -64,16 +64,16 @@ public:
 
     /**
      * @brief
-     *   Lookup the key and return it's stringified value
+     *   Set the callback object with methods that are called on completion
+     *   of the operation.
      *
-     * @param[in] key Key to lookup
-     * @param[in] delegate Callback handler using which the value wiil be returned.
+     * @param[in] delegate The callback object
      */
     virtual void SetDelegate(PersistentStorageResultDelegate * delegate) = 0;
 
     /**
      * @brief
-     *   Lookup the key and return it's stringified value
+     *   Lookup the key and call delegate object with it's stringified value
      *
      * @param[in] key Key to lookup
      */

--- a/src/controller/CHIPPersistentStorageDelegate.h
+++ b/src/controller/CHIPPersistentStorageDelegate.h
@@ -24,6 +24,39 @@
 namespace chip {
 namespace DeviceController {
 
+class DLL_EXPORT PersistentStorageResultDelegate
+{
+public:
+    enum class Operation : uint8_t
+    {
+        kGET = 0,
+        kSET,
+        kDELETE,
+    };
+
+    virtual ~PersistentStorageResultDelegate() {}
+
+    /**
+     * @brief
+     *   Called when a value is returned from the storage.
+     *   This is useful for GetKeyValue() API call.
+     *
+     * @param[in] key Key for which the value is being returned
+     * @param[in] value Value or nullptr if not found.
+     */
+    virtual void OnValue(const char * key, const char * value) = 0;
+
+    /**
+     * @brief
+     *   Called on completion of an operation in PersistentStorageDelegate API
+     *
+     * @param[in] key Key for which the status is being returned
+     * @param[in] op Operation that was being performed on the key
+     * @param[in] result CHIP_NO_ERROR or corresponding error code
+     */
+    virtual void OnStatus(const char * key, Operation op, CHIP_ERROR err) = 0;
+};
+
 class DLL_EXPORT PersistentStorageDelegate
 {
 public:
@@ -34,11 +67,17 @@ public:
      *   Lookup the key and return it's stringified value
      *
      * @param[in] key Key to lookup
-     * @return Value or nullptr if not found. Lifetime of the returned
-     *         buffer is tied to the delegate object. If the delegate is
-     *         freed, the returned value would be inaccessible.
+     * @param[in] delegate Callback handler using which the value wiil be returned.
      */
-    virtual const char * GetKeyValue(const char * key) = 0;
+    virtual void SetDelegate(PersistentStorageResultDelegate * delegate) = 0;
+
+    /**
+     * @brief
+     *   Lookup the key and return it's stringified value
+     *
+     * @param[in] key Key to lookup
+     */
+    virtual void GetKeyValue(const char * key) = 0;
 
     /**
      * @brief
@@ -46,18 +85,16 @@ public:
      *
      * @param[in] key Key to be set
      * @param[in] value Value to be set
-     * @return returns corresponding error if unsuccessful
      */
-    virtual CHIP_ERROR SetKeyValue(const char * key, const char * value) = 0;
+    virtual void SetKeyValue(const char * key, const char * value) = 0;
 
     /**
      * @brief
      *   Deletes the value for the key
      *
      * @param[in] key Key to be deleted
-     * @return returns corresponding error if unsuccessful
      */
-    virtual CHIP_ERROR DeleteKeyValue(const char * key) = 0;
+    virtual void DeleteKeyValue(const char * key) = 0;
 };
 
 } // namespace DeviceController

--- a/src/controller/CHIPPersistentStorageDelegate.h
+++ b/src/controller/CHIPPersistentStorageDelegate.h
@@ -54,7 +54,7 @@ public:
      * @param[in] op Operation that was being performed on the key
      * @param[in] result CHIP_NO_ERROR or corresponding error code
      */
-    virtual void OnStatus(const char * key, Operation op, CHIP_ERROR err) = 0;
+    virtual void OnStatus(const char * key, Operation op, CHIP_ERROR result) = 0;
 };
 
 class DLL_EXPORT PersistentStorageDelegate

--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.h
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.h
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+#import <CHIP/CHIP.h>
 #import <Foundation/Foundation.h>
 
 extern NSString * const kCHIPToolDefaultsDomain;
@@ -24,3 +25,7 @@ extern NSString * const kNetworkPasswordDefaultsKey;
 id CHIPGetDomainValueForKey(NSString * domain, NSString * key);
 void CHIPSetDomainValueForKey(NSString * domain, NSString * key, id value);
 void CHIPRemoveDomainValueForKey(NSString * domain, NSString * key);
+
+@interface CHIPToolPersistentStorageDelegate : NSObject <CHIPPersistentStorageDelegate>
+
+@end

--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
@@ -41,3 +41,26 @@ void CHIPRemoveDomainValueForKey(NSString * domain, NSString * key)
     CFPreferencesSetAppValue((CFStringRef) key, NULL, (CFStringRef) domain);
     CFPreferencesAppSynchronize((CFStringRef) domain);
 }
+
+@implementation CHIPToolPersistentStorageDelegate
+
+// MARK: CHIPPersistentStorageDelegate
+- (void)GetKeyValue:(NSString *)key handler:(SendKeyValue)completionHandler
+{
+    NSString * value = CHIPGetDomainValueForKey(kCHIPToolDefaultsDomain, key);
+    completionHandler(key, value);
+}
+
+- (void)SetKeyValue:(NSString *)key value:(NSString *)value handler:(SendStatus)completionHandler
+{
+    CHIPSetDomainValueForKey(kCHIPToolDefaultsDomain, key, value);
+    completionHandler(key, kSet, [CHIPError errorForCHIPErrorCode:0]);
+}
+
+- (void)DeleteKeyValue:(NSString *)key handler:(SendStatus)completionHandler
+{
+    CHIPRemoveDomainValueForKey(kCHIPToolDefaultsDomain, key);
+    completionHandler(key, kDelete, [CHIPError errorForCHIPErrorCode:0]);
+}
+
+@end

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/AppDelegate.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/AppDelegate.m
@@ -18,8 +18,6 @@
 #import "AppDelegate.h"
 #import "RootViewController.h"
 
-static NSString * const ipKey = @"ipk";
-
 @interface AppDelegate ()
 
 @end

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Echo client/EchoViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Echo client/EchoViewController.m
@@ -32,6 +32,8 @@
 
 @property (readwrite) CHIPDeviceController * chipController;
 
+@property (readonly) CHIPToolPersistentStorageDelegate * persistentStorage;
+
 @end
 
 @implementation EchoViewController
@@ -43,6 +45,8 @@
     [super viewDidLoad];
     [self setupUIElements];
 
+    _persistentStorage = [[CHIPToolPersistentStorageDelegate alloc] init];
+
     // listen for taps to dismiss the keyboard
     UITapGestureRecognizer * tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissKeyboard)];
     [self.view addGestureRecognizer:tap];
@@ -51,6 +55,7 @@
     dispatch_queue_t callbackQueue = dispatch_queue_create("com.zigbee.chip.echovc.callback", DISPATCH_QUEUE_SERIAL);
     self.chipController = [CHIPDeviceController sharedController];
     [self.chipController setDelegate:self queue:callbackQueue];
+    [self.chipController setPersistentStorageDelegate:_persistentStorage queue:callbackQueue];
 }
 
 - (void)dismissKeyboard

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.m
@@ -30,6 +30,8 @@
 
 @property (readwrite) CHIPDeviceController * chipController;
 
+@property (readonly) CHIPToolPersistentStorageDelegate * persistentStorage;
+
 @end
 
 @implementation OnOffViewController
@@ -41,10 +43,13 @@
     [super viewDidLoad];
     [self setupUIElements];
 
+    _persistentStorage = [[CHIPToolPersistentStorageDelegate alloc] init];
+
     // initialize the device controller
     dispatch_queue_t callbackQueue = dispatch_queue_create("com.zigbee.chip.onoffvc.callback", DISPATCH_QUEUE_SERIAL);
     self.chipController = [CHIPDeviceController sharedController];
     [self.chipController setDelegate:self queue:callbackQueue];
+    [self.chipController setPersistentStorageDelegate:_persistentStorage queue:callbackQueue];
     self.onOff = [[CHIPOnOff alloc] initWithDeviceController:self.chipController];
 }
 

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
@@ -65,6 +65,7 @@
 @property (strong, nonatomic) UILabel * errorLabel;
 
 @property (readwrite) CHIPDeviceController * chipController;
+@property (readonly) CHIPToolPersistentStorageDelegate * persistentStorage;
 @end
 
 @implementation QRCodeViewController {
@@ -254,10 +255,13 @@
     [super viewDidLoad];
     [self setupUI];
 
+    _persistentStorage = [[CHIPToolPersistentStorageDelegate alloc] init];
+
     dispatch_queue_t callbackQueue = dispatch_queue_create("com.zigbee.chip.qrcodevc.callback", DISPATCH_QUEUE_SERIAL);
     self.chipController = [CHIPDeviceController sharedController];
     [self.chipController setDelegate:self queue:callbackQueue];
     [self.chipController setPairingDelegate:self queue:callbackQueue];
+    [self.chipController setPersistentStorageDelegate:_persistentStorage queue:callbackQueue];
 
     UITapGestureRecognizer * tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissKeyboard)];
     [self.view addGestureRecognizer:tap];

--- a/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		2C4DF09E248B2C60009307CB /* libmbedtls.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2C4DF09D248B2C60009307CB /* libmbedtls.a */; settings = {ATTRIBUTES = (Required, ); }; };
+		2C8C8FC0253E0C2100797F05 /* CHIPPersistentStorageDelegateBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C8C8FBD253E0C2100797F05 /* CHIPPersistentStorageDelegateBridge.h */; };
+		2C8C8FC1253E0C2100797F05 /* CHIPPersistentStorageDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C8C8FBE253E0C2100797F05 /* CHIPPersistentStorageDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2C8C8FC2253E0C2100797F05 /* CHIPPersistentStorageDelegateBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2C8C8FBF253E0C2100797F05 /* CHIPPersistentStorageDelegateBridge.mm */; };
 		2CB7163B252E8A7B0026E2BB /* CHIPDevicePairingDelegateBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CB71638252E8A7B0026E2BB /* CHIPDevicePairingDelegateBridge.h */; };
 		2CB7163C252E8A7C0026E2BB /* CHIPDevicePairingDelegateBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2CB71639252E8A7B0026E2BB /* CHIPDevicePairingDelegateBridge.mm */; };
 		2CB7163F252F731E0026E2BB /* CHIPDevicePairingDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CB7163E252F731E0026E2BB /* CHIPDevicePairingDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -42,6 +45,9 @@
 
 /* Begin PBXFileReference section */
 		2C4DF09D248B2C60009307CB /* libmbedtls.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libmbedtls.a; path = lib/libmbedtls.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		2C8C8FBD253E0C2100797F05 /* CHIPPersistentStorageDelegateBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPPersistentStorageDelegateBridge.h; sourceTree = "<group>"; };
+		2C8C8FBE253E0C2100797F05 /* CHIPPersistentStorageDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPPersistentStorageDelegate.h; sourceTree = "<group>"; };
+		2C8C8FBF253E0C2100797F05 /* CHIPPersistentStorageDelegateBridge.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPPersistentStorageDelegateBridge.mm; sourceTree = "<group>"; };
 		2CB71638252E8A7B0026E2BB /* CHIPDevicePairingDelegateBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPDevicePairingDelegateBridge.h; sourceTree = "<group>"; };
 		2CB71639252E8A7B0026E2BB /* CHIPDevicePairingDelegateBridge.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPDevicePairingDelegateBridge.mm; sourceTree = "<group>"; };
 		2CB7163E252F731E0026E2BB /* CHIPDevicePairingDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPDevicePairingDelegate.h; sourceTree = "<group>"; };
@@ -112,6 +118,9 @@
 		B202528F2459E34F00F97062 /* CHIP */ = {
 			isa = PBXGroup;
 			children = (
+				2C8C8FBE253E0C2100797F05 /* CHIPPersistentStorageDelegate.h */,
+				2C8C8FBD253E0C2100797F05 /* CHIPPersistentStorageDelegateBridge.h */,
+				2C8C8FBF253E0C2100797F05 /* CHIPPersistentStorageDelegateBridge.mm */,
 				2CB7163E252F731E0026E2BB /* CHIPDevicePairingDelegate.h */,
 				2CB71638252E8A7B0026E2BB /* CHIPDevicePairingDelegateBridge.h */,
 				2CB71639252E8A7B0026E2BB /* CHIPDevicePairingDelegateBridge.mm */,
@@ -165,7 +174,9 @@
 				B2E0D7B2245B0B5C003C5B48 /* CHIPManualSetupPayloadParser.h in Headers */,
 				B2E0D7B1245B0B5C003C5B48 /* CHIP.h in Headers */,
 				B2E0D7B8245B0B5C003C5B48 /* CHIPSetupPayload.h in Headers */,
+				2C8C8FC1253E0C2100797F05 /* CHIPPersistentStorageDelegate.h in Headers */,
 				B2E0D7B5245B0B5C003C5B48 /* CHIPQRCodeSetupPayloadParser.h in Headers */,
+				2C8C8FC0253E0C2100797F05 /* CHIPPersistentStorageDelegateBridge.h in Headers */,
 				515C401D2486BF43004C4DB3 /* CHIPOnOff.h in Headers */,
 				991DC08B247704DC00C13860 /* CHIPLogging.h in Headers */,
 				B2E0D7B4245B0B5C003C5B48 /* CHIPError.h in Headers */,
@@ -292,6 +303,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2C8C8FC2253E0C2100797F05 /* CHIPPersistentStorageDelegateBridge.mm in Sources */,
 				2CB7163C252E8A7C0026E2BB /* CHIPDevicePairingDelegateBridge.mm in Sources */,
 				515C401C2486BF43004C4DB3 /* CHIPOnOff.mm in Sources */,
 				991DC0892475F47D00C13860 /* CHIPDeviceController.mm in Sources */,

--- a/src/darwin/Framework/CHIP/CHIP.h
+++ b/src/darwin/Framework/CHIP/CHIP.h
@@ -21,6 +21,7 @@
 #import <CHIP/CHIPError.h>
 #import <CHIP/CHIPManualSetupPayloadParser.h>
 #import <CHIP/CHIPOnOff.h>
+#import <CHIP/CHIPPersistentStorageDelegate.h>
 #import <CHIP/CHIPQRCodeSetupPayloadParser.h>
 #import <CHIP/CHIPSetupPayload.h>
 

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -29,6 +29,7 @@ typedef void (^ControllerOnErrorBlock)(NSError * error);
 
 @protocol CHIPDeviceControllerDelegate;
 @protocol CHIPDevicePairingDelegate;
+@protocol CHIPPersistentStorageDelegate;
 
 @interface AddressInfo : NSObject
 
@@ -88,6 +89,15 @@ typedef void (^ControllerOnErrorBlock)(NSError * error);
  * @param[in] queue The queue on which the callbacks will be delivered
  */
 - (void)setPairingDelegate:(id<CHIPDevicePairingDelegate>)delegate queue:(dispatch_queue_t)queue;
+
+/**
+ * Set the Delegate for the persistent storage  as well as the Queue on which the Delegate callbacks will be triggered
+ *
+ * @param[in] delegate The delegate for persistent storage
+ *
+ * @param[in] queue The queue on which the callbacks will be delivered
+ */
+- (void)setPersistentStorageDelegate:(id<CHIPPersistentStorageDelegate>)delegate queue:(dispatch_queue_t)queue;
 
 @end
 

--- a/src/darwin/Framework/CHIP/CHIPError.h
+++ b/src/darwin/Framework/CHIP/CHIPError.h
@@ -31,10 +31,12 @@ typedef NS_ERROR_ENUM(CHIPErrorDomain, CHIPErrorCode) {
     CHIPErrorCodeInvalidState = 5,
     CHIPErrorCodeWrongAddressType = 6,
     CHIPErrorCodeIntegrityCheckFailed = 7,
+    CHIPSuccess = 8,
 };
 
 @interface CHIPError : NSObject
 + (nullable NSError *)errorForCHIPErrorCode:(CHIP_ERROR)errorCode;
++ (CHIP_ERROR)errorToCHIPErrorCode:(NSError *)errorCode;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/CHIPError.mm
+++ b/src/darwin/Framework/CHIP/CHIPError.mm
@@ -51,11 +51,41 @@ NSString * const CHIPErrorDomain = @"CHIPErrorDomain";
         return [NSError errorWithDomain:CHIPErrorDomain
                                    code:CHIPErrorCodeIntegrityCheckFailed
                                userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Integrity check failed.", nil) }];
+    case CHIP_NO_ERROR:
+        return [NSError errorWithDomain:CHIPErrorDomain
+                                   code:CHIPSuccess
+                               userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Success.", nil) }];
     default:
         return [NSError errorWithDomain:CHIPErrorDomain
                                    code:CHIPErrorCodeUndefinedError
                                userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Undefined error.", nil) }];
         ;
+    }
+}
+
++ (CHIP_ERROR)errorToCHIPErrorCode:(NSError *)error
+{
+    if (error.domain != CHIPErrorDomain) {
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    switch (error.code) {
+    case CHIPErrorCodeInvalidStringLength:
+        return CHIP_ERROR_INVALID_STRING_LENGTH;
+    case CHIPErrorCodeInvalidIntegerValue:
+        return CHIP_ERROR_INVALID_INTEGER_VALUE;
+    case CHIPErrorCodeInvalidArgument:
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    case CHIPErrorCodeInvalidMessageLength:
+        return CHIP_ERROR_INVALID_MESSAGE_LENGTH;
+    case CHIPErrorCodeInvalidState:
+        return CHIP_ERROR_INCORRECT_STATE;
+    case CHIPErrorCodeIntegrityCheckFailed:
+        return CHIP_ERROR_INTEGRITY_CHECK_FAILED;
+    case CHIPSuccess:
+        return CHIP_NO_ERROR;
+    default:
+        return CHIP_ERROR_INTERNAL;
     }
 }
 @end

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegate.h
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegate.h
@@ -1,0 +1,60 @@
+/**
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "CHIPError.h"
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSUInteger, Operation) {
+    kGet = 0,
+    kSet,
+    kDelete,
+};
+
+typedef void (^SendKeyValue)(NSString * key, NSString * value);
+typedef void (^SendStatus)(NSString * key, Operation operation, NSError * status);
+
+/**
+ * The protocol definition for the CHIPPersistenStorageDelegate
+ *
+ * All delegate methods will be called on the supplied Delegate Queue.
+ */
+@protocol CHIPPersistentStorageDelegate <NSObject>
+@required
+
+/**
+ * Get the value for the given key
+ *
+ */
+- (void)GetKeyValue:(NSString *)key handler:(SendKeyValue)completionHandler;
+
+/**
+ * Set the value of the key to the given value
+ *
+ */
+- (void)SetKeyValue:(NSString *)key value:(NSString *)value handler:(SendStatus)completionHandler;
+
+/**
+ * Delete the key and corresponding value
+ *
+ */
+- (void)DeleteKeyValue:(NSString *)key handler:(SendStatus)completionHandler;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
@@ -1,0 +1,50 @@
+/**
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "CHIPPersistentStorageDelegate.h"
+#import <Foundation/Foundation.h>
+
+#include <controller/CHIPPersistentStorageDelegate.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+class CHIPPersistentStorageDelegateBridge : public chip::DeviceController::PersistentStorageDelegate
+{
+public:
+    CHIPPersistentStorageDelegateBridge();
+    ~CHIPPersistentStorageDelegateBridge();
+
+    void setFrameworkDelegate(id<CHIPPersistentStorageDelegate> delegate, dispatch_queue_t queue);
+
+    void SetDelegate(chip::DeviceController::PersistentStorageResultDelegate * delegate);
+
+    void GetKeyValue(const char * key) override;
+
+    void SetKeyValue(const char * key, const char * value) override;
+
+    void DeleteKeyValue(const char * key) override;
+
+private:
+    id<CHIPPersistentStorageDelegate> mDelegate;
+    dispatch_queue_t mQueue;
+
+    chip::DeviceController::PersistentStorageResultDelegate * mCallback;
+    SendKeyValue mCompletionHandler;
+    SendStatus mStatusHandler;
+};
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
@@ -1,0 +1,110 @@
+/**
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "CHIPPersistentStorageDelegateBridge.h"
+#import "CHIPError.h"
+#import <Foundation/Foundation.h>
+
+CHIPPersistentStorageDelegateBridge::CHIPPersistentStorageDelegateBridge(void)
+    : mDelegate(nil)
+{
+}
+
+CHIPPersistentStorageDelegateBridge::~CHIPPersistentStorageDelegateBridge(void) {}
+
+void CHIPPersistentStorageDelegateBridge::setFrameworkDelegate(id<CHIPPersistentStorageDelegate> delegate, dispatch_queue_t queue)
+{
+    if (delegate && queue) {
+        mDelegate = delegate;
+        mQueue = queue;
+    } else {
+        mDelegate = nil;
+        mQueue = nil;
+    }
+}
+
+void CHIPPersistentStorageDelegateBridge::SetDelegate(chip::DeviceController::PersistentStorageResultDelegate * delegate)
+{
+    if (delegate) {
+        mCallback = delegate;
+
+        mCompletionHandler = ^(NSString * key, NSString * value) {
+            mCallback->OnValue([key UTF8String], [value UTF8String]);
+        };
+
+        mStatusHandler = ^(NSString * key, Operation operation, NSError * status) {
+            chip::DeviceController::PersistentStorageResultDelegate::Operation op
+                = chip::DeviceController::PersistentStorageResultDelegate::Operation::kGET;
+            switch (operation) {
+            case kGet:
+                op = chip::DeviceController::PersistentStorageResultDelegate::Operation::kGET;
+                break;
+            case kSet:
+                op = chip::DeviceController::PersistentStorageResultDelegate::Operation::kSET;
+                break;
+            case kDelete:
+                op = chip::DeviceController::PersistentStorageResultDelegate::Operation::kDELETE;
+                break;
+            }
+            mCallback->OnStatus([key UTF8String], op, [CHIPError errorToCHIPErrorCode:status]);
+        };
+    } else {
+        mCallback = nil;
+        mCompletionHandler = nil;
+        mStatusHandler = nil;
+    }
+}
+
+void CHIPPersistentStorageDelegateBridge::GetKeyValue(const char * key)
+{
+    NSString * keyString = [NSString stringWithUTF8String:key];
+    NSLog(@"PersistentStorageDelegate Get Value for Key: %@", keyString);
+
+    id<CHIPPersistentStorageDelegate> strongDelegate = mDelegate;
+    if (strongDelegate && mQueue) {
+        dispatch_async(mQueue, ^{
+            [strongDelegate GetKeyValue:keyString handler:mCompletionHandler];
+        });
+    }
+}
+
+void CHIPPersistentStorageDelegateBridge::SetKeyValue(const char * key, const char * value)
+{
+    NSString * keyString = [NSString stringWithUTF8String:key];
+    NSString * valueString = [NSString stringWithUTF8String:value];
+    NSLog(@"PersistentStorageDelegate Set Key %@", keyString);
+
+    id<CHIPPersistentStorageDelegate> strongDelegate = mDelegate;
+    if (strongDelegate && mQueue) {
+        dispatch_async(mQueue, ^{
+            [strongDelegate SetKeyValue:keyString value:valueString handler:mStatusHandler];
+        });
+    }
+}
+
+void CHIPPersistentStorageDelegateBridge::DeleteKeyValue(const char * key)
+{
+    NSString * keyString = [NSString stringWithUTF8String:key];
+    NSLog(@"PersistentStorageDelegate Delete Key: %@", keyString);
+
+    id<CHIPPersistentStorageDelegate> strongDelegate = mDelegate;
+    if (strongDelegate && mQueue) {
+        dispatch_async(mQueue, ^{
+            [strongDelegate DeleteKeyValue:keyString handler:mStatusHandler];
+        });
+    }
+}

--- a/src/lib/support/CHIPMem.h
+++ b/src/lib/support/CHIPMem.h
@@ -33,6 +33,12 @@
 namespace chip {
 namespace Platform {
 
+#define CHIP_ZERO_AT(value)                                                                                                        \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        memset(&value, 0, sizeof(value));                                                                                          \
+    } while (0)
+
 /**
  * This function is called by CHIP layer to initialize memory and resources
  * required for proper functionality of the CHIP memory allocator.


### PR DESCRIPTION
#### Problem
CHIP iOS framework and app do not persist device state across application restart.

#### Summary of Changes

- Update Persistent Storage delegate to async calls (as storage I/O can take time)
- Add packet cache in controller to store outgoing packets while secure session is getting established
- Implement delegate for iOS framework
- Hookup persistent storage to CHIP tool app

Related to issue #2797