### PR TITLE
[android] Read NFC tag containing CHIP setup payload

### DIFF
--- a/src/android/CHIPTool/app/src/main/AndroidManifest.xml
+++ b/src/android/CHIPTool/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.NFC" />
 
     <application
         android:allowBackup="true"
@@ -22,6 +23,11 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="ch" /><!-- Process CHIP URIs -->
             </intent-filter>
         </activity>
         <activity

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -41,7 +41,7 @@ class CHIPToolActivity :
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.top_activity)
-    
+
     if (savedInstanceState == null) {
       val fragment = SelectActionFragment.newInstance()
       supportFragmentManager
@@ -99,14 +99,14 @@ class CHIPToolActivity :
   private fun onNfcIntent(intent: Intent?) {
     // Require 1 NDEF message containing 1 NDEF record
     val messages = intent?.getParcelableArrayExtra(NfcAdapter.EXTRA_NDEF_MESSAGES)
-    if (messages?.size != 1) return;
+    if (messages?.size != 1) return
 
     val records = (messages[0] as NdefMessage).records
-    if (records.size != 1) return;
+    if (records.size != 1) return
 
     // Require NDEF URI record starting with "ch:"
     val uri = records[0].toUri()
-    if (!uri?.scheme.equals("ch", true)) return;
+    if (!uri?.scheme.equals("ch", true)) return
 
     val setupPayload = SetupPayloadParser().parseQrCode(uri.toString().toUpperCase())
     val deviceInfo = CHIPDeviceInfo(

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -18,9 +18,12 @@
 package com.google.chip.chiptool
 
 import android.content.Intent
+import android.nfc.NdefMessage
+import android.nfc.NfcAdapter
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import chip.setuppayload.SetupPayloadParser
 import com.google.chip.chiptool.attestation.AttestationTestFragment
 import com.google.chip.chiptool.clusterclient.OnOffClientFragment
 import com.google.chip.chiptool.commissioner.CommissionerActivity
@@ -28,6 +31,7 @@ import com.google.chip.chiptool.echoclient.EchoClientFragment
 import com.google.chip.chiptool.setuppayloadscanner.BarcodeFragment
 import com.google.chip.chiptool.setuppayloadscanner.CHIPDeviceDetailsFragment
 import com.google.chip.chiptool.setuppayloadscanner.CHIPDeviceInfo
+import com.google.chip.chiptool.setuppayloadscanner.QrCodeInfo
 
 class CHIPToolActivity :
     AppCompatActivity(),
@@ -37,7 +41,7 @@ class CHIPToolActivity :
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.top_activity)
-
+    
     if (savedInstanceState == null) {
       val fragment = SelectActionFragment.newInstance()
       supportFragmentManager
@@ -45,6 +49,9 @@ class CHIPToolActivity :
           .add(R.id.fragment_container, fragment, fragment.javaClass.simpleName)
           .commit()
     }
+
+    if (intent?.action == NfcAdapter.ACTION_NDEF_DISCOVERED)
+      onNfcIntent(intent)
   }
 
   override fun onCHIPDeviceInfoReceived(deviceInfo: CHIPDeviceInfo) {
@@ -87,6 +94,31 @@ class CHIPToolActivity :
         .replace(R.id.fragment_container, fragment, fragment.javaClass.simpleName)
         .addToBackStack(null)
         .commit()
+  }
+
+  private fun onNfcIntent(intent: Intent?) {
+    // Require 1 NDEF message containing 1 NDEF record
+    val messages = intent?.getParcelableArrayExtra(NfcAdapter.EXTRA_NDEF_MESSAGES)
+    if (messages?.size != 1) return;
+
+    val records = (messages[0] as NdefMessage).records
+    if (records.size != 1) return;
+
+    // Require NDEF URI record starting with "ch:"
+    val uri = records[0].toUri()
+    if (!uri?.scheme.equals("ch", true)) return;
+
+    val setupPayload = SetupPayloadParser().parseQrCode(uri.toString().toUpperCase())
+    val deviceInfo = CHIPDeviceInfo(
+            setupPayload.version,
+            setupPayload.vendorId,
+            setupPayload.productId,
+            setupPayload.discriminator,
+            setupPayload.setupPinCode,
+            setupPayload.optionalQRCodeInfo.mapValues { (_, info) ->  QrCodeInfo(info.tag, info.type, info.data, info.int32) }
+    )
+
+    onCHIPDeviceInfoReceived(deviceInfo)
   }
 
   companion object {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/BarcodeFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/BarcodeFragment.kt
@@ -117,20 +117,13 @@ class BarcodeFragment : Fragment(), CHIPBarcodeProcessor.BarcodeDetectionListene
             stopCamera()
 
             val payload = SetupPayloadParser().parseQrCode(barcode.displayValue)
-
-            val optionalQrCodeInfo = payload.optionalQRCodeInfo
-            val qrCodeInfoMap = HashMap<Int, QrCodeInfo>()
-            optionalQrCodeInfo.forEach { (i, info) ->
-                qrCodeInfoMap[i] = QrCodeInfo(info.tag, info.type, info.data, info.int32)
-            }
-
             val deviceInfo = CHIPDeviceInfo(
                 payload.version,
                 payload.vendorId,
                 payload.productId,
                 payload.discriminator,
                 payload.setupPinCode,
-                qrCodeInfoMap
+                payload.optionalQRCodeInfo.mapValues { (_, info) ->  QrCodeInfo(info.tag, info.type, info.data, info.int32) }
             )
             FragmentUtil.getHost(this, Callback::class.java)?.onCHIPDeviceInfoReceived(deviceInfo)
         }


### PR DESCRIPTION
 #### Problem
Currently, a device may share its Setup/Onboarding Payload with CHIP Controller using QR Code or Manual Pairing Code. Devices which don't have a display would benefit from another way to send the Setup Payload, that is, via NFC Tag.
Note that usage of NFC in CHIP is not yet confirmed, so the feature should be considered experimental.

 #### Summary of Changes
* Make CHIPTool for Android read NFC Tags containing a NDEF record of type "URI" with scheme "ch:"
* Interpret the URI record as CHIP QR Code Payload
* Switch to Device Details screen to present decoded information

Note: Currently the app assumes the URI record contains QR Code Payload which technically isn't a valid URI since it may contain a space character. It works correctly on Android despite of that flaw, but it will need to be discussed during spec work.

 Fixes #3600
