### PR TITLE
[transport] Add unsecure message support to SecureSessionMgr

### DIFF
--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -204,6 +204,7 @@ public:
      * @param[in] appReqState   Application specific context to be passed back when a message is received or on error
      * @param[in] buffer        The Data Buffer to trasmit to the device
      * @param[in] peerDevice    Device ID of the peer device
+     * @param[in] secure        Should the message be secure
      * @return CHIP_ERROR   The return status
      */
     CHIP_ERROR SendMessage(void * appReqState, System::PacketBuffer * buffer, NodeId peerDevice = kUndefinedNodeId);
@@ -289,6 +290,8 @@ private:
     SecurePairingSession mPairingSession;
     SecurePairingUsingTestSecret * mTestSecurePairingSecret = nullptr;
 
+    bool mIsSecure = true;
+
     SecurePairingSession * mSecurePairingSession = nullptr;
 
     DevicePairingDelegate * mPairingDelegate = nullptr;
@@ -301,7 +304,7 @@ private:
     void ClearRequestState();
     void ClearOpState();
 
-    CHIP_ERROR EstablishSecureSession();
+    CHIP_ERROR EstablishSecureSession(NodeId peer);
     CHIP_ERROR TryEstablishingSecureSession(NodeId peer);
     CHIP_ERROR ResumeSecureSession(NodeId peer);
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -204,7 +204,6 @@ public:
      * @param[in] appReqState   Application specific context to be passed back when a message is received or on error
      * @param[in] buffer        The Data Buffer to trasmit to the device
      * @param[in] peerDevice    Device ID of the peer device
-     * @param[in] secure        Should the message be secure
      * @return CHIP_ERROR   The return status
      */
     CHIP_ERROR SendMessage(void * appReqState, System::PacketBuffer * buffer, NodeId peerDevice = kUndefinedNodeId);

--- a/src/transport/SecurePairingSession.h
+++ b/src/transport/SecurePairingSession.h
@@ -218,6 +218,8 @@ protected:
     uint16_t mLocalKeyId;
 
     uint16_t mPeerKeyId;
+
+    bool mIsSecure;
 };
 
 /*

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -94,7 +94,7 @@ exit:
     return error;
 }
 
-CHIP_ERROR InitUnsecure()
+CHIP_ERROR SecureSession::InitUnsecure()
 {
     mEncrypted = false;
     return CHIP_NO_ERROR;

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -199,7 +199,7 @@ CHIP_ERROR SecureSession::Decrypt(const uint8_t * input, size_t input_length, ui
     VerifyOrExit(input != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(input_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(output != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(mState != State::kInitializedSecure, error = CHIP_ERROR_INVALID_USE_OF_SESSION_KEY);
+    VerifyOrExit(mState != State::kNotInitialized, error = CHIP_ERROR_INVALID_USE_OF_SESSION_KEY);
 
     if (mState == State::kInitializedSecure)
     {

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -79,7 +79,8 @@ public:
 
     /**
      * @brief
-     *   Encrypt the input data using keys established in the secure channel
+     *   Encrypt the input data using keys established in the secure channel. If Session is not secure,
+     * just copy input data to output data.
      *
      * @param input Unencrypted input data
      * @param input_length Length of the input data
@@ -95,7 +96,8 @@ public:
 
     /**
      * @brief
-     *   Decrypt the input data using keys established in the secure channel
+     *   Decrypt the input data using keys established in the secure channel. If Session is not secure,
+     * just copy input data to output data.
      *
      * @param input Encrypted input data
      * @param input_length Length of the input data
@@ -117,7 +119,7 @@ public:
      */
     size_t EncryptionOverhead();
 
-    bool IsEncrypted() { return mEncrypted; }
+    bool IsEncrypted() { return mState == State::kInitializedSecure; }
 
     /**
      * Clears the internal state of secure session back to the state of a new object.
@@ -125,10 +127,15 @@ public:
     void Reset();
 
 private:
+    enum class State : uint8_t
+    {
+        kNotInitialized = 0,
+        kInitializedSecure,
+        kInitializedUnsecure,
+    };
     static constexpr size_t kAES_CCM128_Key_Length = 16;
 
-    bool mKeyAvailable;
-    bool mEncrypted;
+    State mState;
     uint8_t mKey[kAES_CCM128_Key_Length];
 
     static CHIP_ERROR GetIV(const PacketHeader & header, uint8_t * iv, size_t len);

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -41,6 +41,11 @@ public:
     SecureSession & operator=(SecureSession &&) = default;
 
     /**
+     *
+     */
+    CHIP_ERROR InitUnsecure();
+
+    /**
      * @brief
      *   Derive a shared key. The derived key will be used for encryting/decrypting
      *   data exchanged on the secure channel.
@@ -112,6 +117,8 @@ public:
      */
     size_t EncryptionOverhead();
 
+    bool IsEncrypted() { return mEncrypted; }
+
     /**
      * Clears the internal state of secure session back to the state of a new object.
      */
@@ -121,6 +128,7 @@ private:
     static constexpr size_t kAES_CCM128_Key_Length = 16;
 
     bool mKeyAvailable;
