### PR TITLE
Expand ZCL structures which have an occurence in chip-tool in order t…

### DIFF
--- a/examples/chip-tool/commands/clusters/Commands.h
+++ b/examples/chip-tool/commands/clusters/Commands.h
@@ -3608,6 +3608,8 @@ class GroupsGetGroupMembership : public ModelCommand
 public:
     GroupsGetGroupMembership() : ModelCommand("get-group-membership", kGroupsClusterId, 0x02)
     {
+        // groupList is an array, but since chip-tool does not support variable
+        // number of arguments, only a single instance is supported.
         AddArgument("groupList", 0, UINT16_MAX, &mGroupList);
     }
 
@@ -4493,14 +4495,16 @@ public:
         AddArgument("sceneID", 0, UINT8_MAX, &mSceneID);
         AddArgument("transitionTime", 0, UINT16_MAX, &mTransitionTime);
         AddArgument("sceneName", &mSceneName);
-        // FIXME - SExtensionFieldSetList is not supported.
-        AddArgument("extensionFieldSets", &mExtensionFieldSets);
+        // extensionFieldSets is an array, but since chip-tool does not support variable
+        // number of arguments, only a single instance is supported.
+        AddArgument("clusterId", 0, UINT16_MAX, &mClusterId);
+        AddArgument("extensionFieldSet", &mExtensionFieldSet);
     }
 
     uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
     {
         return encodeScenesClusterAddSceneCommand(buffer->Start(), bufferSize, endPointId, mGroupID, mSceneID, mTransitionTime,
-                                                  mSceneName, mExtensionFieldSets);
+                                                  mSceneName, mClusterId, mExtensionFieldSet);
     }
 
     // Global Response: DefaultResponse
@@ -4522,8 +4526,8 @@ private:
     uint8_t mSceneID;
     uint16_t mTransitionTime;
     char * mSceneName;
-    // FIXME - SExtensionFieldSetList is not supported.
-    void * mExtensionFieldSets;
+    uint16_t mClusterId;
+    char * mExtensionFieldSet;
 };
 
 /*
@@ -4581,14 +4585,16 @@ public:
         AddArgument("sceneID", 0, UINT8_MAX, &mSceneID);
         AddArgument("transitionTime", 0, UINT16_MAX, &mTransitionTime);
         AddArgument("sceneName", &mSceneName);
-        // FIXME - SExtensionFieldSetList is not supported.
-        AddArgument("extensionFieldSets", &mExtensionFieldSets);
+        // extensionFieldSets is an array, but since chip-tool does not support variable
+        // number of arguments, only a single instance is supported.
+        AddArgument("clusterId", 0, UINT16_MAX, &mClusterId);
+        AddArgument("extensionFieldSet", &mExtensionFieldSet);
     }
 
     uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
     {
         return encodeScenesClusterEnhancedAddSceneCommand(buffer->Start(), bufferSize, endPointId, mGroupID, mSceneID,
-                                                          mTransitionTime, mSceneName, mExtensionFieldSets);
+                                                          mTransitionTime, mSceneName, mClusterId, mExtensionFieldSet);
     }
 
     // Global Response: DefaultResponse
@@ -4610,8 +4616,8 @@ private:
     uint8_t mSceneID;
     uint16_t mTransitionTime;
     char * mSceneName;
-    // FIXME - SExtensionFieldSetList is not supported.
-    void * mExtensionFieldSets;
+    uint16_t mClusterId;
+    char * mExtensionFieldSet;
 };
 
 /*

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -122,7 +122,6 @@ public:
     {
         return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint32);
     }
-    size_t AddArgument(const char * name, const void * value) { return 0; };
 
     virtual CHIP_ERROR Run(ChipDeviceController * dc, NodeId remoteId) = 0;
 

--- a/src/app/chip-zcl-zpro-codec-api.h
+++ b/src/app/chip-zcl-zpro-codec-api.h
@@ -1057,7 +1057,8 @@ uint16_t encodeOnOffClusterReadOnOffAttribute(uint8_t * buffer, uint16_t buf_len
  *    Encode an add-scene command for Scenes server into buffer including the APS frame
  */
 uint16_t encodeScenesClusterAddSceneCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint16_t groupID,
-                                            uint8_t sceneID, uint16_t transitionTime, char * sceneName, void * extensionFieldSets);
+                                            uint8_t sceneID, uint16_t transitionTime, char * sceneName, uint16_t clusterId,
+                                            char * extensionFieldSet);
 
 /**
  * @brief
@@ -1073,7 +1074,7 @@ uint16_t encodeScenesClusterCopySceneCommand(uint8_t * buffer, uint16_t buf_leng
  */
 uint16_t encodeScenesClusterEnhancedAddSceneCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                     uint16_t groupID, uint8_t sceneID, uint16_t transitionTime, char * sceneName,
