### PR TITLE
Enable -Wstack-usage on device builds

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -186,6 +186,11 @@ config("warnings_default") {
   if (current_os != "mac" && current_os != "ios") {
     ldflags = [ "-Wl,--fatal-warnings" ]
   }
+
+  if (current_os != "mac" && current_os != "ios" && current_os != "linux" &&
+      current_os != "win") {
+    cflags = [ "-Wstack-usage=8192" ]
+  }
 }
 
 config("symbols_default") {

--- a/examples/chip-tool/commands/common/EchoCommand.cpp
+++ b/examples/chip-tool/commands/common/EchoCommand.cpp
@@ -22,7 +22,7 @@ using namespace ::chip;
 using namespace ::chip::DeviceController;
 
 #define SEND_DELAY 5
-static const char * PAYLOAD = "Message from Standalone CHIP echo client!";
+static const char PAYLOAD[] = "Message from Standalone CHIP echo client!";
 
 void EchoCommand::SendEcho() const
 {
@@ -59,19 +59,15 @@ void EchoCommand::SendEcho() const
 void EchoCommand::ReceiveEcho(PacketBuffer * buffer) const
 {
     // attempt to print the incoming message
-    size_t data_len = buffer->DataLength();
-    char msg_buffer[data_len];
-    msg_buffer[data_len] = 0; // Null-terminate whatever we received and treat like a string...
-    memcpy(msg_buffer, buffer->Start(), data_len);
-
-    bool isEchoIdenticalToMessage = strncmp(msg_buffer, PAYLOAD, data_len) == 0;
+    size_t data_len               = buffer->DataLength();
+    bool isEchoIdenticalToMessage = (data_len + 1 == sizeof PAYLOAD) && (memcmp(buffer->Start(), PAYLOAD, data_len) == 0);
     if (isEchoIdenticalToMessage)
     {
         ChipLogProgress(chipTool, "Echo (%s): Received expected message !", GetNetworkName());
     }
     else
     {
-        ChipLogError(chipTool, "Echo: (%s): Error \nSend: %s \nRecv: %s", GetNetworkName(), PAYLOAD, msg_buffer);
+        ChipLogError(chipTool, "Echo: (%s): Error \nSend: %s \nRecv: %.*s", GetNetworkName(), PAYLOAD, data_len, buffer->Start());
     }
 }
 

--- a/src/app/util/ember-print.cpp
+++ b/src/app/util/ember-print.cpp
@@ -50,6 +50,10 @@ void emberAfPrintln(int category, const char * format, ...)
     }
 }
 
+// TODO: issue #3662 - Unbounded stack in emberAfPrintBuffer()
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstack-usage="
+
 void emberAfPrintBuffer(int category, const uint8_t * buffer, uint16_t length, bool withSpace)
 {
     if (buffer != NULL && length > 0)
@@ -72,6 +76,8 @@ void emberAfPrintBuffer(int category, const uint8_t * buffer, uint16_t length, b
         emberAfPrint(EMBER_AF_PRINT_CORE, "NULL");
     }
 }
