### PR TITLE
Add ZCL reporting plugin to be compiled in various examples

### DIFF
--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -87,6 +87,8 @@ efr32_executable("lighting_app") {
     "${chip_root}/examples/common/QRCode/repo/c/qrcodegen.c",
     "${chip_root}/examples/common/chip-app-server/DataModelHandler.cpp",
     "${chip_root}/src/app/clusters/on-off-server/on-off.cpp",
+    "${chip_root}/src/app/reporting/reporting-default-configuration.cpp",
+    "${chip_root}/src/app/reporting/reporting.cpp",
     "${chip_root}/src/app/util/af-event.cpp",
     "${chip_root}/src/app/util/af-main-common.cpp",
     "${chip_root}/src/app/util/attribute-size.cpp",

--- a/examples/lighting-app/efr32/src/gen/callback-stub.c
+++ b/examples/lighting-app/efr32/src/gen/callback-stub.c
@@ -137,17 +137,6 @@ bool emberAfAttributeWriteAccessCallback(uint8_t endpoint, EmberAfClusterId clus
  */
 void emberAfGroupsClusterClearGroupTableCallback(uint8_t endpoint) {}
 
-/** @brief Clear Report Table
- *
- * This function is called by the framework when the application should clear
- * the report table.
- *
- */
-EmberStatus emberAfClearReportTableCallback(void)
-{
-    return EMBER_LIBRARY_NOT_PRESENT;
-}
-
 /** @brief Scenes Cluster ClearSceneTable
  *
  * This function is called by the framework when the application should clear
@@ -199,38 +188,6 @@ void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId) {}
 bool emberAfClusterSecurityCustomCallback(EmberAfProfileId profileId, EmberAfClusterId clusterId, bool incoming, uint8_t commandId)
 {
     // By default, assume APS encryption is not required.
-    return false;
-}
-
-/** @brief Configure Reporting Command
- *
- * This function is called by the application framework when a Configure
- * Reporting command is received from an external device.  The Configure
- * Reporting command contains a series of attribute reporting configuration
- * records.  The application should return true if the message was processed or
- * false if it was not.
- *
- * @param cmd   Ver.: always
- */
-bool emberAfConfigureReportingCommandCallback(const EmberAfClusterCommand * cmd)
-{
-    return false;
-}
-
-/** @brief Configure Reporting Response
- *
- * This function is called by the application framework when a Configure
- * Reporting Response command is received from an external device.  The
- * application should return true if the message was processed or false if it
- * was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param buffer Buffer containing the list of attribute status records.  Ver.:
- * always
- * @param bufLen The length in bytes of the list.  Ver.: always
- */
-bool emberAfConfigureReportingResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
-{
     return false;
 }
 
@@ -1969,36 +1926,6 @@ bool emberAfReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t *
     return false;
 }
 
-/** @brief Read Reporting Configuration Command
- *
- * This function is called by the application framework when a Read Reporting
- * Configuration command is received from an external device.  The application
- * should return true if the message was processed or false if it was not.
- *
- * @param cmd   Ver.: always
- */
-bool emberAfReadReportingConfigurationCommandCallback(const EmberAfClusterCommand * cmd)
-{
-    return false;
-}
-
-/** @brief Read Reporting Configuration Response
- *
- * This function is called by the application framework when a Read Reporting
- * Configuration Response command is received from an external device.  The
- * application should return true if the message was processed or false if it
- * was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param buffer Buffer containing the list of attribute reporting configuration
- * records.  Ver.: always
- * @param bufLen The length in bytes of the list.  Ver.: always
- */
-bool emberAfReadReportingConfigurationResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
-{
-    return false;
-}
-
 /** @brief Scenes Cluster Recall Saved Scene
  *
  * This function is called by the framework when the application should recall a
@@ -2110,25 +2037,6 @@ bool emberAfReportAttributesCallback(EmberAfClusterId clusterId, uint8_t * buffe
 {
     return false;
 }
-
-/** @brief Reporting Attribute Change
- *
- * This function is called by the framework when an attribute managed by the
- * framework changes.  The application should call this function when an
- * externally-managed attribute changes.  The application should use the change
- * notification to inform its reporting decisions.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param data   Ver.: always
- */
-void emberAfReportingAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
-                                             uint8_t mask, uint16_t manufacturerCode, EmberAfAttributeType type, uint8_t * data)
-{}
 
 /** @brief Scan Error
  *

--- a/examples/lighting-app/lighting-common/BUILD.gn
+++ b/examples/lighting-app/lighting-common/BUILD.gn
@@ -25,6 +25,8 @@ source_set("lighting-common") {
   sources = [
     "${chip_root}/examples/common/chip-app-server/DataModelHandler.cpp",
     "${chip_root}/src/app/clusters/on-off-server/on-off.cpp",
+    "${chip_root}/src/app/reporting/reporting-default-configuration.cpp",
+    "${chip_root}/src/app/reporting/reporting.cpp",
     "${chip_root}/src/app/util/af-event.cpp",
     "${chip_root}/src/app/util/af-main-common.cpp",
     "${chip_root}/src/app/util/attribute-size.cpp",

--- a/examples/lighting-app/lighting-common/gen/callback-stub.c
+++ b/examples/lighting-app/lighting-common/gen/callback-stub.c
@@ -137,17 +137,6 @@ bool emberAfAttributeWriteAccessCallback(uint8_t endpoint, EmberAfClusterId clus
  */
 void emberAfGroupsClusterClearGroupTableCallback(uint8_t endpoint) {}
 
