### PR TITLE
[example] Add BLE support to Linux example apps

### DIFF
--- a/examples/common/chip-app-server/RendezvousServer.cpp
+++ b/examples/common/chip-app-server/RendezvousServer.cpp
@@ -115,6 +115,7 @@ void RendezvousServer::OnRendezvousMessageReceived(PacketBuffer * buffer)
     ThreadStackMgr().SetThreadEnabled(false);
     ThreadStackMgr().SetThreadProvision(networkInfo);
     ThreadStackMgr().SetThreadEnabled(true);
+
 #endif
 exit:
     chip::System::PacketBuffer::Free(buffer);

--- a/examples/common/chip-app-server/RendezvousServer.cpp
+++ b/examples/common/chip-app-server/RendezvousServer.cpp
@@ -115,7 +115,6 @@ void RendezvousServer::OnRendezvousMessageReceived(PacketBuffer * buffer)
     ThreadStackMgr().SetThreadEnabled(false);
     ThreadStackMgr().SetThreadProvision(networkInfo);
     ThreadStackMgr().SetThreadEnabled(true);
-
 #endif
 exit:
     chip::System::PacketBuffer::Free(buffer);

--- a/examples/lighting-app/linux/BUILD.gn
+++ b/examples/lighting-app/linux/BUILD.gn
@@ -29,6 +29,7 @@ config("includes") {
 executable("chip-tool-server") {
   sources = [
     "LightingManager.cpp",
+    "Options.cpp",
     "include/LightingManager.h",
     "main.cpp",
   ]

--- a/examples/lighting-app/linux/LightingManager.cpp
+++ b/examples/lighting-app/linux/LightingManager.cpp
@@ -19,6 +19,8 @@
 
 #include "LightingManager.h"
 
+#include <cstdio>
+
 LightingManager LightingManager::sLight;
 
 int LightingManager::Init()

--- a/examples/lighting-app/linux/Options.cpp
+++ b/examples/lighting-app/linux/Options.cpp
@@ -47,7 +47,7 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
     {
 
     case kDeviceOption_BleDevice:
-        if (!ParseInt(aValue, GetLinuxDeviceOptions().mBleDevice))
+        if (!ParseInt(aValue, LinuxDeviceOptions::GetInstance().mBleDevice))
         {
             PrintArgError("%s: invalid value specified for ble device number: %s\n", aProgram, aValue);
             retval = false;
@@ -77,7 +77,7 @@ CHIP_ERROR ParseArguments(int argc, char * argv[])
     return CHIP_NO_ERROR;
 }
 
-LinuxDeviceOptions & GetInstance()
+LinuxDeviceOptions & LinuxDeviceOptions::GetInstance()
 {
     return gDeviceOptions;
 }

--- a/examples/lighting-app/linux/Options.cpp
+++ b/examples/lighting-app/linux/Options.cpp
@@ -35,7 +35,7 @@ LinuxDeviceOptions::LinuxDeviceOptions()
 namespace {
 enum
 {
-    kDeviceOption_BleDevice = 0xF000,
+    kDeviceOption_BleDevice = 0x1000,
 };
 
 OptionDef sDeviceOptionDefs[] = { { "ble-device", kArgumentRequired, kDeviceOption_BleDevice }, {} };

--- a/examples/lighting-app/linux/Options.cpp
+++ b/examples/lighting-app/linux/Options.cpp
@@ -24,15 +24,10 @@
 using namespace chip;
 using namespace chip::ArgParser;
 
-LinuxDeviceOptions LinuxDeviceOptions::mLinuxDeviceOptions;
-
-LinuxDeviceOptions::LinuxDeviceOptions()
-{
-    // Default values
-    mBleDevice = 0;
-}
-
 namespace {
+LinuxDeviceOptions gDeviceOptions;
+
+// Follow the code style of command line arguments in case we need to add more options in the future.
 enum
 {
     kDeviceOption_BleDevice = 0x1000,
@@ -80,4 +75,9 @@ CHIP_ERROR ParseArguments(int argc, char * argv[])
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
     return CHIP_NO_ERROR;
+}
+
+LinuxDeviceOptions & GetInstance()
+{
+    return gDeviceOptions;
 }

--- a/examples/lighting-app/linux/Options.cpp
+++ b/examples/lighting-app/linux/Options.cpp
@@ -1,0 +1,83 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "Options.h"
+
+#include <core/CHIPError.h>
+#include <support/CHIPArgParser.hpp>
+
+using namespace chip;
+using namespace chip::ArgParser;
+
+LinuxDeviceOptions LinuxDeviceOptions::mLinuxDeviceOptions;
+
+LinuxDeviceOptions::LinuxDeviceOptions()
+{
+    // Default values
+    mBleDevice = 0;
+}
+
+namespace {
+enum
+{
+    kDeviceOption_BleDevice = 0xF000,
+};
+
+OptionDef sDeviceOptionDefs[] = { { "ble-device", kArgumentRequired, kDeviceOption_BleDevice }, {} };
+
+const char * sDeviceOptionHelp = "  --ble-device <number>\n"
+                                 "       The device number for CHIPoBLE, without 'hci' prefix, can be found by hciconfig.\n"
+                                 "\n";
+
+bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, const char * aName, const char * aValue)
+{
+    bool retval = true;
+
+    switch (aIdentifier)
+    {
+
+    case kDeviceOption_BleDevice:
+        if (!ParseInt(aValue, GetLinuxDeviceOptions().mBleDevice))
+        {
+            PrintArgError("%s: invalid value specified for ble device number: %s\n", aProgram, aValue);
+            retval = false;
+        }
+        break;
+
+    default:
+        PrintArgError("%s: INTERNAL ERROR: Unhandled option: %s\n", aProgram, aName);
+        retval = false;
+        break;
+    }
+
+    return (retval);
+}
+
+OptionSet sDeviceOptions = { HandleOption, sDeviceOptionDefs, "GENERAL OPTIONS", sDeviceOptionHelp };
+
+OptionSet * sLinuxDeviceOptionSets[] = { &sDeviceOptions, nullptr };
+} // namespace
+
+CHIP_ERROR ParseArguments(int argc, char * argv[])
+{
+    if (!ParseArgs(argv[0], argc, argv, sLinuxDeviceOptionSets))
+    {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+    return CHIP_NO_ERROR;
+}

--- a/examples/lighting-app/linux/README.md
+++ b/examples/lighting-app/linux/README.md
@@ -1,6 +1,9 @@
 # CHIP Linux Lighting Example
 
-An example showing the use of CHIP on the Linux. The document will describe how to build and run CHIP Linux Lighting Example on Raspberry Pi. This doc is tested on **Ubuntu for Respberry Pi Server 20.04 LTS (aarch64)** and **Ubuntu for Respberry Pi Desktop 20.10 (aarch64)**
+An example showing the use of CHIP on the Linux. The document will describe how
+to build and run CHIP Linux Lighting Example on Raspberry Pi. This doc is tested
+on **Ubuntu for Respberry Pi Server 20.04 LTS (aarch64)** and **Ubuntu for
+Respberry Pi Desktop 20.10 (aarch64)**
 
 <hr>
 
@@ -40,44 +43,50 @@ An example showing the use of CHIP on the Linux. The document will describe how 
 >     gn gen out/debug --args='bypass_rendezvous=true'
 >     ninja -C out/debug
 >
-> Note that GN will set bypass_rendezvous for future builds, to enable rendezvous, re-generate using
+> Note that GN will set bypass_rendezvous for future builds, to enable
+> rendezvous, re-generate using
 >
 >     gn gen out/debug --args='bypass_rendezvous=false'
 
-- Prerequisites
+-   Prerequisites
 
-  1. A Raspberry Pi 4 board
-  2. A USB Bluetooth Dongle, Ubuntu desktop will send Bluetooth advertisement, which will block CHIP from connecting via BLE. On Ubuntu server, you need to install `pi-bluetooth` via APT.
-  3. Ubuntu 20.04 or newer image for ARM64 platform.
+    1. A Raspberry Pi 4 board
+    2. A USB Bluetooth Dongle, Ubuntu desktop will send Bluetooth advertisement,
+       which will block CHIP from connecting via BLE. On Ubuntu server, you need
+       to install `pi-bluetooth` via APT.
+    3. Ubuntu 20.04 or newer image for ARM64 platform.
 
-- Building
+-   Building
 
-  Follow [Building](#building) section of this document.
+    Follow [Building](#building) section of this document.
 
-- Running
+-   Running
 
-  - [Optiuonal] Plug USB Bluetooth dongle
+    -   [Optiuonal] Plug USB Bluetooth dongle
 
-    - Plug USB Bluetooth dongle and find its bluetooth device number. The number after `hci` is the bluetooth device number, `1` in this example.
+        -   Plug USB Bluetooth dongle and find its bluetooth device number. The
+            number after `hci` is the bluetooth device number, `1` in this
+            example.
 
-            $ hciconfig
-            hci1:	Type: Primary  Bus: USB
-                BD Address: 00:1A:7D:AA:BB:CC  ACL MTU: 310:10  SCO MTU: 64:8
-                UP RUNNING PSCAN ISCAN 
-                RX bytes:20942 acl:1023 sco:0 events:1140 errors:0
-                TX bytes:16559 acl:1011 sco:0 commands:121 errors:0
+                  $ hciconfig
+                  hci1:	Type: Primary  Bus: USB
+                      BD Address: 00:1A:7D:AA:BB:CC  ACL MTU: 310:10  SCO MTU: 64:8
+                      UP RUNNING PSCAN ISCAN
+                      RX bytes:20942 acl:1023 sco:0 events:1140 errors:0
+                      TX bytes:16559 acl:1011 sco:0 commands:121 errors:0
 
-            hci0:	Type: Primary  Bus: UART
-                BD Address: B8:27:EB:AA:BB:CC  ACL MTU: 1021:8  SCO MTU: 64:1
-                UP RUNNING PSCAN ISCAN 
-                RX bytes:8609495 acl:14 sco:0 events:217484 errors:0
-                TX bytes:92185 acl:20 sco:0 commands:5259 errors:0
+                  hci0:	Type: Primary  Bus: UART
+                      BD Address: B8:27:EB:AA:BB:CC  ACL MTU: 1021:8  SCO MTU: 64:1
+                      UP RUNNING PSCAN ISCAN
+                      RX bytes:8609495 acl:14 sco:0 events:217484 errors:0
+                      TX bytes:92185 acl:20 sco:0 commands:5259 errors:0
 
-    - Run Linux Lighting Example App
+        -   Run Linux Lighting Example App
 
-            $ cd ~/connectedhomeip/examples/lighting-app/linux
-            $ sudo out/debug/chip-tool-server --ble-device [bluetooth device number]
-            # In this example, the device we want to use is hci1
-            $ sudo out/debug/chip-tool-server --ble-device 1
+                  $ cd ~/connectedhomeip/examples/lighting-app/linux
+                  $ sudo out/debug/chip-tool-server --ble-device [bluetooth device number]
+                  # In this example, the device we want to use is hci1
+                  $ sudo out/debug/chip-tool-server --ble-device 1
 
-    - Test the device using ChipDeviceController on your laptop / workstation etc.
+        -   Test the device using ChipDeviceController on your laptop /
+            workstation etc.

--- a/examples/lighting-app/linux/README.md
+++ b/examples/lighting-app/linux/README.md
@@ -1,0 +1,83 @@
+# CHIP Linux Lighting Example
+
+An example showing the use of CHIP on the Linux. The document will describe how to build and run CHIP Linux Lighting Example on Raspberry Pi. This doc is tested on **Ubuntu for Respberry Pi Server 20.04 LTS (aarch64)** and **Ubuntu for Respberry Pi Desktop 20.10 (aarch64)**
+
+<hr>
+
+-   [CHIP Linux Lighting Example](#chip-linux-lighting-example)
+    -   [Building](#building)
+    -   [Running the Complete Example on Raspberry Pi 4](#running-complete-example)
+
+<hr>
+
+<a name="building"></a>
+
+## Building
+
+-   Install tool chain
+
+          $ sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev libglib2.0-dev ninja-build python3-venv python3-dev unzip
+
+-   Build the example application:
+
+          $ cd ~/connectedhomeip/examples/lighting-app/linux
+          $ git submodule update --init
+          $ source third_party/connectedhomeip/scripts/activate.sh
+          $ gn gen out/debug
+          $ ninja -C out/debug
+
+-   To delete generated executable, libraries and object files use:
+
+          $ cd ~/connectedhomeip/examples/lighting-app/linux
+          $ rm -rf out/
+
+<a name="running-complete-example"></a>
+
+## Running the Complete Example on Raspberry Pi 4
+
+> If you want to test ZCL, please disable rendzevous
+>
+>     gn gen out/debug --args='bypass_rendezvous=true'
+>     ninja -C out/debug
+>
+> Note that GN will set bypass_rendezvous for future builds, to enable rendezvous, re-generate using
+>
+>     gn gen out/debug --args='bypass_rendezvous=false'
+
+- Prerequisites
+
+  1. A Raspberry Pi 4 board
+  2. A USB Bluetooth Dongle, Ubuntu desktop will send Bluetooth advertisement, which will block CHIP from connecting via BLE. On Ubuntu server, you need to install `pi-bluetooth` via APT.
+  3. Ubuntu 20.04 or newer image for ARM64 platform.
+
+- Building
+
+  Follow [Building](#building) section of this document.
+
+- Running
+
+  - [Optiuonal] Plug USB Bluetooth dongle
+
+    - Plug USB Bluetooth dongle and find its bluetooth device number. The number after `hci` is the bluetooth device number, `1` in this example.
+
+            $ hciconfig
+            hci1:	Type: Primary  Bus: USB
+                BD Address: 00:1A:7D:AA:BB:CC  ACL MTU: 310:10  SCO MTU: 64:8
+                UP RUNNING PSCAN ISCAN 
+                RX bytes:20942 acl:1023 sco:0 events:1140 errors:0
+                TX bytes:16559 acl:1011 sco:0 commands:121 errors:0
+
+            hci0:	Type: Primary  Bus: UART
+                BD Address: B8:27:EB:AA:BB:CC  ACL MTU: 1021:8  SCO MTU: 64:1
+                UP RUNNING PSCAN ISCAN 
+                RX bytes:8609495 acl:14 sco:0 events:217484 errors:0
+                TX bytes:92185 acl:20 sco:0 commands:5259 errors:0
+
+    - Run Linux Lighting Example App
+
+            $ cd ~/connectedhomeip/examples/lighting-app/linux
+            $ sudo out/debug/chip-tool-server --ble-device [bluetooth device number]
+            # In this example, the device we want to use is hci1
+            $ sudo out/debug/chip-tool-server --ble-device 1
+
+    - Test the device using ChipDeviceController on your laptop / workstation etc.

--- a/examples/lighting-app/linux/include/Options.h
+++ b/examples/lighting-app/linux/include/Options.h
@@ -33,7 +33,7 @@ struct LinuxDeviceOptions
     uint32_t mBleDevice = 0;
 
     LinuxDeviceOptions() {}
-    LinuxDeviceOptions & GetInstance();
+    static LinuxDeviceOptions & GetInstance();
 };
 
 CHIP_ERROR ParseArguments(int argc, char * argv[]);

--- a/examples/lighting-app/linux/include/Options.h
+++ b/examples/lighting-app/linux/include/Options.h
@@ -32,7 +32,6 @@ struct LinuxDeviceOptions
 {
     uint32_t mBleDevice = 0;
 
-    LinuxDeviceOptions() {}
     static LinuxDeviceOptions & GetInstance();
 };
 

--- a/examples/lighting-app/linux/include/Options.h
+++ b/examples/lighting-app/linux/include/Options.h
@@ -1,0 +1,48 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Support functions for parsing command-line arguments.
+ *
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#include <core/CHIPError.h>
+
+class LinuxDeviceOptions
+{
+public:
+    uint32_t mBleDevice;
+
+    LinuxDeviceOptions();
+
+private:
+    friend LinuxDeviceOptions & GetLinuxDeviceOptions();
+    static LinuxDeviceOptions mLinuxDeviceOptions;
+};
+
+inline LinuxDeviceOptions & GetLinuxDeviceOptions()
+{
+    return LinuxDeviceOptions::mLinuxDeviceOptions;
+}
+
+CHIP_ERROR ParseArguments(int argc, char * argv[]);

--- a/examples/lighting-app/linux/include/Options.h
+++ b/examples/lighting-app/linux/include/Options.h
@@ -28,21 +28,12 @@
 
 #include <core/CHIPError.h>
 
-class LinuxDeviceOptions
+struct LinuxDeviceOptions
 {
-public:
-    uint32_t mBleDevice;
+    uint32_t mBleDevice = 0;
 
-    LinuxDeviceOptions();
-
-private:
-    friend LinuxDeviceOptions & GetLinuxDeviceOptions();
-    static LinuxDeviceOptions mLinuxDeviceOptions;
+    LinuxDeviceOptions() {}
+    LinuxDeviceOptions & GetInstance();
 };
-
-inline LinuxDeviceOptions & GetLinuxDeviceOptions()
-{
-    return LinuxDeviceOptions::mLinuxDeviceOptions;
-}
 
 CHIP_ERROR ParseArguments(int argc, char * argv[]);

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -19,6 +19,8 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/PlatformManager.h>
 
+#include <platform/Linux/BLEManagerImpl.h>
+
 #include "gen/attribute-id.h"
 #include "gen/cluster-id.h"
 #include "gen/znet-bookkeeping.h"
@@ -79,6 +81,13 @@ void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint)
 int main()
 {
     chip::DeviceLayer::PlatformMgr().InitChipStack();
+
+    chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName("CHIP0001");
+
+    chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureBle(1, false);
+
+    chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(
+        chip::DeviceLayer::ConnectivityManager::kCHIPoBLEServiceMode_Enabled);
 
     LightingMgr().Init();
 

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -154,7 +154,11 @@ int main()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    chip::DeviceLayer::PlatformMgr().InitChipStack();
+    err = chip::Platform::MemoryInit();
+    SuccessOrExit(err);
+
+    err = chip::DeviceLayer::PlatformMgr().InitChipStack();
+    SuccessOrExit(err);
 
     err = PrintQRCodeContent();
     SuccessOrExit(err);

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -169,7 +169,7 @@ int main(int argc, char * argv[])
 
     chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName(nullptr); // Use default device name (CHIP-XXXX)
 
-    chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureBle(GetLinuxDeviceOptions().mBleDevice, false);
+    chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureBle(LinuxDeviceOptions::GetInstance().mBleDevice, false);
 
     chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(
         chip::DeviceLayer::ConnectivityManager::kCHIPoBLEServiceMode_Enabled);

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -95,7 +95,6 @@ void EventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg
     if (event->Type == chip::DeviceLayer::DeviceEventType::kCHIPoBLEConnectionEstablished)
     {
         ChipLogProgress(DeviceLayer, "Receive kCHIPoBLEConnectionEstablished");
-        // exit(0);
     }
 }
 
@@ -145,7 +144,6 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         std::cerr << "Failed to generate QR Code: " << ErrorStr(err) << std::endl;
-        return 1;
     }
     return err;
 }
@@ -187,6 +185,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         std::cerr << "Failed to run Linux Lighting App: " << ErrorStr(err) << std::endl;
+        // End the program with non zero error code to indicate a error.
         return 1;
     }
     return 0;

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -28,15 +28,24 @@
 #include <app/util/af-types.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/util.h>
+#include <core/CHIPError.h>
+#include <setup_payload/QRCodeSetupPayloadGenerator.h>
+#include <setup_payload/SetupPayload.h>
+#include <support/RandUtils.h>
 
 #include "LightingManager.h"
 #include "Server.h"
 
 #include <cassert>
+#include <iostream>
 
 using namespace chip;
 using namespace chip::Inet;
 using namespace chip::Transport;
+using namespace chip::DeviceLayer;
+
+constexpr uint32_t kDefaultSetupPinCode = 12345678; // TODO: Should be a macro in CHIPProjectConfig.h like other example apps.
+constexpr int kExampleVenderID          = 0xabcd;
 
 extern "C" {
 void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,
@@ -78,6 +87,7 @@ void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint)
 }
 }
 
+namespace {
 void EventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
 {
     (void) arg;
@@ -88,15 +98,72 @@ void EventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg
     }
 }
 
+CHIP_ERROR PrintQRCodeContent()
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    // If we do not have a discriminator, generate one
+    chip::SetupPayload payload;
+    uint32_t setUpPINCode;
+    uint16_t setUpDiscriminator;
+    std::string result;
+
+    err = ConfigurationMgr().GetSetupPinCode(setUpPINCode);
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        setUpPINCode = kDefaultSetupPinCode;
+        err          = ConfigurationMgr().StoreSetupPinCode(setUpPINCode);
+    }
+    SuccessOrExit(err);
+
+    err = ConfigurationMgr().GetSetupDiscriminator(setUpDiscriminator);
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        setUpDiscriminator = GetRandU16() & 0xFFF;
+        err                = ConfigurationMgr().StoreSetupDiscriminator(setUpDiscriminator);
+    }
+    SuccessOrExit(err);
+
+    payload.version       = 1;
+    payload.vendorID      = kExampleVenderID;
+    payload.productID     = 1;
+    payload.setUpPINCode  = setUpPINCode;
+    payload.discriminator = setUpDiscriminator;
+
+    // Wrap it so SuccessOrExit can work
+    {
+        chip::QRCodeSetupPayloadGenerator generator(payload);
+        err = generator.payloadBase41Representation(result);
+        SuccessOrExit(err);
+    }
+
+    std::cout << "SetupPINCode: [" << setUpPINCode << "]" << std::endl;
+    // There might be whitespace in setup QRCode, add brackets to make it clearer.
+    std::cout << "SetupQRCode:  [" << result << "]" << std::endl;
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        std::cerr << "Failed to generate QR Code: " << ErrorStr(err) << std::endl;
+        return 1;
+    }
+    return err;
+}
+} // namespace
+
 int main()
 {
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
     chip::DeviceLayer::PlatformMgr().InitChipStack();
 
     chip::Platform::MemoryInit();
 
+    err = PrintQRCodeContent();
+    SuccessOrExit(err);
+
     chip::DeviceLayer::PlatformMgrImpl().AddEventHandler(EventHandler, 0);
 
-    chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName("CHIP0001");
+    chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName(nullptr); // Use default device name (CHIP-XXXX)
 
     chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureBle(0, false);
 
@@ -110,5 +177,11 @@ int main()
 
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
 
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        std::cerr << "Failed to run Linux Lighting App: " << ErrorStr(err) << std::endl;
+        return 1;
+    }
     return 0;
 }

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -78,13 +78,27 @@ void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint)
 }
 }
 
