### PR TITLE
Use ReferenceCounted for ExchangeContext

### DIFF
--- a/src/lib/core/ReferenceCounted.h
+++ b/src/lib/core/ReferenceCounted.h
@@ -41,14 +41,14 @@ public:
  * A reference counted object maintains a count of usages and when the usage
  * count drops to 0, it deletes itself.
  */
-template <class SUBCLASS, class DELETOR = DeleteDeletor<SUBCLASS>, int INITIAL = 1>
+template <class Subclass, class Deletor = DeleteDeletor<Subclass>, int kInitRefCount = 1>
 class ReferenceCounted
 {
 public:
     typedef uint32_t count_type;
 
     /** Adds one to the usage count of this class */
-    SUBCLASS * Retain()
+    Subclass * Retain()
     {
         if (mRefCount == std::numeric_limits<count_type>::max())
         {
@@ -56,7 +56,7 @@ public:
         }
         ++mRefCount;
 
-        return static_cast<SUBCLASS *>(this);
+        return static_cast<Subclass *>(this);
     }
 
     /** Release usage of this class */
@@ -69,7 +69,7 @@ public:
 
         if (--mRefCount == 0)
         {
-            DELETOR::Release(static_cast<SUBCLASS *>(this));
+            Deletor::Release(static_cast<Subclass *>(this));
         }
     }
 
@@ -77,7 +77,7 @@ public:
     count_type GetReferenceCount() const { return mRefCount; }
 
 private:
-    count_type mRefCount = INITIAL;
+    count_type mRefCount = kInitRefCount;
 };
 
 } // namespace chip

--- a/src/lib/core/ReferenceCounted.h
+++ b/src/lib/core/ReferenceCounted.h
@@ -41,7 +41,7 @@ public:
  * A reference counted object maintains a count of usages and when the usage
  * count drops to 0, it deletes itself.
  */
-template <class SUBCLASS, class DELETOR = DeleteDeletor<SUBCLASS>>
+template <class SUBCLASS, class DELETOR = DeleteDeletor<SUBCLASS>, int INITIAL = 1>
 class ReferenceCounted
 {
 public:
@@ -77,7 +77,7 @@ public:
     count_type GetReferenceCount() const { return mRefCount; }
 
 private:
-    count_type mRefCount = 1;
+    count_type mRefCount = INITIAL;
 };
 
 } // namespace chip

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -205,10 +205,10 @@ void ExchangeContext::Alloc(ExchangeManager * em, uint16_t ExchangeId, uint64_t 
     mAppState = AppState;
 
 #if defined(CHIP_EXCHANGE_CONTEXT_DETAIL_LOGGING)
-    ChipLogProgress(ExchangeManager, "ec++ id: %d, inUse: %d, addr: 0x%x", (this - em->ContextPool + 1), em->GetContextsInUse(), this);
+    ChipLogProgress(ExchangeManager, "ec++ id: %d, inUse: %d, addr: 0x%x", (this - em->ContextPool + 1), em->GetContextsInUse(),
+                    this);
 #endif
     SYSTEM_STATS_INCREMENT(chip::System::Stats::kExchangeMgr_NumContexts);
-
 }
 
 void ExchangeContext::Free()
@@ -226,7 +226,8 @@ void ExchangeContext::Free()
     em->DecrementContextsInUse();
 
 #if defined(CHIP_EXCHANGE_CONTEXT_DETAIL_LOGGING)
-    ChipLogProgress(ExchangeManager, "ec-- id: %d [%04" PRIX16 "], inUse: %d, addr: 0x%x", (this - em->ContextPool + 1), mExchangeId, em->GetContextsInUse(), this);
+    ChipLogProgress(ExchangeManager, "ec-- id: %d [%04" PRIX16 "], inUse: %d, addr: 0x%x", (this - em->ContextPool + 1),
+                    mExchangeId, em->GetContextsInUse(), this);
 #endif
     SYSTEM_STATS_DECREMENT(chip::System::Stats::kExchangeMgr_NumContexts);
 }

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -160,9 +160,7 @@ public:
      */
     CHIP_ERROR UnregisterUnsolicitedMessageHandler(uint32_t protocolId, uint8_t msgType);
 
-    /**
-     *  Decrement current context in use by 1.
-     */
+    void IncrementContextsInUse();
     void DecrementContextsInUse();
 
     SecureSessionMgrBase * GetSessionMgr() const { return mSessionMgr; }
@@ -194,7 +192,7 @@ private:
     UnsolicitedMessageHandler UMHandlerPool[CHIP_CONFIG_MAX_UNSOLICITED_MESSAGE_HANDLERS];
     void (*OnExchangeContextChanged)(size_t numContextsInUse);
 
-    ExchangeContext * AllocContext();
+    ExchangeContext * AllocContext(uint16_t ExchangeId, uint64_t PeerNodeId, bool Initiator, void * AppState);
 
     void DispatchMessage(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader, System::PacketBuffer * msgBuf);
 


### PR DESCRIPTION
Refactor only, no behavior changes.

 #### Problem
`ExchangeContext` uses its own reference counter, but we have `ReferenceCounted` class for the purpose

 #### Summary of Changes
Use ReferenceCounted for ExchangeContext, and refactor context alloc/free logic into `ExchangeContext::Alloc` and  `ExchangeContext::Free` functions