### PR TITLE
Use the 'presentIf' attribute from dotdot XML to prevent reading resp…

### DIFF
--- a/examples/chip-tool/commands/clusters/Commands.h
+++ b/examples/chip-tool/commands/clusters/Commands.h
@@ -498,24 +498,27 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "ReadAttributesResponse (0x01):");
+
         // struct readAttributeResponseRecord[]
         while (messageLen)
         {
             CHECK_MESSAGE_LENGTH(2);
             ChipLogProgress(chipTool, "  %s: 0x%04x", "attributeId", chip::Encoding::LittleEndian::Read16(message)); // attribId
             CHECK_MESSAGE_LENGTH(1);
-            if (!CheckStatus(chip::Encoding::Read8(message))) // zclStatus
+            uint8_t status = chip::Encoding::Read8(message); // zclStatus
+            success        = CheckStatus(status);
+            if (status == 0)
             {
-                return false;
-            }
-            if (!ReadAttributeValue(message, messageLen))
-            {
-                return false;
+                if (!ReadAttributeValue(message, messageLen))
+                {
+                    return false;
+                }
             }
         }
 
-        return true;
+        return success;
     }
 };
 
@@ -529,20 +532,23 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "WriteAttributesResponse (0x04):");
+
         // struct writeAttributeResponseRecord[]
         while (messageLen)
         {
             CHECK_MESSAGE_LENGTH(1);
-            if (!CheckStatus(chip::Encoding::Read8(message))) // zclStatus
+            uint8_t status = chip::Encoding::Read8(message); // zclStatus
+            success        = CheckStatus(status);
+            if (status != 0)
             {
-                return false;
+                CHECK_MESSAGE_LENGTH(2);
+                ChipLogProgress(chipTool, "  %s: 0x%04x", "attributeId", chip::Encoding::LittleEndian::Read16(message)); // attribId
             }
-            CHECK_MESSAGE_LENGTH(2);
-            ChipLogProgress(chipTool, "  %s: 0x%04x", "attributeId", chip::Encoding::LittleEndian::Read16(message)); // attribId
         }
 
-        return true;
+        return success;
     }
 };
 
@@ -556,7 +562,9 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "WriteAttributesNoResponse (0x05):");
+
         // struct writeAttributeRecord[]
         while (messageLen)
         {
@@ -568,7 +576,7 @@ public:
             }
         }
 
-        return true;
+        return success;
     }
 };
 
@@ -582,16 +590,16 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "DefaultResponse (0x0B):");
+
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "commandId", chip::Encoding::Read8(message)); // uint8
         CHECK_MESSAGE_LENGTH(1);
-        if (!CheckStatus(chip::Encoding::Read8(message))) // zclStatus
-        {
-            return false;
-        }
+        uint8_t status = chip::Encoding::Read8(message); // zclStatus
+        success        = CheckStatus(status);
 
-        return true;
+        return success;
     }
 };
 
@@ -605,7 +613,9 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "DiscoverAttributesResponse (0x0D):");
+
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "discoveryComplete", chip::Encoding::Read8(message)); // bool
         // struct discoverAttributesResponseRecord[]
@@ -617,7 +627,7 @@ public:
             ChipLogProgress(chipTool, "  %s: 0x%02x", "attributeType", chip::Encoding::Read8(message)); // zclType
         }
 
-        return true;
+        return success;
     }
 };
 
@@ -2520,11 +2530,13 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "ClearAllPINCodesResponse (0x08):");
+
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "status", chip::Encoding::Read8(message)); // DrlkPassFailStatus
 
-        return true;
+        return success;
     }
 };
 
@@ -2538,11 +2550,13 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "ClearAllRFIDCodesResponse (0x19):");
+
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "status", chip::Encoding::Read8(message)); // DrlkPassFailStatus
 
-        return true;
+        return success;
     }
 };
 
@@ -2556,11 +2570,13 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "ClearHolidayScheduleResponse (0x13):");
+
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "status", chip::Encoding::Read8(message)); // DrlkPassFailStatus
 
-        return true;
+        return success;
     }
 };
 
@@ -2574,11 +2590,13 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "ClearPINCodeResponse (0x07):");
+
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "status", chip::Encoding::Read8(message)); // DrlkPassFailStatus
 
-        return true;
+        return success;
     }
 };
 
@@ -2592,11 +2610,13 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "ClearRFIDCodeResponse (0x18):");
+
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "status", chip::Encoding::Read8(message)); // DrlkPassFailStatus
 
-        return true;
+        return success;
     }
 };
 
