### PR TITLE
API SecureManager::SendMessage, use SecureSessoinHandle instead NodeId

### DIFF
--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -43,13 +43,13 @@ void CommandHandler::OnMessageReceived(Messaging::ExchangeContext * ec, const Pa
     err = ProcessCommandMessage(std::move(payload), kCommandHandlerId);
     SuccessOrExit(err);
 
-    SendCommandResponse(ec->GetPeerNodeId());
+    SendCommandResponse();
 
 exit:
     ChipLogFunctError(err);
 }
 
-CHIP_ERROR CommandHandler::SendCommandResponse(NodeId aNodeId)
+CHIP_ERROR CommandHandler::SendCommandResponse()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 

--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -47,7 +47,7 @@ namespace app {
 class DLL_EXPORT CommandHandler : public Command
 {
 public:
-    CHIP_ERROR SendCommandResponse(NodeId aNodeId);
+    CHIP_ERROR SendCommandResponse();
     void OnMessageReceived(Messaging::ExchangeContext * ec, const PacketHeader & packetHeader, uint32_t protocolId, uint8_t msgType,
                            System::PacketBufferHandle payload);
 

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -40,7 +40,8 @@ CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId)
     ClearExistingExchangeContext();
 
     // Create a new exchange context.
-    mpExchangeCtx = mpExchangeMgr->NewContext(aNodeId, this);
+    // TODO: temprary create a SecureSessionHandle from node id, will be fix in PR 3602
+    mpExchangeCtx = mpExchangeMgr->NewContext({ aNodeId, Transport::kAnyKeyId }, this);
     VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
     mpExchangeCtx->SetResponseTimeout(CHIP_INVOKE_COMMAND_RSP_TIMEOUT);
 
@@ -96,7 +97,7 @@ exit:
 
 void CommandSender::OnResponseTimeout(Messaging::ExchangeContext * apEc)
 {
-    ChipLogProgress(DataManagement, "Time out! failed to receive invoke command response from Node: %llu", apEc->GetPeerNodeId());
+    ChipLogProgress(DataManagement, "Time out! failed to receive invoke command response from Exchange: %d", apEc->GetExchangeId());
     Reset();
 }
 

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -190,7 +190,7 @@ void InteractionModelEngine::OnMessageReceived(Messaging::ExchangeContext * apEc
 
 void InteractionModelEngine::OnResponseTimeout(Messaging::ExchangeContext * ec)
 {
-    ChipLogProgress(DataManagement, "Time out! failed to receive echo response from Node: %llu", ec->GetPeerNodeId());
+    ChipLogProgress(DataManagement, "Time out! failed to receive echo response from Exchange: %d", ec->GetExchangeId());
 }
 
 InteractionModelEngine::HandlerKey::HandlerKey(chip::ClusterId aClusterId, chip::CommandId aCommandId,

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -61,10 +61,10 @@ bool isRendezvousBypassed()
 class ServerCallback : public SecureSessionMgrDelegate
 {
 public:
-    void OnMessageReceived(const PacketHeader & header, const PayloadHeader & payloadHeader,
-                           const Transport::PeerConnectionState * state, System::PacketBufferHandle buffer,
-                           SecureSessionMgr * mgr) override
+    void OnMessageReceived(const PacketHeader & header, const PayloadHeader & payloadHeader, SecureSessionHandle session,
+                           System::PacketBufferHandle buffer, SecureSessionMgr * mgr) override
     {
+        auto state            = mgr->GetPeerConnectionState(session);
         const size_t data_len = buffer->DataLength();
         char src_addr[PeerAddress::kMaxToStringSize];
 
@@ -92,7 +92,7 @@ public:
         }
     }
 
-    void OnNewConnection(const Transport::PeerConnectionState * state, SecureSessionMgr * mgr) override
+    void OnNewConnection(SecureSessionHandle session, SecureSessionMgr * mgr) override
     {
         ChipLogProgress(AppServer, "Received a new connection.");
     }
@@ -181,10 +181,9 @@ void InitServer(AppDelegate * delegate)
     SuccessOrExit(err);
 #endif
 
+    gSessions.SetDelegate(&gCallbacks);
     err = gSessions.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing);
     SuccessOrExit(err);
-
-    gSessions.SetDelegate(&gCallbacks);
 
 exit:
     if (err != CHIP_NO_ERROR)

--- a/src/app/util/chip-message-send.cpp
+++ b/src/app/util/chip-message-send.cpp
@@ -73,7 +73,8 @@ EmberStatus chipSendUnicast(NodeId destination, EmberApsFrame * apsFrame, uint16
     memcpy(buffer->Start() + frameSize, message, messageLength);
     buffer->SetDataLength(dataLength);
 
-    CHIP_ERROR err = SessionManager().SendMessage(destination, std::move(buffer));
+    // TODO: temprary create a handle from node id, will be fix in PR 3602
+    CHIP_ERROR err = SessionManager().SendMessage({ destination, Transport::kAnyKeyId }, std::move(buffer));
     if (err != CHIP_NO_ERROR)
     {
         // FIXME: Figure out better translations between our error types?

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -158,18 +158,38 @@ public:
 
     /**
      * @brief
+     *   Called when a new pairing is being established
+     *
+     * @param session A handle to the secure session
+     * @param mgr     A pointer to the SecureSessionMgr
+     */
+    void OnNewConnection(SecureSessionHandle session, SecureSessionMgr * mgr);
+
+    /**
+     * @brief
+     *   Called when a connection is closing.
+     *
+     *   The receiver should release all resources associated with the connection.
+     *
+     * @param session A handle to the secure session
+     * @param mgr     A pointer to the SecureSessionMgr
+     */
+    void OnConnectionExpired(SecureSessionHandle session, SecureSessionMgr * mgr);
+
+    /**
+     * @brief
      *   This function is called when a message is received from the corresponding CHIP
      *   device. The message ownership is transferred to the function, and it is expected
      *   to release the message buffer before returning.
      *
      * @param[in] header        Reference to common packet header of the received message
      * @param[in] payloadHeader Reference to payload header in the message
-     * @param[in] state         Pointer to the peer connection state on which message is received
+     * @param[in] session       A handle to the secure session
      * @param[in] msgBuf        The message buffer
      * @param[in] mgr           Pointer to secure session manager which received the message
      */
-    void OnMessageReceived(const PacketHeader & header, const PayloadHeader & payloadHeader,
-                           const Transport::PeerConnectionState * state, System::PacketBufferHandle msgBuf, SecureSessionMgr * mgr);
+    void OnMessageReceived(const PacketHeader & header, const PayloadHeader & payloadHeader, SecureSessionHandle session,
+                           System::PacketBufferHandle msgBuf, SecureSessionMgr * mgr);
 
     /**
      * @brief
@@ -179,6 +199,8 @@ public:
     bool IsActive() const { return mActive; }
 
     void SetActive(bool active) { mActive = active; }
+
+    bool IsSecureConnected() const { return IsActive() && mState == ConnectionState::SecureConnected; }
 
     void Reset()
     {
@@ -190,6 +212,8 @@ public:
     }
 
     NodeId GetDeviceId() const { return mDeviceId; }
+
+    bool MatchesSession(SecureSessionHandle session) const { return mSecureSession == session; }
 
     void SetAddress(const Inet::IPAddress & deviceAddr) { mDeviceAddr = deviceAddr; }
 
@@ -241,6 +265,8 @@ private:
     SecureSessionMgr * mSessionManager;
 
     DeviceTransportMgr * mTransportMgr;
+
+    SecureSessionHandle mSecureSession = {};
 
     /* Track all outstanding response callbacks for this device. The callbacks are
        registered when a command is sent to the device, to get notified with the results. */

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -334,24 +334,57 @@ exit:
     return err;
 }
 
-void DeviceController::OnNewConnection(const Transport::PeerConnectionState * peerConnection, SecureSessionMgr * mgr) {}
-
-void DeviceController::OnMessageReceived(const PacketHeader & header, const PayloadHeader & payloadHeader,
-                                         const Transport::PeerConnectionState * state, System::PacketBufferHandle msgBuf,
-                                         SecureSessionMgr * mgr)
+void DeviceController::OnNewConnection(SecureSessionHandle session, SecureSessionMgr * mgr)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint16_t index = 0;
-    NodeId peer;
+
+    VerifyOrExit(mState == State::Initialized, err = CHIP_ERROR_INCORRECT_STATE);
+
+    index = FindDeviceIndex(mgr->GetPeerConnectionState(session)->GetPeerNodeId());
+    VerifyOrExit(index < kNumMaxActiveDevices, err = CHIP_ERROR_INVALID_DEVICE_DESCRIPTOR);
+
+    mActiveDevices[index].OnNewConnection(session, mgr);
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "Failed to process received message: err %d", err);
+    }
+}
+
+void DeviceController::OnConnectionExpired(SecureSessionHandle session, SecureSessionMgr * mgr)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    uint16_t index = 0;
+
+    VerifyOrExit(mState == State::Initialized, err = CHIP_ERROR_INCORRECT_STATE);
+
+    index = FindDeviceIndex(session);
+    VerifyOrExit(index < kNumMaxActiveDevices, err = CHIP_ERROR_INVALID_DEVICE_DESCRIPTOR);
+
+    mActiveDevices[index].OnConnectionExpired(session, mgr);
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "Failed to process received message: err %d", err);
+    }
+}
+
+void DeviceController::OnMessageReceived(const PacketHeader & header, const PayloadHeader & payloadHeader,
+                                         SecureSessionHandle session, System::PacketBufferHandle msgBuf, SecureSessionMgr * mgr)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    uint16_t index = 0;
 
     VerifyOrExit(mState == State::Initialized, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(header.GetSourceNodeId().HasValue(), err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    peer  = header.GetSourceNodeId().Value();
-    index = FindDeviceIndex(peer);
+    index = FindDeviceIndex(session);
     VerifyOrExit(index < kNumMaxActiveDevices, err = CHIP_ERROR_INVALID_DEVICE_DESCRIPTOR);
 
-    mActiveDevices[index].OnMessageReceived(header, payloadHeader, state, std::move(msgBuf), mgr);
+    mActiveDevices[index].OnMessageReceived(header, payloadHeader, session, std::move(msgBuf), mgr);
 
 exit:
     if (err != CHIP_NO_ERROR)
@@ -393,6 +426,20 @@ void DeviceController::ReleaseAllDevices()
     {
         ReleaseDevice(&mActiveDevices[i]);
     }
+}
+
+uint16_t DeviceController::FindDeviceIndex(SecureSessionHandle session)
+{
+    uint16_t i = 0;
+    while (i < kNumMaxActiveDevices)
+    {
+        if (mActiveDevices[i].IsActive() && mActiveDevices[i].IsSecureConnected() && mActiveDevices[i].MatchesSession(session))
+        {
+            return i;
+        }
+        i++;
+    }
+    return i;
 }
 
 uint16_t DeviceController::FindDeviceIndex(NodeId id)

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -192,17 +192,18 @@ protected:
 
     uint16_t mListenPort;
     uint16_t GetInactiveDeviceIndex();
+    uint16_t FindDeviceIndex(SecureSessionHandle session);
     uint16_t FindDeviceIndex(NodeId id);
     void ReleaseDevice(uint16_t index);
     CHIP_ERROR SetPairedDeviceList(const char * pairedDeviceSerializedSet);
 
 private:
     //////////// SecureSessionMgrDelegate Implementation ///////////////
-    void OnMessageReceived(const PacketHeader & header, const PayloadHeader & payloadHeader,
-                           const Transport::PeerConnectionState * state, System::PacketBufferHandle msgBuf,
-                           SecureSessionMgr * mgr) override;
+    void OnMessageReceived(const PacketHeader & header, const PayloadHeader & payloadHeader, SecureSessionHandle session,
+                           System::PacketBufferHandle msgBuf, SecureSessionMgr * mgr) override;
 
-    void OnNewConnection(const Transport::PeerConnectionState * state, SecureSessionMgr * mgr) override;
+    void OnNewConnection(SecureSessionHandle session, SecureSessionMgr * mgr) override;
+    void OnConnectionExpired(SecureSessionHandle session, SecureSessionMgr * mgr) override;
 
     //////////// PersistentStorageResultDelegate Implementation ///////////////
     void OnValue(const char * key, const char * value) override;

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -80,6 +80,7 @@ CHIP_ERROR ExchangeContext::SendMessage(uint16_t protocolId, uint8_t msgType, Pa
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     PayloadHeader payloadHeader;
+    Transport::PeerConnectionState * state = nullptr;
 
     // Don't let method get called on a freed object.
     VerifyOrDie(mExchangeMgr != nullptr && GetReferenceCount() > 0);
@@ -102,8 +103,10 @@ CHIP_ERROR ExchangeContext::SendMessage(uint16_t protocolId, uint8_t msgType, Pa
 
     // If sending via UDP and auto-request ACK feature is enabled, automatically request an acknowledgment,
     // UNLESS the NoAutoRequestAck send flag has been specified.
-    if ((mExchangeMgr->GetSessionMgr()->GetTransportType(mPeerNodeId) == Transport::Type::kUdp) &&
-        mReliableMessageContext.AutoRequestAck() && !sendFlags.Has(SendMessageFlags::kSendFlag_NoAutoRequestAck))
+    state = mExchangeMgr->GetSessionMgr()->GetPeerConnectionState(mSecureSession);
+    VerifyOrExit(state != nullptr, err = CHIP_ERROR_NOT_CONNECTED);
+    if ((state->GetPeerAddress().GetTransportType() == Transport::Type::kUdp) && mReliableMessageContext.AutoRequestAck() &&
+        !sendFlags.Has(SendMessageFlags::kSendFlag_NoAutoRequestAck))
     {
         payloadHeader.SetNeedsAck(true);
     }
@@ -147,12 +150,12 @@ CHIP_ERROR ExchangeContext::SendMessage(uint16_t protocolId, uint8_t msgType, Pa
         err = mExchangeMgr->GetReliableMessageMgr()->AddToRetransTable(&mReliableMessageContext, &entry);
         SuccessOrExit(err);
 
-        err = mExchangeMgr->GetSessionMgr()->SendMessage(payloadHeader, mPeerNodeId, std::move(msgBuf), &entry->retainedBuf);
+        err = mExchangeMgr->GetSessionMgr()->SendMessage(mSecureSession, payloadHeader, std::move(msgBuf), &entry->retainedBuf);
 
         if (err != CHIP_NO_ERROR)
         {
             // Remove from table
-            ChipLogError(ExchangeManager, "Failed to send message to 0x%" PRIx64 " with err %ld", mPeerNodeId, long(err));
+            ChipLogError(ExchangeManager, "Failed to send message with err %ld", long(err));
             mExchangeMgr->GetReliableMessageMgr()->ClearRetransmitTable(*entry);
         }
         else
@@ -162,7 +165,7 @@ CHIP_ERROR ExchangeContext::SendMessage(uint16_t protocolId, uint8_t msgType, Pa
     }
     else
     {
-        err = mExchangeMgr->GetSessionMgr()->SendMessage(payloadHeader, mPeerNodeId, std::move(msgBuf));
+        err = mExchangeMgr->GetSessionMgr()->SendMessage(mSecureSession, payloadHeader, std::move(msgBuf));
         SuccessOrExit(err);
     }
 
@@ -250,7 +253,7 @@ void ExchangeContext::Reset()
     *this = ExchangeContext();
 }
 
-ExchangeContext * ExchangeContext::Alloc(ExchangeManager * em, uint16_t ExchangeId, uint64_t PeerNodeId, bool Initiator,
+ExchangeContext * ExchangeContext::Alloc(ExchangeManager * em, uint16_t ExchangeId, SecureSessionHandle session, bool Initiator,
                                          ExchangeDelegate * delegate)
 {
     VerifyOrDie(mExchangeMgr == nullptr && GetReferenceCount() == 0);
@@ -259,8 +262,8 @@ ExchangeContext * ExchangeContext::Alloc(ExchangeManager * em, uint16_t Exchange
     Retain();
     mExchangeMgr = em;
     em->IncrementContextsInUse();
-    mExchangeId = ExchangeId;
-    mPeerNodeId = PeerNodeId;
+    mExchangeId    = ExchangeId;
+    mSecureSession = session;
     mFlags.Set(ExFlagValues::kFlagInitiator, Initiator);
     mDelegate = delegate;
 
@@ -296,7 +299,8 @@ void ExchangeContext::Free()
     SYSTEM_STATS_DECREMENT(chip::System::Stats::kExchangeMgr_NumContexts);
 }
 
-bool ExchangeContext::MatchExchange(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader)
+bool ExchangeContext::MatchExchange(SecureSessionHandle session, const PacketHeader & packetHeader,
+                                    const PayloadHeader & payloadHeader)
 {
     // A given message is part of a particular exchange if...
     return
@@ -304,8 +308,8 @@ bool ExchangeContext::MatchExchange(const PacketHeader & packetHeader, const Pay
         // The exchange identifier of the message matches the exchange identifier of the context.
         (mExchangeId == payloadHeader.GetExchangeID())
 
-        // AND The message was received from the peer node associated with the exchange, or the peer node identifier is 'any'.
-        && ((mPeerNodeId == kAnyNodeId) || (mPeerNodeId == packetHeader.GetSourceNodeId().Value()))
+        // AND The message was received from the peer node associated with the exchange
+        && (mSecureSession == session)
 
         // AND The message was sent by an initiator and the exchange context is a responder (IsInitiator==false)
         //    OR The message was sent by a responder and the exchange context is an initiator (IsInitiator==true) (for the broadcast

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -133,7 +133,7 @@ public:
 
     ReliableMessageContext * GetReliableMessageContext() { return &mReliableMessageContext; };
 
-    uint64_t GetPeerNodeId() const { return mPeerNodeId; }
+    SecureSessionHandle GetSecureSession() { return mSecureSession; }
 
     uint16_t GetExchangeId() const { return mExchangeId; }
 
@@ -145,7 +145,7 @@ public:
     void Close();
     void Abort();
 
-    ExchangeContext * Alloc(ExchangeManager * em, uint16_t ExchangeId, uint64_t PeerNodeId, bool Initiator,
+    ExchangeContext * Alloc(ExchangeManager * em, uint16_t ExchangeId, SecureSessionHandle session, bool Initiator,
                             ExchangeDelegate * delegate);
     void Free();
     void Reset();
@@ -164,13 +164,15 @@ private:
     ExchangeDelegate * mDelegate   = nullptr;
     ExchangeManager * mExchangeMgr = nullptr;
 
-    uint64_t mPeerNodeId; // Node ID of peer node.
-    uint16_t mExchangeId; // Assigned exchange ID.
+    SecureSessionHandle mSecureSession; // The connection state
+    uint16_t mExchangeId;               // Assigned exchange ID.
 
     BitFlags<uint16_t, ExFlagValues> mFlags; // Internal state flags
 
     /**
      *  Search for an existing exchange that the message applies to.
+     *
+     *  @param[in]    session       The secure session of the received message.
      *
      *  @param[in]    packetHeader  A reference to the PacketHeader object.
      *
@@ -179,7 +181,7 @@ private:
      *  @retval  true                                       If a match is found.
      *  @retval  false                                      If a match is not found.
      */
-    bool MatchExchange(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader);
+    bool MatchExchange(SecureSessionHandle session, const PacketHeader & packetHeader, const PayloadHeader & payloadHeader);
 
     CHIP_ERROR StartResponseTimer();
     void CancelResponseTimer();

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -102,21 +102,9 @@ CHIP_ERROR ExchangeManager::Shutdown()
     return CHIP_NO_ERROR;
 }
 
-ExchangeContext * ExchangeManager::NewContext(const NodeId & peerNodeId, ExchangeDelegate * delegate)
+ExchangeContext * ExchangeManager::NewContext(SecureSessionHandle session, ExchangeDelegate * delegate)
 {
-    return AllocContext(mNextExchangeId++, peerNodeId, true, delegate);
-}
-
-ExchangeContext * ExchangeManager::FindContext(NodeId peerNodeId, ExchangeDelegate * delegate, bool isInitiator)
-{
-    for (auto & ec : mContextPool)
-    {
-        if (ec.GetReferenceCount() > 0 && ec.GetPeerNodeId() == peerNodeId && ec.GetDelegate() == delegate &&
-            ec.IsInitiator() == isInitiator)
-            return &ec;
-    }
-
-    return nullptr;
+    return AllocContext(mNextExchangeId++, session, true, delegate);
 }
 
 CHIP_ERROR ExchangeManager::RegisterUnsolicitedMessageHandler(uint32_t protocolId, ExchangeDelegate * delegate)
@@ -144,7 +132,7 @@ void ExchangeManager::OnReceiveError(CHIP_ERROR error, const Transport::PeerAddr
     ChipLogError(ExchangeManager, "Accept FAILED, err = %s", ErrorStr(error));
 }
 
-ExchangeContext * ExchangeManager::AllocContext(uint16_t ExchangeId, uint64_t PeerNodeId, bool Initiator,
+ExchangeContext * ExchangeManager::AllocContext(uint16_t ExchangeId, SecureSessionHandle session, bool Initiator,
                                                 ExchangeDelegate * delegate)
 {
     CHIP_FAULT_INJECT(FaultInjection::kFault_AllocExchangeContext, return nullptr);
@@ -153,7 +141,7 @@ ExchangeContext * ExchangeManager::AllocContext(uint16_t ExchangeId, uint64_t Pe
     {
         if (ec.GetReferenceCount() == 0)
         {
-            return ec.Alloc(this, ExchangeId, PeerNodeId, Initiator, delegate);
+            return ec.Alloc(this, ExchangeId, session, Initiator, delegate);
         }
     }
 
@@ -161,8 +149,8 @@ ExchangeContext * ExchangeManager::AllocContext(uint16_t ExchangeId, uint64_t Pe
     return nullptr;
 }
 
-void ExchangeManager::DispatchMessage(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
-                                      System::PacketBufferHandle msgBuf)
+void ExchangeManager::DispatchMessage(SecureSessionHandle session, const PacketHeader & packetHeader,
+                                      const PayloadHeader & payloadHeader, System::PacketBufferHandle msgBuf)
 {
     CHIP_ERROR err                          = CHIP_NO_ERROR;
     UnsolicitedMessageHandler * umh         = nullptr;
@@ -172,7 +160,7 @@ void ExchangeManager::DispatchMessage(const PacketHeader & packetHeader, const P
     // Search for an existing exchange that the message applies to. If a match is found...
     for (auto & ec : mContextPool)
     {
-        if (ec.GetReferenceCount() > 0 && ec.MatchExchange(packetHeader, payloadHeader))
+        if (ec.GetReferenceCount() > 0 && ec.MatchExchange(session, packetHeader, payloadHeader))
         {
             // Found a matching exchange. Set flag for correct subsequent CRMP
             // retransmission timeout selection.
@@ -234,12 +222,11 @@ void ExchangeManager::DispatchMessage(const PacketHeader & packetHeader, const P
         {
             // If rcvd msg is from initiator then this exchange is created as not Initiator.
             // If rcvd msg is not from initiator then this exchange is created as Initiator.
-            ec = AllocContext(payloadHeader.GetExchangeID(), packetHeader.GetSourceNodeId().Value(), !payloadHeader.IsInitiator(),
-                              nullptr);
+            ec = AllocContext(payloadHeader.GetExchangeID(), session, !payloadHeader.IsInitiator(), nullptr);
         }
         else
         {
-            ec = AllocContext(payloadHeader.GetExchangeID(), packetHeader.GetSourceNodeId().Value(), false, matchingUMH->Delegate);
+            ec = AllocContext(payloadHeader.GetExchangeID(), session, false, matchingUMH->Delegate);
         }
 
         VerifyOrExit(ec != nullptr, err = CHIP_ERROR_NO_MEMORY);
@@ -310,17 +297,16 @@ CHIP_ERROR ExchangeManager::UnregisterUMH(uint32_t protocolId, int16_t msgType)
 }
 
 void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
-                                        const Transport::PeerConnectionState * state, System::PacketBufferHandle msgBuf,
-                                        SecureSessionMgr * msgLayer)
+                                        SecureSessionHandle session, System::PacketBufferHandle msgBuf, SecureSessionMgr * msgLayer)
 {
-    DispatchMessage(packetHeader, payloadHeader, std::move(msgBuf));
+    DispatchMessage(session, packetHeader, payloadHeader, std::move(msgBuf));
 }
 
-void ExchangeManager::OnConnectionExpired(const Transport::PeerConnectionState * state, SecureSessionMgr * mgr)
+void ExchangeManager::OnConnectionExpired(SecureSessionHandle session, SecureSessionMgr * mgr)
 {
     for (auto & ec : mContextPool)
     {
-        if (ec.GetReferenceCount() > 0 && ec.GetPeerNodeId() == state->GetPeerNodeId())
+        if (ec.GetReferenceCount() > 0 && ec.mSecureSession == session)
         {
             ec.Close();
             // Continue iterate because there can be multiple contexts associated with the connection.

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -91,20 +91,7 @@ public:
      *  @return   A pointer to the created ExchangeContext object On success. Otherwise NULL if no object
      *            can be allocated or is available.
      */
-    ExchangeContext * NewContext(const NodeId & peerNodeId, ExchangeDelegate * delegate);
-
-    /**
-     *  Find the ExchangeContext from a pool matching a given set of parameters.
-     *
-     *  @param[in]    peerNodeId    The node identifier of the peer with which the ExchangeContext has been set up.
-     *
-     *  @param[in]    delegate      A pointer to ExchangeDelegate.
-     *
-     *  @param[in]    isInitiator   Boolean indicator of whether the local node is the initiator of the exchange.
-     *
-     *  @return   A pointer to the ExchangeContext object matching the provided parameters On success, NULL on no match.
-     */
-    ExchangeContext * FindContext(NodeId peerNodeId, ExchangeDelegate * delegate, bool isInitiator);
+    ExchangeContext * NewContext(SecureSessionHandle session, ExchangeDelegate * delegate);
 
     /**
      *  Register an unsolicited message handler for a given protocol identifier. This handler would be
@@ -195,20 +182,20 @@ private:
     UnsolicitedMessageHandler UMHandlerPool[CHIP_CONFIG_MAX_UNSOLICITED_MESSAGE_HANDLERS];
     void (*OnExchangeContextChanged)(size_t numContextsInUse);
 
-    ExchangeContext * AllocContext(uint16_t ExchangeId, uint64_t PeerNodeId, bool Initiator, ExchangeDelegate * delegate);
+    ExchangeContext * AllocContext(uint16_t ExchangeId, SecureSessionHandle session, bool Initiator, ExchangeDelegate * delegate);
 
-    void DispatchMessage(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader, System::PacketBufferHandle msgBuf);
+    void DispatchMessage(SecureSessionHandle session, const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
+                         System::PacketBufferHandle msgBuf);
 
     CHIP_ERROR RegisterUMH(uint32_t protocolId, int16_t msgType, ExchangeDelegate * delegate);
     CHIP_ERROR UnregisterUMH(uint32_t protocolId, int16_t msgType);
 
     void OnReceiveError(CHIP_ERROR error, const Transport::PeerAddress & source, SecureSessionMgr * msgLayer) override;
 
-    void OnMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
-                           const Transport::PeerConnectionState * state, System::PacketBufferHandle msgBuf,
-                           SecureSessionMgr * msgLayer) override;
+    void OnMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader, SecureSessionHandle session,
+                           System::PacketBufferHandle msgBuf, SecureSessionMgr * msgLayer) override;
 
-    void OnConnectionExpired(const Transport::PeerConnectionState * state, SecureSessionMgr * mgr) override;
+    void OnConnectionExpired(SecureSessionHandle session, SecureSessionMgr * mgr) override;
 };
 
 } // namespace Messaging

--- a/src/messaging/ReliableMessageContext.cpp
+++ b/src/messaging/ReliableMessageContext.cpp
@@ -207,11 +207,6 @@ CHIP_ERROR ReliableMessageContext::FlushAcks()
     return err;
 }
 
-uint64_t ReliableMessageContext::GetPeerNodeId()
-{
-    return (mExchange ? mExchange->GetPeerNodeId() : kUndefinedNodeId);
-}
-
 /**
  *  Get the current retransmit timeout. It would be either the initial or
  *  the active retransmit timeout based on whether the ExchangeContext has

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -64,7 +64,6 @@ public:
     void SetDelegate(ReliableMessageDelegate * delegate) { mDelegate = delegate; }
 
     CHIP_ERROR FlushAcks();
-    uint64_t GetPeerNodeId();
     uint64_t GetCurrentRetransmitTimeoutTick();
 
     CHIP_ERROR SendStandaloneAckMessage();

--- a/src/messaging/ReliableMessageManager.cpp
+++ b/src/messaging/ReliableMessageManager.cpp
@@ -399,7 +399,8 @@ CHIP_ERROR ReliableMessageManager::SendFromRetransTable(RetransTableEntry * entr
 
     if (rc)
     {
-        err = mSessionMgr->SendEncryptedMessage(std::move(entry->retainedBuf), &entry->retainedBuf);
+        err = mSessionMgr->SendEncryptedMessage(entry->rc->mExchange->GetSecureSession(), std::move(entry->retainedBuf),
+                                                &entry->retainedBuf);
 
         if (err == CHIP_NO_ERROR)
         {

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -102,6 +102,27 @@ void CheckSimpleInitTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
+class TestSessMgrCallback : public SecureSessionMgrDelegate
+{
+public:
+    void OnMessageReceived(const PacketHeader & header, const PayloadHeader & payloadHeader, SecureSessionHandle session,
+                           System::PacketBufferHandle msgBuf, SecureSessionMgr * mgr) override
+    {
+        ReceiveHandlerCallCount++;
+    }
+
+    void OnNewConnection(SecureSessionHandle session, SecureSessionMgr * mgr) override
+    {
+        mSecureSession = session;
+        NewConnectionHandlerCallCount++;
+    }
+    void OnConnectionExpired(SecureSessionHandle session, SecureSessionMgr * mgr) override {}
+
+    SecureSessionHandle mSecureSession;
+    int ReceiveHandlerCallCount       = 0;
+    int NewConnectionHandlerCallCount = 0;
+};
+
 void CheckNewContextTest(nlTestSuite * inSuite, void * inContext)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
@@ -110,6 +131,23 @@ void CheckNewContextTest(nlTestSuite * inSuite, void * inContext)
     SecureSessionMgr secureSessionMgr;
     CHIP_ERROR err;
 
+    TestSessMgrCallback callback;
+    secureSessionMgr.SetDelegate(&callback);
+
+    IPAddress addr;
+    IPAddress::FromString("127.0.0.1", addr);
+    SecurePairingUsingTestSecret pairing1(Optional<NodeId>::Value(kSourceNodeId), 1, 2);
+    Optional<Transport::PeerAddress> peer1(Transport::PeerAddress::UDP(addr, 1));
+    err = secureSessionMgr.NewPairing(peer1, kDestinationNodeId, &pairing1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    SecureSessionHandle sessionFromSourceToDestination = callback.mSecureSession;
+
+    SecurePairingUsingTestSecret pairing2(Optional<NodeId>::Value(kDestinationNodeId), 2, 1);
+    Optional<Transport::PeerAddress> peer2(Transport::PeerAddress::UDP(addr, 2));
+    err = secureSessionMgr.NewPairing(peer2, kSourceNodeId, &pairing2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    SecureSessionHandle sessionFromDestinationToSource = callback.mSecureSession;
+
     ctx.GetInetLayer().SystemLayer()->Init(nullptr);
 
     err = transportMgr.Init("LOOPBACK");
@@ -123,48 +161,17 @@ void CheckNewContextTest(nlTestSuite * inSuite, void * inContext)
 
     MockAppDelegate mockAppDelegate;
 
-    ExchangeContext * ec1 = exchangeMgr.NewContext(kSourceNodeId, &mockAppDelegate);
+    ExchangeContext * ec1 = exchangeMgr.NewContext(sessionFromDestinationToSource, &mockAppDelegate);
     NL_TEST_ASSERT(inSuite, ec1 != nullptr);
     NL_TEST_ASSERT(inSuite, ec1->IsInitiator() == true);
     NL_TEST_ASSERT(inSuite, ec1->GetExchangeId() != 0);
-    NL_TEST_ASSERT(inSuite, ec1->GetPeerNodeId() == kSourceNodeId);
+    NL_TEST_ASSERT(inSuite, ec1->GetSecureSession() == sessionFromDestinationToSource);
     NL_TEST_ASSERT(inSuite, ec1->GetDelegate() == &mockAppDelegate);
 
-    ExchangeContext * ec2 = exchangeMgr.NewContext(kDestinationNodeId, &mockAppDelegate);
+    ExchangeContext * ec2 = exchangeMgr.NewContext(sessionFromSourceToDestination, &mockAppDelegate);
     NL_TEST_ASSERT(inSuite, ec2 != nullptr);
     NL_TEST_ASSERT(inSuite, ec2->GetExchangeId() > ec1->GetExchangeId());
-    NL_TEST_ASSERT(inSuite, ec2->GetPeerNodeId() == kDestinationNodeId);
-}
-
-void CheckFindContextTest(nlTestSuite * inSuite, void * inContext)
-{
-    TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
-
-    TransportMgr<LoopbackTransport> transportMgr;
-    SecureSessionMgr secureSessionMgr;
-    CHIP_ERROR err;
-
-    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
-
-    err = transportMgr.Init("LOOPBACK");
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    err = secureSessionMgr.Init(kSourceNodeId, ctx.GetInetLayer().SystemLayer(), &transportMgr);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    ExchangeManager exchangeMgr;
-    err = exchangeMgr.Init(&secureSessionMgr);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    MockAppDelegate mockAppDelegate;
-
-    ExchangeContext * ec = exchangeMgr.NewContext(kDestinationNodeId, &mockAppDelegate);
-    NL_TEST_ASSERT(inSuite, ec != nullptr);
-
-    bool result = exchangeMgr.FindContext(kDestinationNodeId, &mockAppDelegate, true);
-    NL_TEST_ASSERT(inSuite, result == true);
-
-    result = exchangeMgr.FindContext(kDestinationNodeId, nullptr, false);
-    NL_TEST_ASSERT(inSuite, result == false);
+    NL_TEST_ASSERT(inSuite, ec2->GetSecureSession() == sessionFromSourceToDestination);
 }
 
 void CheckUmhRegistrationTest(nlTestSuite * inSuite, void * inContext)
@@ -210,12 +217,26 @@ void CheckUmhRegistrationTest(nlTestSuite * inSuite, void * inContext)
 void CheckExchangeMessages(nlTestSuite * inSuite, void * inContext)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
-    CHIP_ERROR err;
 
     TransportMgr<LoopbackTransport> transportMgr;
     SecureSessionMgr secureSessionMgr;
+    CHIP_ERROR err;
+
+    TestSessMgrCallback callback;
+    secureSessionMgr.SetDelegate(&callback);
+
     IPAddress addr;
     IPAddress::FromString("127.0.0.1", addr);
+    SecurePairingUsingTestSecret pairing1(Optional<NodeId>::Value(kSourceNodeId), 1, 2);
+    Optional<Transport::PeerAddress> peer1(Transport::PeerAddress::UDP(addr, 1));
+    err = secureSessionMgr.NewPairing(peer1, kDestinationNodeId, &pairing1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    SecureSessionHandle sessionFromSourceToDestination = callback.mSecureSession;
+
+    SecurePairingUsingTestSecret pairing2(Optional<NodeId>::Value(kDestinationNodeId), 2, 1);
+    Optional<Transport::PeerAddress> peer2(Transport::PeerAddress::UDP(addr, 2));
+    err = secureSessionMgr.NewPairing(peer2, kSourceNodeId, &pairing2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     ctx.GetInetLayer().SystemLayer()->Init(nullptr);
 
@@ -228,18 +249,9 @@ void CheckExchangeMessages(nlTestSuite * inSuite, void * inContext)
     err = exchangeMgr.Init(&secureSessionMgr);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    SecurePairingUsingTestSecret pairing1(Optional<NodeId>::Value(kSourceNodeId), 1, 2);
-    Optional<Transport::PeerAddress> peer1(Transport::PeerAddress::UDP(addr, 1));
-    err = secureSessionMgr.NewPairing(peer1, kSourceNodeId, &pairing1);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    SecurePairingUsingTestSecret pairing2(Optional<NodeId>::Value(kDestinationNodeId), 2, 1);
-    Optional<Transport::PeerAddress> peer2(Transport::PeerAddress::UDP(addr, 2));
-    err = secureSessionMgr.NewPairing(peer2, kDestinationNodeId, &pairing2);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
     // create solicited exchange
     MockAppDelegate mockSolicitedAppDelegate;
-    ExchangeContext * ec1 = exchangeMgr.NewContext(kDestinationNodeId, &mockSolicitedAppDelegate);
+    ExchangeContext * ec1 = exchangeMgr.NewContext(sessionFromSourceToDestination, &mockSolicitedAppDelegate);
 
     // create unsolicited exchange
     MockAppDelegate mockUnsolicitedAppDelegate;
@@ -264,7 +276,6 @@ const nlTest sTests[] =
 {
     NL_TEST_DEF("Test ExchangeMgr::Init",                     CheckSimpleInitTest),
     NL_TEST_DEF("Test ExchangeMgr::NewContext",               CheckNewContextTest),
-    NL_TEST_DEF("Test ExchangeMgr::FindContext",              CheckFindContextTest),
     NL_TEST_DEF("Test ExchangeMgr::CheckUmhRegistrationTest", CheckUmhRegistrationTest),
     NL_TEST_DEF("Test ExchangeMgr::CheckExchangeMessages",    CheckExchangeMessages),
 

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -146,7 +146,8 @@ void CheckAddClearRetrans(nlTestSuite * inSuite, void * inContext)
 
     MockAppDelegate mockAppDelegate;
 
-    ExchangeContext * exchange = exchangeMgr.NewContext(kDestinationNodeId, &mockAppDelegate);
+    // TODO: temprary create a SecureSessionHandle from node id, will be fix in PR 3602
+    ExchangeContext * exchange = exchangeMgr.NewContext({ kDestinationNodeId, kAnyKeyId }, &mockAppDelegate);
     NL_TEST_ASSERT(inSuite, exchange != nullptr);
 
     ReliableMessageManager * rm = exchangeMgr.GetReliableMessageMgr();
@@ -183,7 +184,8 @@ void CheckFailRetrans(nlTestSuite * inSuite, void * inContext)
 
     MockAppDelegate mockAppDelegate;
 
-    ExchangeContext * exchange = exchangeMgr.NewContext(kDestinationNodeId, &mockAppDelegate);
+    // TODO: temprary create a SecureSessionHandle from node id, will be fix in PR 3602
+    ExchangeContext * exchange = exchangeMgr.NewContext({ kDestinationNodeId, kAnyKeyId }, &mockAppDelegate);
     NL_TEST_ASSERT(inSuite, exchange != nullptr);
 
     ReliableMessageManager * rm = exchangeMgr.GetReliableMessageMgr();
@@ -244,7 +246,8 @@ void CheckResendMessage(nlTestSuite * inSuite, void * inContext)
 
     MockAppDelegate mockSender;
 
-    ExchangeContext * exchange = exchangeMgr.NewContext(kDestinationNodeId, &mockSender);
+    // TODO: temprary create a SecureSessionHandle from node id, will be fix in PR 3602
+    ExchangeContext * exchange = exchangeMgr.NewContext({ kDestinationNodeId, kAnyKeyId }, &mockSender);
     NL_TEST_ASSERT(inSuite, exchange != nullptr);
 
     ReliableMessageManager * rm = exchangeMgr.GetReliableMessageMgr();

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -101,7 +101,7 @@ CHIP_ERROR SendEchoRequest(void)
 
     printf("\nSend echo request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
 
-    err = gEchoClient.SendEchoRequest(chip::kTestDeviceNodeId, std::move(payloadBuf));
+    err = gEchoClient.SendEchoRequest(std::move(payloadBuf));
 
     if (err == CHIP_NO_ERROR)
     {
@@ -143,7 +143,7 @@ exit:
     return err;
 }
 
-void HandleEchoResponseReceived(chip::NodeId nodeId, chip::System::PacketBufferHandle payload)
+void HandleEchoResponseReceived(chip::Messaging::ExchangeContext * ec, chip::System::PacketBufferHandle payload)
 {
     uint32_t respTime    = chip::System::Timer::GetCurrentEpoch();
     uint32_t transitTime = respTime - gLastEchoTime;
@@ -151,10 +151,17 @@ void HandleEchoResponseReceived(chip::NodeId nodeId, chip::System::PacketBufferH
     gWaitingForEchoResp = false;
     gEchoRespCount++;
 
-    printf("Echo Response from node %" PRIu64 ": %" PRIu64 "/%" PRIu64 "(%.2f%%) len=%u time=%.3fms\n", nodeId, gEchoRespCount,
-           gEchoCount, static_cast<double>(gEchoRespCount) * 100 / gEchoCount, payload->DataLength(),
-           static_cast<double>(transitTime) / 1000);
+    printf("Echo Response: %" PRIu64 "/%" PRIu64 "(%.2f%%) len=%u time=%.3fms\n", gEchoRespCount, gEchoCount,
+           static_cast<double>(gEchoRespCount) * 100 / gEchoCount, payload->DataLength(), static_cast<double>(transitTime) / 1000);
 }
+
+class TestSecureSessionMgrDelegate : public chip::SecureSessionMgrDelegate
+{
+public:
+    void OnNewConnection(chip::SecureSessionHandle session, chip::SecureSessionMgr * mgr) override { mSecureSession = session; }
+
+    chip::SecureSessionHandle mSecureSession;
+} gTestSecureSessionMgrDelegate;
 
 } // namespace
 
@@ -184,18 +191,20 @@ int main(int argc, char * argv[])
     err = gSessionManager.Init(chip::kTestControllerNodeId, &chip::DeviceLayer::SystemLayer, &gTransportManager);
     SuccessOrExit(err);
 
+    gSessionManager.SetDelegate(&gTestSecureSessionMgrDelegate);
+
     err = gExchangeManager.Init(&gSessionManager);
     SuccessOrExit(err);
-
-    err = gEchoClient.Init(&gExchangeManager);
-    SuccessOrExit(err);
-
-    // Arrange to get a callback whenever an Echo Response is received.
-    gEchoClient.SetEchoResponseReceived(HandleEchoResponseReceived);
 
     // Start the CHIP connection to the CHIP echo responder.
     err = EstablishSecureSession();
     SuccessOrExit(err);
+
+    err = gEchoClient.Init(&gExchangeManager, gTestSecureSessionMgrDelegate.mSecureSession);
+    SuccessOrExit(err);
+
+    // Arrange to get a callback whenever an Echo Response is received.
+    gEchoClient.SetEchoResponseReceived(HandleEchoResponseReceived);
 
     // Connection has been established. Now send the EchoRequests.
     for (unsigned int i = 0; i < kMaxEchoCount; i++)

--- a/src/messaging/tests/echo/echo_responder.cpp
+++ b/src/messaging/tests/echo/echo_responder.cpp
@@ -47,9 +47,9 @@ chip::SecureSessionMgr gSessionManager;
 chip::SecurePairingUsingTestSecret gTestPairing;
 
 // Callback handler when a CHIP EchoRequest is received.
-void HandleEchoRequestReceived(chip::NodeId nodeId, chip::System::PacketBufferHandle payload)
+void HandleEchoRequestReceived(chip::Messaging::ExchangeContext * ec, chip::System::PacketBufferHandle payload)
 {
-    printf("Echo Request from node %" PRIu64 ", len=%u ... sending response.\n", nodeId, payload->DataLength());
+    printf("Echo Request, len=%u ... sending response.\n", payload->DataLength());
 }
 
 } // namespace

--- a/src/protocols/echo/Echo.h
+++ b/src/protocols/echo/Echo.h
@@ -43,11 +43,12 @@ enum
     kEchoMessageType_EchoResponse = 2
 };
 
-typedef void (*EchoFunct)(NodeId nodeId, System::PacketBufferHandle payload);
+using EchoFunct = void (*)(Messaging::ExchangeContext * ec, System::PacketBufferHandle payload);
 
 class DLL_EXPORT EchoClient : public Messaging::ExchangeDelegate
 {
 public:
+    // TODO: Init function will take a Channel instead a SecureSessionHandle, when Channel API is ready
     /**
      *  Initialize the EchoClient object. Within the lifetime
      *  of this instance, this method is invoked once after object
@@ -55,13 +56,14 @@ public:
      *  instance.
      *
      *  @param[in]    exchangeMgr    A pointer to the ExchangeManager object.
+     *  @param[in]    sessoin        A handle to the session.
      *
      *  @retval #CHIP_ERROR_INCORRECT_STATE If the state is not equal to
      *          kState_NotInitialized.
      *  @retval #CHIP_NO_ERROR On success.
      *
      */
-    CHIP_ERROR Init(Messaging::ExchangeManager * exchangeMgr);
+    CHIP_ERROR Init(Messaging::ExchangeManager * exchangeMgr, SecureSessionHandle session);
 
     /**
      *  Shutdown the EchoClient. This terminates this instance
@@ -88,14 +90,14 @@ public:
      *         Other CHIP_ERROR codes as returned by the lower layers.
      *
      */
-    CHIP_ERROR SendEchoRequest(NodeId nodeId, System::PacketBufferHandle payload);
+    CHIP_ERROR SendEchoRequest(System::PacketBufferHandle payload);
 
 private:
     Messaging::ExchangeManager * mExchangeMgr = nullptr;
     Messaging::ExchangeContext * mExchangeCtx = nullptr;
     EchoFunct OnEchoResponseReceived          = nullptr;
+    SecureSessionHandle mSecureSession;
 
-    CHIP_ERROR SendEchoRequest(System::PacketBufferHandle payload);
     void OnMessageReceived(Messaging::ExchangeContext * ec, const PacketHeader & packetHeader, uint32_t protocolId, uint8_t msgType,
                            System::PacketBufferHandle payload) override;
     void OnResponseTimeout(Messaging::ExchangeContext * ec) override;

--- a/src/protocols/echo/EchoClient.cpp
+++ b/src/protocols/echo/EchoClient.cpp
@@ -28,13 +28,14 @@
 namespace chip {
 namespace Protocols {
 
-CHIP_ERROR EchoClient::Init(Messaging::ExchangeManager * exchangeMgr)
+CHIP_ERROR EchoClient::Init(Messaging::ExchangeManager * exchangeMgr, SecureSessionHandle session)
 {
     // Error if already initialized.
     if (mExchangeMgr != nullptr)
         return CHIP_ERROR_INCORRECT_STATE;
 
     mExchangeMgr           = exchangeMgr;
+    mSecureSession         = session;
     OnEchoResponseReceived = nullptr;
     mExchangeCtx           = nullptr;
 
@@ -50,8 +51,10 @@ void EchoClient::Shutdown()
     }
 }
 
-CHIP_ERROR EchoClient::SendEchoRequest(NodeId nodeId, System::PacketBufferHandle payload)
+CHIP_ERROR EchoClient::SendEchoRequest(System::PacketBufferHandle payload)
 {
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
     // Discard any existing exchange context. Effectively we can only have one Echo exchange with
     // a single node at any one time.
     if (mExchangeCtx != nullptr)
@@ -61,18 +64,11 @@ CHIP_ERROR EchoClient::SendEchoRequest(NodeId nodeId, System::PacketBufferHandle
     }
 
     // Create a new exchange context.
-    mExchangeCtx = mExchangeMgr->NewContext(nodeId, this);
+    mExchangeCtx = mExchangeMgr->NewContext(mSecureSession, this);
     if (mExchangeCtx == nullptr)
     {
         return CHIP_ERROR_NO_MEMORY;
     }
-
-    return SendEchoRequest(std::move(payload));
-}
-
-CHIP_ERROR EchoClient::SendEchoRequest(System::PacketBufferHandle payload)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
 
     // Send an Echo Request message.  Discard the exchange context if the send fails.
     err = mExchangeCtx->SendMessage(kProtocol_Echo, kEchoMessageType_EchoRequest, std::move(payload),
@@ -115,13 +111,13 @@ void EchoClient::OnMessageReceived(Messaging::ExchangeContext * ec, const Packet
     // Call the registered OnEchoResponseReceived handler, if any.
     if (OnEchoResponseReceived != nullptr)
     {
-        OnEchoResponseReceived(packetHeader.GetSourceNodeId().ValueOr(0), std::move(payload));
+        OnEchoResponseReceived(ec, std::move(payload));
     }
 }
 
 void EchoClient::OnResponseTimeout(Messaging::ExchangeContext * ec)
 {
-    ChipLogProgress(Echo, "Time out! failed to receive echo response from Node: %llu", ec->GetPeerNodeId());
+    ChipLogProgress(Echo, "Time out! failed to receive echo response from Exchange: %p", ec);
 }
 
 } // namespace Protocols

--- a/src/protocols/echo/EchoServer.cpp
+++ b/src/protocols/echo/EchoServer.cpp
@@ -64,7 +64,7 @@ void EchoServer::OnMessageReceived(Messaging::ExchangeContext * ec, const Packet
     if (OnEchoRequestReceived != nullptr)
     {
         response = payload.Retain();
-        OnEchoRequestReceived(ec->GetPeerNodeId(), std::move(payload));
+        OnEchoRequestReceived(ec, std::move(payload));
     }
     else
     {

--- a/src/transport/PeerConnections.h
+++ b/src/transport/PeerConnections.h
@@ -24,6 +24,11 @@
 namespace chip {
 namespace Transport {
 
+// TODO; use 0xffff to match any key id, this is a temporary solution for
+// InteractionModel, where key id is not obtainable. This will be removed when
+// InteractionModel is migrated to messaging layer
+constexpr const uint16_t kAnyKeyId = 0xffff;
+
 /**
  * Handles a set of peer connection states.
  *
@@ -219,7 +224,7 @@ public:
             {
                 continue;
             }
-            if (iter->GetPeerKeyID() == peerKeyId)
+            if (peerKeyId == kAnyKeyId || iter->GetPeerKeyID() == peerKeyId)
             {
                 if (!nodeId.HasValue() || iter->GetPeerNodeId() == kUndefinedNodeId || iter->GetPeerNodeId() == nodeId.Value())
                 {

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -93,21 +93,21 @@ Transport::Type SecureSessionMgr::GetTransportType(NodeId peerNodeId)
     return Transport::Type::kUndefined;
 }
 
-CHIP_ERROR SecureSessionMgr::SendMessage(NodeId peerNodeId, System::PacketBufferHandle msgBuf)
+CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, System::PacketBufferHandle msgBuf)
 {
     PayloadHeader unusedPayloadHeader;
-    return SendMessage(unusedPayloadHeader, peerNodeId, std::move(msgBuf));
+    return SendMessage(session, unusedPayloadHeader, std::move(msgBuf));
 }
 
-CHIP_ERROR SecureSessionMgr::SendMessage(PayloadHeader & payloadHeader, NodeId peerNodeId, System::PacketBufferHandle msgBuf,
-                                         EncryptedPacketBufferHandle * bufferRetainSlot)
+CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, PayloadHeader & payloadHeader,
+                                         System::PacketBufferHandle msgBuf, EncryptedPacketBufferHandle * bufferRetainSlot)
 {
     PacketHeader ununsedPacketHeader;
-    return SendMessage(payloadHeader, ununsedPacketHeader, peerNodeId, std::move(msgBuf), bufferRetainSlot,
+    return SendMessage(session, payloadHeader, ununsedPacketHeader, std::move(msgBuf), bufferRetainSlot,
                        EncryptionState::kPayloadIsUnencrypted);
 }
 
-CHIP_ERROR SecureSessionMgr::SendEncryptedMessage(EncryptedPacketBufferHandle msgBuf,
+CHIP_ERROR SecureSessionMgr::SendEncryptedMessage(SecureSessionHandle session, EncryptedPacketBufferHandle msgBuf,
                                                   EncryptedPacketBufferHandle * bufferRetainSlot)
 {
     VerifyOrReturnError(!msgBuf.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
@@ -116,19 +116,16 @@ CHIP_ERROR SecureSessionMgr::SendEncryptedMessage(EncryptedPacketBufferHandle ms
     PacketHeader packetHeader;
     ReturnErrorOnFailure(packetHeader.Decode(msgBuf->Start(), msgBuf->DataLength(), &headerSize));
 
-    VerifyOrReturnError(packetHeader.GetDestinationNodeId().HasValue(), CHIP_ERROR_INVALID_DESTINATION_NODE_ID);
-    NodeId peerNodeId = packetHeader.GetDestinationNodeId().Value();
-
     // Advancing the start to encrypted header, since the transport will attach the packet header on top of it
     msgBuf->SetStart(msgBuf->Start() + headerSize);
 
     PayloadHeader payloadHeader;
-    return SendMessage(payloadHeader, packetHeader, peerNodeId, std::move(msgBuf), bufferRetainSlot,
+    return SendMessage(session, payloadHeader, packetHeader, std::move(msgBuf), bufferRetainSlot,
                        EncryptionState::kPayloadIsEncrypted);
 }
 
 CHIP_ERROR SecureSessionMgr::EncryptPayload(Transport::PeerConnectionState * state, PayloadHeader & payloadHeader,
-                                            PacketHeader & packetHeader, NodeId peerNodeId, System::PacketBufferHandle & msgBuf)
+                                            PacketHeader & packetHeader, System::PacketBufferHandle & msgBuf)
 {
     CHIP_ERROR err         = CHIP_NO_ERROR;
     uint8_t * data         = nullptr;
@@ -148,10 +145,10 @@ CHIP_ERROR SecureSessionMgr::EncryptPayload(Transport::PeerConnectionState * sta
     VerifyOrExit(CanCastTo<uint16_t>(payloadLength), err = CHIP_ERROR_NO_MEMORY);
 
     packetHeader
-        .SetSourceNodeId(mLocalNodeId)              //
-        .SetDestinationNodeId(peerNodeId)           //
-        .SetMessageId(msgId)                        //
-        .SetEncryptionKeyID(state->GetLocalKeyID()) //
+        .SetSourceNodeId(mLocalNodeId)                //
+        .SetDestinationNodeId(state->GetPeerNodeId()) //
+        .SetMessageId(msgId)                          //
+        .SetEncryptionKeyID(state->GetLocalKeyID())   //
         .SetPayloadLength(static_cast<uint16_t>(payloadLength));
     packetHeader.GetFlags().Set(Header::FlagValues::kSecure);
 
@@ -188,7 +185,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR SecureSessionMgr::SendMessage(PayloadHeader & payloadHeader, PacketHeader & packetHeader, NodeId peerNodeId,
+CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, PayloadHeader & payloadHeader, PacketHeader & packetHeader,
                                          System::PacketBufferHandle msgBuf, EncryptedPacketBufferHandle * bufferRetainSlot,
                                          EncryptionState encryptionState)
 {
@@ -210,15 +207,15 @@ CHIP_ERROR SecureSessionMgr::SendMessage(PayloadHeader & payloadHeader, PacketHe
     VerifyOrExit(msgBuf->TotalLength() < kMax_SecureSDU_Length, err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
 
     // Find an active connection to the specified peer node
-    state = mPeerConnections.FindPeerConnectionState(peerNodeId, nullptr);
-    VerifyOrExit(state != nullptr, err = CHIP_ERROR_INVALID_DESTINATION_NODE_ID);
+    state = GetPeerConnectionState(session);
+    VerifyOrExit(state != nullptr, err = CHIP_ERROR_NOT_CONNECTED);
 
     // This marks any connection where we send data to as 'active'
     mPeerConnections.MarkConnectionActive(state);
 
     if (encryptionState == EncryptionState::kPayloadIsUnencrypted)
     {
-        err = EncryptPayload(state, payloadHeader, packetHeader, peerNodeId, msgBuf);
+        err = EncryptPayload(state, payloadHeader, packetHeader, msgBuf);
         SuccessOrExit(err);
     }
 
@@ -234,7 +231,7 @@ CHIP_ERROR SecureSessionMgr::SendMessage(PayloadHeader & payloadHeader, PacketHe
     encryptedMsg        = msgBuf.Retain();
     encryptedMsg.mMsgId = packetHeader.GetMessageId();
 
-    ChipLogProgress(Inet, "Sending msg from %llu to %llu", mLocalNodeId, peerNodeId);
+    ChipLogProgress(Inet, "Sending msg from %llu to %llu", mLocalNodeId, state->GetPeerNodeId());
 
     err = mTransportMgr->SendMessage(packetHeader, state->GetPeerAddress(), std::move(msgBuf));
     SuccessOrExit(err);
@@ -298,6 +295,10 @@ CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> &
     {
         err = pairing->DeriveSecureSession(reinterpret_cast<const uint8_t *>(kSpake2pI2RSessionInfo),
                                            strlen(kSpake2pI2RSessionInfo), state->GetSecureSession());
+        if (mCB != nullptr)
+        {
+            mCB->OnNewConnection({ state->GetPeerNodeId(), state->GetPeerKeyID() }, this);
+        }
     }
 
     return err;
@@ -391,7 +392,8 @@ void SecureSessionMgr::OnMessageReceived(const PacketHeader & packetHeader, cons
 
         if (mCB != nullptr)
         {
-            mCB->OnMessageReceived(packetHeader, payloadHeader, state, std::move(msg), this);
+            mCB->OnMessageReceived(packetHeader, payloadHeader, { state->GetPeerNodeId(), state->GetPeerKeyID() }, std::move(msg),
+                                   this);
         }
     }
 
@@ -411,7 +413,7 @@ void SecureSessionMgr::HandleConnectionExpired(const Transport::PeerConnectionSt
 
     if (mCB != nullptr)
     {
-        mCB->OnConnectionExpired(&state, this);
+        mCB->OnConnectionExpired({ state.GetPeerNodeId(), state.GetPeerKeyID() }, this);
     }
 
     mTransportMgr->Disconnect(state.GetPeerAddress());
@@ -428,6 +430,11 @@ void SecureSessionMgr::ExpiryTimerCallback(System::Layer * layer, void * param, 
         [this](const Transport::PeerConnectionState & state1) { HandleConnectionExpired(state1); });
 #endif
     mgr->ScheduleExpiryTimer(); // re-schedule the oneshot timer
+}
+
+PeerConnectionState * SecureSessionMgr::GetPeerConnectionState(SecureSessionHandle session)
+{
+    return mPeerConnections.FindPeerConnectionState(Optional<NodeId>::Value(session.mPeerNodeId), session.mPeerKeyId, nullptr);
 }
 
 } // namespace chip

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -45,6 +45,23 @@ namespace chip {
 
 class SecureSessionMgr;
 
+class SecureSessionHandle
+{
+public:
+    SecureSessionHandle() : mPeerNodeId(kAnyNodeId), mPeerKeyId(0) {}
+    SecureSessionHandle(NodeId peerNodeId, uint16_t peerKeyId) : mPeerNodeId(peerNodeId), mPeerKeyId(peerKeyId) {}
+
+    bool operator==(const SecureSessionHandle & that) const
+    {
+        return mPeerNodeId == that.mPeerNodeId && mPeerKeyId == that.mPeerKeyId;
+    }
+
+private:
+    friend class SecureSessionMgr;
+    NodeId mPeerNodeId;
+    uint16_t mPeerKeyId;
+};
+
 /**
  * @brief
  *  Tracks ownership of a encrypted PacketBuffer.
@@ -109,13 +126,12 @@ public:
      *
      * @param packetHeader  The message header
      * @param payloadHeader The payload header
-     * @param state         The connection state
+     * @param session       The handle to the secure session
      * @param msgBuf        The received message
      * @param mgr           A pointer to the SecureSessionMgr
      */
     virtual void OnMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
-                                   const Transport::PeerConnectionState * state, System::PacketBufferHandle msgBuf,
-                                   SecureSessionMgr * mgr)
+                                   SecureSessionHandle session, System::PacketBufferHandle msgBuf, SecureSessionMgr * mgr)
     {}
 
     /**
@@ -132,19 +148,19 @@ public:
      * @brief
      *   Called when a new pairing is being established
      *
-     * @param state   connection state
+     * @param session The handle to the secure session
      * @param mgr     A pointer to the SecureSessionMgr
      */
-    virtual void OnNewConnection(const Transport::PeerConnectionState * state, SecureSessionMgr * mgr) {}
+    virtual void OnNewConnection(SecureSessionHandle session, SecureSessionMgr * mgr) {}
 
     /**
      * @brief
      *   Called when a new connection is closing
      *
-     * @param state   connection state
+     * @param session The handle to the secure session
      * @param mgr     A pointer to the SecureSessionMgr
      */
-    virtual void OnConnectionExpired(const Transport::PeerConnectionState * state, SecureSessionMgr * mgr) {}
+    virtual void OnConnectionExpired(SecureSessionHandle session, SecureSessionMgr * mgr) {}
 
     virtual ~SecureSessionMgrDelegate() {}
 };
@@ -164,10 +180,13 @@ public:
      *   returns success, the encrypted data that was sent, as well as various other information needed
      *   to retransmit it, will be stored in *bufferRetainSlot.
      */
-    CHIP_ERROR SendMessage(NodeId peerNodeId, System::PacketBufferHandle msgBuf);
-    CHIP_ERROR SendMessage(PayloadHeader & payloadHeader, NodeId peerNodeId, System::PacketBufferHandle msgBuf,
+    CHIP_ERROR SendMessage(SecureSessionHandle session, System::PacketBufferHandle msgBuf);
+    CHIP_ERROR SendMessage(SecureSessionHandle session, PayloadHeader & payloadHeader, System::PacketBufferHandle msgBuf,
                            EncryptedPacketBufferHandle * bufferRetainSlot = nullptr);
-    CHIP_ERROR SendEncryptedMessage(EncryptedPacketBufferHandle msgBuf, EncryptedPacketBufferHandle * bufferRetainSlot);
+    CHIP_ERROR SendEncryptedMessage(SecureSessionHandle session, EncryptedPacketBufferHandle msgBuf,
+                                    EncryptedPacketBufferHandle * bufferRetainSlot);
+
+    Transport::PeerConnectionState * GetPeerConnectionState(SecureSessionHandle session);
 
     /**
      * @brief
@@ -250,9 +269,9 @@ private:
     TransportMgrBase * mTransportMgr = nullptr;
 
     CHIP_ERROR EncryptPayload(Transport::PeerConnectionState * state, PayloadHeader & payloadHeader, PacketHeader & packetHeader,
-                              NodeId peerNodeId, System::PacketBufferHandle & msgBuf);
+                              System::PacketBufferHandle & msgBuf);
 
-    CHIP_ERROR SendMessage(PayloadHeader & payloadHeader, PacketHeader & packetHeader, NodeId peerNodeId,
+    CHIP_ERROR SendMessage(SecureSessionHandle session, PayloadHeader & payloadHeader, PacketHeader & packetHeader,
                            System::PacketBufferHandle msgBuf, EncryptedPacketBufferHandle * bufferRetainSlot,
                            EncryptionState encryptionState);
 


### PR DESCRIPTION
 #### Problem
Currently `SecureSessionMgrBase::SendMessage` takes a `PeerNodeId` as key to find proper `PeerConnectionState`, but is way may causing unexpected behavior. For example.
 * If there are multiple connection to the same node, there is no way to specify which connection to use,
 * When switching a connection (SPAKE -> SIGMA, or SIGMA -> SPAKE), the application can not aware the change, and mistakenly send messages to wrong channel.
 * The ACL permission information is associated with a certification, which is used to initialized the connection, the connection derives access permission from it. So we should use connection as key to verify permission. Using node id is insecure and may cause potential security flaws.

 #### Summary of Changes
1. `SecureSessionMgrBase::SendMessage` take a `Transport::PeerConnectionState *` instead of `PeerNodeId`
2. Enable `SecureSessionMgrDelegate::OnNewConnection` so that upper components can receive a `PeerConnectionState` object
3. Add `SecureSessionMgrDelegate::OnConnectionExpired` callback, so upper components can acknowledge that the connection has been released.