### PR TITLE
[mDNS] check fabric membership when publishing service

### DIFF
--- a/src/lib/protocols/mdns/Publisher.cpp
+++ b/src/lib/protocols/mdns/Publisher.cpp
@@ -64,9 +64,11 @@ void Publisher::HandleMdnsError(void * context, CHIP_ERROR initError)
 CHIP_ERROR Publisher::StartPublishDevice(chip::Inet::InterfaceId interface)
 {
     CHIP_ERROR error;
+    bool shouldPublishFullyProvisioned =
+        chip::DeviceLayer::ConfigurationMgr().IsFullyProvisioned() && chip::DeviceLayer::ConfigurationMgr().IsMemberOfFabric();
 
     // TODO: after multi-admin is decided we may need to publish both _chipc._udp and _chip._tcp service
-    if (chip::DeviceLayer::ConfigurationMgr().IsFullyProvisioned() != mIsPublishingProvisionedDevice)
+    if (shouldPublishFullyProvisioned != mIsPublishingProvisionedDevice)
     {
         SuccessOrExit(error = StopPublishDevice());
         // Set hostname again in case the mac address changes when shifting from soft-AP to station


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Fabric membership check was removed from `IsFullyProvisioned` but we'll
publish fabric information which causes the publish to fail. 
<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Add checking fabric state before fabric provision is landed.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
