### PR TITLE
Fix EFR32 example builds (MemoryInit/MemoryShutdown)

### DIFF
--- a/examples/lighting-app/efr32/src/main.cpp
+++ b/examples/lighting-app/efr32/src/main.cpp
@@ -29,6 +29,7 @@
 #include <mbedtls/threading.h>
 
 #include <platform/CHIPDeviceLayer.h>
+#include <support/CHIPMem.h>
 #include <support/CHIPPlatformMemory.h>
 
 #include <AppTask.h>

--- a/examples/lock-app/efr32/src/main.cpp
+++ b/examples/lock-app/efr32/src/main.cpp
@@ -29,6 +29,7 @@
 #include <mbedtls/threading.h>
 
 #include <platform/CHIPDeviceLayer.h>
+#include <support/CHIPMem.h>
 #include <support/CHIPPlatformMemory.h>
 
 #include <AppTask.h>


### PR DESCRIPTION
#### Problem

Commits #3373 and #3421 crossed paths, making builds  fail for EFR32 examples,
with missing declarations of `chip::Platform::MemoryInit()` and
`chip::Platform::MemoryShutdown()`.

#### Summary of Changes

Include `<support/CHIPMem.h>`