-/** @brief Clear Report Table
- *
- * This function is called by the framework when the application should clear
- * the report table.
- *
- */
-EmberStatus emberAfClearReportTableCallback(void)
-{
-    return EMBER_LIBRARY_NOT_PRESENT;
-}
-
 /** @brief Scenes Cluster ClearSceneTable
  *
  * This function is called by the framework when the application should clear
@@ -199,38 +188,6 @@ void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId) {}
 bool emberAfClusterSecurityCustomCallback(EmberAfProfileId profileId, EmberAfClusterId clusterId, bool incoming, uint8_t commandId)
 {
     // By default, assume APS encryption is not required.
-    return false;
-}
-
-/** @brief Configure Reporting Command
- *
- * This function is called by the application framework when a Configure
- * Reporting command is received from an external device.  The Configure
- * Reporting command contains a series of attribute reporting configuration
- * records.  The application should return true if the message was processed or
- * false if it was not.
- *
- * @param cmd   Ver.: always
- */
-bool emberAfConfigureReportingCommandCallback(const EmberAfClusterCommand * cmd)
-{
-    return false;
-}
-
-/** @brief Configure Reporting Response
- *
- * This function is called by the application framework when a Configure
- * Reporting Response command is received from an external device.  The
- * application should return true if the message was processed or false if it
- * was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param buffer Buffer containing the list of attribute status records.  Ver.:
- * always
- * @param bufLen The length in bytes of the list.  Ver.: always
- */
-bool emberAfConfigureReportingResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
-{
     return false;
 }
 
@@ -1969,36 +1926,6 @@ bool emberAfReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t *
     return false;
 }
 
