### PR TITLE
[android] Add initial Thread provisioning implementation

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OnOffClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OnOffClientFragment.kt
@@ -33,6 +33,11 @@ class OnOffClientFragment : Fragment(), ChipDeviceController.CompletionListener 
     }
   }
 
+  override fun onStart() {
+    super.onStart()
+    ipAddressEd.setText(deviceController.ipAddress ?: requireContext().getString(R.string.enter_ip_address_hint_text))
+  }
+
   override fun onConnectDeviceComplete() {
     sendCommand()
   }

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/CHIPDeviceDetailsFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/CHIPDeviceDetailsFragment.kt
@@ -83,7 +83,6 @@ class CHIPDeviceDetailsFragment : Fragment(), ChipDeviceController.CompletionLis
 
     override fun onStop() {
         super.onStop()
-        gatt?.disconnect()
         gatt = null
         scope.cancel()
     }

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/CHIPDeviceDetailsFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/CHIPDeviceDetailsFragment.kt
@@ -25,6 +25,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import chip.devicecontroller.ChipDeviceController
 import com.google.chip.chiptool.ChipClient
@@ -92,12 +93,17 @@ class CHIPDeviceDetailsFragment : Fragment(), ChipDeviceController.CompletionLis
             scope.launch {
                 val deviceController = ChipClient.getDeviceController()
                 val bluetoothManager = BluetoothManager()
+
+                showMessage(requireContext().getString(R.string.rendezvous_over_ble_scanning_text) + " " + deviceInfo.discriminator.toString())
                 val device = bluetoothManager.getBluetoothDevice(deviceInfo.discriminator) ?: run {
-                    Log.i(TAG, "No device found")
+                    showMessage(requireContext().getString(R.string.rendezvous_over_ble_scanning_failed_text))
                     return@launch
                 }
 
+                showMessage(requireContext().getString(R.string.rendezvous_over_ble_connecting_text) + " " + (device.name ?: device.address.toString()))
                 gatt = bluetoothManager.connect(requireContext(), device)
+
+                showMessage(requireContext().getString(R.string.rendezvous_over_ble_pairing_text))
                 deviceController.setCompletionListener(this@CHIPDeviceDetailsFragment)
                 deviceController.beginConnectDeviceBle(gatt, deviceInfo.setupPinCode);
             }
@@ -105,7 +111,7 @@ class CHIPDeviceDetailsFragment : Fragment(), ChipDeviceController.CompletionLis
     }
 
     override fun onConnectDeviceComplete() {
-        Log.d(TAG, "TODO: Retrieve Wi-Fi/Thread credentials and send to device.")
+        showMessage(requireContext().getString(R.string.rendezvous_over_ble_success_text))
     }
 
     override fun onCloseBleComplete() {
@@ -117,7 +123,7 @@ class CHIPDeviceDetailsFragment : Fragment(), ChipDeviceController.CompletionLis
     }
 
     override fun onSendMessageComplete(message: String?) {
-        Log.d(TAG, "Echo message received: $message")
+        Log.d(TAG, "Message received: $message")
     }
 
     override fun onError(error: Throwable?) {
@@ -126,6 +132,12 @@ class CHIPDeviceDetailsFragment : Fragment(), ChipDeviceController.CompletionLis
 
     private fun onRendezvousSoftApClicked() {
         // TODO: once rendezvous over hotspot is ready in CHIP
+    }
+
+    private fun showMessage(msg: String) {
+        requireActivity().runOnUiThread {
+            Toast.makeText(requireContext(), msg, Toast.LENGTH_SHORT).show()
+        }
     }
 
     companion object {

--- a/src/android/CHIPTool/app/src/main/res/values/strings.xml
+++ b/src/android/CHIPTool/app/src/main/res/values/strings.xml
@@ -33,6 +33,12 @@
     <string name="rendezvous_over_ble_btn_text">Rendezvous over BLE</string>
     <string name="rendezvous_over_soft_ap_btn_text">Rendezvous over Soft AP</string>
 
+    <string name="rendezvous_over_ble_scanning_text">Scanning for BLE device</string>
+    <string name="rendezvous_over_ble_scanning_failed_text">Device not found</string>
+    <string name="rendezvous_over_ble_connecting_text">Connecting to</string>
+    <string name="rendezvous_over_ble_pairing_text">Pairing</string>
+    <string name="rendezvous_over_ble_success_text">Secure channel established. Provisioning</string>
+
     <string name="commissioner_commissioning">Commissioning</string>
     <string name="commissioner_name">Commissioner</string>
     <string name="commissioner_scan_device">Scan Device</string>

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -408,15 +408,22 @@ exit:
     return err;
 }
 
-bool ChipDeviceController::IsConnected()
+bool ChipDeviceController::IsConnected() const
 {
     return mState == kState_Initialized &&
         (mConState == kConnectionState_Connected || mConState == kConnectionState_SecureConnected);
 }
 
-bool ChipDeviceController::IsSecurelyConnected()
+bool ChipDeviceController::IsSecurelyConnected() const
 {
     return mState == kState_Initialized && mConState == kConnectionState_SecureConnected;
+}
+
+bool ChipDeviceController::GetIpAddress(Inet::IPAddress & addr) const
+{
+    if (IsConnected())
+        addr = mDeviceAddr;
+    return IsConnected();
 }
 
 CHIP_ERROR ChipDeviceController::DisconnectDevice()

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -108,7 +108,8 @@ ChipDeviceController::~ChipDeviceController()
     }
 }
 
