### PR TITLE
Switch message header encode/decode input lengths to uint16_t.

### DIFF
--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -364,7 +364,7 @@ CHIP_ERROR RendezvousSession::HandleSecureMessage(PacketBuffer * msgBuf)
 
     payloadlen = packetHeader.GetPayloadLength();
     VerifyOrExit(payloadlen <= len, err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
-    err = mac.Decode(packetHeader, &data[payloadlen], len - payloadlen, &taglen);
+    err = mac.Decode(packetHeader, &data[payloadlen], static_cast<uint16_t>(len - payloadlen), &taglen);
     SuccessOrExit(err);
 
     len = static_cast<uint16_t>(len - taglen);

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -122,7 +122,7 @@ exit:
 }
 
 CHIP_ERROR SecureSession::GetAdditionalAuthData(const PacketHeader & header, const Header::Flags payloadEncodeFlags, uint8_t * aad,
-                                                size_t & len)
+                                                uint16_t & len)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint16_t actualEncodedHeaderSize;
@@ -147,7 +147,7 @@ CHIP_ERROR SecureSession::Encrypt(const uint8_t * input, size_t input_length, ui
     CHIP_ERROR error = CHIP_NO_ERROR;
     uint8_t IV[kAESCCMIVLen];
     uint8_t AAD[kMaxAADLen];
-    size_t aadLen = sizeof(AAD);
+    uint16_t aadLen = sizeof(AAD);
 
     constexpr Header::EncryptionType encType = Header::EncryptionType::kAESCCMTagLen16;
 
@@ -182,7 +182,7 @@ CHIP_ERROR SecureSession::Decrypt(const uint8_t * input, size_t input_length, ui
     const uint8_t * tag = mac.GetTag();
     uint8_t IV[kAESCCMIVLen];
     uint8_t AAD[kMaxAADLen];
-    size_t aadLen = sizeof(AAD);
+    uint16_t aadLen = sizeof(AAD);
 
     VerifyOrExit(mKeyAvailable, error = CHIP_ERROR_INVALID_USE_OF_SESSION_KEY);
     VerifyOrExit(input != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -129,7 +129,7 @@ private:
     // The encryption operations includes AAD when message authentication tag is generated. This tag
     // is used at the time of decryption to integrity check the received data.
     static CHIP_ERROR GetAdditionalAuthData(const PacketHeader & header, Header::Flags payloadEncodeFlags, uint8_t * aad,
-                                            size_t & len);
+                                            uint16_t & len);
 };
 
 } // namespace chip

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -266,7 +266,7 @@ void SecureSessionMgrBase::HandleDataReceived(const PacketHeader & packetHeader,
         VerifyOrExit(
             payloadlen <= len,
             (ChipLogError(Inet, "Secure transport can't find MAC Tag; buffer too short"), err = CHIP_ERROR_INVALID_MESSAGE_LENGTH));
-        err = mac.Decode(packetHeader, &data[payloadlen], len - payloadlen, &taglen);
+        err = mac.Decode(packetHeader, &data[payloadlen], static_cast<uint16_t>(len - payloadlen), &taglen);
         VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Inet, "Secure transport failed to decode MAC Tag: err %d", err));
         len = static_cast<uint16_t>(len - taglen);
         msg->SetDataLength(len, nullptr);

--- a/src/transport/raw/MessageHeader.cpp
+++ b/src/transport/raw/MessageHeader.cpp
@@ -135,7 +135,7 @@ uint16_t MessageAuthenticationCode::TagLenForEncryptionType(Header::EncryptionTy
     }
 }
 
