### PR TITLE
Use ClusterId in some cases where uint16_t snuck in.

### DIFF
--- a/src/app/reporting/reporting.h
+++ b/src/app/reporting/reporting.h
@@ -84,7 +84,7 @@ bool emberAfPluginReportingGetReportingConfigDefaults(EmberAfPluginReportingEntr
 
 #ifdef __cplusplus
 extern "C" {
-#endif
+#endif // __cplusplus
 /** @brief Configure Reporting Command
  *
  * This function is called by the application framework when a Configure
@@ -158,10 +158,10 @@ bool emberAfReadReportingConfigurationResponseCallback(EmberAfClusterId clusterI
  * @param type   Ver.: always
  * @param data   Ver.: always
  */
-void emberAfReportingAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
+void emberAfReportingAttributeChangeCallback(CHIPEndpointId endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
                                              uint8_t mask, uint16_t manufacturerCode, EmberAfAttributeType type, uint8_t * data);
 
 #ifdef __cplusplus
-}
-#endif
+} // extern "C"
+#endif // __cplusplus
 #endif

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -1209,7 +1209,7 @@ uint16_t emAfGetManufacturerCodeForCommand(EmberAfCommandMetadata * command)
  * It returns false, if there were more commands, but were not populated
  * because of maxIdCount limitation.
  */
-bool emberAfExtractCommandIds(bool outgoing, EmberAfClusterCommand * cmd, uint16_t clusterId, uint8_t * buffer,
+bool emberAfExtractCommandIds(bool outgoing, EmberAfClusterCommand * cmd, ClusterId clusterId, uint8_t * buffer,
                               uint16_t bufferLength, uint16_t * bufferIndex, uint8_t startId, uint8_t maxIdCount)
 {
     uint16_t i, count = 0;

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -95,7 +95,7 @@ void emAfCallInits(void);
 
 // Initial configuration
 void emberAfEndpointConfigure(void);
-bool emberAfExtractCommandIds(bool outgoing, EmberAfClusterCommand * cmd, uint16_t clusterId, uint8_t * buffer,
+bool emberAfExtractCommandIds(bool outgoing, EmberAfClusterCommand * cmd, CHIPClusterId clusterId, uint8_t * buffer,
                               uint16_t bufferLength, uint16_t * bufferIndex, uint8_t startId, uint8_t maxIdCount);
 
 EmberAfStatus emAfReadOrWriteAttribute(EmberAfAttributeSearchRecord * attRecord, EmberAfAttributeMetadata ** metadata,

--- a/src/app/util/process-global-message.cpp
+++ b/src/app/util/process-global-message.cpp
@@ -57,6 +57,8 @@
 #include "app/framework/plugin/comms-hub-function-sub-ghz/comms-hub-function-sub-ghz.h"
 #endif
 
+using namespace chip;
+
 // flag to keep track of the fact that we just sent a read attr for time and
 // we should set our time to the result of the read attr response.
 bool emAfSyncingTime = false;
@@ -82,7 +84,7 @@ bool emAfSyncingTime = false;
      % UINT8_MAX) /* make count fit in an 8 bit integer */
 
 #if defined(EMBER_AF_SUPPORT_COMMAND_DISCOVERY)
-static void printDiscoverCommandsResponse(bool generated, uint16_t clusterId, bool discoveryComplete, uint8_t * buffer,
+static void printDiscoverCommandsResponse(bool generated, ClusterId clusterId, bool discoveryComplete, uint8_t * buffer,
                                           uint16_t length)
 {
     uint16_t i;

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -323,8 +323,9 @@ void emberAfStackDown(void)
 // Print out information about each cluster
 // ****************************************
 
-uint16_t emberAfFindClusterNameIndexWithMfgCode(uint16_t cluster, uint16_t mfgCode)
+uint16_t emberAfFindClusterNameIndexWithMfgCode(ClusterId cluster, uint16_t mfgCode)
 {
+    static_assert(sizeof(ClusterId) == 2, "May need to adjust our index type or somehow define it in terms of cluster id type");
     uint16_t index = 0;
     while (zclClusterNames[index].id != ZCL_NULL_CLUSTER_ID)
     {
@@ -344,18 +345,19 @@ uint16_t emberAfFindClusterNameIndexWithMfgCode(uint16_t cluster, uint16_t mfgCo
     return 0xFFFF;
 }
 
-uint16_t emberAfFindClusterNameIndex(uint16_t cluster)
+uint16_t emberAfFindClusterNameIndex(ClusterId cluster)
 {
     return emberAfFindClusterNameIndexWithMfgCode(cluster, EMBER_AF_NULL_MANUFACTURER_CODE);
 }
 
 // This function parses into the cluster name table, and tries to find
 // the index in the table that has the two keys: cluster + mfgcode.
-void emberAfDecodeAndPrintClusterWithMfgCode(uint16_t cluster, uint16_t mfgCode)
+void emberAfDecodeAndPrintClusterWithMfgCode(ClusterId cluster, uint16_t mfgCode)
 {
     uint16_t index = emberAfFindClusterNameIndexWithMfgCode(cluster, mfgCode);
     if (index == 0xFFFF)
     {
+        static_assert(sizeof(ClusterId) == 2, "Adjust the print formatting");
         emberAfPrint(emberAfPrintActiveArea, "(Unknown clus. [0x%2x])", cluster);
     }
     else
@@ -364,7 +366,7 @@ void emberAfDecodeAndPrintClusterWithMfgCode(uint16_t cluster, uint16_t mfgCode)
     }
 }
 
-void emberAfDecodeAndPrintCluster(uint16_t cluster)
+void emberAfDecodeAndPrintCluster(ClusterId cluster)
 {
     emberAfDecodeAndPrintClusterWithMfgCode(cluster, EMBER_AF_NULL_MANUFACTURER_CODE);
 }

--- a/src/app/util/util.h
+++ b/src/app/util/util.h
@@ -154,12 +154,12 @@ uint16_t emberAfGetMfgCodeFromCurrentCommand(void);
 
 void emberAfInit(void);
 void emberAfTick(void);
-uint16_t emberAfFindClusterNameIndex(uint16_t cluster);
-uint16_t emberAfFindClusterNameIndexWithMfgCode(uint16_t cluster, uint16_t mfgCode);
+uint16_t emberAfFindClusterNameIndex(CHIPClusterId cluster);
+uint16_t emberAfFindClusterNameIndexWithMfgCode(CHIPClusterId cluster, uint16_t mfgCode);
 void emberAfStackDown(void);
 
-void emberAfDecodeAndPrintCluster(uint16_t cluster);
-void emberAfDecodeAndPrintClusterWithMfgCode(uint16_t cluster, uint16_t mfgCode);
+void emberAfDecodeAndPrintCluster(CHIPClusterId cluster);
+void emberAfDecodeAndPrintClusterWithMfgCode(CHIPClusterId cluster, uint16_t mfgCode);
 
 bool emberAfProcessMessage(EmberApsFrame * apsFrame, EmberIncomingMessageType type, uint8_t * message, uint16_t msgLen,
                            ChipNodeId source, InterPanHeader * interPanHeader);


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Some `uint16_t` snuck in to represent clusters.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Use `chip::ClusterId` or `CHIPClusterId`

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes https://github.com/project-chip/connectedhomeip/issues/3592

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
