### PR TITLE
Add write attributes commands to chip-tool and src/app

### DIFF
--- a/examples/chip-tool/commands/clusters/Commands.h
+++ b/examples/chip-tool/commands/clusters/Commands.h
@@ -1685,6 +1685,31 @@ public:
     }
 };
 
+class WriteColorControlOptions : public ModelCommand
+{
+public:
+    WriteColorControlOptions() : ModelCommand("write", kColorControlClusterId, 0x01)
+    {
+        AddArgument("attr-name", "options");
+        AddArgument("attr-value", 0, UINT8_MAX, &mOptions);
+        ModelCommand::AddArguments();
+    }
+
+    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
+    {
+        return encodeColorControlClusterWriteOptionsAttribute(buffer->Start(), bufferSize, endPointId, mOptions);
+    }
+
+    // Global Response: WriteAttributesResponse
+    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
+    {
+        WriteAttributesResponse response;
+        return response.HandleCommandResponse(commandId, message, messageLen);
+    }
+
+private:
+    uint8_t mOptions;
+};
 /*
  * Attribute NumberOfPrimaries
  */
@@ -2458,6 +2483,33 @@ public:
         ReadAttributesResponse response;
         return response.HandleCommandResponse(commandId, message, messageLen);
     }
+};
+
+class WriteColorControlStartUpColorTemperatureMireds : public ModelCommand
+{
+public:
+    WriteColorControlStartUpColorTemperatureMireds() : ModelCommand("write", kColorControlClusterId, 0x01)
+    {
+        AddArgument("attr-name", "start-up-color-temperature-mireds");
+        AddArgument("attr-value", 0, UINT16_MAX, &mStartUpColorTemperatureMireds);
+        ModelCommand::AddArguments();
+    }
+
+    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
+    {
+        return encodeColorControlClusterWriteStartUpColorTemperatureMiredsAttribute(buffer->Start(), bufferSize, endPointId,
+                                                                                    mStartUpColorTemperatureMireds);
+    }
+
+    // Global Response: WriteAttributesResponse
+    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
+    {
+        WriteAttributesResponse response;
+        return response.HandleCommandResponse(commandId, message, messageLen);
+    }
+
+private:
+    uint16_t mStartUpColorTemperatureMireds;
 };
 
 /*----------------------------------------------------------------------------*\
@@ -4403,6 +4455,32 @@ public:
     }
 };
 
+class WriteIdentifyIdentifyTime : public ModelCommand
+{
+public:
+    WriteIdentifyIdentifyTime() : ModelCommand("write", kIdentifyClusterId, 0x01)
+    {
+        AddArgument("attr-name", "identify-time");
+        AddArgument("attr-value", 0, UINT16_MAX, &mIdentifyTime);
+        ModelCommand::AddArguments();
+    }
+
+    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
+    {
+        return encodeIdentifyClusterWriteIdentifyTimeAttribute(buffer->Start(), bufferSize, endPointId, mIdentifyTime);
+    }
+
+    // Global Response: WriteAttributesResponse
+    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
+    {
+        WriteAttributesResponse response;
+        return response.HandleCommandResponse(commandId, message, messageLen);
+    }
+
+private:
+    uint16_t mIdentifyTime;
+};
+
 /*----------------------------------------------------------------------------*\
 | Cluster Level                                                       | 0x0008 |
 |------------------------------------------------------------------------------|
@@ -5567,6 +5645,7 @@ void registerClusterColorControl(Commands & commands)
         make_unique<ReadColorControlColorTemperatureMireds>(),
         make_unique<ReadColorControlColorMode>(),
         make_unique<ReadColorControlOptions>(),
+        make_unique<WriteColorControlOptions>(),
         make_unique<ReadColorControlNumberOfPrimaries>(),
         make_unique<ReadColorControlPrimary1X>(),
         make_unique<ReadColorControlPrimary1Y>(),
@@ -5598,6 +5677,7 @@ void registerClusterColorControl(Commands & commands)
         make_unique<ReadColorControlColorTempPhysicalMaxMireds>(),
         make_unique<ReadColorControlCoupleColorTempToLevelMinMireds>(),
         make_unique<ReadColorControlStartUpColorTemperatureMireds>(),
+        make_unique<WriteColorControlStartUpColorTemperatureMireds>(),
     };
 
     commands.Register(clusterName, clusterCommands);
@@ -5647,6 +5727,7 @@ void registerClusterIdentify(Commands & commands)
         make_unique<IdentifyIdentify>(),
         make_unique<IdentifyIdentifyQuery>(),
         make_unique<ReadIdentifyIdentifyTime>(),
+        make_unique<WriteIdentifyIdentifyTime>(),
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/src/app/chip-zcl-zpro-codec-api.h
+++ b/src/app/chip-zcl-zpro-codec-api.h
@@ -358,6 +358,13 @@ uint16_t encodeColorControlClusterReadOptionsAttribute(uint8_t * buffer, uint16_
 
 /**
  * @brief
+ *    Encode a write command for the options attribute for  server into buffer including the APS frame
+ */
+uint16_t encodeColorControlClusterWriteOptionsAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+                                                        uint8_t options);
+
+/**
+ * @brief
  *    Encode a read command for the number-of-primaries attribute for  server into buffer including the APS frame
  */
 uint16_t encodeColorControlClusterReadNumberOfPrimariesAttribute(uint8_t * buffer, uint16_t buf_length,
@@ -558,6 +565,14 @@ uint16_t encodeColorControlClusterReadCoupleColorTempToLevelMinMiredsAttribute(u
  */
 uint16_t encodeColorControlClusterReadStartUpColorTemperatureMiredsAttribute(uint8_t * buffer, uint16_t buf_length,
                                                                              uint8_t destination_endpoint);
+
+/**
+ * @brief
+ *    Encode a write command for the start-up-color-temperature-mireds attribute for  server into buffer including the APS frame
+ */
+uint16_t encodeColorControlClusterWriteStartUpColorTemperatureMiredsAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                                              uint8_t destination_endpoint,
+                                                                              uint16_t startUpColorTemperatureMireds);
 
 /*----------------------------------------------------------------------------*\
 | Cluster DoorLock                                                    | 0x0101 |
@@ -891,6 +906,13 @@ uint16_t encodeIdentifyClusterIdentifyQueryCommand(uint8_t * buffer, uint16_t bu
  *    Encode a read command for the identify-time attribute for  server into buffer including the APS frame
  */
 uint16_t encodeIdentifyClusterReadIdentifyTimeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+
+/**
+ * @brief
+ *    Encode a write command for the identify-time attribute for  server into buffer including the APS frame
+ */
+uint16_t encodeIdentifyClusterWriteIdentifyTimeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+                                                         uint16_t identifyTime);
 
 /*----------------------------------------------------------------------------*\
 | Cluster Level                                                       | 0x0008 |

--- a/src/app/encoder.cpp
+++ b/src/app/encoder.cpp
@@ -41,6 +41,34 @@
     }                                                                                                                              \
     return result;
 
+#define WRITE_ATTRIBUTE(name, cluster_id, value)                                                                                   \
+    BufBound buf = BufBound(buffer, buf_length);                                                                                   \
+    if (_encodeGlobalCommand(buf, destination_endpoint, cluster_id, 0x02))                                                         \
+    {                                                                                                                              \
+        buf.PutLE16(attr_id);                                                                                                      \
+        buf.Put(attr_type);                                                                                                        \
+        switch (attr_type)                                                                                                         \
+        {                                                                                                                          \
+        case 0x18:                                                                                                                 \
+            buf.Put(static_cast<uint8_t>(value));                                                                                  \
+            break;                                                                                                                 \
+        case 0x21:                                                                                                                 \
+            buf.PutLE16(static_cast<uint16_t>(value));                                                                             \
+            break;                                                                                                                 \
+        default:                                                                                                                   \
+            ChipLogError(Zcl, "Error encoding %s command", name);                                                                  \
+            return 0;                                                                                                              \
+        }                                                                                                                          \
+    }                                                                                                                              \
+                                                                                                                                   \
+    uint16_t result = buf.Fit() && CanCastTo<uint16_t>(buf.Written()) ? static_cast<uint16_t>(buf.Written()) : 0;                  \
+    if (result == 0)                                                                                                               \
+    {                                                                                                                              \
+        ChipLogError(Zcl, "Error encoding %s command", name);                                                                      \
+        return 0;                                                                                                                  \
+    }                                                                                                                              \
+    return result;
+
 #define COMMAND_HEADER(name, cluster_id, command_id)                                                                               \
     BufBound buf    = BufBound(buffer, buf_length);                                                                                \
     uint16_t result = _encodeClusterSpecificCommand(buf, destination_endpoint, cluster_id, command_id);                            \
@@ -693,6 +721,14 @@ uint16_t encodeColorControlClusterReadOptionsAttribute(uint8_t * buffer, uint16_
     READ_ATTRIBUTES("ReadColorControlOptions", COLOR_CONTROL_CLUSTER_ID);
 }
 
+uint16_t encodeColorControlClusterWriteOptionsAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+                                                        uint8_t options)
+{
+    uint16_t attr_id  = 0x000F;
+    uint8_t attr_type = { 0x18 };
+    WRITE_ATTRIBUTE("WriteColorControlOptions", COLOR_CONTROL_CLUSTER_ID, options);
+}
+
 /*
  * Attribute NumberOfPrimaries
  */
