### PR TITLE
[nrfconnect/pigweed-app] Added support for the USB transport.

### DIFF
--- a/config/nrfconnect/overlay-usb_support.conf
+++ b/config/nrfconnect/overlay-usb_support.conf
@@ -1,0 +1,25 @@
+#
+#   Copyright (c) 2020 Project CHIP Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+CONFIG_GPIO=y
+
+CONFIG_USB=y
+CONFIG_USB_DEVICE_STACK=y
+CONFIG_USB_UART_CONSOLE=y
+
+CONFIG_UART_INTERRUPT_DRIVEN=y
+CONFIG_UART_LINE_CTRL=y
+CONFIG_UART_CONSOLE_ON_DEV_NAME="CDC_ACM_0"

--- a/examples/pigweed-app/nrfconnect/CMakeLists.txt
+++ b/examples/pigweed-app/nrfconnect/CMakeLists.txt
@@ -18,6 +18,10 @@ cmake_minimum_required(VERSION 3.13.1)
 get_filename_component(CHIP_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/third_party/connectedhomeip REALPATH)
 get_filename_component(NRFCONNECT_COMMON ${CHIP_ROOT}/examples/platform/nrfconnect REALPATH)
 
+if(${BOARD} STREQUAL "nrf52840dongle_nrf52840")
+list(INSERT OVERLAY_CONFIG 0 ${CHIP_ROOT}/config/nrfconnect/overlay-usb_support.conf)
+endif()
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CHIP_ROOT}/config/nrfconnect/)
 set(PIGWEED_ROOT "${CHIP_ROOT}/third_party/pigweed/repo")
 include(nrfconnect-app)

--- a/examples/pigweed-app/nrfconnect/README.md
+++ b/examples/pigweed-app/nrfconnect/README.md
@@ -96,8 +96,9 @@ container:
 
 > **Note**:
 >
-> -   `<board_name>` has to be replaced with a board name which might be nrf52840dk_nrf52840
->     for development kit board or nrf52840dongle_nrf52840 for dongle board.
+> -   `<board_name>` has to be replaced with a board name which might be
+>     nrf52840dk_nrf52840 for development kit board or nrf52840dongle_nrf52840
+>     for dongle board.
 
 If the build succeeds, the binary will be available under
 `/var/chip/examples/pigweed-app/nrfconnect/build/zephyr/zephyr.hex`. Note that
@@ -152,8 +153,9 @@ The following commands will build the `pigweed-app` example:
 
 > **Note**:
 >
-> -   `<board_name>` has to be replaced with a board name which might be nrf52840dk_nrf52840
->     for development kit board or nrf52840dongle_nrf52840 for dongle board.
+> -   `<board_name>` has to be replaced with a board name which might be
+>     nrf52840dk_nrf52840 for development kit board or nrf52840dongle_nrf52840
+>     for dongle board.
 
 After a successful build, the binary will be available under
 `<example-dir>/build/zephyr/zephyr.hex`
@@ -204,8 +206,9 @@ To open the configuration menu, do the following:
 
 > **Note**:
 >
-> -   `<board_name>` has to be replaced with a board name which might be nrf52840dk_nrf52840
->     for development kit board or nrf52840dongle_nrf52840 for dongle board.
+> -   `<board_name>` has to be replaced with a board name which might be
+>     nrf52840dk_nrf52840 for development kit board or nrf52840dongle_nrf52840
+>     for dongle board.
 
 Changes done with `menuconfig` will be lost, if the `build` directory is
 deleted. To make them persistent, save the configuration options in `prj.conf`

