### PR TITLE
Add discover attributes supports to chip-tool and src/app

### DIFF
--- a/examples/chip-tool/commands/clusters/Commands.h
+++ b/examples/chip-tool/commands/clusters/Commands.h
@@ -727,6 +727,27 @@ public:
 };
 
 /*
+ * Discover attributes
+ */
+class DiscoverBarrierControlAttributes : public ModelCommand
+{
+public:
+    DiscoverBarrierControlAttributes() : ModelCommand("discover", kBarrierControlClusterId, 0x0c) { ModelCommand::AddArguments(); }
+
+    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
+    {
+        return encodeBarrierControlClusterDiscoverAttributes(buffer->Start(), bufferSize, endPointId);
+    }
+
+    // Global Response: DiscoverAttributesResponse
+    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
+    {
+        DiscoverAttributesResponse response;
+        return response.HandleCommandResponse(commandId, message, messageLen);
+    }
+};
+
+/*
  * Attribute MovingState
  */
 class ReadBarrierControlMovingState : public ModelCommand
@@ -860,6 +881,27 @@ public:
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
     {
         DefaultResponse response;
+        return response.HandleCommandResponse(commandId, message, messageLen);
+    }
+};
+
+/*
+ * Discover attributes
+ */
+class DiscoverBasicAttributes : public ModelCommand
+{
+public:
+    DiscoverBasicAttributes() : ModelCommand("discover", kBasicClusterId, 0x0c) { ModelCommand::AddArguments(); }
+
+    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
+    {
+        return encodeBasicClusterDiscoverAttributes(buffer->Start(), bufferSize, endPointId);
+    }
+
+    // Global Response: DiscoverAttributesResponse
+    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
+    {
+        DiscoverAttributesResponse response;
         return response.HandleCommandResponse(commandId, message, messageLen);
     }
 };
@@ -1486,6 +1528,27 @@ public:
 private:
     uint8_t mOptionsMask;
     uint8_t mOptionsOverride;
+};
+
+/*
+ * Discover attributes
+ */
+class DiscoverColorControlAttributes : public ModelCommand
+{
+public:
+    DiscoverColorControlAttributes() : ModelCommand("discover", kColorControlClusterId, 0x0c) { ModelCommand::AddArguments(); }
+
+    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
+    {
+        return encodeColorControlClusterDiscoverAttributes(buffer->Start(), bufferSize, endPointId);
+    }
+
+    // Global Response: DiscoverAttributesResponse
+    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
+    {
+        DiscoverAttributesResponse response;
+        return response.HandleCommandResponse(commandId, message, messageLen);
+    }
 };
 
 /*
@@ -3920,6 +3983,27 @@ private:
 };
 
 /*
+ * Discover attributes
+ */
+class DiscoverDoorLockAttributes : public ModelCommand
+{
+public:
+    DiscoverDoorLockAttributes() : ModelCommand("discover", kDoorLockClusterId, 0x0c) { ModelCommand::AddArguments(); }
+
+    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
+    {
+        return encodeDoorLockClusterDiscoverAttributes(buffer->Start(), bufferSize, endPointId);
+    }
+
+    // Global Response: DiscoverAttributesResponse
+    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
+    {
+        DiscoverAttributesResponse response;
+        return response.HandleCommandResponse(commandId, message, messageLen);
+    }
+};
+
+/*
  * Attribute LockState
  */
 class ReadDoorLockLockState : public ModelCommand
@@ -4318,6 +4402,27 @@ private:
 };
 
 /*
+ * Discover attributes
+ */
+class DiscoverGroupsAttributes : public ModelCommand
+{
+public:
+    DiscoverGroupsAttributes() : ModelCommand("discover", kGroupsClusterId, 0x0c) { ModelCommand::AddArguments(); }
+
+    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
+    {
+        return encodeGroupsClusterDiscoverAttributes(buffer->Start(), bufferSize, endPointId);
+    }
+
+    // Global Response: DiscoverAttributesResponse
+    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
+    {
+        DiscoverAttributesResponse response;
+        return response.HandleCommandResponse(commandId, message, messageLen);
+    }
+};
+
+/*
  * Attribute NameSupport
  */
 class ReadGroupsNameSupport : public ModelCommand
