### PR TITLE
Warning: CHIPPersistentStorageDelegateBridge.h 'SetDelegate' override…

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
@@ -30,7 +30,7 @@ public:
 
     void setFrameworkDelegate(id<CHIPPersistentStorageDelegate> delegate, dispatch_queue_t queue);
 
-    void SetDelegate(chip::Controller::PersistentStorageResultDelegate * delegate);
+    void SetDelegate(chip::Controller::PersistentStorageResultDelegate * delegate) override;
 
     void GetKeyValue(const char * key) override;
 


### PR DESCRIPTION
…s a member function but is not marked 'override'
 #### Problem

Missing `override`. Not a big deal but it triggers a warning when building the CHIP Tool app for iOS.

 #### Summary of Changes
 * Add `override` where it is missing