-/** @brief Read Reporting Configuration Command
- *
- * This function is called by the application framework when a Read Reporting
- * Configuration command is received from an external device.  The application
- * should return true if the message was processed or false if it was not.
- *
- * @param cmd   Ver.: always
- */
-bool emberAfReadReportingConfigurationCommandCallback(const EmberAfClusterCommand * cmd)
-{
-    return false;
-}
-
-/** @brief Read Reporting Configuration Response
- *
- * This function is called by the application framework when a Read Reporting
- * Configuration Response command is received from an external device.  The
- * application should return true if the message was processed or false if it
- * was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param buffer Buffer containing the list of attribute reporting configuration
- * records.  Ver.: always
- * @param bufLen The length in bytes of the list.  Ver.: always
- */
-bool emberAfReadReportingConfigurationResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
-{
-    return false;
-}
-
 /** @brief Scenes Cluster Recall Saved Scene
  *
  * This function is called by the framework when the application should recall a
@@ -2110,25 +2037,6 @@ bool emberAfReportAttributesCallback(EmberAfClusterId clusterId, uint8_t * buffe
 {
     return false;
 }
-
-/** @brief Reporting Attribute Change
- *
- * This function is called by the framework when an attribute managed by the
- * framework changes.  The application should call this function when an
- * externally-managed attribute changes.  The application should use the change
- * notification to inform its reporting decisions.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param data   Ver.: always
- */
-void emberAfReportingAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
-                                             uint8_t mask, uint16_t manufacturerCode, EmberAfAttributeType type, uint8_t * data)
-{}
 
 /** @brief Scan Error
  *

--- a/examples/lighting-app/nrfconnect/CMakeLists.txt
+++ b/examples/lighting-app/nrfconnect/CMakeLists.txt
@@ -41,6 +41,8 @@ target_sources(app PRIVATE
                ${CHIP_APP_SERVER}/Server.cpp
                ${CHIP_APP_SERVER}/QRCodeUtil.cpp
                ${CHIP_APP_SERVER}/RendezvousServer.cpp
+               ${CHIP_ROOT}/src/app/reporting/reporting-default-configuration.cpp
+               ${CHIP_ROOT}/src/app/reporting/reporting.cpp
                ${CHIP_ROOT}/src/app/util/af-event.cpp
                ${CHIP_ROOT}/src/app/util/af-main-common.cpp
                ${CHIP_ROOT}/src/app/util/attribute-size.cpp

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -87,6 +87,8 @@ efr32_executable("lock_app") {
     "${chip_root}/examples/common/QRCode/repo/c/qrcodegen.c",
     "${chip_root}/examples/common/chip-app-server/DataModelHandler.cpp",
     "${chip_root}/src/app/clusters/on-off-server/on-off.cpp",
+    "${chip_root}/src/app/reporting/reporting-default-configuration.cpp",
+    "${chip_root}/src/app/reporting/reporting.cpp",
     "${chip_root}/src/app/util/af-event.cpp",
     "${chip_root}/src/app/util/af-main-common.cpp",
     "${chip_root}/src/app/util/attribute-size.cpp",

--- a/examples/lock-app/efr32/src/gen/callback-stub.c
+++ b/examples/lock-app/efr32/src/gen/callback-stub.c
@@ -137,17 +137,6 @@ bool emberAfAttributeWriteAccessCallback(uint8_t endpoint, EmberAfClusterId clus
  */
 void emberAfGroupsClusterClearGroupTableCallback(uint8_t endpoint) {}
 
-/** @brief Clear Report Table
- *
- * This function is called by the framework when the application should clear
- * the report table.
- *
- */
-EmberStatus emberAfClearReportTableCallback(void)
-{
-    return EMBER_LIBRARY_NOT_PRESENT;
-}
-
 /** @brief Scenes Cluster ClearSceneTable
  *
  * This function is called by the framework when the application should clear
@@ -199,38 +188,6 @@ void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId) {}
 bool emberAfClusterSecurityCustomCallback(EmberAfProfileId profileId, EmberAfClusterId clusterId, bool incoming, uint8_t commandId)
 {
     // By default, assume APS encryption is not required.
-    return false;
-}
-
-/** @brief Configure Reporting Command
- *
- * This function is called by the application framework when a Configure
- * Reporting command is received from an external device.  The Configure
- * Reporting command contains a series of attribute reporting configuration
- * records.  The application should return true if the message was processed or
- * false if it was not.
- *
- * @param cmd   Ver.: always
- */
-bool emberAfConfigureReportingCommandCallback(const EmberAfClusterCommand * cmd)
-{
-    return false;
-}
-
-/** @brief Configure Reporting Response
- *
- * This function is called by the application framework when a Configure
- * Reporting Response command is received from an external device.  The
- * application should return true if the message was processed or false if it
- * was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param buffer Buffer containing the list of attribute status records.  Ver.:
- * always
- * @param bufLen The length in bytes of the list.  Ver.: always
- */
-bool emberAfConfigureReportingResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
-{
     return false;
 }
 