@@ -4429,6 +4534,27 @@ public:
     bool HandleSpecificResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
     {
         IdentifyQueryResponse response;
+        return response.HandleCommandResponse(commandId, message, messageLen);
+    }
+};
+
+/*
+ * Discover attributes
+ */
+class DiscoverIdentifyAttributes : public ModelCommand
+{
+public:
+    DiscoverIdentifyAttributes() : ModelCommand("discover", kIdentifyClusterId, 0x0c) { ModelCommand::AddArguments(); }
+
+    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
+    {
+        return encodeIdentifyClusterDiscoverAttributes(buffer->Start(), bufferSize, endPointId);
+    }
+
+    // Global Response: DiscoverAttributesResponse
+    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
+    {
+        DiscoverAttributesResponse response;
         return response.HandleCommandResponse(commandId, message, messageLen);
     }
 };
@@ -4779,6 +4905,27 @@ private:
 };
 
 /*
+ * Discover attributes
+ */
+class DiscoverLevelAttributes : public ModelCommand
+{
+public:
+    DiscoverLevelAttributes() : ModelCommand("discover", kLevelClusterId, 0x0c) { ModelCommand::AddArguments(); }
+
+    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
+    {
+        return encodeLevelClusterDiscoverAttributes(buffer->Start(), bufferSize, endPointId);
+    }
+
+    // Global Response: DiscoverAttributesResponse
+    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
+    {
+        DiscoverAttributesResponse response;
+        return response.HandleCommandResponse(commandId, message, messageLen);
+    }
+};
+
+/*
  * Attribute CurrentLevel
  */
 class ReadLevelCurrentLevel : public ModelCommand
@@ -4877,6 +5024,27 @@ public:
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
     {
         DefaultResponse response;
+        return response.HandleCommandResponse(commandId, message, messageLen);
+    }
+};
+
+/*
+ * Discover attributes
+ */
+class DiscoverOnOffAttributes : public ModelCommand
+{
+public:
+    DiscoverOnOffAttributes() : ModelCommand("discover", kOnOffClusterId, 0x0c) { ModelCommand::AddArguments(); }
+
+    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
+    {
+        return encodeOnOffClusterDiscoverAttributes(buffer->Start(), bufferSize, endPointId);
+    }
+
+    // Global Response: DiscoverAttributesResponse
+    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
+    {
+        DiscoverAttributesResponse response;
         return response.HandleCommandResponse(commandId, message, messageLen);
     }
 };
@@ -5379,6 +5547,27 @@ private:
 };
 
 /*
+ * Discover attributes
+ */
+class DiscoverScenesAttributes : public ModelCommand
+{
+public:
+    DiscoverScenesAttributes() : ModelCommand("discover", kScenesClusterId, 0x0c) { ModelCommand::AddArguments(); }
+
+    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
+    {
+        return encodeScenesClusterDiscoverAttributes(buffer->Start(), bufferSize, endPointId);
+    }
+
+    // Global Response: DiscoverAttributesResponse
+    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
+    {
+        DiscoverAttributesResponse response;
+        return response.HandleCommandResponse(commandId, message, messageLen);
+    }
+};
+
+/*
  * Attribute SceneCount
  */
 class ReadScenesSceneCount : public ModelCommand
@@ -5518,6 +5707,30 @@ public:
 \*----------------------------------------------------------------------------*/
 
 /*
+ * Discover attributes
+ */
+class DiscoverTemperatureMeasurementAttributes : public ModelCommand
+{
+public:
+    DiscoverTemperatureMeasurementAttributes() : ModelCommand("discover", kTempMeasurementClusterId, 0x0c)
+    {
+        ModelCommand::AddArguments();
+    }
+
+    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
+    {
+        return encodeTemperatureMeasurementClusterDiscoverAttributes(buffer->Start(), bufferSize, endPointId);
+    }
+
+    // Global Response: DiscoverAttributesResponse
+    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
+    {
+        DiscoverAttributesResponse response;
+        return response.HandleCommandResponse(commandId, message, messageLen);
+    }
+};
+
+/*
  * Attribute MeasuredValue
  */
 class ReadTemperatureMeasurementMeasuredValue : public ModelCommand
