### PR TITLE
Use src/app/reporting/reporting.h in src/app/util instead of the decl…

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/callback.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/callback.h
@@ -159,30 +159,6 @@ void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId);
  * @param commandId The ZCL command ID being sent/received.  Ver.: always
  */
 bool emberAfClusterSecurityCustomCallback(EmberAfProfileId profileId, EmberAfClusterId clusterId, bool incoming, uint8_t commandId);
-/** @brief Configure Reporting Command
- *
- * This function is called by the application framework when a Configure
- * Reporting command is received from an external device.  The Configure
- * Reporting command contains a series of attribute reporting configuration
- * records.  The application should return true if the message was processed or
- * false if it was not.
- *
- * @param cmd   Ver.: always
- */
-bool emberAfConfigureReportingCommandCallback(const EmberAfClusterCommand * cmd);
-/** @brief Configure Reporting Response
- *
- * This function is called by the application framework when a Configure
- * Reporting Response command is received from an external device.  The
- * application should return true if the message was processed or false if it
- * was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param buffer Buffer containing the list of attribute status records.  Ver.:
- * always
- * @param bufLen The length in bytes of the list.  Ver.: always
- */
-bool emberAfConfigureReportingResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 /** @brief Default Response
  *
  * This function is called by the application framework when a Default Response
@@ -1027,28 +1003,6 @@ bool emberAfPreZDOMessageReceivedCallback(EmberNodeId emberNodeId, EmberApsFrame
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
 bool emberAfReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
-/** @brief Read Reporting Configuration Command
- *
- * This function is called by the application framework when a Read Reporting
- * Configuration command is received from an external device.  The application
- * should return true if the message was processed or false if it was not.
- *
- * @param cmd   Ver.: always
- */
-bool emberAfReadReportingConfigurationCommandCallback(const EmberAfClusterCommand * cmd);
-/** @brief Read Reporting Configuration Response
- *
- * This function is called by the application framework when a Read Reporting
- * Configuration Response command is received from an external device.  The
- * application should return true if the message was processed or false if it
- * was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param buffer Buffer containing the list of attribute reporting configuration
- * records.  Ver.: always
- * @param bufLen The length in bytes of the list.  Ver.: always
- */
-bool emberAfReadReportingConfigurationResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration
@@ -1119,23 +1073,6 @@ void emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks);
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
 bool emberAfReportAttributesCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
-/** @brief Reporting Attribute Change
- *
- * This function is called by the framework when an attribute managed by the
- * framework changes.  The application should call this function when an
- * externally-managed attribute changes.  The application should use the change
- * notification to inform its reporting decisions.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param data   Ver.: always
- */
-void emberAfReportingAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
-                                             uint8_t mask, uint16_t manufacturerCode, EmberAfAttributeType type, uint8_t * data);
 /** @brief Scan Complete
  *
  * This is called by the low-level stack code when an 802.15.4 active scan

--- a/examples/lighting-app/lighting-common/gen/callback.h
+++ b/examples/lighting-app/lighting-common/gen/callback.h
@@ -155,30 +155,6 @@ void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId);
  * @param commandId The ZCL command ID being sent/received.  Ver.: always
  */
 bool emberAfClusterSecurityCustomCallback(EmberAfProfileId profileId, EmberAfClusterId clusterId, bool incoming, uint8_t commandId);
