### PR TITLE
Getting setup with Wi-Fi on raspi with Ubuntu Server

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -75,9 +75,71 @@ Using `rpi-imager`, install the Ubuntu 20.04.1 LTS (Raspberry Pi 3/4) 64-bit
 server OS for arm64 architectures on a micro SD card.
 
 Boot the SD card, login with the default user account "ubuntu" and password
-"ubuntu", then proceed with "How to install prerequisites on Linux".
+"ubuntu", then we can configure the wireless network to connect your Raspberry
+Pi 3/4 to the internet and using it remotely.
 
-Finally, install some Raspberry Pi specific dependencies:
+Getting setup with Wi-Fi:
+
+Please DON'T configure your wireless network using initial configuration files
+that will be loaded during the first boot.
+
+1. Create a WiFi configuration file wpa_supplicant.conf under directory
+   /etc/wpa_supplicant:
+
+```
+Open the wpa-supplicant configuration file in vim:
+
+sudo vim /etc/wpa_supplicant/wpa_supplicant.conf
+
+Add the following network configuration:
+
+    ctrl_interface=/run/wpa_supplicant
+
+    network={
+      ssid="wifi network name"
+      key_mgmt=WPA-PSK
+      psk="wifi password"
+    }
+
+Now save the file by pressing Ctrl+X, then Y, then finally press Enter.
+```
+
+2. Edit file /lib/systemd/system/wpa_supplicant.service to start wpa_supplicant
+   with DBus control interface enabled.
+
+```
+sudo vim /lib/systemd/system/wpa_supplicant.service
+
+Replace "/sbin/wpa_supplicant -u -s -O /run/wpa_supplicant" with
+"/sbin/wpa_supplicant -u -s -c /etc/wpa_supplicant/wpa_supplicant.conf -iwlan0"
+
+sudo reboot
+```
+
+3. Confirm your wpa_supplicant service is stated correctly with command:
+
+```
+systemctl status
+
+For example:
+├─wpa_supplicant.service │ └─1661 /sbin/wpa_supplicant -u -s -c
+/etc/wpa_supplicant/wpa_supplicant.conf -iwlan0
+```
+
+4. Get the IP address with dhclient:
+
+```
+sudo dhclient wlan0
+```
+
+5. Update system to the latest state (optional):
+
+```
+sudo apt update sudo apt upgrade sudo reboot
+```
+
+Then proceed with "How to install prerequisites on Linux". Finally, install some
+Raspberry Pi specific dependencies:
 
 ```
 sudo apt-get install pi-bluetooth


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Currently, we can not access wlan0 interface via D-Bus interface on Raspberry PI of Ubuntu 64-bit Server is installed. We don't see this issue with Ubuntu Desktop 64-bit system.

Unlike, Ubuntu Linux Desktop version which use NetworkManager -> wpa_supplicant to manage the wireless interfaces. Ubuntu Server use netplan directly to create and manage the wlan0.
systemctl status show there are two services to manage the wifi simultaneously:
             ├─netplan-wpa-wlan0.service
             │ └─1510 /sbin/wpa_supplicant -c /run/netplan/wpa-wlan0.conf -iwlan0
             ├─wpa_supplicant.service
             │ └─1668 /sbin/wpa_supplicant -u -s -O /run/wpa_supplicant
And there are two wpa_supplicant process running in the background:
ubuntu@ubuntu:~$ ps -A | grep wpa_supplicant
   1510 ?        00:00:06 wpa_supplicant
   1668 ?        00:00:01 wpa_supplicant

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Disable default wireless configuration with netplan on the system
Configure wireless network using wpa_supplicant.server with D-Bus control interface enabled

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #3383

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
