### PR TITLE
Remove special check on DeviceLayer in logging

### DIFF
--- a/src/platform/EFR32/Logging.cpp
+++ b/src/platform/EFR32/Logging.cpp
@@ -126,22 +126,6 @@ extern "C" void efr32Log(const char * aFormat, ...)
     va_end(v);
 }
 
-namespace {
-
-void GetModuleName(char * buf, uint8_t module)
-{
-    if (module == ::chip::Logging::kLogModule_DeviceLayer)
-    {
-        memcpy(buf, "DL", 3);
-    }
-    else
-    {
-        ::chip::Logging::GetModuleName(buf, module);
-    }
-}
-
-} // unnamed namespace
-
 namespace chip {
 namespace DeviceLayer {
 
@@ -192,7 +176,7 @@ void LogV(uint8_t module, uint8_t category, const char * aFormat, va_list v)
 
         // Form the log prefix, e.g. "[DL] "
         formattedMsg[formattedMsgLen++] = '[';
-        ::GetModuleName(formattedMsg + formattedMsgLen, module);
+        GetModuleName(formattedMsg + formattedMsgLen, module);
         formattedMsgLen                 = strlen(formattedMsg);
         formattedMsg[formattedMsgLen++] = ']';
         formattedMsg[formattedMsgLen++] = ' ';

--- a/src/platform/ESP32/Logging.cpp
+++ b/src/platform/ESP32/Logging.cpp
@@ -32,22 +32,6 @@
 using namespace ::chip;
 using namespace ::chip::DeviceLayer::Internal;
 
-namespace {
-
-void GetModuleName(char * buf, uint8_t module)
-{
-    if (module == ::chip::Logging::kLogModule_DeviceLayer)
-    {
-        memcpy(buf, "DL", 3);
-    }
-    else
-    {
-        ::chip::Logging::GetModuleName(buf, module);
-    }
-}
-
-} // unnamed namespace
-
 namespace chip {
 namespace Logging {
 
@@ -65,7 +49,7 @@ void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
 
         strcpy(tag, "chip[");
         tagLen = strlen(tag);
-        ::GetModuleName(tag + tagLen, module);
+        GetModuleName(tag + tagLen, module);
         tagLen        = strlen(tag);
         tag[tagLen++] = ']';
         tag[tagLen]   = 0;

--- a/src/platform/K32W/Logging.cpp
+++ b/src/platform/K32W/Logging.cpp
@@ -36,24 +36,9 @@
 
 extern "C" void K32WWriteBlocking(const uint8_t * aBuf, uint32_t len);
 
-using namespace ::chip;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::DeviceLayer::Internal;
 using namespace ::chip::Logging;
-
-namespace {
-
-void GetModuleName(char * buf, uint8_t module)
-{
-    if (module == ::chip::Logging::kLogModule_DeviceLayer)
-    {
-        memcpy(buf, "DL", 3);
-    }
-    else
-    {
-        ::chip::Logging::GetModuleName(buf, module);
-    }
-}
 
 void GetMessageString(char * buf, uint8_t chipCategory, uint8_t otLogLevel)
 {

--- a/src/platform/nRF5/Logging.cpp
+++ b/src/platform/nRF5/Logging.cpp
@@ -43,22 +43,6 @@ using namespace ::chip;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::DeviceLayer::Internal;
 
-namespace {
-
-void GetModuleName(char * buf, uint8_t module)
-{
-    if (module == ::chip::Logging::kLogModule_DeviceLayer)
-    {
-        memcpy(buf, "DL", 3);
-    }
-    else
-    {
-        ::chip::Logging::GetModuleName(buf, module);
-    }
-}
-
-} // unnamed namespace
-
 namespace chip {
 namespace DeviceLayer {
 
@@ -100,7 +84,7 @@ void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
 
             // Form the log prefix, e.g. "[DL] "
             formattedMsg[0] = '[';
-            ::GetModuleName(formattedMsg + 1, module);
+            GetModuleName(formattedMsg + 1, module);
             prefixLen                 = strlen(formattedMsg);
             formattedMsg[prefixLen++] = ']';
             formattedMsg[prefixLen++] = ' ';

--- a/src/platform/nrfconnect/Logging.cpp
+++ b/src/platform/nrfconnect/Logging.cpp
@@ -34,22 +34,6 @@ using namespace ::chip::DeviceLayer::Internal;
 
 LOG_MODULE_REGISTER(chip, LOG_LEVEL_DBG);
 
-namespace {
-
-void GetModuleName(char * buf, uint8_t module)
-{
-    if (module == ::chip::Logging::kLogModule_DeviceLayer)
-    {
-        memcpy(buf, "DL", 3);
-    }
-    else
-    {
-        ::chip::Logging::GetModuleName(buf, module);
-    }
-}
-
-} // unnamed namespace
-
 namespace chip {
 namespace DeviceLayer {
 
@@ -83,7 +67,7 @@ void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
 
         // Form the log prefix, e.g. "[DL] "
         formattedMsg[0] = '[';
-        ::GetModuleName(formattedMsg + 1, module);
+        GetModuleName(formattedMsg + 1, module);
         prefixLen                 = strlen(formattedMsg);
         formattedMsg[prefixLen++] = ']';
         formattedMsg[prefixLen++] = ' ';

--- a/src/platform/qpg6100/Logging.cpp
+++ b/src/platform/qpg6100/Logging.cpp
@@ -34,22 +34,6 @@ using namespace ::chip;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::DeviceLayer::Internal;
 
-namespace {
-
-void GetModuleName(char * buf, uint8_t module)
-{
-    if (module == ::chip::Logging::kLogModule_DeviceLayer)
-    {
-        memcpy(buf, "DL", 3);
-    }
-    else
-    {
-        ::chip::Logging::GetModuleName(buf, module);
-    }
-}
-
-} // unnamed namespace
-
 namespace chip {
 namespace DeviceLayer {
 
@@ -99,7 +83,7 @@ void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
         }
         formattedMsg[prefixLen++] = ']';
         formattedMsg[prefixLen++] = '[';
-        ::GetModuleName(&formattedMsg[prefixLen], module);
+        GetModuleName(&formattedMsg[prefixLen], module);
         prefixLen                 = strlen(formattedMsg);
         formattedMsg[prefixLen++] = ']';
         formattedMsg[prefixLen++] = ' ';


### PR DESCRIPTION
 #### Problem
There is special check for the DL module that has propagated through various examples/. I guess it can be removed since DL has been added to the list of module names.

 #### Summary of Changes
 * Remove the special handling in our various examples

 Fixes #1014