### PR TITLE
[Build bustage] src/lib/mdns/DiscoveryManager.cpp:165:13: warning: un…

### DIFF
--- a/examples/shell/qpg6100/BUILD.gn
+++ b/examples/shell/qpg6100/BUILD.gn
@@ -21,7 +21,6 @@ import("${qpg6100_sdk_build_root}/qpg6100_sdk.gni")
 assert(current_os == "freertos")
 
 examples_plat_dir = "${chip_root}/examples/platform/qpg6100"
-project_dir = "${chip_root}/examples/shell"
 
 qpg6100_sdk("sdk") {
   include_dirs = [
@@ -61,7 +60,6 @@ qpg6100_executable("shell_qpg6100") {
   sources = [
     "${examples_plat_dir}/project_include/CHIPProjectConfig.h",
     "${examples_plat_dir}/util/streamer/streamer_qpg6100.cpp",
-    "${project_dir}/test_identity.cpp",
     "main.cpp",
   ]
 

--- a/src/lib/mdns/DiscoveryManager.cpp
+++ b/src/lib/mdns/DiscoveryManager.cpp
@@ -162,7 +162,6 @@ exit:
 CHIP_ERROR DiscoveryManager::PublishUnprovisionedDevice(chip::Inet::IPAddressType addressType, chip::Inet::InterfaceId interface)
 {
 #if CHIP_ENABLE_MDNS
-    uint8_t mac[6]; // 6 byte wifi mac
     CHIP_ERROR error = CHIP_NO_ERROR;
     MdnsService service;
     uint16_t discriminator;

--- a/src/platform/Linux/MdnsImpl.cpp
+++ b/src/platform/Linux/MdnsImpl.cpp
@@ -508,7 +508,6 @@ CHIP_ERROR MdnsAvahi::Browse(const char * type, MdnsServiceProtocol protocol, ch
     AvahiServiceBrowser * browser;
     BrowseContext * browseContext = static_cast<BrowseContext *>(chip::Platform::MemoryAlloc(sizeof(BrowseContext)));
     AvahiIfIndex avahiInterface   = static_cast<AvahiIfIndex>(interface);
-    AvahiProtocol avahiProtocol;
 
     browseContext->mInstance = this;
     browseContext->mContext  = context;

--- a/src/test_driver/linux-cirque/test-on-off-cluster.py
+++ b/src/test_driver/linux-cirque/test-on-off-cluster.py
@@ -76,7 +76,6 @@ class TestOnOffCluster(CHIPVirtualHome):
 
         for device_id in server_ids:
             server_ip_address.add(self.get_device_thread_ip(device_id))
-        server_ip_address.add("::")
 
         command = "chip-tool onoff {} {} {} 1"
 


### PR DESCRIPTION
…used variable 'mac' [-Wunused-variable]

 #### Problem
 
The build is broken because of an unused variable in src/lib.

 #### Summary of Changes
 * Just remove it

