### PR TITLE
Add IAS Zone Server attributes to chip-tool and src/app

### DIFF
--- a/examples/chip-tool/commands/clusters/Commands.h
+++ b/examples/chip-tool/commands/clusters/Commands.h
@@ -642,6 +642,7 @@ public:
 | ColorControl                                                        | 0x0300 |
 | DoorLock                                                            | 0x0101 |
 | Groups                                                              | 0x0004 |
+| IASZone                                                             | 0x0500 |
 | Identify                                                            | 0x0003 |
 | Level                                                               | 0x0008 |
 | OnOff                                                               | 0x0006 |
@@ -654,6 +655,7 @@ constexpr uint16_t kBasicClusterId           = 0x0000;
 constexpr uint16_t kColorControlClusterId    = 0x0300;
 constexpr uint16_t kDoorLockClusterId        = 0x0101;
 constexpr uint16_t kGroupsClusterId          = 0x0004;
+constexpr uint16_t kIASZoneClusterId         = 0x0500;
 constexpr uint16_t kIdentifyClusterId        = 0x0003;
 constexpr uint16_t kLevelClusterId           = 0x0008;
 constexpr uint16_t kOnOffClusterId           = 0x0006;
@@ -1776,6 +1778,7 @@ public:
 private:
     uint8_t mOptions;
 };
+
 /*
  * Attribute NumberOfPrimaries
  */