-CHIP_ERROR PacketHeader::Decode(const uint8_t * const data, size_t size, uint16_t * decode_len)
+CHIP_ERROR PacketHeader::Decode(const uint8_t * const data, uint16_t size, uint16_t * decode_len)
 {
     CHIP_ERROR err    = CHIP_NO_ERROR;
     const uint8_t * p = data;
@@ -186,7 +186,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR PayloadHeader::Decode(Header::Flags flags, const uint8_t * const data, size_t size, uint16_t * decode_len)
+CHIP_ERROR PayloadHeader::Decode(Header::Flags flags, const uint8_t * const data, uint16_t size, uint16_t * decode_len)
 {
     CHIP_ERROR err    = CHIP_NO_ERROR;
     const uint8_t * p = data;
@@ -218,7 +218,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR PacketHeader::Encode(uint8_t * data, size_t size, uint16_t * encode_size, Header::Flags payloadFlags) const
+CHIP_ERROR PacketHeader::Encode(uint8_t * data, uint16_t size, uint16_t * encode_size, Header::Flags payloadFlags) const
 {
     CHIP_ERROR err  = CHIP_NO_ERROR;
     uint8_t * p     = data;
@@ -262,7 +262,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR PayloadHeader::Encode(uint8_t * data, size_t size, uint16_t * encode_size) const
+CHIP_ERROR PayloadHeader::Encode(uint8_t * data, uint16_t size, uint16_t * encode_size) const
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint8_t * p    = data;
@@ -290,7 +290,7 @@ Header::Flags PayloadHeader::GetEncodePacketFlags() const
     return Header::Flags().Set(Header::FlagValues::kVendorIdPresent, mVendorId.HasValue());
 }
 
-CHIP_ERROR MessageAuthenticationCode::Decode(const PacketHeader & packetHeader, const uint8_t * const data, size_t size,
+CHIP_ERROR MessageAuthenticationCode::Decode(const PacketHeader & packetHeader, const uint8_t * const data, uint16_t size,
                                              uint16_t * decode_len)
 {
     CHIP_ERROR err        = CHIP_NO_ERROR;
@@ -309,7 +309,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR MessageAuthenticationCode::Encode(const PacketHeader & packetHeader, uint8_t * data, size_t size,
+CHIP_ERROR MessageAuthenticationCode::Encode(const PacketHeader & packetHeader, uint8_t * data, uint16_t size,
                                              uint16_t * encode_size) const
 {
     CHIP_ERROR err        = CHIP_NO_ERROR;

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -225,7 +225,7 @@ public:
      *    CHIP_ERROR_INVALID_ARGUMENT on insufficient buffer size
      *    CHIP_ERROR_VERSION_MISMATCH if header version is not supported.
      */
-    CHIP_ERROR Decode(const uint8_t * data, size_t size, uint16_t * decode_size);
+    CHIP_ERROR Decode(const uint8_t * data, uint16_t size, uint16_t * decode_size);
 
     /**
      * Encodes a header into the given buffer.
@@ -240,7 +240,7 @@ public:
      * Possible failures:
      *    CHIP_ERROR_INVALID_ARGUMENT on insufficient buffer size
      */
-    CHIP_ERROR Encode(uint8_t * data, size_t size, uint16_t * encode_size, Header::Flags payloadFlags) const;
+    CHIP_ERROR Encode(uint8_t * data, uint16_t size, uint16_t * encode_size, Header::Flags payloadFlags) const;
 
 private:
     /// Represents the current encode/decode header version
@@ -376,7 +376,7 @@ public:
      *    CHIP_ERROR_INVALID_ARGUMENT on insufficient buffer size
      *    CHIP_ERROR_VERSION_MISMATCH if header version is not supported.
      */
-    CHIP_ERROR Decode(Header::Flags flags, const uint8_t * data, size_t size, uint16_t * decode_size);
+    CHIP_ERROR Decode(Header::Flags flags, const uint8_t * data, uint16_t size, uint16_t * decode_size);
 
     /**
      * Encodes the encrypted part of the header into the given buffer.
@@ -390,7 +390,7 @@ public:
      * Possible failures:
      *    CHIP_ERROR_INVALID_ARGUMENT on insufficient buffer size
      */
-    CHIP_ERROR Encode(uint8_t * data, size_t size, uint16_t * encode_size) const;
+    CHIP_ERROR Encode(uint8_t * data, uint16_t size, uint16_t * encode_size) const;
 
     /** Flags required for encoding this payload. */
     Header::Flags GetEncodePacketFlags() const;
@@ -450,7 +450,7 @@ public:
      *    CHIP_ERROR_INVALID_ARGUMENT on insufficient buffer size
      *    CHIP_ERROR_VERSION_MISMATCH if header version is not supported.
      */
-    CHIP_ERROR Decode(const PacketHeader & packetHeader, const uint8_t * data, size_t size, uint16_t * decode_size);
+    CHIP_ERROR Decode(const PacketHeader & packetHeader, const uint8_t * data, uint16_t size, uint16_t * decode_size);
 
     /**
      * Encodes the Messae Authentication Tag into the given buffer.
@@ -465,7 +465,7 @@ public:
      * Possible failures:
      *    CHIP_ERROR_INVALID_ARGUMENT on insufficient buffer size
      */
-    CHIP_ERROR Encode(const PacketHeader & packetHeader, uint8_t * data, size_t size, uint16_t * encode_size) const;
+    CHIP_ERROR Encode(const PacketHeader & packetHeader, uint8_t * data, uint16_t size, uint16_t * encode_size) const;
 
     static uint16_t TagLenForEncryptionType(Header::EncryptionType encType);
 

--- a/src/transport/raw/tests/TestMessageHeader.cpp
+++ b/src/transport/raw/tests/TestMessageHeader.cpp
@@ -191,7 +191,7 @@ void TestPacketHeaderEncodeDecodeBounds(nlTestSuite * inSuite, void * inContext)
     uint8_t buffer[64];
     uint16_t unusedLen;
 
-    for (size_t shortLen = 0; shortLen < 10; shortLen++)
+    for (uint16_t shortLen = 0; shortLen < 10; shortLen++)
     {
         NL_TEST_ASSERT(inSuite, header.Encode(buffer, shortLen, &unusedLen, Header::Flags()) != CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, header.Decode(buffer, shortLen, &unusedLen) != CHIP_NO_ERROR);
@@ -204,7 +204,7 @@ void TestPacketHeaderEncodeDecodeBounds(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, minLen, &encoded_len, Header::Flags()) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, encoded_len == minLen);
     // Verify that decoding at any smaller length fails.
-    for (size_t shortLen = 0; shortLen < encoded_len; shortLen++)
+    for (uint16_t shortLen = 0; shortLen < encoded_len; shortLen++)
     {
         NL_TEST_ASSERT(inSuite, header.Decode(buffer, shortLen, &unusedLen) != CHIP_NO_ERROR);
     }
@@ -214,13 +214,13 @@ void TestPacketHeaderEncodeDecodeBounds(nlTestSuite * inSuite, void * inContext)
 
     // Now test encoding/decoding with a source node id present.
     header.SetSourceNodeId(1);
-    for (size_t shortLen = minLen; shortLen < minLen + 8; shortLen++)
+    for (uint16_t shortLen = minLen; shortLen < minLen + 8; shortLen++)
     {
         NL_TEST_ASSERT(inSuite, header.Encode(buffer, shortLen, &unusedLen, Header::Flags()) != CHIP_NO_ERROR);
     }
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, minLen + 8, &encoded_len, Header::Flags()) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, encoded_len == minLen + 8);
-    for (size_t shortLen = 0; shortLen < encoded_len; shortLen++)
+    for (uint16_t shortLen = 0; shortLen < encoded_len; shortLen++)
     {
         NL_TEST_ASSERT(inSuite, header.Decode(buffer, shortLen, &unusedLen) != CHIP_NO_ERROR);
     }
@@ -229,13 +229,13 @@ void TestPacketHeaderEncodeDecodeBounds(nlTestSuite * inSuite, void * inContext)
 
     // Now test encoding/decoding with a source and destination node id present.
     header.SetDestinationNodeId(1);
-    for (size_t shortLen = minLen; shortLen < minLen + 16; shortLen++)
+    for (uint16_t shortLen = minLen; shortLen < minLen + 16; shortLen++)
     {
         NL_TEST_ASSERT(inSuite, header.Encode(buffer, shortLen, &unusedLen, Header::Flags()) != CHIP_NO_ERROR);
     }
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, minLen + 16, &encoded_len, Header::Flags()) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, encoded_len == minLen + 16);
-    for (size_t shortLen = 0; shortLen < encoded_len; shortLen++)
+    for (uint16_t shortLen = 0; shortLen < encoded_len; shortLen++)
     {
         NL_TEST_ASSERT(inSuite, header.Decode(buffer, shortLen, &unusedLen) != CHIP_NO_ERROR);
     }
@@ -249,7 +249,7 @@ void TestPayloadHeaderEncodeDecodeBounds(nlTestSuite * inSuite, void * inContext
     uint8_t buffer[64];
     uint16_t unusedLen;
 
-    for (size_t shortLen = 0; shortLen < 6; shortLen++)
+    for (uint16_t shortLen = 0; shortLen < 6; shortLen++)
     {
         NL_TEST_ASSERT(inSuite, header.Encode(buffer, shortLen, &unusedLen) != CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, header.Decode(Header::Flags(), buffer, shortLen, &unusedLen) != CHIP_NO_ERROR);


### PR DESCRIPTION
This will remove some impedance mismatches around lengths later on.

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Message header encode/decode functions take length as `size_t`, whereas everything else, pretty much, uses `uint16_t`.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Just use `uint16_t` like elsewhere.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->



<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
