### PR TITLE
[ESP32] Make the 500ms sleep only happen once with NimBLE

### DIFF
--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -403,11 +403,11 @@ void BLEManagerImpl::DriveBLEState(void)
     {
         err = InitESPBleLayer();
         SuccessOrExit(err);
-    }
 
-    // Add delay of 500msec while NimBLE host task gets up and running
-    {
-        vTaskDelay(500 / portTICK_RATE_MS);
+        // Add delay of 500msec while NimBLE host task gets up and running
+        {
+            vTaskDelay(500 / portTICK_RATE_MS);
+        }
     }
 
     // If the application has enabled CHIPoBLE and BLE advertising...


### PR DESCRIPTION
There's a 500ms sleep in DriveBLEState when using NimBLE. Make it only
happen once during initialization.

It still seems wrong, but at least it's less wrong and the whole
rendezvous flow is now 3x faster (~15s -> ~5s).

Fixes #3400