### PR TITLE
Add a buffer reader helper class that can be used to read buffers safely.

### DIFF
--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -49,6 +49,7 @@ static_library("support") {
     "Base64.h",
     "BitFlags.h",
     "BufBound.h",
+    "BufferReader.h",
     "CHIPArgParser.cpp",
     "CHIPCounter.cpp",
     "CHIPCounter.h",

--- a/src/lib/support/BufferReader.h
+++ b/src/lib/support/BufferReader.h
@@ -1,0 +1,150 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *  @file
+ *    Utility classes for safely reading from size-limited buffers.
+ */
+
+#pragma once
+
+#include <climits>
+#include <lib/core/CHIPEncoding.h>
+#include <lib/core/CHIPError.h>
+#include <lib/support/CodeUtils.h>
+#include <stdint.h>
+
+namespace chip {
+namespace Encoding {
+namespace LittleEndian {
+
+/**
+ *  @class Reader
+ *
+ *  Simple reader for reading little-endian things out of buffers.
+ */
+class Reader
+{
+public:
+    /**
+     * Create a data model reader from a given buffer and length.
+     *
+     * @param buffer The octet buffer to read from.  The caller must ensure
+     *               (most simply by allocating the reader on the stack) that
+     *               the buffer outlives the reader.  The buffer is allowed to
+     *               be null if buf_len is 0.
+     * @param buf_len The number of octets in the buffer.
+     */
+    Reader(const uint8_t * buffer, uint16_t buf_len) : mBufStart(buffer), mReadPtr(buffer), mAvailable(buf_len) {}
+
+    /**
+     * Number of octets we have read so far.  This might be able to go away once
+     * we do less switching back and forth between DataModelReader and raw
+     * buffers.
+     */
+    uint16_t OctetsRead() const { return static_cast<uint16_t>(mReadPtr - mBufStart); }
+
+    /**
+     * Read a single 8-bit unsigned integer.
+     *
+     * @param [out] dest Where the 8-bit integer goes.
+     *
+     * @return Whether the read succeeded.  The read can fail if there are not
+     *         enough octets available.
+     */
+    CHECK_RETURN_VALUE
+    CHIP_ERROR Read8(uint8_t * dest) { return Read(dest); }
+
+    /**
+     * Read a single 16-bit unsigned integer.
+     *
+     * @param [out] dest Where the 16-bit integer goes.
+     *
+     * @return Whether the read succeeded.  The read can fail if there are not
+     *         enough octets available.
+     */
+    CHECK_RETURN_VALUE
+    CHIP_ERROR Read16(uint16_t * dest) { return Read(dest); }
+
+    /**
+     * Read a single 32-bit unsigned integer.
+     *
+     * @param [out] dest Where the 32-bit integer goes.
+     *
+     * @return Whether the read succeeded.  The read can fail if there are not
+     *         enough octets available.
+     */
+    CHECK_RETURN_VALUE
+    CHIP_ERROR Read32(uint32_t * dest) { return Read(dest); }
+
+    /**
+     * Read a single 64-bit unsigned integer.
+     *
+     * @param [out] dest Where the 64-bit integer goes.
+     *
+     * @return Whether the read succeeded.  The read can fail if there are not
+     *         enough octets available.
+     */
+    CHECK_RETURN_VALUE
+    CHIP_ERROR Read64(uint64_t * dest) { return Read(dest); }
+
+protected:
+    template <typename T>
+    CHIP_ERROR Read(T * retval)
+    {
+        static_assert(CHAR_BIT == 8, "Our various sizeof checks rely on bytes and octets being the same thing");
+
+        static constexpr size_t data_size = sizeof(T);
+
+        if (mAvailable < data_size)
+        {
+            return CHIP_ERROR_BUFFER_TOO_SMALL;
+        }
+
+        Read(mReadPtr, retval);
+        mAvailable = static_cast<uint16_t>(mAvailable - data_size);
+        return CHIP_NO_ERROR;
+    }
+
+private:
+    // These helper methods return void and put the value being read into an
+    // outparam because that allows us to easily overload on the type of the
+    // thing being read.
+    void Read(const uint8_t *& p, uint8_t * dest) { *dest = Encoding::Read8(p); }
+    void Read(const uint8_t *& p, uint16_t * dest) { *dest = Encoding::LittleEndian::Read16(p); }
+    void Read(const uint8_t *& p, uint32_t * dest) { *dest = Encoding::LittleEndian::Read32(p); }
+    void Read(const uint8_t *& p, uint64_t * dest) { *dest = Encoding::LittleEndian::Read64(p); }
+
+    /**
+     * Our buffer start.
+     */
+    const uint8_t * const mBufStart;
+
+    /**
+     * Our current read point.
+     */
+    const uint8_t * mReadPtr;
+
+    /**
+     * The number of octets we can still read starting at mReadPtr.
+     */
+    uint16_t mAvailable;
+};
+
+} // namespace LittleEndian
+} // namespace Encoding
+} // namespace chip


### PR DESCRIPTION
The idea is to not have people doing ad-hoc, and often incorrect when
they forget to update lengths, length checks.

I did measure the codesize with the Read methods out-of-line, and it's
larger than with the inline methods as far as I can tell.  It might be
worth re-measuring once we have more callers to see what things look
like then.

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
It's too easy to forget to update available length when reading things out of buffers and hence end up with potential buffer overruns.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Add a class that encapsulates the updating of the read pointer and the updating of the available length in one place in a way that guarantees they stay in sync.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes https://github.com/project-chip/connectedhomeip/issues/2914

One open question: Do we still want the `VerifyOrExit` calls that verify that `octets_read` matches some value?  It's not clear that we do: they used to be there to ensure the number we were about to cast to `uint16_t` would in fact fit in `uint16_t`, but that's no longer in question...  Is there another real use for those checks?
<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
