### PR TITLE
Remove references to EmAfZigbeeProNetwork

### DIFF
--- a/examples/lighting-app/efr32/src/gen/callback-stub.c
+++ b/examples/lighting-app/efr32/src/gen/callback-stub.c
@@ -1765,21 +1765,6 @@ bool emberAfPluginNetworkSteeringGetDistributedKeyCallback(EmberKeyData * key)
     return false;
 }
 
-/** @brief Get Node Type
- *
- * This callback allows the application to set the node type that the network
- * steering process will use in joining a network.
- *
- * @param state The current ::EmberAfPluginNetworkSteeringJoiningState.
- *
- * @return An ::EmberNodeType value that the network steering process will
- * try to join a network as.
- */
-EmberNodeType emberAfPluginNetworkSteeringGetNodeTypeCallback(EmberAfPluginNetworkSteeringJoiningState state)
-{
-    return ((emAfCurrentZigbeeProNetwork->nodeType == EMBER_COORDINATOR) ? EMBER_ROUTER : emAfCurrentZigbeeProNetwork->nodeType);
-}
-
 /** @brief Get Power For Radio Channel
  *
  * This callback is fired when the Network Steering plugin needs to set the

--- a/examples/lighting-app/lighting-common/gen/callback-stub.c
+++ b/examples/lighting-app/lighting-common/gen/callback-stub.c
@@ -1765,21 +1765,6 @@ bool emberAfPluginNetworkSteeringGetDistributedKeyCallback(EmberKeyData * key)
     return false;
 }
 
-/** @brief Get Node Type
- *
- * This callback allows the application to set the node type that the network
- * steering process will use in joining a network.
- *
- * @param state The current ::EmberAfPluginNetworkSteeringJoiningState.
- *
- * @return An ::EmberNodeType value that the network steering process will
- * try to join a network as.
- */
-EmberNodeType emberAfPluginNetworkSteeringGetNodeTypeCallback(EmberAfPluginNetworkSteeringJoiningState state)
-{
-    return ((emAfCurrentZigbeeProNetwork->nodeType == EMBER_COORDINATOR) ? EMBER_ROUTER : emAfCurrentZigbeeProNetwork->nodeType);
-}
-
 /** @brief Get Power For Radio Channel
  *
  * This callback is fired when the Network Steering plugin needs to set the
@@ -2484,8 +2469,6 @@ bool emberAfIsCurrentSecurityProfileSmartEnergy(void)
 }
 
 const EmberAfOtaImageId emberAfInvalidImageId;
-
-const EmAfZigbeeProNetwork * emAfCurrentZigbeeProNetwork = NULL;
 
 void emberAfPluginUpdateTcLinkKeyZigbeeKeyEstablishmentCallback(EmberEUI64 partner, EmberKeyStatus status) {}
 

--- a/examples/lock-app/efr32/src/gen/callback-stub.c
+++ b/examples/lock-app/efr32/src/gen/callback-stub.c
@@ -1765,21 +1765,6 @@ bool emberAfPluginNetworkSteeringGetDistributedKeyCallback(EmberKeyData * key)
     return false;
 }
 
-/** @brief Get Node Type
- *
- * This callback allows the application to set the node type that the network
- * steering process will use in joining a network.
- *
- * @param state The current ::EmberAfPluginNetworkSteeringJoiningState.
- *
- * @return An ::EmberNodeType value that the network steering process will
- * try to join a network as.
- */
-EmberNodeType emberAfPluginNetworkSteeringGetNodeTypeCallback(EmberAfPluginNetworkSteeringJoiningState state)
-{
-    return ((emAfCurrentZigbeeProNetwork->nodeType == EMBER_COORDINATOR) ? EMBER_ROUTER : emAfCurrentZigbeeProNetwork->nodeType);
-}
-
 /** @brief Get Power For Radio Channel
  *
  * This callback is fired when the Network Steering plugin needs to set the

--- a/examples/lock-app/lock-common/gen/callback-stub.c
+++ b/examples/lock-app/lock-common/gen/callback-stub.c
@@ -1766,21 +1766,6 @@ bool emberAfPluginNetworkSteeringGetDistributedKeyCallback(EmberKeyData * key)
     return false;
 }
 
-/** @brief Get Node Type
- *
- * This callback allows the application to set the node type that the network
- * steering process will use in joining a network.
- *
- * @param state The current ::EmberAfPluginNetworkSteeringJoiningState.
- *
- * @return An ::EmberNodeType value that the network steering process will
- * try to join a network as.
- */
-EmberNodeType emberAfPluginNetworkSteeringGetNodeTypeCallback(EmberAfPluginNetworkSteeringJoiningState state)
-{
-    return ((emAfCurrentZigbeeProNetwork->nodeType == EMBER_COORDINATOR) ? EMBER_ROUTER : emAfCurrentZigbeeProNetwork->nodeType);
-}
-
 /** @brief Get Power For Radio Channel
  *
  * This callback is fired when the Network Steering plugin needs to set the

--- a/examples/wifi-echo/server/esp32/main/gen/callback-stub.c
+++ b/examples/wifi-echo/server/esp32/main/gen/callback-stub.c
@@ -1745,21 +1745,6 @@ bool emberAfPluginNetworkSteeringGetDistributedKeyCallback(EmberKeyData * key)
     return false;
 }
 
-/** @brief Get Node Type
- *
- * This callback allows the application to set the node type that the network
- * steering process will use in joining a network.
- *
- * @param state The current ::EmberAfPluginNetworkSteeringJoiningState.
- *
- * @return An ::EmberNodeType value that the network steering process will
- * try to join a network as.
- */
-EmberNodeType emberAfPluginNetworkSteeringGetNodeTypeCallback(EmberAfPluginNetworkSteeringJoiningState state)
-{
-    return ((emAfCurrentZigbeeProNetwork->nodeType == EMBER_COORDINATOR) ? EMBER_ROUTER : emAfCurrentZigbeeProNetwork->nodeType);
-}
-
 /** @brief Get Power For Radio Channel
  *
  * This callback is fired when the Network Steering plugin needs to set the

--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -528,15 +528,6 @@ typedef struct
     EmberKeyData preconfiguredKey;
 } EmberAfSecurityProfileData;
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-typedef struct
-{
-    EmberNodeType nodeType;
-    EmberAfSecurityProfile securityProfile;
-} EmAfZigbeeProNetwork;
-
-#endif
-
 #ifdef DOXYGEN_SHOULD_SKIP_THIS
 enum EmberAfEndpointBitmask;
 #else

--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -452,15 +452,6 @@ uint8_t emberAfGetDataSize(uint8_t dataType);
 #if !defined(DOXYGEN_SHOULD_SKIP_THIS)
 // master array of all defined endpoints
 extern EmberAfDefinedEndpoint emAfEndpoints[];
-
-// Master array of all zigbee PRO networks.
-extern const EmAfZigbeeProNetwork emAfZigbeeProNetworks[];
-
-// The current zigbee PRO network or NULL.
-extern const EmAfZigbeeProNetwork * emAfCurrentZigbeeProNetwork;
-
-// true if the current network is a zigbee PRO network.
-#define emAfProIsCurrentNetwork() (emAfCurrentZigbeeProNetwork != NULL)
 #endif
 
 /**

--- a/src/app/util/attribute-storage.c
+++ b/src/app/util/attribute-storage.c
@@ -91,7 +91,6 @@ const uint16_t commandManufacturerCodeCount                   = GENERATED_COMMAN
 const EmberAfAttributeMetadata generatedAttributes[]      = GENERATED_ATTRIBUTES;
 const EmberAfCluster generatedClusters[]                  = GENERATED_CLUSTERS;
 const EmberAfEndpointType generatedEmberAfEndpointTypes[] = GENERATED_ENDPOINT_TYPES;
-const EmAfZigbeeProNetwork emAfZigbeeProNetworks[]        = EM_AF_GENERATED_ZIGBEE_PRO_NETWORKS;
 
 const EmberAfManufacturerCodeEntry clusterManufacturerCodes[]   = GENERATED_CLUSTER_MANUFACTURER_CODES;
 const uint16_t clusterManufacturerCodeCount                     = GENERATED_CLUSTER_MANUFACTURER_CODE_COUNT;


### PR DESCRIPTION
 #### Problem

In order to makes it easier to move forward on #3464, I'm trying to extract the parts that are not fully dependent on ZAP.
It should makes it easier to understand the scope of various changes from #3464

This PR is the part of #3464 that remove the reference to `emAfZigbeeProNetwork` from `attribute-storage.c`

 #### Summary of Changes
 * Remove the references to `emAfZigbeeProNetwork`
 