@@ -2610,11 +2630,13 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "ClearWeekdayScheduleResponse (0x0D):");
+
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "status", chip::Encoding::Read8(message)); // DrlkPassFailStatus
 
-        return true;
+        return success;
     }
 };
 
@@ -2628,11 +2650,13 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "ClearYearDayScheduleResponse (0x10):");
+
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "status", chip::Encoding::Read8(message)); // DrlkPassFailStatus
 
-        return true;
+        return success;
     }
 };
 
@@ -2646,22 +2670,31 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "GetHolidayScheduleResponse (0x12):");
+
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "holidayScheduleId", chip::Encoding::Read8(message)); // uint8
         CHECK_MESSAGE_LENGTH(1);
-        if (!CheckStatus(chip::Encoding::Read8(message))) // zclStatus
+        uint8_t status = chip::Encoding::Read8(message); // zclStatus
+        success        = CheckStatus(status);
+        if (status == 0)
         {
-            return false;
+            CHECK_MESSAGE_LENGTH(4);
+            ChipLogProgress(chipTool, "  %s: 0x%08x", "localStartTime", chip::Encoding::LittleEndian::Read32(message)); // uint32
         }
-        CHECK_MESSAGE_LENGTH(4);
-        ChipLogProgress(chipTool, "  %s: 0x%08x", "localStartTime", chip::Encoding::LittleEndian::Read32(message)); // uint32
-        CHECK_MESSAGE_LENGTH(4);
-        ChipLogProgress(chipTool, "  %s: 0x%08x", "localEndTime", chip::Encoding::LittleEndian::Read32(message)); // uint32
-        CHECK_MESSAGE_LENGTH(1);
-        ChipLogProgress(chipTool, "  %s: 0x%02x", "operatingModeDuringHoliday", chip::Encoding::Read8(message)); // DrlkOperMode
+        if (status == 0)
+        {
+            CHECK_MESSAGE_LENGTH(4);
+            ChipLogProgress(chipTool, "  %s: 0x%08x", "localEndTime", chip::Encoding::LittleEndian::Read32(message)); // uint32
+        }
+        if (status == 0)
+        {
+            CHECK_MESSAGE_LENGTH(1);
+            ChipLogProgress(chipTool, "  %s: 0x%02x", "operatingModeDuringHoliday", chip::Encoding::Read8(message)); // DrlkOperMode
+        }
 
-        return true;
+        return success;
     }
 };
 
@@ -2712,7 +2745,9 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "GetPINCodeResponse (0x06):");
+
         CHECK_MESSAGE_LENGTH(2);
         ChipLogProgress(chipTool, "  %s: 0x%04x", "userId", chip::Encoding::LittleEndian::Read16(message)); // uint16
         CHECK_MESSAGE_LENGTH(1);
@@ -2730,7 +2765,7 @@ public:
             message += codeLen;
         }
 
-        return true;
+        return success;
     }
 };
 
@@ -2744,7 +2779,9 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "GetRFIDCodeResponse (0x17):");
+
         CHECK_MESSAGE_LENGTH(2);
         ChipLogProgress(chipTool, "  %s: 0x%04x", "userId", chip::Encoding::LittleEndian::Read16(message)); // uint16
         CHECK_MESSAGE_LENGTH(1);
@@ -2762,7 +2799,7 @@ public:
             message += rFIdCodeLen;
         }
 
-        return true;
+        return success;
     }
 };
 
@@ -2776,13 +2813,15 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "GetUserTypeResponse (0x15):");
+
         CHECK_MESSAGE_LENGTH(2);
         ChipLogProgress(chipTool, "  %s: 0x%04x", "userId", chip::Encoding::LittleEndian::Read16(message)); // uint16
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "userType", chip::Encoding::Read8(message)); // DrlkUserType
 
-        return true;
+        return success;
     }
 };
 
@@ -2796,28 +2835,43 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "GetWeekdayScheduleResponse (0x0C):");
+
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "scheduleId", chip::Encoding::Read8(message)); // uint8
         CHECK_MESSAGE_LENGTH(2);
         ChipLogProgress(chipTool, "  %s: 0x%04x", "userId", chip::Encoding::LittleEndian::Read16(message)); // uint16
         CHECK_MESSAGE_LENGTH(1);
-        if (!CheckStatus(chip::Encoding::Read8(message))) // zclStatus
+        uint8_t status = chip::Encoding::Read8(message); // zclStatus
+        success        = CheckStatus(status);
+        if (status == 0)
         {
-            return false;
+            CHECK_MESSAGE_LENGTH(1);
+            ChipLogProgress(chipTool, "  %s: 0x%02x", "daysMask", chip::Encoding::Read8(message)); // DrlkDaysMask
         }
