### PR TITLE
Add 'Stop' command for BarrierControl

### DIFF
--- a/examples/chip-tool/commands/clusters/Commands.h
+++ b/examples/chip-tool/commands/clusters/Commands.h
@@ -425,6 +425,7 @@ constexpr uint16_t kTempMeasurementClusterId = 0x0402;
 |------------------------------------------------------------------------------|
 | Commands:                                                           |        |
 | * GoToPercent                                                       |   0x00 |
+| * Stop                                                              |   0x01 |
 |------------------------------------------------------------------------------|
 | Attributes:                                                         |        |
 | * MovingState                                                       | 0x0001 |
@@ -458,6 +459,27 @@ public:
 
 private:
     uint8_t mPercentOpen;
+};
+
+/*
+ * Command Stop
+ */
+class BarrierControlStop : public ModelCommand
+{
+public:
+    BarrierControlStop() : ModelCommand("stop", kBarrierControlClusterId, 0x01) {}
+
+    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
+    {
+        return encodeBarrierControlClusterStopCommand(buffer->Start(), bufferSize, endPointId);
+    }
+
+    // Global Response: DefaultResponse
+    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
+    {
+        DefaultResponse response;
+        return response.HandleCommandResponse(commandId, message, messageLen);
+    }
 };
 
 /*
@@ -5062,9 +5084,9 @@ void registerClusterBarrierControl(Commands & commands)
     const char * clusterName = "BarrierControl";
 
     commands_list clusterCommands = {
-        make_unique<BarrierControlGoToPercent>(),         make_unique<ReadBarrierControlMovingState>(),
-        make_unique<ReadBarrierControlSafetyStatus>(),    make_unique<ReadBarrierControlCapabilities>(),
-        make_unique<ReadBarrierControlBarrierPosition>(),
+        make_unique<BarrierControlGoToPercent>(),      make_unique<BarrierControlStop>(),
+        make_unique<ReadBarrierControlMovingState>(),  make_unique<ReadBarrierControlSafetyStatus>(),
+        make_unique<ReadBarrierControlCapabilities>(), make_unique<ReadBarrierControlBarrierPosition>(),
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/src/app/chip-zcl-zpro-codec-api.h
+++ b/src/app/chip-zcl-zpro-codec-api.h
@@ -50,6 +50,7 @@ extern "C" {
 |------------------------------------------------------------------------------|
 | Commands:                                                           |        |
 | * GoToPercent                                                       |   0x00 |
+| * Stop                                                              |   0x01 |
 |------------------------------------------------------------------------------|
 | Attributes:                                                         |        |
 | * MovingState                                                       | 0x0001 |
@@ -64,6 +65,12 @@ extern "C" {
  */
 uint16_t encodeBarrierControlClusterGoToPercentCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                        uint8_t percentOpen);
+
+/**
+ * @brief
+ *    Encode an stop command for BarrierControl server into buffer including the APS frame
+ */
+uint16_t encodeBarrierControlClusterStopCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
 
 /**
  * @brief

--- a/src/app/encoder.cpp
+++ b/src/app/encoder.cpp
@@ -211,6 +211,7 @@ uint16_t encodeReadAttributesCommand(uint8_t * buffer, uint16_t buf_length, uint
 |------------------------------------------------------------------------------|
 | Commands:                                                           |        |
 | * GoToPercent                                                       |   0x00 |
+| * Stop                                                              |   0x01 |
 |------------------------------------------------------------------------------|
 | Attributes:                                                         |        |
 | * MovingState                                                       | 0x0001 |
@@ -228,6 +229,16 @@ uint16_t encodeBarrierControlClusterGoToPercentCommand(uint8_t * buffer, uint16_
     const char * kName = "BarrierControlGoToPercent";
     COMMAND_HEADER(kName, BARRIER_CONTROL_CLUSTER_ID, 0x00);
     buf.Put(percentOpen);
+    COMMAND_FOOTER(kName);
+}
+
+/*
+ * Command Stop
+ */
+uint16_t encodeBarrierControlClusterStopCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+{
+    const char * kName = "BarrierControlStop";
+    COMMAND_HEADER(kName, BARRIER_CONTROL_CLUSTER_ID, 0x01);
     COMMAND_FOOTER(kName);
 }
 


### PR DESCRIPTION
 #### Problem
  The `Stop` command for BarrierControl was ignored by ZAP because the name of the command is not unique and it was assigned to a different cluster. Once this issue is resolved the Stop command appears at the right place :)

 #### Summary of Changes
 * Add `Stop` command for BarrierControl