### PR TITLE
Don't force enable QPG6100 in gn_build.sh

### DIFF
--- a/gn_build.sh
+++ b/gn_build.sh
@@ -72,7 +72,16 @@ echo 'To build a custom build (for help run "gn args --list out/debug")'
 echo gn args "$CHIP_ROOT/out/custom"
 echo ninja -C "$CHIP_ROOT/out/custom"
 
-extra_args=" enable_qpg6100_builds=true"
+extra_args=""
+
+for arg; do
+    case $arg in
+        enable_qpg6100_builds=true)
+            qpg6100_enabled=1
+            ;;
+    esac
+    extra_args+=" $arg"
+done
 
 # Android SDK setup
 android_sdk_args=""
@@ -130,6 +139,13 @@ else
     echo "(cd $CHIP_ROOT/examples/lock-app/k32w; gn gen out/debug --args='$k32w_sdk_args'; ninja -C out/debug)"
 fi
 echo
+
+if [[ -z "$qpg6100_enabled" ]]; then
+    echo "Hint: Pass enable_qpg6100_builds=true to this script to enable building for QPG6100"
+else
+    echo 'To build the QPG6100 lock sample as a standalone project:'
+    echo "(cd $CHIP_ROOT/examples/lock-app/qpg6100; gn gen out/debug; ninja -C out/debug)"
+fi
 
 echo
 


### PR DESCRIPTION
This doesn't build on the Pi right now since we aren't fetching ARM GCC
on the platform yet (and the Ubuntu arm-none-gcc doesn't seem to have 64
bit integer formatting for printf, breaking the build).

Instead accept GN args on the command line of this script and print a
hint about how to enable it.