### PR TITLE
[nRF Connect] Update README - Building with Docker

### DIFF
--- a/examples/lighting-app/nrfconnect/README.md
+++ b/examples/lighting-app/nrfconnect/README.md
@@ -110,7 +110,8 @@ container:
         $ mkdir ~/nrfconnect
         $ mkdir ~/connectedhomeip
         $ docker pull nordicsemi/nrfconnect-chip
-        $ docker run --rm -it -v ~/nrfconnect:/var/ncs -v ~/connectedhomeip:/var/chip -v /dev/bus/usb:/dev/bus/usb --device-cgroup-rule "c 189:* rmw" nordicsemi/nrfconnect-chip
+        $ docker run --rm -it -e RUNAS=$(id -u) -v ~/nrfconnect:/var/ncs -v ~/connectedhomeip:/var/chip \
+            -v /dev/bus/usb:/dev/bus/usb --device-cgroup-rule "c 189:* rmw" nordicsemi/nrfconnect-chip
 
 > **Note**:
 >
@@ -124,6 +125,8 @@ container:
 >     connected to your computer such as the nRF52840 DK.
 > -   `--rm` flag can be omitted if you don't want the container to be
 >     auto-removed when you exit the container shell session.
+> -   `-e RUNAS=$(id -u)` is needed to start the container session as the
+>     current user instead of root.
 
 If you use the container for the first time and you don't have nRF Connect SDK
 and CHIP sources downloaded yet, run `setup` command in the container to pull

--- a/examples/lock-app/nrfconnect/README.md
+++ b/examples/lock-app/nrfconnect/README.md
@@ -114,7 +114,8 @@ container:
         $ mkdir ~/nrfconnect
         $ mkdir ~/connectedhomeip
         $ docker pull nordicsemi/nrfconnect-chip
-        $ docker run --rm -it -v ~/nrfconnect:/var/ncs -v ~/connectedhomeip:/var/chip -v /dev/bus/usb:/dev/bus/usb --device-cgroup-rule "c 189:* rmw" nordicsemi/nrfconnect-chip
+        $ docker run --rm -it -e RUNAS=$(id -u) -v ~/nrfconnect:/var/ncs -v ~/connectedhomeip:/var/chip \
+            -v /dev/bus/usb:/dev/bus/usb --device-cgroup-rule "c 189:* rmw" nordicsemi/nrfconnect-chip
 
 > **Note**:
 >
@@ -128,6 +129,8 @@ container:
 >     connected to your computer such as the nRF52840 DK.
 > -   `--rm` flag can be omitted if you don't want the container to be
 >     auto-removed when you exit the container shell session.
+> -   `-e RUNAS=$(id -u)` is needed to start the container session as the
+>     current user instead of root.
 
 If you use the container for the first time and you don't have nRF Connect SDK
 and CHIP sources downloaded yet, run `setup` command in the container to pull


### PR DESCRIPTION
 #### Problem
The instruction for building nRF Connect examples using a Docker container was changed recently to use a non-root user for security and usability reasons. The Docker image, however, used a fixed user ID, 1000, which doesn't necessarily match the current user ID. As a result a user outside the container might still not be able to remove files created in the container.

 #### Summary of Changes
Pass the current user ID to the Docker container by an environmental variable handled in the container so that the container session is run as the current user.
