### PR TITLE
Fix unified build

### DIFF
--- a/examples/shell/standalone/BUILD.gn
+++ b/examples/shell/standalone/BUILD.gn
@@ -39,6 +39,6 @@ executable("chip-shell") {
   output_dir = root_out_dir
 }
 
-group("shell") {
+group("standalone") {
   deps = [ ":chip-shell" ]
 }


### PR DESCRIPTION
As of 9e1ac48a ("Refactor of shell application for easier addition new
platforms (#3513)") the unified build fails with the following error:

```
ERROR Unresolved dependencies.
//:standalone_shell(//third_party/pigweed/repo/pw_toolchain/dummy:dummy)
  needs //examples/shell/standalone:standalone(//config/standalone/toolchain:standalone)
```

Fix it by renaming //examples/shell/standalone:shell to
//examples/shell/standalone:standalone.