### PR TITLE
Move Scene Cluster Specific callbaks from gen/callback* to src/app/sc…

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/callback.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/callback.h
@@ -2232,32 +2232,6 @@ bool emberAfGroupsClusterViewGroupResponseCallback(uint8_t status, uint16_t grou
  * @param endpoint The endpoint.  Ver.: always
  */
 void emberAfScenesClusterClearSceneTableCallback(uint8_t endpoint);
-/** @brief Scenes Cluster Make Invalid
- *
- * This function is called to invalidate the valid attribute in the Scenes
- * cluster.
- *
- * @param endpoint   Ver.: always
- */
-EmberAfStatus emberAfScenesClusterMakeInvalidCallback(uint8_t endpoint);
-/** @brief Scenes Cluster Recall Saved Scene
- *
- * This function is called by the framework when the application should recall a
- * saved scene.
- *
- * @param endpoint The endpoint.  Ver.: always
- * @param groupId The group identifier.  Ver.: always
- * @param sceneId The scene identifier.  Ver.: always
- */
-EmberAfStatus emberAfScenesClusterRecallSavedSceneCallback(uint8_t endpoint, uint16_t groupId, uint8_t sceneId);
-/** @brief Scenes Cluster Remove Scenes In Group
- *
- * This function removes the scenes from a specified group.
- *
- * @param endpoint Endpoint  Ver.: always
- * @param groupId Group ID  Ver.: always
- */
-void emberAfScenesClusterRemoveScenesInGroupCallback(uint8_t endpoint, uint16_t groupId);
 /** @brief Scenes Cluster Add Scene
  *
  *
@@ -2583,20 +2557,6 @@ bool emberAfScenesClusterViewSceneCallback(uint16_t groupId, uint8_t sceneId);
  */
 bool emberAfScenesClusterViewSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
                                                    uint8_t * sceneName, uint8_t * extensionFieldSets);
-/** @brief Scenes Cluster Store Current Scene
- *
- * This function is called by the framework when the application should store
- * the current scene.  If an entry already exists in the scene table with the
- * same scene and group ids, the application should update the entry with the
- * current scene.  Otherwise, a new entry should be adde to the scene table, if
- * possible.
- *
- * @param endpoint The endpoint.  Ver.: always
- * @param groupId The group identifier.  Ver.: always
- * @param sceneId The scene identifier.  Ver.: always
- */
-EmberAfStatus emberAfScenesClusterStoreCurrentSceneCallback(uint8_t endpoint, uint16_t groupId, uint8_t sceneId);
-
 /** @} END Scenes Cluster Callbacks */
 
 /** @name On/off Cluster Callbacks */

--- a/examples/lighting-app/lighting-common/gen/callback-stub.cpp
+++ b/examples/lighting-app/lighting-common/gen/callback-stub.cpp
@@ -909,18 +909,6 @@ bool emberAfMainStartCallback(int * returnCode, int argc, char ** argv)
  */
 void emberAfMainTickCallback(void) {}
 
