### PR TITLE
Remove '-Wno-unused-variable' from the default compiler flags

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -139,7 +139,6 @@ config("disabled_warnings") {
     "-Wno-unknown-warning-option",
     "-Wno-missing-field-initializers",
     "-Wno-unused-but-set-variable",
-    "-Wno-unused-variable",
   ]
   cflags_cc = [
     "-Wno-non-virtual-dtor",

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -92,7 +92,9 @@ static void TestInetPre(nlTestSuite * inSuite, void * inContext)
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
     INET_ERROR err         = INET_NO_ERROR;
     IPAddress testDestAddr = IPAddress::Any;
-    char testHostName[20]  = "www.nest.com";
+#if INET_CONFIG_ENABLE_DNS_RESOLVER
+    char testHostName[20] = "www.nest.com";
+#endif // INET_CONFIG_ENABLE_DNS_RESOLVER
 
 #if INET_CONFIG_ENABLE_RAW_ENDPOINT
     err = gInet.NewRawEndPoint(kIPVersion_6, kIPProtocol_ICMPv6, &testRawEP);

--- a/src/inet/tests/TestInetErrorStr.cpp
+++ b/src/inet/tests/TestInetErrorStr.cpp
@@ -83,8 +83,6 @@ static int32_t sContext[] =
 };
 // clang-format on
 
-static const size_t kTestElements = sizeof(sContext) / sizeof(sContext[0]);
-
 static void CheckInetErrorStr(nlTestSuite * inSuite, void * inContext)
 {
     // Register the layer error formatter

--- a/src/lib/core/tests/TestCHIPErrorStr.cpp
+++ b/src/lib/core/tests/TestCHIPErrorStr.cpp
@@ -223,8 +223,6 @@ static int32_t sContext[] =
 };
 // clang-format on
 
-static const size_t kTestElements = sizeof(sContext) / sizeof(sContext[0]);
-
 static void CheckCoreErrorStr(nlTestSuite * inSuite, void * inContext)
 {
     // Register the layer error formatter

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -210,7 +210,7 @@ void ConnectivityManagerImpl::_ClearWiFiStationProvision(void)
     if (mWiFiStationMode != kWiFiStationMode_ApplicationControlled)
     {
         GError * err = nullptr;
-        gboolean ret = wpa_fi_w1_wpa_supplicant1_interface_call_remove_all_networks_sync(mWpaSupplicant.iface, nullptr, &err);
+        wpa_fi_w1_wpa_supplicant1_interface_call_remove_all_networks_sync(mWpaSupplicant.iface, nullptr, &err);
 
         if (err != nullptr)
         {

--- a/src/system/tests/TestSystemErrorStr.cpp
+++ b/src/system/tests/TestSystemErrorStr.cpp
@@ -63,8 +63,6 @@ static int32_t sContext[] =
 };
 // clang-format on
 
-static const size_t kTestElements = sizeof(sContext) / sizeof(sContext[0]);
-
 static void CheckSystemErrorStr(nlTestSuite * inSuite, void * inContext)
 {
     // Register the layer error formatter


### PR DESCRIPTION
 #### Problem

There is only a few unused variable in our tree. Sounds like we can turn `-Wno-unused-variable` globally.

 #### Summary of Changes
 * Remove `-Wno-unused-variable` from build/config/compiler/BUILD.gn
 * Fix the 5 remaining cases.