@@ -5600,9 +5813,10 @@ void registerClusterBarrierControl(Commands & commands)
     const char * clusterName = "BarrierControl";
 
     commands_list clusterCommands = {
-        make_unique<BarrierControlGoToPercent>(),      make_unique<BarrierControlStop>(),
-        make_unique<ReadBarrierControlMovingState>(),  make_unique<ReadBarrierControlSafetyStatus>(),
-        make_unique<ReadBarrierControlCapabilities>(), make_unique<ReadBarrierControlBarrierPosition>(),
+        make_unique<BarrierControlGoToPercent>(),         make_unique<BarrierControlStop>(),
+        make_unique<DiscoverBarrierControlAttributes>(),  make_unique<ReadBarrierControlMovingState>(),
+        make_unique<ReadBarrierControlSafetyStatus>(),    make_unique<ReadBarrierControlCapabilities>(),
+        make_unique<ReadBarrierControlBarrierPosition>(),
     };
 
     commands.Register(clusterName, clusterCommands);
@@ -5614,6 +5828,7 @@ void registerClusterBasic(Commands & commands)
 
     commands_list clusterCommands = {
         make_unique<BasicResetToFactoryDefaults>(),
+        make_unique<DiscoverBasicAttributes>(),
         make_unique<ReadBasicZCLVersion>(),
         make_unique<ReadBasicPowerSource>(),
     };
@@ -5640,6 +5855,7 @@ void registerClusterColorControl(Commands & commands)
         make_unique<ColorControlStepHue>(),
         make_unique<ColorControlStepSaturation>(),
         make_unique<ColorControlStopMoveStep>(),
+        make_unique<DiscoverColorControlAttributes>(),
         make_unique<ReadColorControlCurrentHue>(),
         make_unique<ReadColorControlCurrentSaturation>(),
         make_unique<ReadColorControlRemainingTime>(),
@@ -5702,8 +5918,8 @@ void registerClusterDoorLock(Commands & commands)
         make_unique<DoorLockSetRFIDCode>(),          make_unique<DoorLockSetUserType>(),
         make_unique<DoorLockSetWeekdaySchedule>(),   make_unique<DoorLockSetYearDaySchedule>(),
         make_unique<DoorLockUnlockDoor>(),           make_unique<DoorLockUnlockWithTimeout>(),
-        make_unique<ReadDoorLockLockState>(),        make_unique<ReadDoorLockLockType>(),
-        make_unique<ReadDoorLockActuatorEnabled>(),
+        make_unique<DiscoverDoorLockAttributes>(),   make_unique<ReadDoorLockLockState>(),
+        make_unique<ReadDoorLockLockType>(),         make_unique<ReadDoorLockActuatorEnabled>(),
     };
 
     commands.Register(clusterName, clusterCommands);
@@ -5714,9 +5930,10 @@ void registerClusterGroups(Commands & commands)
     const char * clusterName = "Groups";
 
     commands_list clusterCommands = {
-        make_unique<GroupsAddGroup>(),        make_unique<GroupsAddGroupIfIdentifying>(), make_unique<GroupsGetGroupMembership>(),
-        make_unique<GroupsRemoveAllGroups>(), make_unique<GroupsRemoveGroup>(),           make_unique<GroupsViewGroup>(),
-        make_unique<ReadGroupsNameSupport>(),
+        make_unique<GroupsAddGroup>(),           make_unique<GroupsAddGroupIfIdentifying>(),
+        make_unique<GroupsGetGroupMembership>(), make_unique<GroupsRemoveAllGroups>(),
+        make_unique<GroupsRemoveGroup>(),        make_unique<GroupsViewGroup>(),
+        make_unique<DiscoverGroupsAttributes>(), make_unique<ReadGroupsNameSupport>(),
     };
 
     commands.Register(clusterName, clusterCommands);