-/** @brief Scenes Cluster Make Invalid
- *
- * This function is called to invalidate the valid attribute in the Scenes
- * cluster.
- *
- * @param endpoint   Ver.: always
- */
-EmberAfStatus emberAfScenesClusterMakeInvalidCallback(uint8_t endpoint)
-{
-    return EMBER_ZCL_STATUS_UNSUP_CLUSTER_COMMAND;
-}
-
 /** @brief Mark Buffers
  *
  * This function is called when the garbage collector runs.  Any buffers held by
@@ -1281,20 +1269,6 @@ bool emberAfReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t *
     return false;
 }
 
-/** @brief Scenes Cluster Recall Saved Scene
- *
- * This function is called by the framework when the application should recall a
- * saved scene.
- *
- * @param endpoint The endpoint.  Ver.: always
- * @param groupId The group identifier.  Ver.: always
- * @param sceneId The scene identifier.  Ver.: always
- */
-EmberAfStatus emberAfScenesClusterRecallSavedSceneCallback(uint8_t endpoint, uint16_t groupId, uint8_t sceneId)
-{
-    return EMBER_ZCL_STATUS_FAILURE;
-}
-
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration
@@ -1367,15 +1341,6 @@ EmberStatus emberAfRemoteSetBindingPermissionCallback(const EmberBindingTableEnt
  * @param tasks   Ver.: always
  */
 void emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
-
-/** @brief Scenes Cluster Remove Scenes In Group
- *
- * This function removes the scenes from a specified group.
- *
- * @param endpoint Endpoint  Ver.: always
- * @param groupId Group ID  Ver.: always
- */
-void emberAfScenesClusterRemoveScenesInGroupCallback(uint8_t endpoint, uint16_t groupId) {}
 
 /** @brief Report Attributes
  *
@@ -1611,23 +1576,6 @@ EmberStatus emberAfStartSearchForJoinableNetworkCallback(void)
  *
  */
 void emberAfStopMoveCallback(void) {}
-
-/** @brief Scenes Cluster Store Current Scene
- *
- * This function is called by the framework when the application should store
- * the current scene.  If an entry already exists in the scene table with the
- * same scene and group ids, the application should update the entry with the
- * current scene.  Otherwise, a new entry should be adde to the scene table, if
- * possible.
- *
- * @param endpoint The endpoint.  Ver.: always
- * @param groupId The group identifier.  Ver.: always
- * @param sceneId The scene identifier.  Ver.: always
- */
-EmberAfStatus emberAfScenesClusterStoreCurrentSceneCallback(uint8_t endpoint, uint16_t groupId, uint8_t sceneId)
-{
-    return EMBER_ZCL_STATUS_FAILURE;
-}
 
 /** @brief Trust Center Join
  *

--- a/examples/lighting-app/lighting-common/gen/callback.h
+++ b/examples/lighting-app/lighting-common/gen/callback.h
@@ -2232,32 +2232,6 @@ bool emberAfGroupsClusterViewGroupResponseCallback(uint8_t status, uint16_t grou
  * @param endpoint The endpoint.  Ver.: always
  */
 void emberAfScenesClusterClearSceneTableCallback(uint8_t endpoint);
-/** @brief Scenes Cluster Make Invalid
- *
- * This function is called to invalidate the valid attribute in the Scenes
- * cluster.
- *
- * @param endpoint   Ver.: always
- */
-EmberAfStatus emberAfScenesClusterMakeInvalidCallback(uint8_t endpoint);
-/** @brief Scenes Cluster Recall Saved Scene
- *
- * This function is called by the framework when the application should recall a
- * saved scene.
- *
- * @param endpoint The endpoint.  Ver.: always
- * @param groupId The group identifier.  Ver.: always
- * @param sceneId The scene identifier.  Ver.: always
- */
-EmberAfStatus emberAfScenesClusterRecallSavedSceneCallback(uint8_t endpoint, uint16_t groupId, uint8_t sceneId);
-/** @brief Scenes Cluster Remove Scenes In Group
- *
- * This function removes the scenes from a specified group.
- *
- * @param endpoint Endpoint  Ver.: always
- * @param groupId Group ID  Ver.: always
- */
-void emberAfScenesClusterRemoveScenesInGroupCallback(uint8_t endpoint, uint16_t groupId);
 /** @brief Scenes Cluster Add Scene
  *
  *
@@ -2583,20 +2557,6 @@ bool emberAfScenesClusterViewSceneCallback(uint16_t groupId, uint8_t sceneId);
  */
 bool emberAfScenesClusterViewSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
                                                    uint8_t * sceneName, uint8_t * extensionFieldSets);
-/** @brief Scenes Cluster Store Current Scene
- *
- * This function is called by the framework when the application should store
- * the current scene.  If an entry already exists in the scene table with the
- * same scene and group ids, the application should update the entry with the
- * current scene.  Otherwise, a new entry should be adde to the scene table, if
- * possible.
- *
- * @param endpoint The endpoint.  Ver.: always
- * @param groupId The group identifier.  Ver.: always
- * @param sceneId The scene identifier.  Ver.: always
- */
-EmberAfStatus emberAfScenesClusterStoreCurrentSceneCallback(uint8_t endpoint, uint16_t groupId, uint8_t sceneId);
-
 /** @} END Scenes Cluster Callbacks */
 
 /** @name On/off Cluster Callbacks */

