### PR TITLE
Fix Darwin Framework Tests

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPManualSetupPayloadParser.h
+++ b/src/darwin/Framework/CHIP/CHIPManualSetupPayloadParser.h
@@ -22,8 +22,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface CHIPManualSetupPayloadParser : NSObject
-- (id)initWithDecimalStringRepresentation:(NSString *)decimalStringRepresentation;
-- (CHIPSetupPayload *)populatePayload:(NSError * __autoreleasing *)error;
+- (instancetype)initWithDecimalStringRepresentation:(NSString *)decimalStringRepresentation;
+- (CHIPSetupPayload * __nullable)populatePayload:(NSError * __autoreleasing *)error;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/CHIPManualSetupPayloadParser.mm
+++ b/src/darwin/Framework/CHIP/CHIPManualSetupPayloadParser.mm
@@ -55,9 +55,9 @@
             *error = [CHIPError errorForCHIPErrorCode:chipError];
         }
     } else {
-        //Memory init has failed
+        // Memory init has failed
         if (error) {
-        *error = [CHIPError errorForCHIPErrorCode:CHIP_ERROR_NO_MEMORY];
+            *error = [CHIPError errorForCHIPErrorCode:CHIP_ERROR_NO_MEMORY];
         }
     }
 

--- a/src/darwin/Framework/CHIP/CHIPManualSetupPayloadParser.mm
+++ b/src/darwin/Framework/CHIP/CHIPManualSetupPayloadParser.mm
@@ -34,8 +34,8 @@
         _decimalStringRepresentation = decimalStringRepresentation;
         _chipManualSetupPayloadParser = new chip::ManualSetupPayloadParser(std::string([decimalStringRepresentation UTF8String]));
         if (CHIP_NO_ERROR != chip::Platform::MemoryInit()) {
-               CHIP_LOG_ERROR("Error: couldn't initialize platform memory");
-               delete _chipManualSetupPayloadParser;
+            CHIP_LOG_ERROR("Error: couldn't initialize platform memory");
+            delete _chipManualSetupPayloadParser;
         }
     }
     return self;
@@ -56,7 +56,8 @@
     return payload;
 }
 
--(void)dealloc {
+- (void)dealloc
+{
     delete _chipManualSetupPayloadParser;
     chip::Platform::MemoryShutdown();
 }

--- a/src/darwin/Framework/CHIP/CHIPManualSetupPayloadParser.mm
+++ b/src/darwin/Framework/CHIP/CHIPManualSetupPayloadParser.mm
@@ -17,9 +17,11 @@
 #import "CHIPManualSetupPayloadParser.h"
 
 #import "CHIPError.h"
+#import "CHIPLogging.h"
 
 #import <setup_payload/ManualSetupPayloadParser.h>
 #import <setup_payload/SetupPayload.h>
+#import <support/CHIPMem.h>
 
 @implementation CHIPManualSetupPayloadParser {
     NSString * _decimalStringRepresentation;
@@ -31,6 +33,10 @@
     if (self = [super init]) {
         _decimalStringRepresentation = decimalStringRepresentation;
         _chipManualSetupPayloadParser = new chip::ManualSetupPayloadParser(std::string([decimalStringRepresentation UTF8String]));
+        if (CHIP_NO_ERROR != chip::Platform::MemoryInit()) {
+               CHIP_LOG_ERROR("Error: couldn't initialize platform memory");
+               delete _chipManualSetupPayloadParser;
+        }
     }
     return self;
 }
@@ -48,6 +54,11 @@
     }
 
     return payload;
+}
+
+-(void)dealloc {
+    delete _chipManualSetupPayloadParser;
+    chip::Platform::MemoryShutdown();
 }
 
 @end

--- a/src/darwin/Framework/CHIP/CHIPQRCodeSetupPayloadParser.h
+++ b/src/darwin/Framework/CHIP/CHIPQRCodeSetupPayloadParser.h
@@ -23,8 +23,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface CHIPQRCodeSetupPayloadParser : NSObject
-- (id)initWithBase41Representation:(NSString *)base41Representation;
-- (CHIPSetupPayload *)populatePayload:(NSError * __autoreleasing *)error;
+- (instancetype)initWithBase41Representation:(NSString *)base41Representation;
+- (CHIPSetupPayload * __nullable)populatePayload:(NSError * __autoreleasing *)error;
 @end
-;
+
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/CHIPQRCodeSetupPayloadParser.mm
+++ b/src/darwin/Framework/CHIP/CHIPQRCodeSetupPayloadParser.mm
@@ -55,9 +55,9 @@
             *error = [CHIPError errorForCHIPErrorCode:chipError];
         }
     } else {
-        //Memory init has failed
+        // Memory init has failed
         if (error) {
-        *error = [CHIPError errorForCHIPErrorCode:CHIP_ERROR_NO_MEMORY];
+            *error = [CHIPError errorForCHIPErrorCode:CHIP_ERROR_NO_MEMORY];
         }
     }
 

