### PR TITLE
Add a basic message reader for the data model.

### DIFF
--- a/src/app/message-reader.h
+++ b/src/app/message-reader.h
@@ -1,0 +1,139 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Contains the API definition for a message buffer reader for the data
+ *          model.  This reader does the necessary bounds-checks before reading
+ *          and updates its own state as the buffer is read.
+ */
+
+#pragma once
+
+#include <app/util/basic-types.h>
+#include <lib/core/CHIPError.h>
+#include <lib/support/BufferReader.h>
+#include <lib/support/CodeUtils.h>
+#include <stdint.h>
+
+namespace chip {
+
+class DataModelReader
+{
+public:
+    /**
+     * Create a data model reader from a given buffer and length.
+     *
+     * @param buffer The octet buffer to read from.  The caller must ensure
+     *               (most simply by allocating the reader on the stack) that
+     *               the buffer outlives the reader.  The buffer is allowed to
+     *               be null if buf_len is 0.
+     * @param buf_len The number of octets in the buffer.
+     */
+    DataModelReader(const uint8_t * buffer, uint16_t buf_len) : mReader(buffer, buf_len) {}
+
+    /**
+     * Number of octets we have read so far.  This might be able to go away once
+     * we do less switching back and forth between DataModelReader and raw
+     * buffers.
+     */
+    uint16_t OctetsRead() const { return mReader.OctetsRead(); }
+
+    /**
+     * The reader status.
+     */
+    CHIP_ERROR StatusCode() const { return mReader.StatusCode(); }
+
+    /**
+     * Read a cluster id.
+     *
+     * @param [out] cluster_id Where the cluster id goes.
+     *
+     * @return Whether the read succeeded.  The read can fail if there are not
+     *         enough octets available.
+     */
+    CHECK_RETURN_VALUE DataModelReader & ReadClusterId(ClusterId * cluster_id)
+    {
+        mReader.RawRead(cluster_id);
+        return *this;
+    }
+
+    /**
+     * Read an endpoint id.
+     *
+     * @param [out] endpoint_id Where the endpoint id goes.
+     *
+     * @return Whether the read succeeded.  The read can fail if there are not
+     *         enough octets available.
+     */
+    CHECK_RETURN_VALUE DataModelReader & ReadEndpointId(EndpointId * endpoint_id)
+    {
+        mReader.RawRead(endpoint_id);
+        return *this;
+    }
+
+    /**
+     * Read a group id.
+     *
+     * @param [out] group_id Where the group id goes.
+     *
+     * @return Whether the read succeeded.  The read can fail if there are not
+     *         enough octets available.
+     */
+    CHECK_RETURN_VALUE DataModelReader & ReadGroupId(GroupId * group_id)
+    {
+        mReader.RawRead(group_id);
+        return *this;
+    }
+
+    /**
+     * Read a single octet.
+     *
+     * @param [out] octet Where the octet goes.
+     *
+     * @return Whether the read succeeded.  The read can fail if there are not
+     *         enough octets available.
+     *
+     * @note Use of APIs that read some semantically-meaningful type is preferred.
+     */
+    CHECK_RETURN_VALUE DataModelReader & ReadOctet(uint8_t * octet)
+    {
+        mReader.RawRead(octet);
+        return *this;
+    }
+
+    /**
+     * Read a single 16-bit unsigned integer.
+     *
+     * @param [out] dest Where the 16-bit integer goes.
+     *
+     * @return Whether the read succeeded.  The read can fail if there are not
+     *         enough octets available.
+     *
+     * @note Use of APIs that read some semantically-meaningful type is preferred.
+     */
+    CHECK_RETURN_VALUE DataModelReader & Read16(uint16_t * dest)
+    {
+        mReader.RawRead(dest);
+        return *this;
+    }
+
+private:
+    Encoding::LittleEndian::Reader mReader;
+};
+
+} // namespace chip

--- a/src/lib/support/BufferReader.cpp
+++ b/src/lib/support/BufferReader.cpp
@@ -44,7 +44,7 @@ void ReadHelper(const uint8_t *& p, uint64_t * dest)
 } // anonymous namespace
 
 template <typename T>
-void Reader::Read(T * retval)
+void Reader::RawRead(T * retval)
 {
     static_assert(CHAR_BIT == 8, "Our various sizeof checks rely on bytes and octets being the same thing");
 
@@ -63,10 +63,10 @@ void Reader::Read(T * retval)
 }
 
 // Explicit Read instantiations for the data types we want to support.
-template void Reader::Read(uint8_t *);
-template void Reader::Read(uint16_t *);
-template void Reader::Read(uint32_t *);
-template void Reader::Read(uint64_t *);
+template void Reader::RawRead(uint8_t *);
+template void Reader::RawRead(uint16_t *);
+template void Reader::RawRead(uint32_t *);
+template void Reader::RawRead(uint64_t *);
 
 } // namespace LittleEndian
 } // namespace Encoding

--- a/src/lib/support/BufferReader.h
+++ b/src/lib/support/BufferReader.h
@@ -79,7 +79,7 @@ public:
     CHECK_RETURN_VALUE
     Reader & Read8(uint8_t * dest)
     {
-        Read(dest);
+        RawRead(dest);
         return *this;
     }
 
@@ -96,7 +96,7 @@ public:
     CHECK_RETURN_VALUE
     Reader & Read16(uint16_t * dest)
     {
-        Read(dest);
+        RawRead(dest);
         return *this;
     }
 
@@ -113,7 +113,7 @@ public:
     CHECK_RETURN_VALUE
     Reader & Read32(uint32_t * dest)
     {
-        Read(dest);
+        RawRead(dest);
         return *this;
     }
 
@@ -130,17 +130,19 @@ public:
     CHECK_RETURN_VALUE
     Reader & Read64(uint64_t * dest)
     {
-        Read(dest);
+        RawRead(dest);
         return *this;
     }
 
-protected:
     /**
      * Helper for our various APIs so we don't have to write out various logic
-     * multiple times.
+     * multiple times.  This is public so that consumers that want to read into
+     * whatever size a logical thing they are reading into has don't have to
+     * hardcode the right API.  This is meant for other reader classes that
+     * delegate to this one.
      */
     template <typename T>
-    void Read(T * retval);
+    void RawRead(T * retval);
 
 private:
     /**


### PR DESCRIPTION
The idea is to expose a semantic API where consumers can read things
like "a cluster id" or "an endpoint id", without necessarily making
assumptions about the sizes/representations of these things.

The API does still expose facilities for reading raw unsigned integers
of specific sizes.

More types will be added to this API as needed.

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
We don't have a good setup for reading from a buffer in the data model without ending up with possible length overruns, etc.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Add a data model reader.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes https://github.com/project-chip/connectedhomeip/issues/2168

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
