### PR TITLE
EFR apps build fails on linux platform due to file system case sensitivity

### DIFF
--- a/third_party/efr32_sdk/efr32_sdk.gni
+++ b/third_party/efr32_sdk/efr32_sdk.gni
@@ -144,16 +144,16 @@ template("efr32_sdk") {
     } else if (efr32_family == "efr32mg21") {
       _include_dirs += [
         "${efr32_sdk_root}/hardware/kit/EFR32MG21_${efr32_board}/config",
-        "${efr32_sdk_root}/platform/Device/SiliconLabs/efr32mg21/Include",
+        "${efr32_sdk_root}/platform/Device/SiliconLabs/EFR32MG21/Include",
         "${efr32_sdk_root}/platform/radio/rail_lib/chip/efr32/efr32xg2x",
         "${efr32_sdk_root}/util/third_party/freertos/Source/portable/GCC/ARM_CM3",
       ]
 
       libs += [
-        "${efr32_sdk_root}/protocol/bluetooth/lib/efr32mg21/GCC/libbluetooth.a",
+        "${efr32_sdk_root}/protocol/bluetooth/lib/EFR32MG21/GCC/libbluetooth.a",
         "${efr32_sdk_root}/platform/radio/rail_lib/autogen/librail_release/librail_multiprotocol_efr32xg21_gcc_release.a",
         "${efr32_sdk_root}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a",
-        "${efr32_sdk_root}/protocol/bluetooth/lib/efr32mg21/GCC/libmbedtls.a",
+        "${efr32_sdk_root}/protocol/bluetooth/lib/EFR32MG21/GCC/libmbedtls.a",
       ]
 
       defines += [
@@ -326,8 +326,8 @@ template("efr32_sdk") {
       ]
     } else if (efr32_family == "efr32mg21") {
       sources += [
-        "${efr32_sdk_root}/platform/Device/SiliconLabs/efr32mg21/Source/GCC/startup_efr32mg21.c",
-        "${efr32_sdk_root}/platform/Device/SiliconLabs/efr32mg21/Source/system_efr32mg21.c",
+        "${efr32_sdk_root}/platform/Device/SiliconLabs/EFR32MG21/Source/GCC/startup_efr32mg21.c",
+        "${efr32_sdk_root}/platform/Device/SiliconLabs/EFR32MG21/Source/system_efr32mg21.c",
         "${efr32_sdk_root}/util/third_party/freertos/Source/portable/GCC/ARM_CM3/port.c",
       ]
     }


### PR DESCRIPTION
 #### Problem
Nina build for the lock_app or lighting app fail on Linux due to case sensitive mismatch in a path definition to a GSDK folder

 #### Summary of Changes
Use Uppercase EFR32MGXX for included GDSK path.

