### PR TITLE
[Darwin] Handle short discriminator while pairing

### DIFF
--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -374,7 +374,6 @@ BLE_ERROR BleLayer::NewBleConnection(void * appState, const uint16_t connDiscrim
     BLE_ERROR err = BLE_NO_ERROR;
 
     VerifyOrExit(mState == kState_Initialized, err = BLE_ERROR_INCORRECT_STATE);
-    VerifyOrExit(connDiscriminator != 0, err = BLE_ERROR_BAD_ARGS);
     VerifyOrExit(mConnectionDelegate != nullptr, err = BLE_ERROR_INCORRECT_STATE);
 
     mConnectionDelegate->OnConnectionComplete = onConnectionComplete;

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
@@ -510,7 +510,6 @@
 - (void)handleRendezVous:(CHIPSetupPayload *)payload
 {
     switch (payload.rendezvousInformation) {
-    case kRendezvousInformationNone:
     case kRendezvousInformationThread:
     case kRendezvousInformationEthernet:
     case kRendezvousInformationAllMask:
@@ -520,6 +519,7 @@
         NSLog(@"Rendezvous Wi-Fi");
         [self handleRendezVousWiFi:[self getNetworkName:payload.discriminator]];
         break;
+    case kRendezvousInformationNone:
     case kRendezvousInformationBLE:
         NSLog(@"Rendezvous BLE");
         [self handleRendezVousBLE:payload.discriminator.unsignedShortValue setupPINCode:payload.setUpPINCode.unsignedIntValue];

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -186,6 +186,7 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
       "${chip_root}/src/lib/core",
       "${chip_root}/src/lib/core:chip_config_header",
       "${chip_root}/src/lib/support",
+      "${chip_root}/src/setup_payload",
       "${nlio_root}:nlio",
     ]
 

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -55,7 +55,7 @@ const uint8_t kSerialNumberTag               = 128;
 const uint32_t kTag_QRCodeExensionDescriptor = 0x00;
 
 // The largest value of the 12-bit Payload discriminator
-const uint16_t kMaxDiscriminatorValue = 4095;
+const uint16_t kMaxDiscriminatorValue = 0xFFF;
 
 // clang-format off
 const int kTotalPayloadDataSizeInBits =

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -54,6 +54,9 @@ const int kManualSetupProductIdCharLength = 5;
 const uint8_t kSerialNumberTag               = 128;
 const uint32_t kTag_QRCodeExensionDescriptor = 0x00;
 
+// The largest value of the 12-bit Payload discriminator
+const uint16_t kMaxDiscriminatorValue = 4095;
+
 // clang-format off
 const int kTotalPayloadDataSizeInBits =
     kVersionFieldLengthInBits +

--- a/src/transport/BUILD.gn
+++ b/src/transport/BUILD.gn
@@ -50,6 +50,7 @@ static_library("transport") {
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/platform",
+    "${chip_root}/src/setup_payload",
     "${chip_root}/src/transport/raw",
   ]
 }

--- a/src/transport/BUILD.gn
+++ b/src/transport/BUILD.gn
@@ -50,7 +50,6 @@ static_library("transport") {
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/platform",
-    "${chip_root}/src/setup_payload",
     "${chip_root}/src/transport/raw",
   ]
 }

--- a/src/transport/RendezvousParameters.h
+++ b/src/transport/RendezvousParameters.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <setup_payload/SetupPayload.h>
 #include <transport/raw/Base.h>
 
 #if CONFIG_NETWORK_LAYER_BLE
