### PR TITLE
Add ReportAttributes commands to chip-tool and src/app

### DIFF
--- a/src/app/chip-zcl-zpro-codec-api.h
+++ b/src/app/chip-zcl-zpro-codec-api.h
@@ -88,9 +88,23 @@ uint16_t encodeBarrierControlClusterReadMovingStateAttribute(uint8_t * buffer, u
 
 /**
  * @brief
+ *    Encode a report command for the moving-state attribute for  server into buffer including the APS frame
+ */
+uint16_t encodeBarrierControlClusterReportMovingStateAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+                                                               uint16_t min_interval, uint16_t max_interval);
+
+/**
+ * @brief
  *    Encode a read command for the safety-status attribute for  server into buffer including the APS frame
  */
 uint16_t encodeBarrierControlClusterReadSafetyStatusAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+
+/**
+ * @brief
+ *    Encode a report command for the safety-status attribute for  server into buffer including the APS frame
+ */
+uint16_t encodeBarrierControlClusterReportSafetyStatusAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+                                                                uint16_t min_interval, uint16_t max_interval);
 
 /**
  * @brief
@@ -104,6 +118,14 @@ uint16_t encodeBarrierControlClusterReadCapabilitiesAttribute(uint8_t * buffer, 
  */
 uint16_t encodeBarrierControlClusterReadBarrierPositionAttribute(uint8_t * buffer, uint16_t buf_length,
                                                                  uint8_t destination_endpoint);
+
+/**
+ * @brief
+ *    Encode a report command for the barrier-position attribute for  server into buffer including the APS frame
+ */
+uint16_t encodeBarrierControlClusterReportBarrierPositionAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                                   uint8_t destination_endpoint, uint16_t min_interval,
+                                                                   uint16_t max_interval, uint8_t change);
 
 /*----------------------------------------------------------------------------*\
 | Cluster Basic                                                       | 0x0000 |
@@ -334,10 +356,25 @@ uint16_t encodeColorControlClusterReadCurrentHueAttribute(uint8_t * buffer, uint
 
 /**
  * @brief
+ *    Encode a report command for the current-hue attribute for  server into buffer including the APS frame
+ */
+uint16_t encodeColorControlClusterReportCurrentHueAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+                                                            uint16_t min_interval, uint16_t max_interval, uint8_t change);
+
+/**
+ * @brief
  *    Encode a read command for the current-saturation attribute for  server into buffer including the APS frame
  */
 uint16_t encodeColorControlClusterReadCurrentSaturationAttribute(uint8_t * buffer, uint16_t buf_length,
                                                                  uint8_t destination_endpoint);
+
+/**
+ * @brief
+ *    Encode a report command for the current-saturation attribute for  server into buffer including the APS frame
+ */
+uint16_t encodeColorControlClusterReportCurrentSaturationAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                                   uint8_t destination_endpoint, uint16_t min_interval,
+                                                                   uint16_t max_interval, uint8_t change);
 
 /**
  * @brief
@@ -353,9 +390,23 @@ uint16_t encodeColorControlClusterReadCurrentXAttribute(uint8_t * buffer, uint16
 
 /**
  * @brief
+ *    Encode a report command for the current-x attribute for  server into buffer including the APS frame
+ */
+uint16_t encodeColorControlClusterReportCurrentXAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+                                                          uint16_t min_interval, uint16_t max_interval, uint16_t change);
+
+/**
+ * @brief
  *    Encode a read command for the current-y attribute for  server into buffer including the APS frame
  */
 uint16_t encodeColorControlClusterReadCurrentYAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+
+/**
+ * @brief
+ *    Encode a report command for the current-y attribute for  server into buffer including the APS frame
+ */
+uint16_t encodeColorControlClusterReportCurrentYAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+                                                          uint16_t min_interval, uint16_t max_interval, uint16_t change);
 
 /**
  * @brief
@@ -363,6 +414,14 @@ uint16_t encodeColorControlClusterReadCurrentYAttribute(uint8_t * buffer, uint16
  */
 uint16_t encodeColorControlClusterReadColorTemperatureMiredsAttribute(uint8_t * buffer, uint16_t buf_length,
                                                                       uint8_t destination_endpoint);
