### PR TITLE
[EFR] Init Chip memory management before chip stack

### DIFF
--- a/examples/lighting-app/efr32/src/main.cpp
+++ b/examples/lighting-app/efr32/src/main.cpp
@@ -117,6 +117,10 @@ int main(void)
     EFR32_LOG("==================================================");
 
     EFR32_LOG("Init CHIP Stack");
+
+    // Init Chip memory management before the stack
+    chip::Platform::MemoryInit();
+
     ret = PlatformMgr().InitChipStack();
     if (ret != CHIP_NO_ERROR)
     {
@@ -171,6 +175,8 @@ int main(void)
 
     EFR32_LOG("Starting FreeRTOS scheduler");
     vTaskStartScheduler();
+
+    chip::Platform::MemoryShutdown();
 
     // Should never get here.
     EFR32_LOG("vTaskStartScheduler() failed");

--- a/examples/lock-app/efr32/src/main.cpp
+++ b/examples/lock-app/efr32/src/main.cpp
@@ -117,6 +117,10 @@ int main(void)
     EFR32_LOG("==================================================");
 
     EFR32_LOG("Init CHIP Stack");
+
+    // Init Chip memory management before the stack
+    chip::Platform::MemoryInit();
+
     ret = PlatformMgr().InitChipStack();
     if (ret != CHIP_NO_ERROR)
     {
@@ -171,6 +175,8 @@ int main(void)
 
     EFR32_LOG("Starting FreeRTOS scheduler");
     vTaskStartScheduler();
+
+    chip::Platform::MemoryShutdown();
 
     // Should never get here.
     EFR32_LOG("vTaskStartScheduler() failed");

--- a/src/platform/EFR32/PlatformManagerImpl.cpp
+++ b/src/platform/EFR32/PlatformManagerImpl.cpp
@@ -45,6 +45,9 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     // Initialize LwIP.
     tcpip_init(NULL, NULL);
 
+    // Init Chip memory management before the stack
+    chip::Platform::MemoryInit();
+
     // Call _InitChipStack() on the generic implementation base class
     // to finish the initialization process.
     err = Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>::_InitChipStack();

--- a/src/platform/EFR32/PlatformManagerImpl.cpp
+++ b/src/platform/EFR32/PlatformManagerImpl.cpp
@@ -45,9 +45,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     // Initialize LwIP.
     tcpip_init(NULL, NULL);
 
-    // Init Chip memory management before the stack
-    chip::Platform::MemoryInit();
-
     // Call _InitChipStack() on the generic implementation base class
     // to finish the initialization process.
     err = Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>::_InitChipStack();


### PR DESCRIPTION
 #### Problem
 EFR examples apps stall with error
ABORT: chip::Platform::MemoryCalloc() called before chip::Platform::MemoryInit()


 #### Summary of Changes
Add function call chip::Platform::MemoryInit() before _initChipStack

 Fixes #3372