### PR TITLE
Add default persistent storage in iOS framework

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
@@ -45,6 +45,8 @@ private:
     chip::DeviceController::PersistentStorageResultDelegate * mCallback;
     SendKeyValue mCompletionHandler;
     SendStatus mStatusHandler;
+    NSUserDefaults * mDefaultPersistentStorage;
+    dispatch_queue_t mDefaultCallbackQueue;
 };
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
 #### Problem
The user (application) of CHIP iOS framework is required to implement persistent storage delegate, to store key/value pairs. It'll be nice to have a default implementation in the framework, in case the application doesn't have specific storage requirements.

 #### Summary of Changes
If the application doesn't register a storage delegate, `NSUserDefaults` will be used by the framework to persist key/value pairs.