@@ -987,6 +1023,15 @@ uint16_t encodeColorControlClusterReadStartUpColorTemperatureMiredsAttribute(uin
 {
     uint16_t attr_ids[] = { 0x4010 };
     READ_ATTRIBUTES("ReadColorControlStartUpColorTemperatureMireds", COLOR_CONTROL_CLUSTER_ID);
+}
+
+uint16_t encodeColorControlClusterWriteStartUpColorTemperatureMiredsAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                                              uint8_t destination_endpoint,
+                                                                              uint16_t startUpColorTemperatureMireds)
+{
+    uint16_t attr_id  = 0x4010;
+    uint8_t attr_type = { 0x21 };
+    WRITE_ATTRIBUTE("WriteColorControlStartUpColorTemperatureMireds", COLOR_CONTROL_CLUSTER_ID, startUpColorTemperatureMireds);
 }
 
 /*----------------------------------------------------------------------------*\
@@ -1508,6 +1553,14 @@ uint16_t encodeIdentifyClusterReadIdentifyTimeAttribute(uint8_t * buffer, uint16
 {
     uint16_t attr_ids[] = { 0x0000 };
     READ_ATTRIBUTES("ReadIdentifyIdentifyTime", IDENTIFY_CLUSTER_ID);
+}
+
+uint16_t encodeIdentifyClusterWriteIdentifyTimeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+                                                         uint16_t identifyTime)
+{
+    uint16_t attr_id  = 0x0000;
+    uint8_t attr_type = { 0x21 };
+    WRITE_ATTRIBUTE("WriteIdentifyIdentifyTime", IDENTIFY_CLUSTER_ID, identifyTime);
 }
 
 /*----------------------------------------------------------------------------*\


### PR DESCRIPTION
 #### Problem

`write` attributes command is missing in chip-tool and `write` attributes support is missing in `src/app`

The PR adds supports for the attributes we are using for the `wifi-echo` app. The support is limited in the sense that only those types of attributes are supported in the `WRITE_ATTRIBUTE` macro. So it is enough to write tests for them but there will likely be more types in the future.

#### Summary of Changes
 * Add write attributes commands to chip-tool
 * Add support for those attributes in src/app