### PR TITLE
CodeQL: Comparison result is always the same in src/inet/tests/TestIn…

### DIFF
--- a/src/inet/tests/TestInetLayer.cpp
+++ b/src/inet/tests/TestInetLayer.cpp
@@ -322,7 +322,7 @@ static bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdent
     {
 
     case kToolOptInterval:
-        if (!ParseInt(aValue, gSendIntervalMs) || gSendIntervalMs > UINT32_MAX)
+        if (!ParseInt(aValue, gSendIntervalMs))
         {
             PrintArgError("%s: invalid value specified for send interval: %s\n", aProgram, aValue);
             retval = false;

--- a/src/inet/tests/TestInetLayerMulticast.cpp
+++ b/src/inet/tests/TestInetLayerMulticast.cpp
@@ -353,7 +353,7 @@ static bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdent
     {
 
     case kToolOptInterval:
-        if (!ParseInt(aValue, gSendIntervalMs) || gSendIntervalMs > UINT32_MAX)
+        if (!ParseInt(aValue, gSendIntervalMs))
         {
             PrintArgError("%s: invalid value specified for send interval: %s\n", aProgram, aValue);
             retval = false;


### PR DESCRIPTION
…etLayer.cpp and src/inet/tests/TestInetLayerMulticast.cpp

 #### Problem

https://github.com/project-chip/connectedhomeip/security/code-scanning/148

CodeQL complains that the comparison is always the same.
I guess it is correct since the definition of `gSendIntervalMs` is `uint32_t gSendIntervalMs;` so there is no chance that it goes over `UINT32_MAX`

 #### Summary of Changes
 * Remove `gSendIntervalMs > UINT32_MAX` checks
