### PR TITLE
Remove '-Wno-unused-but-set-variable' from compiler flags

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -138,7 +138,6 @@ config("disabled_warnings") {
     "-Wno-deprecated-declarations",
     "-Wno-unknown-warning-option",
     "-Wno-missing-field-initializers",
-    "-Wno-unused-but-set-variable",
   ]
   cflags_cc = [
     "-Wno-non-virtual-dtor",

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -90,10 +90,10 @@ static void TestInetPre(nlTestSuite * inSuite, void * inContext)
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     TCPEndPoint * testTCPEP = nullptr;
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
-    INET_ERROR err         = INET_NO_ERROR;
-    IPAddress testDestAddr = IPAddress::Any;
+    INET_ERROR err = INET_NO_ERROR;
 #if INET_CONFIG_ENABLE_DNS_RESOLVER
-    char testHostName[20] = "www.nest.com";
+    IPAddress testDestAddr = IPAddress::Any;
+    char testHostName[20]  = "www.nest.com";
 #endif // INET_CONFIG_ENABLE_DNS_RESOLVER
 
 #if INET_CONFIG_ENABLE_RAW_ENDPOINT


### PR DESCRIPTION
 #### Problem

There is only a one unused but set variable in our tree. Sounds like we can turn `-Wno-unused-but-set-variable` globally.

 #### Summary of Changes
 * Remove `-Wno-unused-but-set-variable` from `build/config/compiler/BUILD.gn`
 * Fix the only occurence where it happens