@@ -4448,6 +4451,194 @@ public:
 };
 
 /*----------------------------------------------------------------------------*\
+| Cluster IASZone                                                     | 0x0500 |
+|------------------------------------------------------------------------------|
+| Responses:                                                          |        |
+|                                                                     |        |
+|------------------------------------------------------------------------------|
+| Commands:                                                           |        |
+|------------------------------------------------------------------------------|
+| Attributes:                                                         |        |
+| * ZoneState                                                         | 0x0000 |
+| * ZoneType                                                          | 0x0001 |
+| * ZoneStatus                                                        | 0x0002 |
+| * IASCIEAddress                                                     | 0x0010 |
+| * ZoneID                                                            | 0x0011 |
+\*----------------------------------------------------------------------------*/
+
+/*
+ * Discover attributes
+ */
+class DiscoverIASZoneAttributes : public ModelCommand
+{
+public:
+    DiscoverIASZoneAttributes() : ModelCommand("discover", kIASZoneClusterId, 0x0c) { ModelCommand::AddArguments(); }
+
+    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
+    {
+        return encodeIASZoneClusterDiscoverAttributes(buffer->Start(), bufferSize, endPointId);
+    }
+
+    // Global Response: DiscoverAttributesResponse
+    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
+    {
+        DiscoverAttributesResponse response;
+        return response.HandleCommandResponse(commandId, message, messageLen);
+    }
+};
+
+/*
+ * Attribute ZoneState
+ */
+class ReadIASZoneZoneState : public ModelCommand
+{
+public:
+    ReadIASZoneZoneState() : ModelCommand("read", kIASZoneClusterId, 0x00)
+    {
+        AddArgument("attr-name", "zone-state");
+        ModelCommand::AddArguments();
+    }
+
+    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
+    {
+        return encodeIASZoneClusterReadZoneStateAttribute(buffer->Start(), bufferSize, endPointId);
+    }
+
+    // Global Response: ReadAttributesResponse
+    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
+    {
+        ReadAttributesResponse response;
+        return response.HandleCommandResponse(commandId, message, messageLen);
+    }
+};
+
+/*
+ * Attribute ZoneType
+ */
+class ReadIASZoneZoneType : public ModelCommand
+{
+public:
+    ReadIASZoneZoneType() : ModelCommand("read", kIASZoneClusterId, 0x00)
+    {
+        AddArgument("attr-name", "zone-type");
+        ModelCommand::AddArguments();
+    }
+
+    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
+    {
+        return encodeIASZoneClusterReadZoneTypeAttribute(buffer->Start(), bufferSize, endPointId);
+    }
+
+    // Global Response: ReadAttributesResponse
+    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
+    {
+        ReadAttributesResponse response;
+        return response.HandleCommandResponse(commandId, message, messageLen);
+    }
+};
+
+/*
+ * Attribute ZoneStatus
+ */
+class ReadIASZoneZoneStatus : public ModelCommand
+{
+public:
+    ReadIASZoneZoneStatus() : ModelCommand("read", kIASZoneClusterId, 0x00)
+    {
+        AddArgument("attr-name", "zone-status");
+        ModelCommand::AddArguments();
+    }
+
+    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
+    {
+        return encodeIASZoneClusterReadZoneStatusAttribute(buffer->Start(), bufferSize, endPointId);
+    }
+
+    // Global Response: ReadAttributesResponse
+    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
+    {
+        ReadAttributesResponse response;
+        return response.HandleCommandResponse(commandId, message, messageLen);
+    }
+};
+
+/*
+ * Attribute IASCIEAddress
+ */
+class ReadIASZoneIASCIEAddress : public ModelCommand
+{
+public:
+    ReadIASZoneIASCIEAddress() : ModelCommand("read", kIASZoneClusterId, 0x00)
+    {
+        AddArgument("attr-name", "iascieaddress");
+        ModelCommand::AddArguments();
+    }
+
+    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
+    {
+        return encodeIASZoneClusterReadIASCIEAddressAttribute(buffer->Start(), bufferSize, endPointId);
+    }
+
+    // Global Response: ReadAttributesResponse
+    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
+    {
+        ReadAttributesResponse response;
+        return response.HandleCommandResponse(commandId, message, messageLen);
+    }
+};
+
+class WriteIASZoneIASCIEAddress : public ModelCommand
+{
+public:
+    WriteIASZoneIASCIEAddress() : ModelCommand("write", kIASZoneClusterId, 0x01)
+    {
+        AddArgument("attr-name", "iascieaddress");
+        AddArgument("attr-value", 0, UINT64_MAX, &mIASCIEAddress);
+        ModelCommand::AddArguments();
+    }
+
+    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
+    {
+        return encodeIASZoneClusterWriteIASCIEAddressAttribute(buffer->Start(), bufferSize, endPointId, mIASCIEAddress);
+    }
+
+    // Global Response: WriteAttributesResponse
+    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
+    {
+        WriteAttributesResponse response;
+        return response.HandleCommandResponse(commandId, message, messageLen);
+    }
+
+private:
+    uint64_t mIASCIEAddress;
+};
+
+/*
+ * Attribute ZoneID
+ */
+class ReadIASZoneZoneID : public ModelCommand
+{
+public:
+    ReadIASZoneZoneID() : ModelCommand("read", kIASZoneClusterId, 0x00)
+    {
+        AddArgument("attr-name", "zone-id");
+        ModelCommand::AddArguments();
+    }
+
+    uint16_t EncodeCommand(PacketBuffer * buffer, uint16_t bufferSize, uint8_t endPointId) override
+    {
+        return encodeIASZoneClusterReadZoneIDAttribute(buffer->Start(), bufferSize, endPointId);
+    }
+
+    // Global Response: ReadAttributesResponse
+    bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
+    {
+        ReadAttributesResponse response;
+        return response.HandleCommandResponse(commandId, message, messageLen);
+    }
+};
+
+/*----------------------------------------------------------------------------*\
 | Cluster Identify                                                    | 0x0003 |
 |------------------------------------------------------------------------------|
 | Responses:                                                          |        |
@@ -5939,6 +6130,19 @@ void registerClusterGroups(Commands & commands)
     commands.Register(clusterName, clusterCommands);
 }
 
+void registerClusterIASZone(Commands & commands)
+{
+    const char * clusterName = "IASZone";
+
+    commands_list clusterCommands = {
+        make_unique<DiscoverIASZoneAttributes>(), make_unique<ReadIASZoneZoneState>(),     make_unique<ReadIASZoneZoneType>(),
+        make_unique<ReadIASZoneZoneStatus>(),     make_unique<ReadIASZoneIASCIEAddress>(), make_unique<WriteIASZoneIASCIEAddress>(),
+        make_unique<ReadIASZoneZoneID>(),
+    };
+
+    commands.Register(clusterName, clusterCommands);
+}
+
 void registerClusterIdentify(Commands & commands)
 {
     const char * clusterName = "Identify";
@@ -6020,6 +6224,7 @@ void registerClusters(Commands & commands)
     registerClusterColorControl(commands);
     registerClusterDoorLock(commands);
     registerClusterGroups(commands);
+    registerClusterIASZone(commands);
     registerClusterIdentify(commands);
     registerClusterLevel(commands);
     registerClusterOnOff(commands);

--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -107,8 +107,11 @@ bool Command::InitArgument(size_t argIndex, const char * argValue)
         ss >> tmpValue;
         if (chip::CanCastTo<uint8_t>(tmpValue))
         {
-            *value          = static_cast<uint8_t>(tmpValue);
-            isValidArgument = (!ss.fail() && ss.eof() && *value >= arg.min && *value <= arg.max);
+            *value = static_cast<uint8_t>(tmpValue);
+
+            uint64_t min    = chip::CanCastTo<uint64_t>(arg.min) ? static_cast<uint64_t>(arg.min) : 0;
+            uint64_t max    = arg.max;
+            isValidArgument = (!ss.fail() && ss.eof() && *value >= min && *value <= max);
         }
         else
         {
@@ -121,7 +124,10 @@ bool Command::InitArgument(size_t argIndex, const char * argValue)
         uint16_t * value = reinterpret_cast<uint16_t *>(arg.value);
         std::stringstream ss(argValue);
         ss >> *value;
-        isValidArgument = (!ss.fail() && ss.eof() && *value >= arg.min && *value <= arg.max);
+
+        uint64_t min    = chip::CanCastTo<uint64_t>(arg.min) ? static_cast<uint64_t>(arg.min) : 0;
+        uint64_t max    = arg.max;
+        isValidArgument = (!ss.fail() && ss.eof() && *value >= min && *value <= max);
         break;
     }
 
@@ -129,7 +135,21 @@ bool Command::InitArgument(size_t argIndex, const char * argValue)
         uint32_t * value = reinterpret_cast<uint32_t *>(arg.value);
         std::stringstream ss(argValue);
         ss >> *value;
-        isValidArgument = (!ss.fail() && ss.eof() && *value >= arg.min && *value <= arg.max);
+
+        uint64_t min    = chip::CanCastTo<uint64_t>(arg.min) ? static_cast<uint64_t>(arg.min) : 0;
+        uint64_t max    = arg.max;
+        isValidArgument = (!ss.fail() && ss.eof() && *value >= min && *value <= max);
+        break;
+    }
+
+    case ArgumentType::Number_uint64: {
+        uint64_t * value = reinterpret_cast<uint64_t *>(arg.value);
+        std::stringstream ss(argValue);
+        ss >> *value;
+
+        uint64_t min    = chip::CanCastTo<uint64_t>(arg.min) ? static_cast<uint64_t>(arg.min) : 0;
+        uint64_t max    = arg.max;
+        isValidArgument = (!ss.fail() && ss.eof() && *value >= min && *value <= max);
         break;
     }
 
@@ -137,7 +157,10 @@ bool Command::InitArgument(size_t argIndex, const char * argValue)
         int8_t * value = reinterpret_cast<int8_t *>(arg.value);
         std::stringstream ss(argValue);
         ss >> *value;
-        isValidArgument = (!ss.fail() && ss.eof() && *value >= arg.min && *value <= arg.max);
+
+        int64_t min     = arg.min;
+        int64_t max     = chip::CanCastTo<int64_t>(arg.max) ? static_cast<int64_t>(arg.max) : INT64_MAX;
+        isValidArgument = (!ss.fail() && ss.eof() && *value >= min && *value <= max);
         break;
     }
 
@@ -145,7 +168,10 @@ bool Command::InitArgument(size_t argIndex, const char * argValue)
         int16_t * value = reinterpret_cast<int16_t *>(arg.value);
         std::stringstream ss(argValue);
         ss >> *value;
-        isValidArgument = (!ss.fail() && ss.eof() && *value >= arg.min && *value <= arg.max);
+
+        int64_t min     = arg.min;
+        int64_t max     = chip::CanCastTo<int64_t>(arg.max) ? static_cast<int64_t>(arg.max) : INT64_MAX;
+        isValidArgument = (!ss.fail() && ss.eof() && *value >= min && *value <= max);
         break;
     }
 
@@ -153,7 +179,21 @@ bool Command::InitArgument(size_t argIndex, const char * argValue)
         int32_t * value = reinterpret_cast<int32_t *>(arg.value);
         std::stringstream ss(argValue);
         ss >> *value;
-        isValidArgument = (!ss.fail() && ss.eof() && *value >= arg.min && *value <= arg.max);
+
+        int64_t min     = arg.min;
+        int64_t max     = chip::CanCastTo<int64_t>(arg.max) ? static_cast<int64_t>(arg.max) : INT64_MAX;
+        isValidArgument = (!ss.fail() && ss.eof() && *value >= min && *value <= max);
+        break;
+    }
+
+    case ArgumentType::Number_int64: {
+        int64_t * value = reinterpret_cast<int64_t *>(arg.value);
+        std::stringstream ss(argValue);
+        ss >> *value;
+
+        int64_t min     = arg.min;
+        int64_t max     = chip::CanCastTo<int64_t>(arg.max) ? static_cast<int64_t>(arg.max) : INT64_MAX;
+        isValidArgument = (!ss.fail() && ss.eof() && *value >= min && *value <= max);
         break;
     }
 
@@ -205,7 +245,7 @@ size_t Command::AddArgument(const char * name, AddressWithInterface * out)
     return mArgs.size();
 }
 
-size_t Command::AddArgument(const char * name, int64_t min, int64_t max, void * out, ArgumentType type)
+size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, void * out, ArgumentType type)
 {
     Argument arg;
     arg.type  = type;
@@ -218,7 +258,7 @@ size_t Command::AddArgument(const char * name, int64_t min, int64_t max, void * 
     return mArgs.size();
 }
 
-size_t Command::AddArgument(const char * name, int64_t min, int64_t max, void * out)
+size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, void * out)
 {
     Argument arg;
     arg.type  = ArgumentType::Number_uint8;

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -47,9 +47,11 @@ enum ArgumentType
     Number_uint8,
     Number_uint16,
     Number_uint32,
+    Number_uint64,
     Number_int8,
     Number_int16,
     Number_int32,
+    Number_int64,
     String,
     Attribute,
     Address
@@ -60,7 +62,7 @@ struct Argument
     const char * name;
     ArgumentType type;
     int64_t min;
-    int64_t max;
+    uint64_t max;
     void * value;
 };
 
@@ -98,29 +100,37 @@ public:
      */
     size_t AddArgument(const char * name, char ** value);
     size_t AddArgument(const char * name, AddressWithInterface * out);
