### PR TITLE
Remove '-Wno-non-virtual-dtor' from compiler flags

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -139,10 +139,7 @@ config("disabled_warnings") {
     "-Wno-unknown-warning-option",
     "-Wno-missing-field-initializers",
   ]
-  cflags_cc = [
-    "-Wno-non-virtual-dtor",
-    "-Wno-deprecated-copy",
-  ]
+  cflags_cc = [ "-Wno-deprecated-copy" ]
   if (!is_debug) {
     # assert() causes unused variable warnings in release.
     cflags += [ "-Wno-unused" ]
@@ -158,6 +155,8 @@ config("disabled_warnings") {
 
 config("strict_warnings") {
   cflags = [ "-Wall" ]
+
+  cflags_cc = [ "-Wnon-virtual-dtor" ]
 
   ldflags = []
 

--- a/src/ble/BleApplicationDelegate.h
+++ b/src/ble/BleApplicationDelegate.h
@@ -35,6 +35,8 @@ namespace Ble {
 class DLL_EXPORT BleApplicationDelegate
 {
 public:
+    virtual ~BleApplicationDelegate() {}
+
     // CHIP calls this function once it closes the last BLEEndPoint associated with a BLE given connection object.
     // A call to this function means CHIP no longer cares about the state of the given BLE connection.
     // The application can use this callback to e.g. close the underlying BLE conection if it is no longer needed,

--- a/src/ble/BleConnectionDelegate.h
+++ b/src/ble/BleConnectionDelegate.h
@@ -41,6 +41,8 @@ namespace Ble {
 class DLL_EXPORT BleConnectionDelegate
 {
 public:
+    virtual ~BleConnectionDelegate() {}
+
     // Public function pointers:
     typedef void (*OnConnectionCompleteFunct)(void * appState, BLE_CONNECTION_OBJECT connObj);
     OnConnectionCompleteFunct OnConnectionComplete;

--- a/src/ble/BlePlatformDelegate.h
+++ b/src/ble/BlePlatformDelegate.h
@@ -40,6 +40,8 @@ using ::chip::System::PacketBuffer;
 class DLL_EXPORT BlePlatformDelegate
 {
 public:
+    virtual ~BlePlatformDelegate() {}
+
     // Following APIs must be implemented by platform:
 
     // Subscribe to updates and indications on the specfied characteristic

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -106,6 +106,7 @@ template <typename Sig>
 class ECPKey
 {
 public:
+    virtual ~ECPKey() {}
     virtual SupportedECPKeyTypes Type() const = 0;
     virtual size_t Length() const             = 0;
     virtual operator const uint8_t *() const  = 0;
@@ -181,6 +182,8 @@ template <typename PK, typename Secret, typename Sig>
 class ECPKeypair
 {
 public:
+    virtual ~ECPKeypair() {}
+
     /** @brief Generate a new Certificate Signing Request (CSR).
      * @param csr Newly generated CSR
      * @param csr_length The caller provides the length of input buffer (csr). The function returns the actual length of generated

--- a/src/lib/support/CHIPArgParser.hpp
+++ b/src/lib/support/CHIPArgParser.hpp
@@ -87,6 +87,7 @@ class OptionSetBase : public OptionSet
 {
 public:
     OptionSetBase();
+    virtual ~OptionSetBase() {}
     virtual bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg) = 0;
 
 private:

--- a/src/transport/RendezvousSessionDelegate.h
+++ b/src/transport/RendezvousSessionDelegate.h
@@ -47,6 +47,8 @@ public:
 class DLL_EXPORT RendezvousDeviceCredentialsDelegate
 {
 public:
+    virtual ~RendezvousDeviceCredentialsDelegate() {}
+
     virtual void SendNetworkCredentials(const char * ssid, const char * passwd)          = 0;
     virtual void SendThreadCredentials(const DeviceLayer::Internal::DeviceNetworkInfo &) = 0;
     virtual void SendOperationalCredentials()                                            = 0;


### PR DESCRIPTION

 #### Problem

It seems like there is no reasons (at least in term of code in the tree) to use this flag.


 #### Summary of Changes
 * Remove `-Wno-non-virtual-dtor` from `build/config/compiler/BUILD.gn`