### PR TITLE
Minor cleanup on screen component

### DIFF
--- a/examples/common/screen-framework/ScreenManager.cpp
+++ b/examples/common/screen-framework/ScreenManager.cpp
@@ -115,9 +115,11 @@ void DisplayVLED(int id)
                  vleds[id].on ? vleds[id].color : vleds[id].color_off);
 }
 
-}; // namespace
+} // namespace
 
-void ScreenManager::Init()
+namespace ScreenManager {
+
+void Init()
 {
     mutex = xSemaphoreCreateRecursiveMutex();
 
@@ -129,7 +131,7 @@ void ScreenManager::Init()
     ScreenTitleSafeTop = ScreenFontHeight * 5 / 2;
 }
 
-void ScreenManager::Display()
+void Display()
 {
     Lock lock;
 
@@ -184,7 +186,7 @@ void ScreenManager::Display()
     screens.back()->Display();
 }
 
-void ScreenManager::ButtonPressed(int id)
+void ButtonPressed(int id)
 {
     Lock lock;
     LazyDisplay lazy;
@@ -218,7 +220,7 @@ void ScreenManager::ButtonPressed(int id)
     }
 }
 
-void ScreenManager::PushScreen(Screen * screen)
+void PushScreen(Screen * screen)
 {
     Lock lock;
     LazyDisplay lazy;
@@ -249,7 +251,7 @@ void ScreenManager::PushScreen(Screen * screen)
     Display();
 }
 
-void ScreenManager::PopScreen()
+void PopScreen()
 {
     Lock lock;
     LazyDisplay lazy;
@@ -282,7 +284,7 @@ void ScreenManager::PopScreen()
     Display();
 }
 
-void ScreenManager::FocusBack()
+void FocusBack()
 {
     Lock lock;
     if (screens.size() > 1)
@@ -299,7 +301,7 @@ void ScreenManager::FocusBack()
     }
 }
 
-int ScreenManager::AddVLED(color_t color)
+int AddVLED(color_t color)
 {
     Lock lock;
     int id = vleds.size();
@@ -308,7 +310,7 @@ int ScreenManager::AddVLED(color_t color)
     return id;
 }
 
-void ScreenManager::SetVLED(int id, bool on)
+void SetVLED(int id, bool on)
 {
     Lock lock;
     if (vleds[id].on == on)
@@ -321,12 +323,14 @@ void ScreenManager::SetVLED(int id, bool on)
     WakeDisplay();
 }
 
-void ScreenManager::ToggleVLED(int id)
+void ToggleVLED(int id)
 {
     Lock lock;
     vleds[id].on = !vleds[id].on;
     DisplayVLED(id);
     WakeDisplay();
 }
+
+} // namespace ScreenManager
 
 #endif // CONFIG_HAVE_DISPLAY

--- a/examples/common/screen-framework/include/ListScreen.h
+++ b/examples/common/screen-framework/include/ListScreen.h
@@ -60,17 +60,17 @@ public:
 
     virtual ~ListScreen() { chip::Platform::Delete(model); }
 
-    virtual std::string GetTitle() { return model->GetTitle(); }
+    std::string GetTitle() override { return model->GetTitle(); }
 
-    virtual std::string GetButtonText(int id);
+    std::string GetButtonText(int id) override;
 
-    virtual void Display();
+    void Display() override;
 
-    virtual bool IsFocusable() { return model->GetItemCount() > 0; }
+    bool IsFocusable() override { return model->GetItemCount() > 0; }
 
-    virtual void Focus(FocusType focus);
+    void Focus(FocusType focus) override;
 
-    virtual void Action() { model->ItemAction(focusIndex); }
+    void Action() override { model->ItemAction(focusIndex); }
 };
 
 class SimpleListModel : public ListScreen::Model
@@ -80,11 +80,11 @@ class SimpleListModel : public ListScreen::Model
     std::vector<std::tuple<std::string, std::function<void()>>> items;
 
 public:
-    virtual std::string GetTitle() { return title; }
-    virtual int GetItemCount() { return items.size(); }
-    virtual std::string GetItemText(int i) { return std::get<0>(items[i]); }
+    std::string GetTitle() override { return title; }
+    int GetItemCount() override { return items.size(); }
+    std::string GetItemText(int i) override { return std::get<0>(items[i]); }
 
-    virtual void ItemAction(int i)
+    void ItemAction(int i) override
     {
         auto & action = std::get<1>(items[i]);
         if (action)

--- a/examples/common/screen-framework/include/ScreenManager.h
+++ b/examples/common/screen-framework/include/ScreenManager.h
@@ -39,26 +39,26 @@ extern color_t ScreenFocusColor;
 
 class Screen;
 
-class ScreenManager
-{
-public:
-    static void Init();
+namespace ScreenManager {
 
-    static void Display();
+void Init();
 
-    static void ButtonPressed(int id);
+void Display();
 
-    static void PushScreen(Screen * screen);
+void ButtonPressed(int id);
 
-    static void PopScreen();
+void PushScreen(Screen * screen);
 
-    static void FocusBack();
+void PopScreen();
 
-    static int AddVLED(color_t color);
+void FocusBack();
 
-    static void SetVLED(int id, bool on);
+int AddVLED(color_t color);
 
-    static void ToggleVLED(int id);
-};
+void SetVLED(int id, bool on);
+
+void ToggleVLED(int id);
+
+} // namespace ScreenManager
 
 #endif // CONFIG_HAVE_DISPLAY


### PR DESCRIPTION
 #### Summary of Changes
 Use 'override' to flag virtual functions overrides.
Change 'ScreenManager' from a 'class with only public static methods' to a namespace.