### PR TITLE
Fix build error on Raspi-P4 with -Werror=class-memaccess enabled

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -59,11 +59,6 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
       "${nlunit_test_root}:nlunit-test",
     ]
 
-    # Temporary until RNG issue sorted out
-    if (current_os != "android") {
-      deps += [ "${chip_root}/src/lib/message" ]
-    }
-
     if (chip_build_tests) {
       deps += [ "//src:tests" ]
     }


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
ninja build failed on Raspi P4 with the following error:

g++ -MMD -MF obj/src/lib/message/libChipMessage.CHIPExchangeMgr.cpp.o.d -O0 -g2 -fno-common -ffunction-sections -fdata-sections -fno-exceptions -fPIC -Wall -Werror -Wno-deprecated-declarations -Wno-unknown-warning-option -Wno-missing-field-initializers -Wno-unused-but-set-variable -Wno-unused-variable -Wno-psabi -Wno-cast-function-type -Wno-maybe-uninitialized -fdiagnostics-color -fno-strict-aliasing -D_REENTRANT -isystem../../third_party/ot-br-posix/repo/src -isystem../../third_party/ot-br-posix/repo/include -I/usr/include/dbus-1.0 -I/usr/lib/aarch64-linux-gnu/dbus-1.0/include -I/usr/include/gio-unix-2.0 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/glib-2.0 -I/usr/lib/aarch64-linux-gnu/glib-2.0/include -std=gnu++11 -fno-rtti -Wno-non-virtual-dtor -Wno-deprecated-copy -DCHIP_HAVE_CONFIG_H=1 -DCHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE=true -DLWIP_IPV4=1 -DLWIP_IPV6=1 -DLWIP_API=1 -DLWIP_ETHERNET=1 -DLWIP_SLIP=0 -DLWIP_6LOWPAN=1 -DLWIP_PPP=1 -I../../src/lib/message -I../../src/include -I../../src -Igen/include -I../../config/standalone -I../../src/lib -I../../third_party/nlassert/repo/include -I../../third_party/nlfaultinjection/repo/include -I../../third_party/nlio/repo/include -I../../src/lwip/standalone -I../../third_party/lwip/repo/lwip/src/include -I../../src/lwip/include -I../../src/app/gen -I../../src/app/util -I../../src/app -Igen/src/app/include -Igen -Igen -I../../third_party/inipp/repo/inipp -c ../../src/lib/message/CHIPExchangeMgr.cpp -o obj/src/lib/message/libChipMessage.CHIPExchangeMgr.cpp.o
../../src/lib/message/CHIPExchangeMgr.cpp: In member function ‘CHIP_ERROR chip::ChipExchangeManager::Init(chip::ChipMessageLayer*)’:
../../src/lib/message/CHIPExchangeMgr.cpp:95:47: error: ‘void* memset(void*, int, size_t)’ clearing an object of type ‘class chip::ExchangeContext’ with no trivial copy-assignment; use assignment or value-initialization instead [-Werror=class-memaccess]
   95 |     memset(ContextPool, 0, sizeof(ContextPool));
      |                                               ^
In file included from ../../src/lib/message/CHIPExchangeMgr.cpp:39:
../../src/lib/message/CHIPExchangeMgr.h:96:18: note: ‘class chip::ExchangeContext’ declared here
   96 | class DLL_EXPORT ExchangeContext
      |                  ^~~~~~~~~~~~~~~

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
The error occurs in the legacy wml based messaging stack with  -Werror=class-memaccess enabled on Raspi. Disable this stack since it will not be used based on the latest consensus, but we still keep it in the repository for reference until we cherry pick all features to current messaging stack

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->


<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