+    bool mEncrypted;
     uint8_t mKey[kAES_CCM128_Key_Length];
 
     static CHIP_ERROR GetIV(const PacketHeader & header, uint8_t * iv, size_t len);

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -222,9 +222,9 @@ CHIP_ERROR SecureSessionMgrBase::NewUnsecureSession(const Transport::PeerAddress
     *state = nullptr;
 
     // Find any existing connection with the same node and key ID
-    if (mPeerConnections.FindPeerConnectionState(peerAddr, &state))
+    if (mPeerConnections.FindPeerConnectionState(peerAddr, state))
     {
-        mPeerConnections.MarkConnectionExpired(state);
+        mPeerConnections.MarkConnectionExpired(*state);
     }
 
     ChipLogDetail(Inet, "New unsecure session for address!!");
@@ -263,7 +263,7 @@ void SecureSessionMgrBase::HandleDataReceived(const PacketHeader & packetHeader,
     CHIP_ERROR err                 = CHIP_NO_ERROR;
     System::PacketBuffer * origMsg = nullptr;
     PeerConnectionState * state    = nullptr;
-    const bool encrypted           = packetHeader.GetFlags().Get(Header::FlagValues::kEncrypted);
+    const bool encrypted           = packetHeader.GetFlags().Has(Header::FlagValues::kEncrypted);
 
     VerifyOrExit(msg != nullptr, ChipLogError(Inet, "Secure transport received NULL packet, discarding"));
 

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -283,7 +283,7 @@ void SecureSessionMgrBase::HandleDataReceived(const PacketHeader & packetHeader,
         if (!connection->mPeerConnections.FindPeerConnectionState(peerAddress, &state))
         {
             // We did not have connections with this peer before, create a new state
-            err = NewUnsecureSession(peerAddress, packetHeader.GetSourceNodeId(), &state);
+            err = connection->NewUnsecureSession(peerAddress, packetHeader.GetSourceNodeId(), &state);
             SuccessOrExit(err);
         }
     }

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -231,6 +231,8 @@ CHIP_ERROR SecureSessionMgrBase::NewUnsecureSession(const Transport::PeerAddress
     err = mPeerConnections.CreateNewPeerConnectionState(peerAddr, state);
     SuccessOrExit(err);
 
+    (*state)->GetSecureSession().InitUnsecure();
+
     if (nodeId.HasValue())
     {
         (*state)->SetPeerNodeId(nodeId.Value());

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -128,6 +128,17 @@ public:
 
     /**
      * @brief
+     *   Record a new unsecure session with a peer node
+     *
+     * @details
+     *   This method sets up a new session with the peer node without
+     *   encryption.
+     */
+    CHIP_ERROR NewUnsecureSession(const Transport::PeerAddress & peerAddr, const Optional<NodeId> & nodeId,
+                                  PeerConnectionState ** state);
+
+    /**
+     * @brief
      *   Return the System Layer pointer used by current SecureSessionMgr.
      */
     System::Layer * SystemLayer() { return mSystemLayer; }

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -135,7 +135,7 @@ public:
      *   encryption.
      */
     CHIP_ERROR NewUnsecureSession(const Transport::PeerAddress & peerAddr, const Optional<NodeId> & nodeId,
-                                  PeerConnectionState ** state);
+                                  Transport::PeerConnectionState ** state);
 
     /**
      * @brief

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -74,6 +74,9 @@ enum class FlagValues : uint16_t
     /// Header flag specifying that it is a control message for secure session.
     kSecureSessionControlMessage = 0x0800,
 
+    // A single bit field identifying that the message is encrypted and authenticated.
+    kEncrypted = 0x0001,
+
 };
 
 using Flags   = BitFlags<uint16_t, FlagValues>;

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -83,10 +83,10 @@ using Flags   = BitFlags<uint16_t, FlagValues>;
 using ExFlags = BitFlags<uint8_t, ExFlagValues>;
 
 // Header is a 16-bit value of the form
-//  |  4 bit  | 4 bit |  4 bit  |  4 bit   |
-//  +---------+-------+---------+----------|
-//  | version | Flags | encType | reserved |
-static constexpr uint16_t kFlagsMask = 0x0F00;
+//  |  4 bit  | 4 bit |Security Flags  (8b)|
+//  +---------+-------+--------------------+
+//  | version |-|T|S|D|P|C|Reserved  (5b)|E|
+static constexpr uint16_t kFlagsMask = 0x0FC1;
 
 } // namespace Header
 


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Currently, SecureSessionMgr only supports encrypted messages, and assume all packets are encrypted. However, messages like secure pairing, are not encrypted. We need to allow SecureSessionMgr able to process packets that are not encrypted, so we can unify BLE, TCP and UDP packet processing.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
1. Adds `mEncrypted` flag to `SecureSession` to mark if the session is encrypted.
2. Adds `InitUnsecure()` to `SecureSession` to create a unsecure session.
3. Adds `NewUnsecureSession()` to `SecureSessionMgr` for creating unsecure sessions.
4. Updated DeviceController to use unsecure session. This should be updated after secure pairing is implemented on chip-tool.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #3526

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