@@ -1969,19 +1926,6 @@ bool emberAfReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t *
     return false;
 }
 
-/** @brief Read Reporting Configuration Command
- *
- * This function is called by the application framework when a Read Reporting
- * Configuration command is received from an external device.  The application
- * should return true if the message was processed or false if it was not.
- *
- * @param cmd   Ver.: always
- */
-bool emberAfReadReportingConfigurationCommandCallback(const EmberAfClusterCommand * cmd)
-{
-    return false;
-}
-
 /** @brief Activate Door Lock Callback
  * This function is provided by the door lock server plugin.
  *
@@ -1994,23 +1938,6 @@ bool emberAfPluginDoorLockServerActivateDoorLockCallback(bool activate)
 {
     return false;
 };
-
-/** @brief Read Reporting Configuration Response
- *
- * This function is called by the application framework when a Read Reporting
- * Configuration Response command is received from an external device.  The
- * application should return true if the message was processed or false if it
- * was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param buffer Buffer containing the list of attribute reporting configuration
- * records.  Ver.: always
- * @param bufLen The length in bytes of the list.  Ver.: always
- */
-bool emberAfReadReportingConfigurationResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
-{
-    return false;
-}
 
 /** @brief Scenes Cluster Recall Saved Scene
  *
@@ -2123,25 +2050,6 @@ bool emberAfReportAttributesCallback(EmberAfClusterId clusterId, uint8_t * buffe
 {
     return false;
 }
-
-/** @brief Reporting Attribute Change
- *
- * This function is called by the framework when an attribute managed by the
- * framework changes.  The application should call this function when an
- * externally-managed attribute changes.  The application should use the change
- * notification to inform its reporting decisions.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param data   Ver.: always
- */
-void emberAfReportingAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
-                                             uint8_t mask, uint16_t manufacturerCode, EmberAfAttributeType type, uint8_t * data)
-{}
 
 /** @brief Scan Error
  *

--- a/examples/lock-app/lock-common/BUILD.gn
+++ b/examples/lock-app/lock-common/BUILD.gn
@@ -26,6 +26,8 @@ source_set("lock-common") {
   sources = [
     "${chip_root}/examples/common/chip-app-server/DataModelHandler.cpp",
     "${chip_root}/src/app/clusters/on-off-server/on-off.cpp",
+    "${chip_root}/src/app/reporting/reporting-default-configuration.cpp",
+    "${chip_root}/src/app/reporting/reporting.cpp",
     "${chip_root}/src/app/util/af-event.cpp",
     "${chip_root}/src/app/util/af-main-common.cpp",
     "${chip_root}/src/app/util/attribute-size.cpp",

--- a/examples/lock-app/lock-common/gen/callback-stub.c
+++ b/examples/lock-app/lock-common/gen/callback-stub.c
@@ -138,17 +138,6 @@ bool emberAfAttributeWriteAccessCallback(uint8_t endpoint, EmberAfClusterId clus
  */
 void emberAfGroupsClusterClearGroupTableCallback(uint8_t endpoint) {}
 
