### PR TITLE
Add door lock callback for door lock cluster in the esp32 demo app

### DIFF
--- a/examples/wifi-echo/server/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/wifi-echo/server/esp32/main/CHIPDeviceManager.cpp
@@ -113,6 +113,17 @@ void emberAfPluginBasicResetToFactoryDefaultsCallback(uint8_t endpointId)
     }
 }
 
+bool emberAfPluginDoorLockServerActivateDoorLockCallback(bool activate)
+{
+    CHIPDeviceManagerCallbacks * cb = CHIPDeviceManager::GetInstance().GetCHIPDeviceManagerCallbacks();
+    if (cb != nullptr)
+    {
+        return cb->PluginDoorLockActivateDoorLockCallback(activate);
+    }
+
+    return false;
+}
+
 } // extern "C"
 
 } // namespace DeviceManager

--- a/examples/wifi-echo/server/esp32/main/DeviceCallbacks.cpp
+++ b/examples/wifi-echo/server/esp32/main/DeviceCallbacks.cpp
@@ -175,3 +175,10 @@ void DeviceCallbacks::PluginBasicResetToFactoryDefaultsCallback(uint8_t endpoint
 exit:
     return;
 }
+
+bool DeviceCallbacks::PluginDoorLockActivateDoorLockCallback(bool activate)
+{
+    ESP_LOGI(TAG, "PluginDoorLockActivateDoorLockCallback: '0x%02x'", activate);
+    // Simulate that locking/unlocking the door is always succesful.
+    return true;
+}

--- a/examples/wifi-echo/server/esp32/main/gen/callback-stub.c
+++ b/examples/wifi-echo/server/esp32/main/gen/callback-stub.c
@@ -2367,15 +2367,3 @@ bool emberAfPluginIdentifyStopFeedbackCallback(uint8_t endpoint)
     emberAfPrintln(EMBER_AF_PRINT_IDENTIFY_CLUSTER, "Stop identify callback on endpoint %d", endpoint);
     return false;
 }
-/** @brief Activate Door Lock Callback
- * This function is provided by the door lock server plugin.
- *
- * @param activate True if the lock should move to the locked position,
- *  false if it should move to the unlocked position Ver.: always
- *
- * @returns true if the callback was able to activate/deactivate the Lock.
- */
-bool emberAfPluginDoorLockServerActivateDoorLockCallback(bool activate)
-{
-    return false;
-};

--- a/examples/wifi-echo/server/esp32/main/include/CHIPDeviceManager.h
+++ b/examples/wifi-echo/server/esp32/main/include/CHIPDeviceManager.h
@@ -69,6 +69,17 @@ public:
 
     /**
      * @brief
+     *    Activate Door Lock Callback
+     *
+     * @param activate True if the lock should move to the locked position,
+     *                 False if it should move to the unlocked position
+     *
+     * @returns true if the callback was able to activate/deactivate the Lock.
+     */
+    virtual bool PluginDoorLockActivateDoorLockCallback(bool activate);
+
+    /**
+     * @brief
      *   Called after an attribute has been changed
      *
      * @param endpoint           endpoint id

--- a/examples/wifi-echo/server/esp32/main/include/DeviceCallbacks.h
+++ b/examples/wifi-echo/server/esp32/main/include/DeviceCallbacks.h
@@ -34,6 +34,7 @@ class DeviceCallbacks : public chip::DeviceManager::CHIPDeviceManagerCallbacks
 public:
     virtual void DeviceEventCallback(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
     virtual void PluginBasicResetToFactoryDefaultsCallback(uint8_t endpointId);
+    virtual bool PluginDoorLockActivateDoorLockCallback(bool activate);
     virtual void PostAttributeChangeCallback(uint8_t endpointId, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
                                              uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value);
 


### PR DESCRIPTION
 #### Problem
 The current door lock stub always returns `false` when one tries to lock/unlock the virtual door.
 The current patch implement a dumb callback that returns `true` is the command has been handled by the ESP32 demo app. If we keep returning `false` it looks like there is a problem with the command.

 #### Summary of Changes
 * Handle the callback in the ESP32 demo app