### PR TITLE
Add Initiator flag encoding/decoding in payload header

### DIFF
--- a/src/transport/raw/MessageHeader.cpp
+++ b/src/transport/raw/MessageHeader.cpp
@@ -210,15 +210,6 @@ CHIP_ERROR PayloadHeader::Decode(Header::Flags flags, const uint8_t * const data
 
     mExchangeFlags.SetRaw(header);
 
-    if (mExchangeFlags.Has(Header::ExFlagValues::kExchangeFlag_Initiator))
-    {
-        SetInitiator(true);
-    }
-    else
-    {
-        SetInitiator(false);
-    }
-
     VerifyOrExit(size >= static_cast<size_t>(p - data) + sizeof(uint16_t), err = CHIP_ERROR_INVALID_ARGUMENT);
     mProtocolID = LittleEndian::Read16(p);
 
@@ -278,11 +269,9 @@ CHIP_ERROR PayloadHeader::Encode(uint8_t * data, size_t size, uint16_t * encode_
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint8_t * p    = data;
-    uint8_t header = 0;
+    uint8_t header = mExchangeFlags.Raw();
 
     VerifyOrExit(size >= EncodeSizeBytes(), err = CHIP_ERROR_INVALID_ARGUMENT);
-
-    header = header | mExchangeFlags.Raw();
 
     Write8(p, header);
     Write8(p, mMessageType);

--- a/src/transport/raw/MessageHeader.cpp
+++ b/src/transport/raw/MessageHeader.cpp
@@ -190,12 +190,13 @@ CHIP_ERROR PayloadHeader::Decode(Header::Flags flags, const uint8_t * const data
 {
     CHIP_ERROR err    = CHIP_NO_ERROR;
     const uint8_t * p = data;
+    uint8_t header;
 
     VerifyOrExit(size >= kEncryptedHeaderSizeBytes, err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    mExchangeHeader = Read8(p);
-    mMessageType    = Read8(p);
-    mExchangeID     = LittleEndian::Read16(p);
+    header       = Read8(p);
+    mMessageType = Read8(p);
+    mExchangeID  = LittleEndian::Read16(p);
 
     if (flags.Has(Header::FlagValues::kVendorIdPresent))
     {
@@ -205,6 +206,17 @@ CHIP_ERROR PayloadHeader::Decode(Header::Flags flags, const uint8_t * const data
     else
     {
         mVendorId.ClearValue();
+    }
+
+    mExchangeFlags.SetRaw(header);
+
+    if (mExchangeFlags.Has(Header::ExFlagValues::kExchangeFlag_Initiator))
+    {
+        SetInitiator(true);
+    }
+    else
+    {
+        SetInitiator(false);
     }
 
     VerifyOrExit(size >= static_cast<size_t>(p - data) + sizeof(uint16_t), err = CHIP_ERROR_INVALID_ARGUMENT);
@@ -266,9 +278,13 @@ CHIP_ERROR PayloadHeader::Encode(uint8_t * data, size_t size, uint16_t * encode_
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint8_t * p    = data;
+    uint8_t header = 0;
+
     VerifyOrExit(size >= EncodeSizeBytes(), err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    Write8(p, mExchangeHeader);
+    header = header | mExchangeFlags.Raw();
+
+    Write8(p, header);
     Write8(p, mMessageType);
     LittleEndian::Write16(p, mExchangeID);
     if (mVendorId.HasValue())

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -54,10 +54,10 @@ enum class EncryptionType
  *  @brief
  *    The CHIP Exchange header flag bits.
  */
-enum class ExFlagValues : uint16_t
+enum class ExFlagValues : uint8_t
 {
     /// Set when current message is sent by the initiator of an exchange.
-    kExchangeFlag_Initiator = 0x0001,
+    kExchangeFlag_Initiator = 0x01,
 };
 
 enum class FlagValues : uint16_t
@@ -76,7 +76,8 @@ enum class FlagValues : uint16_t
 
 };
 
-using Flags = BitFlags<uint16_t, FlagValues>;
+using Flags   = BitFlags<uint16_t, FlagValues>;
+using ExFlags = BitFlags<uint8_t, ExFlagValues>;
 
 // Header is a 16-bit value of the form
 //  |  4 bit  | 4 bit |  4 bit  |  4 bit   |
@@ -396,9 +397,6 @@ public:
     Header::Flags GetEncodePacketFlags() const;
 
 private:
-    /// Header structure for exchange information
-    uint8_t mExchangeHeader = 0;
-
     /// Packet type (application data, security control packets, e.g. pairing,
     /// configuration, rekey etc)
     uint8_t mMessageType = 0;
@@ -413,7 +411,7 @@ private:
     uint16_t mProtocolID = 0;
 
     /// Bit flag indicators for CHIP Exchange header
-    BitFlags<uint16_t, Header::ExFlagValues> mExchangeFlags;
+    Header::ExFlags mExchangeFlags;
 };
 
 /** Handles encoding/decoding of CHIP message headers */

--- a/src/transport/raw/tests/TestMessageHeader.cpp
+++ b/src/transport/raw/tests/TestMessageHeader.cpp
@@ -151,7 +151,7 @@ void TestPayloadHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     header.SetMessageType(112).SetExchangeID(2233);
     NL_TEST_ASSERT(inSuite, !header.GetVendorId().HasValue());
 
-    header.SetMessageType(112).SetExchangeID(2233).SetProtocolID(1221);
+    header.SetMessageType(112).SetExchangeID(2233).SetProtocolID(1221).SetInitiator(true);
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
 
     header.SetMessageType(221).SetExchangeID(3322).SetProtocolID(4567);
@@ -161,6 +161,7 @@ void TestPayloadHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.GetExchangeID() == 2233);
     NL_TEST_ASSERT(inSuite, header.GetProtocolID() == 1221);
     NL_TEST_ASSERT(inSuite, !header.GetVendorId().HasValue());
+    NL_TEST_ASSERT(inSuite, header.IsInitiator());
 
     header.SetMessageType(112).SetExchangeID(2233).SetProtocolID(1221);
     header.SetVendorId(6789);


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Currently, Initiator flag is set but not encoded in payload header, this field is now needed for ExchangeManager dispatching

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Add Initiator flag encoding/decoding in payload header

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->



<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
