### PR TITLE
Move 'emberAfPluginBasicResetToFactoryDefaultsCallback' into src/app/…

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/callback.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/callback.h
@@ -2847,18 +2847,6 @@ EmberAfStatus emberAfOnOffClusterSetValueCallback(uint8_t endpoint, uint8_t comm
  */
 void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint);
 
-/** @brief Basic Cluster Reset To Factory Defaults
- *
- * This function is called by the Basic server plugin when a request to
- * reset to factory defaults is received. The plugin will reset attributes
- * managed by the framework to their default values.
- * The application should perform any other necessary reset-related operations
- * in this callback, including resetting any externally-stored attributes.
- *
- * @param endpoint Endpoint that is being initialized  Ver.: always
- */
-void emberAfPluginBasicResetToFactoryDefaultsCallback(uint8_t endpoint);
-
 /** @} END On/off Cluster Callbacks */
 
 /** @name On/off Switch Configuration Cluster Callbacks */

--- a/examples/all-clusters-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/all-clusters-app/esp32/main/CHIPDeviceManager.cpp
@@ -103,15 +103,6 @@ void emberAfPostAttributeChangeCallback(uint8_t endpointId, EmberAfClusterId clu
         cb->PostAttributeChangeCallback(endpointId, clusterId, attributeId, mask, manufacturerCode, type, size, value);
     }
 }
-
-void emberAfPluginBasicResetToFactoryDefaultsCallback(uint8_t endpointId)
-{
-    CHIPDeviceManagerCallbacks * cb = CHIPDeviceManager::GetInstance().GetCHIPDeviceManagerCallbacks();
-    if (cb != nullptr)
-    {
-        cb->PluginBasicResetToFactoryDefaultsCallback(endpointId);
-    }
-}
 } // extern "C"
 
 } // namespace DeviceManager

--- a/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
@@ -163,15 +163,3 @@ void DeviceCallbacks::OnIdentifyPostAttributeChangeCallback(uint8_t endpointId, 
 exit:
     return;
 }
-
-void DeviceCallbacks::PluginBasicResetToFactoryDefaultsCallback(uint8_t endpointId)
-{
-    ESP_LOGI(TAG, "PluginBasicResetToFactoryDefaultsCallback - EndPoint ID: '0x%02x'", endpointId);
-
-    VerifyOrExit(endpointId == 1, ESP_LOGE(TAG, "Unexpected EndPoint ID: `0x%02x'", endpointId));
-
-    ConfigurationMgr().InitiateFactoryReset();
-
-exit:
-    return;
-}

--- a/examples/all-clusters-app/esp32/main/include/CHIPDeviceManager.h
+++ b/examples/all-clusters-app/esp32/main/include/CHIPDeviceManager.h
@@ -61,14 +61,6 @@ public:
 
     /**
      * @brief
-     *   Called when the ResetToFactoryDefaults method of the Basic cluster object has been called
-     *
-     * @param endpoint           endpoint id
-     */
-    virtual void PluginBasicResetToFactoryDefaultsCallback(uint8_t endpointId);
-
-    /**
-     * @brief
      *   Called after an attribute has been changed
      *
      * @param endpoint           endpoint id

--- a/examples/all-clusters-app/esp32/main/include/DeviceCallbacks.h
+++ b/examples/all-clusters-app/esp32/main/include/DeviceCallbacks.h
@@ -33,7 +33,6 @@ class DeviceCallbacks : public chip::DeviceManager::CHIPDeviceManagerCallbacks
 {
 public:
     virtual void DeviceEventCallback(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
-    virtual void PluginBasicResetToFactoryDefaultsCallback(uint8_t endpointId);
     virtual void PostAttributeChangeCallback(uint8_t endpointId, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
                                              uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value);
 

--- a/examples/all-clusters-app/linux/main.cpp
+++ b/examples/all-clusters-app/linux/main.cpp
@@ -44,8 +44,6 @@ extern "C" {
 void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
 {}
-
-void emberAfPluginBasicResetToFactoryDefaultsCallback(uint8_t endpointId) {}
 } // extern "C"
 
 int main(int argc, char * argv[])

--- a/examples/lighting-app/lighting-common/gen/callback.h
+++ b/examples/lighting-app/lighting-common/gen/callback.h
@@ -2842,18 +2842,6 @@ EmberAfStatus emberAfOnOffClusterSetValueCallback(uint8_t endpoint, uint8_t comm
  */
 void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint);
 
-/** @brief Basic Cluster Reset To Factory Defaults
- *
- * This function is called by the Basic server plugin when a request to
- * reset to factory defaults is received. The plugin will reset attributes
- * managed by the framework to their default values.
- * The application should perform any other necessary reset-related operations
- * in this callback, including resetting any externally-stored attributes.
- *
- * @param endpoint Endpoint that is being initialized  Ver.: always
- */
-void emberAfPluginBasicResetToFactoryDefaultsCallback(uint8_t endpoint);
-
 /** @} END On/off Cluster Callbacks */
 
 /** @name On/off Switch Configuration Cluster Callbacks */