-/** @brief Clear Report Table
- *
- * This function is called by the framework when the application should clear
- * the report table.
- *
- */
-EmberStatus emberAfClearReportTableCallback(void)
-{
-    return EMBER_LIBRARY_NOT_PRESENT;
-}
-
 /** @brief Scenes Cluster ClearSceneTable
  *
  * This function is called by the framework when the application should clear
@@ -200,38 +189,6 @@ void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId) {}
 bool emberAfClusterSecurityCustomCallback(EmberAfProfileId profileId, EmberAfClusterId clusterId, bool incoming, uint8_t commandId)
 {
     // By default, assume APS encryption is not required.
-    return false;
-}
-
-/** @brief Configure Reporting Command
- *
- * This function is called by the application framework when a Configure
- * Reporting command is received from an external device.  The Configure
- * Reporting command contains a series of attribute reporting configuration
- * records.  The application should return true if the message was processed or
- * false if it was not.
- *
- * @param cmd   Ver.: always
- */
-bool emberAfConfigureReportingCommandCallback(const EmberAfClusterCommand * cmd)
-{
-    return false;
-}
-
-/** @brief Configure Reporting Response
- *
- * This function is called by the application framework when a Configure
- * Reporting Response command is received from an external device.  The
- * application should return true if the message was processed or false if it
- * was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param buffer Buffer containing the list of attribute status records.  Ver.:
- * always
- * @param bufLen The length in bytes of the list.  Ver.: always
- */
-bool emberAfConfigureReportingResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
-{
     return false;
 }
 
@@ -1970,19 +1927,6 @@ bool emberAfReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t *
     return false;
 }
 
-/** @brief Read Reporting Configuration Command
- *
- * This function is called by the application framework when a Read Reporting
- * Configuration command is received from an external device.  The application
- * should return true if the message was processed or false if it was not.
- *
- * @param cmd   Ver.: always
- */
-bool emberAfReadReportingConfigurationCommandCallback(const EmberAfClusterCommand * cmd)
-{
-    return false;
-}
-
 /** @brief Activate Door Lock Callback
  * This function is provided by the door lock server plugin.
  *
@@ -1995,23 +1939,6 @@ bool emberAfPluginDoorLockServerActivateDoorLockCallback(bool activate)
 {
     return false;
 };
-
-/** @brief Read Reporting Configuration Response
- *
- * This function is called by the application framework when a Read Reporting
- * Configuration Response command is received from an external device.  The
- * application should return true if the message was processed or false if it
- * was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param buffer Buffer containing the list of attribute reporting configuration
- * records.  Ver.: always
- * @param bufLen The length in bytes of the list.  Ver.: always
- */
-bool emberAfReadReportingConfigurationResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
-{
-    return false;
-}
 
 /** @brief Scenes Cluster Recall Saved Scene
  *
@@ -2124,25 +2051,6 @@ bool emberAfReportAttributesCallback(EmberAfClusterId clusterId, uint8_t * buffe
 {
     return false;
 }
-
-/** @brief Reporting Attribute Change
- *
- * This function is called by the framework when an attribute managed by the
- * framework changes.  The application should call this function when an
- * externally-managed attribute changes.  The application should use the change
- * notification to inform its reporting decisions.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param data   Ver.: always
- */
-void emberAfReportingAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
-                                             uint8_t mask, uint16_t manufacturerCode, EmberAfAttributeType type, uint8_t * data)
-{}
 
 /** @brief Scan Error
  *

--- a/examples/lock-app/nrfconnect/CMakeLists.txt
+++ b/examples/lock-app/nrfconnect/CMakeLists.txt
@@ -41,6 +41,8 @@ target_sources(app PRIVATE
                ${CHIP_APP_SERVER}/Server.cpp
                ${CHIP_APP_SERVER}/QRCodeUtil.cpp
                ${CHIP_APP_SERVER}/RendezvousServer.cpp
+               ${CHIP_ROOT}/src/app/reporting/reporting-default-configuration.cpp
+               ${CHIP_ROOT}/src/app/reporting/reporting.cpp
                ${CHIP_ROOT}/src/app/util/af-event.cpp
                ${CHIP_ROOT}/src/app/util/af-main-common.cpp
                ${CHIP_ROOT}/src/app/util/attribute-size.cpp

--- a/examples/temperature-measurement-app/esp32/main/gen/callback-stub.c
+++ b/examples/temperature-measurement-app/esp32/main/gen/callback-stub.c
@@ -119,17 +119,6 @@ bool emberAfAttributeWriteAccessCallback(uint8_t endpoint, EmberAfClusterId clus
  */
 void emberAfGroupsClusterClearGroupTableCallback(uint8_t endpoint) {}
 