+
+/**
+ * @brief
+ *    Encode a report command for the color-temperature-mireds attribute for  server into buffer including the APS frame
+ */
+uint16_t encodeColorControlClusterReportColorTemperatureMiredsAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                                        uint8_t destination_endpoint, uint16_t min_interval,
+                                                                        uint16_t max_interval, uint16_t change);
 
 /**
  * @brief
@@ -821,6 +880,13 @@ uint16_t encodeDoorLockClusterReadLockStateAttribute(uint8_t * buffer, uint16_t 
 
 /**
  * @brief
+ *    Encode a report command for the lock-state attribute for  server into buffer including the APS frame
+ */
+uint16_t encodeDoorLockClusterReportLockStateAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+                                                       uint16_t min_interval, uint16_t max_interval);
+
+/**
+ * @brief
  *    Encode a read command for the lock-type attribute for  server into buffer including the APS frame
  */
 uint16_t encodeDoorLockClusterReadLockTypeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
@@ -1109,6 +1175,13 @@ uint16_t encodeLevelClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_len
  */
 uint16_t encodeLevelClusterReadCurrentLevelAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
 
+/**
+ * @brief
+ *    Encode a report command for the current-level attribute for  server into buffer including the APS frame
+ */
+uint16_t encodeLevelClusterReportCurrentLevelAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+                                                       uint16_t min_interval, uint16_t max_interval, uint8_t change);
+
 /*----------------------------------------------------------------------------*\
 | Cluster OnOff                                                       | 0x0006 |
 |------------------------------------------------------------------------------|
@@ -1153,6 +1226,13 @@ uint16_t encodeOnOffClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_len
  *    Encode a read command for the on-off attribute for  server into buffer including the APS frame
  */
 uint16_t encodeOnOffClusterReadOnOffAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+
+/**
+ * @brief
+ *    Encode a report command for the on-off attribute for  server into buffer including the APS frame
+ */
+uint16_t encodeOnOffClusterReportOnOffAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+                                                uint16_t min_interval, uint16_t max_interval);
 
 /*----------------------------------------------------------------------------*\
 | Cluster Scenes                                                      | 0x0005 |
@@ -1295,6 +1375,14 @@ uint16_t encodeTemperatureMeasurementClusterDiscoverAttributes(uint8_t * buffer,
  */
 uint16_t encodeTemperatureMeasurementClusterReadMeasuredValueAttribute(uint8_t * buffer, uint16_t buf_length,
                                                                        uint8_t destination_endpoint);
