### PR TITLE
DeviceController: Add API to manually set udp listen port

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -91,6 +91,7 @@ ChipDeviceController::ChipDeviceController()
     mOnNewConnection   = nullptr;
     mPairingDelegate   = nullptr;
     mStorageDelegate   = nullptr;
+    mListenPort        = CHIP_PORT;
     mDeviceAddr        = IPAddress::Any;
     mDevicePort        = CHIP_PORT;
     mInterface         = INET_NULL_INTERFACEID;
@@ -271,6 +272,13 @@ CHIP_ERROR ChipDeviceController::ConnectDeviceWithoutSecurePairing(NodeId remote
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR ChipDeviceController::SetUdpListenPort(uint16_t listenPort)
+{
+    if (mState != kState_Initialized || mConState != kConnectionState_NotConnected) return CHIP_ERROR_INCORRECT_STATE;
+    mListenPort = listenPort;
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR ChipDeviceController::EstablishSecureSession()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -281,7 +289,7 @@ CHIP_ERROR ChipDeviceController::EstablishSecureSession()
     mSessionManager = chip::Platform::New<SecureSessionMgr<Transport::UDP>>();
 
     err = mSessionManager->Init(mLocalDeviceId, mSystemLayer,
-                                Transport::UdpListenParameters(mInetLayer).SetAddressType(mDeviceAddr.Type()));
+                                Transport::UdpListenParameters(mInetLayer).SetAddressType(mDeviceAddr.Type()).SetListenPort(mListenPort));
     SuccessOrExit(err);
 
     mSessionManager->SetDelegate(this);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -274,7 +274,8 @@ CHIP_ERROR ChipDeviceController::ConnectDeviceWithoutSecurePairing(NodeId remote
 
 CHIP_ERROR ChipDeviceController::SetUdpListenPort(uint16_t listenPort)
 {
-    if (mState != kState_Initialized || mConState != kConnectionState_NotConnected) return CHIP_ERROR_INCORRECT_STATE;
+    if (mState != kState_Initialized || mConState != kConnectionState_NotConnected)
+        return CHIP_ERROR_INCORRECT_STATE;
     mListenPort = listenPort;
     return CHIP_NO_ERROR;
 }
@@ -288,8 +289,9 @@ CHIP_ERROR ChipDeviceController::EstablishSecureSession()
 
     mSessionManager = chip::Platform::New<SecureSessionMgr<Transport::UDP>>();
 
-    err = mSessionManager->Init(mLocalDeviceId, mSystemLayer,
-                                Transport::UdpListenParameters(mInetLayer).SetAddressType(mDeviceAddr.Type()).SetListenPort(mListenPort));
+    err = mSessionManager->Init(
+        mLocalDeviceId, mSystemLayer,
+        Transport::UdpListenParameters(mInetLayer).SetAddressType(mDeviceAddr.Type()).SetListenPort(mListenPort));
     SuccessOrExit(err);
 
     mSessionManager->SetDelegate(this);

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -123,6 +123,8 @@ public:
                     DevicePairingDelegate * pairingDelegate = nullptr, PersistentStorageDelegate * storageDelegate = nullptr);
     CHIP_ERROR Shutdown();
 
+    CHIP_ERROR SetUdpListenPort(uint16_t listenPort);
+
     // ----- Connection Management -----
     /**
      * @brief
@@ -281,6 +283,7 @@ private:
     System::PacketBuffer * mCurReqMsg;
 
     NodeId mLocalDeviceId;
+    uint16_t mListenPort;
     Inet::IPAddress mDeviceAddr;
     uint16_t mDevicePort;
     Inet::InterfaceId mInterface;


### PR DESCRIPTION
 #### Problem

When simultaneous runs `chip-tool-server` from `examples/lighting-app/linux` and `chip-tool` on the same box, both of them will bind to 11095, and only one of them will be able to receive UDP packets. It is very inconvenient for develops to try examples and debug.

 #### Summary of Changes

Add an API to manually set the binding port for `DeviceController` so one can change the binding port of the chip-server or chip-tool.