### PR TITLE
Fix BLE advertisement service data format

### DIFF
--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -47,7 +47,6 @@ using namespace chip::Transport;
 using namespace chip::DeviceLayer;
 
 constexpr uint32_t kDefaultSetupPinCode = 12345678; // TODO: Should be a macro in CHIPProjectConfig.h like other example apps.
-constexpr int kExampleVenderID          = 0xabcd;
 
 extern "C" {
 void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,
@@ -106,6 +105,8 @@ CHIP_ERROR PrintQRCodeContent()
     chip::SetupPayload payload;
     uint32_t setUpPINCode;
     uint16_t setUpDiscriminator;
+    uint16_t vendorId;
+    uint16_t productId;
     std::string result;
 
     err = ConfigurationMgr().GetSetupPinCode(setUpPINCode);
@@ -124,9 +125,15 @@ CHIP_ERROR PrintQRCodeContent()
     }
     SuccessOrExit(err);
 
+    err = ConfigurationMgr().GetVendorId(vendorId);
+    SuccessOrExit(err);
+
+    err = ConfigurationMgr().GetProductId(productId);
+    SuccessOrExit(err);
+
     payload.version       = 1;
-    payload.vendorID      = kExampleVenderID;
-    payload.productID     = 1;
+    payload.vendorID      = vendorId;
+    payload.productID     = productId;
     payload.setUpPINCode  = setUpPINCode;
     payload.discriminator = setUpDiscriminator;
 

--- a/examples/lighting-app/nrf5/main/AppTask.cpp
+++ b/examples/lighting-app/nrf5/main/AppTask.cpp
@@ -57,7 +57,6 @@ constexpr int kFactoryResetCancelWindowTimeout = 3000;
 constexpr size_t kAppTaskStackSize             = 4096;
 constexpr int kAppTaskPriority                 = 2;
 constexpr int kAppEventQueueSize               = 10;
-constexpr int kExampleVenderID                 = 0xabcd;
 
 SemaphoreHandle_t sCHIPEventLock;
 
@@ -175,6 +174,8 @@ int AppTask::Init()
         chip::SetupPayload payload;
         uint32_t setUpPINCode       = 0;
         uint16_t setUpDiscriminator = 0;
+        uint16_t vendorId           = 0;
+        uint16_t productId          = 0;
 
         err = ConfigurationMgr().GetSetupPinCode(setUpPINCode);
         if (err != CHIP_NO_ERROR)
@@ -188,9 +189,21 @@ int AppTask::Init()
             NRF_LOG_INFO("ConfigurationMgr().GetSetupDiscriminator() failed: %s", chip::ErrorStr(err));
         }
 
+        err = ConfigurationMgr().GetVendorId(vendorId);
+        if (err != CHIP_NO_ERROR)
+        {
+            NRF_LOG_INFO("ConfigurationMgr().GetVendorId() failed: %s", chip::ErrorStr(err));
+        }
+
+        err = ConfigurationMgr().GetVendorId(productId);
+        if (err != CHIP_NO_ERROR)
+        {
+            NRF_LOG_INFO("ConfigurationMgr().GetVendorId() failed: %s", chip::ErrorStr(err));
+        }
+
         payload.version       = 1;
