### PR TITLE
Document dependency on avahi-client

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -43,7 +43,7 @@ On Debian-based Linux distributions such as Ubuntu, these dependencies can be
 satisfied with the following:
 
 ```
-sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev libglib2.0-dev ninja-build python3-venv python3-dev unzip
+sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev libglib2.0-dev libavahi-client-dev ninja-build python3-venv python3-dev unzip
 ```
 
 #### How to install prerequisites on macOS


### PR DESCRIPTION
#### Problem

Recent commit #3241 causes Linux building to fail if certain Avahi files are not present.

#### Summary of Changes

Add `libavahi-client-dev` to the list of required dependencies for Linux in `BUILDING.md`.