--- a/examples/pigweed-app/nrfconnect/README.md
+++ b/examples/pigweed-app/nrfconnect/README.md
@@ -13,6 +13,8 @@ An example application showing the use
         -   [Supported nRF Connect SDK versions](#supported-nrf-connect-sdk-versions)
     -   [Configuring the example](#configuring-the-example)
     -   [Flashing and debugging](#flashing-and-debugging)
+        -   [Flashing nRF52840 DK](#nrf52840dk_flashing)
+        -   [Flashing nRF52840 Dongle](#nrf52840dongle_flashing)
     -   [Currently implemented features](#currently-implemented-features)
 
 <hr>
@@ -64,7 +66,7 @@ container:
 > -   `-v /dev/bus/usb:/dev/bus/usb --device-cgroup-rule 'c 189:* rmw`
 >     parameters can be omitted if you're not planning to flash the example onto
 >     hardware. The parameters give the container access to USB devices
->     connected to your computer such as the nRF52840 DK.
+>     connected to your computer such as the nRF52840 DK or nRF52840 Dongle.
 > -   `--rm` flag can be omitted if you don't want the container to be
 >     auto-removed when you exit the container shell session.
 > -   `-e RUNAS=$(id -u)` is needed to start the container session as the
@@ -90,7 +92,12 @@ Now you may build the example by running the commands below in the Docker
 container:
 
         $ cd /var/chip/examples/pigweed-app/nrfconnect
-        $ west build -b nrf52840dk_nrf52840
+        $ west build -b <board_name>
+
+> **Note**:
+>
+> -   `<board_name>` has to be replaced with a board name which might be nrf52840dk_nrf52840
+>     for development kit board or nrf52840dongle_nrf52840 for dongle board.
 
 If the build succeeds, the binary will be available under
 `/var/chip/examples/pigweed-app/nrfconnect/build/zephyr/zephyr.hex`. Note that
@@ -138,10 +145,15 @@ The following commands will build the `pigweed-app` example:
         $ cd ~/connectedhomeip/examples/pigweed-app/nrfconnect
 
         # If this is a first time build or if `build` directory was deleted
-        $ west build -b nrf52840dk_nrf52840
+        $ west build -b <board_name>
 
         # Any subsequent build
         $ west build
+
+> **Note**:
+>
+> -   `<board_name>` has to be replaced with a board name which might be nrf52840dk_nrf52840
+>     for development kit board or nrf52840dongle_nrf52840 for dongle board.
 
 After a successful build, the binary will be available under
 `<example-dir>/build/zephyr/zephyr.hex`
@@ -181,7 +193,7 @@ To open the configuration menu, do the following:
 
         $ cd <example-dir>
         # First time build
-        $ west build -b nrf52840dk_nrf52840 -t menuconfig
+        $ west build -b <board_name> -t menuconfig
 
         # Any subsequent build
         $ west build -t menuconfig
@@ -189,6 +201,11 @@ To open the configuration menu, do the following:
         # Running menuconfig with ninja
         $ cd <example-dir>/build
         $ ninja menuconfig
+
+> **Note**:
+>
+> -   `<board_name>` has to be replaced with a board name which might be nrf52840dk_nrf52840
+>     for development kit board or nrf52840dongle_nrf52840 for dongle board.
 
 Changes done with `menuconfig` will be lost, if the `build` directory is
 deleted. To make them persistent, save the configuration options in `prj.conf`
@@ -200,7 +217,13 @@ file.
 
 The example application is designed to run on the
 [Nordic nRF52840 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK)
-development kit.
+development kit board or
+[Nordic nRF52840 Dongle](https://www.nordicsemi.com/Software-and-tools/Development-Kits/nRF52840-Dongle)
+board.
+
+<a name="nrf52840dk_flashing"></a>
+
+### Flashing nRF52840 DK
 
 To flash the application to the device, use the `west` tool:
 
@@ -214,6 +237,14 @@ To debug the application on target:
 
         $ cd <example-dir>
         $ west debug
+
+<a name="nrf52840dongle_flashing"></a>
+
+### Flashing nRF52840 Dongle
+
+Visit
+[Programming and Flashing nRF52840 Dongle](https://docs.zephyrproject.org/latest/boards/arm/nrf52840dongle_nrf52840/doc/index.html#programming-and-debugging)
+to read detailed information on this and other board related topics.
 
 <a name="currently-implemented-features"></a>
 

--- a/examples/pigweed-app/nrfconnect/prj.conf
+++ b/examples/pigweed-app/nrfconnect/prj.conf
@@ -22,8 +22,8 @@ CONFIG_POSIX_API=y
 CONFIG_PTHREAD_IPC=y
 CONFIG_EVENTFD=y
 
-CONFIG_LOG=y
-CONFIG_LOG_MINIMAL=y
+CONFIG_LOG=n
+CONFIG_LOG_MINIMAL=n
 CONFIG_ASSERT=y
 CONFIG_HW_STACK_PROTECTION=y
 
@@ -68,10 +68,6 @@ CONFIG_MBEDTLS_GCM_C=n
 # Add support for LEDs and buttons on Nordic development kits
 CONFIG_DK_LIBRARY=y
 
-# Long log strings
-CONFIG_LOG_STRDUP_MAX_STRING=256
-CONFIG_LOG_STRDUP_BUF_COUNT=20
-
 # Additional configs for debbugging experience.
 CONFIG_THREAD_NAME=y
 CONFIG_MPU_STACK_GUARD=y
@@ -85,3 +81,4 @@ CONFIG_STD_CPP17=y
 # Add support for Zephyr console component to use it for Pigweed console purposes
 CONFIG_CONSOLE_SUBSYS=y
 CONFIG_CONSOLE_GETCHAR=y
+CONFIG_CONSOLE_GETCHAR_BUFSIZE=256

--- a/examples/platform/nrfconnect/pw_sys_io/sys_io_nrfconnect.cc
+++ b/examples/platform/nrfconnect/pw_sys_io/sys_io_nrfconnect.cc
@@ -22,9 +22,20 @@
 #include <cassert>
 #include <zephyr.h>
 
+#ifdef CONFIG_USB
+#include <usb/usb_device.h>
+#endif
+
 extern "C" void pw_sys_io_Init()
 {
-    int err = console_init();
+    int err;
+
+#ifdef CONFIG_USB
+    err = usb_enable(nullptr);
+    assert(err == 0);
+#endif
+
+    err = console_init();
     assert(err == 0);
 }
 
@@ -37,6 +48,7 @@ Status ReadByte(std::byte * dest)
 
     const int c = console_getchar();
     *dest       = static_cast<std::byte>(c);
+
     return c < 0 ? Status::FAILED_PRECONDITION : Status::OK;
 }
 


### PR DESCRIPTION
 #### Problem
Pigweed-app console currently supports using only UART interface, while nRF52840 dongle needs to use USB.

 #### Summary of Changes
* Added an overlay enabling USB, which is added to build in case of using nrf52840dongle_nrf52840 board.
* Disabled logs for Pigweed-app to avoid interference with the command frames.

 Fixes #3747 
