### PR TITLE
Move emberAfPluginLevelControlClusterServerPostInitCallback definitio…

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/callback-stub.c
+++ b/examples/all-clusters-app/all-clusters-common/gen/callback-stub.c
@@ -55,16 +55,6 @@
  */
 void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint) {}
 
-/** @brief Level Control Cluster Server Post Init
- *
- * Following resolution of the Current Level at startup for this endpoint,
- * perform any additional initialization needed; e.g., synchronize hardware
- * state.
- *
- * @param endpoint Endpoint that is being initialized  Ver.: always
- */
-void emberAfPluginLevelControlClusterServerPostInitCallback(uint8_t endpoint) {}
-
 /** @brief Add To Current App Tasks
  *
  * This function is only useful to sleepy end devices.  This function will note

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -1014,3 +1014,5 @@ static bool areStartUpLevelControlServerAttributesTokenized(EndpointId endpoint)
     return true;
 }
 #endif
+
+void emberAfPluginLevelControlClusterServerPostInitCallback(EndpointId endpoint) {}


### PR DESCRIPTION
…n into src/app/clusters/level-control

 #### Problem

#3464 does not have any informations about plugins and will not generate definitions or stubs for the level control methods.

 #### Summary of Changes
 * Move level-control server plugin callbacks into `src/app/clusters/level-control`
 * Remove the related definitions/stubs from `gen/callback.h` and `gen/callback-stubs.c`