@@ -5727,9 +5944,8 @@ void registerClusterIdentify(Commands & commands)
     const char * clusterName = "Identify";
 
     commands_list clusterCommands = {
-        make_unique<IdentifyIdentify>(),
-        make_unique<IdentifyIdentifyQuery>(),
-        make_unique<ReadIdentifyIdentifyTime>(),
+        make_unique<IdentifyIdentify>(),           make_unique<IdentifyIdentifyQuery>(),
+        make_unique<DiscoverIdentifyAttributes>(), make_unique<ReadIdentifyIdentifyTime>(),
         make_unique<WriteIdentifyIdentifyTime>(),
     };
 
@@ -5741,9 +5957,16 @@ void registerClusterLevel(Commands & commands)
     const char * clusterName = "Level";
 
     commands_list clusterCommands = {
-        make_unique<LevelMove>(),          make_unique<LevelMoveToLevel>(),   make_unique<LevelMoveToLevelWithOnOff>(),
-        make_unique<LevelMoveWithOnOff>(), make_unique<LevelStep>(),          make_unique<LevelStepWithOnOff>(),
-        make_unique<LevelStop>(),          make_unique<LevelStopWithOnOff>(), make_unique<ReadLevelCurrentLevel>(),
+        make_unique<LevelMove>(),
+        make_unique<LevelMoveToLevel>(),
+        make_unique<LevelMoveToLevelWithOnOff>(),
+        make_unique<LevelMoveWithOnOff>(),
+        make_unique<LevelStep>(),
+        make_unique<LevelStepWithOnOff>(),
+        make_unique<LevelStop>(),
+        make_unique<LevelStopWithOnOff>(),
+        make_unique<DiscoverLevelAttributes>(),
+        make_unique<ReadLevelCurrentLevel>(),
     };
 
     commands.Register(clusterName, clusterCommands);
@@ -5754,9 +5977,7 @@ void registerClusterOnOff(Commands & commands)
     const char * clusterName = "OnOff";
 
     commands_list clusterCommands = {
-        make_unique<OnOffOff>(),
-        make_unique<OnOffOn>(),
-        make_unique<OnOffToggle>(),
+        make_unique<OnOffOff>(),       make_unique<OnOffOn>(), make_unique<OnOffToggle>(), make_unique<DiscoverOnOffAttributes>(),
         make_unique<ReadOnOffOnOff>(),
     };
 
@@ -5770,8 +5991,9 @@ void registerClusterScenes(Commands & commands)
     commands_list clusterCommands = {
         make_unique<ScenesAddScene>(),         make_unique<ScenesGetSceneMembership>(), make_unique<ScenesRecallScene>(),
         make_unique<ScenesRemoveAllScenes>(),  make_unique<ScenesRemoveScene>(),        make_unique<ScenesStoreScene>(),
-        make_unique<ScenesViewScene>(),        make_unique<ReadScenesSceneCount>(),     make_unique<ReadScenesCurrentScene>(),
-        make_unique<ReadScenesCurrentGroup>(), make_unique<ReadScenesSceneValid>(),     make_unique<ReadScenesNameSupport>(),
+        make_unique<ScenesViewScene>(),        make_unique<DiscoverScenesAttributes>(), make_unique<ReadScenesSceneCount>(),
+        make_unique<ReadScenesCurrentScene>(), make_unique<ReadScenesCurrentGroup>(),   make_unique<ReadScenesSceneValid>(),
+        make_unique<ReadScenesNameSupport>(),
     };
 
     commands.Register(clusterName, clusterCommands);
