### PR TITLE
Move kVendorIdPresent flag from message header to exchange header

### DIFF
--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -58,6 +58,9 @@ enum class ExFlagValues : uint16_t
 {
     /// Set when current message is sent by the initiator of an exchange.
     kExchangeFlag_Initiator = 0x0001,
+
+    /// Header flag specifying that a source vendor id is included in the header.
+    kVendorIdPresent = 0x0002,
 };
 
 enum class FlagValues : uint16_t
@@ -68,12 +71,8 @@ enum class FlagValues : uint16_t
     /// Header flag specifying that a source node id is included in the header.
     kSourceNodeIdPresent = 0x0200,
 
-    /// Header flag specifying that a source vendor id is included in the header.
-    kVendorIdPresent = 0x0400,
-
     /// Header flag specifying that it is a control message for secure session.
-    kSecureSessionControlMessage = 0x0800,
-
+    kSecureSessionControlMessage = 0x0400,
 };
 
 using Flags = BitFlags<uint16_t, FlagValues>;
@@ -297,6 +296,7 @@ public:
     PayloadHeader & SetVendorId(uint16_t id)
     {
         mVendorId.SetValue(id);
+        mExchangeFlags.Set(Header::ExFlagValues::kVendorIdPresent);
 
         return *this;
     }
@@ -305,6 +305,7 @@ public:
     PayloadHeader & SetVendorId(Optional<uint16_t> id)
     {
         mVendorId = id;
+        mExchangeFlags.Set(Header::ExFlagValues::kVendorIdPresent, id.HasValue());
 
         return *this;
     }
@@ -313,9 +314,18 @@ public:
     PayloadHeader & ClearVendorId()
     {
         mVendorId.ClearValue();
+        mExchangeFlags.Set(Header::ExFlagValues::kVendorIdPresent, false);
 
         return *this;
     }
+
+    /**
+     *  Determine whether the source vendor id is included in the header.
+     *
+     *  @return Returns 'true' if it is included, else 'false'.
+     *
+     */
+    bool IsVendorIdPresent() const { return mExchangeFlags.Has(Header::ExFlagValues::kVendorIdPresent); }
 
     /** Set the secure message type for this header. */
     PayloadHeader & SetMessageType(uint8_t type)


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Currently, kVendorIdPresent is defined as message header flag in code, but it is defined as the exchange header flag in spec.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Move kVendorIdPresent flag from message header to exchange header to align with the MessageFormat defined in the latest spec: https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/secure_channel/Message_Format.adoc

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #3360

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
