### PR TITLE
Use 'libssl' and 'libcrypto' instead of 'openssl'.

### DIFF
--- a/src/crypto/BUILD.gn
+++ b/src/crypto/BUILD.gn
@@ -37,7 +37,7 @@ if (chip_crypto == "openssl") {
   import("//build/config/linux/pkg_config.gni")
 
   pkg_config("openssl_config") {
-    packages = [ "openssl" ]
+    packages = [ "libssl", "libcrypto" ]
   }
 } else {
   import("//build_overrides/mbedtls.gni")

--- a/src/crypto/BUILD.gn
+++ b/src/crypto/BUILD.gn
@@ -37,7 +37,10 @@ if (chip_crypto == "openssl") {
   import("//build/config/linux/pkg_config.gni")
 
   pkg_config("openssl_config") {
-    packages = [ "libssl", "libcrypto" ]
+    packages = [
+      "libssl",
+      "libcrypto",
+    ]
   }
 } else {
   import("//build_overrides/mbedtls.gni")


### PR DESCRIPTION
 #### Problem
Compile failure on Ubuntu 20.04 LTS. Apparently openssl.pc does not exist anymore.

 #### Summary of Changes
Our docker images add libssl-dev and libcrypto-dev. Use these for package configuration.
