### PR TITLE
Move 'emberAfPluginOnOffClusterServerPostInitCallback' to src/app/clu…

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/callback-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/gen/callback-stub.cpp
@@ -47,16 +47,6 @@
 
 using namespace chip;
 
-/** @brief On/off Cluster Server Post Init
- *
- * Following resolution of the On/Off state at startup for this endpoint,
- * perform any additional initialization needed; e.g., synchronize hardware
- * state.
- *
- * @param endpoint Endpoint that is being initialized  Ver.: always
- */
-void emberAfPluginOnOffClusterServerPostInitCallback(EndpointId endpoint) {}
-
 /** @brief Add To Current App Tasks
  *
  * This function is only useful to sleepy end devices.  This function will note

--- a/examples/all-clusters-app/all-clusters-common/gen/callback.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/callback.h
@@ -2730,16 +2730,6 @@ void emberAfOnOffClusterServerTickCallback(chip::EndpointId endpoint);
  *
  */
 bool emberAfOnOffClusterToggleCallback(void);
-
-/** @brief On/off Cluster Server Post Init
- *
- * Following resolution of the On/Off state at startup for this endpoint, perform any
- * additional initialization needed; e.g., synchronize hardware state.
- *
- * @param endpoint Endpoint that is being initialized  Ver.: always
- */
-void emberAfPluginOnOffClusterServerPostInitCallback(chip::EndpointId endpoint);
-
 /** @} END On/off Cluster Callbacks */
 
 /** @name On/off Switch Configuration Cluster Callbacks */

--- a/examples/lighting-app/efr32/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/efr32/src/ZclCallbacks.cpp
@@ -56,15 +56,23 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
     }
 }
 
-/** @brief On/off Cluster Server Post Init
+/** @brief Cluster Init
  *
- * Following resolution of the On/Off state at startup for this endpoint,
- * perform any additional initialization needed; e.g., synchronize hardware
- * state.
+ * This function is called when a specific cluster is initialized. It gives the
+ * application an opportunity to take care of cluster initialization procedures.
+ * It is called exactly once for each endpoint where cluster is present.
  *
- * @param endpoint Endpoint that is being initialized  Ver.: always
+ * @param endpoint   Ver.: always
+ * @param clusterId   Ver.: always
+ *
+ * TODO Issue #3841
+ * emberAfClusterInitCallback happens before the stack initialize the cluster
+ * attributes to the default value.
+ * The logic here expects something similar to the deprecated Plugins callback
+ * emberAfPluginOnOffClusterServerPostInitCallback.
+ *
  */
-void emberAfPluginOnOffClusterServerPostInitCallback(EndpointId endpoint)
+void emberAfClusterInitCallback(EndpointId endpoint, ClusterId clusterId)
 {
-    // TODO: implement any additional On/off Cluster Server post init actions
+    // TODO: implement any additional Cluster Server init actions
 }

--- a/examples/lighting-app/lighting-common/gen/callback-stub.cpp
+++ b/examples/lighting-app/lighting-common/gen/callback-stub.cpp
@@ -154,17 +154,6 @@ bool emberAfKeyEstablishmentClusterClientCommandReceivedCallback(EmberAfClusterC
     return false;
 }
 
-/** @brief Cluster Init
- *
- * This function is called when a specific cluster is initialized. It gives the
- * application an opportunity to take care of cluster initialization procedures.
- * It is called exactly once for each endpoint where cluster is present.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- */
-void emberAfClusterInitCallback(EndpointId endpoint, ClusterId clusterId) {}
-
 /** @brief Default Response
  *
  * This function is called by the application framework when a Default Response

--- a/examples/lighting-app/lighting-common/gen/callback.h
+++ b/examples/lighting-app/lighting-common/gen/callback.h
@@ -2729,15 +2729,6 @@ void emberAfOnOffClusterServerTickCallback(chip::EndpointId endpoint);
  *
  */
 bool emberAfOnOffClusterToggleCallback(void);
-/** @brief On/off Cluster Server Post Init
- *
- * Following resolution of the On/Off state at startup for this endpoint, perform any
- * additional initialization needed; e.g., synchronize hardware state.
- *
- * @param endpoint Endpoint that is being initialized  Ver.: always
- */
-void emberAfPluginOnOffClusterServerPostInitCallback(chip::EndpointId endpoint);
-
 /** @} END On/off Cluster Callbacks */
 
 /** @name On/off Switch Configuration Cluster Callbacks */

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -73,17 +73,25 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
     }
 }
 
-/** @brief On/off Cluster Server Post Init
+/** @brief Cluster Init
  *
- * Following resolution of the On/Off state at startup for this endpoint,
- * perform any additional initialization needed; e.g., synchronize hardware
- * state.
+ * This function is called when a specific cluster is initialized. It gives the
+ * application an opportunity to take care of cluster initialization procedures.
+ * It is called exactly once for each endpoint where cluster is present.
  *
- * @param endpoint Endpoint that is being initialized  Ver.: always
+ * @param endpoint   Ver.: always
+ * @param clusterId   Ver.: always
+ *
+ * TODO Issue #3841
+ * emberAfClusterInitCallback happens before the stack initialize the cluster
+ * attributes to the default value.
+ * The logic here expects something similar to the deprecated Plugins callback
+ * emberAfPluginOnOffClusterServerPostInitCallback.
+ *
  */