-        CHECK_MESSAGE_LENGTH(1);
-        ChipLogProgress(chipTool, "  %s: 0x%02x", "daysMask", chip::Encoding::Read8(message)); // DrlkDaysMask
-        CHECK_MESSAGE_LENGTH(1);
-        ChipLogProgress(chipTool, "  %s: 0x%02x", "startHour", chip::Encoding::Read8(message)); // uint8
-        CHECK_MESSAGE_LENGTH(1);
-        ChipLogProgress(chipTool, "  %s: 0x%02x", "startMinute", chip::Encoding::Read8(message)); // uint8
-        CHECK_MESSAGE_LENGTH(1);
-        ChipLogProgress(chipTool, "  %s: 0x%02x", "endHour", chip::Encoding::Read8(message)); // uint8
-        CHECK_MESSAGE_LENGTH(1);
-        ChipLogProgress(chipTool, "  %s: 0x%02x", "endMinute", chip::Encoding::Read8(message)); // uint8
+        if (status == 0)
+        {
+            CHECK_MESSAGE_LENGTH(1);
+            ChipLogProgress(chipTool, "  %s: 0x%02x", "startHour", chip::Encoding::Read8(message)); // uint8
+        }
+        if (status == 0)
+        {
+            CHECK_MESSAGE_LENGTH(1);
+            ChipLogProgress(chipTool, "  %s: 0x%02x", "startMinute", chip::Encoding::Read8(message)); // uint8
+        }
+        if (status == 0)
+        {
+            CHECK_MESSAGE_LENGTH(1);
+            ChipLogProgress(chipTool, "  %s: 0x%02x", "endHour", chip::Encoding::Read8(message)); // uint8
+        }
+        if (status == 0)
+        {
+            CHECK_MESSAGE_LENGTH(1);
+            ChipLogProgress(chipTool, "  %s: 0x%02x", "endMinute", chip::Encoding::Read8(message)); // uint8
+        }
 
-        return true;
+        return success;
     }
 };
 
@@ -2831,22 +2885,28 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "GetYearDayScheduleResponse (0x0F):");
+
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "scheduleId", chip::Encoding::Read8(message)); // uint8
         CHECK_MESSAGE_LENGTH(2);
         ChipLogProgress(chipTool, "  %s: 0x%04x", "userId", chip::Encoding::LittleEndian::Read16(message)); // uint16
         CHECK_MESSAGE_LENGTH(1);
-        if (!CheckStatus(chip::Encoding::Read8(message))) // zclStatus
+        uint8_t status = chip::Encoding::Read8(message); // zclStatus
+        success        = CheckStatus(status);
+        if (status == 0)
         {
-            return false;
+            CHECK_MESSAGE_LENGTH(4);
+            ChipLogProgress(chipTool, "  %s: 0x%08x", "localStartTime", chip::Encoding::LittleEndian::Read32(message)); // uint32
         }
-        CHECK_MESSAGE_LENGTH(4);
-        ChipLogProgress(chipTool, "  %s: 0x%08x", "localStartTime", chip::Encoding::LittleEndian::Read32(message)); // uint32
-        CHECK_MESSAGE_LENGTH(4);
-        ChipLogProgress(chipTool, "  %s: 0x%08x", "localEndTime", chip::Encoding::LittleEndian::Read32(message)); // uint32
+        if (status == 0)
+        {
+            CHECK_MESSAGE_LENGTH(4);
+            ChipLogProgress(chipTool, "  %s: 0x%08x", "localEndTime", chip::Encoding::LittleEndian::Read32(message)); // uint32
+        }
 
-        return true;
+        return success;
     }
 };
 
@@ -2860,14 +2920,14 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "LockDoorResponse (0x00):");
-        CHECK_MESSAGE_LENGTH(1);
-        if (!CheckStatus(chip::Encoding::Read8(message))) // zclStatus
-        {
-            return false;
-        }
 
-        return true;
+        CHECK_MESSAGE_LENGTH(1);
+        uint8_t status = chip::Encoding::Read8(message); // zclStatus
+        success        = CheckStatus(status);
+
+        return success;
     }
 };
 
@@ -2881,11 +2941,13 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "SetHolidayScheduleResponse (0x11):");
+
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "status", chip::Encoding::Read8(message)); // DrlkPassFailStatus
 
