### PR TITLE
CodeQL: Too many arguments to formatting function in src/platform/ESP…

### DIFF
--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -635,7 +635,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     err = ConfigurationMgr().GetBLEDeviceIdentificationInfo(deviceIdInfo);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "GetBLEDeviceIdentificationInfo(): ", ErrorStr(err));
+        ChipLogError(DeviceLayer, "GetBLEDeviceIdentificationInfo(): %s", ErrorStr(err));
         ExitNow();
     }
 


### PR DESCRIPTION
…32/nimble/BLEManagerImpl.cpp

 #### Problem
 
Missing `%s` found by CodeQL

 #### Summary of Changes
 * Add the missing `%s`...