### PR TITLE
[submodule] Use https clone url for bluez

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,7 +40,7 @@
 	branch = master
 [submodule "bluez"]
 	path = third_party/bluez/repo
-	url = git://git.kernel.org/pub/scm/bluetooth/bluez.git
+	url = https://kernel.googlesource.com/pub/scm/bluetooth/bluez.git
 	branch = master
 [submodule "ot-commissioner"]
 	path = third_party/ot-commissioner/repo


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Currently, we are using git protocol for bluez submodule clone, the backend of git protocol is ssh, and the clone process is very slow (3 KB/s) in China. However, when using the https url, the speed is acceptable (1 MB/s).

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Change the repo url of bluez https://kernel.googlesource.com/pub/scm/bluetooth/bluez.git to according to https://git.kernel.org/pub/scm/bluetooth/bluez.git/

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #3431 
<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
