### PR TITLE
Fix Darwin build for missing mDNS impl

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
@@ -30,7 +30,9 @@
 
 // Include the non-inline definitions for the GenericPlatformManagerImpl<> template,
 // from which the GenericPlatformManagerImpl_POSIX<> template inherits.
+#if CHIP_ENABLE_MDNS
 #include <platform/Linux/MdnsImpl.h>
+#endif
 #include <platform/internal/GenericPlatformManagerImpl.cpp>
 
 #include <system/SystemLayer.h>


### PR DESCRIPTION
 #### Problem
CHIP doesn't build on `macOS`.

 #### Summary of Changes
`Darwin` platform manager is dependent on POSIX. Recently, `mDNS` was added for POSIX, but it doesn't work for Darwin platform. There's a conditional preprocessor, that enables the `mDNS` in this file. The code is unconditionally including some headers, which is causing build issues.

For now, this change puts the header inclusion in the same conditional checks. This fixes the immediate build issue. Eventually, we need to add `mDNS` implementation for Darwin target.

 Fixes #3437