@@ -5782,6 +6004,7 @@ void registerClusterTempMeasurement(Commands & commands)
     const char * clusterName = "TemperatureMeasurement";
 
     commands_list clusterCommands = {
+        make_unique<DiscoverTemperatureMeasurementAttributes>(),
         make_unique<ReadTemperatureMeasurementMeasuredValue>(),
         make_unique<ReadTemperatureMeasurementMinMeasuredValue>(),
         make_unique<ReadTemperatureMeasurementMaxMeasuredValue>(),

--- a/src/app/chip-zcl-zpro-codec-api.h
+++ b/src/app/chip-zcl-zpro-codec-api.h
@@ -75,6 +75,12 @@ uint16_t encodeBarrierControlClusterStopCommand(uint8_t * buffer, uint16_t buf_l
 
 /**
  * @brief
+ *    Encode a discover command for  server into buffer including the APS frame
+ */
+uint16_t encodeBarrierControlClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+
+/**
+ * @brief
  *    Encode a read command for the moving-state attribute for  server into buffer including the APS frame
  */
 uint16_t encodeBarrierControlClusterReadMovingStateAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
@@ -117,6 +123,12 @@ uint16_t encodeBarrierControlClusterReadBarrierPositionAttribute(uint8_t * buffe
  *    Encode an reset-to-factory-defaults command for Basic server into buffer including the APS frame
  */
 uint16_t encodeBasicClusterResetToFactoryDefaultsCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+
+/**
+ * @brief
+ *    Encode a discover command for  server into buffer including the APS frame
+ */
+uint16_t encodeBasicClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
 
 /**
  * @brief
@@ -306,6 +318,12 @@ uint16_t encodeColorControlClusterStepSaturationCommand(uint8_t * buffer, uint16
  */
 uint16_t encodeColorControlClusterStopMoveStepCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
                                                       uint8_t optionsMask, uint8_t optionsOverride);
+
+/**
+ * @brief
+ *    Encode a discover command for  server into buffer including the APS frame
+ */
+uint16_t encodeColorControlClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
 
 /**
  * @brief
@@ -790,6 +808,12 @@ uint16_t encodeDoorLockClusterUnlockWithTimeoutCommand(uint8_t * buffer, uint16_
 
 /**
  * @brief
+ *    Encode a discover command for  server into buffer including the APS frame
+ */
+uint16_t encodeDoorLockClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+
+/**
+ * @brief
  *    Encode a read command for the lock-state attribute for  server into buffer including the APS frame
  */
 uint16_t encodeDoorLockClusterReadLockStateAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
@@ -871,6 +895,12 @@ uint16_t encodeGroupsClusterViewGroupCommand(uint8_t * buffer, uint16_t buf_leng
 
 /**
  * @brief
+ *    Encode a discover command for  server into buffer including the APS frame
+ */
+uint16_t encodeGroupsClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+
+/**
+ * @brief
  *    Encode a read command for the name-support attribute for  server into buffer including the APS frame
  */
 uint16_t encodeGroupsClusterReadNameSupportAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
@@ -902,6 +932,12 @@ uint16_t encodeIdentifyClusterIdentifyCommand(uint8_t * buffer, uint16_t buf_len
  *    Encode an identify-query command for Identify server into buffer including the APS frame
  */
 uint16_t encodeIdentifyClusterIdentifyQueryCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+
+/**
+ * @brief
+ *    Encode a discover command for  server into buffer including the APS frame
+ */
+uint16_t encodeIdentifyClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
 
 /**
  * @brief
@@ -996,6 +1032,12 @@ uint16_t encodeLevelClusterStopWithOnOffCommand(uint8_t * buffer, uint16_t buf_l
 
 /**
  * @brief
+ *    Encode a discover command for  server into buffer including the APS frame
+ */
+uint16_t encodeLevelClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+
+/**
+ * @brief
  *    Encode a read command for the current-level attribute for  server into buffer including the APS frame
  */
 uint16_t encodeLevelClusterReadCurrentLevelAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
@@ -1032,6 +1074,12 @@ uint16_t encodeOnOffClusterOnCommand(uint8_t * buffer, uint16_t buf_length, uint
  *    Encode an toggle command for OnOff server into buffer including the APS frame
  */
 uint16_t encodeOnOffClusterToggleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+
+/**
+ * @brief
+ *    Encode a discover command for  server into buffer including the APS frame
+ */
+uint16_t encodeOnOffClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
 
 /**
  * @brief
@@ -1120,6 +1168,12 @@ uint16_t encodeScenesClusterViewSceneCommand(uint8_t * buffer, uint16_t buf_leng
 
 /**
  * @brief
+ *    Encode a discover command for  server into buffer including the APS frame
+ */
+uint16_t encodeScenesClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+
+/**
+ * @brief
  *    Encode a read command for the scene-count attribute for  server into buffer including the APS frame
  */
 uint16_t encodeScenesClusterReadSceneCountAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
@@ -1161,6 +1215,12 @@ uint16_t encodeScenesClusterReadNameSupportAttribute(uint8_t * buffer, uint16_t 
 | * MinMeasuredValue                                                  | 0x0001 |
 | * MaxMeasuredValue                                                  | 0x0002 |
 \*----------------------------------------------------------------------------*/
+
+/**
+ * @brief
+ *    Encode a discover command for  server into buffer including the APS frame
+ */
+uint16_t encodeTemperatureMeasurementClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
 
 /**
  * @brief

--- a/src/app/encoder.cpp
+++ b/src/app/encoder.cpp
@@ -71,6 +71,23 @@ using namespace chip;
     }                                                                                                                              \
     return result;
 
+#define DISCOVER_ATTRIBUTES(name, cluster_id)                                                                                      \
+    BufBound buf = BufBound(buffer, buf_length);                                                                                   \
+    if (_encodeGlobalCommand(buf, destination_endpoint, cluster_id, 0x0c))                                                         \
+    {                                                                                                                              \
+        /* Discover all attributes */                                                                                              \
+        buf.PutLE16(0x0000);                                                                                                       \
+        buf.Put(0xFF);                                                                                                             \
+    }                                                                                                                              \
+                                                                                                                                   \
+    uint16_t result = buf.Fit() && CanCastTo<uint16_t>(buf.Written()) ? static_cast<uint16_t>(buf.Written()) : 0;                  \
+    if (result == 0)                                                                                                               \
+    {                                                                                                                              \
+        ChipLogError(Zcl, "Error encoding %s command", name);                                                                      \
+        return 0;                                                                                                                  \
+    }                                                                                                                              \
+    return result;
+
 #define COMMAND_HEADER(name, cluster_id, command_id)                                                                               \
     BufBound buf    = BufBound(buffer, buf_length);                                                                                \
     uint16_t result = _encodeClusterSpecificCommand(buf, destination_endpoint, cluster_id, command_id);                            \
@@ -272,6 +289,11 @@ uint16_t encodeBarrierControlClusterStopCommand(uint8_t * buffer, uint16_t buf_l
     COMMAND_FOOTER(kName);
 }
 
+uint16_t encodeBarrierControlClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+{
+    DISCOVER_ATTRIBUTES("DiscoverBarrierControlAttributes", BARRIER_CONTROL_CLUSTER_ID);
+}
+
 /*
  * Attribute MovingState
  */
@@ -331,6 +353,11 @@ uint16_t encodeBasicClusterResetToFactoryDefaultsCommand(uint8_t * buffer, uint1
     const char * kName = "BasicResetToFactoryDefaults";
     COMMAND_HEADER(kName, BASIC_CLUSTER_ID, 0x00);
     COMMAND_FOOTER(kName);
+}
+
+uint16_t encodeBasicClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+{
+    DISCOVER_ATTRIBUTES("DiscoverBasicAttributes", BASIC_CLUSTER_ID);
 }
 
 /*
@@ -647,6 +674,11 @@ uint16_t encodeColorControlClusterStopMoveStepCommand(uint8_t * buffer, uint16_t
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
     COMMAND_FOOTER(kName);
+}
+
+uint16_t encodeColorControlClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+{
+    DISCOVER_ATTRIBUTES("DiscoverColorControlAttributes", COLOR_CONTROL_CLUSTER_ID);
 }
 
 /*
@@ -1381,6 +1413,11 @@ uint16_t encodeDoorLockClusterUnlockWithTimeoutCommand(uint8_t * buffer, uint16_
     COMMAND_FOOTER(kName);
 }
 
+uint16_t encodeDoorLockClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+{
+    DISCOVER_ATTRIBUTES("DiscoverDoorLockAttributes", DOOR_LOCK_CLUSTER_ID);
+}
+
 /*
  * Attribute LockState
  */
@@ -1503,6 +1540,11 @@ uint16_t encodeGroupsClusterViewGroupCommand(uint8_t * buffer, uint16_t buf_leng
     COMMAND_FOOTER(kName);
 }
 
+uint16_t encodeGroupsClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+{
+    DISCOVER_ATTRIBUTES("DiscoverGroupsAttributes", GROUPS_CLUSTER_ID);
+}
+
 /*
  * Attribute NameSupport
  */
@@ -1547,6 +1589,11 @@ uint16_t encodeIdentifyClusterIdentifyQueryCommand(uint8_t * buffer, uint16_t bu
     const char * kName = "IdentifyIdentifyQuery";
     COMMAND_HEADER(kName, IDENTIFY_CLUSTER_ID, 0x01);
     COMMAND_FOOTER(kName);
+}
+
+uint16_t encodeIdentifyClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+{
+    DISCOVER_ATTRIBUTES("DiscoverIdentifyAttributes", IDENTIFY_CLUSTER_ID);
 }
 
 /*
@@ -1706,6 +1753,11 @@ uint16_t encodeLevelClusterStopWithOnOffCommand(uint8_t * buffer, uint16_t buf_l
     COMMAND_FOOTER(kName);
 }
 
+uint16_t encodeLevelClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+{
+    DISCOVER_ATTRIBUTES("DiscoverLevelAttributes", LEVEL_CLUSTER_ID);
+}
+
 /*
  * Attribute CurrentLevel
  */
@@ -1758,6 +1810,11 @@ uint16_t encodeOnOffClusterToggleCommand(uint8_t * buffer, uint16_t buf_length, 
     const char * kName = "OnOffToggle";
     COMMAND_HEADER(kName, ON_OFF_CLUSTER_ID, 0x02);
     COMMAND_FOOTER(kName);
+}
+
+uint16_t encodeOnOffClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+{
+    DISCOVER_ATTRIBUTES("DiscoverOnOffAttributes", ON_OFF_CLUSTER_ID);
 }
 
 /*
@@ -1893,6 +1950,11 @@ uint16_t encodeScenesClusterViewSceneCommand(uint8_t * buffer, uint16_t buf_leng
     COMMAND_FOOTER(kName);
 }
 
+uint16_t encodeScenesClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+{
+    DISCOVER_ATTRIBUTES("DiscoverScenesAttributes", SCENES_CLUSTER_ID);
+}
+
 /*
  * Attribute SceneCount
  */
@@ -1951,6 +2013,11 @@ uint16_t encodeScenesClusterReadNameSupportAttribute(uint8_t * buffer, uint16_t 
 | * MinMeasuredValue                                                  | 0x0001 |
 | * MaxMeasuredValue                                                  | 0x0002 |
 \*----------------------------------------------------------------------------*/
+
+uint16_t encodeTemperatureMeasurementClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+{
+    DISCOVER_ATTRIBUTES("DiscoverTemperatureMeasurementAttributes", TEMPERATURE_MEASUREMENT_CLUSTER_ID);
+}
 
 /*
  * Attribute MeasuredValue


### PR DESCRIPTION
 #### Problem

This PR adds discover attributes for a given cluster to `chip-tool` and `src/app`.

Theorically you can specify an attribute id to start the search but since we have avoid to exposes the values of attribute ids for now I've just added a the command in order to search for all attributes of a given cluster.

 #### Summary of Changes
* Add discover attributes methods to `chip-tool`
* Add discover attributes methods to `src/app`
