### PR TITLE
Add '-Wshadow' to the compiler flags

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -157,7 +157,10 @@ config("disabled_warnings") {
 }
 
 config("strict_warnings") {
-  cflags = [ "-Wall" ]
+  cflags = [
+    "-Wall",
+    "-Wshadow",
+  ]
 
   ldflags = []
 

--- a/src/app/clusters/barrier-control-server/barrier-control-server.cpp
+++ b/src/app/clusters/barrier-control-server/barrier-control-server.cpp
@@ -129,10 +129,10 @@ static uint16_t getOpenOrClosePeriod(EndpointId endpoint, bool open)
     return period;
 }
 
-static void setMovingState(EndpointId endpoint, uint8_t state)
+static void setMovingState(EndpointId endpoint, uint8_t newState)
 {
     EmberAfStatus status = emberAfWriteServerAttribute(endpoint, ZCL_BARRIER_CONTROL_CLUSTER_ID,
-                                                       ZCL_BARRIER_MOVING_STATE_ATTRIBUTE_ID, &state, ZCL_ENUM8_ATTRIBUTE_TYPE);
+                                                       ZCL_BARRIER_MOVING_STATE_ATTRIBUTE_ID, &newState, ZCL_ENUM8_ATTRIBUTE_TYPE);
     assert(status == EMBER_ZCL_STATUS_SUCCESS);
 }
 

--- a/src/messaging/ReliableMessageContext.cpp
+++ b/src/messaging/ReliableMessageContext.cpp
@@ -342,7 +342,7 @@ CHIP_ERROR ReliableMessageContext::HandleRcvdAck(uint32_t AckMsgId)
     return err;
 }
 
-CHIP_ERROR ReliableMessageContext::HandleNeedsAck(uint32_t MessageId, BitFlags<uint32_t, MessageFlagValues> Flags)
+CHIP_ERROR ReliableMessageContext::HandleNeedsAck(uint32_t MessageId, BitFlags<uint32_t, MessageFlagValues> MsgFlags)
 
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -351,7 +351,7 @@ CHIP_ERROR ReliableMessageContext::HandleNeedsAck(uint32_t MessageId, BitFlags<u
     mManager->ExpireTicks();
 
     // If the message IS a duplicate.
-    if (Flags.Has(MessageFlagValues::kChipMessageFlag_DuplicateMessage))
+    if (MsgFlags.Has(MessageFlagValues::kChipMessageFlag_DuplicateMessage))
     {
 #if !defined(NDEBUG)
         ChipLogProgress(ExchangeManager, "Forcing tx of solitary ack for duplicate MsgId:%08" PRIX32, MessageId);


### PR DESCRIPTION

 #### Problem

CodeQL is complaining about a local variable hiding a global variable in https://github.com/project-chip/connectedhomeip/security/code-scanning/3500?query=ref%3Arefs%2Fheads%2Fmaster

Adding `-Wshadow` to the compiler flags will let us caught these before hands instead of having too look in the long list created by CodeQL.

 #### Summary of Changes
  * Add `-Wshadow` to the compiler flags
  * Rename `state` to `newState` in `src/app/clusters/barrier-control-server/barrier-control-server.cpp` to avoid the warning