### PR TITLE
Move 'emberAfPluginIdentify[Start/Stop]FeedbackCallback' callbacks into src/app/clusters/identify

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/callback-stub.c
+++ b/examples/all-clusters-app/all-clusters-common/gen/callback-stub.c
@@ -1652,31 +1652,6 @@ void halRadioPowerUpHandler(void) {}
  */
 void halSleepCallback(bool enter, SleepModes sleepMode) {}
 
-/** @brief Identify Cluster Start Feedback Callback
- *
- *
- *
- * @param endpoint Endpoint id
- * @param identifyTime Identify time
- */
-bool emberAfPluginIdentifyStartFeedbackCallback(uint8_t endpoint, uint16_t identifyTime)
-{
-    emberAfPrintln(EMBER_AF_PRINT_IDENTIFY_CLUSTER, "Start identify callback on endpoint %d time %d", endpoint, identifyTime);
-    return false;
-}
-
-/** @brief Identify Cluster Stop Feedback Callback
- *
- *
- *
- * @param endpoint Endpoint id
- */
-bool emberAfPluginIdentifyStopFeedbackCallback(uint8_t endpoint)
-{
-    emberAfPrintln(EMBER_AF_PRINT_IDENTIFY_CLUSTER, "Stop identify callback on endpoint %d", endpoint);
-    return false;
-}
-
 /** @brief Compute Pwm from HSV
  *
  * This function is called from the color server when it is time for the PWMs to

--- a/examples/all-clusters-app/all-clusters-common/gen/callback.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/callback.h
@@ -2042,10 +2042,6 @@ bool emberAfIdentifyClusterTriggerEffectCallback(uint8_t effectId, uint8_t effec
  */
 bool emberAfIdentifyClusterUpdateCommissionStateCallback(uint8_t action, uint8_t commissionStateMask);
 
-bool emberAfPluginIdentifyStartFeedbackCallback(uint8_t endpoint, uint16_t identifyTime);
-
-bool emberAfPluginIdentifyStopFeedbackCallback(uint8_t endpoint);
-
 /** @} END Identify Cluster Callbacks */
 
 /** @name Groups Cluster Callbacks */

--- a/src/app/clusters/identify/identify.cpp
+++ b/src/app/clusters/identify/identify.cpp
@@ -44,6 +44,7 @@
 // *
 // * Copyright 2007 by Ember Corporation. All rights reserved.              *80*
 // *******************************************************************
+#include "identify.h"
 
 // this file contains all the common includes for clusters in the util
 #include <app/util/af.h>
@@ -214,4 +215,16 @@ static EmberStatus scheduleIdentifyTick(EndpointId endpoint)
     state->identifying = false;
     emberAfPluginIdentifyStopFeedbackCallback(endpoint);
     return emberAfDeactivateServerTick(endpoint, ZCL_IDENTIFY_CLUSTER_ID);
+}
+
+bool emberAfPluginIdentifyStartFeedbackCallback(EndpointId endpoint, uint16_t identifyTime)
+{
+    emberAfPrintln(EMBER_AF_PRINT_IDENTIFY_CLUSTER, "Start identify callback on endpoint %d time %d", endpoint, identifyTime);
+    return false;
+}
+
+bool emberAfPluginIdentifyStopFeedbackCallback(EndpointId endpoint)
+{
+    emberAfPrintln(EMBER_AF_PRINT_IDENTIFY_CLUSTER, "Stop identify callback on endpoint %d", endpoint);
+    return false;
 }

--- a/src/app/clusters/identify/identify.h
+++ b/src/app/clusters/identify/identify.h
@@ -1,0 +1,45 @@
+/**
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/util/basic-types.h>
+
+/** @brief Start Feedback.
+ *
+ * This function is called by the Identify plugin when identification begins.
+ * It informs the Identify Feedback plugin that it should begin providing its
+ * implemented feedback functionality (e.g. LED blinking, buzzer sounding, etc.)
+ * until the Identify plugin tells it to stop.
+ * The identify time is purely a matter of informational convenience; this plugin
+ * does not need to know how long it will identify (the Identify plugin will
+ * perform the necessary timekeeping.)
+ *
+ * @param endpoint The endpoint.  Ver.: always
+ * @param identityTime  Ver.: always
+ */
+bool emberAfPluginIdentifyStartFeedbackCallback(CHIPEndpointId endpoint, uint16_t identifyTime);
+
+/** @brief Stop Feedback.
+ *
+ * This function is called by the Identify plugin when identification is finished.
+ * It tells the Identify Feedback plugin to stop providing its implemented feedback
+ * functionality.
+ *
+ * @param endpoint The endpoint.  Ver.: always
+ */
+bool emberAfPluginIdentifyStopFeedbackCallback(CHIPEndpointId endpoint);


### PR DESCRIPTION
 #### Problem

#3464 does not have any informations about plugins and will not generate definitions or stubs for the identify methods.

 #### Summary of Changes
 * Move identify server plugin callbacks into `src/app/clusters/identify`
 * Remove the related definitions/stubs from `gen/callback.h` and `gen/callback-stubs.c`