-CHIP_ERROR ChipDeviceController::Init(NodeId localNodeId)
+CHIP_ERROR ChipDeviceController::Init(NodeId localNodeId, DevicePairingDelegate * pairingDelegate,
+                                      PersistentStorageDelegate * storageDelegate)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -118,37 +119,26 @@ CHIP_ERROR ChipDeviceController::Init(NodeId localNodeId)
     err = DeviceLayer::PlatformMgr().InitChipStack();
     SuccessOrExit(err);
 
-    err = Init(localNodeId, &DeviceLayer::SystemLayer, &DeviceLayer::InetLayer);
+    err = Init(localNodeId, &DeviceLayer::SystemLayer, &DeviceLayer::InetLayer, pairingDelegate, storageDelegate);
 #endif // CONFIG_DEVICE_LAYER
 
 exit:
     return err;
 }
 
-CHIP_ERROR ChipDeviceController::Init(NodeId localNodeId, System::Layer * systemLayer, InetLayer * inetLayer)
+CHIP_ERROR ChipDeviceController::Init(NodeId localNodeId, System::Layer * systemLayer, InetLayer * inetLayer,
+                                      DevicePairingDelegate * pairingDelegate, PersistentStorageDelegate * storageDelegate)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     VerifyOrExit(mState == kState_NotInitialized, err = CHIP_ERROR_INCORRECT_STATE);
 