+void EventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
+{
+    (void) arg;
+    if (event->Type == chip::DeviceLayer::DeviceEventType::kCHIPoBLEConnectionEstablished)
+    {
+        ChipLogProgress(DeviceLayer, "Receive kCHIPoBLEConnectionEstablished");
+        // exit(0);
+    }
+}
+
 int main()
 {
     chip::DeviceLayer::PlatformMgr().InitChipStack();
 
+    chip::Platform::MemoryInit();
+
+    chip::DeviceLayer::PlatformMgrImpl().AddEventHandler(EventHandler, 0);
+
     chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName("CHIP0001");
 
-    chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureBle(1, false);
+    chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureBle(0, false);
 
     chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(
         chip::DeviceLayer::ConnectivityManager::kCHIPoBLEServiceMode_Enabled);

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -156,8 +156,6 @@ int main()
 
     chip::DeviceLayer::PlatformMgr().InitChipStack();
 
-    chip::Platform::MemoryInit();
-
     err = PrintQRCodeContent();
     SuccessOrExit(err);
 

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -31,6 +31,7 @@
 #include <core/CHIPError.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <setup_payload/SetupPayload.h>
+#include <support/CHIPMem.h>
 #include <support/RandUtils.h>
 
 #include "LightingManager.h"

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -34,6 +34,7 @@
 #include <support/RandUtils.h>
 
 #include "LightingManager.h"
+#include "Options.h"
 #include "Server.h"
 
 #include <cassert>
@@ -150,11 +151,14 @@ exit:
 }
 } // namespace
 
