### PR TITLE
[nrfconnect] Don't recommend using Docker in privileged mode

### DIFF
--- a/examples/lighting-app/nrfconnect/README.md
+++ b/examples/lighting-app/nrfconnect/README.md
@@ -106,7 +106,8 @@ container:
 
         $ mkdir ~/nrfconnect
         $ mkdir ~/connectedhomeip
-        $ docker run --rm -it --privileged -v ~/nrfconnect:/var/ncs -v ~/connectedhomeip:/var/chip nordicsemi/nrfconnect-chip
+        $ docker pull nordicsemi/nrfconnect-chip
+        $ docker run --rm -it -v ~/nrfconnect:/var/ncs -v ~/connectedhomeip:/var/chip -v /dev/bus/usb:/dev/bus/usb --device-cgroup-rule "c 189:* rmw" nordicsemi/nrfconnect-chip
 
 > **Note**:
 >
@@ -114,9 +115,9 @@ container:
 >     source directory in case you have it already installed.
 > -   Likewise, `~/connectedhomeip` can be replaced with an absolute path to
 >     CHIP source directory.
-> -   `--privileged` flag can be omitted if you're not planning to flash the
->     example onto hardware. The parameter gives the container access to devices
->     connected to your computer when the container is started.
+> -   `-v /dev/bus/usb:/dev/bus/usb --device-cgroup-rule 'c 189:* rmw` parameters can be omitted if you're not planning to flash the
+>     example onto hardware. The parameters give the container access to USB devices
+>     connected to your computer such as the nRF52840 DK.
 > -   `--rm` flag can be omitted if you don't want the container to be
 >     auto-removed when you exit the container shell session.
 

--- a/examples/lighting-app/nrfconnect/README.md
+++ b/examples/lighting-app/nrfconnect/README.md
@@ -115,8 +115,9 @@ container:
 >     source directory in case you have it already installed.
 > -   Likewise, `~/connectedhomeip` can be replaced with an absolute path to
 >     CHIP source directory.
-> -   `-v /dev/bus/usb:/dev/bus/usb --device-cgroup-rule 'c 189:* rmw` parameters can be omitted if you're not planning to flash the
->     example onto hardware. The parameters give the container access to USB devices
+> -   `-v /dev/bus/usb:/dev/bus/usb --device-cgroup-rule 'c 189:* rmw`
+>     parameters can be omitted if you're not planning to flash the example onto
+>     hardware. The parameters give the container access to USB devices
 >     connected to your computer such as the nRF52840 DK.
 > -   `--rm` flag can be omitted if you don't want the container to be
 >     auto-removed when you exit the container shell session.

--- a/examples/lock-app/nrfconnect/README.md
+++ b/examples/lock-app/nrfconnect/README.md
@@ -110,7 +110,8 @@ container:
 
         $ mkdir ~/nrfconnect
         $ mkdir ~/connectedhomeip
-        $ docker run --rm -it --privileged -v ~/nrfconnect:/var/ncs -v ~/connectedhomeip:/var/chip nordicsemi/nrfconnect-chip
+        $ docker pull nordicsemi/nrfconnect-chip
+        $ docker run --rm -it -v ~/nrfconnect:/var/ncs -v ~/connectedhomeip:/var/chip -v /dev/bus/usb:/dev/bus/usb --device-cgroup-rule "c 189:* rmw" nordicsemi/nrfconnect-chip
 
 > **Note**:
 >
@@ -118,9 +119,9 @@ container:
 >     source directory in case you have it already installed.
 > -   Likewise, `~/connectedhomeip` can be replaced with an absolute path to
 >     CHIP source directory.
-> -   `--privileged` flag can be omitted if you're not planning to flash the
->     example onto hardware. The parameter gives the container access to devices
->     connected to your computer when the container is started.
+> -   `-v /dev/bus/usb:/dev/bus/usb --device-cgroup-rule 'c 189:* rmw` parameters can be omitted if you're not planning to flash the
+>     example onto hardware. The parameters give the container access to USB devices
+>     connected to your computer such as the nRF52840 DK.
 > -   `--rm` flag can be omitted if you don't want the container to be
 >     auto-removed when you exit the container shell session.
 

--- a/examples/lock-app/nrfconnect/README.md
+++ b/examples/lock-app/nrfconnect/README.md
@@ -119,8 +119,9 @@ container:
 >     source directory in case you have it already installed.
 > -   Likewise, `~/connectedhomeip` can be replaced with an absolute path to
 >     CHIP source directory.
-> -   `-v /dev/bus/usb:/dev/bus/usb --device-cgroup-rule 'c 189:* rmw` parameters can be omitted if you're not planning to flash the
->     example onto hardware. The parameters give the container access to USB devices
+> -   `-v /dev/bus/usb:/dev/bus/usb --device-cgroup-rule 'c 189:* rmw`
+>     parameters can be omitted if you're not planning to flash the example onto
+>     hardware. The parameters give the container access to USB devices
 >     connected to your computer such as the nRF52840 DK.
 > -   `--rm` flag can be omitted if you don't want the container to be
 >     auto-removed when you exit the container shell session.


### PR DESCRIPTION
 #### Problem
Following the instructions in examples/lock-app/nrfconnect/README.md creates root-owned files in the source checkout. 
Also running a docker image with --privileged flag which gives access to all devices may raise security concerns.

 #### Summary of Changes
Update "Building/Using Docker container" sections of the nRF Connect README files:
- run "docker pull" to pull a new version of nrfconnect-chip image which uses non-root user by default
- don't run the container in privileged mode. Instead, give it access to USB devices only

 Fixes #3069