### PR TITLE
Add JavaScript to .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -230,4 +230,7 @@ StatementMacros:
   - QT_REQUIRE_VERSION
 TabWidth:        8
 UseTab:          Never
+---
+Language: JavaScript
+ColumnLimit:     132
 ...


### PR DESCRIPTION
…e a valid format for .js file yet

 #### Problem

Restyler complains in #3638 because it is trying to run `clang-format` on a `.js` file but `.clang-format` does not contains rules for JS.

 #### Summary of Changes
In order to move forward with #3638 I just removed the line that add `**/*.js` files to `clang-format`.
One other solution could be to add some JS rules to clang-format though.