--- a/examples/lock-app/lock-common/gen/callback-stub.cpp
+++ b/examples/lock-app/lock-common/gen/callback-stub.cpp
@@ -910,18 +910,6 @@ bool emberAfMainStartCallback(int * returnCode, int argc, char ** argv)
  */
 void emberAfMainTickCallback(void) {}
 
-/** @brief Scenes Cluster Make Invalid
- *
- * This function is called to invalidate the valid attribute in the Scenes
- * cluster.
- *
- * @param endpoint   Ver.: always
- */
-EmberAfStatus emberAfScenesClusterMakeInvalidCallback(uint8_t endpoint)
-{
-    return EMBER_ZCL_STATUS_UNSUP_CLUSTER_COMMAND;
-}
-
 /** @brief Mark Buffers
  *
  * This function is called when the garbage collector runs.  Any buffers held by
@@ -1282,20 +1270,6 @@ bool emberAfReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t *
     return false;
 }
 
-/** @brief Scenes Cluster Recall Saved Scene
- *
- * This function is called by the framework when the application should recall a
- * saved scene.
- *
- * @param endpoint The endpoint.  Ver.: always
- * @param groupId The group identifier.  Ver.: always
- * @param sceneId The scene identifier.  Ver.: always
- */
-EmberAfStatus emberAfScenesClusterRecallSavedSceneCallback(uint8_t endpoint, uint16_t groupId, uint8_t sceneId)
-{
-    return EMBER_ZCL_STATUS_FAILURE;
-}
-
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration
@@ -1368,15 +1342,6 @@ EmberStatus emberAfRemoteSetBindingPermissionCallback(const EmberBindingTableEnt
  * @param tasks   Ver.: always
  */
 void emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
-
-/** @brief Scenes Cluster Remove Scenes In Group
- *
- * This function removes the scenes from a specified group.
- *
- * @param endpoint Endpoint  Ver.: always
- * @param groupId Group ID  Ver.: always
- */
-void emberAfScenesClusterRemoveScenesInGroupCallback(uint8_t endpoint, uint16_t groupId) {}
 
 /** @brief Report Attributes
  *
@@ -1612,23 +1577,6 @@ EmberStatus emberAfStartSearchForJoinableNetworkCallback(void)
  *
  */
 void emberAfStopMoveCallback(void) {}
-
-/** @brief Scenes Cluster Store Current Scene
- *
- * This function is called by the framework when the application should store
- * the current scene.  If an entry already exists in the scene table with the
- * same scene and group ids, the application should update the entry with the
- * current scene.  Otherwise, a new entry should be adde to the scene table, if
- * possible.
- *
- * @param endpoint The endpoint.  Ver.: always
- * @param groupId The group identifier.  Ver.: always
- * @param sceneId The scene identifier.  Ver.: always
- */
-EmberAfStatus emberAfScenesClusterStoreCurrentSceneCallback(uint8_t endpoint, uint16_t groupId, uint8_t sceneId)
-{
-    return EMBER_ZCL_STATUS_FAILURE;
-}
 
 /** @brief Trust Center Join
  *

--- a/examples/lock-app/lock-common/gen/callback.h
+++ b/examples/lock-app/lock-common/gen/callback.h
@@ -2232,32 +2232,6 @@ bool emberAfGroupsClusterViewGroupResponseCallback(uint8_t status, uint16_t grou
  * @param endpoint The endpoint.  Ver.: always
  */
 void emberAfScenesClusterClearSceneTableCallback(uint8_t endpoint);
-/** @brief Scenes Cluster Make Invalid
- *
- * This function is called to invalidate the valid attribute in the Scenes
- * cluster.
- *
- * @param endpoint   Ver.: always
- */
-EmberAfStatus emberAfScenesClusterMakeInvalidCallback(uint8_t endpoint);
-/** @brief Scenes Cluster Recall Saved Scene
- *
- * This function is called by the framework when the application should recall a
- * saved scene.
- *
- * @param endpoint The endpoint.  Ver.: always
- * @param groupId The group identifier.  Ver.: always
- * @param sceneId The scene identifier.  Ver.: always
- */
-EmberAfStatus emberAfScenesClusterRecallSavedSceneCallback(uint8_t endpoint, uint16_t groupId, uint8_t sceneId);
-/** @brief Scenes Cluster Remove Scenes In Group
- *
- * This function removes the scenes from a specified group.
- *
- * @param endpoint Endpoint  Ver.: always
- * @param groupId Group ID  Ver.: always
- */
-void emberAfScenesClusterRemoveScenesInGroupCallback(uint8_t endpoint, uint16_t groupId);
 /** @brief Scenes Cluster Add Scene
  *
  *
@@ -2583,20 +2557,6 @@ bool emberAfScenesClusterViewSceneCallback(uint16_t groupId, uint8_t sceneId);
  */
 bool emberAfScenesClusterViewSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
                                                    uint8_t * sceneName, uint8_t * extensionFieldSets);
