### PR TITLE
Implement and publish mDNS on esp32

### DIFF
--- a/examples/temperature-measurement-app/esp32/main/ResponseServer.cpp
+++ b/examples/temperature-measurement-app/esp32/main/ResponseServer.cpp
@@ -54,6 +54,13 @@ using namespace ::chip::Inet;
 using namespace ::chip::Transport;
 
 extern const NodeId kLocalNodeId = 12344321;
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+extern const uint64_t TestDeviceId = kLocalNodeId; // For chip::DeviceLayer::GetDeviceId
+}
+} // namespace DeviceLayer
+} // namespace chip
 
 namespace {
 

--- a/examples/temperature-measurement-app/esp32/main/ResponseServer.cpp
+++ b/examples/temperature-measurement-app/esp32/main/ResponseServer.cpp
@@ -54,13 +54,6 @@ using namespace ::chip::Inet;
 using namespace ::chip::Transport;
 
 extern const NodeId kLocalNodeId = 12344321;
-namespace chip {
-namespace DeviceLayer {
-namespace Internal {
-extern const uint64_t TestDeviceId = kLocalNodeId; // For chip::DeviceLayer::GetDeviceId
-}
-} // namespace DeviceLayer
-} // namespace chip
 
 namespace {
 

--- a/examples/temperature-measurement-app/esp32/main/wifi-echo.cpp
+++ b/examples/temperature-measurement-app/esp32/main/wifi-echo.cpp
@@ -55,6 +55,13 @@ const char * TAG = "wifi-echo-demo";
 
 static DeviceCallbacks EchoCallbacks;
 RendezvousDeviceDelegate * rendezvousDelegate = nullptr;
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+const uint64_t TestDeviceId = kLocalNodeId; // For chip::DeviceLayer::GetDeviceId
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip
 
 namespace {
 

--- a/examples/wifi-echo/server/esp32/main/DeviceCallbacks.cpp
+++ b/examples/wifi-echo/server/esp32/main/DeviceCallbacks.cpp
@@ -24,10 +24,12 @@
  **/
 #include "DeviceCallbacks.h"
 
+#include "CHIPDeviceManager.h"
 #include "LEDWidget.h"
 #include "WiFiWidget.h"
 #include "esp_heap_caps.h"
 #include "esp_log.h"
+#include <lib/protocols/mdns/Publisher.h>
 #include <support/CodeUtils.h>
 
 extern "C" {
@@ -45,6 +47,8 @@ using namespace ::chip::DeviceLayer;
 extern LEDWidget statusLED1;
 extern LEDWidget statusLED2;
 extern WiFiWidget wifiLED;
+extern const chip::NodeId kLocalNodeId;
+extern chip::Protocols::Mdns::Publisher publisher;
 
 uint32_t identifyTimerCount;
 constexpr uint32_t kIdentifyTimerDelayMS = 250;
@@ -96,6 +100,7 @@ void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event
     {
         ESP_LOGI(TAG, "Server ready at: %s:%d", event->InternetConnectivityChange.address, CHIP_PORT);
         wifiLED.Set(true);
+        publisher.StartPublishDevice();
     }
     else if (event->InternetConnectivityChange.IPv4 == kConnectivity_Lost)
     {
@@ -105,6 +110,7 @@ void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event
     if (event->InternetConnectivityChange.IPv6 == kConnectivity_Established)
     {
         ESP_LOGI(TAG, "IPv6 Server ready...");
+        publisher.StartPublishDevice();
     }
     else if (event->InternetConnectivityChange.IPv6 == kConnectivity_Lost)
     {

--- a/examples/wifi-echo/server/esp32/main/DeviceCallbacks.cpp
+++ b/examples/wifi-echo/server/esp32/main/DeviceCallbacks.cpp
@@ -25,6 +25,7 @@
 #include "DeviceCallbacks.h"
 
 #include "CHIPDeviceManager.h"
+#include "Globals.h"
 #include "LEDWidget.h"
 #include "WiFiWidget.h"
 #include "esp_heap_caps.h"
@@ -42,13 +43,6 @@ static const char * TAG = "echo-devicecallbacks";
 using namespace ::chip::Inet;
 using namespace ::chip::System;
 using namespace ::chip::DeviceLayer;
-
-// In wifi-echo.cpp
-extern LEDWidget statusLED1;
-extern LEDWidget statusLED2;
-extern WiFiWidget wifiLED;
-extern const chip::NodeId kLocalNodeId;
-extern chip::Protocols::Mdns::Publisher publisher;
 
 uint32_t identifyTimerCount;
 constexpr uint32_t kIdentifyTimerDelayMS = 250;

--- a/examples/wifi-echo/server/esp32/main/EchoServer.cpp
+++ b/examples/wifi-echo/server/esp32/main/EchoServer.cpp
@@ -46,6 +46,7 @@
 #include <transport/raw/UDP.h>
 
 #include "DataModelHandler.h"
+#include "Globals.h"
 #include "LEDWidget.h"
 
 static const char * TAG = "echo_server";
@@ -53,16 +54,6 @@ static const char * TAG = "echo_server";
 using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::Transport;
-
-extern const NodeId kLocalNodeId = 12344321;
-namespace chip {
-namespace DeviceLayer {
-namespace Internal {
-extern const uint64_t TestDeviceId = kLocalNodeId; // For chip::DeviceLayer::GetDeviceId
-}
-} // namespace DeviceLayer
-} // namespace chip
-extern LEDWidget statusLED1; // In wifi-echo.cpp
 
 namespace {
 

--- a/examples/wifi-echo/server/esp32/main/EchoServer.cpp
+++ b/examples/wifi-echo/server/esp32/main/EchoServer.cpp
@@ -55,6 +55,13 @@ using namespace ::chip::Inet;
 using namespace ::chip::Transport;
 
 extern const NodeId kLocalNodeId = 12344321;
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+extern const uint64_t TestDeviceId = kLocalNodeId; // For chip::DeviceLayer::GetDeviceId
+}
+} // namespace DeviceLayer
+} // namespace chip
 extern LEDWidget statusLED1; // In wifi-echo.cpp
 
 namespace {

--- a/examples/wifi-echo/server/esp32/main/Globals.cpp
+++ b/examples/wifi-echo/server/esp32/main/Globals.cpp
@@ -1,0 +1,25 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "Globals.h"
+
+LEDWidget statusLED1;
+LEDWidget statusLED2;
+BluetoothWidget bluetoothLED;
+WiFiWidget wifiLED;
+chip::Protocols::Mdns::Publisher publisher;
+const chip::NodeId kLocalNodeId = 12344321;

--- a/examples/wifi-echo/server/esp32/main/RendezvousDeviceDelegate.cpp
+++ b/examples/wifi-echo/server/esp32/main/RendezvousDeviceDelegate.cpp
@@ -18,6 +18,7 @@
 #include "RendezvousDeviceDelegate.h"
 
 #include "BluetoothWidget.h"
+#include "Globals.h"
 #include "esp_log.h"
 #include <platform/ConfigurationManager.h>
 #include <support/CHIPMem.h>
@@ -29,8 +30,6 @@ using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
 
-extern BluetoothWidget bluetoothLED;
-extern NodeId kLocalNodeId;
 extern void PairingComplete(SecurePairingSession * pairing);
 
 static const char * TAG = "rendezvous-devicedelegate";

--- a/examples/wifi-echo/server/esp32/main/include/Globals.h
+++ b/examples/wifi-echo/server/esp32/main/include/Globals.h
@@ -29,5 +29,3 @@ extern BluetoothWidget bluetoothLED;
 extern WiFiWidget wifiLED;
 extern chip::Protocols::Mdns::Publisher publisher;
 extern const chip::NodeId kLocalNodeId;
-
-

--- a/examples/wifi-echo/server/esp32/main/include/Globals.h
+++ b/examples/wifi-echo/server/esp32/main/include/Globals.h
@@ -1,0 +1,33 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "BluetoothWidget.h"
+#include "LEDWidget.h"
+#include "WiFiWidget.h"
+#include "lib/protocols/mdns/Publisher.h"
+#include "transport/raw/MessageHeader.h"
+
+extern LEDWidget statusLED1;
+extern LEDWidget statusLED2;
+extern BluetoothWidget bluetoothLED;
+extern WiFiWidget wifiLED;
+extern chip::Protocols::Mdns::Publisher publisher;
+extern const chip::NodeId kLocalNodeId;
+
+

--- a/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
@@ -44,6 +44,7 @@
 #include <vector>
 
 #include <crypto/CHIPCryptoPAL.h>
+#include <lib/protocols/mdns/Publisher.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <setup_payload/ManualSetupPayloadGenerator.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
@@ -87,6 +88,7 @@ LEDWidget statusLED1;
 LEDWidget statusLED2;
 BluetoothWidget bluetoothLED;
 WiFiWidget wifiLED;
+chip::Protocols::Mdns::Publisher publisher;
 
 extern void PairingComplete(SecurePairingSession * pairing);
 
@@ -523,6 +525,7 @@ extern "C" void app_main()
     }
 
     SetupPretendDevices();
+    publisher.Init();
 
     statusLED1.Init(STATUS_LED_GPIO_NUM);
     // Our second LED doesn't map to any physical LEDs so far, just to virtual

--- a/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
@@ -529,6 +529,7 @@ extern "C" void app_main()
 
     SetupPretendDevices();
     publisher.Init();
+    publisher.StopPublishDevice();
 
     statusLED1.Init(STATUS_LED_GPIO_NUM);
     // Our second LED doesn't map to any physical LEDs so far, just to virtual

--- a/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
+++ b/examples/wifi-echo/server/esp32/main/wifi-echo.cpp
@@ -21,6 +21,7 @@
 #include "DataModelHandler.h"
 #include "DeviceCallbacks.h"
 #include "Display.h"
+#include "Globals.h"
 #include "LEDWidget.h"
 #include "ListScreen.h"
 #include "QRCodeScreen.h"
@@ -84,18 +85,20 @@ extern void startServer();
 // Used to indicate that an IP address has been added to the QRCode
 #define EXAMPLE_VENDOR_TAG_IP 1
 
-LEDWidget statusLED1;
-LEDWidget statusLED2;
-BluetoothWidget bluetoothLED;
-WiFiWidget wifiLED;
-chip::Protocols::Mdns::Publisher publisher;
-
 extern void PairingComplete(SecurePairingSession * pairing);
 
 const char * TAG = "wifi-echo-demo";
 
 static DeviceCallbacks EchoCallbacks;
 RendezvousDeviceDelegate * rendezvousDelegate = nullptr;
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+const uint64_t TestDeviceId = kLocalNodeId; // For chip::DeviceLayer::GetDeviceId
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip
 
 namespace {
 

--- a/src/lib/protocols/mdns/BUILD.gn
+++ b/src/lib/protocols/mdns/BUILD.gn
@@ -13,37 +13,20 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
-import("${chip_root}/src/platform/device.gni")
 
-config("includes") {
-  include_dirs = [ "." ]
+source_set("platform_header") {
+  sources = [ "platform/Mdns.h" ]
 }
 
-static_library("lib") {
+static_library("mdns") {
   public_deps = [
-    "${chip_root}/src/app",
-    "${chip_root}/src/ble",
-    "${chip_root}/src/controller",
-    "${chip_root}/src/crypto",
-    "${chip_root}/src/inet",
-    "${chip_root}/src/lib/core",
+    ":platform_header",
     "${chip_root}/src/lib/support",
-    "${chip_root}/src/messaging",
     "${chip_root}/src/platform",
-    "${chip_root}/src/setup_payload",
-    "${chip_root}/src/system",
-    "${chip_root}/src/transport",
   ]
 
-  if (chip_enable_mdns) {
-    public_deps += [ "${chip_root}/src/lib/protocols/mdns" ]
-  }
-
-  cflags = [ "-Wconversion" ]
-
-  output_name = "libCHIP"
-
-  output_dir = "${root_out_dir}/lib"
-
-  complete_static_lib = true
+  sources = [
+    "Publisher.cpp",
+    "Publisher.h",
+  ]
 }

--- a/src/lib/protocols/mdns/Publisher.cpp
+++ b/src/lib/protocols/mdns/Publisher.cpp
@@ -1,0 +1,96 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "Publisher.h"
+
+#include <inttypes.h>
+
+#include "lib/protocols/mdns/platform/Mdns.h"
+#include "lib/support/logging/CHIPLogging.h"
+#include "platform/CHIPDeviceBuildConfig.h"
+#include "platform/CHIPDeviceLayer.h"
+#include "support/CodeUtils.h"
+#include "support/ErrorStr.h"
+
+namespace chip {
+namespace Protocols {
+namespace Mdns {
+
+CHIP_ERROR Publisher::Init()
+{
+    return ChipMdnsInit(HandleMdnsInit, HandleMdnsError, this);
+}
+
+void Publisher::HandleMdnsInit(void * context, CHIP_ERROR initError)
+{
+    Publisher * publisher = static_cast<Publisher *>(context);
+
+    if (initError == CHIP_NO_ERROR)
+    {
+        publisher->mInitialized = true;
+    }
+    else
+    {
+        ChipLogError(Discovery, "mDNS initialization failed with %s", chip::ErrorStr(initError));
+    }
+}
+
+void Publisher::HandleMdnsError(void * context, CHIP_ERROR initError)
+{
+
+    ChipLogError(Discovery, "mDNS error: %s", chip::ErrorStr(initError));
+}
+
+CHIP_ERROR Publisher::StartPublishDevice(chip::Inet::InterfaceId interface)
+{
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    MdnsService service;
+    char key[] = "device_id";
+    char deviceIdVal[20];
+    uint16_t discriminator;
+    uint64_t deviceId;
+    TextEntry entry;
+
+    VerifyOrExit(mInitialized, error = CHIP_ERROR_INCORRECT_STATE);
+    ChipLogProgress(Discovery, "setup mdns service");
+    SuccessOrExit(error = chip::DeviceLayer::ConfigurationMgr().GetSetupDiscriminator(discriminator));
+    sprintf(service.mName, "CHIP-%04d", discriminator);
+    strcpy(service.mType, "_chip");
+    service.mProtocol = MdnsServiceProtocol::kMdnsProtocolUdp;
+    SuccessOrExit(error = chip::DeviceLayer::ConfigurationMgr().GetDeviceId(deviceId));
+    entry.mKey = key;
+    sprintf(deviceIdVal, "%" PRIu64, deviceId);
+    entry.mData            = reinterpret_cast<const uint8_t *>(deviceIdVal);
+    entry.mDataSize        = strlen(reinterpret_cast<const char *>(entry.mData));
+    service.mTextEntryies  = &entry;
+    service.mTextEntrySize = 1;
+    service.mPort          = CHIP_PORT;
+
+    error = ChipMdnsPublishService(&service);
+
+exit:
+    return error;
+}
+
+CHIP_ERROR Publisher::StopPublishDevice()
+{
+    return ChipMdnsStopPublish();
+}
+
+} // namespace Mdns
+} // namespace Protocols
+} // namespace chip

--- a/src/lib/protocols/mdns/Publisher.cpp
+++ b/src/lib/protocols/mdns/Publisher.cpp
@@ -51,7 +51,6 @@ void Publisher::HandleMdnsInit(void * context, CHIP_ERROR initError)
 
 void Publisher::HandleMdnsError(void * context, CHIP_ERROR initError)
 {
-
     ChipLogError(Discovery, "mDNS error: %s", chip::ErrorStr(initError));
 }
 

--- a/src/lib/protocols/mdns/Publisher.cpp
+++ b/src/lib/protocols/mdns/Publisher.cpp
@@ -25,6 +25,7 @@
 #include "platform/CHIPDeviceLayer.h"
 #include "support/CodeUtils.h"
 #include "support/ErrorStr.h"
+#include "support/RandUtils.h"
 
 namespace chip {
 namespace Protocols {
@@ -32,7 +33,13 @@ namespace Mdns {
 
 CHIP_ERROR Publisher::Init()
 {
-    return ChipMdnsInit(HandleMdnsInit, HandleMdnsError, this);
+    CHIP_ERROR error;
+
+    mUnprovisionedInstanceName = GetRandU64();
+    SuccessOrExit(error = ChipMdnsInit(HandleMdnsInit, HandleMdnsError, this));
+    SuccessOrExit(error = SetupHostname());
+exit:
+    return error;
 }
 
 void Publisher::HandleMdnsInit(void * context, CHIP_ERROR initError)
@@ -56,31 +63,102 @@ void Publisher::HandleMdnsError(void * context, CHIP_ERROR initError)
 
 CHIP_ERROR Publisher::StartPublishDevice(chip::Inet::InterfaceId interface)
 {
+    CHIP_ERROR error;
+
+    // TODO: after multi-admin is decided we may need to publish both _chipc._udp and _chip._tcp service
+    if (chip::DeviceLayer::ConfigurationMgr().IsFullyProvisioned() != mIsPublishingProvisionedDevice)
+    {
+        SuccessOrExit(error = StopPublishDevice());
+        // Set hostname again in case the mac address changes when shifting from soft-AP to station
+        SuccessOrExit(error = SetupHostname());
+    }
+    mIsPublishingProvisionedDevice = chip::DeviceLayer::ConfigurationMgr().IsFullyProvisioned();
+
+    if (mIsPublishingProvisionedDevice)
+    {
+        error = PublishProvisionedDevice(interface);
+    }
+    else
+    {
+        error = PublishUnprovisionedDevice(interface);
+    }
+exit:
+    return error;
+}
+
+CHIP_ERROR Publisher::SetupHostname()
+{
+    uint8_t mac[6];    // 6 byte wifi mac
+    char hostname[13]; // Hostname will be the hex representation of mac.
+    CHIP_ERROR error;
+
+    SuccessOrExit(error = chip::DeviceLayer::ConfigurationMgr().GetPrimaryWiFiMACAddress(mac));
+    for (size_t i = 0; i < sizeof(mac); i++)
+    {
+        snprintf(&hostname[i * 2], sizeof(hostname) - i * 2, "%02X", mac[i]);
+    }
+    SuccessOrExit(error = ChipMdnsSetHostname(hostname));
+
+exit:
+    return error;
+}
+
+CHIP_ERROR Publisher::PublishUnprovisionedDevice(chip::Inet::InterfaceId interface)
+{
     CHIP_ERROR error = CHIP_NO_ERROR;
     MdnsService service;
-    char key[] = "device_id";
-    char deviceIdVal[20];
     uint16_t discriminator;
-    uint64_t deviceId;
-    TextEntry entry;
+    uint16_t vendorID;
+    uint16_t productID;
+    char discriminatorBuf[5];  // hex representation of 16-bit discriminator
+    char vendorProductBuf[10]; // "FFFF+FFFF"
+    // TODO: The text entry will be updated in the spec, update accordingly.
+    TextEntry entries[2] = {
+        { "D", nullptr, 0 },
+        { "VP", nullptr, 0 },
+    };
 
     VerifyOrExit(mInitialized, error = CHIP_ERROR_INCORRECT_STATE);
     ChipLogProgress(Discovery, "setup mdns service");
     SuccessOrExit(error = chip::DeviceLayer::ConfigurationMgr().GetSetupDiscriminator(discriminator));
-    sprintf(service.mName, "CHIP-%04d", discriminator);
-    strcpy(service.mType, "_chip");
+    snprintf(service.mName, sizeof(service.mName), "%016" PRIx64, mUnprovisionedInstanceName);
+    strncpy(service.mType, "_chipc", sizeof(service.mType));
     service.mProtocol = MdnsServiceProtocol::kMdnsProtocolUdp;
-    SuccessOrExit(error = chip::DeviceLayer::ConfigurationMgr().GetDeviceId(deviceId));
-    entry.mKey = key;
-    sprintf(deviceIdVal, "%" PRIu64, deviceId);
-    entry.mData            = reinterpret_cast<const uint8_t *>(deviceIdVal);
-    entry.mDataSize        = strlen(reinterpret_cast<const char *>(entry.mData));
-    service.mTextEntryies  = &entry;
-    service.mTextEntrySize = 1;
+    SuccessOrExit(error = chip::DeviceLayer::ConfigurationMgr().GetVendorId(vendorID));
+    SuccessOrExit(error = chip::DeviceLayer::ConfigurationMgr().GetProductId(productID));
+    snprintf(discriminatorBuf, sizeof(discriminatorBuf), "%04X", discriminator);
+    snprintf(vendorProductBuf, sizeof(vendorProductBuf), "%04X+%04X", vendorID, productID);
+    entries[0].mData       = reinterpret_cast<const uint8_t *>(discriminatorBuf);
+    entries[0].mDataSize   = strnlen(discriminatorBuf, sizeof(discriminatorBuf));
+    entries[1].mData       = reinterpret_cast<const uint8_t *>(vendorProductBuf);
+    entries[1].mDataSize   = strnlen(discriminatorBuf, sizeof(vendorProductBuf));
+    service.mTextEntryies  = entries;
+    service.mTextEntrySize = sizeof(entries) / sizeof(TextEntry);
     service.mPort          = CHIP_PORT;
 
     error = ChipMdnsPublishService(&service);
 
+exit:
+    return error;
+}
+
+CHIP_ERROR Publisher::PublishProvisionedDevice(chip::Inet::InterfaceId interface)
+{
+    uint64_t deviceId;
+    uint64_t fabricId;
+    MdnsService service;
+    CHIP_ERROR error = CHIP_NO_ERROR;
+
+    // TODO: There may be multilple device/fabrid ids after multi-admin.
+    SuccessOrExit(error = chip::DeviceLayer::ConfigurationMgr().GetFabricId(fabricId));
+    SuccessOrExit(error = chip::DeviceLayer::ConfigurationMgr().GetDeviceId(deviceId));
+    snprintf(service.mName, sizeof(service.mName), "%" PRIX64 "-%" PRIX64, deviceId, fabricId);
+    strncpy(service.mType, "_chip", sizeof(service.mType));
+    service.mProtocol      = MdnsServiceProtocol::kMdnsProtocolTcp;
+    service.mPort          = CHIP_PORT;
+    service.mTextEntryies  = nullptr;
+    service.mTextEntrySize = 0;
+    error                  = ChipMdnsPublishService(&service);
 exit:
     return error;
 }

--- a/src/lib/protocols/mdns/Publisher.h
+++ b/src/lib/protocols/mdns/Publisher.h
@@ -1,0 +1,80 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "core/CHIPError.h"
+#include "inet/InetInterface.h"
+
+namespace chip {
+namespace Protocols {
+namespace Mdns {
+
+class Publisher
+{
+public:
+    Publisher() = default;
+
+    /**
+     * This method initializes the publisher.
+     *
+     * @retval CHIP_NO_ERROR                The initialization succeeds.
+     * @retval Error code                   The initialization fails.
+     *
+     */
+    CHIP_ERROR Init();
+
+    /**
+     * This method publishes the device on mDNS.
+     *
+     * This fucntion will fetch device name and other information and publish them
+     * via mDNS. If device meta data has changed, you can call this function again
+     * to update the information.
+     *
+     * @param[in] interface   The interface to send mDNS multicast.
+     *
+     * @retval CHIP_NO_ERROR                The publish succeeds.
+     * @retval CHIP_NO_ERROR                The publish succeeds.
+     * @retval Error code                   The publish fails.
+     *
+     */
+    CHIP_ERROR StartPublishDevice(chip::Inet::InterfaceId interface = INET_NULL_INTERFACEID);
+
+    /**
+     * This function stops publishing the device on mDNS.
+     *
+     * @retval CHIP_NO_ERROR                The publish stops successfully.
+     * @retval Error code                   Stopping the publish fails.
+     *
+     */
+    CHIP_ERROR StopPublishDevice();
+
+    ~Publisher() = default;
+
+private:
+    Publisher(const Publisher &) = delete;
+    Publisher & operator=(const Publisher &) = delete;
+
+    static void HandleMdnsInit(void * context, CHIP_ERROR initError);
+    static void HandleMdnsError(void * context, CHIP_ERROR initError);
+
+    bool mInitialized = false;
+};
+
+} // namespace Mdns
+} // namespace Protocols
+} // namespace chip

--- a/src/lib/protocols/mdns/Publisher.h
+++ b/src/lib/protocols/mdns/Publisher.h
@@ -32,9 +32,6 @@ public:
     /**
      * This method initializes the publisher.
      *
-     * @retval CHIP_NO_ERROR                The initialization succeeds.
-     * @retval Error code                   The initialization fails.
-     *
      */
     CHIP_ERROR Init();
 
@@ -47,23 +44,14 @@ public:
      *
      * @param[in] interface   The interface to send mDNS multicast.
      *
-     * @retval CHIP_NO_ERROR                The publish succeeds.
-     * @retval CHIP_NO_ERROR                The publish succeeds.
-     * @retval Error code                   The publish fails.
-     *
      */
     CHIP_ERROR StartPublishDevice(chip::Inet::InterfaceId interface = INET_NULL_INTERFACEID);
 
     /**
      * This function stops publishing the device on mDNS.
      *
-     * @retval CHIP_NO_ERROR                The publish stops successfully.
-     * @retval Error code                   Stopping the publish fails.
-     *
      */
     CHIP_ERROR StopPublishDevice();
-
-    ~Publisher() = default;
 
 private:
     Publisher(const Publisher &) = delete;

--- a/src/lib/protocols/mdns/Publisher.h
+++ b/src/lib/protocols/mdns/Publisher.h
@@ -38,7 +38,7 @@ public:
     /**
      * This method publishes the device on mDNS.
      *
-     * This fucntion will fetch device name and other information and publish them
+     * This function will fetch device name and other information and publish them
      * via mDNS. If device meta data has changed, you can call this function again
      * to update the information.
      *
@@ -57,10 +57,16 @@ private:
     Publisher(const Publisher &) = delete;
     Publisher & operator=(const Publisher &) = delete;
 
+    CHIP_ERROR PublishUnprovisionedDevice(chip::Inet::InterfaceId interface);
+    CHIP_ERROR PublishProvisionedDevice(chip::Inet::InterfaceId interface);
+    CHIP_ERROR SetupHostname();
+
     static void HandleMdnsInit(void * context, CHIP_ERROR initError);
     static void HandleMdnsError(void * context, CHIP_ERROR initError);
 
-    bool mInitialized = false;
+    uint64_t mUnprovisionedInstanceName;
+    bool mInitialized                   = false;
+    bool mIsPublishingProvisionedDevice = false;
 };
 
 } // namespace Mdns

--- a/src/lib/protocols/mdns/platform/Mdns.h
+++ b/src/lib/protocols/mdns/platform/Mdns.h
@@ -69,8 +69,8 @@ struct MdnsService
 /**
  * The callback function for mDNS resolve.
  *
- * The callback function SHALL NOT take the ownership of the result->mService.mTextEntries
- * memory.
+ * The callback function SHALL NOT take the ownership of the service pointer or
+ * any pointer inside this structure.
  *
  * @param[in] context     The context passed to ChipMdnsBrowse or ChipMdnsResolve.
  * @param[in] result      The mdns resolve result, can be nullptr if error happens.
@@ -82,8 +82,8 @@ using MdnsResolveCallback = void (*)(void * context, MdnsService * result, CHIP_
 /**
  * The callback function for mDNS browse.
  *
- * The callback function SHALL NOT take the ownership of the service->mTextEntries
- * memory.
+ * The callback function SHALL NOT take the ownership of the service pointer or
+ * any pointer inside this structure.
  *
  * @param[in] context       The context passed to ChipMdnsBrowse or ChipMdnsResolve.
  * @param[in] services      The service list, can be nullptr.

--- a/src/lib/protocols/mdns/platform/Mdns.h
+++ b/src/lib/protocols/mdns/platform/Mdns.h
@@ -36,7 +36,7 @@ namespace chip {
 namespace Protocols {
 namespace Mdns {
 
-static constexpr uint8_t kMdnsNameMaxSize  = 32;
+static constexpr uint8_t kMdnsNameMaxSize  = 33;
 static constexpr uint8_t kMdnsTypeMaxSize  = 32;
 static constexpr uint16_t kMdnsTextMaxSize = 64;
 
@@ -107,6 +107,14 @@ using MdnsAsnycReturnCallback = void (*)(void * context, CHIP_ERROR error);
  *
  */
 CHIP_ERROR ChipMdnsInit(MdnsAsnycReturnCallback initCallback, MdnsAsnycReturnCallback errorCallback, void * context);
+
+/**
+ * This function sets the host name for services.
+ *
+ * @param[in] hostname   The hostname.
+ *
+ */
+CHIP_ERROR ChipMdnsSetHostname(const char * hostname);
 
 /**
  * This function publishes an service via mDNS.

--- a/src/lib/support/logging/CHIPLogging.cpp
+++ b/src/lib/support/logging/CHIPLogging.cpp
@@ -89,6 +89,7 @@ static const char ModuleNames[] = "-\0\0" // None
                                   "DL\0"  // DeviceLayer
                                   "SPL"   // SetupPayload
                                   "SVR"   // AppServer
+                                  "DIS"   // Discovery
     ;
 
 #define ModuleNamesCount ((sizeof(ModuleNames) - 1) / ChipLoggingModuleNameLen)

--- a/src/lib/support/logging/CHIPLogging.h
+++ b/src/lib/support/logging/CHIPLogging.h
@@ -110,6 +110,7 @@ enum LogModule
     kLogModule_DeviceLayer,
     kLogModule_SetupPayload,
     kLogModule_AppServer,
+    kLogModule_Discovery,
 
     kLogModule_Max
 };

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -267,6 +267,7 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
         "ESP32/ESP32Utils.h",
         "ESP32/Logging.cpp",
         "ESP32/LwIPCoreLock.cpp",
+        "ESP32/MdnsImpl.cpp",
         "ESP32/NetworkProvisioningServerImpl.h",
         "ESP32/PlatformManagerImpl.cpp",
         "ESP32/PlatformManagerImpl.h",
@@ -338,6 +339,8 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
           "Linux/MdnsImpl.cpp",
           "Linux/MdnsImpl.h",
         ]
+
+        public_deps += [ "${chip_root}/src/lib/protocols/mdns:platform_header" ]
 
         public_configs += [ ":avahi_client_config" ]
       }

--- a/src/platform/ESP32/MdnsImpl.cpp
+++ b/src/platform/ESP32/MdnsImpl.cpp
@@ -43,7 +43,7 @@ CHIP_ERROR ChipMdnsInit(MdnsAsnycReturnCallback initCallback, MdnsAsnycReturnCal
     CHIP_ERROR error = CHIP_NO_ERROR;
     esp_err_t espError;
     uint16_t discriminator;
-    char hostname[11]; // Hostname willbe "CHIP-XXXX"
+    char hostname[11]; // Hostname will be "CHIP-XXXX"
 
     espError = mdns_init();
     VerifyOrExit(espError == ESP_OK, error = CHIP_ERROR_INTERNAL);
@@ -89,7 +89,7 @@ CHIP_ERROR ChipMdnsPublishService(const MdnsService * service)
     espError = mdns_service_add(service->mName, service->mType, GetProtocolString(service->mProtocol), service->mPort, items,
                                 service->mTextEntrySize);
     // The mdns_service_add will return error if we try to add an existing service
-    if (espError != ESP_OK)
+    if (espError != ESP_OK && espError != ESP_ERR_NO_MEM)
     {
         espError = mdns_service_txt_set(service->mType, GetProtocolString(service->mProtocol), items,
                                         static_cast<uint8_t>(service->mTextEntrySize));
@@ -121,9 +121,7 @@ CHIP_ERROR ChipMdnsBrowse(const char * type, MdnsServiceProtocol protocol, chip:
     TextEntry * textEntries;
     size_t serviceSize = 0;
 
-    ChipLogProgress(DeviceLayer, "call mdns_query_ptr, type=%s protocol=%s", type, GetProtocolString(protocol));
     espError = mdns_query_ptr(type, GetProtocolString(protocol), kTimeoutMilli, kMaxResults, &results);
-    ChipLogProgress(DeviceLayer, "call mdns_query_ptr error=%s result=%p", esp_err_to_name(espError), results);
     VerifyOrExit(espError == ESP_OK, error = CHIP_ERROR_INTERNAL);
     if (results == nullptr)
     {

--- a/src/platform/ESP32/MdnsImpl.cpp
+++ b/src/platform/ESP32/MdnsImpl.cpp
@@ -1,0 +1,241 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "lib/protocols/mdns/platform/Mdns.h"
+
+#include <esp_err.h>
+#include <lwip/ip4_addr.h>
+#include <lwip/ip6_addr.h>
+#include <mdns.h>
+
+#include "platform/CHIPDeviceLayer.h"
+#include "support/CHIPMem.h"
+#include "support/CodeUtils.h"
+#include "support/logging/CHIPLogging.h"
+
+namespace {
+
+static constexpr uint32_t kTimeoutMilli = 3000;
+static constexpr size_t kMaxResults     = 20;
+
+} // namespace
+
+namespace chip {
+namespace Protocols {
+namespace Mdns {
+
+CHIP_ERROR ChipMdnsInit(MdnsAsnycReturnCallback initCallback, MdnsAsnycReturnCallback errorCallback, void * context)
+{
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    esp_err_t espError;
+    uint16_t discriminator;
+    char hostname[11]; // Hostname willbe "CHIP-XXXX"
+
+    espError = mdns_init();
+    VerifyOrExit(espError == ESP_OK, error = CHIP_ERROR_INTERNAL);
+    SuccessOrExit(error = DeviceLayer::ConfigurationMgr().GetSetupDiscriminator(discriminator));
+    snprintf(hostname, sizeof(hostname), "CHIP-%04d", discriminator);
+    espError = mdns_hostname_set(hostname);
+    VerifyOrExit(espError == ESP_OK, error = CHIP_ERROR_INTERNAL);
+
+exit:
+    if (espError != ESP_OK)
+    {
+        ChipLogError(DeviceLayer, "esp mdns internal error: %s", esp_err_to_name(espError));
+    }
+    initCallback(context, error);
+
+    return error;
+}
+
+static const char * GetProtocolString(MdnsServiceProtocol protocol)
+{
+    return protocol == MdnsServiceProtocol::kMdnsProtocolTcp ? "_tcp" : "_udp";
+}
+
+CHIP_ERROR ChipMdnsPublishService(const MdnsService * service)
+{
+    CHIP_ERROR error        = CHIP_NO_ERROR;
+    mdns_txt_item_t * items = nullptr;
+    esp_err_t espError;
+
+    VerifyOrExit(service->mTextEntrySize <= UINT8_MAX, error = CHIP_ERROR_INVALID_ARGUMENT);
+    if (service->mTextEntryies)
+    {
+        items = static_cast<mdns_txt_item_t *>(chip::Platform::MemoryCalloc(service->mTextEntrySize, sizeof(mdns_txt_item_t)));
+        VerifyOrExit(items != nullptr, error = CHIP_ERROR_NO_MEMORY);
+        for (size_t i = 0; i < service->mTextEntrySize; i++)
+        {
+            items[i].key = service->mTextEntryies[i].mKey;
+            // Unfortunately ESP mdns stack dosen't support arbitrary binary data
+            items[i].value = reinterpret_cast<const char *>(service->mTextEntryies[i].mData);
+        }
+    }
+
+    espError = mdns_service_add(service->mName, service->mType, GetProtocolString(service->mProtocol), service->mPort, items,
+                                service->mTextEntrySize);
+    // The mdns_service_add will return error if we try to add an existing service
+    if (espError != ESP_OK)
+    {
+        espError = mdns_service_txt_set(service->mType, GetProtocolString(service->mProtocol), items,
+                                        static_cast<uint8_t>(service->mTextEntrySize));
+    }
+    VerifyOrExit(espError == ESP_OK, error = CHIP_ERROR_INTERNAL);
+
+exit:
+    if (items != nullptr)
+    {
+        chip::Platform::MemoryFree(items);
+    }
+
+    return error;
+}
+
+CHIP_ERROR ChipMdnsStopPublish()
+{
+    return mdns_service_remove_all() == ESP_OK ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL;
+}
+
+CHIP_ERROR ChipMdnsBrowse(const char * type, MdnsServiceProtocol protocol, chip::Inet::InterfaceId interface,
+                          MdnsBrowseCallback callback, void * context)
+{
+    mdns_result_t * results = nullptr;
+    mdns_result_t * current;
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    esp_err_t espError;
+    MdnsService * services = nullptr;
+    TextEntry * textEntries;
+    size_t serviceSize = 0;
+
+    ChipLogProgress(DeviceLayer, "call mdns_query_ptr, type=%s protocol=%s", type, GetProtocolString(protocol));
+    espError = mdns_query_ptr(type, GetProtocolString(protocol), kTimeoutMilli, kMaxResults, &results);
+    ChipLogProgress(DeviceLayer, "call mdns_query_ptr error=%s result=%p", esp_err_to_name(espError), results);
+    VerifyOrExit(espError == ESP_OK, error = CHIP_ERROR_INTERNAL);
+    if (results == nullptr)
+    {
+        ChipLogProgress(DeviceLayer, "ChipMdnsBrowse: No result");
+        callback(context, nullptr, 0, CHIP_NO_ERROR);
+    }
+    else
+    {
+        current = results;
+        while (current != nullptr)
+        {
+            serviceSize++;
+            current = current->next;
+        }
+        ChipLogProgress(DeviceLayer, "Service size=%zu", serviceSize);
+        services = static_cast<MdnsService *>(chip::Platform::MemoryCalloc(serviceSize, sizeof(MdnsService)));
+        VerifyOrExit(services != nullptr, error = CHIP_ERROR_NO_MEMORY);
+        current = results;
+
+        for (size_t i = 0; i < serviceSize; i++, current = current->next)
+        {
+            mdns_ip_addr_t * addr          = current->addr;
+            mdns_ip_addr_t * preferredAddr = addr;
+
+            while (addr != nullptr)
+            {
+                if (addr->addr.type == ESP_IPADDR_TYPE_V6)
+                {
+                    preferredAddr = addr;
+
+                    break;
+                }
+                addr = addr->next;
+            }
+            if (preferredAddr && preferredAddr->addr.type == ESP_IPADDR_TYPE_V6)
+            {
+                ip6_addr_t addrBinary;
+
+                memcpy(&addrBinary, &preferredAddr->addr.u_addr.ip6, sizeof(addrBinary));
+                services[i].mAddress.SetValue(chip::Inet::IPAddress::FromIPv6(addrBinary));
+            }
+            else if (preferredAddr && preferredAddr->addr.type == ESP_IPADDR_TYPE_V4)
+            {
+                ip4_addr_t addrBinary;
+
+                memcpy(&addrBinary, &preferredAddr->addr.u_addr.ip4, sizeof(addrBinary));
+                services[i].mAddress.SetValue(chip::Inet::IPAddress::FromIPv4(addrBinary));
+            }
+            if (current->instance_name)
+            {
+                strncpy(services[i].mName, current->instance_name, sizeof(services[i].mName));
+            }
+            services[i].mPort     = current->port;
+            services[i].mProtocol = protocol;
+            strncpy(services[i].mType, type, sizeof(services[i].mType));
+        }
+        ChipLogProgress(DeviceLayer, "Call callback");
+        callback(context, services, serviceSize, CHIP_NO_ERROR);
+    }
+
+exit:
+    if (services != nullptr)
+    {
+        chip::Platform::MemoryFree(services);
+    }
+    if (results != nullptr)
+    {
+        mdns_query_results_free(results);
+    }
+
+    return error;
+}
+
+CHIP_ERROR ChipMdnsResolve(MdnsService * service, chip::Inet::InterfaceId interface, MdnsResolveCallback callback, void * context)
+{
+    CHIP_ERROR error           = CHIP_NO_ERROR;
+    mdns_result_t * textResult = nullptr;
+    TextEntry * textEntries;
+    esp_err_t espError;
+
+    VerifyOrExit(service != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
+    espError = mdns_query_txt(service->mName, service->mType, GetProtocolString(service->mProtocol), kTimeoutMilli, &textResult);
+    VerifyOrExit(espError == ESP_OK && textResult != nullptr, error = CHIP_ERROR_INTERNAL);
+
+    if (textResult->txt_count > 0)
+    {
+        textEntries = static_cast<TextEntry *>(chip::Platform::MemoryCalloc(textResult->txt_count, sizeof(TextEntry)));
+        for (size_t i = 0; i < textResult->txt_count; i++)
+        {
+            textEntries[i].mKey      = textResult->txt[i].key;
+            textEntries[i].mData     = reinterpret_cast<const uint8_t *>(textResult->txt[i].value);
+            textEntries[i].mDataSize = strlen(textResult->txt[i].value);
+        }
+        service->mTextEntryies = textEntries;
+    }
+    service->mTextEntrySize = textResult->txt_count;
+
+    callback(context, service, error);
+
+exit:
+    if (textEntries != nullptr)
+    {
+        chip::Platform::MemoryFree(textEntries);
+    }
+    if (textResult != nullptr)
+    {
+        mdns_query_results_free(textResult);
+    }
+
+    return error;
+}
+
+} // namespace Mdns
+} // namespace Protocols
+} // namespace chip

--- a/src/platform/Linux/MdnsImpl.cpp
+++ b/src/platform/Linux/MdnsImpl.cpp
@@ -306,6 +306,17 @@ exit:
     return error;
 }
 
+CHIP_ERROR MdnsAvahi::SetHostname(const char * hostname)
+{
+    CHIP_ERROR error = CHIP_NO_ERROR;
+
+    VerifyOrExit(mClient != nullptr, error = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(avahi_client_set_host_name(mClient, hostname) == 0, error = CHIP_ERROR_INTERNAL);
+
+exit:
+    return error;
+}
+
 void MdnsAvahi::HandleClientState(AvahiClient * client, AvahiClientState state, void * context)
 {
     static_cast<MdnsAvahi *>(context)->HandleClientState(client, state);
@@ -652,6 +663,11 @@ void ProcessMdns(fd_set & readFdSet, fd_set & writeFdSet, fd_set & errorFdSet)
 CHIP_ERROR ChipMdnsInit(MdnsAsnycReturnCallback initCallback, MdnsAsnycReturnCallback errorCallback, void * context)
 {
     return MdnsAvahi::GetInstance().Init(initCallback, errorCallback, context);
+}
+
+CHIP_ERROR ChipMdnsSetHostname(const char * hostname)
+{
+    return MdnsAvahi::GetInstance().SetHostname(hostname);
 }
 
 CHIP_ERROR ChipMdnsPublishService(const MdnsService * service)

--- a/src/platform/Linux/MdnsImpl.h
+++ b/src/platform/Linux/MdnsImpl.h
@@ -102,6 +102,7 @@ public:
     MdnsAvahi & operator=(const MdnsAvahi &) = delete;
 
     CHIP_ERROR Init(MdnsAsnycReturnCallback initCallback, MdnsAsnycReturnCallback errorCallback, void * context);
+    CHIP_ERROR SetHostname(const char * hostname);
     CHIP_ERROR PublishService(const MdnsService & service);
     CHIP_ERROR StopPublish();
     CHIP_ERROR Browse(const char * type, MdnsServiceProtocol protocol, chip::Inet::InterfaceId interface,

--- a/src/platform/Linux/MdnsImpl.h
+++ b/src/platform/Linux/MdnsImpl.h
@@ -33,7 +33,7 @@
 #include <avahi-common/error.h>
 #include <avahi-common/watch.h>
 
-#include "lib/protocols/mdns/Mdns.h"
+#include "lib/protocols/mdns/platform/Mdns.h"
 
 struct AvahiWatch
 {

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -43,7 +43,8 @@ declare_args() {
   chip_enable_ble =
       chip_device_platform == "linux" || chip_device_platform == "darwin"
 
-  chip_enable_mdns = chip_device_platform == "linux"
+  chip_enable_mdns =
+      chip_device_platform == "linux" || chip_device_platform == "esp32"
 }
 
 _chip_device_layer = "none"

--- a/src/platform/tests/TestMdns.cpp
+++ b/src/platform/tests/TestMdns.cpp
@@ -4,7 +4,7 @@
 
 #include <nlunit-test.h>
 
-#include "lib/protocols/mdns/Mdns.h"
+#include "lib/protocols/mdns/platform/Mdns.h"
 #include "platform/CHIPDeviceLayer.h"
 #include "support/CHIPMem.h"
 


### PR DESCRIPTION
 #### Problem
mDNS is not implemented on esp32 platform.


 #### Summary of Changes
- Implement the platform mDNS api on esp32.
- Add publisher api.
- Publish device information via mDNS.