### PR TITLE
Move 'emberAfPluginDoorLockServerActivateDoorLockCallback' into src/a…

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/callback.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/callback.h
@@ -2926,16 +2926,6 @@ void emberAfOnOffClusterServerTickCallback(uint8_t endpoint);
  */
 bool emberAfOnOffClusterToggleCallback(void);
 
-/** @brief Activate Door Lock Callback
- * This function is provided by the door lock server plugin.
- *
- * @param activate True if the lock should move to the locked position,
- *  false if it should move to the unlocked position Ver.: always
- *
- * @returns true if the callback was able to activate/deactivate the Lock.
- */
-bool emberAfPluginDoorLockServerActivateDoorLockCallback(bool activate);
-
 /** @brief On/off Cluster Set Value
  *
  * This function is called when the on/off value needs to be set, either through

--- a/examples/all-clusters-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/all-clusters-app/esp32/main/CHIPDeviceManager.cpp
@@ -112,18 +112,6 @@ void emberAfPluginBasicResetToFactoryDefaultsCallback(uint8_t endpointId)
         cb->PluginBasicResetToFactoryDefaultsCallback(endpointId);
     }
 }
-
-bool emberAfPluginDoorLockServerActivateDoorLockCallback(bool activate)
-{
-    CHIPDeviceManagerCallbacks * cb = CHIPDeviceManager::GetInstance().GetCHIPDeviceManagerCallbacks();
-    if (cb != nullptr)
-    {
-        return cb->PluginDoorLockActivateDoorLockCallback(activate);
-    }
-
-    return false;
-}
-
 } // extern "C"
 
 } // namespace DeviceManager

--- a/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
@@ -175,10 +175,3 @@ void DeviceCallbacks::PluginBasicResetToFactoryDefaultsCallback(uint8_t endpoint
 exit:
     return;
 }
-
-bool DeviceCallbacks::PluginDoorLockActivateDoorLockCallback(bool activate)
-{
-    ESP_LOGI(TAG, "PluginDoorLockActivateDoorLockCallback: '0x%02x'", activate);
-    // Simulate that locking/unlocking the door is always succesful.
-    return true;
-}

--- a/examples/all-clusters-app/esp32/main/include/CHIPDeviceManager.h
+++ b/examples/all-clusters-app/esp32/main/include/CHIPDeviceManager.h
@@ -69,17 +69,6 @@ public:
 
     /**
      * @brief
-     *    Activate Door Lock Callback
-     *
-     * @param activate True if the lock should move to the locked position,
-     *                 False if it should move to the unlocked position
-     *
-     * @returns true if the callback was able to activate/deactivate the Lock.
-     */
-    virtual bool PluginDoorLockActivateDoorLockCallback(bool activate);
-
-    /**
-     * @brief
      *   Called after an attribute has been changed
      *
      * @param endpoint           endpoint id

--- a/examples/all-clusters-app/esp32/main/include/DeviceCallbacks.h
+++ b/examples/all-clusters-app/esp32/main/include/DeviceCallbacks.h
@@ -34,7 +34,6 @@ class DeviceCallbacks : public chip::DeviceManager::CHIPDeviceManagerCallbacks
 public:
     virtual void DeviceEventCallback(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
     virtual void PluginBasicResetToFactoryDefaultsCallback(uint8_t endpointId);
-    virtual bool PluginDoorLockActivateDoorLockCallback(bool activate);
     virtual void PostAttributeChangeCallback(uint8_t endpointId, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
                                              uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value);
 

--- a/examples/all-clusters-app/linux/main.cpp
+++ b/examples/all-clusters-app/linux/main.cpp
@@ -46,11 +46,6 @@ void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clust
 {}
 
 void emberAfPluginBasicResetToFactoryDefaultsCallback(uint8_t endpointId) {}
-bool emberAfPluginDoorLockServerActivateDoorLockCallback(bool activate)
-{
-    return true;
-}
-
 } // extern "C"
 
 int main(int argc, char * argv[])

--- a/examples/lock-app/lock-common/gen/callback-stub.c
+++ b/examples/lock-app/lock-common/gen/callback-stub.c
@@ -1282,19 +1282,6 @@ bool emberAfReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t *
     return false;
 }
 
-/** @brief Activate Door Lock Callback
- * This function is provided by the door lock server plugin.
- *
- * @param activate True if the lock should move to the locked position,
- *  false if it should move to the unlocked position Ver.: always
- *
- * @returns true if the callback was able to activate/deactivate the Lock.
- */
-bool emberAfPluginDoorLockServerActivateDoorLockCallback(bool activate)
-{
-    return false;
-};
-
 /** @brief Scenes Cluster Recall Saved Scene
  *
  * This function is called by the framework when the application should recall a

--- a/examples/lock-app/lock-common/gen/callback.h
+++ b/examples/lock-app/lock-common/gen/callback.h
@@ -2916,15 +2916,6 @@ void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
 void emberAfPluginBasicResetToFactoryDefaultsCallback(uint8_t endpoint);
-/** @brief Activate Door Lock Callback
- * This function is provided by the door lock server plugin.
- *
- * @param activate True if the lock should move to the locked position,
- *  false if it should move to the unlocked position Ver.: always
- *
- * @returns true if the callback was able to activate/deactivate the Lock.
- */
-bool emberAfPluginDoorLockServerActivateDoorLockCallback(bool activate);
 
 /** @} END On/off Cluster Callbacks */
 

--- a/src/app/clusters/door-lock-server/door-lock-server-user.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server-user.cpp
@@ -774,3 +774,8 @@ bool emberAfDoorLockClusterUnlockWithTimeoutCallback(uint16_t timeoutS, uint8_t 
 
     return true;
 }
+
+bool emberAfPluginDoorLockServerActivateDoorLockCallback(bool activate)
+{
+    return true;
+}

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -250,4 +250,14 @@ bool emAfPluginDoorLockServerCheckForSufficientSpace(uint16_t spaceReq, uint8_t 
 #define EmberAfDoorLockScheduleEntry EmberAfPluginDoorLockServerWeekdayScheduleEntry
 #define EmberAfDoorLockUser EmberAfPluginDoorLockServerUser
 
+/** @brief Activate Door Lock Callback
+ * This function is provided by the door lock server plugin.
+ *
+ * @param activate True if the lock should move to the locked position,
+ *  false if it should move to the unlocked position Ver.: always
+ *
+ * @returns true if the callback was able to activate/deactivate the Lock.
+ */
+bool emberAfPluginDoorLockServerActivateDoorLockCallback(bool activate);
+
 #endif // SILABS_DOOR_LOCK_SERVER_H


### PR DESCRIPTION
…pp/door-lock-server/


 #### Problem
 
#3464 does not have any informations about **plugins** and will not generate definitions or stubs for the door-lock-server methods.


 #### Summary of Changes
 * Move `emberAfPluginDoorLockServerActivateDoorLockCallback` into `src/app/door-lock-server`.
 * Remove the related definitions/stubs from `gen/callback.h` and `gen/callback-stubs.h` 