-/** @brief Scenes Cluster Store Current Scene
- *
- * This function is called by the framework when the application should store
- * the current scene.  If an entry already exists in the scene table with the
- * same scene and group ids, the application should update the entry with the
- * current scene.  Otherwise, a new entry should be adde to the scene table, if
- * possible.
- *
- * @param endpoint The endpoint.  Ver.: always
- * @param groupId The group identifier.  Ver.: always
- * @param sceneId The scene identifier.  Ver.: always
- */
-EmberAfStatus emberAfScenesClusterStoreCurrentSceneCallback(uint8_t endpoint, uint16_t groupId, uint8_t sceneId);
-
 /** @} END Scenes Cluster Callbacks */
 
 /** @name On/off Cluster Callbacks */

--- a/examples/temperature-measurement-app/esp32/main/gen/callback-stub.cpp
+++ b/examples/temperature-measurement-app/esp32/main/gen/callback-stub.cpp
@@ -902,18 +902,6 @@ bool emberAfMainStartCallback(int * returnCode, int argc, char ** argv)
  */
 void emberAfMainTickCallback(void) {}
 
-/** @brief Scenes Cluster Make Invalid
- *
- * This function is called to invalidate the valid attribute in the Scenes
- * cluster.
- *
- * @param endpoint   Ver.: always
- */
-EmberAfStatus emberAfScenesClusterMakeInvalidCallback(uint8_t endpoint)
-{
-    return EMBER_ZCL_STATUS_UNSUP_CLUSTER_COMMAND;
-}
-
 /** @brief Mark Buffers
  *
  * This function is called when the garbage collector runs.  Any buffers held by
@@ -1275,20 +1263,6 @@ bool emberAfReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t *
     return false;
 }
 
-/** @brief Scenes Cluster Recall Saved Scene
- *
- * This function is called by the framework when the application should recall a
- * saved scene.
- *
- * @param endpoint The endpoint.  Ver.: always
- * @param groupId The group identifier.  Ver.: always
- * @param sceneId The scene identifier.  Ver.: always
- */
-EmberAfStatus emberAfScenesClusterRecallSavedSceneCallback(uint8_t endpoint, uint16_t groupId, uint8_t sceneId)
-{
-    return EMBER_ZCL_STATUS_FAILURE;
-}
-
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration
@@ -1361,15 +1335,6 @@ EmberStatus emberAfRemoteSetBindingPermissionCallback(const EmberBindingTableEnt
  * @param tasks   Ver.: always
  */
 void emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
-
-/** @brief Scenes Cluster Remove Scenes In Group
- *
- * This function removes the scenes from a specified group.
- *
- * @param endpoint Endpoint  Ver.: always
- * @param groupId Group ID  Ver.: always
- */
-void emberAfScenesClusterRemoveScenesInGroupCallback(uint8_t endpoint, uint16_t groupId) {}
 
 /** @brief Report Attributes
  *
@@ -1612,23 +1577,6 @@ EmberStatus emberAfStartSearchForJoinableNetworkCallback(void)
  *
  */
 void emberAfStopMoveCallback(void) {}
-
-/** @brief Scenes Cluster Store Current Scene
- *
- * This function is called by the framework when the application should store
- * the current scene.  If an entry already exists in the scene table with the
- * same scene and group ids, the application should update the entry with the
- * current scene.  Otherwise, a new entry should be adde to the scene table, if
- * possible.
- *
- * @param endpoint The endpoint.  Ver.: always
- * @param groupId The group identifier.  Ver.: always
- * @param sceneId The scene identifier.  Ver.: always
- */
-EmberAfStatus emberAfScenesClusterStoreCurrentSceneCallback(uint8_t endpoint, uint16_t groupId, uint8_t sceneId)
-{
-    return EMBER_ZCL_STATUS_FAILURE;
-}
 
 /** @brief Trust Center Join
  *

--- a/examples/temperature-measurement-app/esp32/main/gen/callback.h
+++ b/examples/temperature-measurement-app/esp32/main/gen/callback.h
@@ -2217,32 +2217,6 @@ bool emberAfGroupsClusterViewGroupResponseCallback(uint8_t status, uint16_t grou
  * @param endpoint The endpoint.  Ver.: always
  */
 void emberAfScenesClusterClearSceneTableCallback(uint8_t endpoint);
-/** @brief Scenes Cluster Make Invalid
- *
- * This function is called to invalidate the valid attribute in the Scenes
- * cluster.
- *
- * @param endpoint   Ver.: always
- */
-EmberAfStatus emberAfScenesClusterMakeInvalidCallback(uint8_t endpoint);
-/** @brief Scenes Cluster Recall Saved Scene
- *
- * This function is called by the framework when the application should recall a
- * saved scene.
- *
- * @param endpoint The endpoint.  Ver.: always
- * @param groupId The group identifier.  Ver.: always
- * @param sceneId The scene identifier.  Ver.: always
- */
-EmberAfStatus emberAfScenesClusterRecallSavedSceneCallback(uint8_t endpoint, uint16_t groupId, uint8_t sceneId);
-/** @brief Scenes Cluster Remove Scenes In Group
- *
- * This function removes the scenes from a specified group.
- *
- * @param endpoint Endpoint  Ver.: always
- * @param groupId Group ID  Ver.: always
- */
-void emberAfScenesClusterRemoveScenesInGroupCallback(uint8_t endpoint, uint16_t groupId);
 /** @brief Scenes Cluster Add Scene
  *
  *
@@ -2568,20 +2542,6 @@ bool emberAfScenesClusterViewSceneCallback(uint16_t groupId, uint8_t sceneId);
  */
 bool emberAfScenesClusterViewSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
                                                    uint8_t * sceneName, uint8_t * extensionFieldSets);