-void emberAfPluginOnOffClusterServerPostInitCallback(EndpointId endpoint)
+void emberAfClusterInitCallback(EndpointId endpoint, ClusterId clusterId)
 {
-    // TODO: implement any additional On/off Cluster Server post init actions
+    // TODO: implement any additional Cluster Server init actions
 }
 
 namespace {

--- a/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
@@ -46,15 +46,26 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
     LightingMgr().InitiateAction(*value ? LightingManager::ON_ACTION : LightingManager::OFF_ACTION, AppEvent::kEventType_Lighting);
 }
 
-/** @brief On/off Cluster Server Post Init
+/** @brief Cluster Init
  *
- * Following resolution of the On/Off state at startup for this endpoint,
- * perform any additional initialization needed; e.g., synchronize hardware
- * state.
+ * This function is called when a specific cluster is initialized. It gives the
+ * application an opportunity to take care of cluster initialization procedures.
+ * It is called exactly once for each endpoint where cluster is present.
  *
- * @param endpoint Endpoint that is being initialized  Ver.: always
+ * @param endpoint   Ver.: always
+ * @param clusterId   Ver.: always
+ *
+ * TODO Issue #3841
+ * emberAfClusterInitCallback happens before the stack initialize the cluster
+ * attributes to the default value.
+ * The logic here expects something similar to the deprecated Plugins callback
+ * emberAfPluginOnOffClusterServerPostInitCallback.
+ *
  */
-void emberAfPluginOnOffClusterServerPostInitCallback(EndpointId endpoint)
+void emberAfClusterInitCallback(EndpointId endpoint, ClusterId clusterId)
 {
-    GetAppTask().UpdateClusterState();
+    if (clusterId == ZCL_ON_OFF_CLUSTER_ID)
+    {
+        GetAppTask().UpdateClusterState();
+    }
 }

--- a/examples/lock-app/efr32/src/ZclCallbacks.cpp
+++ b/examples/lock-app/efr32/src/ZclCallbacks.cpp
@@ -57,15 +57,23 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
     }
 }
 
-/** @brief On/off Cluster Server Post Init
+/** @brief Cluster Init
  *
- * Following resolution of the On/Off state at startup for this endpoint,
- * perform any additional initialization needed; e.g., synchronize hardware
- * state.
+ * This function is called when a specific cluster is initialized. It gives the
+ * application an opportunity to take care of cluster initialization procedures.
+ * It is called exactly once for each endpoint where cluster is present.
  *
- * @param endpoint Endpoint that is being initialized  Ver.: always
+ * @param endpoint   Ver.: always
+ * @param clusterId   Ver.: always
+ *
+ * TODO Issue #3841
+ * emberAfClusterInitCallback happens before the stack initialize the cluster
+ * attributes to the default value.
+ * The logic here expects something similar to the deprecated Plugins callback
+ * emberAfPluginOnOffClusterServerPostInitCallback.
+ *
  */
-void emberAfPluginOnOffClusterServerPostInitCallback(EndpointId endpoint)
+void emberAfClusterInitCallback(EndpointId endpoint, ClusterId clusterId)
 {
-    // TODO: implement any additional On/off Cluster Server post init actions
+    // TODO: implement any additional Cluster Server init actions
 }

--- a/examples/lock-app/k32w/main/ZclCallbacks.cpp
+++ b/examples/lock-app/k32w/main/ZclCallbacks.cpp
@@ -45,15 +45,23 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
     BoltLockMgr().InitiateAction(0, *value ? BoltLockManager::LOCK_ACTION : BoltLockManager::UNLOCK_ACTION);
 }
 
-/** @brief On/off Cluster Server Post Init
+/** @brief Cluster Init
  *
- * Following resolution of the On/Off state at startup for this endpoint,
- * perform any additional initialization needed; e.g., synchronize hardware
- * state.
+ * This function is called when a specific cluster is initialized. It gives the
+ * application an opportunity to take care of cluster initialization procedures.
+ * It is called exactly once for each endpoint where cluster is present.
  *
- * @param endpoint Endpoint that is being initialized  Ver.: always
+ * @param endpoint   Ver.: always
+ * @param clusterId   Ver.: always
+ *
+ * TODO Issue #3841
+ * emberAfClusterInitCallback happens before the stack initialize the cluster
+ * attributes to the default value.
+ * The logic here expects something similar to the deprecated Plugins callback
+ * emberAfPluginOnOffClusterServerPostInitCallback.
+ *
  */
-void emberAfPluginOnOffClusterServerPostInitCallback(EndpointId endpoint)
+void emberAfClusterInitCallback(EndpointId endpoint, ClusterId clusterId)
 {
-    // TODO: implement any additional On/off Cluster Server post init actions
+    // TODO: implement any additional Cluster Server init actions
 }