-int main()
+int main(int argc, char * argv[])
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     err = chip::Platform::MemoryInit();
+    SuccessOrExit(err);
+
+    err = ParseArguments(argc, argv);
     SuccessOrExit(err);
 
     err = chip::DeviceLayer::PlatformMgr().InitChipStack();
@@ -167,7 +171,7 @@ int main()
 
     chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName(nullptr); // Use default device name (CHIP-XXXX)
 
-    chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureBle(0, false);
+    chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureBle(GetLinuxDeviceOptions().mBleDevice, false);
 
     chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(
         chip::DeviceLayer::ConnectivityManager::kCHIPoBLEServiceMode_Enabled);

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -31,6 +31,7 @@
 
 #include <inttypes.h>
 #include <stddef.h>
+#include <cstring>
 
 #include <core/CHIPCore.h>
 #include <core/CHIPEncoding.h>
@@ -70,7 +71,7 @@ CHIP_ERROR ExchangeManager::Init(SecureSessionMgrBase * sessionMgr)
 
     mNextExchangeId = GetRandU16();
 
-    memset(ContextPool, 0, sizeof(ContextPool));
+    memset((void*)ContextPool, 0, sizeof(ContextPool));
     mContextsInUse = 0;
 
     memset(UMHandlerPool, 0, sizeof(UMHandlerPool));

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -29,9 +29,9 @@
 #define __STDC_LIMIT_MACROS
 #endif
 