-/** @brief Scenes Cluster Store Current Scene
- *
- * This function is called by the framework when the application should store
- * the current scene.  If an entry already exists in the scene table with the
- * same scene and group ids, the application should update the entry with the
- * current scene.  Otherwise, a new entry should be adde to the scene table, if
- * possible.
- *
- * @param endpoint The endpoint.  Ver.: always
- * @param groupId The group identifier.  Ver.: always
- * @param sceneId The scene identifier.  Ver.: always
- */
-EmberAfStatus emberAfScenesClusterStoreCurrentSceneCallback(uint8_t endpoint, uint16_t groupId, uint8_t sceneId);
-
 /** @} END Scenes Cluster Callbacks */
 
 /** @name On/off Cluster Callbacks */

--- a/src/app/clusters/groups-server/groups-server.cpp
+++ b/src/app/clusters/groups-server/groups-server.cpp
@@ -49,6 +49,10 @@
 #include <app/util/af.h>
 #include <app/util/binding-table.h>
 
+#ifdef EMBER_AF_PLUGIN_SCENES
+#include <app/clusters/scenes/scenes.h>
+#endif // EMBER_AF_PLUGIN_SCENES
+
 using namespace chip;
 
 static bool isGroupPresent(EndpointId endpoint, GroupId groupId);

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -48,6 +48,10 @@
 #include <app/reporting/reporting.h>
 #endif
 