-                                                    void * extensionFieldSets);
+                                                    uint16_t clusterId, char * extensionFieldSet);
 
 /**
  * @brief

--- a/src/app/encoder.cpp
+++ b/src/app/encoder.cpp
@@ -60,14 +60,16 @@
     return result;
 
 #define COMMAND_INSERT_STRING(name, str)                                                                                           \
-    size_t length = strlen(str);                                                                                                   \
-    if (!CanCastTo<uint8_t>(length))                                                                                               \
     {                                                                                                                              \
-        ChipLogError(Zcl, "Error encoding %s command. String too long: %d", name, length);                                         \
-        return 0;                                                                                                                  \
-    }                                                                                                                              \
-    buf.Put(static_cast<uint8_t>(length));                                                                                         \
-    buf.Put(str);
+        size_t length = strlen(str);                                                                                               \
+        if (!CanCastTo<uint8_t>(length))                                                                                           \
+        {                                                                                                                          \
+            ChipLogError(Zcl, "Error encoding %s command. String too long: %d", name, length);                                     \
+            return 0;                                                                                                              \
+        }                                                                                                                          \
+        buf.Put(static_cast<uint8_t>(length));                                                                                     \
+        buf.Put(str);                                                                                                              \
+    }
 
 #define COMMAND(name, cluster_id, command_id)                                                                                      \
     COMMAND_HEADER(name, cluster_id, command_id);                                                                                  \
@@ -223,9 +225,10 @@ uint16_t encodeReadAttributesCommand(uint8_t * buffer, uint16_t buf_length, uint
 uint16_t encodeBarrierControlClusterGoToPercentCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                        uint8_t percentOpen)
 {
-    COMMAND_HEADER("BarrierControlGoToPercent", BARRIER_CONTROL_CLUSTER_ID, 0x00);
+    const char * kName = "BarrierControlGoToPercent";
+    COMMAND_HEADER(kName, BARRIER_CONTROL_CLUSTER_ID, 0x00);
     buf.Put(percentOpen);
-    COMMAND_FOOTER("BarrierControlGoToPercent");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -284,8 +287,9 @@ uint16_t encodeBarrierControlClusterReadBarrierPositionAttribute(uint8_t * buffe
  */
 uint16_t encodeBasicClusterResetToFactoryDefaultsCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
 {
-    COMMAND_HEADER("BasicResetToFactoryDefaults", BASIC_CLUSTER_ID, 0x00);
-    COMMAND_FOOTER("BasicResetToFactoryDefaults");
+    const char * kName = "BasicResetToFactoryDefaults";
+    COMMAND_HEADER(kName, BASIC_CLUSTER_ID, 0x00);
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -376,12 +380,13 @@ uint16_t encodeBasicClusterReadPowerSourceAttribute(uint8_t * buffer, uint16_t b
 uint16_t encodeColorControlClusterMoveColorCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                    int16_t rateX, int16_t rateY, uint8_t optionsMask, uint8_t optionsOverride)
 {
-    COMMAND_HEADER("ColorControlMoveColor", COLOR_CONTROL_CLUSTER_ID, 0x08);
+    const char * kName = "ColorControlMoveColor";
+    COMMAND_HEADER(kName, COLOR_CONTROL_CLUSTER_ID, 0x08);
     buf.PutLE16(static_cast<uint16_t>(rateX));
     buf.PutLE16(static_cast<uint16_t>(rateY));
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
-    COMMAND_FOOTER("ColorControlMoveColor");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -393,14 +398,15 @@ uint16_t encodeColorControlClusterMoveColorTemperatureCommand(uint8_t * buffer, 
                                                               uint16_t colorTemperatureMaximumMireds, uint8_t optionsMask,
                                                               uint8_t optionsOverride)
 {
-    COMMAND_HEADER("ColorControlMoveColorTemperature", COLOR_CONTROL_CLUSTER_ID, 0x4B);
+    const char * kName = "ColorControlMoveColorTemperature";
+    COMMAND_HEADER(kName, COLOR_CONTROL_CLUSTER_ID, 0x4B);
     buf.Put(moveMode);
     buf.PutLE16(rate);
     buf.PutLE16(colorTemperatureMinimumMireds);
     buf.PutLE16(colorTemperatureMaximumMireds);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
-    COMMAND_FOOTER("ColorControlMoveColorTemperature");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -409,12 +415,13 @@ uint16_t encodeColorControlClusterMoveColorTemperatureCommand(uint8_t * buffer, 
 uint16_t encodeColorControlClusterMoveHueCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                  uint8_t moveMode, uint8_t rate, uint8_t optionsMask, uint8_t optionsOverride)
 {
-    COMMAND_HEADER("ColorControlMoveHue", COLOR_CONTROL_CLUSTER_ID, 0x01);
+    const char * kName = "ColorControlMoveHue";
+    COMMAND_HEADER(kName, COLOR_CONTROL_CLUSTER_ID, 0x01);
     buf.Put(moveMode);
     buf.Put(rate);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
-    COMMAND_FOOTER("ColorControlMoveHue");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -424,12 +431,13 @@ uint16_t encodeColorControlClusterMoveSaturationCommand(uint8_t * buffer, uint16
                                                         uint8_t moveMode, uint8_t rate, uint8_t optionsMask,
                                                         uint8_t optionsOverride)
 {
-    COMMAND_HEADER("ColorControlMoveSaturation", COLOR_CONTROL_CLUSTER_ID, 0x04);
+    const char * kName = "ColorControlMoveSaturation";
+    COMMAND_HEADER(kName, COLOR_CONTROL_CLUSTER_ID, 0x04);
     buf.Put(moveMode);
     buf.Put(rate);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
-    COMMAND_FOOTER("ColorControlMoveSaturation");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -439,13 +447,14 @@ uint16_t encodeColorControlClusterMoveToColorCommand(uint8_t * buffer, uint16_t 
                                                      uint16_t colorX, uint16_t colorY, uint16_t transitionTime, uint8_t optionsMask,
                                                      uint8_t optionsOverride)
 {
-    COMMAND_HEADER("ColorControlMoveToColor", COLOR_CONTROL_CLUSTER_ID, 0x07);
+    const char * kName = "ColorControlMoveToColor";
+    COMMAND_HEADER(kName, COLOR_CONTROL_CLUSTER_ID, 0x07);
     buf.PutLE16(colorX);
     buf.PutLE16(colorY);
     buf.PutLE16(transitionTime);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
-    COMMAND_FOOTER("ColorControlMoveToColor");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -455,12 +464,13 @@ uint16_t encodeColorControlClusterMoveToColorTemperatureCommand(uint8_t * buffer
                                                                 uint16_t colorTemperatureMireds, uint16_t transitionTime,
                                                                 uint8_t optionsMask, uint8_t optionsOverride)
 {
-    COMMAND_HEADER("ColorControlMoveToColorTemperature", COLOR_CONTROL_CLUSTER_ID, 0x0A);
+    const char * kName = "ColorControlMoveToColorTemperature";
+    COMMAND_HEADER(kName, COLOR_CONTROL_CLUSTER_ID, 0x0A);
     buf.PutLE16(colorTemperatureMireds);
     buf.PutLE16(transitionTime);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
-    COMMAND_FOOTER("ColorControlMoveToColorTemperature");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -470,13 +480,14 @@ uint16_t encodeColorControlClusterMoveToHueCommand(uint8_t * buffer, uint16_t bu
                                                    uint8_t direction, uint16_t transitionTime, uint8_t optionsMask,
                                                    uint8_t optionsOverride)
 {
-    COMMAND_HEADER("ColorControlMoveToHue", COLOR_CONTROL_CLUSTER_ID, 0x00);
+    const char * kName = "ColorControlMoveToHue";
+    COMMAND_HEADER(kName, COLOR_CONTROL_CLUSTER_ID, 0x00);
     buf.Put(hue);
     buf.Put(direction);
     buf.PutLE16(transitionTime);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
-    COMMAND_FOOTER("ColorControlMoveToHue");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -486,13 +497,14 @@ uint16_t encodeColorControlClusterMoveToHueAndSaturationCommand(uint8_t * buffer
                                                                 uint8_t hue, uint8_t saturation, uint16_t transitionTime,
                                                                 uint8_t optionsMask, uint8_t optionsOverride)
 {
-    COMMAND_HEADER("ColorControlMoveToHueAndSaturation", COLOR_CONTROL_CLUSTER_ID, 0x06);
+    const char * kName = "ColorControlMoveToHueAndSaturation";
+    COMMAND_HEADER(kName, COLOR_CONTROL_CLUSTER_ID, 0x06);
     buf.Put(hue);
     buf.Put(saturation);
     buf.PutLE16(transitionTime);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
-    COMMAND_FOOTER("ColorControlMoveToHueAndSaturation");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -502,12 +514,13 @@ uint16_t encodeColorControlClusterMoveToSaturationCommand(uint8_t * buffer, uint
                                                           uint8_t saturation, uint16_t transitionTime, uint8_t optionsMask,
                                                           uint8_t optionsOverride)
 {
-    COMMAND_HEADER("ColorControlMoveToSaturation", COLOR_CONTROL_CLUSTER_ID, 0x03);
+    const char * kName = "ColorControlMoveToSaturation";
+    COMMAND_HEADER(kName, COLOR_CONTROL_CLUSTER_ID, 0x03);
     buf.Put(saturation);
     buf.PutLE16(transitionTime);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
-    COMMAND_FOOTER("ColorControlMoveToSaturation");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -517,13 +530,14 @@ uint16_t encodeColorControlClusterStepColorCommand(uint8_t * buffer, uint16_t bu
                                                    int16_t stepX, int16_t stepY, uint16_t transitionTime, uint8_t optionsMask,
                                                    uint8_t optionsOverride)
 {
-    COMMAND_HEADER("ColorControlStepColor", COLOR_CONTROL_CLUSTER_ID, 0x09);
+    const char * kName = "ColorControlStepColor";
+    COMMAND_HEADER(kName, COLOR_CONTROL_CLUSTER_ID, 0x09);
     buf.PutLE16(static_cast<uint16_t>(stepX));
     buf.PutLE16(static_cast<uint16_t>(stepY));
     buf.PutLE16(transitionTime);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
-    COMMAND_FOOTER("ColorControlStepColor");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -535,7 +549,8 @@ uint16_t encodeColorControlClusterStepColorTemperatureCommand(uint8_t * buffer, 
                                                               uint16_t colorTemperatureMaximumMireds, uint8_t optionsMask,
                                                               uint8_t optionsOverride)
 {
-    COMMAND_HEADER("ColorControlStepColorTemperature", COLOR_CONTROL_CLUSTER_ID, 0x4C);
+    const char * kName = "ColorControlStepColorTemperature";
+    COMMAND_HEADER(kName, COLOR_CONTROL_CLUSTER_ID, 0x4C);
     buf.Put(stepMode);
     buf.PutLE16(stepSize);
     buf.PutLE16(transitionTime);
@@ -543,7 +558,7 @@ uint16_t encodeColorControlClusterStepColorTemperatureCommand(uint8_t * buffer, 
     buf.PutLE16(colorTemperatureMaximumMireds);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
-    COMMAND_FOOTER("ColorControlStepColorTemperature");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -553,13 +568,14 @@ uint16_t encodeColorControlClusterStepHueCommand(uint8_t * buffer, uint16_t buf_
                                                  uint8_t stepMode, uint8_t stepSize, uint8_t transitionTime, uint8_t optionsMask,
                                                  uint8_t optionsOverride)
 {
-    COMMAND_HEADER("ColorControlStepHue", COLOR_CONTROL_CLUSTER_ID, 0x02);
+    const char * kName = "ColorControlStepHue";
+    COMMAND_HEADER(kName, COLOR_CONTROL_CLUSTER_ID, 0x02);
     buf.Put(stepMode);
     buf.Put(stepSize);
     buf.Put(transitionTime);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
-    COMMAND_FOOTER("ColorControlStepHue");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -569,13 +585,14 @@ uint16_t encodeColorControlClusterStepSaturationCommand(uint8_t * buffer, uint16
                                                         uint8_t stepMode, uint8_t stepSize, uint8_t transitionTime,
                                                         uint8_t optionsMask, uint8_t optionsOverride)
 {
-    COMMAND_HEADER("ColorControlStepSaturation", COLOR_CONTROL_CLUSTER_ID, 0x05);
+    const char * kName = "ColorControlStepSaturation";
+    COMMAND_HEADER(kName, COLOR_CONTROL_CLUSTER_ID, 0x05);
     buf.Put(stepMode);
     buf.Put(stepSize);
     buf.Put(transitionTime);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
-    COMMAND_FOOTER("ColorControlStepSaturation");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -584,10 +601,11 @@ uint16_t encodeColorControlClusterStepSaturationCommand(uint8_t * buffer, uint16
 uint16_t encodeColorControlClusterStopMoveStepCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                       uint8_t optionsMask, uint8_t optionsOverride)
 {
-    COMMAND_HEADER("ColorControlStopMoveStep", COLOR_CONTROL_CLUSTER_ID, 0x47);
+    const char * kName = "ColorControlStopMoveStep";
+    COMMAND_HEADER(kName, COLOR_CONTROL_CLUSTER_ID, 0x47);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
-    COMMAND_FOOTER("ColorControlStopMoveStep");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1025,8 +1043,9 @@ uint16_t encodeColorControlClusterReadStartUpColorTemperatureMiredsAttribute(uin
  */
 uint16_t encodeDoorLockClusterClearAllPINCodesCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
 {
-    COMMAND_HEADER("DoorLockClearAllPINCodes", DOOR_LOCK_CLUSTER_ID, 0x08);
-    COMMAND_FOOTER("DoorLockClearAllPINCodes");
+    const char * kName = "DoorLockClearAllPINCodes";
+    COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x08);
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1034,8 +1053,9 @@ uint16_t encodeDoorLockClusterClearAllPINCodesCommand(uint8_t * buffer, uint16_t
  */
 uint16_t encodeDoorLockClusterClearAllRFIDCodesCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
 {
-    COMMAND_HEADER("DoorLockClearAllRFIDCodes", DOOR_LOCK_CLUSTER_ID, 0x19);
-    COMMAND_FOOTER("DoorLockClearAllRFIDCodes");
+    const char * kName = "DoorLockClearAllRFIDCodes";
+    COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x19);
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1044,9 +1064,10 @@ uint16_t encodeDoorLockClusterClearAllRFIDCodesCommand(uint8_t * buffer, uint16_
 uint16_t encodeDoorLockClusterClearHolidayScheduleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                           uint8_t holidayScheduleID)
 {
-    COMMAND_HEADER("DoorLockClearHolidaySchedule", DOOR_LOCK_CLUSTER_ID, 0x13);
+    const char * kName = "DoorLockClearHolidaySchedule";
+    COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x13);
     buf.Put(holidayScheduleID);
-    COMMAND_FOOTER("DoorLockClearHolidaySchedule");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1055,9 +1076,10 @@ uint16_t encodeDoorLockClusterClearHolidayScheduleCommand(uint8_t * buffer, uint
 uint16_t encodeDoorLockClusterClearPINCodeCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                   uint16_t userID)
 {
-    COMMAND_HEADER("DoorLockClearPINCode", DOOR_LOCK_CLUSTER_ID, 0x07);
+    const char * kName = "DoorLockClearPINCode";
+    COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x07);
     buf.PutLE16(userID);
-    COMMAND_FOOTER("DoorLockClearPINCode");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1066,9 +1088,10 @@ uint16_t encodeDoorLockClusterClearPINCodeCommand(uint8_t * buffer, uint16_t buf
 uint16_t encodeDoorLockClusterClearRFIDCodeCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                    uint16_t userID)
 {
-    COMMAND_HEADER("DoorLockClearRFIDCode", DOOR_LOCK_CLUSTER_ID, 0x18);
+    const char * kName = "DoorLockClearRFIDCode";
+    COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x18);
     buf.PutLE16(userID);
-    COMMAND_FOOTER("DoorLockClearRFIDCode");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1077,10 +1100,11 @@ uint16_t encodeDoorLockClusterClearRFIDCodeCommand(uint8_t * buffer, uint16_t bu
 uint16_t encodeDoorLockClusterClearWeekdayScheduleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                           uint8_t scheduleID, uint16_t userID)
 {
-    COMMAND_HEADER("DoorLockClearWeekdaySchedule", DOOR_LOCK_CLUSTER_ID, 0x0D);
+    const char * kName = "DoorLockClearWeekdaySchedule";
+    COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x0D);
     buf.Put(scheduleID);
     buf.PutLE16(userID);
-    COMMAND_FOOTER("DoorLockClearWeekdaySchedule");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1089,10 +1113,11 @@ uint16_t encodeDoorLockClusterClearWeekdayScheduleCommand(uint8_t * buffer, uint
 uint16_t encodeDoorLockClusterClearYearDayScheduleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                           uint8_t scheduleID, uint16_t userID)
 {
-    COMMAND_HEADER("DoorLockClearYearDaySchedule", DOOR_LOCK_CLUSTER_ID, 0x10);
+    const char * kName = "DoorLockClearYearDaySchedule";
+    COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x10);
     buf.Put(scheduleID);
     buf.PutLE16(userID);
-    COMMAND_FOOTER("DoorLockClearYearDaySchedule");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1101,9 +1126,10 @@ uint16_t encodeDoorLockClusterClearYearDayScheduleCommand(uint8_t * buffer, uint
 uint16_t encodeDoorLockClusterGetHolidayScheduleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                         uint8_t holidayScheduleID)
 {
-    COMMAND_HEADER("DoorLockGetHolidaySchedule", DOOR_LOCK_CLUSTER_ID, 0x12);
+    const char * kName = "DoorLockGetHolidaySchedule";
+    COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x12);
     buf.Put(holidayScheduleID);
-    COMMAND_FOOTER("DoorLockGetHolidaySchedule");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1112,9 +1138,10 @@ uint16_t encodeDoorLockClusterGetHolidayScheduleCommand(uint8_t * buffer, uint16
 uint16_t encodeDoorLockClusterGetLogRecordCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                   uint16_t logIndex)
 {
-    COMMAND_HEADER("DoorLockGetLogRecord", DOOR_LOCK_CLUSTER_ID, 0x04);
+    const char * kName = "DoorLockGetLogRecord";
+    COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x04);
     buf.PutLE16(logIndex);
-    COMMAND_FOOTER("DoorLockGetLogRecord");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1123,9 +1150,10 @@ uint16_t encodeDoorLockClusterGetLogRecordCommand(uint8_t * buffer, uint16_t buf
 uint16_t encodeDoorLockClusterGetPINCodeCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                 uint16_t userID)
 {
-    COMMAND_HEADER("DoorLockGetPINCode", DOOR_LOCK_CLUSTER_ID, 0x06);
+    const char * kName = "DoorLockGetPINCode";
+    COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x06);
     buf.PutLE16(userID);
-    COMMAND_FOOTER("DoorLockGetPINCode");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1134,9 +1162,10 @@ uint16_t encodeDoorLockClusterGetPINCodeCommand(uint8_t * buffer, uint16_t buf_l
 uint16_t encodeDoorLockClusterGetRFIDCodeCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                  uint16_t userID)
 {
-    COMMAND_HEADER("DoorLockGetRFIDCode", DOOR_LOCK_CLUSTER_ID, 0x17);
+    const char * kName = "DoorLockGetRFIDCode";
+    COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x17);
     buf.PutLE16(userID);
-    COMMAND_FOOTER("DoorLockGetRFIDCode");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1145,9 +1174,10 @@ uint16_t encodeDoorLockClusterGetRFIDCodeCommand(uint8_t * buffer, uint16_t buf_
 uint16_t encodeDoorLockClusterGetUserTypeCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                  uint16_t userID)
 {
-    COMMAND_HEADER("DoorLockGetUserType", DOOR_LOCK_CLUSTER_ID, 0x15);
+    const char * kName = "DoorLockGetUserType";
+    COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x15);
     buf.PutLE16(userID);
-    COMMAND_FOOTER("DoorLockGetUserType");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1156,10 +1186,11 @@ uint16_t encodeDoorLockClusterGetUserTypeCommand(uint8_t * buffer, uint16_t buf_
 uint16_t encodeDoorLockClusterGetWeekdayScheduleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                         uint8_t scheduleID, uint16_t userID)
 {
-    COMMAND_HEADER("DoorLockGetWeekdaySchedule", DOOR_LOCK_CLUSTER_ID, 0x0C);
+    const char * kName = "DoorLockGetWeekdaySchedule";
+    COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x0C);
     buf.Put(scheduleID);
     buf.PutLE16(userID);
-    COMMAND_FOOTER("DoorLockGetWeekdaySchedule");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1168,10 +1199,11 @@ uint16_t encodeDoorLockClusterGetWeekdayScheduleCommand(uint8_t * buffer, uint16
 uint16_t encodeDoorLockClusterGetYearDayScheduleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                         uint8_t scheduleID, uint16_t userID)
 {
-    COMMAND_HEADER("DoorLockGetYearDaySchedule", DOOR_LOCK_CLUSTER_ID, 0x0F);
+    const char * kName = "DoorLockGetYearDaySchedule";
+    COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x0F);
     buf.Put(scheduleID);
     buf.PutLE16(userID);
-    COMMAND_FOOTER("DoorLockGetYearDaySchedule");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1180,9 +1212,10 @@ uint16_t encodeDoorLockClusterGetYearDayScheduleCommand(uint8_t * buffer, uint16
 uint16_t encodeDoorLockClusterLockDoorCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                               char * pINOrRFIDCode)
 {
-    COMMAND_HEADER("DoorLockLockDoor", DOOR_LOCK_CLUSTER_ID, 0x00);
-    COMMAND_INSERT_STRING("DoorLockLockDoor", pINOrRFIDCode);
-    COMMAND_FOOTER("DoorLockLockDoor");
+    const char * kName = "DoorLockLockDoor";
+    COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x00);
+    COMMAND_INSERT_STRING(kName, pINOrRFIDCode);
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1192,10 +1225,11 @@ uint16_t encodeDoorLockClusterSetHolidayScheduleCommand(uint8_t * buffer, uint16
                                                         uint8_t holidayScheduleID, uint32_t localStartTime, uint32_t localEndTime,
                                                         uint8_t operatingModeDuringHoliday)
 {
-    COMMAND_HEADER("DoorLockSetHolidaySchedule", DOOR_LOCK_CLUSTER_ID, 0x11);
+    const char * kName = "DoorLockSetHolidaySchedule";
+    COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x11);
     buf.Put(holidayScheduleID);
     buf.Put(operatingModeDuringHoliday);
-    COMMAND_FOOTER("DoorLockSetHolidaySchedule");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1204,12 +1238,13 @@ uint16_t encodeDoorLockClusterSetHolidayScheduleCommand(uint8_t * buffer, uint16
 uint16_t encodeDoorLockClusterSetPINCodeCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                 uint16_t userID, uint8_t userStatus, uint8_t userType, char * pIN)
 {
-    COMMAND_HEADER("DoorLockSetPINCode", DOOR_LOCK_CLUSTER_ID, 0x05);
+    const char * kName = "DoorLockSetPINCode";
+    COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x05);
     buf.PutLE16(userID);
     buf.Put(userStatus);
     buf.Put(userType);
-    COMMAND_INSERT_STRING("DoorLockSetPINCode", pIN);
-    COMMAND_FOOTER("DoorLockSetPINCode");
+    COMMAND_INSERT_STRING(kName, pIN);
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1218,12 +1253,13 @@ uint16_t encodeDoorLockClusterSetPINCodeCommand(uint8_t * buffer, uint16_t buf_l
 uint16_t encodeDoorLockClusterSetRFIDCodeCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                  uint16_t userID, uint8_t userStatus, uint8_t userType, char * rFIDCode)
 {
-    COMMAND_HEADER("DoorLockSetRFIDCode", DOOR_LOCK_CLUSTER_ID, 0x16);
+    const char * kName = "DoorLockSetRFIDCode";
+    COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x16);
     buf.PutLE16(userID);
     buf.Put(userStatus);
     buf.Put(userType);
-    COMMAND_INSERT_STRING("DoorLockSetRFIDCode", rFIDCode);
-    COMMAND_FOOTER("DoorLockSetRFIDCode");
+    COMMAND_INSERT_STRING(kName, rFIDCode);
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1232,10 +1268,11 @@ uint16_t encodeDoorLockClusterSetRFIDCodeCommand(uint8_t * buffer, uint16_t buf_
 uint16_t encodeDoorLockClusterSetUserTypeCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                  uint16_t userID, uint8_t userType)
 {
-    COMMAND_HEADER("DoorLockSetUserType", DOOR_LOCK_CLUSTER_ID, 0x14);
+    const char * kName = "DoorLockSetUserType";
+    COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x14);
     buf.PutLE16(userID);
     buf.Put(userType);
-    COMMAND_FOOTER("DoorLockSetUserType");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1245,7 +1282,8 @@ uint16_t encodeDoorLockClusterSetWeekdayScheduleCommand(uint8_t * buffer, uint16
                                                         uint8_t scheduleID, uint16_t userID, uint8_t daysMask, uint8_t startHour,
                                                         uint8_t startMinute, uint8_t endHour, uint8_t endMinute)
 {
-    COMMAND_HEADER("DoorLockSetWeekdaySchedule", DOOR_LOCK_CLUSTER_ID, 0x0B);
+    const char * kName = "DoorLockSetWeekdaySchedule";
+    COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x0B);
     buf.Put(scheduleID);
     buf.PutLE16(userID);
     buf.Put(daysMask);
@@ -1253,7 +1291,7 @@ uint16_t encodeDoorLockClusterSetWeekdayScheduleCommand(uint8_t * buffer, uint16
     buf.Put(startMinute);
     buf.Put(endHour);
     buf.Put(endMinute);
-    COMMAND_FOOTER("DoorLockSetWeekdaySchedule");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1263,10 +1301,11 @@ uint16_t encodeDoorLockClusterSetYearDayScheduleCommand(uint8_t * buffer, uint16
                                                         uint8_t scheduleID, uint16_t userID, uint32_t localStartTime,
                                                         uint32_t localEndTime)
 {
-    COMMAND_HEADER("DoorLockSetYearDaySchedule", DOOR_LOCK_CLUSTER_ID, 0x0E);
+    const char * kName = "DoorLockSetYearDaySchedule";
+    COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x0E);
     buf.Put(scheduleID);
     buf.PutLE16(userID);
-    COMMAND_FOOTER("DoorLockSetYearDaySchedule");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1275,9 +1314,10 @@ uint16_t encodeDoorLockClusterSetYearDayScheduleCommand(uint8_t * buffer, uint16
 uint16_t encodeDoorLockClusterUnlockDoorCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                 char * pINOrRFIDCode)
 {
-    COMMAND_HEADER("DoorLockUnlockDoor", DOOR_LOCK_CLUSTER_ID, 0x01);
-    COMMAND_INSERT_STRING("DoorLockUnlockDoor", pINOrRFIDCode);
-    COMMAND_FOOTER("DoorLockUnlockDoor");
+    const char * kName = "DoorLockUnlockDoor";
+    COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x01);
+    COMMAND_INSERT_STRING(kName, pINOrRFIDCode);
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1286,10 +1326,11 @@ uint16_t encodeDoorLockClusterUnlockDoorCommand(uint8_t * buffer, uint16_t buf_l
 uint16_t encodeDoorLockClusterUnlockWithTimeoutCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                        uint16_t timeoutInSeconds, char * pINOrRFIDCode)
 {
-    COMMAND_HEADER("DoorLockUnlockWithTimeout", DOOR_LOCK_CLUSTER_ID, 0x03);
+    const char * kName = "DoorLockUnlockWithTimeout";
+    COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x03);
     buf.PutLE16(timeoutInSeconds);
-    COMMAND_INSERT_STRING("DoorLockUnlockWithTimeout", pINOrRFIDCode);
-    COMMAND_FOOTER("DoorLockUnlockWithTimeout");
+    COMMAND_INSERT_STRING(kName, pINOrRFIDCode);
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1347,10 +1388,11 @@ uint16_t encodeDoorLockClusterReadActuatorEnabledAttribute(uint8_t * buffer, uin
 uint16_t encodeGroupsClusterAddGroupCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint16_t groupId,
                                             char * groupName)
 {
-    COMMAND_HEADER("GroupsAddGroup", GROUPS_CLUSTER_ID, 0x00);
+    const char * kName = "GroupsAddGroup";
+    COMMAND_HEADER(kName, GROUPS_CLUSTER_ID, 0x00);
     buf.PutLE16(groupId);
-    COMMAND_INSERT_STRING("GroupsAddGroup", groupName);
-    COMMAND_FOOTER("GroupsAddGroup");
+    COMMAND_INSERT_STRING(kName, groupName);
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1359,10 +1401,11 @@ uint16_t encodeGroupsClusterAddGroupCommand(uint8_t * buffer, uint16_t buf_lengt
 uint16_t encodeGroupsClusterAddGroupIfIdentifyingCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                          uint16_t groupId, char * groupName)
 {
-    COMMAND_HEADER("GroupsAddGroupIfIdentifying", GROUPS_CLUSTER_ID, 0x05);
+    const char * kName = "GroupsAddGroupIfIdentifying";
+    COMMAND_HEADER(kName, GROUPS_CLUSTER_ID, 0x05);
     buf.PutLE16(groupId);
-    COMMAND_INSERT_STRING("GroupsAddGroupIfIdentifying", groupName);
-    COMMAND_FOOTER("GroupsAddGroupIfIdentifying");
+    COMMAND_INSERT_STRING(kName, groupName);
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1371,9 +1414,10 @@ uint16_t encodeGroupsClusterAddGroupIfIdentifyingCommand(uint8_t * buffer, uint1
 uint16_t encodeGroupsClusterGetGroupMembershipCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                       uint16_t groupList)
 {
-    COMMAND_HEADER("GroupsGetGroupMembership", GROUPS_CLUSTER_ID, 0x02);
+    const char * kName = "GroupsGetGroupMembership";
+    COMMAND_HEADER(kName, GROUPS_CLUSTER_ID, 0x02);
     buf.PutLE16(groupList);
-    COMMAND_FOOTER("GroupsGetGroupMembership");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1381,8 +1425,9 @@ uint16_t encodeGroupsClusterGetGroupMembershipCommand(uint8_t * buffer, uint16_t
  */
 uint16_t encodeGroupsClusterRemoveAllGroupsCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
 {
-    COMMAND_HEADER("GroupsRemoveAllGroups", GROUPS_CLUSTER_ID, 0x04);
-    COMMAND_FOOTER("GroupsRemoveAllGroups");
+    const char * kName = "GroupsRemoveAllGroups";
+    COMMAND_HEADER(kName, GROUPS_CLUSTER_ID, 0x04);
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1391,9 +1436,10 @@ uint16_t encodeGroupsClusterRemoveAllGroupsCommand(uint8_t * buffer, uint16_t bu
 uint16_t encodeGroupsClusterRemoveGroupCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                uint16_t groupId)
 {
-    COMMAND_HEADER("GroupsRemoveGroup", GROUPS_CLUSTER_ID, 0x03);
+    const char * kName = "GroupsRemoveGroup";
+    COMMAND_HEADER(kName, GROUPS_CLUSTER_ID, 0x03);
     buf.PutLE16(groupId);
-    COMMAND_FOOTER("GroupsRemoveGroup");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1401,9 +1447,10 @@ uint16_t encodeGroupsClusterRemoveGroupCommand(uint8_t * buffer, uint16_t buf_le
  */
 uint16_t encodeGroupsClusterViewGroupCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint16_t groupId)
 {
-    COMMAND_HEADER("GroupsViewGroup", GROUPS_CLUSTER_ID, 0x01);
+    const char * kName = "GroupsViewGroup";
+    COMMAND_HEADER(kName, GROUPS_CLUSTER_ID, 0x01);
     buf.PutLE16(groupId);
-    COMMAND_FOOTER("GroupsViewGroup");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1436,9 +1483,10 @@ uint16_t encodeGroupsClusterReadNameSupportAttribute(uint8_t * buffer, uint16_t 
 uint16_t encodeIdentifyClusterIdentifyCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                               uint16_t identifyTime)
 {
-    COMMAND_HEADER("IdentifyIdentify", IDENTIFY_CLUSTER_ID, 0x00);
+    const char * kName = "IdentifyIdentify";
+    COMMAND_HEADER(kName, IDENTIFY_CLUSTER_ID, 0x00);
     buf.PutLE16(identifyTime);
-    COMMAND_FOOTER("IdentifyIdentify");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1446,8 +1494,9 @@ uint16_t encodeIdentifyClusterIdentifyCommand(uint8_t * buffer, uint16_t buf_len
  */
 uint16_t encodeIdentifyClusterIdentifyQueryCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
 {
-    COMMAND_HEADER("IdentifyIdentifyQuery", IDENTIFY_CLUSTER_ID, 0x01);
-    COMMAND_FOOTER("IdentifyIdentifyQuery");
+    const char * kName = "IdentifyIdentifyQuery";
+    COMMAND_HEADER(kName, IDENTIFY_CLUSTER_ID, 0x01);
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1485,12 +1534,13 @@ uint16_t encodeIdentifyClusterReadIdentifyTimeAttribute(uint8_t * buffer, uint16
 uint16_t encodeLevelClusterMoveCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint8_t moveMode,
                                        uint8_t rate, uint8_t optionsMask, uint8_t optionsOverride)
 {
-    COMMAND_HEADER("LevelMove", LEVEL_CLUSTER_ID, 0x01);
+    const char * kName = "LevelMove";
+    COMMAND_HEADER(kName, LEVEL_CLUSTER_ID, 0x01);
     buf.Put(moveMode);
     buf.Put(rate);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
-    COMMAND_FOOTER("LevelMove");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1499,12 +1549,13 @@ uint16_t encodeLevelClusterMoveCommand(uint8_t * buffer, uint16_t buf_length, ui
 uint16_t encodeLevelClusterMoveToLevelCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint8_t level,
                                               uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride)
 {
-    COMMAND_HEADER("LevelMoveToLevel", LEVEL_CLUSTER_ID, 0x00);
+    const char * kName = "LevelMoveToLevel";
+    COMMAND_HEADER(kName, LEVEL_CLUSTER_ID, 0x00);
     buf.Put(level);
     buf.PutLE16(transitionTime);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
-    COMMAND_FOOTER("LevelMoveToLevel");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1514,12 +1565,13 @@ uint16_t encodeLevelClusterMoveToLevelWithOnOffCommand(uint8_t * buffer, uint16_
                                                        uint8_t level, uint16_t transitionTime, uint8_t optionsMask,
                                                        uint8_t optionsOverride)
 {
-    COMMAND_HEADER("LevelMoveToLevelWithOnOff", LEVEL_CLUSTER_ID, 0x04);
+    const char * kName = "LevelMoveToLevelWithOnOff";
+    COMMAND_HEADER(kName, LEVEL_CLUSTER_ID, 0x04);
     buf.Put(level);
     buf.PutLE16(transitionTime);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
-    COMMAND_FOOTER("LevelMoveToLevelWithOnOff");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1528,12 +1580,13 @@ uint16_t encodeLevelClusterMoveToLevelWithOnOffCommand(uint8_t * buffer, uint16_
 uint16_t encodeLevelClusterMoveWithOnOffCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                 uint8_t moveMode, uint8_t rate, uint8_t optionsMask, uint8_t optionsOverride)
 {
-    COMMAND_HEADER("LevelMoveWithOnOff", LEVEL_CLUSTER_ID, 0x05);
+    const char * kName = "LevelMoveWithOnOff";
+    COMMAND_HEADER(kName, LEVEL_CLUSTER_ID, 0x05);
     buf.Put(moveMode);
     buf.Put(rate);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
-    COMMAND_FOOTER("LevelMoveWithOnOff");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1542,13 +1595,14 @@ uint16_t encodeLevelClusterMoveWithOnOffCommand(uint8_t * buffer, uint16_t buf_l
 uint16_t encodeLevelClusterStepCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint8_t stepMode,
                                        uint8_t stepSize, uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride)
 {
-    COMMAND_HEADER("LevelStep", LEVEL_CLUSTER_ID, 0x02);
+    const char * kName = "LevelStep";
+    COMMAND_HEADER(kName, LEVEL_CLUSTER_ID, 0x02);
     buf.Put(stepMode);
     buf.Put(stepSize);
     buf.PutLE16(transitionTime);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
-    COMMAND_FOOTER("LevelStep");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1558,13 +1612,14 @@ uint16_t encodeLevelClusterStepWithOnOffCommand(uint8_t * buffer, uint16_t buf_l
                                                 uint8_t stepMode, uint8_t stepSize, uint16_t transitionTime, uint8_t optionsMask,
                                                 uint8_t optionsOverride)
 {
-    COMMAND_HEADER("LevelStepWithOnOff", LEVEL_CLUSTER_ID, 0x06);
+    const char * kName = "LevelStepWithOnOff";
+    COMMAND_HEADER(kName, LEVEL_CLUSTER_ID, 0x06);
     buf.Put(stepMode);
     buf.Put(stepSize);
     buf.PutLE16(transitionTime);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
-    COMMAND_FOOTER("LevelStepWithOnOff");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1573,10 +1628,11 @@ uint16_t encodeLevelClusterStepWithOnOffCommand(uint8_t * buffer, uint16_t buf_l
 uint16_t encodeLevelClusterStopCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint8_t optionsMask,
                                        uint8_t optionsOverride)
 {
-    COMMAND_HEADER("LevelStop", LEVEL_CLUSTER_ID, 0x03);
+    const char * kName = "LevelStop";
+    COMMAND_HEADER(kName, LEVEL_CLUSTER_ID, 0x03);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
-    COMMAND_FOOTER("LevelStop");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1585,10 +1641,11 @@ uint16_t encodeLevelClusterStopCommand(uint8_t * buffer, uint16_t buf_length, ui
 uint16_t encodeLevelClusterStopWithOnOffCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                 uint8_t optionsMask, uint8_t optionsOverride)
 {
-    COMMAND_HEADER("LevelStopWithOnOff", LEVEL_CLUSTER_ID, 0x07);
+    const char * kName = "LevelStopWithOnOff";
+    COMMAND_HEADER(kName, LEVEL_CLUSTER_ID, 0x07);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
-    COMMAND_FOOTER("LevelStopWithOnOff");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1620,8 +1677,9 @@ uint16_t encodeLevelClusterReadCurrentLevelAttribute(uint8_t * buffer, uint16_t 
  */
 uint16_t encodeOnOffClusterOffCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
 {
-    COMMAND_HEADER("OnOffOff", ON_OFF_CLUSTER_ID, 0x00);
-    COMMAND_FOOTER("OnOffOff");
+    const char * kName = "OnOffOff";
+    COMMAND_HEADER(kName, ON_OFF_CLUSTER_ID, 0x00);
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1629,8 +1687,9 @@ uint16_t encodeOnOffClusterOffCommand(uint8_t * buffer, uint16_t buf_length, uin
  */
 uint16_t encodeOnOffClusterOnCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
 {
-    COMMAND_HEADER("OnOffOn", ON_OFF_CLUSTER_ID, 0x01);
-    COMMAND_FOOTER("OnOffOn");
+    const char * kName = "OnOffOn";
+    COMMAND_HEADER(kName, ON_OFF_CLUSTER_ID, 0x01);
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1638,8 +1697,9 @@ uint16_t encodeOnOffClusterOnCommand(uint8_t * buffer, uint16_t buf_length, uint
  */
 uint16_t encodeOnOffClusterToggleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
 {
-    COMMAND_HEADER("OnOffToggle", ON_OFF_CLUSTER_ID, 0x02);
-    COMMAND_FOOTER("OnOffToggle");
+    const char * kName = "OnOffToggle";
+    COMMAND_HEADER(kName, ON_OFF_CLUSTER_ID, 0x02);
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1690,14 +1750,18 @@ uint16_t encodeOnOffClusterReadOnOffAttribute(uint8_t * buffer, uint16_t buf_len
  * Command AddScene
  */
 uint16_t encodeScenesClusterAddSceneCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint16_t groupID,
-                                            uint8_t sceneID, uint16_t transitionTime, char * sceneName, void * extensionFieldSets)
+                                            uint8_t sceneID, uint16_t transitionTime, char * sceneName, uint16_t clusterId,
+                                            char * extensionFieldSet)
 {
-    COMMAND_HEADER("ScenesAddScene", SCENES_CLUSTER_ID, 0x00);
+    const char * kName = "ScenesAddScene";
+    COMMAND_HEADER(kName, SCENES_CLUSTER_ID, 0x00);
     buf.PutLE16(groupID);
     buf.Put(sceneID);
     buf.PutLE16(transitionTime);
-    COMMAND_INSERT_STRING("ScenesAddScene", sceneName);
-    COMMAND_FOOTER("ScenesAddScene");
+    COMMAND_INSERT_STRING(kName, sceneName);
+    buf.PutLE16(clusterId);
+    COMMAND_INSERT_STRING(kName, extensionFieldSet);
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1707,13 +1771,14 @@ uint16_t encodeScenesClusterCopySceneCommand(uint8_t * buffer, uint16_t buf_leng
                                              uint16_t groupIdentifierFrom, uint8_t sceneIdentifierFrom, uint16_t groupIdentifierTo,
                                              uint8_t sceneIdentifierTo)
 {
-    COMMAND_HEADER("ScenesCopyScene", SCENES_CLUSTER_ID, 0x42);
+    const char * kName = "ScenesCopyScene";
+    COMMAND_HEADER(kName, SCENES_CLUSTER_ID, 0x42);
     buf.Put(mode);
     buf.PutLE16(groupIdentifierFrom);
     buf.Put(sceneIdentifierFrom);
     buf.PutLE16(groupIdentifierTo);
     buf.Put(sceneIdentifierTo);
-    COMMAND_FOOTER("ScenesCopyScene");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1721,14 +1786,17 @@ uint16_t encodeScenesClusterCopySceneCommand(uint8_t * buffer, uint16_t buf_leng
  */
 uint16_t encodeScenesClusterEnhancedAddSceneCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                     uint16_t groupID, uint8_t sceneID, uint16_t transitionTime, char * sceneName,
-                                                    void * extensionFieldSets)
+                                                    uint16_t clusterId, char * extensionFieldSet)
 {
-    COMMAND_HEADER("ScenesEnhancedAddScene", SCENES_CLUSTER_ID, 0x40);
+    const char * kName = "ScenesEnhancedAddScene";
+    COMMAND_HEADER(kName, SCENES_CLUSTER_ID, 0x40);
     buf.PutLE16(groupID);
     buf.Put(sceneID);
     buf.PutLE16(transitionTime);
-    COMMAND_INSERT_STRING("ScenesEnhancedAddScene", sceneName);
-    COMMAND_FOOTER("ScenesEnhancedAddScene");
+    COMMAND_INSERT_STRING(kName, sceneName);
+    buf.PutLE16(clusterId);
+    COMMAND_INSERT_STRING(kName, extensionFieldSet);
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1737,10 +1805,11 @@ uint16_t encodeScenesClusterEnhancedAddSceneCommand(uint8_t * buffer, uint16_t b
 uint16_t encodeScenesClusterEnhancedViewSceneCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                      uint16_t groupID, uint8_t sceneID)
 {
-    COMMAND_HEADER("ScenesEnhancedViewScene", SCENES_CLUSTER_ID, 0x41);
+    const char * kName = "ScenesEnhancedViewScene";
+    COMMAND_HEADER(kName, SCENES_CLUSTER_ID, 0x41);
     buf.PutLE16(groupID);
     buf.Put(sceneID);
-    COMMAND_FOOTER("ScenesEnhancedViewScene");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1749,9 +1818,10 @@ uint16_t encodeScenesClusterEnhancedViewSceneCommand(uint8_t * buffer, uint16_t 
 uint16_t encodeScenesClusterGetSceneMembershipCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                       uint16_t groupID)
 {
-    COMMAND_HEADER("ScenesGetSceneMembership", SCENES_CLUSTER_ID, 0x06);
+    const char * kName = "ScenesGetSceneMembership";
+    COMMAND_HEADER(kName, SCENES_CLUSTER_ID, 0x06);
     buf.PutLE16(groupID);
-    COMMAND_FOOTER("ScenesGetSceneMembership");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1760,11 +1830,12 @@ uint16_t encodeScenesClusterGetSceneMembershipCommand(uint8_t * buffer, uint16_t
 uint16_t encodeScenesClusterRecallSceneCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                uint16_t groupID, uint8_t sceneID, uint16_t transitionTime)
 {
-    COMMAND_HEADER("ScenesRecallScene", SCENES_CLUSTER_ID, 0x05);
+    const char * kName = "ScenesRecallScene";
+    COMMAND_HEADER(kName, SCENES_CLUSTER_ID, 0x05);
     buf.PutLE16(groupID);
     buf.Put(sceneID);
     buf.PutLE16(transitionTime);
-    COMMAND_FOOTER("ScenesRecallScene");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1773,9 +1844,10 @@ uint16_t encodeScenesClusterRecallSceneCommand(uint8_t * buffer, uint16_t buf_le
 uint16_t encodeScenesClusterRemoveAllScenesCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                    uint16_t groupID)
 {
-    COMMAND_HEADER("ScenesRemoveAllScenes", SCENES_CLUSTER_ID, 0x03);
+    const char * kName = "ScenesRemoveAllScenes";
+    COMMAND_HEADER(kName, SCENES_CLUSTER_ID, 0x03);
     buf.PutLE16(groupID);
-    COMMAND_FOOTER("ScenesRemoveAllScenes");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1784,10 +1856,11 @@ uint16_t encodeScenesClusterRemoveAllScenesCommand(uint8_t * buffer, uint16_t bu
 uint16_t encodeScenesClusterRemoveSceneCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                uint16_t groupID, uint8_t sceneID)
 {
-    COMMAND_HEADER("ScenesRemoveScene", SCENES_CLUSTER_ID, 0x02);
+    const char * kName = "ScenesRemoveScene";
+    COMMAND_HEADER(kName, SCENES_CLUSTER_ID, 0x02);
     buf.PutLE16(groupID);
     buf.Put(sceneID);
-    COMMAND_FOOTER("ScenesRemoveScene");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1796,10 +1869,11 @@ uint16_t encodeScenesClusterRemoveSceneCommand(uint8_t * buffer, uint16_t buf_le
 uint16_t encodeScenesClusterStoreSceneCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint16_t groupID,
                                               uint8_t sceneID)
 {
-    COMMAND_HEADER("ScenesStoreScene", SCENES_CLUSTER_ID, 0x04);
+    const char * kName = "ScenesStoreScene";
+    COMMAND_HEADER(kName, SCENES_CLUSTER_ID, 0x04);
     buf.PutLE16(groupID);
     buf.Put(sceneID);
-    COMMAND_FOOTER("ScenesStoreScene");
+    COMMAND_FOOTER(kName);
 }
 
 /*
@@ -1808,10 +1882,11 @@ uint16_t encodeScenesClusterStoreSceneCommand(uint8_t * buffer, uint16_t buf_len
 uint16_t encodeScenesClusterViewSceneCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint16_t groupID,
                                              uint8_t sceneID)
 {
-    COMMAND_HEADER("ScenesViewScene", SCENES_CLUSTER_ID, 0x01);
+    const char * kName = "ScenesViewScene";
+    COMMAND_HEADER(kName, SCENES_CLUSTER_ID, 0x01);
     buf.PutLE16(groupID);
     buf.Put(sceneID);
-    COMMAND_FOOTER("ScenesViewScene");
+    COMMAND_FOOTER(kName);
 }
 
 /*


### PR DESCRIPTION
…o use simple types as command parameters

 #### Problem
 Currently chip-tool does not support ZCL structures when they are used as an argument to a command. The current PR expand the structure to simple types in order to not expose those structures to the high level API. 
 
 #### Summary of Changes
 * Expand structure to simple types in src/app
 * Expand structure to simple types in examples/chip-tool/commands/clusters/Commands.h