### PR TITLE
Move PWM color control callbacks from type stubs to the esp32 demo app

### DIFF
--- a/examples/wifi-echo/server/esp32/main/gen/callback-stub.c
+++ b/examples/wifi-echo/server/esp32/main/gen/callback-stub.c
@@ -2367,3 +2367,30 @@ bool emberAfPluginIdentifyStopFeedbackCallback(uint8_t endpoint)
     emberAfPrintln(EMBER_AF_PRINT_IDENTIFY_CLUSTER, "Stop identify callback on endpoint %d", endpoint);
     return false;
 }
+
+/** @brief Compute Pwm from HSV
+ *
+ * This function is called from the color server when it is time for the PWMs to
+ * be driven with a new value from the HSV values.
+ *
+ * @param endpoint The identifying endpoint Ver.: always
+ */
+void emberAfPluginColorControlServerComputePwmFromHsvCallback(uint8_t endpoint) {}
+
+/** @brief Compute Pwm from HSV
+ *
+ * This function is called from the color server when it is time for the PWMs to
+ * be driven with a new value from the color temperature.
+ *
+ * @param endpoint The identifying endpoint Ver.: always
+ */
+void emberAfPluginColorControlServerComputePwmFromTempCallback(uint8_t endpoint) {}
+
+/** @brief Compute Pwm from HSV
+ *
+ * This function is called from the color server when it is time for the PWMs to
+ * be driven with a new value from the color X and color Y values.
+ *
+ * @param endpoint The identifying endpoint Ver.: always
+ */
+void emberAfPluginColorControlServerComputePwmFromXyCallback(uint8_t endpoint) {}

--- a/examples/wifi-echo/server/esp32/main/gen/callback.h
+++ b/examples/wifi-echo/server/esp32/main/gen/callback.h
@@ -8616,6 +8616,31 @@ bool emberAfColorControlClusterStepSaturationCallback(uint8_t stepMode, uint8_t 
  */
 bool emberAfColorControlClusterStopMoveStepCallback(uint8_t optionsMask, uint8_t optionsOverride);
 
+/** @brief Compute Pwm from HSV
+ *
+ * This function is called from the color server when it is time for the PWMs to
+ * be driven with a new value from the HSV values.
+ *
+ * @param endpoint The identifying endpoint Ver.: always
+ */
+void emberAfPluginColorControlServerComputePwmFromHsvCallback(uint8_t endpoint);
+/** @brief Compute Pwm from HSV
+ *
+ * This function is called from the color server when it is time for the PWMs to
+ * be driven with a new value from the color X and color Y values.
+ *
+ * @param endpoint The identifying endpoint Ver.: always
+ */
+void emberAfPluginColorControlServerComputePwmFromXyCallback(uint8_t endpoint);
+/** @brief Compute Pwm from HSV
+ *
+ * This function is called from the color server when it is time for the PWMs to
+ * be driven with a new value from the color temperature.
+ *
+ * @param endpoint The identifying endpoint Ver.: always
+ */
+void emberAfPluginColorControlServerComputePwmFromTempCallback(uint8_t endpoint);
+
 /** @} END Color Control Cluster Callbacks */
 
 /** @name Ballast Configuration Cluster Callbacks */

--- a/src/app/util/types_stub.h
+++ b/src/app/util/types_stub.h
@@ -1957,10 +1957,6 @@ typedef struct
 #define MILLISECOND_TICKS_PER_SECOND 1000
 #define MILLISECOND_TICKS_PER_DECISECOND (MILLISECOND_TICKS_PER_SECOND / 10)
 
-#define emberAfPluginColorControlServerComputePwmFromXyCallback(endpoint) (void) 0
-#define emberAfPluginColorControlServerComputePwmFromHsvCallback(endpoint) (void) 0
-#define emberAfPluginColorControlServerComputePwmFromTempCallback(endpoint) (void) 0
-
 /**
  * @brief Macro that copies the token value from non-volatile storage into a RAM
  * location.  This macro can only be used with tokens that are defined using


### PR DESCRIPTION
 #### Problem

I don't think it makes sense for the PWM color control callbacks to have been stubbed out as `#define` in `src/app/util/types_stub.h` since it prevents users of color control to implement the callback themselves and it looks like an app specific callback.

 #### Summary of Changes
 * Moves the stubs from being defined in the framework to the application side

 Fixes #2431

I'm marking it fixing #2431 because the other bits of #2431 has already been implemented by #2915 and I don't think there is anything left for the platform side in #2431 