+
+#pragma GCC diagnostic pop // -Wstack-usage
 
 void emberAfPrintString(int category, const uint8_t * string)
 {

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -63,15 +63,16 @@ namespace DeviceController {
 
 using namespace chip::Encoding;
 
-constexpr const char * kDeviceCredentialsKeyPrefix = "DeviceCredentials";
-constexpr const char * kDeviceAddressKeyPrefix     = "DeviceAddress";
+constexpr const char kDeviceCredentialsKeyPrefix[] = "DeviceCredentials";
+constexpr const char kDeviceAddressKeyPrefix[]     = "DeviceAddress";
 
 // This macro generates a key using node ID an key prefix, and performs the given action
 // on that key.
 #define PERSISTENT_KEY_OP(node, keyPrefix, key, action)                                                                            \
     do                                                                                                                             \
     {                                                                                                                              \
-        const size_t len = strlen(keyPrefix);                                                                                      \
+        constexpr size_t len = std::extent<decltype(keyPrefix)>::value;                                                            \
+        nlSTATIC_ASSERT_PRINT(len > 0, "keyPrefix length must be known at compile time");                                          \
         /* 2 * sizeof(NodeId) to accomodate 2 character for each byte in Node Id */                                                \
         char key[len + 2 * sizeof(NodeId) + 1];                                                                                    \
         nlSTATIC_ASSERT_PRINT(sizeof(node) <= sizeof(uint64_t), "Node ID size is greater than expected");                          \

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -35,15 +35,17 @@
 
 #include <crypto/CHIPCryptoPAL.h>
 
+#include <core/CHIPError.h>
 #include <nlunit-test.h>
 #include <support/CodeUtils.h>
+#include <support/ScopedBuffer.h>
 #include <support/TestUtils.h>
 
 #include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <support/CodeUtils.h>
-#include <support/TestUtils.h>
 
 using namespace chip;
 using namespace chip::Crypto;
@@ -66,13 +68,17 @@ static void TestAES_CCM_256EncryptTestVectors(nlTestSuite * inSuite, void * inCo
         if (vector->key_len == 32 && vector->pt_len > 0)
         {
             numOfTestsRan++;
-            uint8_t out_ct[vector->ct_len];
-            uint8_t out_tag[vector->tag_len];
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_ct;
+            out_ct.Alloc(vector->ct_len);
+            NL_TEST_ASSERT(inSuite, out_ct);
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_tag;
+            out_tag.Alloc(vector->tag_len);
+            NL_TEST_ASSERT(inSuite, out_tag);
 
             CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, vector->key, vector->key_len,
-                                             vector->iv, vector->iv_len, out_ct, out_tag, vector->tag_len);
-            bool areCTsEqual  = memcmp(out_ct, vector->ct, vector->ct_len) == 0;
-            bool areTagsEqual = memcmp(out_tag, vector->tag, vector->tag_len) == 0;
+                                             vector->iv, vector->iv_len, out_ct.Get(), out_tag.Get(), vector->tag_len);
+            bool areCTsEqual  = memcmp(out_ct.Get(), vector->ct, vector->ct_len) == 0;
+            bool areTagsEqual = memcmp(out_tag.Get(), vector->tag, vector->tag_len) == 0;
             NL_TEST_ASSERT(inSuite, areCTsEqual);
             NL_TEST_ASSERT(inSuite, areTagsEqual);
             NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -100,11 +106,13 @@ static void TestAES_CCM_256DecryptTestVectors(nlTestSuite * inSuite, void * inCo
         if (vector->key_len == 32 && vector->pt_len > 0)
         {
             numOfTestsRan++;
-            uint8_t out_pt[vector->pt_len];
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_pt;
+            out_pt.Alloc(vector->pt_len);
+            NL_TEST_ASSERT(inSuite, out_pt);
             CHIP_ERROR err = AES_CCM_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag, vector->tag_len,
-                                             vector->key, vector->key_len, vector->iv, vector->iv_len, out_pt);
+                                             vector->key, vector->key_len, vector->iv, vector->iv_len, out_pt.Get());
 
-            bool arePTsEqual = memcmp(vector->pt, out_pt, vector->pt_len) == 0;
+            bool arePTsEqual = memcmp(vector->pt, out_pt.Get(), vector->pt_len) == 0;
             NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
             NL_TEST_ASSERT(inSuite, arePTsEqual);
             if (!arePTsEqual)
@@ -126,11 +134,15 @@ static void TestAES_CCM_256EncryptInvalidPlainText(nlTestSuite * inSuite, void *
         if (vector->key_len == 32 && vector->pt_len > 0)
         {
             numOfTestsRan++;
-            uint8_t out_ct[vector->ct_len];
-            uint8_t out_tag[vector->tag_len];
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_ct;
+            out_ct.Alloc(vector->ct_len);
+            NL_TEST_ASSERT(inSuite, out_ct);
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_tag;
+            out_tag.Alloc(vector->tag_len);
+            NL_TEST_ASSERT(inSuite, out_tag);
 
             CHIP_ERROR err = AES_CCM_encrypt(vector->pt, 0, vector->aad, vector->aad_len, vector->key, vector->key_len, vector->iv,
-                                             vector->iv_len, out_ct, out_tag, vector->tag_len);
+                                             vector->iv_len, out_ct.Get(), out_tag.Get(), vector->tag_len);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -148,11 +160,15 @@ static void TestAES_CCM_256EncryptNilKey(nlTestSuite * inSuite, void * inContext
         if (vector->key_len == 32 && vector->pt_len > 0)
         {
             numOfTestsRan++;
-            uint8_t out_ct[vector->ct_len];
-            uint8_t out_tag[vector->tag_len];
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_ct;
+            out_ct.Alloc(vector->ct_len);
+            NL_TEST_ASSERT(inSuite, out_ct);
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_tag;
+            out_tag.Alloc(vector->tag_len);
+            NL_TEST_ASSERT(inSuite, out_tag);
 
             CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, nullptr, 32, vector->iv,
-                                             vector->iv_len, out_ct, out_tag, vector->tag_len);
+                                             vector->iv_len, out_ct.Get(), out_tag.Get(), vector->tag_len);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -170,11 +186,15 @@ static void TestAES_CCM_256EncryptInvalidIVLen(nlTestSuite * inSuite, void * inC
         if (vector->key_len == 32 && vector->pt_len > 0)
         {
             numOfTestsRan++;
-            uint8_t out_ct[vector->ct_len];
-            uint8_t out_tag[vector->tag_len];
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_ct;
+            out_ct.Alloc(vector->ct_len);
+            NL_TEST_ASSERT(inSuite, out_ct);
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_tag;
+            out_tag.Alloc(vector->tag_len);
+            NL_TEST_ASSERT(inSuite, out_tag);
 
             CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, vector->key, vector->key_len,
-                                             vector->iv, 0, out_ct, out_tag, vector->tag_len);
+                                             vector->iv, 0, out_ct.Get(), out_tag.Get(), vector->tag_len);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -192,11 +212,15 @@ static void TestAES_CCM_256EncryptInvalidTagLen(nlTestSuite * inSuite, void * in
         if (vector->key_len == 32 && vector->pt_len > 0)
         {
             numOfTestsRan++;
-            uint8_t out_ct[vector->ct_len];
-            uint8_t out_tag[vector->tag_len];
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_ct;
+            out_ct.Alloc(vector->ct_len);
+            NL_TEST_ASSERT(inSuite, out_ct);
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_tag;
+            out_tag.Alloc(vector->tag_len);
+            NL_TEST_ASSERT(inSuite, out_tag);
 
             CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, vector->key, vector->key_len,
-                                             vector->iv, vector->iv_len, out_ct, out_tag, 13);
+                                             vector->iv, vector->iv_len, out_ct.Get(), out_tag.Get(), 13);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -214,9 +238,11 @@ static void TestAES_CCM_256DecryptInvalidCipherText(nlTestSuite * inSuite, void 
         if (vector->key_len == 32 && vector->pt_len > 0)
         {
             numOfTestsRan++;
-            uint8_t out_pt[vector->pt_len];
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_pt;
+            out_pt.Alloc(vector->pt_len);
+            NL_TEST_ASSERT(inSuite, out_pt);
             CHIP_ERROR err = AES_CCM_decrypt(vector->ct, 0, vector->aad, vector->aad_len, vector->tag, vector->tag_len, vector->key,
-                                             vector->key_len, vector->iv, vector->iv_len, out_pt);
+                                             vector->key_len, vector->iv, vector->iv_len, out_pt.Get());
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -234,9 +260,11 @@ static void TestAES_CCM_256DecryptInvalidKey(nlTestSuite * inSuite, void * inCon
         if (vector->key_len == 32 && vector->pt_len > 0)
         {
             numOfTestsRan++;
-            uint8_t out_pt[vector->pt_len];
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_pt;
+            out_pt.Alloc(vector->pt_len);
+            NL_TEST_ASSERT(inSuite, out_pt);
             CHIP_ERROR err = AES_CCM_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag, vector->tag_len,
-                                             nullptr, 32, vector->iv, vector->iv_len, out_pt);
+                                             nullptr, 32, vector->iv, vector->iv_len, out_pt.Get());
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -254,9 +282,11 @@ static void TestAES_CCM_256DecryptInvalidIVLen(nlTestSuite * inSuite, void * inC
         if (vector->key_len == 32 && vector->pt_len > 0)
         {
             numOfTestsRan++;
-            uint8_t out_pt[vector->pt_len];
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_pt;
+            out_pt.Alloc(vector->pt_len);
+            NL_TEST_ASSERT(inSuite, out_pt);
             CHIP_ERROR err = AES_CCM_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag, vector->tag_len,
-                                             vector->key, vector->key_len, vector->iv, 0, out_pt);
+                                             vector->key, vector->key_len, vector->iv, 0, out_pt.Get());
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -274,11 +304,13 @@ static void TestAES_CCM_256DecryptInvalidTestVectors(nlTestSuite * inSuite, void
         if (vector->key_len == 32 && vector->pt_len > 0)
         {
             numOfTestsRan++;
-            uint8_t out_pt[vector->pt_len];
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_pt;
+            out_pt.Alloc(vector->pt_len);
+            NL_TEST_ASSERT(inSuite, out_pt);
             CHIP_ERROR err = AES_CCM_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag, vector->tag_len,
-                                             vector->key, vector->key_len, vector->iv, vector->iv_len, out_pt);
+                                             vector->key, vector->key_len, vector->iv, vector->iv_len, out_pt.Get());
 
-            bool arePTsEqual = memcmp(vector->pt, out_pt, vector->pt_len) == 0;
+            bool arePTsEqual = memcmp(vector->pt, out_pt.Get(), vector->pt_len) == 0;
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INTERNAL);
             NL_TEST_ASSERT(inSuite, arePTsEqual == false);
         }
@@ -296,17 +328,21 @@ static void TestAES_CCM_128EncryptTestVectors(nlTestSuite * inSuite, void * inCo
         if (vector->pt_len > 0)
         {
             numOfTestsRan++;
-            uint8_t out_ct[vector->ct_len];
-            uint8_t out_tag[vector->tag_len];
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_ct;
+            out_ct.Alloc(vector->ct_len);
+            NL_TEST_ASSERT(inSuite, out_ct);
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_tag;
+            out_tag.Alloc(vector->tag_len);
+            NL_TEST_ASSERT(inSuite, out_tag);
 
             CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, vector->key, vector->key_len,
-                                             vector->iv, vector->iv_len, out_ct, out_tag, vector->tag_len);
+                                             vector->iv, vector->iv_len, out_ct.Get(), out_tag.Get(), vector->tag_len);
             NL_TEST_ASSERT(inSuite, err == vector->result);
 
             if (vector->result == CHIP_NO_ERROR)
             {
-                bool areCTsEqual  = memcmp(out_ct, vector->ct, vector->ct_len) == 0;
-                bool areTagsEqual = memcmp(out_tag, vector->tag, vector->tag_len) == 0;
+                bool areCTsEqual  = memcmp(out_ct.Get(), vector->ct, vector->ct_len) == 0;
+                bool areTagsEqual = memcmp(out_tag.Get(), vector->tag, vector->tag_len) == 0;
                 NL_TEST_ASSERT(inSuite, areCTsEqual);
                 NL_TEST_ASSERT(inSuite, areTagsEqual);
                 if (!areCTsEqual)
@@ -333,14 +369,16 @@ static void TestAES_CCM_128DecryptTestVectors(nlTestSuite * inSuite, void * inCo
         if (vector->pt_len > 0)
         {
             numOfTestsRan++;
-            uint8_t out_pt[vector->pt_len];
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_pt;
+            out_pt.Alloc(vector->pt_len);
+            NL_TEST_ASSERT(inSuite, out_pt);
             CHIP_ERROR err = AES_CCM_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag, vector->tag_len,
-                                             vector->key, vector->key_len, vector->iv, vector->iv_len, out_pt);
+                                             vector->key, vector->key_len, vector->iv, vector->iv_len, out_pt.Get());
 
             NL_TEST_ASSERT(inSuite, err == vector->result);
             if (vector->result == CHIP_NO_ERROR)
             {
-                bool arePTsEqual = memcmp(vector->pt, out_pt, vector->pt_len) == 0;
+                bool arePTsEqual = memcmp(vector->pt, out_pt.Get(), vector->pt_len) == 0;
                 NL_TEST_ASSERT(inSuite, arePTsEqual);
                 if (!arePTsEqual)
                 {
@@ -362,11 +400,15 @@ static void TestAES_CCM_128EncryptInvalidPlainText(nlTestSuite * inSuite, void *
         if (vector->pt_len > 0)
         {
             numOfTestsRan++;
-            uint8_t out_ct[vector->ct_len];
-            uint8_t out_tag[vector->tag_len];
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_ct;
+            out_ct.Alloc(vector->ct_len);
+            NL_TEST_ASSERT(inSuite, out_ct);
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_tag;
+            out_tag.Alloc(vector->tag_len);
+            NL_TEST_ASSERT(inSuite, out_tag);
 
             CHIP_ERROR err = AES_CCM_encrypt(vector->pt, 0, vector->aad, vector->aad_len, vector->key, vector->key_len, vector->iv,
-                                             vector->iv_len, out_ct, out_tag, vector->tag_len);
+                                             vector->iv_len, out_ct.Get(), out_tag.Get(), vector->tag_len);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -384,11 +426,15 @@ static void TestAES_CCM_128EncryptNilKey(nlTestSuite * inSuite, void * inContext
         if (vector->pt_len > 0)
         {
             numOfTestsRan++;
-            uint8_t out_ct[vector->ct_len];
-            uint8_t out_tag[vector->tag_len];
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_ct;
+            out_ct.Alloc(vector->ct_len);
+            NL_TEST_ASSERT(inSuite, out_ct);
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_tag;
+            out_tag.Alloc(vector->tag_len);
+            NL_TEST_ASSERT(inSuite, out_tag);
 
             CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, nullptr, 0, vector->iv,
-                                             vector->iv_len, out_ct, out_tag, vector->tag_len);
+                                             vector->iv_len, out_ct.Get(), out_tag.Get(), vector->tag_len);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -406,11 +452,15 @@ static void TestAES_CCM_128EncryptInvalidIVLen(nlTestSuite * inSuite, void * inC
         if (vector->pt_len > 0)
         {
             numOfTestsRan++;
-            uint8_t out_ct[vector->ct_len];
-            uint8_t out_tag[vector->tag_len];
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_ct;
+            out_ct.Alloc(vector->ct_len);
+            NL_TEST_ASSERT(inSuite, out_ct);
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_tag;
+            out_tag.Alloc(vector->tag_len);
+            NL_TEST_ASSERT(inSuite, out_tag);
 
             CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, vector->key, vector->key_len,
-                                             vector->iv, 0, out_ct, out_tag, vector->tag_len);
+                                             vector->iv, 0, out_ct.Get(), out_tag.Get(), vector->tag_len);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -428,11 +478,15 @@ static void TestAES_CCM_128EncryptInvalidTagLen(nlTestSuite * inSuite, void * in
         if (vector->pt_len > 0)
         {
             numOfTestsRan++;
-            uint8_t out_ct[vector->ct_len];
-            uint8_t out_tag[vector->tag_len];
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_ct;
+            out_ct.Alloc(vector->ct_len);
+            NL_TEST_ASSERT(inSuite, out_ct);
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_tag;
+            out_tag.Alloc(vector->tag_len);
+            NL_TEST_ASSERT(inSuite, out_tag);
 
             CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, vector->key, vector->key_len,
-                                             vector->iv, vector->iv_len, out_ct, out_tag, 13);
+                                             vector->iv, vector->iv_len, out_ct.Get(), out_tag.Get(), 13);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -567,10 +621,12 @@ static void TestHKDF_SHA256(nlTestSuite * inSuite, void * inContext)
     {
         hkdf_sha256_vector v = hkdf_sha256_test_vectors[numOfTestsExecuted];
         size_t out_length    = v.output_key_material_length;
-        uint8_t out_buffer[out_length];
-        HKDF_SHA256(v.initial_key_material, v.initial_key_material_length, v.salt, v.salt_length, v.info, v.info_length, out_buffer,
-                    v.output_key_material_length);
-        bool success = memcmp(v.output_key_material, out_buffer, out_length) == 0;
+        chip::Platform::ScopedMemoryBuffer<uint8_t> out_buffer;
+        out_buffer.Alloc(out_length);
+        NL_TEST_ASSERT(inSuite, out_buffer);
+        HKDF_SHA256(v.initial_key_material, v.initial_key_material_length, v.salt, v.salt_length, v.info, v.info_length,
+                    out_buffer.Get(), v.output_key_material_length);
+        bool success = memcmp(v.output_key_material, out_buffer.Get(), out_length) == 0;
         NL_TEST_ASSERT(inSuite, success);
     }
     NL_TEST_ASSERT(inSuite, numOfTestsExecuted == 3);
@@ -857,15 +913,17 @@ static void TestPBKDF2_SHA256_TestVectors(nlTestSuite * inSuite, void * inContex
         if (vector->plen > 0)
         {
             numOfTestsRan++;
-            uint8_t out_key[vector->key_len];
+            chip::Platform::ScopedMemoryBuffer<uint8_t> out_key;
+            out_key.Alloc(vector->key_len);
+            NL_TEST_ASSERT(inSuite, out_key);
 
-            CHIP_ERROR err =
-                pbkdf2_sha256(vector->password, vector->plen, vector->salt, vector->slen, vector->iter, vector->key_len, out_key);
+            CHIP_ERROR err = pbkdf2_sha256(vector->password, vector->plen, vector->salt, vector->slen, vector->iter,
+                                           vector->key_len, out_key.Get());
             NL_TEST_ASSERT(inSuite, err == vector->result);
 
             if (vector->result == CHIP_NO_ERROR)
             {
-                NL_TEST_ASSERT(inSuite, memcmp(out_key, vector->key, vector->key_len) == 0);
+                NL_TEST_ASSERT(inSuite, memcmp(out_key.Get(), vector->key, vector->key_len) == 0);
             }
         }
     }
@@ -1364,6 +1422,26 @@ static const nlTest sTests[] = {
     NL_TEST_SENTINEL()
 };
 
+/**
+ *  Set up the test suite.
+ */
+int TestCHIPCryptoPAL_Setup(void * inContext)
+{
+    CHIP_ERROR error = chip::Platform::MemoryInit();
+    if (error != CHIP_NO_ERROR)
+        return FAILURE;
+    return SUCCESS;
+}
+
+/**
+ *  Tear down the test suite.
+ */
+int TestCHIPCryptoPAL_Teardown(void * inContext)
+{
+    chip::Platform::MemoryShutdown();
+    return SUCCESS;
+}
+
 int TestCHIPCryptoPAL(void)
 {
     // clang-format off
@@ -1371,8 +1449,8 @@ int TestCHIPCryptoPAL(void)
     {
         "CHIP Crypto PAL tests",
         &sTests[0],
-        nullptr,
-        nullptr
+        TestCHIPCryptoPAL_Setup,
+        TestCHIPCryptoPAL_Teardown
     };
     // clang-format on
     // Run test suit againt one context.

--- a/src/inet/tests/TestInetCommon.cpp
+++ b/src/inet/tests/TestInetCommon.cpp
@@ -48,6 +48,7 @@
 #include <inet/InetFaultInjection.h>
 #include <support/CHIPFaultInjection.h>
 #include <support/CHIPMem.h>
+#include <support/ScopedBuffer.h>
 #include <system/SystemFaultInjection.h>
 #include <system/SystemTimer.h>
 
@@ -665,11 +666,17 @@ void DumpMemory(const uint8_t * mem, uint32_t len, const char * prefix)
 
     DumpMemory(mem, len, prefix, kRowWidth);
 }
+
 static void RebootCallbackFn()
 {
-    char * lArgv[sRestartCallbackCtx.mArgc + 2];
     int i;
     int j = 0;
+    chip::Platform::ScopedMemoryBuffer<char *> lArgv;
+    if (!lArgv.Alloc(sRestartCallbackCtx.mArgc + 2))
+    {
+        printf("** failed to allocate memory **\n");
+        ExitNow();
+    }
 
     if (gSigusr1Received)
     {
@@ -707,7 +714,7 @@ static void RebootCallbackFn()
 
     printf("********** Restarting *********\n");
     fflush(stdout);
-    execvp(lArgv[0], lArgv);
+    execvp(lArgv[0], lArgv.Get());
 
 exit:
     return;

--- a/src/lib/support/tests/TestSerializableIntegerSet.cpp
+++ b/src/lib/support/tests/TestSerializableIntegerSet.cpp
@@ -19,6 +19,7 @@
 #include "TestSupport.h"
 
 #include <support/CHIPMem.h>
+#include <support/CHIPMemString.h>
 #include <support/SerializableIntegerSet.h>
 #include <support/TestUtils.h>
 
@@ -126,17 +127,17 @@ void TestSerializableIntegerSetSerialize(nlTestSuite * inSuite, void * inContext
     NL_TEST_ASSERT(inSuite, set.SerializeBase64(buf, size) == nullptr);
     NL_TEST_ASSERT(inSuite, size != 0);
 
-    char buf1[size];
-    NL_TEST_ASSERT(inSuite, set.SerializeBase64(buf1, size) == buf1);
+    chip::Platform::ScopedMemoryString buf1("", size);
+    NL_TEST_ASSERT(inSuite, set.SerializeBase64(buf1.Get(), size) == buf1.Get());
     NL_TEST_ASSERT(inSuite, size != 0);
 
     uint16_t size2 = static_cast<uint16_t>(2 * size);
-    char buf2[size2];
-    NL_TEST_ASSERT(inSuite, set.SerializeBase64(buf2, size2) == buf2);
+    chip::Platform::ScopedMemoryString buf2("", size2);
+    NL_TEST_ASSERT(inSuite, set.SerializeBase64(buf2.Get(), size2) == buf2.Get());
     NL_TEST_ASSERT(inSuite, size2 == size);
 
     chip::SerializableU64Set<8> set2;
-    NL_TEST_ASSERT(inSuite, set2.DeserializeBase64(buf2, size2) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, set2.DeserializeBase64(buf2.Get(), size2) == CHIP_NO_ERROR);
 
     for (uint64_t i = 1; i <= 6; i++)
     {

--- a/src/setup_payload/ManualSetupPayloadGenerator.cpp
+++ b/src/setup_payload/ManualSetupPayloadGenerator.cpp
@@ -40,7 +40,7 @@ static uint32_t shortPayloadRepresentation(const SetupPayload & payload)
     return result;
 }
 
-static std::string decimalStringWithPadding(uint32_t number, int minLength)
+static inline std::string decimalStringWithPadding(uint32_t number, int minLength)
 {
     char buf[minLength + 1];
     snprintf(buf, sizeof(buf), "%0*" PRIu32, minLength, number);

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -207,6 +207,10 @@ static CHIP_ERROR generateBitSet(SetupPayload & payload, uint8_t * bits, uint8_t
     return err;
 }
 
+// TODO: issue #3663 - Unbounded stack in payloadBase41RepresentationWithTLV()
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstack-usage="
+
 static CHIP_ERROR payloadBase41RepresentationWithTLV(SetupPayload & setupPayload, string & base41Representation, size_t bitsetSize,
                                                      uint8_t * tlvDataStart, size_t tlvDataLengthInBytes)
 {
@@ -247,3 +251,5 @@ CHIP_ERROR QRCodeSetupPayloadGenerator::payloadBase41Representation(string & bas
 exit:
     return err;
 }
+
+#pragma GCC diagnostic pop // -Wstack-usage

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -152,7 +152,8 @@ CHIP_ERROR SecureSession::Encrypt(const uint8_t * input, size_t input_length, ui
     constexpr Header::EncryptionType encType = Header::EncryptionType::kAESCCMTagLen16;
 
     const size_t taglen = MessageAuthenticationCode::TagLenForEncryptionType(encType);
-    uint8_t tag[taglen];
+    assert(taglen <= kMaxTagLen);
+    uint8_t tag[kMaxTagLen];
 
     VerifyOrExit(mKeyAvailable, error = CHIP_ERROR_INVALID_USE_OF_SESSION_KEY);
     VerifyOrExit(input != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);


### PR DESCRIPTION
#### Problem

RAM on small devices is limited, so excesssive stack should not be used
without good reason. Stack allocation is also not easily checked at run
time so overflow is likely to cause crashes.

#### Summary of Changes

- Add a `-Wstack-usage` compiler flag on embedded builds. (For this
  purpose, an ‘embedded build’ is any that is not using a whitelisted
  non-embedded OS, so new platforms will have this enabled by default.)

  In this PR, the stack limit is set high enough that _only_ dynamically
  unbounded stack usage triggers it. The intent is to lower the limit
  in the future so that any unusually large stack requires whitelisting
  with justification in review.

- Replace most uses of dynamically unbounded stack.

- Filed separate issues for two remaining uses of dynamic stack:
    - #3662 emberAfPrintBuffer()
    - #3663 payloadBase41RepresentationWithTLV()

fixes #3505 Use "-Wstack-usage" for device builds
