### PR TITLE
Print cluster name in lowercase for chip-tool so it match what is exp…

### DIFF
--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -188,7 +188,10 @@ void Commands::ShowClusters(std::string executable)
     fprintf(stderr, "  +-------------------------------------------------------------------------------------+\n");
     for (auto & cluster : mClusters)
     {
-        fprintf(stderr, "  | * %-82s|\n", cluster.first.c_str());
+        std::string clusterName(cluster.first);
+        std::transform(clusterName.begin(), clusterName.end(), clusterName.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
+        fprintf(stderr, "  | * %-82s|\n", clusterName.c_str());
     }
     fprintf(stderr, "  +-------------------------------------------------------------------------------------+\n");
 }


### PR DESCRIPTION
…ected on the command line


 #### Problem
Cluster names are not printed in lowercase in the chip-tool help while the command lien expects them to be lowercase. I have been told that this is counter intuitive (which is likely true...)


 #### Summary of Changes
 * Print cluster name in lowercase...