-    size_t AddArgument(const char * name, int64_t min, int64_t max, int8_t * out)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, int8_t * out)
     {
         return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int8);
     }
-    size_t AddArgument(const char * name, int64_t min, int64_t max, int16_t * out)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, int16_t * out)
     {
         return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int16);
     }
-    size_t AddArgument(const char * name, int64_t min, int64_t max, int32_t * out)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, int32_t * out)
     {
         return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int32);
     }
-    size_t AddArgument(const char * name, int64_t min, int64_t max, uint8_t * out)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, int64_t * out)
+    {
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int64);
+    }
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint8_t * out)
     {
         return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint8);
     }
-    size_t AddArgument(const char * name, int64_t min, int64_t max, uint16_t * out)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint16_t * out)
     {
         return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint16);
     }
-    size_t AddArgument(const char * name, int64_t min, int64_t max, uint32_t * out)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint32_t * out)
     {
         return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint32);
+    }
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint64_t * out)
+    {
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint64);
     }
 
     virtual CHIP_ERROR Run(ChipDeviceController * dc, NodeId remoteId) = 0;
@@ -130,8 +140,8 @@ public:
 
 private:
     bool InitArgument(size_t argIndex, const char * argValue);
-    size_t AddArgument(const char * name, int64_t min, int64_t max, void * out, ArgumentType type);
-    size_t AddArgument(const char * name, int64_t min, int64_t max, void * out);
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, void * out, ArgumentType type);
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, void * out);
 
     bool mCommandExitStatus = false;
     const char * mName      = nullptr;

