### PR TITLE
Fix freeing packet buffers in Rendezvous session

### DIFF
--- a/src/transport/NetworkProvisioning.cpp
+++ b/src/transport/NetworkProvisioning.cpp
@@ -188,16 +188,16 @@ CHIP_ERROR NetworkProvisioning::SendIPAddress(const Inet::IPAddress & addr)
     VerifyOrExit(CanCastTo<uint16_t>(addrLen), err = CHIP_ERROR_INVALID_ARGUMENT);
     buffer->SetDataLength(static_cast<uint16_t>(addrLen));
 
-    err = mDelegate->SendSecureMessage(Protocols::kChipProtocol_NetworkProvisioning,
+    err    = mDelegate->SendSecureMessage(Protocols::kChipProtocol_NetworkProvisioning,
                                        NetworkProvisioning::MsgTypes::kIPAddressAssigned, buffer);
+    buffer = nullptr;
     SuccessOrExit(err);
 
 exit:
-    if (CHIP_NO_ERROR != err)
-    {
-        ChipLogError(NetworkProvisioning, "Failed in sending IP address. error %s\n", ErrorStr(err));
+    if (buffer)
         System::PacketBuffer::Free(buffer);
-    }
+    if (CHIP_NO_ERROR != err)
+        ChipLogError(NetworkProvisioning, "Failed in sending IP address. error %s\n", ErrorStr(err));
     return err;
 }
 
@@ -216,16 +216,16 @@ CHIP_ERROR NetworkProvisioning::SendNetworkCredentials(const char * ssid, const 
     VerifyOrExit(CanCastTo<uint16_t>(bbuf.Written()), err = CHIP_ERROR_INVALID_ARGUMENT);
     buffer->SetDataLength(static_cast<uint16_t>(bbuf.Written()));
 
-    err = mDelegate->SendSecureMessage(Protocols::kChipProtocol_NetworkProvisioning,
+    err    = mDelegate->SendSecureMessage(Protocols::kChipProtocol_NetworkProvisioning,
                                        NetworkProvisioning::MsgTypes::kWiFiAssociationRequest, buffer);
-    SuccessOrExit(err);
+    buffer = nullptr;
+    SuccessOrExit(err); 
 
 exit:
-    if (CHIP_NO_ERROR != err)
-    {
-        ChipLogError(NetworkProvisioning, "Failed in sending Network Creds. error %s\n", ErrorStr(err));
+    if (buffer)
         System::PacketBuffer::Free(buffer);
-    }
+    if (CHIP_NO_ERROR != err)
+        ChipLogError(NetworkProvisioning, "Failed in sending Network Creds. error %s\n", ErrorStr(err));
     return err;
 }
 

--- a/src/transport/NetworkProvisioning.cpp
+++ b/src/transport/NetworkProvisioning.cpp
@@ -219,7 +219,7 @@ CHIP_ERROR NetworkProvisioning::SendNetworkCredentials(const char * ssid, const 
     err    = mDelegate->SendSecureMessage(Protocols::kChipProtocol_NetworkProvisioning,
                                        NetworkProvisioning::MsgTypes::kWiFiAssociationRequest, buffer);
     buffer = nullptr;
-    SuccessOrExit(err); 
+    SuccessOrExit(err);
 
 exit:
     if (buffer)

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -97,6 +97,7 @@ CHIP_ERROR RendezvousSession::SendMessage(System::PacketBuffer * msgBuf)
         break;
 
     default:
+        System::PacketBuffer::Free(msgBuf);
         err = CHIP_ERROR_INCORRECT_STATE;
         break;
     };
@@ -124,10 +125,13 @@ CHIP_ERROR RendezvousSession::SendPairingMessage(System::PacketBuffer * msgBuf)
     SuccessOrExit(err);
 
     msgBuf->ConsumeHead(headerSize);
-    err = mTransport->SendMessage(header, Header::Flags(), Transport::PeerAddress::BLE(), msgBuf);
+    err    = mTransport->SendMessage(header, Header::Flags(), Transport::PeerAddress::BLE(), msgBuf);
+    msgBuf = nullptr;
     SuccessOrExit(err);
 
 exit:
+    if (msgBuf)
+        System::PacketBuffer::Free(msgBuf);
     return err;
 }
 
@@ -174,13 +178,15 @@ CHIP_ERROR RendezvousSession::SendSecureMessage(Protocols::CHIPProtocolId protoc
     VerifyOrExit(CanCastTo<uint16_t>(totalLen + taglen), err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
     msgBuf->SetDataLength(static_cast<uint16_t>(totalLen + taglen));
 
-    err = mTransport->SendMessage(packetHeader, payloadHeader.GetEncodePacketFlags(), Transport::PeerAddress::BLE(), msgBuf);
+    err    = mTransport->SendMessage(packetHeader, payloadHeader.GetEncodePacketFlags(), Transport::PeerAddress::BLE(), msgBuf);
+    msgBuf = nullptr;
     SuccessOrExit(err);
 
     mSecureMessageIndex++;
-    msgBuf = nullptr;
 
 exit:
+    if (msgBuf)
+        System::PacketBuffer::Free(msgBuf);
     return err;
 }
 


### PR DESCRIPTION
 #### Problem
Rendezvous methods for sending messages don't follow the pattern of releasing packet buffers which is used in the lower layers:
- Rendezvous methods for sending messages release a packet buffer if the send operation fails, otherwise they assume that the underlying component has taken care of freeing the buffer.
- BLE::SendMessage() releases a buffer if it fails in its own body, but once the buffer is passed down the stack it assumes ownership of the buffer was taken by the callee regardless of its result. The same is assumed in BLEEndpoint, UDPEndpoint and similar classes.

This may lead to a double-release if one tries to send a message in a rendezvous session and it fails in lower layers like BLEEndpoint.

 #### Summary of Changes
Align buffer handling in RendezvousSession and related classes with the rest of CHIP code. 

 Fixes #3393