-        return true;
+        return success;
     }
 };
 
@@ -2899,11 +2961,13 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "SetPINCodeResponse (0x05):");
+
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "status", chip::Encoding::Read8(message)); // DrlkSetCodeStatus
 
-        return true;
+        return success;
     }
 };
 
@@ -2917,11 +2981,13 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "SetRFIDCodeResponse (0x16):");
+
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "status", chip::Encoding::Read8(message)); // DrlkSetCodeStatus
 
-        return true;
+        return success;
     }
 };
 
@@ -2935,11 +3001,13 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "SetUserTypeResponse (0x14):");
+
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "status", chip::Encoding::Read8(message)); // DrlkPassFailStatus
 
-        return true;
+        return success;
     }
 };
 
@@ -2953,11 +3021,13 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "SetWeekdayScheduleResponse (0x0B):");
+
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "status", chip::Encoding::Read8(message)); // DrlkPassFailStatus
 
-        return true;
+        return success;
     }
 };
 
@@ -2971,11 +3041,13 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "SetYearDayScheduleResponse (0x0E):");
+
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "status", chip::Encoding::Read8(message)); // DrlkPassFailStatus
 
-        return true;
+        return success;
     }
 };
 
@@ -2989,14 +3061,14 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "UnlockDoorResponse (0x01):");
-        CHECK_MESSAGE_LENGTH(1);
-        if (!CheckStatus(chip::Encoding::Read8(message))) // zclStatus
-        {
-            return false;
-        }
 
-        return true;
+        CHECK_MESSAGE_LENGTH(1);
+        uint8_t status = chip::Encoding::Read8(message); // zclStatus
+        success        = CheckStatus(status);
+
+        return success;
     }
 };
 
@@ -3010,14 +3082,14 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "UnlockWithTimeoutResponse (0x03):");
-        CHECK_MESSAGE_LENGTH(1);
-        if (!CheckStatus(chip::Encoding::Read8(message))) // zclStatus
-        {
-            return false;
-        }
 
-        return true;
+        CHECK_MESSAGE_LENGTH(1);
+        uint8_t status = chip::Encoding::Read8(message); // zclStatus
+        success        = CheckStatus(status);
+
+        return success;
     }
 };
 
@@ -3973,13 +4045,15 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "AddGroupResponse (0x00):");
+
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "status", chip::Encoding::Read8(message)); // enum8
         CHECK_MESSAGE_LENGTH(2);
         ChipLogProgress(chipTool, "  %s: 0x%04x", "groupId", chip::Encoding::LittleEndian::Read16(message)); // uint16
 
-        return true;
+        return success;
     }
 };
 
@@ -3993,7 +4067,9 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "GetGroupMembershipResponse (0x02):");
+
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "capacity", chip::Encoding::Read8(message)); // uint8
         CHECK_MESSAGE_LENGTH(1);
@@ -4005,7 +4081,7 @@ public:
             ChipLogProgress(chipTool, "  %s: 0x%04x", "groupList", chip::Encoding::LittleEndian::Read16(message)); // uint16
         }
 
-        return true;
+        return success;
     }
 };
 
@@ -4019,13 +4095,15 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "RemoveGroupResponse (0x03):");
+
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "status", chip::Encoding::Read8(message)); // enum8
         CHECK_MESSAGE_LENGTH(2);
         ChipLogProgress(chipTool, "  %s: 0x%04x", "groupId", chip::Encoding::LittleEndian::Read16(message)); // uint16
 
-        return true;
+        return success;
     }
 };
 
@@ -4039,7 +4117,9 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "ViewGroupResponse (0x01):");
+
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "status", chip::Encoding::Read8(message)); // enum8
         CHECK_MESSAGE_LENGTH(2);
@@ -4055,7 +4135,7 @@ public:
             message += groupNameLen;
         }
 
-        return true;
+        return success;
     }
 };
 
@@ -4306,11 +4386,13 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "IdentifyQueryResponse (0x00):");
+
         CHECK_MESSAGE_LENGTH(2);
         ChipLogProgress(chipTool, "  %s: 0x%04x", "timeout", chip::Encoding::LittleEndian::Read16(message)); // uint16
 
-        return true;
+        return success;
     }
 };
 
@@ -4862,18 +4944,18 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "AddSceneResponse (0x00):");
+
         CHECK_MESSAGE_LENGTH(1);
