### PR TITLE
Move IAS Zone Client Plugin callbacks into src/app/ias-zone-client

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/clusters-callback-stubs.cpp
+++ b/examples/all-clusters-app/all-clusters-common/gen/clusters-callback-stubs.cpp
@@ -73,9 +73,3 @@ EmberAfStatus emberAfPollControlClusterServerPreAttributeChangedCallback(uint8_t
 {
     return EMBER_ZCL_STATUS_SUCCESS;
 }
-
-void emberAfPluginIasZoneClientZdoCallback(EmberNodeId emberNodeId, EmberApsFrame * apsFrame, uint8_t * message, uint16_t length) {}
-
-void emberAfPluginIasZoneClientWriteAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen) {}
-
-void emberAfPluginIasZoneClientReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen) {}

--- a/examples/all-clusters-app/all-clusters-common/gen/gen_config.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/gen_config.h
@@ -349,8 +349,6 @@
 // Use this macro to check if HAL Library plugin is included
 #define EMBER_AF_PLUGIN_HAL_LIBRARY
 
-// Use this macro to check if IAS Zone Client plugin is included
-#define EMBER_AF_PLUGIN_IAS_ZONE_CLIENT
 // User options for plugin IAS Zone Client
 #define EMBER_AF_PLUGIN_IAS_ZONE_CLIENT_MAX_DEVICES 10
 

--- a/examples/temperature-measurement-app/esp32/main/gen/clusters-callback-stubs.cpp
+++ b/examples/temperature-measurement-app/esp32/main/gen/clusters-callback-stubs.cpp
@@ -377,9 +377,3 @@ EmberAfStatus emberAfPollControlClusterServerPreAttributeChangedCallback(uint8_t
 {
     return EMBER_ZCL_STATUS_SUCCESS;
 }
-
-void emberAfPluginIasZoneClientZdoCallback(EmberNodeId emberNodeId, EmberApsFrame * apsFrame, uint8_t * message, uint16_t length) {}
-
-void emberAfPluginIasZoneClientWriteAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen) {}
-
-void emberAfPluginIasZoneClientReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen) {}

--- a/src/app/clusters/ias-zone-client/ias-zone-client.cpp
+++ b/src/app/clusters/ias-zone-client/ias-zone-client.cpp
@@ -609,3 +609,9 @@ void emberAfPluginIasZoneClientReadAttributesResponseCallback(EmberAfClusterId c
         clearState();
     }
 }
+
+void emberAfPluginIasZoneClientZdoCallback(EmberNodeId emberNodeId, EmberApsFrame * apsFrame, uint8_t * message, uint16_t length) {}
+
+void emberAfPluginIasZoneClientWriteAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen) {}
+
+void emberAfPluginIasZoneClientReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen) {}


### PR DESCRIPTION
 #### Problem

#3464 does not have any informations about plugins and will not generate definitions or stubs for the IAS Zone Client methods.

 #### Summary of Changes
 * Move IAS Zone Client plugin callbacks into `src/app/clusters/ias-zone-client`
 * Remove the related definitions/stubs from `gen/clusters-callback-stubs.c`