### PR TITLE
Add support for emberEventControlGetActive

### DIFF
--- a/src/app/util/af-event.cpp
+++ b/src/app/util/af-event.cpp
@@ -169,6 +169,11 @@ void emberEventControlSetInactive(EmberEventControl * control)
     }
 }
 
+bool emberEventControlGetActive(EmberEventControl * control)
+{
+    return control->status != EMBER_EVENT_INACTIVE;
+}
+
 void emberEventControlSetActive(EmberEventControl * control)
 {
     control->status = EMBER_EVENT_ZERO_DELAY;

--- a/src/app/util/af-event.h
+++ b/src/app/util/af-event.h
@@ -74,6 +74,10 @@ void emAfInitEvents(void);
  */
 void emberEventControlSetInactive(EmberEventControl * control);
 
+/** @brief Returns true is ::EmberEventControl is active.
+ */
+bool emberEventControlGetActive(EmberEventControl * control);
+
 /** @brief Sets this ::EmberEventControl to run as soon as possible.
  */
 void emberEventControlSetActive(EmberEventControl * control);

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -1206,7 +1206,7 @@ EmberStatus emberAfEndpointEventControlSetInactive(EmberEventControl * controls,
 bool emberAfEndpointEventControlGetActive(EmberEventControl * controls, uint8_t endpoint)
 {
     uint8_t index = emberAfIndexFromEndpoint(endpoint);
-    return (index != 0xFF && false /*emberEventControlGetActive(controls[index])*/);
+    return (index != 0xFF && emberEventControlGetActive(&controls[index]));
 }
 
 EmberStatus emberAfEndpointEventControlSetActive(EmberEventControl * controls, uint8_t endpoint)


### PR DESCRIPTION
 #### Problem

This PR implements `emberEventControlGetActive` and uncomment the code that uses it.

 #### Summary of Changes
* Implement emberEventControlGetActive
* Uncomment the code that uses it

 Fixes #1944 