### PR TITLE
Add some missing #ifdefs into src/app

### DIFF
--- a/src/app/clusters/on-off-server/on-off.c
+++ b/src/app/clusters/on-off-server/on-off.c
@@ -106,21 +106,25 @@ EmberAfStatus emberAfOnOffClusterSetValueCallback(uint8_t endpoint, uint8_t comm
             return status;
         }
 
+#ifdef EMBER_AF_PLUGIN_LEVEL_CONTROL
         // If initiatedByLevelChange is false, then we assume that the level change
         // ZCL stuff has not happened and we do it here
         if (!initiatedByLevelChange && emberAfContainsServer(endpoint, ZCL_LEVEL_CONTROL_CLUSTER_ID))
         {
             emberAfOnOffClusterLevelControlEffectCallback(endpoint, newValue);
         }
+#endif // EMBER_AF_PLUGIN_LEVEL_CONTROL
     }
     else
     {
+#ifdef EMBER_AF_PLUGIN_LEVEL_CONTROL
         // If initiatedByLevelChange is false, then we assume that the level change
         // ZCL stuff has not happened and we do it here
         if (!initiatedByLevelChange && emberAfContainsServer(endpoint, ZCL_LEVEL_CONTROL_CLUSTER_ID))
         {
             emberAfOnOffClusterLevelControlEffectCallback(endpoint, newValue);
         }
+#endif // EMBER_AF_PLUGIN_LEVEL_CONTROL
 
         // write the new on/off value
         status = emberAfWriteAttribute(endpoint, ZCL_ON_OFF_CLUSTER_ID, ZCL_ON_OFF_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
@@ -139,6 +143,7 @@ EmberAfStatus emberAfOnOffClusterSetValueCallback(uint8_t endpoint, uint8_t comm
     }
 #endif
 
+#ifdef EMBER_AF_PLUGIN_SCENES
     // the scene has been changed (the value of on/off has changed) so
     // the current scene as descibed in the attribute table is invalid,
     // so mark it as invalid (just writes the valid/invalid attribute)
@@ -146,6 +151,7 @@ EmberAfStatus emberAfOnOffClusterSetValueCallback(uint8_t endpoint, uint8_t comm
     {
         emberAfScenesClusterMakeInvalidCallback(endpoint);
     }
+#endif // EMBER_AF_PLUGIN_SCENES
 
     // The returned status is based solely on the On/Off cluster.  Errors in the
     // Level Control and/or Scenes cluster are ignored.

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -439,6 +439,7 @@ static bool dispatchZclMessage(EmberAfClusterCommand * cmd)
         emberAfDebugPrintln("0x%02x", cmd->apsFrame->profileId);
         return false;
     }
+#ifdef EMBER_AF_PLUGIN_GROUPS_SERVER
     else if ((cmd->type == EMBER_INCOMING_MULTICAST || cmd->type == EMBER_INCOMING_MULTICAST_LOOPBACK) &&
              !emberAfGroupsClusterEndpointInGroupCallback(cmd->apsFrame->destinationEndpoint, cmd->apsFrame->groupId))
     {
@@ -447,6 +448,7 @@ static bool dispatchZclMessage(EmberAfClusterCommand * cmd)
         emberAfDebugPrintln("0x%02x", cmd->apsFrame->groupId);
         return false;
     }
+#endif // EMBER_AF_PLUGIN_GROUPS_SERVER
     else
     {
         return (cmd->clusterSpecific ? emAfProcessClusterSpecificCommand(cmd) : emAfProcessGlobalCommand(cmd));


### PR DESCRIPTION

 #### Problem
 In order to makes it easier to move forward on #3464, I'm trying to extract the parts that are not fully dependent on ZAP.
It should makes it easier to understand the scope of various changes from #3464

This PR is the part of #3464 that adds some missing #ifdefs to files in `src/app`

 #### Summary of Changes
 * Add missing #ifdefs to files in `src/app`