### PR TITLE
Reduce OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS to 32 for nrf5

### DIFF
--- a/examples/platform/nrf528xx/app/chipinit.cpp
+++ b/examples/platform/nrf528xx/app/chipinit.cpp
@@ -49,6 +49,7 @@ extern "C" {
 #endif // CHIP_ENABLE_OPENTHREAD
 #include <core/CHIPError.h>
 #include <platform/CHIPDeviceLayer.h>
+#include <support/CHIPMem.h>
 #include <support/logging/CHIPLogging.h>
 
 using namespace ::chip;
@@ -77,6 +78,13 @@ ret_code_t ChipInit()
     ret_code_t ret = CHIP_NO_ERROR;
 
     NRF_LOG_INFO("Init CHIP stack");
+    ret = chip::Platform::MemoryInit();
+    if (ret != CHIP_NO_ERROR)
+    {
+        NRF_LOG_INFO("PlatformMgr().InitChipStack() failed");
+        APP_ERROR_HANDLER(ret);
+    }
+
     ret = PlatformMgr().InitChipStack();
     if (ret != CHIP_NO_ERROR)
     {

--- a/examples/platform/nrf528xx/app/project_include/OpenThreadConfig.h
+++ b/examples/platform/nrf528xx/app/project_include/OpenThreadConfig.h
@@ -49,6 +49,8 @@
 #define OPENTHREAD_CONFIG_NCP_UART_ENABLE 1
 #define OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE 1
 
+#define OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS 32 // Default is 160, set to 32
+
 // Use the Nordic-supplied default platform configuration for remainder
 // of OpenThread config options.
 //

--- a/examples/platform/nrf528xx/app/project_include/OpenThreadConfig.h
+++ b/examples/platform/nrf528xx/app/project_include/OpenThreadConfig.h
@@ -49,7 +49,9 @@
 #define OPENTHREAD_CONFIG_NCP_UART_ENABLE 1
 #define OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE 1
 
-#define OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS 32 // Default is 160, set to 32
+// overly large numbers consume too many memory, especially when the device are
+// not intended to process large traffic
+#define OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS 44
 
 // Use the Nordic-supplied default platform configuration for remainder
 // of OpenThread config options.


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS is 160 as a default for nrf52840 example apps.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Change OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS to 32

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Related #3417 

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