-        payload.vendorID      = kExampleVenderID;
-        payload.productID     = 1;
+        payload.vendorID      = vendorId;
+        payload.productID     = productId;
         payload.setUpPINCode  = setUpPINCode;
         payload.discriminator = setUpDiscriminator;
         chip::QRCodeSetupPayloadGenerator generator(payload);

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/bluetooth/BluetoothManager.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/bluetooth/BluetoothManager.kt
@@ -29,7 +29,27 @@ import kotlinx.coroutines.withTimeoutOrNull
 class BluetoothManager {
     private val bluetoothAdapter = BluetoothAdapter.getDefaultAdapter()
 
-    suspend fun getBluetoothDevice(discriminator: Int): BluetoothDevice? {
+    /** Converts an integer to a ByteArray with the first [size] bytes of the [Int]. */
+    private fun Int.toByteArray(size: Int): ByteArray {
+        return ByteArray(size) { i -> (this shr (8 * i)).toByte() }
+    }
+
+    private fun getServiceData(discriminator: Int, vendorId: Int, productId: Int): ByteArray {
+      var opcode = 0
+      var version = 0
+      var versionDiscriminator = ((version and 0xf) shl 12) or (discriminator and 0xfff)
+      return intArrayOf(
+         opcode,
+         versionDiscriminator,
+         versionDiscriminator shr 8,
+         vendorId,
+         vendorId shr 8,
+         productId,
+         productId shr 8
+      ).map { it.toByte() }.toByteArray()
+    }
+
+    suspend fun getBluetoothDevice(discriminator: Int, vendorId: Int, productId: Int): BluetoothDevice? {
         val scanner = bluetoothAdapter.bluetoothLeScanner ?: run {
             Log.e(TAG, "No bluetooth scanner found")
             return null
@@ -50,18 +70,32 @@ class BluetoothManager {
                     }
                 }
 
-                val scanFilter = ScanFilter.Builder()
+
+                var serviceDataList = listOf(
+                   getServiceData(discriminator, vendorId, productId),
+
+                   // TODO - Remove this incorrect format.
+                   discriminator.toByteArray(3)
+                )
+
+                serviceDataList.forEach {
+                  Log.v(TAG, "Matching service " + CHIP_UUID.substring(4, 8) + " " + it.map { String.format("%02x", it) } )
+                }
+
+                val scanFilters = serviceDataList.map { ScanFilter.Builder()
                     .setServiceData(
                       ParcelUuid(UUID.fromString(CHIP_UUID)),
-                      byteArrayOf(0, discriminator.toByte(), (discriminator shr 8).toByte())
+                      it
                     )
                     .build()
+                }
+
                 val scanSettings = ScanSettings.Builder()
                     .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
                     .build()
 
                 Log.i(TAG, "Starting Bluetooth scan")
-                scanner.startScan(listOf(scanFilter), scanSettings, scanCallback)
+                scanner.startScan(scanFilters, scanSettings, scanCallback)
                 awaitClose { scanner.stopScan(scanCallback) }
             }.first()
         }

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/bluetooth/BluetoothManager.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/bluetooth/BluetoothManager.kt
@@ -34,22 +34,18 @@ class BluetoothManager {
         return ByteArray(size) { i -> (this shr (8 * i)).toByte() }
     }
 
-    private fun getServiceData(discriminator: Int, vendorId: Int, productId: Int): ByteArray {
+    private fun getServiceData(discriminator: Int): ByteArray {
       var opcode = 0
       var version = 0
       var versionDiscriminator = ((version and 0xf) shl 12) or (discriminator and 0xfff)
       return intArrayOf(
          opcode,
          versionDiscriminator,
-         versionDiscriminator shr 8,
-         vendorId,
-         vendorId shr 8,
-         productId,
-         productId shr 8
+         versionDiscriminator shr 8
       ).map { it.toByte() }.toByteArray()
     }
 
-    suspend fun getBluetoothDevice(discriminator: Int, vendorId: Int, productId: Int): BluetoothDevice? {
+    suspend fun getBluetoothDevice(discriminator: Int): BluetoothDevice? {
         val scanner = bluetoothAdapter.bluetoothLeScanner ?: run {
             Log.e(TAG, "No bluetooth scanner found")
             return null
@@ -70,9 +66,8 @@ class BluetoothManager {
                     }
                 }
 
-
                 var serviceDataList = listOf(
-                   getServiceData(discriminator, vendorId, productId),
+                   getServiceData(discriminator),
 
                    // TODO - Remove this incorrect format.
                    discriminator.toByteArray(3)

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/CHIPDeviceDetailsFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/CHIPDeviceDetailsFragment.kt
@@ -94,7 +94,7 @@ class CHIPDeviceDetailsFragment : Fragment(), ChipDeviceController.CompletionLis
                 val bluetoothManager = BluetoothManager()
 
                 showMessage(requireContext().getString(R.string.rendezvous_over_ble_scanning_text) + " " + deviceInfo.discriminator.toString())
-                val device = bluetoothManager.getBluetoothDevice(deviceInfo.discriminator, deviceInfo.vendorId, deviceInfo.productId) ?: run {
+                val device = bluetoothManager.getBluetoothDevice(deviceInfo.discriminator) ?: run {
                     showMessage(requireContext().getString(R.string.rendezvous_over_ble_scanning_failed_text))
                     return@launch
                 }

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/CHIPDeviceDetailsFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/CHIPDeviceDetailsFragment.kt
@@ -94,7 +94,7 @@ class CHIPDeviceDetailsFragment : Fragment(), ChipDeviceController.CompletionLis
                 val bluetoothManager = BluetoothManager()
 
                 showMessage(requireContext().getString(R.string.rendezvous_over_ble_scanning_text) + " " + deviceInfo.discriminator.toString())
-                val device = bluetoothManager.getBluetoothDevice(deviceInfo.discriminator) ?: run {
+                val device = bluetoothManager.getBluetoothDevice(deviceInfo.discriminator, deviceInfo.vendorId, deviceInfo.productId) ?: run {
                     showMessage(requireContext().getString(R.string.rendezvous_over_ble_scanning_failed_text))
                     return@launch
                 }

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -823,7 +823,7 @@ GenericConfigurationManagerImpl<ImplClass>::_GetBLEDeviceIdentificationInfo(Ble:
         ? Ble::ChipBLEDeviceIdentificationInfo::kPairingStatus_Paired
         : Ble::ChipBLEDeviceIdentificationInfo::kPairingStatus_Unpaired;
 #elif CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
-    deviceIdInfo.PairingStatus = ConnectivityMgr().IsWiFiStationProvisioned()
+    deviceIdInfo.PairingStatus = ConnectivityMgr().IsWiFiStationConnected()
         ? Ble::ChipBLEDeviceIdentificationInfo::kPairingStatus_Paired
         : Ble::ChipBLEDeviceIdentificationInfo::kPairingStatus_Unpaired;
 #else

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -822,6 +822,10 @@ GenericConfigurationManagerImpl<ImplClass>::_GetBLEDeviceIdentificationInfo(Ble:
     deviceIdInfo.PairingStatus = ThreadStackMgr().IsThreadAttached()
         ? Ble::ChipBLEDeviceIdentificationInfo::kPairingStatus_Paired
         : Ble::ChipBLEDeviceIdentificationInfo::kPairingStatus_Unpaired;
+#elif CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
+    deviceIdInfo.PairingStatus = ConnectivityMgr().IsWiFiStationProvisioned()
+        ? Ble::ChipBLEDeviceIdentificationInfo::kPairingStatus_Paired
+        : Ble::ChipBLEDeviceIdentificationInfo::kPairingStatus_Unpaired;
 #else
     deviceIdInfo.PairingStatus = Impl()->_IsPairedToAccount() ? Ble::ChipBLEDeviceIdentificationInfo::kPairingStatus_Paired
                                                               : Ble::ChipBLEDeviceIdentificationInfo::kPairingStatus_Unpaired;

--- a/src/platform/Darwin/BleConnectionDelegateImpl.mm
+++ b/src/platform/Darwin/BleConnectionDelegateImpl.mm
@@ -125,10 +125,18 @@ namespace DeviceLayer {
                 NSData * serviceData = [servicesData objectForKey:serviceUUID];
 
                 NSUInteger length = [serviceData length];
-                if (length == 3) {
+                if (length == 3 || length == 7) {
                     const uint8_t * bytes = (const uint8_t *) [serviceData bytes];
                     uint8_t opCode = bytes[0];
-                    uint16_t discriminator = static_cast<uint16_t>(((bytes[1] & 0x0F) << 8) | bytes[2]);
+                    uint16_t discriminator;
+                    if (length == 7) {
+                        discriminator = (bytes[1] | (bytes[2] << 8)) & 0xfff;
+                    } else {
+                        // TODO - Remove this incorrect format.
+                        ChipLogError(Ble, "Using deprecated BLE advertisement format");
+                        discriminator = static_cast<uint16_t>(((bytes[1] & 0x0F) << 8) | bytes[2]);
+                    }
+
                     if (opCode == 0 && discriminator == _deviceDiscriminator) {
                         ChipLogProgress(Ble, "Connecting to device: %@", peripheral);
                         [self connect:peripheral];

--- a/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
@@ -264,7 +264,7 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
     case DeviceEventType::kFabricMembershipChange:
     case DeviceEventType::kServiceProvisioningChange:
     case DeviceEventType::kAccountPairingChange:
-
+    case DeviceEventType::kWiFiConnectivityChange:
         // If CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED is enabled, and there is a change to the
         // device's provisioning state, then automatically disable CHIPoBLE advertising if the device
         // is now fully provisioned.
@@ -277,7 +277,9 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 #endif // CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
 
         // Force the advertising configuration to be refreshed to reflect new provisioning state.
+        ChipLogProgress(DeviceLayer, "Updating advertising data");
         ClearFlag(mFlags, kFlag_AdvertisingConfigured);
+        SetFlag(mFlags, kFlag_AdvertisingRefreshNeeded);
 
         DriveBLEState();
 

--- a/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
@@ -47,8 +47,6 @@
 #define CHIP_ADV_DATA_TYPE_FLAGS 0x01
 #define CHIP_ADV_DATA_FLAGS 0x06
 #define CHIP_ADV_DATA_TYPE_SERVICE_DATA 0x16
-#define CHIP_BLE_OPCODE 0x00
-#define CHIP_ADV_VERSION 0x00
 
 using namespace ::chip;
 using namespace ::chip::Ble;
@@ -627,8 +625,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
 {
     CHIP_ERROR err;
     uint8_t advData[MAX_ADV_DATA_LEN];
-    uint16_t advDataVersionDiscriminator = 0;
-    uint8_t index                        = 0;
+    uint8_t index = 0;
 
     // If a custom device name has not been specified, generate a CHIP-standard name based on the
     // discriminator value
@@ -648,8 +645,6 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
         ChipLogError(DeviceLayer, "esp_ble_gap_set_device_name() failed: %s", ErrorStr(err));
         ExitNow();
     }
-
-    advDataVersionDiscriminator = (discriminator | (CHIP_ADV_VERSION << 12));
 
     memset(advData, 0, sizeof(advData));
     advData[index++] = 0x02;                            // length

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -49,8 +49,6 @@
 #define CHIP_ADV_DATA_TYPE_FLAGS 0x01
 #define CHIP_ADV_DATA_FLAGS 0x06
 #define CHIP_ADV_DATA_TYPE_SERVICE_DATA 0x16
-#define CHIP_BLE_OPCODE 0x00
-#define CHIP_ADV_VERSION 0x00
 
 using namespace ::chip;
 using namespace ::chip::Ble;
@@ -600,8 +598,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
 {
     CHIP_ERROR err;
     uint8_t advData[MAX_ADV_DATA_LEN];
-    uint16_t advDataVersionDiscriminator = 0;
-    uint8_t index                        = 0;
+    uint8_t index = 0;
 
     // If a custom device name has not been specified, generate a CHIP-standard name based on the
     // bottom digits of the Chip device id.
@@ -621,8 +618,6 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
         ChipLogError(DeviceLayer, "ble_svc_gap_device_name_set() failed: %s", ErrorStr(err));
         ExitNow();
     }
-
-    advDataVersionDiscriminator = (discriminator | (CHIP_ADV_VERSION << 12));
 
     memset(advData, 0, sizeof(advData));
     advData[index++] = 0x02;                            // length
@@ -649,7 +644,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     err = ble_gap_adv_set_data(advData, sizeof(advData));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "ble_gap_adv_set_data failed: %s %d", ErrorStr(err), advDataVersionDiscriminator);
+        ChipLogError(DeviceLayer, "ble_gap_adv_set_data failed: %s %d", ErrorStr(err), discriminator);
         ExitNow();
     }
 

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -257,6 +257,7 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
     case DeviceEventType::kFabricMembershipChange:
     case DeviceEventType::kServiceProvisioningChange:
     case DeviceEventType::kAccountPairingChange:
+    case DeviceEventType::kWiFiConnectivityChange:
 
         // If CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED is enabled, and there is a change to the
         // device's provisioning state, then automatically disable CHIPoBLE advertising if the device
@@ -270,7 +271,9 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 #endif // CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
 
         // Force the advertising configuration to be refreshed to reflect new provisioning state.
+        ChipLogProgress(DeviceLayer, "Updating advertising data");
         ClearFlag(mFlags, kFlag_AdvertisingConfigured);
+        SetFlag(mFlags, kFlag_AdvertisingRefreshNeeded);
 
         DriveBLEState();
         break;

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -628,13 +628,22 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     advData[index++] = 0x02;                            // length
     advData[index++] = CHIP_ADV_DATA_TYPE_FLAGS;        // AD type : flags
     advData[index++] = CHIP_ADV_DATA_FLAGS;             // AD value
-    advData[index++] = 0x06;                            // length
+    advData[index++] = 0x0A;                            // length
     advData[index++] = CHIP_ADV_DATA_TYPE_SERVICE_DATA; // AD type: (Service Data - 16-bit UUID)
     advData[index++] = ShortUUID_CHIPoBLEService[0];    // AD value
     advData[index++] = ShortUUID_CHIPoBLEService[1];    // AD value
-    advData[index++] = CHIP_BLE_OPCODE;                 // Used to differentiate from operational CHIP Ble adv
-    advData[index++] = static_cast<uint8_t>(advDataVersionDiscriminator >> 8); // Bits[15:12] == version - Bits[11:0] Discriminator
-    advData[index++] = static_cast<uint8_t>(advDataVersionDiscriminator & 0x00FF);
+
+    chip::Ble::ChipBLEDeviceIdentificationInfo deviceIdInfo;
+    err = ConfigurationMgr().GetBLEDeviceIdentificationInfo(deviceIdInfo);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "GetBLEDeviceIdentificationInfo(): ", ErrorStr(err));
+        ExitNow();
+    }
+
+    VerifyOrExit(index + sizeof(deviceIdInfo) <= sizeof(advData), err = BLE_ERROR_OUTBOUND_MESSAGE_TOO_BIG);
+    memcpy(&advData[index], &deviceIdInfo, sizeof(deviceIdInfo));
+    index = static_cast<uint8_t>(index + sizeof(deviceIdInfo));
 
     // Construct the Chip BLE Service Data to be sent in the scan response packet.
     err = ble_gap_adv_set_data(advData, sizeof(advData));

--- a/src/platform/Linux/CHIPBluezHelper.h
+++ b/src/platform/Linux/CHIPBluezHelper.h
@@ -55,6 +55,7 @@
 #include <stdint.h>
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 
+#include "ble/CHIPBleServiceData.h"
 #include "platform/Linux/dbus/bluez/DbusBluez.h"
 
 namespace chip {
@@ -167,7 +168,7 @@ struct BluezEndpoint
     bool mIsNotify;
     bool mIsCentral;
     char * mpAdvertisingUUID;
-    CHIPServiceData * mpChipServiceData;
+    chip::Ble::ChipBLEDeviceIdentificationInfo mDeviceIdInfo;
     ChipAdvType mType;  ///< Advertisement type.
     uint16_t mDuration; ///< Advertisement interval (in ms).
     bool mIsAdvertising;


### PR DESCRIPTION
 #### Problem

Several components are using an incorrect format for BLE advertisement.


<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
 
The correct format is implemented in ChipBLEDeviceIdentificationInfo.
Update the Linux, ESP32, Android, and Darwin ports to support the
correct format during Rendezvous.

Fixes #3556
