### PR TITLE
Change the output target in chip-templates.json to be .cpp instead of .c

### DIFF
--- a/src/app/zap-templates/chip-templates.json
+++ b/src/app/zap-templates/chip-templates.json
@@ -26,7 +26,7 @@
         {
             "path": "call-command-handler-src.zapt",
             "name": "ZCL call-command-handler source",
-            "output": "call-command-handler.c"
+            "output": "call-command-handler.cpp"
         },
         {
             "path": "call-command-handler.zapt",
@@ -36,7 +36,7 @@
         {
             "path": "callback-stub-src.zapt",
             "name": "ZCL callback-stub source",
-            "output": "callback-stub.c"
+            "output": "callback-stub.cpp"
         },
         {
             "path": "callback.zapt",


### PR DESCRIPTION


 #### Problem
 
#3754 has renamed the `gen/*.c` files to `.cpp`. Even if the `zap-templates` folder are not used at the moment, I want to make sure to keep it in sync with what's going on in the tree.

 #### Summary of Changes
 * Replace `.c` to `.cpp` in `chip-templates.json`