### PR TITLE
Update CHIP to use release/v4.1 branch instead of the v4.1 release.

### DIFF
--- a/examples/all-clusters-app/esp32/README.md
+++ b/examples/all-clusters-app/esp32/README.md
@@ -33,7 +33,7 @@ Development Framework and the xtensa-esp32-elf toolchain.
 The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
--   Clone the Espressif ESP-IDF and checkout release v4.1
+-   Clone the Espressif ESP-IDF and checkout release/v4.1 branch
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools

--- a/integrations/docker/images/chip-build-esp32/Dockerfile
+++ b/integrations/docker/images/chip-build-esp32/Dockerfile
@@ -7,7 +7,7 @@ RUN set -x \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y python \
     && mkdir -p /opt/espressif \
     && cd /opt/espressif \
-    && git clone --progress -b v4.1 https://github.com/espressif/esp-idf.git \
+    && git clone --progress -b release/v4.1 https://github.com/espressif/esp-idf.git \
     && cd esp-idf \
     && git submodule update --init --progress \
     && IDF_TOOLS_PATH=/opt/espressif/tools ./install.sh \

--- a/src/test_driver/esp32/README.md
+++ b/src/test_driver/esp32/README.md
@@ -29,13 +29,13 @@ The `chip-build` Docker container and VSCode devcontainer has these components
 pre-installed, so you can skip this step. To install these components manually,
 follow these steps:
 
--   Clone the Espressif ESP-IDF and checkout release tag v4.1
+-   Clone the Espressif ESP-IDF and checkout release/v4.1 branch
 
           $ mkdir -p ${HOME}/tools
           $ cd ${HOME}/tools
           $ git clone https://github.com/espressif/esp-idf.git
           $ cd esp-idf
-          $ git checkout tags/v4.1
+          $ git checkout release/v4.1
           $ git submodule update --init
           $ export IDF_PATH=${HOME}/tools/esp-idf
           $ ./install.sh


### PR DESCRIPTION
 #### Problem
Need to update CHIP to use release/v4.1 branch. release/v4.1 branch is updated with critical fixes periodically as against v4.1 release tag which is fixed.

 #### Summary of Changes
Update the documentation to use release/v4.1 branch instead of v4.1 tag