### PR TITLE
Stop calling OnRendezvousMessageReceived in Rendezvous Session

### DIFF
--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -384,11 +384,6 @@ CHIP_ERROR RendezvousSession::HandleSecureMessage(PacketBuffer * msgBuf)
         err = mNetworkProvision.HandleNetworkProvisioningMessage(payloadHeader.GetMessageType(), msgBuf);
         SuccessOrExit(err);
     }
-    else // This else condition should eventually be removed, once all messages are handled via delegate callbacks
-    {
-        mDelegate->OnRendezvousMessageReceived(msgBuf);
-        msgBuf = nullptr;
-    }
 
 exit:
     if (origMsg != nullptr)


### PR DESCRIPTION
 #### Problem
`OnRendezvousMessageReceived` was a stop gap fix until all example device and controller code was changed to using delegate callbacks. Since, now all code blocks are using delegates, we should remove call to `OnRendezvousMessageReceived`.

 #### Summary of Changes
Removed the call to `OnRendezvousMessageReceived` in `RendevousSession`.
