### PR TITLE
Use a real clock for the reporting plugin instead of the stub vers…

### DIFF
--- a/src/app/reporting/reporting.cpp
+++ b/src/app/reporting/reporting.cpp
@@ -45,6 +45,7 @@
 #include <app/util/attribute-storage.h>
 #include <app/util/binding-table.h>
 #include <app/util/common.h>
+#include <system/SystemLayer.h>
 
 #ifdef ATTRIBUTE_LARGEST
 #define READ_DATA_SIZE ATTRIBUTE_LARGEST
@@ -194,7 +195,8 @@ extern "C" void emberAfPluginReportingTickEventHandler(void)
         // We will only send reports for active reported attributes and only if a
         // reportable change has occurred and the minimum interval has elapsed or
         // if the maximum interval is set and has elapsed.
-        elapsedMs = elapsedTimeInt32u(emAfPluginReportVolatileData[i].lastReportTimeMs, halCommonGetInt32uMillisecondTick());
+        elapsedMs =
+            elapsedTimeInt32u(emAfPluginReportVolatileData[i].lastReportTimeMs, chip::System::Layer::GetClock_MonotonicMS());
         if (entry.endpoint == EMBER_AF_PLUGIN_REPORTING_UNUSED_ENDPOINT_ID ||
             entry.direction != EMBER_ZCL_REPORTING_DIRECTION_REPORTED ||
             (elapsedMs < entry.data.reported.minInterval * MILLISECOND_TICKS_PER_SECOND) ||
@@ -304,7 +306,7 @@ extern "C" void emberAfPluginReportingTickEventHandler(void)
         // and changes.  We only track changes for data types that are small enough
         // for us to compare. For CHAR and OCTET strings, we substitute a 32-bit hash.
         emAfPluginReportVolatileData[i].reportableChange = false;
-        emAfPluginReportVolatileData[i].lastReportTimeMs = halCommonGetInt32uMillisecondTick();
+        emAfPluginReportVolatileData[i].lastReportTimeMs = chip::System::Layer::GetClock_MonotonicMS();
         uint32_t stringHash                              = 0;
         uint8_t * copyData                               = readData;
         uint8_t copySize                                 = dataSize;
@@ -776,7 +778,7 @@ static void scheduleTick(void)
             uint32_t minIntervalMs = (entry.data.reported.minInterval * MILLISECOND_TICKS_PER_SECOND);
             uint32_t maxIntervalMs = (entry.data.reported.maxInterval * MILLISECOND_TICKS_PER_SECOND);
             uint32_t elapsedMs =
-                elapsedTimeInt32u(emAfPluginReportVolatileData[i].lastReportTimeMs, halCommonGetInt32uMillisecondTick());
+                elapsedTimeInt32u(emAfPluginReportVolatileData[i].lastReportTimeMs, chip::System::Layer::GetClock_MonotonicMS());
             uint32_t remainingMs = MAX_INT32U_VALUE;
             if (emAfPluginReportVolatileData[i].reportableChange)
             {
@@ -907,7 +909,7 @@ EmberAfStatus emberAfPluginReportingConfigureReportedAttribute(const EmberAfPlug
         entry.manufacturerCode = newEntry->manufacturerCode;
         if (index < REPORT_TABLE_SIZE)
         {
-            emAfPluginReportVolatileData[index].lastReportTimeMs = halCommonGetInt32uMillisecondTick();
+            emAfPluginReportVolatileData[index].lastReportTimeMs = chip::System::Layer::GetClock_MonotonicMS();
             emAfPluginReportVolatileData[index].lastReportValue  = 0;
         }
     }

--- a/src/app/util/types_stub.h
+++ b/src/app/util/types_stub.h
@@ -1996,8 +1996,6 @@ typedef struct
  */
 #define halCommonSetIndexedToken(token, index, data)
 
-uint32_t halCommonGetInt32uMillisecondTick(void);
-
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -1353,8 +1353,3 @@ uint8_t emberAfMake8bitEncodedChanPg(uint8_t page, uint8_t channel)
         return channel | ENCODED_8BIT_CHANPG_PAGE_MASK_PAGE_0;
     }
 }
-
-uint32_t halCommonGetInt32uMillisecondTick(void)
-{
-    return 0; // Stub for now. Implement stubs in zcl reporting cluster #2470
-}


### PR DESCRIPTION
…ion of halCommonGetInt32uMillisecondTick

 #### Problem
 
The reporting plugin use a stub version of `halCommonGetInt32uMillisecondTick` which always return 0.

I did not fix `halCommonGetInt32uMillisecondTick` because I believe the goal is to remove this method at the end since the platform layer already act as the HAL layer.

 #### Summary of Changes
 * Use a platform specific clock to get the elapsed time in MS