### PR TITLE
Set Debug flag when running debug builds

### DIFF
--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -31,6 +31,10 @@ config("includes") {
   if (chip_device_platform == "linux" || chip_device_platform == "darwin") {
     defines += [ "CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE=${chip_enable_ble}" ]
   }
+
+  if (is_debug) {
+    defines += [ "DEBUG=1" ]
+  }
 }
 
 if (chip_build_tests) {


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
We don't seem to use a unified way of checking whether a build is debug or release. 
Some parts of the code use `#ifdef NDEBUG` while some other recently added bits are using `#if defined(DEBUG)`

The latter has resulted in some code that would not compile to make its way into the tree. See #3542.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Added a define to set `DEBUG=1` so that the new debug checks cause a failure. ~~**This PR is expected to fail until rebased on https://github.com/project-chip/connectedhomeip/pull/3551**~~ This PR should now pass. 

**Alternatively** we can replace the `DEBUG` checks to use `NDEBUG`. Whatever the reviewers prefer. 

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->


<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