-/** @brief Clear Report Table
- *
- * This function is called by the framework when the application should clear
- * the report table.
- *
- */
-EmberStatus emberAfClearReportTableCallback(void)
-{
-    return EMBER_LIBRARY_NOT_PRESENT;
-}
-
 /** @brief Scenes Cluster ClearSceneTable
  *
  * This function is called by the framework when the application should clear
@@ -181,38 +170,6 @@ void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId) {}
 bool emberAfClusterSecurityCustomCallback(EmberAfProfileId profileId, EmberAfClusterId clusterId, bool incoming, uint8_t commandId)
 {
     // By default, assume APS encryption is not required.
-    return false;
-}
-
-/** @brief Configure Reporting Command
- *
- * This function is called by the application framework when a Configure
- * Reporting command is received from an external device.  The Configure
- * Reporting command contains a series of attribute reporting configuration
- * records.  The application should return true if the message was processed or
- * false if it was not.
- *
- * @param cmd   Ver.: always
- */
-bool emberAfConfigureReportingCommandCallback(const EmberAfClusterCommand * cmd)
-{
-    return false;
-}
-
-/** @brief Configure Reporting Response
- *
- * This function is called by the application framework when a Configure
- * Reporting Response command is received from an external device.  The
- * application should return true if the message was processed or false if it
- * was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param buffer Buffer containing the list of attribute status records.  Ver.:
- * always
- * @param bufLen The length in bytes of the list.  Ver.: always
- */
-bool emberAfConfigureReportingResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
-{
     return false;
 }
 
@@ -1975,36 +1932,6 @@ bool emberAfReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t *
     return false;
 }
 
-/** @brief Read Reporting Configuration Command
- *
- * This function is called by the application framework when a Read Reporting
- * Configuration command is received from an external device.  The application
- * should return true if the message was processed or false if it was not.
- *
- * @param cmd   Ver.: always
- */
-bool emberAfReadReportingConfigurationCommandCallback(const EmberAfClusterCommand * cmd)
-{
-    return false;
-}
-
-/** @brief Read Reporting Configuration Response
- *
- * This function is called by the application framework when a Read Reporting
- * Configuration Response command is received from an external device.  The
- * application should return true if the message was processed or false if it
- * was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param buffer Buffer containing the list of attribute reporting configuration
- * records.  Ver.: always
- * @param bufLen The length in bytes of the list.  Ver.: always
- */
-bool emberAfReadReportingConfigurationResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
-{
-    return false;
-}
-
 /** @brief Scenes Cluster Recall Saved Scene
  *
  * This function is called by the framework when the application should recall a
@@ -2116,25 +2043,6 @@ bool emberAfReportAttributesCallback(EmberAfClusterId clusterId, uint8_t * buffe
 {
     return false;
 }
-
-/** @brief Reporting Attribute Change
- *
- * This function is called by the framework when an attribute managed by the
- * framework changes.  The application should call this function when an
- * externally-managed attribute changes.  The application should use the change
- * notification to inform its reporting decisions.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param data   Ver.: always
- */
-void emberAfReportingAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
-                                             uint8_t mask, uint16_t manufacturerCode, EmberAfAttributeType type, uint8_t * data)
-{}
 
 /** @brief Scan Complete
  *

--- a/examples/wifi-echo/server/esp32/main/gen/callback-stub.c
+++ b/examples/wifi-echo/server/esp32/main/gen/callback-stub.c
@@ -228,23 +228,6 @@ bool emberAfClusterSecurityCustomCallback(EmberAfProfileId profileId, EmberAfClu
     return false;
 }
 
-/** @brief Configure Reporting Response
- *
- * This function is called by the application framework when a Configure
- * Reporting Response command is received from an external device.  The
- * application should return true if the message was processed or false if it
- * was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param buffer Buffer containing the list of attribute status records.  Ver.:
- * always
- * @param bufLen The length in bytes of the list.  Ver.: always
- */
-bool emberAfConfigureReportingResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
-{
-    return false;
-}
-
 /** @brief Default Response
  *
  * This function is called by the application framework when a Default Response
@@ -1922,23 +1905,6 @@ bool emberAfPreZDOMessageReceivedCallback(EmberNodeId emberNodeId, EmberApsFrame
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
 bool emberAfReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
-{
-    return false;
-}
-
-/** @brief Read Reporting Configuration Response
- *
- * This function is called by the application framework when a Read Reporting
- * Configuration Response command is received from an external device.  The
- * application should return true if the message was processed or false if it
- * was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param buffer Buffer containing the list of attribute reporting configuration
- * records.  Ver.: always
- * @param bufLen The length in bytes of the list.  Ver.: always
- */
-bool emberAfReadReportingConfigurationResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
     return false;
 }

