### PR TITLE
Update secure pairing messaging to not encode and re-decode headers

### DIFF
--- a/src/transport/RendezvousSession.h
+++ b/src/transport/RendezvousSession.h
@@ -92,7 +92,7 @@ public:
     SecurePairingSession & GetPairingSession() { return mPairingSession; }
 
     //////////// SecurePairingSessionDelegate Implementation ///////////////
-    CHIP_ERROR SendMessage(System::PacketBuffer * msgBuf) override;
+    CHIP_ERROR SendPairingMessage(const PacketHeader & header, Header::Flags payloadFlags, System::PacketBuffer * msgBuf) override;
     void OnPairingError(CHIP_ERROR err) override;
     void OnPairingComplete() override;
 
@@ -122,7 +122,6 @@ public:
     const Inet::IPAddress & GetIPAddress() const { return mNetworkProvision.GetIPAddress(); }
 
 private:
-    CHIP_ERROR SendPairingMessage(System::PacketBuffer * msgBug);
     CHIP_ERROR HandlePairingMessage(System::PacketBuffer * msgBug);
     CHIP_ERROR Pair(Optional<NodeId> nodeId, uint32_t setupPINCode);
     CHIP_ERROR WaitForPairing(Optional<NodeId> nodeId, uint32_t setupPINCode);

--- a/src/transport/SecurePairingSession.cpp
+++ b/src/transport/SecurePairingSession.cpp
@@ -173,12 +173,7 @@ CHIP_ERROR SecurePairingSession::AttachHeaderAndSend(uint8_t msgType, System::Pa
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    PacketHeader packetHeader;
     PayloadHeader payloadHeader;
-
-    packetHeader
-        .SetSourceNodeId(mLocalNodeId) //
-        .SetEncryptionKeyID(mLocalKeyId);
 
     payloadHeader
         .SetMessageType(msgType) //
@@ -194,18 +189,8 @@ CHIP_ERROR SecurePairingSession::AttachHeaderAndSend(uint8_t msgType, System::Pa
     SuccessOrExit(err);
     VerifyOrExit(headerSize == actualEncodedHeaderSize, err = CHIP_ERROR_INTERNAL);
 
-    headerSize              = packetHeader.EncodeSizeBytes();
-    actualEncodedHeaderSize = 0;
-
-    VerifyOrExit(msgBuf->EnsureReservedSize(headerSize), err = CHIP_ERROR_NO_MEMORY);
-
-    msgBuf->SetStart(msgBuf->Start() - headerSize);
-    err =
-        packetHeader.Encode(msgBuf->Start(), msgBuf->DataLength(), &actualEncodedHeaderSize, payloadHeader.GetEncodePacketFlags());
-    SuccessOrExit(err);
-    VerifyOrExit(headerSize == actualEncodedHeaderSize, err = CHIP_ERROR_INTERNAL);
-
-    err    = mDelegate->SendMessage(msgBuf);
+    err    = mDelegate->SendPairingMessage(PacketHeader().SetSourceNodeId(mLocalNodeId).SetEncryptionKeyID(mLocalKeyId),
+                                        payloadHeader.GetEncodePacketFlags(), msgBuf);
     msgBuf = nullptr;
     SuccessOrExit(err);
 

--- a/src/transport/SecurePairingSession.h
+++ b/src/transport/SecurePairingSession.h
@@ -45,10 +45,15 @@ public:
      * @brief
      *   Called when pairing session generates a new message that should be sent to peer.
      *
-     * @param msgBuf the new message that should be sent to the peer
+     * @param header the message header for the sent message
+     * @param payloadFlags payload encoding flags
+     * @param msgBuf the raw data for the message being sent
      * @return CHIP_ERROR Error thrown when sending the message
      */
-    virtual CHIP_ERROR SendMessage(System::PacketBuffer * msgBuf) { return CHIP_NO_ERROR; }
+    virtual CHIP_ERROR SendPairingMessage(const PacketHeader & header, Header::Flags payloadFlags, System::PacketBuffer * msgBuf)
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
 
     /**
      * @brief

--- a/src/transport/tests/TestSecurePairingSession.cpp
+++ b/src/transport/tests/TestSecurePairingSession.cpp
@@ -39,20 +39,10 @@ using namespace chip;
 class TestSecurePairingDelegate : public SecurePairingSessionDelegate
 {
 public:
-    CHIP_ERROR SendMessage(System::PacketBuffer * msgBuf) override
+    CHIP_ERROR SendPairingMessage(const PacketHeader & header, Header::Flags payloadFlags, System::PacketBuffer * msgBuf) override
     {
         mNumMessageSend++;
-        if (peer != nullptr)
-        {
-            PacketHeader hdr;
-            uint16_t headerSize = 0;
-
-            hdr.Decode(msgBuf->Start(), msgBuf->DataLength(), &headerSize);
-            msgBuf->ConsumeHead(headerSize);
-
-            return peer->HandlePeerMessage(hdr, msgBuf);
-        }
-        return mMessageSendError;
+        return (peer != nullptr) ? peer->HandlePeerMessage(header, msgBuf) : mMessageSendError;
     }
 
     void OnPairingError(CHIP_ERROR error) override { mNumPairingErrors++; }


### PR DESCRIPTION
 #### Problem
Secure Pairing message flow seems to allow for simplification:
   - regular pairing message headers are encoded and then re-decoded for transport
   - pairing message method is not used during network provisioning

 #### Summary of Changes
- remove the extra encode/decode step
- mark the 'send secure pairing' method as a unique name, to clarify its usage.