### PR TITLE
[nrfconnect] Remove functional code from assert

### DIFF
--- a/examples/platform/nrfconnect/pw_sys_io/sys_io_nrfconnect.cc
+++ b/examples/platform/nrfconnect/pw_sys_io/sys_io_nrfconnect.cc
@@ -23,7 +23,8 @@
 
 extern "C" void pw_sys_io_Init()
 {
-    assert(console_init() == 0);
+    int err = console_init();
+    assert(err == 0);
 }
 
 namespace pw::sys_io {


### PR DESCRIPTION
 #### Problem
Functional code should not be called inside assert function, since it won't work if `NDEBUG` flag is set.

 #### Summary of Changes
Remove functional code from assert.