+#ifdef EMBER_AF_PLUGIN_SCENES
+#include <app/clusters/scenes/scenes.h>
+#endif // EMBER_AF_PLUGIN_SCENES
+
 #ifdef EMBER_AF_PLUGIN_ZLL_LEVEL_CONTROL_SERVER
 #include "app/framework/plugin/zll-level-control-server/zll-level-control-server.h"
 #endif // EMBER_AF_PLUGIN_ZLL_LEVEL_CONTROL_SERVER

--- a/src/app/clusters/on-off-server/on-off.cpp
+++ b/src/app/clusters/on-off-server/on-off.cpp
@@ -46,7 +46,7 @@
 #endif
 
 #ifdef EMBER_AF_PLUGIN_SCENES
-#include "../scenes/scenes.h"
+#include <app/clusters/scenes/scenes.h>
 #endif // EMBER_AF_PLUGIN_SCENES
 
 #ifdef EMBER_AF_PLUGIN_ZLL_ON_OFF_SERVER

--- a/src/app/clusters/scenes/scenes.h
+++ b/src/app/clusters/scenes/scenes.h
@@ -82,3 +82,46 @@ extern EmberAfSceneTableEntry emberAfPluginScenesServerSceneTable[];
 bool emberAfPluginScenesServerParseAddScene(const EmberAfClusterCommand * cmd, CHIPGroupId groupId, uint8_t sceneId,
                                             uint16_t transitionTime, uint8_t * sceneName, uint8_t * extensionFieldSets);
 bool emberAfPluginScenesServerParseViewScene(const EmberAfClusterCommand * cmd, CHIPGroupId groupId, uint8_t sceneId);
+
+/** @brief Scenes Cluster Recall Saved Scene
+ *
+ * This function is called by the framework when the application should recall a
+ * saved scene.
+ *
+ * @param endpoint The endpoint.  Ver.: always
+ * @param groupId The group identifier.  Ver.: always
+ * @param sceneId The scene identifier.  Ver.: always
+ */
+EmberAfStatus emberAfScenesClusterRecallSavedSceneCallback(CHIPEndpointId endpoint, CHIPGroupId groupId, uint8_t sceneId);
+
+/** @brief Scenes Cluster Store Current Scene
+ *
+ * This function is called by the framework when the application should store
+ * the current scene.  If an entry already exists in the scene table with the
+ * same scene and group ids, the application should update the entry with the
+ * current scene.  Otherwise, a new entry should be adde to the scene table, if
+ * possible.
+ *
+ * @param endpoint The endpoint.  Ver.: always
+ * @param groupId The group identifier.  Ver.: always
+ * @param sceneId The scene identifier.  Ver.: always
+ */
+EmberAfStatus emberAfScenesClusterStoreCurrentSceneCallback(CHIPEndpointId endpoint, CHIPGroupId groupId, uint8_t sceneId);
+
+/** @brief Scenes Cluster Remove Scenes In Group
+ *
+ * This function removes the scenes from a specified group.
+ *
+ * @param endpoint Endpoint  Ver.: always
+ * @param groupId Group ID  Ver.: always
+ */
+void emberAfScenesClusterRemoveScenesInGroupCallback(CHIPEndpointId endpoint, CHIPGroupId groupId);
+
+/** @brief Scenes Cluster Make Invalid
+ *
+ * This function is called to invalidate the valid attribute in the Scenes
+ * cluster.
+ *
+ * @param endpoint   Ver.: always
+ */
+EmberAfStatus emberAfScenesClusterMakeInvalidCallback(CHIPEndpointId endpoint);


### PR DESCRIPTION
…enes/scenes.h

 #### Problem

CHIP `src/app/clusters` have some interdependencies that is inherited from the SiLabs Plugins. #3464 does not have any information about plugins - only clusters. As a result it can not generate declarations/stubs for the plugins related methods.

This PR moves some methods that belongs to the `Scenes` plugin directly under `src/app/clusters/scenes`. The result is that other plugins that are dependent of the `Scenes` plugin must directly `#include <app/clusters/scenes/scenes.h>` instead of relying on potential stubs.

 #### Summary of Changes
 * Move declarations from `gen/callback*` files to `src/app/scenes/scenes.h`
 * Add required `#include <app/clusters/scenes/scenes.h>` into the dependent plugins