+
+/**
+ * @brief
+ *    Encode a report command for the measured-value attribute for  server into buffer including the APS frame
+ */
+uint16_t encodeTemperatureMeasurementClusterReportMeasuredValueAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                                         uint8_t destination_endpoint, uint16_t min_interval,
+                                                                         uint16_t max_interval, int16_t change);
 
 /**
  * @brief

--- a/src/app/encoder.cpp
+++ b/src/app/encoder.cpp
@@ -74,6 +74,59 @@ using namespace chip;
     }                                                                                                                              \
     return result;
 
+#define REPORT_ATTRIBUTE(name, cluster_id, isAnalog, value)                                                                        \
+    BufBound buf = BufBound(buffer, buf_length);                                                                                   \
+    if (_encodeGlobalCommand(buf, destination_endpoint, cluster_id, 0x06))                                                         \
+    {                                                                                                                              \
+        uint8_t direction = 0x00;                                                                                                  \
+        buf.Put(direction);                                                                                                        \
+        buf.PutLE16(attr_id);                                                                                                      \
+        buf.Put(attr_type);                                                                                                        \
+        buf.PutLE16(min_interval);                                                                                                 \
+        buf.PutLE16(max_interval);                                                                                                 \
+        if (isAnalog)                                                                                                              \
+        {                                                                                                                          \
+            switch (attr_type)                                                                                                     \
+            {                                                                                                                      \
+            case 0x20:                                                                                                             \
+                buf.Put(static_cast<uint8_t>(value));                                                                              \
+                break;                                                                                                             \
+            case 0x21:                                                                                                             \
+                buf.PutLE16(static_cast<uint16_t>(value));                                                                         \
+                break;                                                                                                             \
+            case 0x23:                                                                                                             \
+                buf.PutLE32(static_cast<uint32_t>(value));                                                                         \
+                break;                                                                                                             \
+            case 0x27:                                                                                                             \
+                buf.PutLE64(static_cast<uint64_t>(value));                                                                         \
+                break;                                                                                                             \
+            case 0x28:                                                                                                             \
+                buf.Put(static_cast<uint8_t>(value));                                                                              \
+                break;                                                                                                             \
+            case 0x29:                                                                                                             \
+                buf.PutLE16(static_cast<uint16_t>(value));                                                                         \
+                break;                                                                                                             \
+            case 0x2B:                                                                                                             \
+                buf.PutLE32(static_cast<uint32_t>(value));                                                                         \
+                break;                                                                                                             \
+            case 0x2f:                                                                                                             \
+                buf.PutLE64(static_cast<uint64_t>(value));                                                                         \
+                break;                                                                                                             \
+            default:                                                                                                               \
+                ChipLogError(Zcl, "Type is not supported for report attribute: '0x%02x'", attr_type);                              \
+                break;                                                                                                             \
+            }                                                                                                                      \
+        }                                                                                                                          \
+    }                                                                                                                              \
+                                                                                                                                   \
+    uint16_t result = buf.Fit() && CanCastTo<uint16_t>(buf.Written()) ? static_cast<uint16_t>(buf.Written()) : 0;                  \
+    if (result == 0)                                                                                                               \
+    {                                                                                                                              \
+        ChipLogError(Zcl, "Error encoding %s command", name);                                                                      \
+        return 0;                                                                                                                  \
+    }                                                                                                                              \
+    return result;
+
 #define DISCOVER_ATTRIBUTES(name, cluster_id)                                                                                      \
     BufBound buf = BufBound(buffer, buf_length);                                                                                   \
     if (_encodeGlobalCommand(buf, destination_endpoint, cluster_id, 0x0c))                                                         \
@@ -308,6 +361,14 @@ uint16_t encodeBarrierControlClusterReadMovingStateAttribute(uint8_t * buffer, u
     READ_ATTRIBUTES("ReadBarrierControlMovingState", BARRIER_CONTROL_CLUSTER_ID);
 }
 
+uint16_t encodeBarrierControlClusterReportMovingStateAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+                                                               uint16_t min_interval, uint16_t max_interval)
+{
+    uint16_t attr_id  = 0x0001;
+    uint8_t attr_type = { 0x30 };
+    REPORT_ATTRIBUTE("ReportBarrierControlMovingState", BARRIER_CONTROL_CLUSTER_ID, false, 0);
+}
+
 /*
  * Attribute SafetyStatus
  */
@@ -315,6 +376,14 @@ uint16_t encodeBarrierControlClusterReadSafetyStatusAttribute(uint8_t * buffer, 
 {
     uint16_t attr_ids[] = { 0x0002 };
     READ_ATTRIBUTES("ReadBarrierControlSafetyStatus", BARRIER_CONTROL_CLUSTER_ID);
+}
+
+uint16_t encodeBarrierControlClusterReportSafetyStatusAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+                                                                uint16_t min_interval, uint16_t max_interval)
+{
+    uint16_t attr_id  = 0x0002;
+    uint8_t attr_type = { 0x19 };
+    REPORT_ATTRIBUTE("ReportBarrierControlSafetyStatus", BARRIER_CONTROL_CLUSTER_ID, false, 0);
 }
 
 /*
@@ -334,6 +403,15 @@ uint16_t encodeBarrierControlClusterReadBarrierPositionAttribute(uint8_t * buffe
 {
     uint16_t attr_ids[] = { 0x000A };
     READ_ATTRIBUTES("ReadBarrierControlBarrierPosition", BARRIER_CONTROL_CLUSTER_ID);
+}
+
+uint16_t encodeBarrierControlClusterReportBarrierPositionAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                                   uint8_t destination_endpoint, uint16_t min_interval,
+                                                                   uint16_t max_interval, uint8_t change)
+{
+    uint16_t attr_id  = 0x000A;
+    uint8_t attr_type = { 0x20 };
+    REPORT_ATTRIBUTE("ReportBarrierControlBarrierPosition", BARRIER_CONTROL_CLUSTER_ID, true, change);
 }
 
 /*----------------------------------------------------------------------------*\
@@ -695,6 +773,14 @@ uint16_t encodeColorControlClusterReadCurrentHueAttribute(uint8_t * buffer, uint
     READ_ATTRIBUTES("ReadColorControlCurrentHue", COLOR_CONTROL_CLUSTER_ID);
 }
 
+uint16_t encodeColorControlClusterReportCurrentHueAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+                                                            uint16_t min_interval, uint16_t max_interval, uint8_t change)
+{
+    uint16_t attr_id  = 0x0000;
+    uint8_t attr_type = { 0x20 };
+    REPORT_ATTRIBUTE("ReportColorControlCurrentHue", COLOR_CONTROL_CLUSTER_ID, true, change);
+}
+
 /*
  * Attribute CurrentSaturation
  */
