### PR TITLE
inet: remove kSendFlag_RetainBuffer

### DIFF
--- a/src/inet/IPEndPointBasis.h
+++ b/src/inet/IPEndPointBasis.h
@@ -79,15 +79,6 @@ public:
     } mState;
 
     /**
-     * @brief   Transmit option flags for the \c SendMsg method.
-     */
-    enum
-    {
-        /** Do not destructively queue the message directly. Queue a copy. */
-        kSendFlag_RetainBuffer = 0x0040
-    };
-
-    /**
      * @brief   Type of message text reception event handling function.
      *
      * @param[in]   endPoint    The endpoint associated with the event.

--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -489,11 +489,6 @@ INET_ERROR UDPEndPoint::SendTo(const IPAddress & addr, uint16_t port, chip::Syst
  *      destination \c addr (with \c intfId used as the scope
  *      identifier for IPv6 link-local destinations) and \c port with the
  *      transmit option flags encoded in \c sendFlags.
- *
- *      Where <tt>(sendFlags & kSendFlag_RetainBuffer) != 0</tt>, calls
- *      <tt>chip::System::PacketBuffer::Free</tt> on behalf of the caller, otherwise this
- *      method deep-copies \c msg into a fresh object, and queues that for
- *      transmission, leaving the original \c msg available after return.
  */
 INET_ERROR UDPEndPoint::SendTo(const IPAddress & addr, uint16_t port, InterfaceId intfId, chip::System::PacketBuffer * msg,
                                uint16_t sendFlags)
@@ -538,59 +533,16 @@ INET_ERROR UDPEndPoint::SendTo(const IPAddress & addr, uint16_t port, InterfaceI
  *      \c pktInfo.  If \c pktInfo contains an interface id, the message will be sent
  *      over the specified interface.  If \c pktInfo contains a source address, the
  *      given address will be used as the source of the UDP message.
- *
- *      Where <tt>(sendFlags & kSendFlag_RetainBuffer) != 0</tt>, calls
- *      <tt>chip::System::PacketBuffer::Free</tt> on behalf of the caller, otherwise this
- *      method deep-copies \c msg into a fresh object, and queues that for
- *      transmission, leaving the original \c msg available after return.
  */
 INET_ERROR UDPEndPoint::SendMsg(const IPPacketInfo * pktInfo, PacketBuffer * msg, uint16_t sendFlags)
 {
     INET_ERROR res             = INET_NO_ERROR;
     const IPAddress & destAddr = pktInfo->DestAddress;
 
-    INET_FAULT_INJECT(FaultInjection::kFault_Send, if ((sendFlags & kSendFlag_RetainBuffer) == 0) PacketBuffer::Free(msg);
-                      return INET_ERROR_UNKNOWN_INTERFACE;);
-    INET_FAULT_INJECT(FaultInjection::kFault_SendNonCritical,
-                      if ((sendFlags & kSendFlag_RetainBuffer) == 0) PacketBuffer::Free(msg);
-                      return INET_ERROR_NO_MEMORY;);
+    INET_FAULT_INJECT(FaultInjection::kFault_Send, PacketBuffer::Free(msg); return INET_ERROR_UNKNOWN_INTERFACE;);
+    INET_FAULT_INJECT(FaultInjection::kFault_SendNonCritical, PacketBuffer::Free(msg); return INET_ERROR_NO_MEMORY;);
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
-
-    if (sendFlags & kSendFlag_RetainBuffer)
-    {
-        // when retaining a buffer, the caller expects the msg to be
-        // unmodified.  LwIP stack will normally prepend the packet
-        // headers as the packet traverses the UDP/IP/netif layers,
-        // which normally modifies the packet.  We prepend a small
-        // pbuf to the beginning of the pbuf chain, s.t. all headers
-        // are added to the temporary space, just large enough to hold
-        // the transport headers. Careful reader will note:
-        //
-        // * we're actually oversizing the reserved space, the
-        //   transport header is large enough for the TCP header which
-        //   is larger than the UDP header, but it seemed cleaner than
-        //   the combination of PBUF_IP for reserve space, UDP_HLEN
-        //   for payload, and post allocation adjustment of the header
-        //   space).
-        //
-        // * the code deviates from the existing PacketBuffer
-        //   abstractions and needs to reach into the underlying pbuf
-        //   code.  The code in PacketBuffer also forces us to perform
-        //   (effectively) a reinterpret_cast rather than a
-        //   static_cast.  JIRA WEAV-811 is filed to track the
-        //   re-architecting of the memory management.
-
-        pbuf * msgCopy = pbuf_alloc(PBUF_TRANSPORT, 0, PBUF_RAM);
-
-        if (msgCopy == NULL)
-        {
-            return INET_ERROR_NO_MEMORY;
-        }
-
-        pbuf_chain(msgCopy, (pbuf *) msg);
-        msg = (PacketBuffer *) msgCopy;
-    }
 
     // Lock LwIP stack
     LOCK_TCPIP_CORE();
@@ -695,16 +647,12 @@ INET_ERROR UDPEndPoint::SendMsg(const IPPacketInfo * pktInfo, PacketBuffer * msg
     SuccessOrExit(res);
 
     res = IPEndPointBasis::SendMsg(pktInfo, msg, sendFlags);
-
-    if ((sendFlags & kSendFlag_RetainBuffer) == 0)
-        PacketBuffer::Free(msg);
+    PacketBuffer::Free(msg);
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
 #if CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
     res = IPEndPointBasis::SendMsg(pktInfo, msg, sendFlags);
-
-    if ((sendFlags & kSendFlag_RetainBuffer) == 0)
-        PacketBuffer::Free(msg);
+    PacketBuffer::Free(msg);
 #endif // CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
 exit:


### PR DESCRIPTION
 #### Problem
 The `RetainBuffer` flag is a legacy flags used in Weave to optimize packet re-transmission. Now there are multiple layer in the `SendMessage` code path, and they will modify the packet, so the flags won't work as expected.

 #### Summary of Changes
Remove `Inet::kSendFlag_RetainBuffer` flag.