### PR TITLE
Fix buffer overrun in ESP32 WiFi provisioning

### DIFF
--- a/src/platform/ESP32/ServiceProvisioning.cpp
+++ b/src/platform/ESP32/ServiceProvisioning.cpp
@@ -19,6 +19,8 @@
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
 
+#include <algorithm>
+
 #include "esp_wifi.h"
 
 #include "ServiceProvisioning.h"
@@ -34,8 +36,8 @@ CHIP_ERROR SetWiFiStationProvisioning(const char * ssid, const char * key)
 
     // Set the wifi configuration
     memset(&wifiConfig, 0, sizeof(wifiConfig));
-    memcpy(wifiConfig.sta.ssid, ssid, strlen(ssid) + 1);
-    memcpy(wifiConfig.sta.password, key, strlen(key) + 1);
+    memcpy(wifiConfig.sta.ssid, ssid, std::min(strlen(ssid) + 1, sizeof(wifiConfig.sta.ssid)));
+    memcpy(wifiConfig.sta.password, key, std::min(strlen(key) + 1, sizeof(wifiConfig.sta.password)));
     wifiConfig.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
     wifiConfig.sta.sort_method = WIFI_CONNECT_AP_BY_SIGNAL;
 


### PR DESCRIPTION
There's no bounds check on the SSID & password fields in
SetWiFiStationProvisioning for ESP32. Add it.

Null termination is not required; when specifying the 64
digit PSK directly, there's no space for a null terminator
but this case does work.

 #### Problem

There's a buffer overrun in SetWiFiStationProvisioning.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes

Bound the `memcpy` calls in `SetWiFiStationProvisioning`.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