@@ -703,6 +789,15 @@ uint16_t encodeColorControlClusterReadCurrentSaturationAttribute(uint8_t * buffe
 {
     uint16_t attr_ids[] = { 0x0001 };
     READ_ATTRIBUTES("ReadColorControlCurrentSaturation", COLOR_CONTROL_CLUSTER_ID);
+}
+
+uint16_t encodeColorControlClusterReportCurrentSaturationAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                                   uint8_t destination_endpoint, uint16_t min_interval,
+                                                                   uint16_t max_interval, uint8_t change)
+{
+    uint16_t attr_id  = 0x0001;
+    uint8_t attr_type = { 0x20 };
+    REPORT_ATTRIBUTE("ReportColorControlCurrentSaturation", COLOR_CONTROL_CLUSTER_ID, true, change);
 }
 
 /*
@@ -723,6 +818,14 @@ uint16_t encodeColorControlClusterReadCurrentXAttribute(uint8_t * buffer, uint16
     READ_ATTRIBUTES("ReadColorControlCurrentX", COLOR_CONTROL_CLUSTER_ID);
 }
 
+uint16_t encodeColorControlClusterReportCurrentXAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+                                                          uint16_t min_interval, uint16_t max_interval, uint16_t change)
+{
+    uint16_t attr_id  = 0x0003;
+    uint8_t attr_type = { 0x21 };
+    REPORT_ATTRIBUTE("ReportColorControlCurrentX", COLOR_CONTROL_CLUSTER_ID, true, change);
+}
+
 /*
  * Attribute CurrentY
  */
@@ -730,6 +833,14 @@ uint16_t encodeColorControlClusterReadCurrentYAttribute(uint8_t * buffer, uint16
 {
     uint16_t attr_ids[] = { 0x0004 };
     READ_ATTRIBUTES("ReadColorControlCurrentY", COLOR_CONTROL_CLUSTER_ID);
+}
+
+uint16_t encodeColorControlClusterReportCurrentYAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+                                                          uint16_t min_interval, uint16_t max_interval, uint16_t change)
+{
+    uint16_t attr_id  = 0x0004;
+    uint8_t attr_type = { 0x21 };
+    REPORT_ATTRIBUTE("ReportColorControlCurrentY", COLOR_CONTROL_CLUSTER_ID, true, change);
 }
 
 /*
@@ -740,6 +851,15 @@ uint16_t encodeColorControlClusterReadColorTemperatureMiredsAttribute(uint8_t * 
 {
     uint16_t attr_ids[] = { 0x0007 };
     READ_ATTRIBUTES("ReadColorControlColorTemperatureMireds", COLOR_CONTROL_CLUSTER_ID);
+}
+
+uint16_t encodeColorControlClusterReportColorTemperatureMiredsAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                                        uint8_t destination_endpoint, uint16_t min_interval,
+                                                                        uint16_t max_interval, uint16_t change)
+{
+    uint16_t attr_id  = 0x0007;
+    uint8_t attr_type = { 0x21 };
+    REPORT_ATTRIBUTE("ReportColorControlColorTemperatureMireds", COLOR_CONTROL_CLUSTER_ID, true, change);
 }
 
 /*
@@ -1432,6 +1552,14 @@ uint16_t encodeDoorLockClusterReadLockStateAttribute(uint8_t * buffer, uint16_t 
     READ_ATTRIBUTES("ReadDoorLockLockState", DOOR_LOCK_CLUSTER_ID);
 }
 
+uint16_t encodeDoorLockClusterReportLockStateAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+                                                       uint16_t min_interval, uint16_t max_interval)
+{
+    uint16_t attr_id  = 0x0000;
+    uint8_t attr_type = { 0x30 };
+    REPORT_ATTRIBUTE("ReportDoorLockLockState", DOOR_LOCK_CLUSTER_ID, false, 0);
+}
+
 /*
  * Attribute LockType
  */
