### PR TITLE
Add Add GroupCount field to GetGroupMembership command for src/app

### DIFF
--- a/examples/chip-tool/commands/clusters/Commands.h
+++ b/examples/chip-tool/commands/clusters/Commands.h
@@ -3632,6 +3632,8 @@ public:
         ChipLogProgress(chipTool, "GetGroupMembershipResponse (0x02):");
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "capacity", chip::Encoding::Read8(message)); // uint8
+        CHECK_MESSAGE_LENGTH(1);
+        ChipLogProgress(chipTool, "  %s: 0x%02x", "groupCount", chip::Encoding::Read8(message)); // uint8
         // uint16_t uint16[]
         while (messageLen)
         {
@@ -3766,6 +3768,7 @@ class GroupsGetGroupMembership : public ModelCommand
 public:
     GroupsGetGroupMembership() : ModelCommand("get-group-membership", kGroupsClusterId, 0x02)
     {
+        AddArgument("groupCount", 0, UINT8_MAX, &mGroupCount);
         // groupList is an array, but since chip-tool does not support variable
         // number of arguments, only a single instance is supported.
         AddArgument("groupList", 0, UINT16_MAX, &mGroupList);
@@ -3773,7 +3776,7 @@ public:
 
     uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
     {
-        return encodeGroupsClusterGetGroupMembershipCommand(buffer->Start(), bufferSize, endPointId, mGroupList);
+        return encodeGroupsClusterGetGroupMembershipCommand(buffer->Start(), bufferSize, endPointId, mGroupCount, mGroupList);
     }
 
     // Global Response: DefaultResponse
@@ -3791,6 +3794,7 @@ public:
     }
 
 private:
+    uint8_t mGroupCount;
     uint16_t mGroupList;
 };
 

--- a/src/app/chip-zcl-zpro-codec-api.h
+++ b/src/app/chip-zcl-zpro-codec-api.h
@@ -840,7 +840,7 @@ uint16_t encodeGroupsClusterAddGroupIfIdentifyingCommand(uint8_t * buffer, uint1
  *    Encode an get-group-membership command for Groups server into buffer including the APS frame
  */
 uint16_t encodeGroupsClusterGetGroupMembershipCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                      uint16_t groupList);
+                                                      uint8_t groupCount, uint16_t groupList);
 
 /**
  * @brief

--- a/src/app/encoder.cpp
+++ b/src/app/encoder.cpp
@@ -1427,10 +1427,11 @@ uint16_t encodeGroupsClusterAddGroupIfIdentifyingCommand(uint8_t * buffer, uint1
  * Command GetGroupMembership
  */
 uint16_t encodeGroupsClusterGetGroupMembershipCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                      uint16_t groupList)
+                                                      uint8_t groupCount, uint16_t groupList)
 {
     const char * kName = "GroupsGetGroupMembership";
     COMMAND_HEADER(kName, GROUPS_CLUSTER_ID, 0x02);
+    buf.Put(groupCount);
     buf.PutLE16(groupList);
     COMMAND_FOOTER(kName);
 }


### PR DESCRIPTION
 #### Problem
 The group count field for the GetGroupMembership command was missing in the dotdot XML file I used to generate the code. While our implementation expects it to be here.

 #### Summary of Changes
 * Add the missing field to chip-tool and src/app