+#include <cstring>
 #include <inttypes.h>
 #include <stddef.h>
-#include <cstring>
 
 #include <core/CHIPCore.h>
 #include <core/CHIPEncoding.h>
@@ -71,7 +71,7 @@ CHIP_ERROR ExchangeManager::Init(SecureSessionMgrBase * sessionMgr)
 
     mNextExchangeId = GetRandU16();
 
-    memset((void*)ContextPool, 0, sizeof(ContextPool));
+    memset((void *) ContextPool, 0, sizeof(ContextPool));
     mContextsInUse = 0;
 
     memset(UMHandlerPool, 0, sizeof(UMHandlerPool));

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -48,6 +48,9 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
 {
     CHIP_ERROR err;
 
+    err = chip::Platform::MemoryInit();
+    SuccessOrExit(err);
+
 #if CHIP_WITH_GIO
     GError * error = nullptr;
 

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -26,6 +26,7 @@
 
 #include <platform/PlatformManager.h>
 #include <platform/internal/GenericPlatformManagerImpl_POSIX.cpp>
+#include <support/CHIPMem.h>
 
 #include <thread>
 
@@ -48,9 +49,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
 {
     CHIP_ERROR err;
 
-    err = chip::Platform::MemoryInit();
-    SuccessOrExit(err);
-
 #if CHIP_WITH_GIO
     GError * error = nullptr;
 
@@ -59,6 +57,9 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
     std::thread gdbusThread(GDBus_Thread);
     gdbusThread.detach();
 #endif
+
+    err = chip::Platform::MemoryInit();
+    SuccessOrExit(err);
 
     // Initialize the configuration system.
     err = Internal::PosixConfig::Init();

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -58,9 +58,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
     gdbusThread.detach();
 #endif
 
-    err = chip::Platform::MemoryInit();
-    SuccessOrExit(err);
-
     // Initialize the configuration system.
     err = Internal::PosixConfig::Init();
     SuccessOrExit(err);


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
On linux platforms, we have BLE for device layer, however, BLE is not enabled by Linux example app code.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
1. Adds initial BLE support to Linux example app
2. In linux example app, generate a random discriminator so we can distinguish it from other devices
3. Print setup pin code and qr code on device start
4. Add chip::Platform::MemoryInit(); call to InitChipStack for Linux
    - This makes sense since we only need Chip memory management for Chip code, user code are not likely to use CHIP memory management.
5. SetDeviceName() can gererate a default device name like other platforms.

 #### Test
Tested by using the device controller in #3385 

(Preferred to use btvirt and bluetoothd from bluez in third_party)

```
sudo btvirt -l2 -L &
sudo bluetoothd --experimental --debug &
```

```
$ python3 chip-device-ctrl.py
Chip Device Controller Shell

chip-device-ctrl > ble-adapter-select 00:AA:01:01:00:24
chip-device-ctrl > ble-scan-connect CHIP-1383
2020-10-24 21:44:27,365 ChipBLEMgr   INFO     scanning started
2020-10-24 21:44:30,973 ChipBLEMgr   INFO     Name =    CHIP-1383
2020-10-24 21:44:30,973 ChipBLEMgr   INFO     ID =      ae0125dc-e621-3e05-9166-70ca7ea07985
2020-10-24 21:44:30,974 ChipBLEMgr   INFO     RSSI =    127
2020-10-24 21:44:30,974 ChipBLEMgr   INFO     address = 00:AA:01:00:00:23
2020-10-24 21:44:30,976 ChipBLEMgr   INFO     ADV data: 0000feaf-0000-1000-8000-00805f9b34fb
2020-10-24 21:44:30,976 ChipBLEMgr   INFO
2020-10-24 21:44:30,977 ChipBLEMgr   INFO     scanning stopped
2020-10-24 21:44:30,979 ChipBLEMgr   INFO     trying to connect to CHIP-1383
2020-10-24 21:44:32,989 ChipBLEMgr   INFO     BLE connecting
2020-10-24 21:44:32,990 ChipBLEMgr   INFO     Discovering services
2020-10-24 21:44:33,119 ChipBLEMgr   INFO     Service discovering success
2020-10-24 21:44:33,128 ChipBLEMgr   INFO     connect success
chip-device-ctrl > set-pairing-wifi-credential testap testtest
WiFi credential set
chip-device-ctrl > connect 12345678
CHIP:BLE: subscribe complete, ep = 0x7f22a9d27760
CHIP:BLE: peripheral chose BTP version 3; central expected between 2 and 3
CHIP:BLE: using BTP fragment sizes rx 20 / tx 128.
CHIP:BLE: local and remote recv window size = 3
CHIP:CTL: Remote device completed SPAKE2+ handshake

CHIP:CTL: Will Call on mOnNewConnection(0x7f22abd3c240)

Rendezvoud Complete
CHIP:NP: Sending Network Creds. Delegate 0x142ed10

Connected
chip-device-ctrl >
```

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #3408 Fixes #3384 

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