-/** @brief Configure Reporting Command
- *
- * This function is called by the application framework when a Configure
- * Reporting command is received from an external device.  The Configure
- * Reporting command contains a series of attribute reporting configuration
- * records.  The application should return true if the message was processed or
- * false if it was not.
- *
- * @param cmd   Ver.: always
- */
-bool emberAfConfigureReportingCommandCallback(const EmberAfClusterCommand * cmd);
-/** @brief Configure Reporting Response
- *
- * This function is called by the application framework when a Configure
- * Reporting Response command is received from an external device.  The
- * application should return true if the message was processed or false if it
- * was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param buffer Buffer containing the list of attribute status records.  Ver.:
- * always
- * @param bufLen The length in bytes of the list.  Ver.: always
- */
-bool emberAfConfigureReportingResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 /** @brief Default Response
  *
  * This function is called by the application framework when a Default Response
@@ -1023,28 +999,6 @@ bool emberAfPreZDOMessageReceivedCallback(EmberNodeId emberNodeId, EmberApsFrame
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
 bool emberAfReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
-/** @brief Read Reporting Configuration Command
- *
- * This function is called by the application framework when a Read Reporting
- * Configuration command is received from an external device.  The application
- * should return true if the message was processed or false if it was not.
- *
- * @param cmd   Ver.: always
- */
-bool emberAfReadReportingConfigurationCommandCallback(const EmberAfClusterCommand * cmd);
-/** @brief Read Reporting Configuration Response
- *
- * This function is called by the application framework when a Read Reporting
- * Configuration Response command is received from an external device.  The
- * application should return true if the message was processed or false if it
- * was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param buffer Buffer containing the list of attribute reporting configuration
- * records.  Ver.: always
- * @param bufLen The length in bytes of the list.  Ver.: always
- */
-bool emberAfReadReportingConfigurationResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration
@@ -1115,23 +1069,6 @@ void emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks);
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
 bool emberAfReportAttributesCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
-/** @brief Reporting Attribute Change
- *
- * This function is called by the framework when an attribute managed by the
- * framework changes.  The application should call this function when an
- * externally-managed attribute changes.  The application should use the change
- * notification to inform its reporting decisions.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param data   Ver.: always
- */
-void emberAfReportingAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
-                                             uint8_t mask, uint16_t manufacturerCode, EmberAfAttributeType type, uint8_t * data);
 /** @brief Scan Complete
  *
  * This is called by the low-level stack code when an 802.15.4 active scan

--- a/examples/lock-app/lock-common/gen/callback.h
+++ b/examples/lock-app/lock-common/gen/callback.h
@@ -155,30 +155,6 @@ void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId);
  * @param commandId The ZCL command ID being sent/received.  Ver.: always
  */
 bool emberAfClusterSecurityCustomCallback(EmberAfProfileId profileId, EmberAfClusterId clusterId, bool incoming, uint8_t commandId);
-/** @brief Configure Reporting Command
- *
- * This function is called by the application framework when a Configure
- * Reporting command is received from an external device.  The Configure
- * Reporting command contains a series of attribute reporting configuration
- * records.  The application should return true if the message was processed or
- * false if it was not.
- *
- * @param cmd   Ver.: always
- */
-bool emberAfConfigureReportingCommandCallback(const EmberAfClusterCommand * cmd);
-/** @brief Configure Reporting Response
- *
- * This function is called by the application framework when a Configure
- * Reporting Response command is received from an external device.  The
- * application should return true if the message was processed or false if it
- * was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param buffer Buffer containing the list of attribute status records.  Ver.:
- * always
- * @param bufLen The length in bytes of the list.  Ver.: always
- */
-bool emberAfConfigureReportingResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 /** @brief Default Response
  *
  * This function is called by the application framework when a Default Response
@@ -1023,28 +999,6 @@ bool emberAfPreZDOMessageReceivedCallback(EmberNodeId emberNodeId, EmberApsFrame
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
 bool emberAfReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
-/** @brief Read Reporting Configuration Command
- *
- * This function is called by the application framework when a Read Reporting
- * Configuration command is received from an external device.  The application
- * should return true if the message was processed or false if it was not.
- *
- * @param cmd   Ver.: always
- */
-bool emberAfReadReportingConfigurationCommandCallback(const EmberAfClusterCommand * cmd);
-/** @brief Read Reporting Configuration Response
- *
- * This function is called by the application framework when a Read Reporting
- * Configuration Response command is received from an external device.  The
- * application should return true if the message was processed or false if it
- * was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param buffer Buffer containing the list of attribute reporting configuration
- * records.  Ver.: always
- * @param bufLen The length in bytes of the list.  Ver.: always
- */
-bool emberAfReadReportingConfigurationResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration
@@ -1115,23 +1069,6 @@ void emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks);
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
 bool emberAfReportAttributesCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
