### PR TITLE
Add gsl-lite into third-party and use it in some cleanup places

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -68,3 +68,6 @@
 	path = third_party/zap/repo
 	url = https://github.com/project-chip/zap.git
 	branch = master
+[submodule "third_party/gsl-lite/repo"]
+	path = third_party/gsl-lite/repo
+	url = https://github.com/gsl-lite/gsl-lite

--- a/src/lib/mdns/BUILD.gn
+++ b/src/lib/mdns/BUILD.gn
@@ -21,6 +21,7 @@ source_set("platform_header") {
 static_library("mdns") {
   public_deps = [
     ":platform_header",
+    "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/platform",
   ]

--- a/src/transport/BUILD.gn
+++ b/src/transport/BUILD.gn
@@ -52,5 +52,6 @@ static_library("transport") {
     "${chip_root}/src/lib/support",
     "${chip_root}/src/platform",
     "${chip_root}/src/transport/raw",
+    "${chip_root}/third_party/gsl-lite",
   ]
 }

--- a/src/transport/SecurePairingSession.cpp
+++ b/src/transport/SecurePairingSession.cpp
@@ -194,6 +194,13 @@ CHIP_ERROR SecurePairingSession::AttachHeaderAndSend(uint8_t msgType, System::Pa
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
+    auto clean_buffer = gsl::finally([&msgBuf]() {
+        if (msgBuf != nullptr)
+        {
+            System::PacketBuffer::Free(msgBuf);
+        }
+    });
+
     PayloadHeader payloadHeader;
 
     payloadHeader
@@ -216,8 +223,6 @@ CHIP_ERROR SecurePairingSession::AttachHeaderAndSend(uint8_t msgType, System::Pa
     SuccessOrExit(err);
 
 exit:
-    if (msgBuf)
-        System::PacketBuffer::Free(msgBuf);
     return err;
 }
 

--- a/src/transport/SecurePairingSession.cpp
+++ b/src/transport/SecurePairingSession.cpp
@@ -27,16 +27,18 @@
  *      (https://www.ietf.org/id/draft-bar-cfrg-spake2plus-01.html)
  *
  */
+#include <transport/SecurePairingSession.h>
 
 #include <inttypes.h>
 #include <string.h>
+
+#include <gsl/gsl-lite.hpp>
 
 #include <core/CHIPSafeCasts.h>
 #include <protocols/Protocols.h>
 #include <support/BufBound.h>
 #include <support/CodeUtils.h>
 #include <support/SafeInt.h>
-#include <transport/SecurePairingSession.h>
 
 namespace chip {
 
@@ -228,6 +230,13 @@ CHIP_ERROR SecurePairingSession::Pair(uint32_t peerSetUpPINCode, uint32_t pbkdf2
 
     System::PacketBuffer * resp = nullptr;
 
+    auto clean_buffer = gsl::finally([&resp]() {
+        if (resp != nullptr)
+        {
+            System::PacketBuffer::Free(resp);
+        }
+    });
+
     CHIP_ERROR err = Init(peerSetUpPINCode, pbkdf2IterCount, salt, saltLen, myNodeId, myKeyId, delegate);
     SuccessOrExit(err);
 
@@ -260,14 +269,7 @@ CHIP_ERROR SecurePairingSession::Pair(uint32_t peerSetUpPINCode, uint32_t pbkdf2
     return err;
 
 exit:
-
     mNextExpectedMsg = Spake2pMsgType::kSpake2pMsgTypeMax;
-
-    if (resp != nullptr)
-    {
-        System::PacketBuffer::Free(resp);
-    }
-
     return err;
 }
 
@@ -302,6 +304,13 @@ CHIP_ERROR SecurePairingSession::HandleCompute_pA(const PacketHeader & header, S
     size_t buf_len      = msg->TotalLength();
 
     System::PacketBuffer * resp = nullptr;
+
+    auto clean_buffer = gsl::finally([&resp]() {
+        if (resp != nullptr)
+        {
+            System::PacketBuffer::Free(resp);
+        }
+    });
 
     VerifyOrExit(buf != nullptr, err = CHIP_ERROR_MESSAGE_INCOMPLETE);
     VerifyOrExit(buf_len == kMAX_Point_Length, err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
@@ -347,12 +356,6 @@ CHIP_ERROR SecurePairingSession::HandleCompute_pA(const PacketHeader & header, S
 exit:
 
     mNextExpectedMsg = Spake2pMsgType::kSpake2pMsgTypeMax;
-
-    if (resp != nullptr)
-    {
-        System::PacketBuffer::Free(resp);
-    }
-
     return err;
 }
 
@@ -368,6 +371,13 @@ CHIP_ERROR SecurePairingSession::HandleCompute_pB_cB(const PacketHeader & header
     size_t buf_len      = msg->TotalLength();
 
     System::PacketBuffer * resp = nullptr;
+
+    auto clean_buffer = gsl::finally([&resp]() {
+        if (resp != nullptr)
+        {
+            System::PacketBuffer::Free(resp);
+        }
+    });
 
     VerifyOrExit(buf != nullptr, err = CHIP_ERROR_MESSAGE_INCOMPLETE);
     VerifyOrExit(buf_len == kMAX_Point_Length + kMAX_Hash_Length, err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
@@ -413,11 +423,6 @@ CHIP_ERROR SecurePairingSession::HandleCompute_pB_cB(const PacketHeader & header
 exit:
 
     mNextExpectedMsg = Spake2pMsgType::kSpake2pMsgTypeMax;
-
-    if (resp != nullptr)
-    {
-        System::PacketBuffer::Free(resp);
-    }
 
     return err;
 }

--- a/src/transport/raw/BUILD.gn
+++ b/src/transport/raw/BUILD.gn
@@ -38,5 +38,6 @@ static_library("raw") {
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/platform",
+    "${chip_root}/third_party/gsl-lite",
   ]
 }

--- a/third_party/gsl-lite/BUILD.gn
+++ b/third_party/gsl-lite/BUILD.gn
@@ -18,11 +18,11 @@ config("gsl-lite-config") {
 
 source_set("gsl-lite") {
   sources = [
+    "repo/include/gsl-lite/gsl-lite.hpp",
     "repo/include/gsl.h",
     "repo/include/gsl.hpp",
     "repo/include/gsl/gsl-lite.h",
     "repo/include/gsl/gsl-lite.hpp",
-    "repo/include/gsl-lite/gsl-lite.hpp",
   ]
 
   public_configs = [ ":gsl-lite-config" ]

--- a/third_party/gsl-lite/BUILD.gn
+++ b/third_party/gsl-lite/BUILD.gn
@@ -21,10 +21,9 @@ source_set("gsl-lite") {
     "repo/include/gsl.h",
     "repo/include/gsl.hpp",
     "repo/include/gsl/gsl-lite.h",
-    "repo/include/gsl/gsl",
     "repo/include/gsl/gsl-lite.hpp",
     "repo/include/gsl-lite/gsl-lite.hpp",
   ]
 
-  public_configs = [ ":nlassert_config" ]
+  public_configs = [ ":gsl-lite-config" ]
 }

--- a/third_party/gsl-lite/BUILD.gn
+++ b/third_party/gsl-lite/BUILD.gn
@@ -1,0 +1,30 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+config("gsl-lite-config") {
+  include_dirs = [ "repo/include" ]
+}
+
+source_set("gsl-lite") {
+  sources = [
+    "repo/include/gsl.h",
+    "repo/include/gsl.hpp",
+    "repo/include/gsl/gsl-lite.h",
+    "repo/include/gsl/gsl",
+    "repo/include/gsl/gsl-lite.hpp",
+    "repo/include/gsl-lite/gsl-lite.hpp",
+  ]
+
+  public_configs = [ ":nlassert_config" ]
+}


### PR DESCRIPTION
 #### Problem
GSL-lite provides some nice helpers that seem to even make code smaller. Things we can use:
   - final cleanup actions
   - not_null assertions
   - owner  of raw pointer assertions

 #### Summary of Changes
Include gsl-lite as a third party submodule.
Use gsl::finally actions to mark some buffer cleanup.

```
❯ bloaty ~/tmp/chip-all-clusters-app-pre-gsl.elf -- examples/all-clusters-app/esp32/build/chip-all-clusters-app.elf
    FILE SIZE        VM SIZE    
 --------------  -------------- 
  -0.1%    -144  -0.1%    -144    .flash.rodata
  -0.2%    -160  [ = ]       0    .debug_aranges
  -0.0%    -357  [ = ]       0    .debug_loc
  -0.3%    -480  [ = ]       0    .debug_frame
  -0.3%    -512  [ = ]       0    .debug_ranges
  -0.1%    -628  -0.1%    -628    .flash.text
  -0.4%    -688  [ = ]       0    .symtab
  -0.4% -2.47Ki  [ = ]       0    .debug_abbrev
 -38.6% -3.86Ki  [ = ]       0    [Unmapped]
  -0.2% -4.89Ki  [ = ]       0    .debug_line
  -2.5% -5.35Ki  [ = ]       0    .strtab
  -0.6% -7.74Ki  [ = ]       0    .debug_str
  -0.4% -31.9Ki  [ = ]       0    .debug_info
  -0.4% -59.1Ki  -0.1%    -772    TOTAL
```