--- a/examples/lock-app/lock-common/gen/callback.h
+++ b/examples/lock-app/lock-common/gen/callback.h
@@ -2842,18 +2842,6 @@ EmberAfStatus emberAfOnOffClusterSetValueCallback(uint8_t endpoint, uint8_t comm
  */
 void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint);
 
-/** @brief Basic Cluster Reset To Factory Defaults
- *
- * This function is called by the Basic server plugin when a request to
- * reset to factory defaults is received. The plugin will reset attributes
- * managed by the framework to their default values.
- * The application should perform any other necessary reset-related operations
- * in this callback, including resetting any externally-stored attributes.
- *
- * @param endpoint Endpoint that is being initialized  Ver.: always
- */
-void emberAfPluginBasicResetToFactoryDefaultsCallback(uint8_t endpoint);
-
 /** @} END On/off Cluster Callbacks */
 
 /** @name On/off Switch Configuration Cluster Callbacks */

--- a/examples/temperature-measurement-app/esp32/main/gen/callback-stub.c
+++ b/examples/temperature-measurement-app/esp32/main/gen/callback-stub.c
@@ -1067,18 +1067,6 @@ bool emberAfPerformingKeyEstablishmentCallback(void)
     return false;
 }
 
-/** @brief Reset To Factory Defaults
- *
- * This function is called by the Basic server plugin when a request to reset
- * to factory defaults is received. The plugin will reset attributes managed by
- * the framework to their default values. The application should perform any
- * other necessary reset-related operations in this callback, including
- * resetting any externally-stored attributes.
- *
- * @param endpoint   Ver.: always
- */
-void emberAfPluginBasicResetToFactoryDefaultsCallback(uint8_t endpoint) {}
-
 /** @brief Over temperature state changed
  *
  * This callback is generated when the temperature rises over the assert

--- a/examples/temperature-measurement-app/esp32/main/gen/callback.h
+++ b/examples/temperature-measurement-app/esp32/main/gen/callback.h
@@ -23261,22 +23261,6 @@ void halRadioPowerDownHandler(void);
 void halSleepCallback(bool enter, SleepModes sleepMode);
 /** @} END HAL Library Plugin Callbacks */
 
-/** @name Basic Server Cluster Plugin Callbacks */
-// @{
-
-/** @brief Reset To Factory Defaults
- *
- * This function is called by the Basic server plugin when a request to reset
- * to factory defaults is received. The plugin will reset attributes managed by
- * the framework to their default values. The application should perform any
- * other necessary reset-related operations in this callback, including
- * resetting any externally-stored attributes.
- *
- * @param endpoint   Ver.: always
- */
-void emberAfPluginBasicResetToFactoryDefaultsCallback(uint8_t endpoint);
-/** @} END Basic Server Cluster Plugin Callbacks */
-
 /** @} END addtogroup */
 #ifdef __cplusplus
 }

--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -37,10 +37,13 @@
  *plugin.
  *******************************************************************************
  ******************************************************************************/
+#include "basic.h"
 
 #include "af.h"
-
 #include <app/util/attribute-storage.h>
+#include <platform/CHIPDeviceLayer.h>
+
+using namespace chip;
 
 bool emberAfBasicClusterResetToFactoryDefaultsCallback(void)
 {
@@ -49,4 +52,9 @@ bool emberAfBasicClusterResetToFactoryDefaultsCallback(void)
     emberAfPluginBasicResetToFactoryDefaultsCallback(emberAfCurrentEndpoint());
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
+}
+
+void emberAfPluginBasicResetToFactoryDefaultsCallback(EndpointId endpoint)
+{
+    DeviceLayer::ConfigurationMgr().InitiateFactoryReset();
 }

--- a/src/app/clusters/basic/basic.h
+++ b/src/app/clusters/basic/basic.h
@@ -1,0 +1,32 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/util/basic-types.h>
+
+/** @brief Basic Cluster Reset To Factory Defaults
+ *
+ * This function is called by the Basic server plugin when a request to
+ * reset to factory defaults is received. The plugin will reset attributes
+ * managed by the framework to their default values.
+ * The application should perform any other necessary reset-related operations
+ * in this callback, including resetting any externally-stored attributes.
+ *
+ * @param endpoint Endpoint that is being initialized  Ver.: always
+ */
+void emberAfPluginBasicResetToFactoryDefaultsCallback(CHIPEndpointId endpoint);


### PR DESCRIPTION
…basic

 #### Problem
`emberAfPluginBasicResetToFactoryDefaultsCallback` declaration currently lives into the `callback.h` file of `gen/` folders.

Most declarations but the one for the all-clusters-app demo are stubs. I guess it can be moved down into the stack so that all users of the Basic cluster will inherit the implementation of it, which just calls `ConfigurationMgr().InitiateFactoryReset()`

#3464 is also trying to move the code down into the stack, but it does not provide an implementation for it and just break the one from the all-clusters-app demo.

 #### Summary of Changes
 * Add `src/app/clusters/basic.h` which contains the definition of `emberAfPluginBasicResetToFactoryDefaultsCallback`
 * Remove the previous definitions from the various `callback.h` files
 * Move the implementation from the àll-clusters-app demo down into the stack so that all apps using the Basic cluster inherits it.
 