--- a/src/app/reporting/reporting.cpp
+++ b/src/app/reporting/reporting.cpp
@@ -361,7 +361,7 @@ static void conditionallySendReport(uint8_t endpoint, EmberAfClusterId clusterId
     }
 }
 
-bool emberAfConfigureReportingCommandCallback(const EmberAfClusterCommand * cmd)
+extern "C" bool emberAfConfigureReportingCommandCallback(const EmberAfClusterCommand * cmd)
 {
     EmberStatus sendStatus;
     uint16_t bufIndex = cmd->payloadStartIndex;
@@ -512,7 +512,7 @@ bool emberAfConfigureReportingCommandCallback(const EmberAfClusterCommand * cmd)
     return true;
 }
 
-bool emberAfReadReportingConfigurationCommandCallback(const EmberAfClusterCommand * cmd)
+extern "C" bool emberAfReadReportingConfigurationCommandCallback(const EmberAfClusterCommand * cmd)
 {
     EmberStatus sendStatus;
     uint16_t bufIndex = cmd->payloadStartIndex;
@@ -641,7 +641,7 @@ bool emberAfReadReportingConfigurationCommandCallback(const EmberAfClusterComman
     return true;
 }
 
-EmberStatus emberAfClearReportTableCallback(void)
+extern "C" EmberStatus emberAfClearReportTableCallback(void)
 {
     uint8_t i;
     for (i = 0; i < REPORT_TABLE_SIZE; i++)
@@ -663,8 +663,9 @@ EmberStatus emAfPluginReportingRemoveEntry(uint8_t index)
     return status;
 }
 
-void emberAfReportingAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
-                                             uint8_t mask, uint16_t manufacturerCode, EmberAfAttributeType type, uint8_t * data)
+extern "C" void emberAfReportingAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId,
+                                                        EmberAfAttributeId attributeId, uint8_t mask, uint16_t manufacturerCode,
+                                                        EmberAfAttributeType type, uint8_t * data)
 {
     uint8_t i;
     for (i = 0; i < REPORT_TABLE_SIZE; i++)
@@ -1061,4 +1062,14 @@ uint8_t emAfPluginReportingConditionallyAddReportingEntry(EmberAfPluginReporting
         return emAfPluginReportingAddEntry(newEntry);
     }
     return 0;
+}
+
+extern "C" bool emberAfConfigureReportingResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+{
+    return false;
+}
+
+extern "C" bool emberAfReadReportingConfigurationResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+{
+    return false;
 }

--- a/src/app/reporting/reporting.h
+++ b/src/app/reporting/reporting.h
@@ -48,6 +48,11 @@
 // The default reporting will generate a table that is mandatory
 // but user may still allocate some table for adding more reporting over
 // the air or by cli as part of reporting plugin.
