### PR TITLE
Force java home to avoid XML class not found errors during builds

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -29,6 +29,7 @@ jobs:
         env:
             BUILD_TYPE: android_${{ matrix.type }}
             TARGET_CPU: ${{ matrix.type }}
+            JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64/
 
         runs-on: ubuntu-latest
 


### PR DESCRIPTION
 #### Problem
Default java in our updated docker image is not able to run sdkmanager.

 #### Summary of Changes
Force JAVA_HOME to a version that can run it.