--- a/src/darwin/Framework/CHIP/CHIPQRCodeSetupPayloadParser.mm
+++ b/src/darwin/Framework/CHIP/CHIPQRCodeSetupPayloadParser.mm
@@ -17,9 +17,11 @@
 
 #import "CHIPQRCodeSetupPayloadParser.h"
 #import "CHIPError.h"
+#import "CHIPLogging.h"
 
 #import <setup_payload/QRCodeSetupPayloadParser.h>
 #import <setup_payload/SetupPayload.h>
+#import <support/CHIPMem.h>
 
 @implementation CHIPQRCodeSetupPayloadParser {
     NSString * _base41Representation;
@@ -31,6 +33,10 @@
     if (self = [super init]) {
         _base41Representation = base41Representation;
         _chipQRCodeSetupPayloadParser = new chip::QRCodeSetupPayloadParser(std::string([base41Representation UTF8String]));
+        if (CHIP_NO_ERROR != chip::Platform::MemoryInit()) {
+               CHIP_LOG_ERROR("Error: couldn't initialize platform memory");
+               delete _chipQRCodeSetupPayloadParser;
+        }
     }
     return self;
 }
@@ -48,4 +54,10 @@
     }
     return payload;
 }
+
+-(void)dealloc {
+    delete _chipQRCodeSetupPayloadParser;
+    chip::Platform::MemoryShutdown();
+}
+
 @end

--- a/src/darwin/Framework/CHIP/CHIPQRCodeSetupPayloadParser.mm
+++ b/src/darwin/Framework/CHIP/CHIPQRCodeSetupPayloadParser.mm
@@ -44,20 +44,30 @@
 - (CHIPSetupPayload *)populatePayload:(NSError * __autoreleasing *)error
 {
     chip::SetupPayload cPlusPluspayload;
-    CHIP_ERROR chipError = _chipQRCodeSetupPayloadParser->populatePayload(cPlusPluspayload);
-
     CHIPSetupPayload * payload;
-    if (chipError == 0) {
-        payload = [[CHIPSetupPayload alloc] initWithSetupPayload:cPlusPluspayload];
-    } else if (error) {
-        *error = [CHIPError errorForCHIPErrorCode:chipError];
+
+    if (_chipQRCodeSetupPayloadParser) {
+        CHIP_ERROR chipError = _chipQRCodeSetupPayloadParser->populatePayload(cPlusPluspayload);
+
+        if (chipError == 0) {
+            payload = [[CHIPSetupPayload alloc] initWithSetupPayload:cPlusPluspayload];
+        } else if (error) {
+            *error = [CHIPError errorForCHIPErrorCode:chipError];
+        }
+    } else {
+        //Memory init has failed
+        if (error) {
+        *error = [CHIPError errorForCHIPErrorCode:CHIP_ERROR_NO_MEMORY];
+        }
     }
+
     return payload;
 }
 
 - (void)dealloc
 {
     delete _chipQRCodeSetupPayloadParser;
+    _chipQRCodeSetupPayloadParser = nullptr;
     chip::Platform::MemoryShutdown();
 }
 

--- a/src/darwin/Framework/CHIP/CHIPQRCodeSetupPayloadParser.mm
+++ b/src/darwin/Framework/CHIP/CHIPQRCodeSetupPayloadParser.mm
@@ -31,12 +31,12 @@
 - (id)initWithBase41Representation:(NSString *)base41Representation
 {
     if (self = [super init]) {
-        _base41Representation = base41Representation;
-        _chipQRCodeSetupPayloadParser = new chip::QRCodeSetupPayloadParser(std::string([base41Representation UTF8String]));
         if (CHIP_NO_ERROR != chip::Platform::MemoryInit()) {
             CHIP_LOG_ERROR("Error: couldn't initialize platform memory");
-            delete _chipQRCodeSetupPayloadParser;
+            return self;
         }
+        _base41Representation = base41Representation;
+        _chipQRCodeSetupPayloadParser = new chip::QRCodeSetupPayloadParser(std::string([base41Representation UTF8String]));
     }
     return self;
 }

--- a/src/darwin/Framework/CHIP/CHIPQRCodeSetupPayloadParser.mm
+++ b/src/darwin/Framework/CHIP/CHIPQRCodeSetupPayloadParser.mm
@@ -34,8 +34,8 @@
         _base41Representation = base41Representation;
         _chipQRCodeSetupPayloadParser = new chip::QRCodeSetupPayloadParser(std::string([base41Representation UTF8String]));
         if (CHIP_NO_ERROR != chip::Platform::MemoryInit()) {
-               CHIP_LOG_ERROR("Error: couldn't initialize platform memory");
-               delete _chipQRCodeSetupPayloadParser;
+            CHIP_LOG_ERROR("Error: couldn't initialize platform memory");
+            delete _chipQRCodeSetupPayloadParser;
         }
     }
     return self;
@@ -55,7 +55,8 @@
     return payload;
 }
 
--(void)dealloc {
+- (void)dealloc
+{
     delete _chipQRCodeSetupPayloadParser;
     chip::Platform::MemoryShutdown();
 }


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
The Darwin tests fail because the QRCode bits are not initializing platform memory. 

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Init platform memory when the parsers are created and shut it down when the parsers are released. 
<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->