### PR TITLE
Disable HAL tokens for the reporting plugin

### DIFF
--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -49,6 +49,11 @@
 #include "gen/znet-bookkeeping.h"
 //#include "hal/micro/crc.h"
 
+// TODO: Need to figure out what needs to happen wrt HAL tokens here, but for
+// now define ESZP_HOST to disable it.  See
+// https://github.com/project-chip/connectedhomeip/issues/3275
+#define EZSP_HOST
+
 //------------------------------------------------------------------------------
 // Forward Declarations
 


### PR DESCRIPTION
 #### Problem
The reporting plugin use HAL tokens to get the report configuration to survive between reboots.

While we definitively need to figure out what to do with HAL tokens (tracked in #3275) this PR disable the use of Tokens for reporting since it does not work at the moment and it prevent us to test/use the reporting plugin code

 #### Summary of Changes
 * Disable the usage of HAL tokens in `src/app/reporting/reporting.cpp` 