@@ -27,6 +26,9 @@
 #include <support/logging/CHIPLogging.h>
 
 namespace chip {
+
+// The largest supported value for Rendezvous discriminators
+const uint16_t kMaxRendezvousDiscriminatorValue = 0xFFF;
 
 class RendezvousParameters
 {
@@ -43,7 +45,7 @@ public:
         return *this;
     }
 
-    bool HasDiscriminator() const { return mDiscriminator <= kMaxDiscriminatorValue; }
+    bool HasDiscriminator() const { return mDiscriminator <= kMaxRendezvousDiscriminatorValue; }
     uint16_t GetDiscriminator() const { return mDiscriminator; }
     RendezvousParameters & SetDiscriminator(uint16_t discriminator)
     {

--- a/src/transport/RendezvousParameters.h
+++ b/src/transport/RendezvousParameters.h
@@ -23,6 +23,7 @@
 #include <ble/Ble.h>
 #endif // CONFIG_NETWORK_LAYER_BLE
 
+#include <support/SafeInt.h>
 #include <support/logging/CHIPLogging.h>
 
 namespace chip {
@@ -42,8 +43,8 @@ public:
         return *this;
     }
 
-    bool HasDiscriminator() const { return mDiscriminator != -1; }
-    uint16_t GetDiscriminator() const { return (uint16_t) mDiscriminator; }
+    bool HasDiscriminator() const { return mDiscriminator != -1 && CanCastTo<uint16_t>(mDiscriminator); }
+    uint16_t GetDiscriminator() const { return static_cast<uint16_t>(mDiscriminator); }
     RendezvousParameters & SetDiscriminator(uint16_t discriminator)
     {
         mDiscriminator = discriminator;

--- a/src/transport/RendezvousParameters.h
+++ b/src/transport/RendezvousParameters.h
@@ -42,8 +42,8 @@ public:
         return *this;
     }
 
-    bool HasDiscriminator() const { return mDiscriminator != 0; }
-    uint16_t GetDiscriminator() const { return mDiscriminator; }
+    bool HasDiscriminator() const { return mDiscriminator != -1; }
+    uint16_t GetDiscriminator() const { return (uint16_t) mDiscriminator; }
     RendezvousParameters & SetDiscriminator(uint16_t discriminator)
     {
         mDiscriminator = discriminator;
@@ -80,8 +80,8 @@ public:
 
 private:
     Optional<NodeId> mLocalNodeId; ///< the local node id
-    uint32_t mSetupPINCode  = 0;   ///< the target peripheral setup PIN Code
-    uint16_t mDiscriminator = 0;   ///< the target peripheral discriminator
+    uint32_t mSetupPINCode = 0;    ///< the target peripheral setup PIN Code
+    int32_t mDiscriminator = -1;   ///< the target peripheral discriminator
 
 #if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * mBleLayer               = nullptr;

--- a/src/transport/RendezvousParameters.h
+++ b/src/transport/RendezvousParameters.h
@@ -17,13 +17,13 @@
 
 #pragma once
 
+#include <setup_payload/SetupPayload.h>
 #include <transport/raw/Base.h>
 
 #if CONFIG_NETWORK_LAYER_BLE
 #include <ble/Ble.h>
 #endif // CONFIG_NETWORK_LAYER_BLE
 
-#include <support/SafeInt.h>
 #include <support/logging/CHIPLogging.h>
 
 namespace chip {
@@ -43,8 +43,8 @@ public:
         return *this;
     }
 
-    bool HasDiscriminator() const { return mDiscriminator != -1 && CanCastTo<uint16_t>(mDiscriminator); }
-    uint16_t GetDiscriminator() const { return static_cast<uint16_t>(mDiscriminator); }
+    bool HasDiscriminator() const { return mDiscriminator <= kMaxDiscriminatorValue; }
+    uint16_t GetDiscriminator() const { return mDiscriminator; }
     RendezvousParameters & SetDiscriminator(uint16_t discriminator)
     {
         mDiscriminator = discriminator;
@@ -80,9 +80,9 @@ public:
 #endif // CONFIG_NETWORK_LAYER_BLE
 
 private:
-    Optional<NodeId> mLocalNodeId; ///< the local node id
-    uint32_t mSetupPINCode = 0;    ///< the target peripheral setup PIN Code
-    int32_t mDiscriminator = -1;   ///< the target peripheral discriminator
+    Optional<NodeId> mLocalNodeId;        ///< the local node id
+    uint32_t mSetupPINCode  = 0;          ///< the target peripheral setup PIN Code
+    uint16_t mDiscriminator = UINT16_MAX; ///< the target peripheral discriminator
 
 #if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * mBleLayer               = nullptr;


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
The commissioner logic doesn't deal with Short Rendezvous Discriminators correctly. 
The requirement for the Short 11-digit Setup Payload is to only include the least significant 4-bits of the device's discriminator. The commissioner code doesn't factor this in when looking for matching devices. 

Additionally, since the last 4bits of the discriminator can be 0 (`F00`, our current default, for example), the RendezvousPayload container and BleLayer must not invalidate a discriminator of 0. 

Finally, there's no way to test this functionality out with the CHIPTool iOS application. 

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
1. Fixed the Darwin BLEConnectionDelegate's Discriminator check to correctly handle the Short Discriminators.
2. Updated the RendezvousPayload and BleLayer classes to not invalidate a Discriminator of 0. 
3. Updated the CHIPTool iOS application to allow connecting to a device based on the shorter manual entry code.  
<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
