### PR TITLE
ESP32: Fix PluginBasicResetToFactoryDefaultsCallback to call the correct API

### DIFF
--- a/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
@@ -170,7 +170,7 @@ void DeviceCallbacks::PluginBasicResetToFactoryDefaultsCallback(uint8_t endpoint
 
     VerifyOrExit(endpointId == 1, ESP_LOGE(TAG, "Unexpected EndPoint ID: `0x%02x'", endpointId));
 
-    ConnectivityMgr().ClearWiFiStationProvision();
+    ConfigurationMgr().InitiateFactoryReset();
 
 exit:
     return;


### PR DESCRIPTION
ESP32: Fix PluginBasicResetToFactoryDefaultsCallback to call the correct API

 #### Problem
While testing basic cluster using the CHIPTool through the command `./out/debug/chip-tool basic reset-to-factory-defaults <Endpoint_ID> <IP_Addr> <Port_Num>`, I noticed that the device doesn't reboot on its own after successful execution of this command. On checking the code, saw that only the wifi config is reset (memset 0) and restarted.

I think that, as per the name of the command, it should ideally reset the device to factory settings.

 #### Summary of Changes
Used the reset to factory API provided by the Configuration Manager instead.