### PR TITLE
[EFR]Add the implementation for _ProvisionThreadNetwork for efr platforms

### DIFF
--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -228,6 +228,7 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
         "EFR32/ConfigurationManagerImpl.h",
         "EFR32/ConnectivityManagerImpl.cpp",
         "EFR32/ConnectivityManagerImpl.h",
+        "EFR32/DeviceNetworkProvisioningDelegateImpl.cpp",
         "EFR32/DeviceNetworkProvisioningDelegateImpl.h",
         "EFR32/EFR32Config.cpp",
         "EFR32/EFR32Config.h",

--- a/src/platform/EFR32/DeviceNetworkProvisioningDelegateImpl.cpp
+++ b/src/platform/EFR32/DeviceNetworkProvisioningDelegateImpl.cpp
@@ -15,29 +15,29 @@
  *    limitations under the License.
  */
 
-#pragma once
+#include "DeviceNetworkProvisioningDelegateImpl.h"
 
-#include <platform/internal/GenericDeviceNetworkProvisioningDelegateImpl.h>
+#if CHIP_ENABLE_OPENTHREAD
+#include <platform/ThreadStackManager.h>
+#endif
 
 namespace chip {
 namespace DeviceLayer {
 
-namespace Internal {
-
-template <class ImplClass>
-class GenericDeviceNetworkProvisioningDelegateImpl;
-
-} // namespace Internal
-
-class DeviceNetworkProvisioningDelegateImpl final
-    : public Internal::GenericDeviceNetworkProvisioningDelegateImpl<DeviceNetworkProvisioningDelegateImpl>
+CHIP_ERROR DeviceNetworkProvisioningDelegateImpl::_ProvisionThreadNetwork(DeviceLayer::Internal::DeviceNetworkInfo & threadData)
 {
-    friend class GenericDeviceNetworkProvisioningDelegateImpl<DeviceNetworkProvisioningDelegateImpl>;
+#if CHIP_ENABLE_OPENTHREAD
+    CHIP_ERROR error = CHIP_NO_ERROR;
 
-private:
-    CHIP_ERROR _ProvisionWiFiNetwork(const char * ssid, const char * passwd) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _ProvisionThreadNetwork(DeviceLayer::Internal::DeviceNetworkInfo & threadData);
-};
+    SuccessOrExit(error = ThreadStackMgr().SetThreadEnabled(false));
+    SuccessOrExit(error = ThreadStackMgr().SetThreadProvision(threadData));
+    SuccessOrExit(error = ThreadStackMgr().SetThreadEnabled(true));
+exit:
+    return error;
+#else
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+#endif // CHIP_ENABLE_OPENTHREAD
+}
 
 } // namespace DeviceLayer
 } // namespace chip


### PR DESCRIPTION
 #### Problem
The BLE thread network provisionning fails with error **CHIP_ERROR_NOT_IMPLEMENTED**
The message is succesfully decoded in _DecodeThreadAssociationRequest_ but the parsed network information is not applied because __ProvisionThreadNetwork_ isn't implementated for efr platforms.

 #### Summary of Changes
Add the implementation of __ProvisionThreadNetwork_ for efr platforms
The function applies the thread network information provided and set the ThreadEnabled flag to true