### PR TITLE
Move Groups Cluster Specific callbacks from gen/callback* to src/app/…

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/callback.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/callback.h
@@ -1988,16 +1988,6 @@ bool emberAfIdentifyClusterUpdateCommissionStateCallback(uint8_t action, uint8_t
  * @param endpoint The endpoint.  Ver.: always
  */
 void emberAfGroupsClusterClearGroupTableCallback(uint8_t endpoint);
-/** @brief Groups Cluster Endpoint In Group
- *
- * This function is called by the framework when it needs to determine if an
- * endpoint is a member of a group.  The application should return true if the
- * endpoint is a member of the group and false otherwise.
- *
- * @param endpoint The endpoint.  Ver.: always
- * @param groupId The group identifier.  Ver.: always
- */
-bool emberAfGroupsClusterEndpointInGroupCallback(uint8_t endpoint, uint16_t groupId);
 /** @brief Groups Cluster Add Group
  *
  *

--- a/examples/lighting-app/lighting-common/gen/callback-stub.cpp
+++ b/examples/lighting-app/lighting-common/gen/callback-stub.cpp
@@ -289,20 +289,6 @@ void emberAfEepromNoteInitializedStateCallback(bool state) {}
  */
 void emberAfEepromShutdownCallback(void) {}
 
-/** @brief Groups Cluster Endpoint In Group
- *
- * This function is called by the framework when it needs to determine if an
- * endpoint is a member of a group.  The application should return true if the
- * endpoint is a member of the group and false otherwise.
- *
- * @param endpoint The endpoint.  Ver.: always
- * @param groupId The group identifier.  Ver.: always
- */
-bool emberAfGroupsClusterEndpointInGroupCallback(uint8_t endpoint, uint16_t groupId)
-{
-    return false;
-}
-
 /** @brief External Attribute Read
  *
  * Like emberAfExternalAttributeWriteCallback above, this function is called

--- a/examples/lighting-app/lighting-common/gen/callback.h
+++ b/examples/lighting-app/lighting-common/gen/callback.h
@@ -1988,16 +1988,6 @@ bool emberAfIdentifyClusterUpdateCommissionStateCallback(uint8_t action, uint8_t
  * @param endpoint The endpoint.  Ver.: always
  */
 void emberAfGroupsClusterClearGroupTableCallback(uint8_t endpoint);
-/** @brief Groups Cluster Endpoint In Group
- *
- * This function is called by the framework when it needs to determine if an
- * endpoint is a member of a group.  The application should return true if the
- * endpoint is a member of the group and false otherwise.
- *
- * @param endpoint The endpoint.  Ver.: always
- * @param groupId The group identifier.  Ver.: always
- */
-bool emberAfGroupsClusterEndpointInGroupCallback(uint8_t endpoint, uint16_t groupId);
 /** @brief Groups Cluster Add Group
  *
  *

--- a/examples/lock-app/lock-common/gen/callback-stub.cpp
+++ b/examples/lock-app/lock-common/gen/callback-stub.cpp
@@ -290,20 +290,6 @@ void emberAfEepromNoteInitializedStateCallback(bool state) {}
  */
 void emberAfEepromShutdownCallback(void) {}
 
-/** @brief Groups Cluster Endpoint In Group
- *
- * This function is called by the framework when it needs to determine if an
- * endpoint is a member of a group.  The application should return true if the
- * endpoint is a member of the group and false otherwise.
- *
- * @param endpoint The endpoint.  Ver.: always
- * @param groupId The group identifier.  Ver.: always
- */
-bool emberAfGroupsClusterEndpointInGroupCallback(uint8_t endpoint, uint16_t groupId)
-{
-    return false;
-}
-
 /** @brief External Attribute Read
  *
  * Like emberAfExternalAttributeWriteCallback above, this function is called

--- a/examples/lock-app/lock-common/gen/callback.h
+++ b/examples/lock-app/lock-common/gen/callback.h
@@ -1988,16 +1988,6 @@ bool emberAfIdentifyClusterUpdateCommissionStateCallback(uint8_t action, uint8_t
  * @param endpoint The endpoint.  Ver.: always
  */
 void emberAfGroupsClusterClearGroupTableCallback(uint8_t endpoint);
-/** @brief Groups Cluster Endpoint In Group
- *
- * This function is called by the framework when it needs to determine if an
- * endpoint is a member of a group.  The application should return true if the
- * endpoint is a member of the group and false otherwise.
- *
- * @param endpoint The endpoint.  Ver.: always
- * @param groupId The group identifier.  Ver.: always
- */
-bool emberAfGroupsClusterEndpointInGroupCallback(uint8_t endpoint, uint16_t groupId);
 /** @brief Groups Cluster Add Group
  *
  *

--- a/examples/temperature-measurement-app/esp32/main/gen/callback-stub.cpp
+++ b/examples/temperature-measurement-app/esp32/main/gen/callback-stub.cpp
@@ -271,20 +271,6 @@ void emberAfEepromNoteInitializedStateCallback(bool state) {}
  */
 void emberAfEepromShutdownCallback(void) {}
 
-/** @brief Groups Cluster Endpoint In Group
- *
- * This function is called by the framework when it needs to determine if an
- * endpoint is a member of a group.  The application should return true if the
- * endpoint is a member of the group and false otherwise.
- *
- * @param endpoint The endpoint.  Ver.: always
- * @param groupId The group identifier.  Ver.: always
- */
-bool emberAfGroupsClusterEndpointInGroupCallback(uint8_t endpoint, uint16_t groupId)
-{
-    return false;
-}
-
 /** @brief Energy Scan Result
  *
  * This is called by the low-level stack code when an 802.15.4 energy scan

--- a/examples/temperature-measurement-app/esp32/main/gen/callback.h
+++ b/examples/temperature-measurement-app/esp32/main/gen/callback.h
@@ -1973,16 +1973,6 @@ bool emberAfIdentifyClusterUpdateCommissionStateCallback(uint8_t action, uint8_t
  * @param endpoint The endpoint.  Ver.: always
  */
 void emberAfGroupsClusterClearGroupTableCallback(uint8_t endpoint);
-/** @brief Groups Cluster Endpoint In Group
- *
- * This function is called by the framework when it needs to determine if an
- * endpoint is a member of a group.  The application should return true if the
- * endpoint is a member of the group and false otherwise.
- *
- * @param endpoint The endpoint.  Ver.: always
- * @param groupId The group identifier.  Ver.: always
- */
-bool emberAfGroupsClusterEndpointInGroupCallback(uint8_t endpoint, uint16_t groupId);
 /** @brief Groups Cluster Add Group
  *
  *

--- a/src/app/clusters/groups-server/groups-server.h
+++ b/src/app/clusters/groups-server/groups-server.h
@@ -47,3 +47,14 @@ void emberAfPluginGroupsServerSetGroupNameCallback(CHIPEndpointId endpoint, CHIP
  * @param endpoint Endpoint Ver.: always
  */
 bool emberAfPluginGroupsServerGroupNamesSupportedCallback(CHIPEndpointId endpoint);
+
+/** @brief Groups Cluster Endpoint In Group
+ *
+ * This function is called by the framework when it needs to determine if an
+ * endpoint is a member of a group.  The application should return true if the
+ * endpoint is a member of the group and false otherwise.
+ *
+ * @param endpoint The endpoint.  Ver.: always
+ * @param groupId The group identifier.  Ver.: always
+ */
+bool emberAfGroupsClusterEndpointInGroupCallback(CHIPEndpointId endpoint, CHIPGroupId groupId);

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -48,6 +48,10 @@
 //#include "app/framework/util/time-util.h"
 //#include "hal/micro/crc.h"
 
+#ifdef EMBER_AF_PLUGIN_GROUPS_SERVER
+#include <app/clusters/groups-server/groups-server.h>
+#endif // EMBER_AF_PLUGIN_GROUPS_SERVER
+
 using namespace chip;
 
 // TODO: Need to figure out what needs to happen wrt HAL tokens here, but for


### PR DESCRIPTION
…groups-server


 #### Problem
CHIP `src/app/clusters` have some interdependencies that is inherited from the SiLabs Plugins. #3464 does not have any information about plugins - only clusters. As a result it can not generate declarations/stubs for the plugins related methods.

This PR moves some methods that belongs to the `Groups` plugin directly under `src/app/clusters/groups-server`. The result is that other plugins that are dependent of the `Groups` plugin must directly #include <app/clusters/groups-server/groups-server.h> instead of relying on potential stubs.

 #### Summary of Changes
 * Move declarations from `gen/callback*` files to `src/app/groups-server/groups-server.h`
 * Add required `#include <app/clusters/groups-server/groups-server.h>` into the dependent plugins
 * In order to not to have to rewrite the same code a bunch of time, a method has been added to `scenes.cpp` in order to know if a endpoint is part of a group. The content of the method is different depending if the `Groups` plugin is activated or not.