### PR TITLE
Remove EmberAfProfileId and its dependencies

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/af-structs.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/af-structs.h
@@ -398,7 +398,6 @@ typedef struct _DeviceInformationRecord
 {
     uint8_t * ieeeAddress;
     uint8_t endpointId;
-    uint16_t profileId;
     uint16_t deviceId;
     uint8_t version;
     uint8_t groupIdCount;
@@ -417,7 +416,6 @@ typedef struct _EndpointInformationRecord
 {
     uint16_t networkAddress;
     uint8_t endpointId;
-    uint16_t profileId;
     uint16_t deviceId;
     uint8_t version;
 } EndpointInformationRecord;
@@ -428,7 +426,6 @@ typedef struct _GpTranslationTableUpdateTranslation
     uint8_t index;
     uint8_t gpdCommandId;
     uint8_t endpoint;
-    uint16_t profile;
     uint16_t cluster;
     uint8_t zigbeeCommandId;
     uint8_t * zigbeeCommandPayload;

--- a/examples/all-clusters-app/all-clusters-common/gen/callback.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/callback.h
@@ -21982,12 +21982,11 @@ bool emberAfZllCommissioningClusterDeviceInformationResponseCallback(uint32_t tr
  * @param ieeeAddress   Ver.: always
  * @param networkAddress   Ver.: always
  * @param endpointId   Ver.: always
- * @param profileId   Ver.: always
  * @param deviceId   Ver.: always
  * @param version   Ver.: always
  */
 bool emberAfZllCommissioningClusterEndpointInformationCallback(uint8_t * ieeeAddress, uint16_t networkAddress, uint8_t endpointId,
-                                                               uint16_t profileId, uint16_t deviceId, uint8_t version);
+                                                               uint16_t deviceId, uint8_t version);
 /** @brief ZLL Commissioning Cluster Get Endpoint List Request
  *
  *
@@ -22182,7 +22181,6 @@ bool emberAfZllCommissioningClusterScanRequestCallback(uint32_t transaction, uin
  * @param numberOfSubDevices   Ver.: always
  * @param totalGroupIds   Ver.: always
  * @param endpointId   Ver.: always
- * @param profileId   Ver.: always
  * @param deviceId   Ver.: always
  * @param version   Ver.: always
  * @param groupIdCount   Ver.: always
@@ -22191,8 +22189,8 @@ bool emberAfZllCommissioningClusterScanResponseCallback(uint32_t transaction, ui
                                                         uint8_t zllInformation, uint16_t keyBitmask, uint32_t responseId,
                                                         uint8_t * extendedPanId, uint8_t networkUpdateId, uint8_t logicalChannel,
                                                         uint16_t panId, uint16_t networkAddress, uint8_t numberOfSubDevices,
-                                                        uint8_t totalGroupIds, chip::EndpointId endpointId, uint16_t profileId,
-                                                        uint16_t deviceId, uint8_t version, uint8_t groupIdCount);
+                                                        uint8_t totalGroupIds, chip::EndpointId endpointId, uint16_t deviceId,
+                                                        uint8_t version, uint8_t groupIdCount);
 /** @brief ZLL Commissioning Cluster Server Attribute Changed
  *
  * Server Attribute Changed

--- a/examples/lighting-app/lighting-common/gen/af-structs.h
+++ b/examples/lighting-app/lighting-common/gen/af-structs.h
@@ -398,7 +398,6 @@ typedef struct _DeviceInformationRecord
 {
     uint8_t * ieeeAddress;
     uint8_t endpointId;
-    uint16_t profileId;
     uint16_t deviceId;
     uint8_t version;
     uint8_t groupIdCount;
@@ -417,7 +416,6 @@ typedef struct _EndpointInformationRecord
 {
     uint16_t networkAddress;
     uint8_t endpointId;
-    uint16_t profileId;
     uint16_t deviceId;
     uint8_t version;
 } EndpointInformationRecord;
@@ -428,7 +426,6 @@ typedef struct _GpTranslationTableUpdateTranslation
     uint8_t index;
     uint8_t gpdCommandId;
     uint8_t endpoint;
-    uint16_t profile;
     uint16_t cluster;
     uint8_t zigbeeCommandId;
     uint8_t * zigbeeCommandPayload;

--- a/examples/lighting-app/lighting-common/gen/callback.h
+++ b/examples/lighting-app/lighting-common/gen/callback.h
@@ -21980,12 +21980,11 @@ bool emberAfZllCommissioningClusterDeviceInformationResponseCallback(uint32_t tr
  * @param ieeeAddress   Ver.: always
  * @param networkAddress   Ver.: always
  * @param endpointId   Ver.: always
- * @param profileId   Ver.: always
  * @param deviceId   Ver.: always
  * @param version   Ver.: always
  */
 bool emberAfZllCommissioningClusterEndpointInformationCallback(uint8_t * ieeeAddress, uint16_t networkAddress, uint8_t endpointId,
-                                                               uint16_t profileId, uint16_t deviceId, uint8_t version);
+                                                               uint16_t deviceId, uint8_t version);
 /** @brief ZLL Commissioning Cluster Get Endpoint List Request
  *
  *
@@ -22180,7 +22179,6 @@ bool emberAfZllCommissioningClusterScanRequestCallback(uint32_t transaction, uin
  * @param numberOfSubDevices   Ver.: always
  * @param totalGroupIds   Ver.: always
  * @param endpointId   Ver.: always
- * @param profileId   Ver.: always
  * @param deviceId   Ver.: always
  * @param version   Ver.: always
  * @param groupIdCount   Ver.: always
@@ -22189,8 +22187,8 @@ bool emberAfZllCommissioningClusterScanResponseCallback(uint32_t transaction, ui
                                                         uint8_t zllInformation, uint16_t keyBitmask, uint32_t responseId,
                                                         uint8_t * extendedPanId, uint8_t networkUpdateId, uint8_t logicalChannel,
                                                         uint16_t panId, uint16_t networkAddress, uint8_t numberOfSubDevices,
-                                                        uint8_t totalGroupIds, chip::EndpointId endpointId, uint16_t profileId,
-                                                        uint16_t deviceId, uint8_t version, uint8_t groupIdCount);
+                                                        uint8_t totalGroupIds, chip::EndpointId endpointId, uint16_t deviceId,
+                                                        uint8_t version, uint8_t groupIdCount);
 /** @brief ZLL Commissioning Cluster Server Attribute Changed
  *
  * Server Attribute Changed

--- a/examples/lock-app/lock-common/gen/af-structs.h
+++ b/examples/lock-app/lock-common/gen/af-structs.h
@@ -398,7 +398,6 @@ typedef struct _DeviceInformationRecord
 {
     uint8_t * ieeeAddress;
     uint8_t endpointId;
-    uint16_t profileId;
     uint16_t deviceId;
     uint8_t version;
     uint8_t groupIdCount;
@@ -417,7 +416,6 @@ typedef struct _EndpointInformationRecord
 {
     uint16_t networkAddress;
     uint8_t endpointId;
-    uint16_t profileId;
     uint16_t deviceId;
     uint8_t version;
 } EndpointInformationRecord;
@@ -428,7 +426,6 @@ typedef struct _GpTranslationTableUpdateTranslation
     uint8_t index;
     uint8_t gpdCommandId;
     uint8_t endpoint;
-    uint16_t profile;
     uint16_t cluster;
     uint8_t zigbeeCommandId;
     uint8_t * zigbeeCommandPayload;

--- a/examples/lock-app/lock-common/gen/callback.h
+++ b/examples/lock-app/lock-common/gen/callback.h
@@ -21981,12 +21981,11 @@ bool emberAfZllCommissioningClusterDeviceInformationResponseCallback(uint32_t tr
  * @param ieeeAddress   Ver.: always
  * @param networkAddress   Ver.: always
  * @param endpointId   Ver.: always
- * @param profileId   Ver.: always
  * @param deviceId   Ver.: always
  * @param version   Ver.: always
  */
 bool emberAfZllCommissioningClusterEndpointInformationCallback(uint8_t * ieeeAddress, uint16_t networkAddress, uint8_t endpointId,
-                                                               uint16_t profileId, uint16_t deviceId, uint8_t version);
+                                                               uint16_t deviceId, uint8_t version);
 /** @brief ZLL Commissioning Cluster Get Endpoint List Request
  *
  *
@@ -22181,7 +22180,6 @@ bool emberAfZllCommissioningClusterScanRequestCallback(uint32_t transaction, uin
  * @param numberOfSubDevices   Ver.: always
  * @param totalGroupIds   Ver.: always
  * @param endpointId   Ver.: always
- * @param profileId   Ver.: always
  * @param deviceId   Ver.: always
  * @param version   Ver.: always
  * @param groupIdCount   Ver.: always
@@ -22190,8 +22188,8 @@ bool emberAfZllCommissioningClusterScanResponseCallback(uint32_t transaction, ui
                                                         uint8_t zllInformation, uint16_t keyBitmask, uint32_t responseId,
                                                         uint8_t * extendedPanId, uint8_t networkUpdateId, uint8_t logicalChannel,
                                                         uint16_t panId, uint16_t networkAddress, uint8_t numberOfSubDevices,
-                                                        uint8_t totalGroupIds, chip::EndpointId endpointId, uint16_t profileId,
-                                                        uint16_t deviceId, uint8_t version, uint8_t groupIdCount);
+                                                        uint8_t totalGroupIds, chip::EndpointId endpointId, uint16_t deviceId,
+                                                        uint8_t version, uint8_t groupIdCount);
 /** @brief ZLL Commissioning Cluster Server Attribute Changed
  *
  * Server Attribute Changed

--- a/examples/temperature-measurement-app/esp32/main/gen/af-structs.h
+++ b/examples/temperature-measurement-app/esp32/main/gen/af-structs.h
@@ -379,7 +379,6 @@ typedef struct _DeviceInformationRecord
 {
     uint8_t * ieeeAddress;
     uint8_t endpointId;
-    uint16_t profileId;
     uint16_t deviceId;
     uint8_t version;
     uint8_t groupIdCount;
@@ -398,7 +397,6 @@ typedef struct _EndpointInformationRecord
 {
     uint16_t networkAddress;
     uint8_t endpointId;
-    uint16_t profileId;
     uint16_t deviceId;
     uint8_t version;
 } EndpointInformationRecord;
@@ -409,7 +407,6 @@ typedef struct _GpTranslationTableUpdateTranslation
     uint8_t index;
     uint8_t gpdCommandId;
     uint8_t endpoint;
-    uint16_t profile;
     uint16_t cluster;
     uint8_t zigbeeCommandId;
     uint8_t * zigbeeCommandPayload;

--- a/examples/temperature-measurement-app/esp32/main/gen/callback.h
+++ b/examples/temperature-measurement-app/esp32/main/gen/callback.h
@@ -21958,12 +21958,11 @@ bool emberAfZllCommissioningClusterDeviceInformationResponseCallback(uint32_t tr
  * @param ieeeAddress   Ver.: always
  * @param networkAddress   Ver.: always
  * @param endpointId   Ver.: always
- * @param profileId   Ver.: always
  * @param deviceId   Ver.: always
  * @param version   Ver.: always
  */
 bool emberAfZllCommissioningClusterEndpointInformationCallback(uint8_t * ieeeAddress, uint16_t networkAddress, uint8_t endpointId,
-                                                               uint16_t profileId, uint16_t deviceId, uint8_t version);
+                                                               uint16_t deviceId, uint8_t version);
 /** @brief ZLL Commissioning Cluster Get Endpoint List Request
  *
  *
@@ -22158,7 +22157,6 @@ bool emberAfZllCommissioningClusterScanRequestCallback(uint32_t transaction, uin
  * @param numberOfSubDevices   Ver.: always
  * @param totalGroupIds   Ver.: always
  * @param endpointId   Ver.: always
- * @param profileId   Ver.: always
  * @param deviceId   Ver.: always
  * @param version   Ver.: always
  * @param groupIdCount   Ver.: always
@@ -22167,8 +22165,8 @@ bool emberAfZllCommissioningClusterScanResponseCallback(uint32_t transaction, ui
                                                         uint8_t zllInformation, uint16_t keyBitmask, uint32_t responseId,
                                                         uint8_t * extendedPanId, uint8_t networkUpdateId, uint8_t logicalChannel,
                                                         uint16_t panId, uint16_t networkAddress, uint8_t numberOfSubDevices,
-                                                        uint8_t totalGroupIds, chip::EndpointId endpointId, uint16_t profileId,
-                                                        uint16_t deviceId, uint8_t version, uint8_t groupIdCount);
+                                                        uint8_t totalGroupIds, chip::EndpointId endpointId, uint16_t deviceId,
+                                                        uint8_t version, uint8_t groupIdCount);
 /** @brief ZLL Commissioning Cluster Server Attribute Changed
  *
  * Server Attribute Changed

--- a/src/app/chip-zcl-zpro-codec.h
+++ b/src/app/chip-zcl-zpro-codec.h
@@ -28,8 +28,6 @@ typedef uint16_t EmberApsOption;
  */
 typedef struct
 {
-    /** The application profile ID that describes the format of the message. */
-    uint16_t profileId;
     /** The cluster ID for this message. */
     chip::ClusterId clusterId;
     /** The source endpoint. */

--- a/src/app/clusters/ias-zone-client/ias-zone-client.cpp
+++ b/src/app/clusters/ias-zone-client/ias-zone-client.cpp
@@ -444,7 +444,6 @@ static void iasZoneClientServiceDiscoveryCallback(const EmberAfServiceDiscoveryR
 static void checkForIasZoneServer(EmberNodeId emberNodeId, uint8_t * ieeeAddress)
 {
     uint8_t endpointIndex = emberAfIndexFromEndpoint(myEndpoint);
-    uint16_t profileId    = emberAfProfileIdFromIndex(endpointIndex);
     uint8_t serverIndex   = addServer(emberNodeId, ieeeAddress);
 
     if (serverIndex == NO_INDEX)
@@ -465,9 +464,9 @@ static void checkForIasZoneServer(EmberNodeId emberNodeId, uint8_t * ieeeAddress
         return;
     }
 
-    EmberStatus status = emberAfFindDevicesByProfileAndCluster(emberNodeId, profileId, ZCL_IAS_ZONE_CLUSTER_ID,
-                                                               true, // server cluster?
-                                                               iasZoneClientServiceDiscoveryCallback);
+    EmberStatus status = emberAfFindDevicesByCluster(emberNodeId, ZCL_IAS_ZONE_CLUSTER_ID,
+                                                     true, // server cluster?
+                                                     iasZoneClientServiceDiscoveryCallback);
 
     if (status != EMBER_SUCCESS)
     {

--- a/src/app/decoder.cpp
+++ b/src/app/decoder.cpp
@@ -47,7 +47,6 @@ uint16_t extractApsFrame(uint8_t * buffer, uint16_t buf_length, EmberApsFrame * 
     // Skip first byte, because that's the always-0 frame control.
     uint8_t ignored;
     err = reader.ReadOctet(&ignored)
-              .Read16(&outApsFrame->profileId)
               .ReadClusterId(&outApsFrame->clusterId)
               .ReadEndpointId(&outApsFrame->sourceEndpoint)
               .ReadEndpointId(&outApsFrame->destinationEndpoint)
@@ -64,12 +63,11 @@ exit:
 
 void printApsFrame(EmberApsFrame * frame)
 {
-    ChipLogProgress(
-        Zcl,
-        "\n<EmberApsFrame %p> profileID %d, clusterID %d, sourceEndpoint %d, destinationEndPoint %d, options %d, groupID %d, "
-        "sequence %d, radius %d\n",
-        frame, frame->profileId, frame->clusterId, frame->sourceEndpoint, frame->destinationEndpoint, frame->options,
-        frame->groupId, frame->sequence, frame->radius);
+    ChipLogProgress(Zcl,
+                    "\n<EmberApsFrame %p> clusterID %d, sourceEndpoint %d, destinationEndPoint %d, options %d, groupID %d, "
+                    "sequence %d, radius %d\n",
+                    frame, frame->clusterId, frame->sourceEndpoint, frame->destinationEndpoint, frame->options, frame->groupId,
+                    frame->sequence, frame->radius);
 }
 
 uint16_t extractMessage(uint8_t * buffer, uint16_t buffer_length, uint8_t ** msg)

--- a/src/app/encoder.cpp
+++ b/src/app/encoder.cpp
@@ -211,14 +211,12 @@ extern "C" {
 #define SCENES_CLUSTER_ID 0x0005
 #define TEMPERATURE_MEASUREMENT_CLUSTER_ID 0x0402
 
-static uint16_t doEncodeApsFrame(BufBound & buf, uint16_t profileID, ClusterId clusterId, EndpointId sourceEndpoint,
-                                 EndpointId destinationEndpoint, EmberApsOption options, GroupId groupId, uint8_t sequence,
-                                 uint8_t radius, bool isMeasuring)
+static uint16_t doEncodeApsFrame(BufBound & buf, ClusterId clusterId, EndpointId sourceEndpoint, EndpointId destinationEndpoint,
+                                 EmberApsOption options, GroupId groupId, uint8_t sequence, uint8_t radius, bool isMeasuring)
 {
 
     uint8_t control_byte = 0;
     buf.Put(control_byte); // Put in a control byte
-    buf.PutLE16(profileID);
     buf.PutLE16(clusterId);
     buf.Put(sourceEndpoint);
     buf.Put(destinationEndpoint);
@@ -251,8 +249,8 @@ static uint16_t doEncodeApsFrame(BufBound & buf, uint16_t profileID, ClusterId c
 uint16_t encodeApsFrame(uint8_t * buffer, uint16_t buf_length, EmberApsFrame * apsFrame)
 {
     BufBound buf = BufBound(buffer, buf_length);
-    return doEncodeApsFrame(buf, apsFrame->profileId, apsFrame->clusterId, apsFrame->sourceEndpoint, apsFrame->destinationEndpoint,
-                            apsFrame->options, apsFrame->groupId, apsFrame->sequence, apsFrame->radius, !buffer);
+    return doEncodeApsFrame(buf, apsFrame->clusterId, apsFrame->sourceEndpoint, apsFrame->destinationEndpoint, apsFrame->options,
+                            apsFrame->groupId, apsFrame->sequence, apsFrame->radius, !buffer);
 }
 
 uint16_t _encodeCommand(BufBound & buf, EndpointId destination_endpoint, ClusterId cluster_id, CommandId command,
@@ -260,12 +258,10 @@ uint16_t _encodeCommand(BufBound & buf, EndpointId destination_endpoint, Cluster
 {
     CHECK_FRAME_LENGTH(buf.Size(), "Buffer is empty");
 
-    uint8_t seq_num         = 1;     // Transaction sequence number.  Just pick something.
-    uint8_t source_endpoint = 1;     // Pick source endpoint as 1 for now.
-    uint16_t profile_id     = 65535; // Profile is 65535 because that matches our simple generated code, but we
-                                     // should sort out the profile situation.
+    uint8_t seq_num         = 1; // Transaction sequence number.  Just pick something.
+    uint8_t source_endpoint = 1; // Pick source endpoint as 1 for now.
 
-    if (doEncodeApsFrame(buf, profile_id, cluster_id, source_endpoint, destination_endpoint, 0, 0, 0, 0, false))
+    if (doEncodeApsFrame(buf, cluster_id, source_endpoint, destination_endpoint, 0, 0, 0, 0, false))
     {
         buf.Put(frame_control);
         buf.Put(seq_num);

--- a/src/app/util/af-main-common.cpp
+++ b/src/app/util/af-main-common.cpp
@@ -233,13 +233,11 @@ static EmberStatus send(EmberOutgoingMessageType type, uint64_t indexOrDestinati
     }
 
     // The source endpoint in the APS frame MUST be valid at this point.  We use
-    // it to set the appropriate outgoing network as well as the profile id in
-    // the APS frame.
+    // it to set the appropriate outgoing network in the APS frame.
     EmberAfEndpointInfoStruct endpointInfo;
     uint8_t networkIndex = 0;
     if (emberAfGetEndpointInfoCallback(apsFrame->sourceEndpoint, &networkIndex, &endpointInfo))
     {
-        apsFrame->profileId = endpointInfo.profileId;
         //        status              = emberAfPushNetworkIndex(networkIndex);
         //        if (status != EMBER_SUCCESS)
         //        {
@@ -258,7 +256,6 @@ static EmberStatus send(EmberOutgoingMessageType type, uint64_t indexOrDestinati
         //        {
         //            return status;
         //        }
-        apsFrame->profileId = emberAfProfileIdFromIndex(index);
     }
 
 #ifdef EMBER_AF_PLUGIN_SUB_GHZ_CLIENT
@@ -502,8 +499,7 @@ EmberStatus emberAfSendUnicastToBindings(EmberApsFrame * apsFrame, uint16_t mess
 }
 
 EmberStatus emberAfSendInterPan(EmberPanId panId, const EmberEUI64 destinationLongId, EmberNodeId destinationShortId,
-                                GroupId multicastId, ClusterId clusterId, EmberAfProfileId profileId, uint16_t messageLength,
-                                uint8_t * messageBytes)
+                                GroupId multicastId, ClusterId clusterId, uint16_t messageLength, uint8_t * messageBytes)
 {
     EmberAfInterpanHeader header;
     memset(&header, 0, sizeof(EmberAfInterpanHeader));
@@ -525,7 +521,6 @@ EmberStatus emberAfSendInterPan(EmberPanId panId, const EmberEUI64 destinationLo
         header.messageType =
             (destinationShortId < EMBER_BROADCAST_ADDRESS ? EMBER_AF_INTER_PAN_UNICAST : EMBER_AF_INTER_PAN_BROADCAST);
     }
-    header.profileId = profileId;
     header.clusterId = clusterId;
     return emberAfInterpanSendMessageCallback(&header, messageLength, messageBytes);
 }
@@ -557,7 +552,7 @@ void emAfPrintStatus(const char * task, EmberStatus status)
 
 static void printMessage(EmberIncomingMessageType type, EmberApsFrame * apsFrame, uint16_t messageLength, uint8_t * messageContents)
 {
-    emberAfAppPrint("Profile: 0x%2X, Cluster: 0x%2X, %d bytes,", apsFrame->profileId, apsFrame->clusterId, messageLength);
+    emberAfAppPrint("Cluster: 0x%2X, %d bytes,", apsFrame->clusterId, messageLength);
     if (messageLength >= 3)
     {
         emberAfAppPrint(" ZCL %p Cmd ID: %d", (messageContents[0] & ZCL_CLUSTER_SPECIFIC_COMMAND ? "Cluster" : "Global"),

--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -84,15 +84,9 @@ typedef void (*EmberAfGenericClusterFunction)(void);
 
 /**
  * @brief A distinguished manufacturer code that is used to indicate the
- * absence of a manufacturer-specific profile, cluster, command, or attribute.
+ * absence of a manufacturer-specific cluster, command, or attribute.
  */
 #define EMBER_AF_NULL_MANUFACTURER_CODE 0x0000
-
-/**
- * @brief An invalid profile ID
- * This is a reserved profileId.
- */
-#define EMBER_AF_INVALID_PROFILE_ID 0xFFFF
 
 /**
  * @brief Type for default values.
@@ -387,7 +381,6 @@ typedef struct
     /**
      * APS data
      */
-    EmberAfProfileId profileId;
     chip::ClusterId clusterId;
     /**
      * The groupId is only used for
@@ -417,7 +410,6 @@ typedef uint8_t EmberAfAllowedInterpanOptions;
  */
 typedef struct
 {
-    EmberAfProfileId profileId;
     chip::ClusterId clusterId;
     chip::CommandId commandId;
     EmberAfAllowedInterpanOptions options;
@@ -507,10 +499,6 @@ typedef struct
      * Actual zigbee endpoint number.
      */
     chip::EndpointId endpoint;
-    /**
-     * Profile ID of the device on this endpoint.
-     */
-    EmberAfProfileId profileId;
     /**
      * Device ID of the device on this endpoint.
      */
@@ -675,7 +663,6 @@ typedef struct
     const chip::ClusterId * inClusterList;
     uint8_t outClusterCount;
     const chip::ClusterId * outClusterList;
-    EmberAfProfileId profileId;
     uint16_t deviceId;
     chip::EndpointId endpoint;
 } EmberAfClusterList;
@@ -1133,7 +1120,6 @@ typedef struct
 {
     EmberNodeId networkAddress;
     chip::EndpointId endpointId;
-    uint16_t profileId;
     uint16_t deviceId;
     uint8_t version;
 } EmberAfPluginZllCommissioningEndpointInformationRecord;
@@ -1634,7 +1620,6 @@ typedef uint16_t EmberAfRemoteClusterType;
 typedef struct
 {
     chip::ClusterId clusterId;
-    EmberAfProfileId profileId;
     uint16_t deviceId;
     chip::EndpointId endpoint;
     EmberAfRemoteClusterType type;
@@ -1669,7 +1654,6 @@ typedef struct
 typedef struct
 {
     EmberAfClusterInfo clusters[EMBER_AF_MAX_CLUSTERS_PER_ENDPOINT];
-    EmberAfProfileId profileId;
     uint16_t deviceId;
     chip::EndpointId endpoint;
     uint8_t clusterCount;

--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -471,11 +471,6 @@ uint8_t emberAfFindClusterClientEndpointIndex(chip::EndpointId endpoint, chip::C
 uint8_t emberAfFindClusterServerEndpointIndex(chip::EndpointId endpoint, chip::ClusterId clusterId);
 
 /**
- * @brief Macro that takes index of endpoint, and returns profile Id for it
- */
-#define emberAfProfileIdFromIndex(index) (emAfEndpoints[(index)].profileId)
-
-/**
  * @brief Macro that takes index of endpoint, and returns device Id for it
  */
 #define emberAfDeviceIdFromIndex(index) (emAfEndpoints[(index)].deviceId)
@@ -489,14 +484,6 @@ uint8_t emberAfFindClusterServerEndpointIndex(chip::EndpointId endpoint, chip::C
  * @brief Macro that takes index of endpoint, and returns network index for it
  */
 #define emberAfNetworkIndexFromEndpointIndex(index) (emAfEndpoints[(index)].networkIndex)
-
-/**
- * @brief Macro that returns primary profile ID.
- *
- * Primary profile is the profile of a primary endpoint as defined
- * in AppBuilder.
- */
-#define emberAfPrimaryProfileId() emberAfProfileIdFromIndex(0)
 
 /**
  * @brief Macro that returns the primary endpoint.
@@ -1324,8 +1311,8 @@ EmberStatus emberAfSendUnicastToBindingsWithCallback(EmberApsFrame * apsFrame, u
  * @brief Sends interpan message.
  */
 EmberStatus emberAfSendInterPan(EmberPanId panId, const EmberEUI64 destinationLongId, EmberNodeId destinationShortId,
-                                chip::GroupId multicastId, chip::ClusterId clusterId, EmberAfProfileId profileId,
-                                uint16_t messageLength, uint8_t * messageBytes);
+                                chip::GroupId multicastId, chip::ClusterId clusterId, uint16_t messageLength,
+                                uint8_t * messageBytes);
 
 /**
  * @brief Sends end device binding request.
@@ -1435,7 +1422,7 @@ EmberStatus emberAfSendCommandBroadcastWithAlias(EmberNodeId destination, EmberN
  * multicastId is not zero, the message will be sent using multicast mode.
  */
 EmberStatus emberAfSendCommandInterPan(EmberPanId panId, const EmberEUI64 destinationLongId, EmberNodeId destinationShortId,
-                                       chip::GroupId multicastId, EmberAfProfileId profileId);
+                                       chip::GroupId multicastId);
 
 /**
  * @brief Sends a default response to a cluster command.
@@ -1504,19 +1491,19 @@ void emberAfSetCommandEndpoints(chip::EndpointId sourceEndpoint, chip::EndpointI
 
 /**
  * @brief Friendly define for use in discovering client clusters with
- * ::emberAfFindDevicesByProfileAndCluster().
+ * ::emberAfFindDevicesByCluster().
  */
 #define EMBER_AF_CLIENT_CLUSTER_DISCOVERY false
 
 /**
  * @brief Friendly define for use in discovering server clusters with
- * ::emberAfFindDevicesByProfileAndCluster().
+ * ::emberAfFindDevicesByCluster().
  */
 #define EMBER_AF_SERVER_CLUSTER_DISCOVERY true
 
 /**
  * @brief Use this function to find devices in the network with endpoints
- *   matching a given profile ID and cluster ID in their descriptors.
+ *   matching a given cluster ID in their descriptors.
  *   Target may either be a specific device, or the broadcast
  *   address EMBER_RX_ON_WHEN_IDLE_BROADCAST_ADDRESS.
  *
@@ -1530,7 +1517,6 @@ void emberAfSetCommandEndpoints(chip::EndpointId sourceEndpoint, chip::EndpointI
  *
  * @param target The destination node ID for the discovery; either a specific
  *  node's ID or EMBER_RX_ON_WHEN_IDLE_BROADCAST_ADDRESS.
- * @param profileId The application profile for the cluster being discovered.
  * @param clusterId The cluster being discovered.
  * @param serverCluster EMBER_AF_SERVER_CLUSTER_DISCOVERY (true) if discovering
  *  servers for the target cluster; EMBER_AF_CLIENT_CLUSTER_DISCOVERY (false)
@@ -1539,8 +1525,8 @@ void emberAfSetCommandEndpoints(chip::EndpointId sourceEndpoint, chip::EndpointI
  *  a match is discovered.  (For broadcast discoveries, this is called once per
  *  matching node, even if a node has multiple matching endpoints.)
  */
-EmberStatus emberAfFindDevicesByProfileAndCluster(EmberNodeId target, EmberAfProfileId profileId, chip::ClusterId clusterId,
-                                                  bool serverCluster, EmberAfServiceDiscoveryCallback * callback);
+EmberStatus emberAfFindDevicesByCluster(EmberNodeId target, chip::ClusterId clusterId, bool serverCluster,
+                                        EmberAfServiceDiscoveryCallback * callback);
 
 /**
  * @brief Use this function to find all of the given in and out clusters

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -99,7 +99,6 @@ const uint16_t attributeManufacturerCodeCount                   = GENERATED_ATTR
 
 #if !defined(EMBER_SCRIPTED_TEST)
 #define endpointNumber(x) fixedEndpoints[x]
-#define endpointProfileId(x) fixedProfileIds[x]
 #define endpointDeviceId(x) fixedDeviceIds[x]
 #define endpointDeviceVersion(x) fixedDeviceVersions[x]
 // Added 'Macro' to silence MISRA warning about conflict with synonymous vars.
@@ -122,7 +121,6 @@ void emberAfEndpointConfigure(void)
 
 #if !defined(EMBER_SCRIPTED_TEST)
     uint8_t fixedEndpoints[]            = FIXED_ENDPOINT_ARRAY;
-    uint16_t fixedProfileIds[]          = FIXED_PROFILE_IDS;
     uint16_t fixedDeviceIds[]           = FIXED_DEVICE_IDS;
     uint8_t fixedDeviceVersions[]       = FIXED_DEVICE_VERSIONS;
     uint8_t fixedEmberAfEndpointTypes[] = FIXED_ENDPOINT_TYPES;
@@ -133,7 +131,6 @@ void emberAfEndpointConfigure(void)
     for (ep = 0; ep < FIXED_ENDPOINT_COUNT; ep++)
     {
         emAfEndpoints[ep].endpoint      = endpointNumber(ep);
-        emAfEndpoints[ep].profileId     = endpointProfileId(ep);
         emAfEndpoints[ep].deviceId      = endpointDeviceId(ep);
         emAfEndpoints[ep].deviceVersion = endpointDeviceVersion(ep);
         emAfEndpoints[ep].endpointType  = endpointTypeMacro(ep);
@@ -953,22 +950,12 @@ EmberAfCluster * emberAfGetClusterByIndex(EndpointId endpoint, uint8_t clusterIn
     return &(definedEndpoint->endpointType->cluster[clusterIndex]);
 }
 
-EmberAfProfileId emberAfGetProfileIdForEndpoint(EndpointId endpoint)
-{
-    uint8_t endpointIndex = emberAfIndexFromEndpoint(endpoint);
-    if (endpointIndex == 0xFF)
-    {
-        return EMBER_AF_INVALID_PROFILE_ID;
-    }
-    return emAfEndpoints[endpointIndex].profileId;
-}
-
 uint16_t emberAfGetDeviceIdForEndpoint(EndpointId endpoint)
 {
     uint8_t endpointIndex = emberAfIndexFromEndpoint(endpoint);
     if (endpointIndex == 0xFF)
     {
-        return EMBER_AF_INVALID_PROFILE_ID;
+        return 0xFFFF;
     }
     return emAfEndpoints[endpointIndex].deviceId;
 }

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -219,5 +219,4 @@ bool emberAfEndpointIsEnabled(chip::EndpointId endpoint);
 uint8_t emberAfGetClusterCountForEndpoint(chip::EndpointId endpoint);
 EmberAfCluster * emberAfGetClusterByIndex(chip::EndpointId endpoint, uint8_t clusterIndex);
 
-EmberAfProfileId emberAfGetProfileIdForEndpoint(chip::EndpointId endpoint);
 uint16_t emberAfGetDeviceIdForEndpoint(chip::EndpointId endpoint);

--- a/src/app/util/basic-types.h
+++ b/src/app/util/basic-types.h
@@ -35,10 +35,3 @@ typedef uint16_t AttributeId;
 typedef uint16_t GroupId;
 typedef uint8_t CommandId;
 } // namespace chip
-
-/**
- * @brief Type for referring to zigbee application profile id
- *        TODO: This is probably not needed for CHIP and should be removed.
- *        https://github.com/project-chip/connectedhomeip/issues/3444
- */
-typedef uint16_t EmberAfProfileId;

--- a/src/app/util/client-api.cpp
+++ b/src/app/util/client-api.cpp
@@ -351,10 +351,9 @@ EmberStatus emberAfSendCommandMulticastToBindings(void)
 // }
 
 // EmberStatus emberAfSendCommandInterPan(EmberPanId panId, const EmberEUI64 destinationLongId, EmberNodeId destinationShortId,
-//                                        GroupId multicastId, EmberAfProfileId profileId)
+//                                        GroupId multicastId)
 // {
 //     return emberAfSendInterPan(panId, destinationLongId, destinationShortId, multicastId, emAfCommandApsFrame->clusterId,
-//     profileId,
 //                                *emAfResponseLengthPtr, emAfZclBuffer);
 // }
 

--- a/src/app/util/config.h
+++ b/src/app/util/config.h
@@ -97,10 +97,6 @@
 #define ZA_END_DEVICE 3
 #define ZA_SLEEPY_END_DEVICE 4
 
-#define CBA_PROFILE_ID (0x0105)
-#define HA_PROFILE_ID (0x0104)
-#define SE_PROFILE_ID (0x0109)
-
 // A subtle distniction:
 //   EMBER_AF_MANUFACTURER_CODE is the MFG code set by AppBuilder
 //     for use in the App Framework (AF).  If not set by AppBuilder we default
@@ -136,11 +132,7 @@
 // The maximum APS payload, not including any APS options.  This value is also
 // available from emberMaximumApsPayloadLength() or ezspMaximumPayloadLength().
 // See http://portal.ember.com/faq/payload for more information.
-#ifdef EMBER_AF_HAS_SECURITY_PROFILE_NONE
-#define EMBER_AF_MAXIMUM_APS_PAYLOAD_LENGTH 100 - EMBER_AF_SOURCE_ROUTING_RESERVED_PAYLOAD_LENGTH
-#else
 #define EMBER_AF_MAXIMUM_APS_PAYLOAD_LENGTH 82 - EMBER_AF_SOURCE_ROUTING_RESERVED_PAYLOAD_LENGTH
-#endif
 
 // Max PHY size = 128
 //   -1 byte for PHY length
@@ -184,18 +176,8 @@
 // Defines needed for enabling security
 //
 
-// Unless we are not using security, our stack profile is 2 (ZigBee Pro).  The
-// stack will set up other configuration values based on profile.
-#ifndef EMBER_AF_HAS_SECURITY_PROFILE_NONE
+// Our stack profile is 2 (ZigBee Pro).
 #define EMBER_STACK_PROFILE 2
-#else
-#ifndef EMBER_STACK_PROFILE
-#define EMBER_STACK_PROFILE 0
-#endif
-#ifndef EMBER_SECURITY_LEVEL
-#define EMBER_SECURITY_LEVEL 0
-#endif
-#endif
 
 // *******************************************************************
 // Application Handlers
@@ -283,12 +265,6 @@
 #error "Custom options cannot be used with the standard network init"
 #endif
 #else
-#ifdef EMBER_AF_HAS_SECURITY_PROFILE_Z3 // Z3 Compliant end devices must send a rejoin request on reboot
-#define Z3_NETWORK_INIT_BEHAVIOR EMBER_NETWORK_INIT_END_DEVICE_REJOIN_ON_REBOOT
-#else // EMBER_AF_HAS_SECURITY_PROFILE_Z3
-#define Z3_NETWORK_INIT_BEHAVIOR EMBER_NETWORK_INIT_NO_OPTIONS
-#endif // EMBER_AF_HAS_SECURITY_PROFILE_Z3
-
 // We always want to store our parent info in a token. This prevents doing an
 // orphan scan upon reboot, which can suffer from the multiple-parent-
 // responses issue

--- a/src/app/util/types_stub.h
+++ b/src/app/util/types_stub.h
@@ -414,8 +414,6 @@ enum
 
 typedef struct
 {
-    /** Identifies the endpoint's application profile. */
-    uint16_t profileId;
     /** The endpoint's device ID within the application profile. */
     uint16_t deviceId;
     /** The endpoint's device version. */
@@ -749,16 +747,6 @@ typedef struct
     uint8_t power;
     uint8_t timeout;
 } EmberChildData;
-
-/**
- * @brief The profile ID used to address all the public profiles.
- */
-#define EMBER_WILDCARD_PROFILE_ID 0xFFFF
-
-/**
- * @brief The maximum value for a profile ID in the standard profile range.
- */
-#define EMBER_MAXIMUM_STANDARD_PROFILE_ID 0x7FFF
 
 /**
  * @brief A distinguished network ID that will never be assigned

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -216,7 +216,6 @@ EmberAfDifferenceType emberAfGetDifference(uint8_t * pData, EmberAfDifferenceTyp
 
 static void prepareForResponse(const EmberAfClusterCommand * cmd)
 {
-    emberAfResponseApsFrame.profileId           = cmd->apsFrame->profileId;
     emberAfResponseApsFrame.clusterId           = cmd->apsFrame->clusterId;
     emberAfResponseApsFrame.sourceEndpoint      = cmd->apsFrame->destinationEndpoint;
     emberAfResponseApsFrame.destinationEndpoint = cmd->apsFrame->sourceEndpoint;
@@ -429,15 +428,6 @@ static bool dispatchZclMessage(EmberAfClusterCommand * cmd)
         emberAfDebugPrint("Drop cluster 0x%2x command 0x%x", cmd->apsFrame->clusterId, cmd->commandId);
         emberAfDebugPrint(" for endpoint 0x%x due to wrong %s: ", cmd->apsFrame->destinationEndpoint, "network");
         emberAfDebugPrintln("%d", cmd->networkIndex);
-        return false;
-    }
-    else if (emberAfProfileIdFromIndex(index) != cmd->apsFrame->profileId &&
-             (cmd->apsFrame->profileId != EMBER_WILDCARD_PROFILE_ID ||
-              (EMBER_MAXIMUM_STANDARD_PROFILE_ID < emberAfProfileIdFromIndex(index))))
-    {
-        emberAfDebugPrint("Drop cluster 0x%2x command 0x%x", cmd->apsFrame->clusterId, cmd->commandId);
-        emberAfDebugPrint(" for endpoint 0x%x due to wrong %s: ", cmd->apsFrame->destinationEndpoint, "profile");
-        emberAfDebugPrintln("0x%02x", cmd->apsFrame->profileId);
         return false;
     }
 #ifdef EMBER_AF_PLUGIN_GROUPS_SERVER


### PR DESCRIPTION
 #### Problem
  EmberAfProfileId will likely not be used.

I also removes methods that use the profile id and are related to security. My understanding so far is that all messages will be encrypted anyway...

 #### Summary of Changes
 * Remove references to emberAfProfileId
 * Remove methods that use the profile and are related to security. 

Fixes #3444