--- a/examples/lock-app/lock-common/gen/callback-stub.cpp
+++ b/examples/lock-app/lock-common/gen/callback-stub.cpp
@@ -155,17 +155,6 @@ bool emberAfKeyEstablishmentClusterClientCommandReceivedCallback(EmberAfClusterC
     return false;
 }
 
-/** @brief Cluster Init
- *
- * This function is called when a specific cluster is initialized. It gives the
- * application an opportunity to take care of cluster initialization procedures.
- * It is called exactly once for each endpoint where cluster is present.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- */
-void emberAfClusterInitCallback(EndpointId endpoint, ClusterId clusterId) {}
-
 /** @brief Default Response
  *
  * This function is called by the application framework when a Default Response

--- a/examples/lock-app/lock-common/gen/callback.h
+++ b/examples/lock-app/lock-common/gen/callback.h
@@ -2730,15 +2730,6 @@ void emberAfOnOffClusterServerTickCallback(chip::EndpointId endpoint);
  *
  */
 bool emberAfOnOffClusterToggleCallback(void);
-/** @brief On/off Cluster Server Post Init
- *
- * Following resolution of the On/Off state at startup for this endpoint, perform any
- * additional initialization needed; e.g., synchronize hardware state.
- *
- * @param endpoint Endpoint that is being initialized  Ver.: always
- */
-void emberAfPluginOnOffClusterServerPostInitCallback(chip::EndpointId endpoint);
-
 /** @} END On/off Cluster Callbacks */
 
 /** @name On/off Switch Configuration Cluster Callbacks */

--- a/examples/lock-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lock-app/nrfconnect/main/ZclCallbacks.cpp
@@ -46,15 +46,26 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
     BoltLockMgr().InitiateAction(0, *value ? BoltLockManager::LOCK_ACTION : BoltLockManager::UNLOCK_ACTION);
 }
 
-/** @brief On/off Cluster Server Post Init
+/** @brief Cluster Init
  *
- * Following resolution of the On/Off state at startup for this endpoint,
- * perform any additional initialization needed; e.g., synchronize hardware
- * state.
+ * This function is called when a specific cluster is initialized. It gives the
+ * application an opportunity to take care of cluster initialization procedures.
+ * It is called exactly once for each endpoint where cluster is present.
  *
- * @param endpoint Endpoint that is being initialized  Ver.: always
+ * @param endpoint   Ver.: always
+ * @param clusterId   Ver.: always
+ *
+ * TODO Issue #3841
+ * emberAfClusterInitCallback happens before the stack initialize the cluster
+ * attributes to the default value.
+ * The logic here expects something similar to the deprecated Plugins callback
+ * emberAfPluginOnOffClusterServerPostInitCallback.
+ *
  */
-void emberAfPluginOnOffClusterServerPostInitCallback(EndpointId endpoint)
+void emberAfClusterInitCallback(EndpointId endpoint, ClusterId clusterId)
 {
-    GetAppTask().UpdateClusterState();
+    if (clusterId == ZCL_ON_OFF_CLUSTER_ID)
+    {
+        GetAppTask().UpdateClusterState();
+    }
 }

--- a/src/app/clusters/on-off-server/on-off.cpp
+++ b/src/app/clusters/on-off-server/on-off.cpp
@@ -284,3 +284,5 @@ static bool areStartUpOnOffServerAttributesTokenized(EndpointId endpoint)
     return true;
 }
 #endif
+
+void emberAfPluginOnOffClusterServerPostInitCallback(EndpointId endpoint) {}

--- a/src/app/clusters/on-off-server/on-off.h
+++ b/src/app/clusters/on-off-server/on-off.h
@@ -41,3 +41,13 @@ EmberAfStatus emberAfOnOffClusterSetValueCallback(chip::EndpointId endpoint, uin
  * @param newValue   Ver.: always
  */
 void emberAfOnOffClusterLevelControlEffectCallback(chip::EndpointId endpoint, bool newValue);
+
+/** @brief On/off Cluster Server Post Init
+ *
+ * Following resolution of the On/Off state at startup for this endpoint,
+ * perform any additional initialization needed; e.g., synchronize hardware
+ * state.
+ *
+ * @param endpoint Endpoint that is being initialized  Ver.: always
+ */
+void emberAfPluginOnOffClusterServerPostInitCallback(chip::EndpointId endpoint);


### PR DESCRIPTION
…ster/on-off-server

 #### Problem
 
#3464 does not have any informations about plugins and will not generate definitions or stubs for the OnOff server methods.

This callback was used by a few applications. I replaced it by `emberAfClusterInitCallback` but there is a semantic difference.
The previous callback was done __Post__ init which means the default value of the light was set into the platform before it is called. But `emberAfClusterInitCallback` is called just before it is set.

In practice, and in the current shape of the tree there should be no differences. But this is one of the case where it the API was used so I though it worth mentioning it since we may want to provide something at some points to have an equivalent method.

 #### Summary of Changes
  * Move  `emberAfPluginOnOffClusterServerPostInitCallback`  into `src/app/clusters/on-off-server`
  * Remove the related definitions/stubs from gen/ folders