### PR TITLE
Fix to use emberEventControlSetDelayMS instead of emberAfEventControlSetDelayMS

### DIFF
--- a/src/app/clusters/color-control-server/color-control-server.c
+++ b/src/app/clusters/color-control-server/color-control-server.c
@@ -381,7 +381,7 @@ bool emberAfColorControlClusterMoveToHueAndSaturationCallback(uint8_t hue, uint8
     writeRemainingTime(endpoint, transitionTime);
 
     // kick off the state machine:
-    emberEventControlSetDelayMS(COLOR_HSV_CONTROL, UPDATE_TIME_MS);
+    emberEventControlSetDelayMS(&COLOR_HSV_CONTROL, UPDATE_TIME_MS);
 
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
@@ -440,7 +440,7 @@ bool emberAfColorControlClusterMoveHueCallback(uint8_t moveMode, uint8_t rate, u
     colorSaturationTransitionState.stepsRemaining = 0;
 
     // kick off the state machine:
-    emberEventControlSetDelayMS(COLOR_HSV_CONTROL, UPDATE_TIME_MS);
+    emberEventControlSetDelayMS(&COLOR_HSV_CONTROL, UPDATE_TIME_MS);
 
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
@@ -497,7 +497,7 @@ bool emberAfColorControlClusterMoveSaturationCallback(uint8_t moveMode, uint8_t 
     writeRemainingTime(endpoint, transitionTime);
 
     // kick off the state machine:
-    emberEventControlSetDelayMS(COLOR_HSV_CONTROL, UPDATE_TIME_MS);
+    emberEventControlSetDelayMS(&COLOR_HSV_CONTROL, UPDATE_TIME_MS);
 
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
@@ -590,7 +590,7 @@ bool emberAfColorControlClusterMoveToHueCallback(uint8_t hue, uint8_t hueMoveMod
     writeRemainingTime(endpoint, transitionTime);
 
     // kick off the state machine:
-    emberEventControlSetDelayMS(COLOR_HSV_CONTROL, UPDATE_TIME_MS);
+    emberEventControlSetDelayMS(&COLOR_HSV_CONTROL, UPDATE_TIME_MS);
 
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
@@ -643,7 +643,7 @@ bool emberAfColorControlClusterMoveToSaturationCallback(uint8_t saturation, uint
     writeRemainingTime(endpoint, transitionTime);
 
     // kick off the state machine:
-    emberEventControlSetDelayMS(COLOR_HSV_CONTROL, UPDATE_TIME_MS);
+    emberEventControlSetDelayMS(&COLOR_HSV_CONTROL, UPDATE_TIME_MS);
 
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
@@ -705,7 +705,7 @@ bool emberAfColorControlClusterStepHueCallback(uint8_t stepMode, uint8_t stepSiz
     writeRemainingTime(endpoint, transitionTime);
 
     // kick off the state machine:
-    emberEventControlSetDelayMS(COLOR_HSV_CONTROL, UPDATE_TIME_MS);
+    emberEventControlSetDelayMS(&COLOR_HSV_CONTROL, UPDATE_TIME_MS);
 
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
@@ -766,7 +766,7 @@ bool emberAfColorControlClusterStepSaturationCallback(uint8_t stepMode, uint8_t 
     writeRemainingTime(endpoint, transitionTime);
 
     // kick off the state machine:
-    emberEventControlSetDelayMS(COLOR_HSV_CONTROL, UPDATE_TIME_MS);
+    emberEventControlSetDelayMS(&COLOR_HSV_CONTROL, UPDATE_TIME_MS);
 
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
@@ -881,7 +881,7 @@ bool emberAfColorControlClusterMoveToColorCallback(uint16_t colorX, uint16_t col
     writeRemainingTime(endpoint, transitionTime);
 
     // kick off the state machine:
-    emberEventControlSetDelayMS(COLOR_XY_CONTROL, UPDATE_TIME_MS);
+    emberEventControlSetDelayMS(&COLOR_XY_CONTROL, UPDATE_TIME_MS);
 
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
@@ -961,7 +961,7 @@ bool emberAfColorControlClusterMoveColorCallback(int16_t rateX, int16_t rateY, u
     }
 
     // kick off the state machine:
-    emberEventControlSetDelayMS(COLOR_XY_CONTROL, UPDATE_TIME_MS);
+    emberEventControlSetDelayMS(&COLOR_XY_CONTROL, UPDATE_TIME_MS);
 
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
@@ -1014,7 +1014,7 @@ bool emberAfColorControlClusterStepColorCallback(int16_t stepX, int16_t stepY, u
     writeRemainingTime(endpoint, transitionTime);
 
     // kick off the state machine:
-    emberEventControlSetDelayMS(COLOR_XY_CONTROL, UPDATE_TIME_MS);
+    emberEventControlSetDelayMS(&COLOR_XY_CONTROL, UPDATE_TIME_MS);
 
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
@@ -1106,7 +1106,7 @@ static void moveToColorTemp(uint8_t endpoint, uint16_t colorTemperature, uint16_
     colorTempTransitionState.highLimit      = temperatureMax;
 
     // kick off the state machine:
-    emberEventControlSetDelayMS(COLOR_TEMP_CONTROL, UPDATE_TIME_MS);
+    emberEventControlSetDelayMS(&COLOR_TEMP_CONTROL, UPDATE_TIME_MS);
 }
 
 bool emberAfColorControlClusterMoveToColorTemperatureCallback(uint16_t colorTemperature, uint16_t transitionTime,
@@ -1204,7 +1204,7 @@ bool emberAfColorControlClusterMoveColorTemperatureCallback(uint8_t moveMode, ui
     writeRemainingTime(endpoint, transitionTime);
 
     // kick off the state machine:
-    emberEventControlSetDelayMS(COLOR_TEMP_CONTROL, UPDATE_TIME_MS);
+    emberEventControlSetDelayMS(&COLOR_TEMP_CONTROL, UPDATE_TIME_MS);
 
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
@@ -1271,7 +1271,7 @@ bool emberAfColorControlClusterStepColorTemperatureCallback(uint8_t stepMode, ui
     writeRemainingTime(endpoint, transitionTime);
 
     // kick off the state machine:
-    emberEventControlSetDelayMS(COLOR_TEMP_CONTROL, UPDATE_TIME_MS);
+    emberEventControlSetDelayMS(&COLOR_TEMP_CONTROL, UPDATE_TIME_MS);
 
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
@@ -1544,7 +1544,7 @@ void emberAfPluginColorControlServerHueSatTransitionEventHandler(void)
     }
     else
     {
-        emberEventControlSetDelayMS(COLOR_HSV_CONTROL, UPDATE_TIME_MS);
+        emberEventControlSetDelayMS(&COLOR_HSV_CONTROL, UPDATE_TIME_MS);
     }
 
     writeHue(colorHueTransitionState.endpoint, colorHueTransitionState.currentHue);
@@ -1648,7 +1648,7 @@ void emberAfPluginColorControlServerXyTransitionEventHandler(void)
     }
     else
     {
-        emberEventControlSetDelayMS(COLOR_XY_CONTROL, UPDATE_TIME_MS);
+        emberEventControlSetDelayMS(&COLOR_XY_CONTROL, UPDATE_TIME_MS);
     }
 
     // update the attributes
@@ -1674,7 +1674,7 @@ void emberAfPluginColorControlServerTempTransitionEventHandler(void)
     }
     else
     {
-        emberEventControlSetDelayMS(COLOR_TEMP_CONTROL, UPDATE_TIME_MS);
+        emberEventControlSetDelayMS(&COLOR_TEMP_CONTROL, UPDATE_TIME_MS);
     }
 
     writeColorTemperature(colorTempTransitionState.endpoint, colorTempTransitionState.currentValue);

--- a/src/app/clusters/door-lock-server/door-lock-server-user.c
+++ b/src/app/clusters/door-lock-server/door-lock-server-user.c
@@ -611,7 +611,7 @@ static void startLockout()
     uint8_t lockoutTimeS = getUserCodeTemporaryDisableTime();
     if (lockoutTimeS != 0)
     {
-        emberEventControlSetDelayMS(emberAfPluginDoorLockServerLockoutEventControl, lockoutTimeS * MILLISECOND_TICKS_PER_SECOND);
+        emberEventControlSetDelayMS(&emberAfPluginDoorLockServerLockoutEventControl, lockoutTimeS * MILLISECOND_TICKS_PER_SECOND);
     }
 }
 
@@ -681,7 +681,7 @@ static void scheduleAutoRelock(uint32_t autoRelockTimeS)
     }
     else
     {
-        emberEventControlSetDelayMS(emberAfPluginDoorLockServerRelockEventControl,
+        emberEventControlSetDelayMS(&emberAfPluginDoorLockServerRelockEventControl,
                                     (autoRelockTimeS * MILLISECOND_TICKS_PER_SECOND));
     }
 }

--- a/src/app/reporting/reporting.cpp
+++ b/src/app/reporting/reporting.cpp
@@ -795,7 +795,7 @@ static void scheduleTick(void)
     if (delayMs != MAX_INT32U_VALUE)
     {
         emberAfDebugPrintln("sched report event for: 0x%4x", delayMs);
-        emberAfEventControlSetDelayMS(&emberAfPluginReportingTickEventControl, delayMs);
+        emberEventControlSetDelayMS(&emberAfPluginReportingTickEventControl, delayMs);
     }
     else
     {

--- a/src/app/util/af-event.cpp
+++ b/src/app/util/af-event.cpp
@@ -142,7 +142,7 @@ static EmberAfEventContext * findEventContext(uint8_t endpoint, EmberAfClusterId
     return NULL;
 }
 
-EmberStatus emberAfEventControlSetDelayMS(EmberEventControl * control, uint32_t delayMs)
+EmberStatus emberEventControlSetDelayMS(EmberEventControl * control, uint32_t delayMs)
 {
     if (delayMs == 0)
     {
@@ -179,7 +179,7 @@ EmberStatus emberAfEventControlSetDelayQS(EmberEventControl * control, uint32_t 
 {
     if (delayQs <= EMBER_MAX_EVENT_CONTROL_DELAY_QS)
     {
-        return emberAfEventControlSetDelayMS(control, delayQs << 8);
+        return emberEventControlSetDelayMS(control, delayQs << 8);
     }
     else
     {
@@ -191,7 +191,7 @@ EmberStatus emberAfEventControlSetDelayMinutes(EmberEventControl * control, uint
 {
     if (delayM <= EMBER_MAX_EVENT_CONTROL_DELAY_MINUTES)
     {
-        return emberAfEventControlSetDelayMS(control, delayM << 16);
+        return emberEventControlSetDelayMS(control, delayM << 16);
     }
     else
     {
@@ -209,7 +209,7 @@ EmberStatus emberAfScheduleTickExtended(uint8_t endpoint, EmberAfClusterId clust
     EMBER_TEST_ASSERT(emberAfEndpointIsEnabled(endpoint));
 
     if (context != NULL && emberAfEndpointIsEnabled(endpoint) &&
-        (emberAfEventControlSetDelayMS(context->eventControl, delayMs) == EMBER_SUCCESS))
+        (emberEventControlSetDelayMS(context->eventControl, delayMs) == EMBER_SUCCESS))
     {
         context->pollControl  = pollControl;
         context->sleepControl = sleepControl;

--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -1081,7 +1081,7 @@ EmberStatus emberAfDeactivateServerTick(uint8_t endpoint, EmberAfClusterId clust
            event and return ::EMBER_SUCCESS.  Otherwise it will return
            ::EMBER_BAD_ARGUMENT.
  */
-EmberStatus emberAfEventControlSetDelayMS(EmberEventControl * control, uint32_t delayMs);
+EmberStatus emberEventControlSetDelayMS(EmberEventControl * control, uint32_t delayMs);
 
 /**
  * @brief Sets the ::EmberEventControl to run "delayQs" quarter seconds in the
@@ -1134,14 +1134,14 @@ void emberAfNetworkEventControlSetActive(EmberEventControl * controls);
 /**
  * @brief Sets the ::EmberEventControl for the current network, and only the
  * current network, to run "delayMs" milliseconds in the future.  See
- * ::emberAfEventControlSetDelayMS.
+ * ::emberEventControlSetDelayMS.
  */
 EmberStatus emberAfNetworkEventControlSetDelayMS(EmberEventControl * controls, uint32_t delayMs);
 #ifdef DOXYGEN_SHOULD_SKIP_THIS
 /**
  * @brief Sets the ::EmberEventControl for the current network, and only the
  * current network, to run "delayMs" milliseconds in the future.  See
- * ::emberAfEventControlSetDelayMS.
+ * ::emberEventControlSetDelayMS.
  */
 EmberStatus emberAfNetworkEventControlSetDelay(EmberEventControl * controls, uint32_t delayMs);
 #else
@@ -1177,13 +1177,13 @@ bool emberAfEndpointEventControlGetActive(EmberEventControl * controls, uint8_t 
 EmberStatus emberAfEndpointEventControlSetActive(EmberEventControl * controls, uint8_t endpoint);
 /**
  * @brief Sets the ::EmberEventControl for the specified endpoint to run
- * "delayMs" milliseconds in the future.  See ::emberAfEventControlSetDelayMS.
+ * "delayMs" milliseconds in the future.  See ::emberEventControlSetDelayMS.
  */
 EmberStatus emberAfEndpointEventControlSetDelayMS(EmberEventControl * controls, uint8_t endpoint, uint32_t delayMs);
 #ifdef DOXYGEN_SHOULD_SKIP_THIS
 /**
  * @brief Sets the ::EmberEventControl for the specified endpoint to run
- * "delayMs" milliseconds in the future.  See ::emberAfEventControlSetDelayMS.
+ * "delayMs" milliseconds in the future.  See ::emberEventControlSetDelayMS.
  */
 EmberStatus emberAfEndpointEventControlSetDelay(EmberEventControl * controls, uint8_t endpoint, uint32_t delayMs);
 #else

--- a/src/app/util/types_stub.h
+++ b/src/app/util/types_stub.h
@@ -1957,8 +1957,6 @@ typedef struct
 #define MILLISECOND_TICKS_PER_SECOND 1000
 #define MILLISECOND_TICKS_PER_DECISECOND (MILLISECOND_TICKS_PER_SECOND / 10)
 
-#define emberEventControlSetDelayMS(control, delay) (void) 0
-
 #define emberAfPluginColorControlServerComputePwmFromXyCallback(endpoint) (void) 0
 #define emberAfPluginColorControlServerComputePwmFromHsvCallback(endpoint) (void) 0
 #define emberAfPluginColorControlServerComputePwmFromTempCallback(endpoint) (void) 0


### PR DESCRIPTION

 #### Problem
Color control cluster attributes were not being updated and propagated to the application. On debugging found that emberEventControlSetDelayMS is no-op.

 #### Summary of Changes
i. Remove the existing no-op macro for emberAfEventControlSetDelayMS
ii. Replace usage of emberAfEventControlSetDelayMS with emberEventControlSetDelayMS at all places
With this change, the attributes and their appropriate values are received in the device callback