-        if (!CheckStatus(chip::Encoding::Read8(message))) // zclStatus
-        {
-            return false;
-        }
+        uint8_t status = chip::Encoding::Read8(message); // zclStatus
+        success        = CheckStatus(status);
         CHECK_MESSAGE_LENGTH(2);
         ChipLogProgress(chipTool, "  %s: 0x%04x", "groupId", chip::Encoding::LittleEndian::Read16(message)); // SGroupId
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "sceneId", chip::Encoding::Read8(message)); // uint8
 
-        return true;
+        return success;
     }
 };
 
@@ -4989,12 +5071,12 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "GetSceneMembershipResponse (0x06):");
+
         CHECK_MESSAGE_LENGTH(1);
-        if (!CheckStatus(chip::Encoding::Read8(message))) // zclStatus
-        {
-            return false;
-        }
+        uint8_t status = chip::Encoding::Read8(message); // zclStatus
+        success        = CheckStatus(status);
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "capacity", chip::Encoding::Read8(message)); // uint8
         CHECK_MESSAGE_LENGTH(2);
@@ -5006,7 +5088,7 @@ public:
             ChipLogProgress(chipTool, "  %s: 0x%02x", "sceneList", chip::Encoding::Read8(message)); // uint8
         }
 
-        return true;
+        return success;
     }
 };
 
@@ -5020,16 +5102,16 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "RemoveAllScenesResponse (0x03):");
+
         CHECK_MESSAGE_LENGTH(1);
-        if (!CheckStatus(chip::Encoding::Read8(message))) // zclStatus
-        {
-            return false;
-        }
+        uint8_t status = chip::Encoding::Read8(message); // zclStatus
+        success        = CheckStatus(status);
         CHECK_MESSAGE_LENGTH(2);
         ChipLogProgress(chipTool, "  %s: 0x%04x", "groupId", chip::Encoding::LittleEndian::Read16(message)); // SGroupId
 
-        return true;
+        return success;
     }
 };
 
@@ -5043,18 +5125,18 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "RemoveSceneResponse (0x02):");
+
         CHECK_MESSAGE_LENGTH(1);
-        if (!CheckStatus(chip::Encoding::Read8(message))) // zclStatus
-        {
-            return false;
-        }
+        uint8_t status = chip::Encoding::Read8(message); // zclStatus
+        success        = CheckStatus(status);
         CHECK_MESSAGE_LENGTH(2);
         ChipLogProgress(chipTool, "  %s: 0x%04x", "groupId", chip::Encoding::LittleEndian::Read16(message)); // SGroupId
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "sceneId", chip::Encoding::Read8(message)); // uint8
 
-        return true;
+        return success;
     }
 };
 
@@ -5068,18 +5150,18 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "StoreSceneResponse (0x04):");
+
         CHECK_MESSAGE_LENGTH(1);
-        if (!CheckStatus(chip::Encoding::Read8(message))) // zclStatus
-        {
-            return false;
-        }
+        uint8_t status = chip::Encoding::Read8(message); // zclStatus
+        success        = CheckStatus(status);
         CHECK_MESSAGE_LENGTH(2);
         ChipLogProgress(chipTool, "  %s: 0x%04x", "groupId", chip::Encoding::LittleEndian::Read16(message)); // SGroupId
         CHECK_MESSAGE_LENGTH(1);
         ChipLogProgress(chipTool, "  %s: 0x%02x", "sceneId", chip::Encoding::Read8(message)); // uint8
 
-        return true;
+        return success;
     }
 };
 
@@ -5093,12 +5175,12 @@ public:
 
     bool HandleResponse(uint8_t * message, uint16_t messageLen) const override
     {
+        bool success = true;
         ChipLogProgress(chipTool, "ViewSceneResponse (0x01):");
+
         CHECK_MESSAGE_LENGTH(1);
-        if (!CheckStatus(chip::Encoding::Read8(message))) // zclStatus
-        {
-            return false;
-        }
+        uint8_t status = chip::Encoding::Read8(message); // zclStatus
+        success        = CheckStatus(status);
         CHECK_MESSAGE_LENGTH(2);
         ChipLogProgress(chipTool, "  %s: 0x%04x", "groupId", chip::Encoding::LittleEndian::Read16(message)); // SGroupId
         CHECK_MESSAGE_LENGTH(1);
@@ -5132,7 +5214,7 @@ public:
             }
         }
 
-        return true;
+        return success;
     }
 };
 


### PR DESCRIPTION
…onse fields depending on the response status

 #### Problem
The presence of various fields in command responses depends of some other fields of the response itself.

 #### Summary of Changes
* Use the `presentIf` field from dot dot xml