### PR TITLE
Remove '-Wno-maybe-uninitialized' from compiler flags

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -151,7 +151,6 @@ config("disabled_warnings") {
     cflags += [
       "-Wno-psabi",
       "-Wno-cast-function-type",
-      "-Wno-maybe-uninitialized",
     ]
   }
 }

--- a/src/platform/qpg6100/BLEManagerImpl.cpp
+++ b/src/platform/qpg6100/BLEManagerImpl.cpp
@@ -140,17 +140,16 @@ CHIP_ERROR BLEManagerImpl::_GetDeviceName(char * buf, size_t bufSize)
 
 CHIP_ERROR BLEManagerImpl::_SetDeviceName(const char * devName)
 {
-    CHIP_ERROR err;
+    CHIP_ERROR err = CHIP_NO_ERROR;
 
-    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_NotSupported)
-    {
-        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-    }
+    VerifyOrExit(mServiceMode != ConnectivityManager::kCHIPoBLEServiceMode_NotSupported, err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
+
     if (devName != nullptr && devName[0] != 0)
     {
         err = qvCHIP_BleSetDeviceName(devName);
     }
 
+exit:
     return err;
 }
 
@@ -230,13 +229,12 @@ bool BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const ChipBleUU
     CHIP_ERROR err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     bool isRxHandle;
     uint16_t cId;
-    uint16_t dataLen;
+    uint16_t dataLen = data->DataLength();
 
     VerifyOrExit(IsSubscribed(conId), err = CHIP_ERROR_INVALID_ARGUMENT);
     ChipLogDetail(DeviceLayer, "Sending indication for CHIPoBLE TX characteristic (con %u, len %u)", conId, dataLen);
 
     isRxHandle = UUIDsMatch(&chipUUID_CHIPoBLEChar_RX, charId);
-    dataLen    = data->DataLength();
     cId        = qvCHIP_BleGetHandle(isRxHandle);
 
     qvCHIP_TxData(conId, cId, dataLen, data->Start());

--- a/third_party/efr32_sdk/efr32_sdk.gni
+++ b/third_party/efr32_sdk/efr32_sdk.gni
@@ -169,6 +169,8 @@ template("efr32_sdk") {
       cflags += [ "-isystem" + rebase_path(include_dir, root_build_dir) ]
     }
 
+    cflags += [ "-Wno-maybe-uninitialized" ]
+
     if (defined(invoker.defines)) {
       defines += invoker.defines
     }

--- a/third_party/lwip/lwip.gni
+++ b/third_party/lwip/lwip.gni
@@ -88,6 +88,7 @@ template("lwip_target") {
       "-Wno-format",
       "-Wno-type-limits",
       "-Wno-unused-variable",
+      "-Wno-maybe-uninitialized",
     ]
   }
 

--- a/third_party/mbedtls/mbedtls.gni
+++ b/third_party/mbedtls/mbedtls.gni
@@ -19,6 +19,10 @@ template("mbedtls_target") {
 
   _mbedtls_root = "${mbedtls_root}/repo"
 
+  config("${mbedtls_target_name}_warnings") {
+    cflags = [ "-Wno-maybe-uninitialized" ]
+  }
+
   config("${mbedtls_target_name}_config") {
     include_dirs = [ "${_mbedtls_root}/include" ]
   }
@@ -105,6 +109,13 @@ template("mbedtls_target") {
     if (current_os != "freertos") {
       sources += [ "${_mbedtls_root}/library/timing.c" ]
     }
+
+    if (!defined(configs)) {
+      configs = []
+    }
+
+    # Relax warnings for third_party code.
+    configs += [ ":${mbedtls_target_name}_warnings" ]
 
     if (!defined(public_configs)) {
       public_configs = []


### PR DESCRIPTION
 #### Problem
 
The compiler flags hide potential uniitialized variables.

 #### Summary of Changes
  * Remove `-Wno-maybe-uninitialized` from the list of compiler flags
  * Add `-Wno-maybe-uninitialized` to some `third_party` repo
  * Fixes the potentially uninitialised variables in `qpg6100`