### PR TITLE
Allow nesting Platform::MemoryInit and MemoryShutdown

### DIFF
--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -52,6 +52,7 @@ static_library("support") {
     "CHIPArgParser.cpp",
     "CHIPCounter.cpp",
     "CHIPCounter.h",
+    "CHIPMem.cpp",
     "CHIPMem.h",
     "CHIPMemString.h",
     "CHIPPlatformMemory.cpp",

--- a/src/lib/support/CHIPMem-Malloc.cpp
+++ b/src/lib/support/CHIPMem-Malloc.cpp
@@ -59,7 +59,7 @@ static void VerifyInitialized(const char * func)
 
 #endif
 
-CHIP_ERROR MemoryInit(void * buf, size_t bufSize)
+CHIP_ERROR MemoryAllocatorInit(void * buf, size_t bufSize)
 {
 #ifndef NDEBUG
     if (memoryInitialized++ > 0)
@@ -71,7 +71,7 @@ CHIP_ERROR MemoryInit(void * buf, size_t bufSize)
     return CHIP_NO_ERROR;
 }
 
-void MemoryShutdown()
+void MemoryAllocatorShutdown()
 {
 #ifndef NDEBUG
     if (--memoryInitialized < 0)

--- a/src/lib/support/CHIPMem-SimpleAlloc.cpp
+++ b/src/lib/support/CHIPMem-SimpleAlloc.cpp
@@ -32,7 +32,7 @@
  *      implementation should be reviewed and adjusted accordingly.
  *
  *      Where available, the library can also consume dedicated memory buffer during memory initialization
- *      with MemoryInit() function.
+ *      with MemoryAllocatorInit() function.
  *
  *      The Simple Allocator design is highly parametrized and the number of
  *      buffers, number and sizes of memory blocks can be changed according to new
@@ -260,7 +260,7 @@ static const BlockMark_t sBufferAllocationMask[kNumberOfNetworkBuffers] = {
 
 /**
  * A boolean indicating whether (true) or not (false) the network buffers are used by Simple Allocator.
- * When false - dedicated buffer provided with MemoryInit() function is used.
+ * When false - dedicated buffer provided with MemoryAllocatorInit() function is used.
  *
  */
 static bool sNetworkBuffersUsed = true;
@@ -331,7 +331,7 @@ static uint16_t GetBlockSize(void * p)
     return 0;
 }
 
-CHIP_ERROR MemoryInit(void * buf, size_t bufSize)
+CHIP_ERROR MemoryAllocatorInit(void * buf, size_t bufSize)
 {
     if (buf != NULL)
     {
@@ -356,7 +356,7 @@ CHIP_ERROR MemoryInit(void * buf, size_t bufSize)
     return CHIP_NO_ERROR;
 }
 
-void MemoryShutdown()
+void MemoryAllocatorShutdown()
 {
     if (sNetworkBuffersUsed)
     {

--- a/src/lib/support/CHIPMem.cpp
+++ b/src/lib/support/CHIPMem.cpp
@@ -1,0 +1,67 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements parts of the CHIP allocation API that are
+ *      independent of the configured allocator.
+ *
+ */
+
+#include <core/CHIPConfig.h>
+#include <support/CHIPMem.h>
+#include <support/CHIPPlatformMemory.h>
+
+#include <atomic>
+#include <stdlib.h>
+
+namespace chip {
+namespace Platform {
+
+extern CHIP_ERROR MemoryAllocatorInit(void * buf, size_t bufSize);
+extern void MemoryAllocatorShutdown();
+
+static std::atomic_int memoryInitializationCount{ 0 };
+
+CHIP_ERROR MemoryInit(void * buf, size_t bufSize)
+{
+    if (memoryInitializationCount++ > 0)
+    {
+        return CHIP_NO_ERROR;
+    }
+    // Initialize the allocator.
+    CHIP_ERROR err = MemoryAllocatorInit(buf, bufSize);
+    if (err != CHIP_NO_ERROR)
+    {
+        return err;
+    }
+    // Here we do things like mbedtls_platform_set_calloc_free(), depending on configuration.
+    return err;
+}
+
+void MemoryShutdown()
+{
+    if ((memoryInitializationCount > 0) && (--memoryInitializationCount == 0))
+    {
+        // Here we undo things like mbedtls_platform_set_calloc_free()
+        MemoryAllocatorShutdown();
+    }
+}
+
+} // namespace Platform
+} // namespace chip


### PR DESCRIPTION
#### Problem

Some code wants to use `CHIPMem.h` allocation in contexts where
higher-level code might or might not already have initialized it.
Allowing multiple calls (proposed in issue #3398) solves this.

#### Summary of Changes

- Rename the allocator-specific `MemoryInit()` and `MemoryShutdown()`.
- Call those renamed functions from an allocator-independent
  `MemoryInit()` and `MemoryShutdown()` that allow mulitple calls
  and invoke the underlying allocator only once.

Fixes #3398 — Figure out how QR code parsing can be used safely with the MemoryInit requirement
