### PR TITLE
Move Groups Plugin callbacks into src/app/groups-server

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/callback-stub.c
+++ b/examples/all-clusters-app/all-clusters-common/gen/callback-stub.c
@@ -65,39 +65,6 @@ void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint) {}
  */
 void emberAfPluginLevelControlClusterServerPostInitCallback(uint8_t endpoint) {}
 
-/** @brief Get Group Name
- *
- * This function returns the name of a group with the provided group ID, should
- * it exist.
- *
- * @param endpoint Endpoint Ver.: always
- * @param groupId Group ID Ver.: always
- * @param groupName Group Name Ver.: always
- */
-void emberAfPluginGroupsServerGetGroupNameCallback(uint8_t endpoint, uint16_t groupId, uint8_t * groupName) {}
-
-/** @brief Group Names Supported
- *
- * This function is called by the framework when it is necessary to determine
- * whether or not group names are supported.
- *
- * @param endpoint The endpoint. Ver.: always
- */
-bool emberAfPluginGroupsServerGroupNamesSupportedCallback(uint8_t endpoint)
-{
-    return false;
-}
-
-/** @brief Set Group Name
- *
- * This function sets the name of a group with the provided group ID.
- *
- * @param endpoint Endpoint Ver.: always
- * @param groupId Group ID Ver.: always
- * @param groupName Group Name Ver.: always
- */
-void emberAfPluginGroupsServerSetGroupNameCallback(uint8_t endpoint, uint16_t groupId, uint8_t * groupName) {}
-
 /** @brief Add To Current App Tasks
  *
  * This function is only useful to sleepy end devices.  This function will note

--- a/examples/all-clusters-app/all-clusters-common/gen/callback.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/callback.h
@@ -2292,37 +2292,6 @@ bool emberAfGroupsClusterViewGroupResponseCallback(uint8_t status, uint16_t grou
 
 /** @} END Groups Cluster Callbacks */
 
-/** @name Groups Server Cluster Plugin Callbacks */
-// @{
-
-/** @brief Get Group Name
- *
- * This function returns the name of a group with the provided group ID, should
- * it exist.
- *
- * @param endpoint Endpoint Ver.: always
- * @param groupId Group ID Ver.: always
- * @param groupName Group Name Ver.: always
- */
-void emberAfPluginGroupsServerGetGroupNameCallback(uint8_t endpoint, uint16_t groupId, uint8_t * groupName);
-/** @brief Set Group Name
- *
- * This function sets the name of a group with the provided group ID.
- *
- * @param endpoint Endpoint Ver.: always
- * @param groupId Group ID Ver.: always
- * @param groupName Group Name Ver.: always
- */
-void emberAfPluginGroupsServerSetGroupNameCallback(uint8_t endpoint, uint16_t groupId, uint8_t * groupName);
-/** @brief Group Names Supported
- *
- * This function returns whether or not group names are supported.
- *
- * @param endpoint Endpoint Ver.: always
- */
-bool emberAfPluginGroupsServerGroupNamesSupportedCallback(uint8_t endpoint);
-/** @} END Groups Server Cluster Plugin Callbacks */
-
 /** @name Scenes Cluster Callbacks */
 // @{
 

--- a/src/app/clusters/groups-server/groups-server.cpp
+++ b/src/app/clusters/groups-server/groups-server.cpp
@@ -44,6 +44,7 @@
 // *
 // * Copyright 2010 by Ember Corporation. All rights reserved.              *80*
 // *******************************************************************
+#include "groups-server.h"
 
 #include <app/util/af.h>
 #include <app/util/binding-table.h>
@@ -446,3 +447,12 @@ static uint8_t findGroupIndex(EndpointId endpoint, GroupId groupId)
     }
     return EMBER_AF_GROUP_TABLE_NULL_INDEX;
 }
+
+void emberAfPluginGroupsServerGetGroupNameCallback(EndpointId endpoint, GroupId groupId, uint8_t * groupName) {}
+
+bool emberAfPluginGroupsServerGroupNamesSupportedCallback(EndpointId endpoint)
+{
+    return false;
+}
+
+void emberAfPluginGroupsServerSetGroupNameCallback(EndpointId endpoint, GroupId groupId, uint8_t * groupName) {}

--- a/src/app/clusters/groups-server/groups-server.h
+++ b/src/app/clusters/groups-server/groups-server.h
@@ -1,0 +1,49 @@
+/**
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/util/basic-types.h>
+
+/** @brief Get Group Name
+ *
+ * This function returns the name of a group with the provided group ID, should
+ * it exist.
+ *
+ * @param endpoint Endpoint Ver.: always
+ * @param groupId Group ID Ver.: always
+ * @param groupName Group Name Ver.: always
+ */
+void emberAfPluginGroupsServerGetGroupNameCallback(CHIPEndpointId endpoint, CHIPGroupId groupId, uint8_t * groupName);
+
+/** @brief Set Group Name
+ *
+ * This function sets the name of a group with the provided group ID.
+ *
+ * @param endpoint Endpoint Ver.: always
+ * @param groupId Group ID Ver.: always
+ * @param groupName Group Name Ver.: always
+ */
+void emberAfPluginGroupsServerSetGroupNameCallback(CHIPEndpointId endpoint, CHIPGroupId groupId, uint8_t * groupName);
+
+/** @brief Group Names Supported
+ *
+ * This function returns whether or not group names are supported.
+ *
+ * @param endpoint Endpoint Ver.: always
+ */
+bool emberAfPluginGroupsServerGroupNamesSupportedCallback(CHIPEndpointId endpoint);


### PR DESCRIPTION
 #### Problem

#3464 does not have any informations about plugins and will not generate definitions or stubs for the groups-server methods.

 #### Summary of Changes
 * Move groups server plugin callbacks into `src/app/clusters/groups-server`
  * Remove the related definitions/stubs from `gen/callback.h` and `gen/callback-stubs.c`