--- a/src/app/chip-zcl-zpro-codec-api.h
+++ b/src/app/chip-zcl-zpro-codec-api.h
@@ -36,6 +36,7 @@ extern "C" {
 | ColorControl                                                        | 0x0300 |
 | DoorLock                                                            | 0x0101 |
 | Groups                                                              | 0x0004 |
+| IASZone                                                             | 0x0500 |
 | Identify                                                            | 0x0003 |
 | Level                                                               | 0x0008 |
 | OnOff                                                               | 0x0006 |
@@ -904,6 +905,72 @@ uint16_t encodeGroupsClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_le
  *    Encode a read command for the name-support attribute for  server into buffer including the APS frame
  */
 uint16_t encodeGroupsClusterReadNameSupportAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+
+/*----------------------------------------------------------------------------*\
+| Cluster IASZone                                                     | 0x0500 |
+|------------------------------------------------------------------------------|
+| Responses:                                                          |        |
+|                                                                     |        |
+|------------------------------------------------------------------------------|
+| Commands:                                                           |        |
+|------------------------------------------------------------------------------|
+| Attributes:                                                         |        |
+| * ZoneState                                                         | 0x0000 |
+| * ZoneType                                                          | 0x0001 |
+| * ZoneStatus                                                        | 0x0002 |
+| * IASCIEAddress                                                     | 0x0010 |
+| * ZoneID                                                            | 0x0011 |
+\*----------------------------------------------------------------------------*/
+
+/**
+ * @brief
+ *    Encode an zone-enroll-response command for IASZone server into buffer including the APS frame
+ */
+uint16_t encodeIASZoneClusterZoneEnrollResponseCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+                                                       uint8_t enrollResponseCode, uint8_t zoneID);
+
+/**
+ * @brief
+ *    Encode a discover command for  server into buffer including the APS frame
+ */
+uint16_t encodeIASZoneClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+
+/**
+ * @brief
+ *    Encode a read command for the zone-state attribute for  server into buffer including the APS frame
+ */
+uint16_t encodeIASZoneClusterReadZoneStateAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+
+/**
+ * @brief
+ *    Encode a read command for the zone-type attribute for  server into buffer including the APS frame
+ */
+uint16_t encodeIASZoneClusterReadZoneTypeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+
+/**
+ * @brief
+ *    Encode a read command for the zone-status attribute for  server into buffer including the APS frame
+ */
+uint16_t encodeIASZoneClusterReadZoneStatusAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+
+/**
+ * @brief
+ *    Encode a read command for the iascieaddress attribute for  server into buffer including the APS frame
+ */
+uint16_t encodeIASZoneClusterReadIASCIEAddressAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+
+/**
+ * @brief
+ *    Encode a write command for the iascieaddress attribute for  server into buffer including the APS frame
+ */
+uint16_t encodeIASZoneClusterWriteIASCIEAddressAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+                                                         uint64_t iASCIEAddress);
+
+/**
+ * @brief
+ *    Encode a read command for the zone-id attribute for  server into buffer including the APS frame
+ */
+uint16_t encodeIASZoneClusterReadZoneIDAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
 
 /*----------------------------------------------------------------------------*\
 | Cluster Identify                                                    | 0x0003 |

--- a/src/app/encoder.cpp
+++ b/src/app/encoder.cpp
@@ -57,6 +57,9 @@ using namespace chip;
         case 0x21:                                                                                                                 \
             buf.PutLE16(static_cast<uint16_t>(value));                                                                             \
             break;                                                                                                                 \
+        case 0xF0:                                                                                                                 \
+            buf.PutLE64(static_cast<uint64_t>(value));                                                                             \
+            break;                                                                                                                 \
         default:                                                                                                                   \
             ChipLogError(Zcl, "Error encoding %s command", name);                                                                  \
             return 0;                                                                                                              \
@@ -133,6 +136,7 @@ extern "C" {
 | ColorControl                                                        | 0x0300 |
 | DoorLock                                                            | 0x0101 |
 | Groups                                                              | 0x0004 |
+| IASZone                                                             | 0x0500 |
 | Identify                                                            | 0x0003 |
 | Level                                                               | 0x0008 |
 | OnOff                                                               | 0x0006 |
@@ -145,6 +149,7 @@ extern "C" {
 #define COLOR_CONTROL_CLUSTER_ID 0x0300
 #define DOOR_LOCK_CLUSTER_ID 0x0101
 #define GROUPS_CLUSTER_ID 0x0004
+#define IAS_ZONE_CLUSTER_ID 0x0500
 #define IDENTIFY_CLUSTER_ID 0x0003
 #define LEVEL_CLUSTER_ID 0x0008
 #define ON_OFF_CLUSTER_ID 0x0006
@@ -1552,6 +1557,93 @@ uint16_t encodeGroupsClusterReadNameSupportAttribute(uint8_t * buffer, uint16_t 
 {
     uint16_t attr_ids[] = { 0x0000 };
     READ_ATTRIBUTES("ReadGroupsNameSupport", GROUPS_CLUSTER_ID);
+}
+
+/*----------------------------------------------------------------------------*\
+| Cluster IASZone                                                     | 0x0500 |
+|------------------------------------------------------------------------------|
+| Responses:                                                          |        |
+|                                                                     |        |
+|------------------------------------------------------------------------------|
+| Commands:                                                           |        |
+|------------------------------------------------------------------------------|
+| Attributes:                                                         |        |
+| * ZoneState                                                         | 0x0000 |
+| * ZoneType                                                          | 0x0001 |
+| * ZoneStatus                                                        | 0x0002 |
+| * IASCIEAddress                                                     | 0x0010 |
+| * ZoneID                                                            | 0x0011 |
+\*----------------------------------------------------------------------------*/
+
+/*
+ * Command ZoneEnrollResponse
+ */
+uint16_t encodeIASZoneClusterZoneEnrollResponseCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+                                                       uint8_t enrollResponseCode, uint8_t zoneID)
+{
+    const char * kName = "IASZoneZoneEnrollResponse";
+    COMMAND_HEADER(kName, IAS_ZONE_CLUSTER_ID, 0x00);
+    buf.Put(enrollResponseCode);
+    buf.Put(zoneID);
+    COMMAND_FOOTER(kName);
+}
+
+uint16_t encodeIASZoneClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+{
+    DISCOVER_ATTRIBUTES("DiscoverIASZoneAttributes", IAS_ZONE_CLUSTER_ID);
+}
+
+/*
+ * Attribute ZoneState
+ */
+uint16_t encodeIASZoneClusterReadZoneStateAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+{
+    uint16_t attr_ids[] = { 0x0000 };
+    READ_ATTRIBUTES("ReadIASZoneZoneState", IAS_ZONE_CLUSTER_ID);
+}
+
+/*
+ * Attribute ZoneType
+ */
+uint16_t encodeIASZoneClusterReadZoneTypeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+{
+    uint16_t attr_ids[] = { 0x0001 };
+    READ_ATTRIBUTES("ReadIASZoneZoneType", IAS_ZONE_CLUSTER_ID);
+}
+
+/*
+ * Attribute ZoneStatus
+ */
+uint16_t encodeIASZoneClusterReadZoneStatusAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+{
+    uint16_t attr_ids[] = { 0x0002 };
+    READ_ATTRIBUTES("ReadIASZoneZoneStatus", IAS_ZONE_CLUSTER_ID);
+}
+
+/*
+ * Attribute IASCIEAddress
+ */
+uint16_t encodeIASZoneClusterReadIASCIEAddressAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+{
+    uint16_t attr_ids[] = { 0x0010 };
+    READ_ATTRIBUTES("ReadIASZoneIASCIEAddress", IAS_ZONE_CLUSTER_ID);
+}
+
+uint16_t encodeIASZoneClusterWriteIASCIEAddressAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+                                                         uint64_t iASCIEAddress)
+{
+    uint16_t attr_id  = 0x0010;
+    uint8_t attr_type = { 0xF0 };
+    WRITE_ATTRIBUTE("WriteIASZoneIASCIEAddress", IAS_ZONE_CLUSTER_ID, iASCIEAddress);
+}
+
+/*
+ * Attribute ZoneID
+ */
+uint16_t encodeIASZoneClusterReadZoneIDAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+{
+    uint16_t attr_ids[] = { 0x0011 };
+    READ_ATTRIBUTES("ReadIASZoneZoneID", IAS_ZONE_CLUSTER_ID);
 }
 
 /*----------------------------------------------------------------------------*\


### PR DESCRIPTION
 #### Problem

This PR adds the IAS Zone cluster support to chip-tool. IAS Zone is the first cluster to uses uint64_t value, and that's why there is some changes on `Argument` in the `Command.*` file from chip-tool. 

 #### Summary of Changes
 * Add IAS Zone attributes to chip-tool
 * Add IAS Zone attributes to src/app
 * Add support for uint64_t argument to chip-tool