-/** @brief Reporting Attribute Change
- *
- * This function is called by the framework when an attribute managed by the
- * framework changes.  The application should call this function when an
- * externally-managed attribute changes.  The application should use the change
- * notification to inform its reporting decisions.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param data   Ver.: always
- */
-void emberAfReportingAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
-                                             uint8_t mask, uint16_t manufacturerCode, EmberAfAttributeType type, uint8_t * data);
 /** @brief Scan Complete
  *
  * This is called by the low-level stack code when an 802.15.4 active scan

--- a/examples/temperature-measurement-app/esp32/main/gen/callback.h
+++ b/examples/temperature-measurement-app/esp32/main/gen/callback.h
@@ -140,30 +140,6 @@ void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId);
  * @param commandId The ZCL command ID being sent/received.  Ver.: always
  */
 bool emberAfClusterSecurityCustomCallback(EmberAfProfileId profileId, EmberAfClusterId clusterId, bool incoming, uint8_t commandId);
-/** @brief Configure Reporting Command
- *
- * This function is called by the application framework when a Configure
- * Reporting command is received from an external device.  The Configure
- * Reporting command contains a series of attribute reporting configuration
- * records.  The application should return true if the message was processed or
- * false if it was not.
- *
- * @param cmd   Ver.: always
- */
-bool emberAfConfigureReportingCommandCallback(const EmberAfClusterCommand * cmd);
-/** @brief Configure Reporting Response
- *
- * This function is called by the application framework when a Configure
- * Reporting Response command is received from an external device.  The
- * application should return true if the message was processed or false if it
- * was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param buffer Buffer containing the list of attribute status records.  Ver.:
- * always
- * @param bufLen The length in bytes of the list.  Ver.: always
- */
-bool emberAfConfigureReportingResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 /** @brief Default Response
  *
  * This function is called by the application framework when a Default Response
@@ -1008,28 +984,6 @@ bool emberAfPreZDOMessageReceivedCallback(EmberNodeId emberNodeId, EmberApsFrame
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
 bool emberAfReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
-/** @brief Read Reporting Configuration Command
- *
- * This function is called by the application framework when a Read Reporting
- * Configuration command is received from an external device.  The application
- * should return true if the message was processed or false if it was not.
- *
- * @param cmd   Ver.: always
- */
-bool emberAfReadReportingConfigurationCommandCallback(const EmberAfClusterCommand * cmd);
-/** @brief Read Reporting Configuration Response
- *
- * This function is called by the application framework when a Read Reporting
- * Configuration Response command is received from an external device.  The
- * application should return true if the message was processed or false if it
- * was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param buffer Buffer containing the list of attribute reporting configuration
- * records.  Ver.: always
- * @param bufLen The length in bytes of the list.  Ver.: always
- */
-bool emberAfReadReportingConfigurationResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration
@@ -1100,23 +1054,6 @@ void emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks);
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
 bool emberAfReportAttributesCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