-    mSystemLayer = systemLayer;
-    mInetLayer   = inetLayer;
-
-    mState         = kState_Initialized;
-    mLocalDeviceId = localNodeId;
-
-exit:
-    return err;
-}
-
-CHIP_ERROR ChipDeviceController::Init(NodeId localNodeId, DevicePairingDelegate * pairingDelegate,
-                                      PersistentStorageDelegate * storage)
-{
-    CHIP_ERROR err = Init(localNodeId);
-    SuccessOrExit(err);
-
+    mState           = kState_Initialized;
+    mLocalDeviceId   = localNodeId;
+    mSystemLayer     = systemLayer;
+    mInetLayer       = inetLayer;
     mPairingDelegate = pairingDelegate;
-    mStorageDelegate = storage;
+    mStorageDelegate = storageDelegate;
 
     if (mStorageDelegate != nullptr)
     {

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -178,7 +178,7 @@ public:
      *
      * @return bool   If there is an active connection
      */
-    bool IsConnected();
+    bool IsConnected() const;
 
     /**
      * @brief
@@ -186,7 +186,15 @@ public:
      *
      * @return bool   If the connection is active and security context is established
      */
-    bool IsSecurelyConnected();
+    bool IsSecurelyConnected() const;
+
+    /**
+     * @brief
+     *   Get IP Address of the peer if the connection is active
+     *
+     * @return bool   If IP Address was returned
+     */
+    bool GetIpAddress(Inet::IPAddress & addr) const;
 
     // ----- Messaging -----
     /**

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -114,13 +114,13 @@ public:
      * Init function to be used when there exists a device layer that takes care of initializing
      * System::Layer and InetLayer.
      */
-    CHIP_ERROR Init(NodeId localDeviceId);
+    CHIP_ERROR Init(NodeId localDeviceId, DevicePairingDelegate * pairingDelegate = nullptr,
+                    PersistentStorageDelegate * storageDelegate = nullptr);
     /**
      * Init function to be used when already-initialized System::Layer and InetLayer are available.
      */
-    CHIP_ERROR Init(NodeId localDeviceId, System::Layer * systemLayer, Inet::InetLayer * inetLayer);
-    CHIP_ERROR Init(NodeId localDeviceId, DevicePairingDelegate * pairingDelegate,
-                    PersistentStorageDelegate * storageDelegate = nullptr);
+    CHIP_ERROR Init(NodeId localDeviceId, System::Layer * systemLayer, Inet::InetLayer * inetLayer,
+                    DevicePairingDelegate * pairingDelegate = nullptr, PersistentStorageDelegate * storageDelegate = nullptr);
     CHIP_ERROR Shutdown();
 
     // ----- Connection Management -----

--- a/src/controller/java/AndroidDevicePairingDelegate.cpp
+++ b/src/controller/java/AndroidDevicePairingDelegate.cpp
@@ -1,0 +1,53 @@
+/*
+ *   Copyright (c) 2020 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "AndroidDevicePairingDelegate.h"
+
+#include <transport/RendezvousSessionDelegate.h>
+
+void AndroidDevicePairingDelegate::OnNetworkCredentialsRequested(chip::RendezvousDeviceCredentialsDelegate * callback)
+{
+    using namespace chip::DeviceLayer::Internal;
+
+    // This is a dummy implementation of Thread provisioning which allows to test Rendezvous over BLE with
+    // Thread-enabled devices by sending OpenThread Border Router default credentials.
+    //
+    // TODO:
+    // 1. Figure out whether WiFi or Thread provisioning should be performed
+    // 2. Call Java code to prompt a user for credentials or use the commissioner component of the app
+
+    constexpr uint8_t XPAN_ID[kThreadExtendedPANIdLength]  = { 0x11, 0x11, 0x11, 0x11, 0x22, 0x22, 0x22, 0x22 };
+    constexpr uint8_t MESH_PREFIX[kThreadMeshPrefixLength] = { 0xFD, 0x11, 0x11, 0x11, 0x11, 0x22, 0x00, 0x00 };
+    constexpr uint8_t NETWORK_KEY[kThreadMasterKeyLength]  = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+                                                              0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF };
+
+    DeviceNetworkInfo threadData = {};
+    memcpy(threadData.ThreadExtendedPANId, XPAN_ID, sizeof(XPAN_ID));
+    memcpy(threadData.ThreadMeshPrefix, MESH_PREFIX, sizeof(MESH_PREFIX));
+    memcpy(threadData.ThreadMasterKey, NETWORK_KEY, sizeof(NETWORK_KEY));
+    threadData.ThreadPANId                      = 0x1234;
+    threadData.ThreadChannel                    = 15;
+    threadData.FieldPresent.ThreadExtendedPANId = 1;
+    threadData.FieldPresent.ThreadMeshPrefix    = 1;
+
+    callback->SendThreadCredentials(threadData);
+}
+
+void AndroidDevicePairingDelegate::OnOperationalCredentialsRequested(const char * csr, size_t csr_length,
+                                                                     chip::RendezvousDeviceCredentialsDelegate * callback)
+{}

--- a/src/controller/java/AndroidDevicePairingDelegate.h
+++ b/src/controller/java/AndroidDevicePairingDelegate.h
@@ -1,0 +1,29 @@
+/*
+ *   Copyright (c) 2020 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include <controller/CHIPDeviceController.h>
+
+class AndroidDevicePairingDelegate : public chip::DeviceController::DevicePairingDelegate
+{
+public:
+    void OnNetworkCredentialsRequested(chip::RendezvousDeviceCredentialsDelegate * callback) override;
+    void OnOperationalCredentialsRequested(const char * csr, size_t csr_length,
+                                           chip::RendezvousDeviceCredentialsDelegate * callback) override;
+};

--- a/src/controller/java/BUILD.gn
+++ b/src/controller/java/BUILD.gn
@@ -27,6 +27,8 @@ shared_library("jni") {
     "AndroidBleConnectionDelegate.h",
     "AndroidBlePlatformDelegate.cpp",
     "AndroidBlePlatformDelegate.h",
+    "AndroidDevicePairingDelegate.cpp",
+    "AndroidDevicePairingDelegate.h",
     "CHIPDeviceController-JNI.cpp",
   ]
 

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -25,6 +25,7 @@
 #include "AndroidBleApplicationDelegate.h"
 #include "AndroidBleConnectionDelegate.h"
 #include "AndroidBlePlatformDelegate.h"
+#include "AndroidDevicePairingDelegate.h"
 
 #include <ble/BleUUID.h>
 #include <controller/CHIPDeviceController.h>
@@ -89,6 +90,7 @@ namespace {
 JavaVM * sJVM;
 System::Layer sSystemLayer;
 Inet::InetLayer sInetLayer;
+AndroidDevicePairingDelegate sDevicePairingDelegate;
 
 #if CONFIG_NETWORK_LAYER_BLE
 Ble::BleLayer sBleLayer;
@@ -239,7 +241,7 @@ JNI_METHOD(jlong, newDeviceController)(JNIEnv * env, jobject self)
     deviceController = new ChipDeviceController();
     VerifyOrExit(deviceController != NULL, err = CHIP_ERROR_NO_MEMORY);
 
-    err = deviceController->Init(kLocalDeviceId, &sSystemLayer, &sInetLayer);
+    err = deviceController->Init(kLocalDeviceId, &sSystemLayer, &sInetLayer, &sDevicePairingDelegate);
     SuccessOrExit(err);
 
     deviceController->AppState = (void *) env->NewGlobalRef(self);

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -531,6 +531,23 @@ JNI_METHOD(jboolean, isConnected)(JNIEnv * env, jobject self, jlong deviceContro
     return JNI_FALSE;
 }
 
+JNI_METHOD(jstring, getIpAddress)(JNIEnv * env, jobject self, jlong deviceControllerPtr)
+{
+    ChipDeviceController * deviceController = (ChipDeviceController *) deviceControllerPtr;
+
+    chip::Inet::IPAddress addr;
+    char addrStr[50];
+
+    {
+        ScopedPthreadLock lock(&sStackLock);
+        if (!deviceController->GetIpAddress(addr))
+            return nullptr;
+    }
+
+    addr.ToString(addrStr, sizeof(addrStr));
+    return env->NewStringUTF(addrStr);
+}
+
 JNI_METHOD(jboolean, disconnectDevice)(JNIEnv * env, jobject self, jlong deviceControllerPtr)
 {
     ChipLogProgress(Controller, "disconnectDevice() called");

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -68,6 +68,10 @@ public class ChipDeviceController {
     return isConnected(deviceControllerPtr);
   }
 
+  public String getIpAddress() {
+    return getIpAddress(deviceControllerPtr);
+  }
+
   public void beginSendMessage(String message) {
     beginSendMessage(deviceControllerPtr, message);
   }
@@ -147,6 +151,8 @@ public class ChipDeviceController {
   private native void beginConnectDeviceIp(long deviceControllerPtr, String ipAddress);
 
   private native boolean isConnected(long deviceControllerPtr);
+
+  private native String getIpAddress(long deviceControllerPtr);
 
   private native void beginSendMessage(long deviceControllerPtr, String message);
 

--- a/src/transport/NetworkProvisioning.cpp
+++ b/src/transport/NetworkProvisioning.cpp
@@ -239,16 +239,16 @@ CHIP_ERROR NetworkProvisioning::SendThreadCredentials(const DeviceLayer::Interna
         VerifyOrExit(bbuf.Fit(), err = CHIP_ERROR_BUFFER_TOO_SMALL);
         buffer->SetDataLength(static_cast<uint16_t>(bbuf.Written()));
 
-        err = mDelegate->SendSecureMessage(Protocols::kChipProtocol_NetworkProvisioning,
+        err    = mDelegate->SendSecureMessage(Protocols::kChipProtocol_NetworkProvisioning,
                                            NetworkProvisioning::MsgTypes::kThreadAssociationRequest, buffer);
+        buffer = nullptr;
     }
 
 exit:
-    if (CHIP_NO_ERROR != err)
-    {
-        ChipLogError(NetworkProvisioning, "Failed to send Thread Credentials: %s", ErrorStr(err));
+    if (buffer)
         System::PacketBuffer::Free(buffer);
-    }
+    if (CHIP_NO_ERROR != err)
+        ChipLogError(NetworkProvisioning, "Failed to send Thread Credentials: %s", ErrorStr(err));
     return err;
 }
 

--- a/src/transport/NetworkProvisioning.h
+++ b/src/transport/NetworkProvisioning.h
@@ -108,6 +108,7 @@ public:
     ~NetworkProvisioning();
 
     CHIP_ERROR SendNetworkCredentials(const char * ssid, const char * passwd);
+    CHIP_ERROR SendThreadCredentials(const DeviceLayer::Internal::DeviceNetworkInfo & threadData);
 
     CHIP_ERROR HandleNetworkProvisioningMessage(uint8_t msgType, System::PacketBuffer * msgBuf);
 

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -425,5 +425,10 @@ void RendezvousSession::SendNetworkCredentials(const char * ssid, const char * p
     mNetworkProvision.SendNetworkCredentials(ssid, passwd);
 }
 
+void RendezvousSession::SendThreadCredentials(const DeviceLayer::Internal::DeviceNetworkInfo & threadData)
+{
+    mNetworkProvision.SendThreadCredentials(threadData);
+}
+
 void RendezvousSession::SendOperationalCredentials() {}
 } // namespace chip

--- a/src/transport/RendezvousSession.h
+++ b/src/transport/RendezvousSession.h
@@ -106,6 +106,7 @@ public:
 
     //////////// RendezvousDeviceCredentialsDelegate Implementation ///////////////
     void SendNetworkCredentials(const char * ssid, const char * passwd) override;
+    void SendThreadCredentials(const DeviceLayer::Internal::DeviceNetworkInfo & threadData) override;
     void SendOperationalCredentials() override;
 
     //////////// NetworkProvisioningDelegate Implementation ///////////////

--- a/src/transport/RendezvousSessionDelegate.h
+++ b/src/transport/RendezvousSessionDelegate.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <core/CHIPCore.h>
+#include <platform/internal/DeviceNetworkInfo.h>
 
 namespace chip {
 
@@ -46,8 +47,9 @@ public:
 class DLL_EXPORT RendezvousDeviceCredentialsDelegate
 {
 public:
-    virtual void SendNetworkCredentials(const char * ssid, const char * passwd) = 0;
-    virtual void SendOperationalCredentials()                                   = 0;
+    virtual void SendNetworkCredentials(const char * ssid, const char * passwd)          = 0;
+    virtual void SendThreadCredentials(const DeviceLayer::Internal::DeviceNetworkInfo &) = 0;
+    virtual void SendOperationalCredentials()                                            = 0;
 };
 
 } // namespace chip


### PR DESCRIPTION
Note that one change, adding kThreadAssociationRequest message type, is shared with #3303.

 #### Problem
CHIPTool for Android is currently not able to provision a Thread device over BLE

 #### Summary of Changes
- Implement initial version of Thread provisioning in the CHIPTool by sending fixed network data during Rendezvous over BLE
- If the device responds with IP Address, update the editbox in "On/Off Cluster" screen so that a user doesn't need to type it manually.

 Fixes #3389