@@ -1859,6 +1987,14 @@ uint16_t encodeLevelClusterReadCurrentLevelAttribute(uint8_t * buffer, uint16_t 
     READ_ATTRIBUTES("ReadLevelCurrentLevel", LEVEL_CLUSTER_ID);
 }
 
+uint16_t encodeLevelClusterReportCurrentLevelAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+                                                       uint16_t min_interval, uint16_t max_interval, uint8_t change)
+{
+    uint16_t attr_id  = 0x0000;
+    uint8_t attr_type = { 0x20 };
+    REPORT_ATTRIBUTE("ReportLevelCurrentLevel", LEVEL_CLUSTER_ID, true, change);
+}
+
 /*----------------------------------------------------------------------------*\
 | Cluster OnOff                                                       | 0x0006 |
 |------------------------------------------------------------------------------|
@@ -1916,6 +2052,14 @@ uint16_t encodeOnOffClusterReadOnOffAttribute(uint8_t * buffer, uint16_t buf_len
 {
     uint16_t attr_ids[] = { 0x0000 };
     READ_ATTRIBUTES("ReadOnOffOnOff", ON_OFF_CLUSTER_ID);
+}
+
+uint16_t encodeOnOffClusterReportOnOffAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+                                                uint16_t min_interval, uint16_t max_interval)
+{
+    uint16_t attr_id  = 0x0000;
+    uint8_t attr_type = { 0x10 };
+    REPORT_ATTRIBUTE("ReportOnOffOnOff", ON_OFF_CLUSTER_ID, false, 0);
 }
 
 /*----------------------------------------------------------------------------*\
@@ -2119,6 +2263,15 @@ uint16_t encodeTemperatureMeasurementClusterReadMeasuredValueAttribute(uint8_t *
 {
     uint16_t attr_ids[] = { 0x0000 };
     READ_ATTRIBUTES("ReadTemperatureMeasurementMeasuredValue", TEMPERATURE_MEASUREMENT_CLUSTER_ID);
+}
+
+uint16_t encodeTemperatureMeasurementClusterReportMeasuredValueAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                                         uint8_t destination_endpoint, uint16_t min_interval,
+                                                                         uint16_t max_interval, int16_t change)
+{
+    uint16_t attr_id  = 0x0000;
+    uint8_t attr_type = { 0x29 };
+    REPORT_ATTRIBUTE("ReportTemperatureMeasurementMeasuredValue", TEMPERATURE_MEASUREMENT_CLUSTER_ID, true, change);
 }
 
 /*


### PR DESCRIPTION

 #### Problem

This PR adds support for report attributes commands to `chip-tool` and `src/app`

In the meantime it also adds the code for the response to a bunch of optional global commands I've not implemented yet:
 * ReadReportingConfigurationResponse
 * WriteAttributesStructuredResponse  
 * DiscoverCommandsReceivedResponse 
 * DiscoverCommandsGeneratedResponse
 * DiscoverAttributesExtendedResponse

I'm working on cleaning up my template code in order to provide a template diff as requested by @bzbarsky-apple last time.

 #### Summary of Changes
* Add report attributes commands to `chip-tool`
* Add report attributes command to `src/app`