-/** @brief Reporting Attribute Change
- *
- * This function is called by the framework when an attribute managed by the
- * framework changes.  The application should call this function when an
- * externally-managed attribute changes.  The application should use the change
- * notification to inform its reporting decisions.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param data   Ver.: always
- */
-void emberAfReportingAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
-                                             uint8_t mask, uint16_t manufacturerCode, EmberAfAttributeType type, uint8_t * data);
 /** @brief Scan Complete
  *
  * This is called by the low-level stack code when an 802.15.4 active scan

--- a/src/app/util/attribute-table.cpp
+++ b/src/app/util/attribute-table.cpp
@@ -51,6 +51,10 @@
 
 #include "gen/enums.h"
 
+#ifdef EMBER_AF_PLUGIN_REPORTING
+#include <app/reporting/reporting.h>
+#endif // EMBER_AF_PLUGIN_REPORTING
+
 using namespace chip;
 
 //------------------------------------------------------------------------------
@@ -602,7 +606,9 @@ EmberAfStatus emAfWriteAttribute(EndpointId endpoint, EmberAfClusterId cluster, 
         // Function itself will weed out tokens that are not tokenized.
         emAfSaveAttributeToToken(data, endpoint, cluster, metadata);
 
+#ifdef EMBER_AF_PLUGIN_REPORTING
         emberAfReportingAttributeChangeCallback(endpoint, cluster, attributeID, mask, manufacturerCode, dataType, data);
+#endif // EMBER_AF_PLUGIN_REPORTING
 
         // Post write attribute callback for all attributes changes, regardless
         // of cluster.

--- a/src/app/util/process-global-message.cpp
+++ b/src/app/util/process-global-message.cpp
@@ -44,6 +44,10 @@
 
 #include <app/clusters/ias-zone-client/ias-zone-client.h>
 
+#ifdef EMBER_AF_PLUGIN_REPORTING
+#include <app/reporting/reporting.h>
+#endif // EMBER_AF_PLUGIN_REPORTING
+
 //#include "../plugin/key-establishment/key-establishment.h"
 //#include "../plugin/smart-energy-registration/smart-energy-registration.h"
 //#include "../plugin/trust-center-keepalive/trust-center-keepalive.h"
@@ -475,6 +479,7 @@ bool emAfProcessGlobalCommand(EmberAfClusterCommand * cmd)
         return true;
     }
 
+#ifdef EMBER_AF_PLUGIN_REPORTING
     case ZCL_CONFIGURE_REPORTING_COMMAND_ID:
         if (emberAfConfigureReportingCommandCallback(cmd))
         {
@@ -488,6 +493,7 @@ bool emAfProcessGlobalCommand(EmberAfClusterCommand * cmd)
             return true;
         }
         break;
+#endif // EMBER_AF_PLUGIN_REPORTING
 
     // ([attribute id:2] [status:1] [type:0/1] [value:0/V])+
     case ZCL_READ_ATTRIBUTES_RESPONSE_COMMAND_ID:
@@ -573,6 +579,7 @@ bool emAfProcessGlobalCommand(EmberAfClusterCommand * cmd)
         }
         return true;
 
+#ifdef EMBER_AF_PLUGIN_REPORTING
     // ([status:1] [direction:1] [attribute id:2])+
     case ZCL_CONFIGURE_REPORTING_RESPONSE_COMMAND_ID:
         if (!emberAfConfigureReportingResponseCallback(clusterId, message + msgIndex, static_cast<uint16_t>(msgLen - msgIndex)))
@@ -591,6 +598,7 @@ bool emAfProcessGlobalCommand(EmberAfClusterCommand * cmd)
             emberAfSendDefaultResponse(cmd, EMBER_ZCL_STATUS_SUCCESS);
         }
         return true;
+#endif // EMBER_AF_PLUGIN_REPORTING
 
     // ([attribute id:2] [type:1] [data:V])+
     case ZCL_REPORT_ATTRIBUTES_COMMAND_ID:


### PR DESCRIPTION
…arations from gen/callback.h

 #### Problem

#3608 has added the reporting plugin callbacks definitions into `src/app/reporting/reporting.h` but `src/app/util/attribute-table.cpp` and `src/app/util/process-global-message.cpp` continue to use the definitions from the gen/ folders.

#3464 is trying to add `reporting.h` headers into those files but does it without any conditions. It will not work if some apps does not use reporting.

 #### Summary of Changes
 * Remove the definitions from the various `gen/callback.h` files
 * Use the definitions from `src/app/reporting/reporting.h` in `src/app/util`
 * `#ifdef` the calls to the reporting plugin if reporting is not used since we can not rely on the declarations from `gen/callback-stubs` anymore
