### PR TITLE
Remove timer spam

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
@@ -153,7 +153,6 @@ void GenericPlatformManagerImpl_POSIX<ImplClass>::SysProcess()
     int64_t nextTimeoutMs;
 
     nextTimeoutMs = mNextTimeout.tv_sec * 1000 + mNextTimeout.tv_usec / 1000;
-    ChipLogDetail(DeviceLayer, "Timer: " PRId64, nextTimeoutMs);
     _StartChipTimer(nextTimeoutMs);
 
     Impl()->UnlockChipStack();


### PR DESCRIPTION
This removes a constant stream of

`  CHIP:DL: Timer: ld`

from the output of the POSIX port. The ld was supposed to be a format
string but the % is missing.

 #### Problem

Timers are generating logs even when nothing is happening.

 #### Summary of Changes

Remove timer prints.
