### PR TITLE
[nrf] add timestamp in nrfconnect logs

### DIFF
--- a/src/platform/nrfconnect/Logging.cpp
+++ b/src/platform/nrfconnect/Logging.cpp
@@ -24,6 +24,7 @@
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 #include <support/logging/CHIPLogging.h>
 
+#include <kernel.h>
 #include <logging/log.h>
 
 #include <cstdio>
@@ -60,14 +61,16 @@ void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
 
     {
         char formattedMsg[CHIP_DEVICE_CONFIG_LOG_MESSAGE_MAX_SIZE];
-        size_t prefixLen;
+        size_t prefixLen = 0;
 
         constexpr size_t maxPrefixLen = ChipLoggingModuleNameLen + 3;
         static_assert(sizeof(formattedMsg) > maxPrefixLen);
 
+        prefixLen += snprintf(formattedMsg, sizeof(formattedMsg), "%u", k_uptime_get_32());
+
         // Form the log prefix, e.g. "[DL] "
-        formattedMsg[0] = '[';
-        GetModuleName(formattedMsg + 1, module);
+        formattedMsg[prefixLen++] = '[';
+        GetModuleName(formattedMsg + prefixLen, module);
         prefixLen                 = strlen(formattedMsg);
         formattedMsg[prefixLen++] = ']';
         formattedMsg[prefixLen++] = ' ';


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

Timestamp is missing from nrfconnect log. This is a desired feature when debugging.

 #### Summary of Changes

Adds the timestamp.