+
+#ifndef EMBER_AF_PLUGIN_REPORTING_TABLE_SIZE
+#define EMBER_AF_PLUGIN_REPORTING_TABLE_SIZE 5
+#endif // EMBER_AF_PLUGIN_REPORTING_TABLE_SIZE
+
 #ifndef REPORT_TABLE_SIZE
 #if defined EMBER_AF_GENERATED_REPORTING_CONFIG_DEFAULTS_TABLE_SIZE
 #define REPORT_TABLE_SIZE (EMBER_AF_GENERATED_REPORTING_CONFIG_DEFAULTS_TABLE_SIZE + EMBER_AF_PLUGIN_REPORTING_TABLE_SIZE)
@@ -73,4 +78,87 @@ bool emAfPluginReportingDoEntriesMatch(const EmberAfPluginReportingEntry * const
 uint8_t emAfPluginReportingConditionallyAddReportingEntry(EmberAfPluginReportingEntry * newEntry);
 void emberAfPluginReportingLoadReportingConfigDefaults(void);
 bool emberAfPluginReportingGetReportingConfigDefaults(EmberAfPluginReportingEntry * defaultConfiguration);
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/** @brief Configure Reporting Command
+ *
+ * This function is called by the application framework when a Configure
+ * Reporting command is received from an external device.  The Configure
+ * Reporting command contains a series of attribute reporting configuration
+ * records.  The application should return true if the message was processed or
+ * false if it was not.
+ *
+ * @param cmd   Ver.: always
+ */
+bool emberAfConfigureReportingCommandCallback(const EmberAfClusterCommand * cmd);
+
+/** @brief Read Reporting Configuration Command
+ *
+ * This function is called by the application framework when a Read Reporting
+ * Configuration command is received from an external device.  The application
+ * should return true if the message was processed or false if it was not.
+ *
+ * @param cmd   Ver.: always
+ */
+bool emberAfReadReportingConfigurationCommandCallback(const EmberAfClusterCommand * cmd);
+
+/** @brief Clear Report Table
+ *
+ * This function is called by the framework when the application should clear
+ * the report table.
+ *
+ */
+EmberStatus emberAfClearReportTableCallback(void);
+
+/** @brief Configure Reporting Response
+ *
+ * This function is called by the application framework when a Configure
+ * Reporting Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute status records.  Ver.:
+ * always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool emberAfConfigureReportingResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+
+/** @brief Read Reporting Configuration Response
+ *
+ * This function is called by the application framework when a Read Reporting
+ * Configuration Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute reporting configuration
+ * records.  Ver.: always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool emberAfReadReportingConfigurationResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+
+/** @brief Reporting Attribute Change
+ *
+ * This function is called by the framework when an attribute managed by the
+ * framework changes.  The application should call this function when an
+ * externally-managed attribute changes.  The application should use the change
+ * notification to inform its reporting decisions.
+ *
+ * @param endpoint   Ver.: always
+ * @param clusterId   Ver.: always
+ * @param attributeId   Ver.: always
+ * @param mask   Ver.: always
+ * @param manufacturerCode   Ver.: always
+ * @param type   Ver.: always
+ * @param data   Ver.: always
+ */
+void emberAfReportingAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
+                                             uint8_t mask, uint16_t manufacturerCode, EmberAfAttributeType type, uint8_t * data);
+
+#ifdef __cplusplus
+}
+#endif
 #endif


### PR DESCRIPTION

 #### Problem

In order to makes it easier to move forward on #3464, I'm trying to extract the parts that are not fully dependent on ZAP.
It should makes it easier to understand the scope of various changes from #3464

This PR is the part of #3464 that includes the **reporting** plugin inside various examples beside _wifi-echo_
This is the reason why some of the reporting plugin callbacks have been made `extern "C" ` 

 #### Summary of Changes
 * Add `reporting.c` and `reporting-default-configuration.cpp` to the lock-app and lighting-app examples
 * Remove the reporting callback stubs from all the examples
 * Move the declaration and definition of the stubs directly inside the reporting plugin
