### PR TITLE
Add attestation app communcation layer

### DIFF
--- a/src/android/CHIPTool/app/build.gradle
+++ b/src/android/CHIPTool/app/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.preference:preference:1.1.1'
     implementation "com.google.android.gms:play-services-vision:20.1.0"
+    implementation 'androidx.fragment:fragment:1.3.0-beta01'
     implementation "androidx.annotation:annotation:1.1.0"
     implementation 'androidx.navigation:navigation-fragment-ktx:2.3.0'
     implementation 'androidx.navigation:navigation-ui-ktx:2.3.0'

--- a/src/android/CHIPTool/app/src/main/AndroidManifest.xml
+++ b/src/android/CHIPTool/app/src/main/AndroidManifest.xml
@@ -31,4 +31,10 @@
         </activity>
     </application>
 
+    <queries>
+        <intent>
+            <action android:name="chip.intent.action.ATTESTATION"/>
+        </intent>
+    </queries>
+
 </manifest>

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -21,6 +21,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import com.google.chip.chiptool.attestation.AttestationTestFragment
 import com.google.chip.chiptool.clusterclient.OnOffClientFragment
 import com.google.chip.chiptool.commissioner.CommissionerActivity
 import com.google.chip.chiptool.echoclient.EchoClientFragment
@@ -65,6 +66,10 @@ class CHIPToolActivity :
 
   override fun handleOnOffClicked() {
     showFragment(OnOffClientFragment.newInstance())
+  }
+
+  override fun handleAttestationTestClicked() {
+    showFragment(AttestationTestFragment.newInstance())
   }
 
   override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/SelectActionFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/SelectActionFragment.kt
@@ -38,6 +38,7 @@ class SelectActionFragment : Fragment() {
       commissioningBtn.setOnClickListener { getCallback()?.handleCommissioningClicked() }
       echoClientBtn.setOnClickListener { getCallback()?.handleEchoClientClicked() }
       onOffClusterBtn.setOnClickListener { getCallback()?.handleOnOffClicked() }
+      attestationTestBtn.setOnClickListener { getCallback()?.handleAttestationTestClicked() }
     }
   }
 
@@ -53,6 +54,8 @@ class SelectActionFragment : Fragment() {
     fun handleEchoClientClicked()
     /** Notifies listener of send command button click. */
     fun handleOnOffClicked()
+    /** Notifies listener of attestation command button clicked. */
+    fun handleAttestationTestClicked()
   }
 
   companion object {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/attestation/AttestationAppLauncher.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/attestation/AttestationAppLauncher.kt
@@ -1,0 +1,53 @@
+package com.google.chip.chiptool.attestation
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.util.Log
+import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+
+/** Class for finding and launching external attestation apps */
+object AttestationAppLauncher {
+  /** Registers and returns an [ActivityResultLauncher] for attestation */
+  fun getLauncher(
+    caller: ActivityResultCaller,
+    block: (String?) -> Unit
+  ): ActivityResultLauncher<Intent> {
+    return caller.registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+      val data = result.data
+      if (result.resultCode == Activity.RESULT_OK && data != null) {
+        val chipResult = data.getStringExtra(CHIP_RESULT_KEY)
+        Log.i(TAG, "Attestation result: $chipResult")
+        block(chipResult)
+      }
+    }
+  }
+
+  /** Queries apps which support attestation and returns the first [Intent] */
+  fun getAttestationIntent(context: Context): Intent? {
+    val packageManager = context.packageManager as PackageManager
+    val attestationActivityIntent = Intent(CHIP_ACTION)
+    val attestationAppInfo = packageManager
+      .queryIntentActivities(attestationActivityIntent, 0)
+      .firstOrNull()
+
+    return if (attestationAppInfo != null) {
+      attestationActivityIntent.setClassName(
+        attestationAppInfo.activityInfo.packageName,
+        attestationAppInfo.activityInfo.name
+      )
+
+      attestationActivityIntent
+    } else {
+      Log.e(TAG, "No attestation app found")
+      null
+    }
+  }
+
+  private const val TAG = "AttestationAppLauncher"
+  private const val CHIP_ACTION = "chip.intent.action.ATTESTATION"
+  private const val CHIP_RESULT_KEY = "chip_result_key"
+}

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/attestation/AttestationTestFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/attestation/AttestationTestFragment.kt
@@ -1,0 +1,38 @@
+package com.google.chip.chiptool.attestation
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.google.chip.chiptool.R
+import kotlinx.android.synthetic.main.attestation_test_fragment.view.*
+
+/** Fragment for launching external attestation apps */
+class AttestationTestFragment : Fragment() {
+  override fun onCreateView(
+    inflater: LayoutInflater,
+    container: ViewGroup?,
+    savedInstanceState: Bundle?
+  ): View? {
+    return inflater.inflate(R.layout.attestation_test_fragment, container, false).apply {
+      attestationText.text = context.getString(R.string.attestation_fetching_status)
+      val appIntent = AttestationAppLauncher.getAttestationIntent(requireContext())
+
+      if (appIntent != null) {
+        AttestationAppLauncher
+          .getLauncher(this@AttestationTestFragment) { result ->
+            attestationText.text = result
+          }
+          .launch(appIntent)
+      } else {
+        attestationText.text = context.getString(R.string.attestation_app_not_found)
+      }
+    }
+  }
+
+  companion object {
+    @JvmStatic
+    fun newInstance(): AttestationTestFragment = AttestationTestFragment()
+  }
+}

--- a/src/android/CHIPTool/app/src/main/res/layout/attestation_test_fragment.xml
+++ b/src/android/CHIPTool/app/src/main/res/layout/attestation_test_fragment.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+  <TextView
+      android:id="@+id/attestationText"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_margin="16dp"
+      android:textSize="20sp"/>
+</LinearLayout>

--- a/src/android/CHIPTool/app/src/main/res/layout/select_action_fragment.xml
+++ b/src/android/CHIPTool/app/src/main/res/layout/select_action_fragment.xml
@@ -35,4 +35,13 @@
         android:layout_marginTop="8dp"
         android:text="@string/on_off_btn_text" />
 
+    <Button
+        android:id="@+id/attestationTestBtn"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:visibility="gone"
+        android:text="@string/attestation_test_btn_text" />
+
 </LinearLayout>

--- a/src/android/CHIPTool/app/src/main/res/values/strings.xml
+++ b/src/android/CHIPTool/app/src/main/res/values/strings.xml
@@ -53,4 +53,8 @@
     <string name="commissioner_location_permission_missing_alert_title">Location permission missing</string>
     <string name="commissioner_location_permission_missing_alert_message">Location permission is required to scan BLE devices.</string>
     <string name="commissioner_location_permission_missing_alert_try_again">Try again</string>
+
+    <string name="attestation_test_btn_text">Attestation Test</string>
+    <string name="attestation_fetching_status">Fetching…</string>
+    <string name="attestation_app_not_found">No attestation app found</string>
 </resources>


### PR DESCRIPTION
#### Problem
For security, during setup of an IoT device running CHIP, the operational credentials generated by the device must be attested and validated by an ecosystem before allowing apps to send or receive information from the device.

#### Summary of Changes
Adds basic communication layer to external attestation apps
Queries for all apps which have an activity with the action "chip.intent.action.ATTESTATION"
Currently randomly chooses an app but will show an app picker in the future
Full API still WIP