### PR TITLE
Add 'write' attributes command support to chip-tool

### DIFF
--- a/examples/chip-tool/commands/common/Commands.h
+++ b/examples/chip-tool/commands/common/Commands.h
@@ -37,11 +37,11 @@ private:
     CHIP_ERROR RunCommand(ChipDeviceController & dc, NodeId remoteId, int argc, char ** argv);
     std::map<std::string, CommandsVector>::iterator GetCluster(std::string clusterName);
     Command * GetCommand(CommandsVector & commands, std::string commandName);
-    Command * GetReadCommand(CommandsVector & commands, std::string commandName, std::string attributeName);
+    Command * GetReadWriteCommand(CommandsVector & commands, std::string commandName, std::string attributeName);
 
     void ShowClusters(std::string executable);
     void ShowCluster(std::string executable, std::string clusterName, CommandsVector & commands);
-    void ShowClusterAttributes(std::string executable, std::string clusterName, CommandsVector & commands);
+    void ShowClusterAttributes(std::string executable, std::string clusterName, std::string commandName, CommandsVector & commands);
     void ShowCommand(std::string executable, std::string clusterName, Command * command);
 
     std::map<std::string, CommandsVector> mClusters;


### PR DESCRIPTION
 #### Problem
  ChipTool supports `read` attributes commands by showing one a single instance of the command name in the help even if there is multiple attributes. It does not the same for `write` commands.
Please note that at the moment there is no `write`command in chip-tool but I will have a few of them soon.

 #### Summary of Changes
 * Add support for `write` command similarly to `read`command.