### PR TITLE
Fix initialization of NetworkProvisioning delegate

### DIFF
--- a/src/transport/NetworkProvisioning.cpp
+++ b/src/transport/NetworkProvisioning.cpp
@@ -32,10 +32,8 @@ namespace chip {
 
 void NetworkProvisioning::Init(NetworkProvisioningDelegate * delegate, DeviceNetworkProvisioningDelegate * deviceDelegate)
 {
-    if (deviceDelegate != nullptr)
-    {
-        mDeviceDelegate = deviceDelegate;
-    }
+    mDelegate       = delegate;
+    mDeviceDelegate = deviceDelegate;
 }
 
 NetworkProvisioning::~NetworkProvisioning()


### PR DESCRIPTION
NetworkProvisioning::Init needs to initialize mDelegate to its
first argument.

This was dropped unintentionally in #3405