### PR TITLE
[nrfconnect] Added workaround fixing improper select method operation.

### DIFF
--- a/config/nrfconnect/nrfconnect-app.cmake
+++ b/config/nrfconnect/nrfconnect-app.cmake
@@ -53,6 +53,9 @@ endif()
 # ==================================================
 find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
+# TODO: temporary fix forcing time_t size to be equal long size - remove it after merging fix from Zephyr project.
+zephyr_compile_definitions(_USE_LONG_TIME_T)
+
 # ==================================================
 # General settings
 # ==================================================


### PR DESCRIPTION
 #### Problem
Select method is not working properly, because of the internal Zephyr's implementation problem with casting timeval types.

 #### Summary of Changes
* Added compile definition to force using time_t type of size equal to the long size and fix problem until the real problem solution will be merged in the Zephyr project.

 Fixes #3799 