### PR TITLE
Add missing uint32_t parameters to src/app/encoder.cpp

### DIFF
--- a/src/app/encoder.cpp
+++ b/src/app/encoder.cpp
@@ -1228,6 +1228,8 @@ uint16_t encodeDoorLockClusterSetHolidayScheduleCommand(uint8_t * buffer, uint16
     const char * kName = "DoorLockSetHolidaySchedule";
     COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x11);
     buf.Put(holidayScheduleID);
+    buf.PutLE32(localStartTime);
+    buf.PutLE32(localEndTime);
     buf.Put(operatingModeDuringHoliday);
     COMMAND_FOOTER(kName);
 }
@@ -1305,6 +1307,8 @@ uint16_t encodeDoorLockClusterSetYearDayScheduleCommand(uint8_t * buffer, uint16
     COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x0E);
     buf.Put(scheduleID);
     buf.PutLE16(userID);
+    buf.PutLE32(localStartTime);
+    buf.PutLE32(localEndTime);
     COMMAND_FOOTER(kName);
 }
 


### PR DESCRIPTION
 #### Problem
`uint32_t` parameters were not generated.

 #### Summary of Changes
 * generate them