### PR TITLE
Have mbedtls use CHIPMem when enabled

### DIFF
--- a/src/platform/EFR32/efr32-chip-mbedtls-config.h
+++ b/src/platform/EFR32/efr32-chip-mbedtls-config.h
@@ -238,13 +238,6 @@ typedef void mbedtls_ecp_restart_ctx;
 #define MBEDTLS_ECP_FIXED_POINT_OPTIM 0 /**< Enable fixed-point speed-up */
 #define MBEDTLS_ENTROPY_MAX_SOURCES 1   /**< Maximum number of sources supported */
 
-// #if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
-#define MBEDTLS_PLATFORM_STD_CALLOC calloc /**< Default allocator to use, can be undefined */
-#define MBEDTLS_PLATFORM_STD_FREE free     /**< Default free to use, can be undefined */
-// #else
-// #define MBEDTLS_MEMORY_BUFFER_ALLOC_C
-// #endif
-
 #if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
 #define MBEDTLS_SSL_MAX_CONTENT_LEN 900 /**< Maxium fragment length in bytes */
 #else


### PR DESCRIPTION
#### Problem

Heap allocations from code used by CHIP should go through `CHIPMem.h`
functions. MbedTLS uses heap, and requires configuration once CHIPMem
is initialized.

#### Summary of Changes

- Add run-time mbedtls configurutation to MemoryInit/MemoryShutdown.
- Remove compile-time mbedtls configuration forcing non-CHIP heap allocation.

fixes #3178
