### PR TITLE
Add attribute-size.h to src/app/zap-templates/chip-templates.json

### DIFF
--- a/src/app/zap-templates/attribute-size.zapt
+++ b/src/app/zap-templates/attribute-size.zapt
@@ -1,0 +1,11 @@
+{{chip_header}}
+
+// Prevent multiple inclusion
+#pragma once
+
+// ZCL attribute sizes
+{{#zcl_atomics}}
+{{#if size}}
+{{ident}}ZCL_{{asDelimitedMacro name}}_ATTRIBUTE_TYPE, {{size}}, \
+{{/if}}
+{{/zcl_atomics}}

--- a/src/app/zap-templates/attribute-type.zapt
+++ b/src/app/zap-templates/attribute-type.zapt
@@ -9,12 +9,3 @@ enum {
 {{ident}}ZCL_{{asDelimitedMacro name}}_ATTRIBUTE_TYPE = {{asHex atomicId 2}}, // {{description}}
 {{/zcl_atomics}}
 };
-
-// ZCL attribute sizes
-#define ZAP_GENERATED_ATTRIBUTE_SIZES { \
-{{#zcl_atomics}}
-{{#if size}}
-{{ident}}ZCL_{{asDelimitedMacro name}}_ATTRIBUTE_TYPE, {{size}}, \
-{{/if}}
-{{/zcl_atomics}}
-}

--- a/src/app/zap-templates/chip-templates.json
+++ b/src/app/zap-templates/chip-templates.json
@@ -24,6 +24,11 @@
             "output": "attribute-type.h"
         },
         {
+            "path": "attribute-size.zapt",
+            "name": "ZCL attribute-size header",
+            "output": "attribute-size.h"
+        },
+        {
             "path": "call-command-handler-src.zapt",
             "name": "ZCL call-command-handler source",
             "output": "call-command-handler.c"


### PR DESCRIPTION

 #### Problem

The templates extracted from #3464 that have landed in #3638 remove the previous `gen/attribute-size.h` file and get it merged into `attribute-type.h`.

That's not a bad thing but for the sake of being able to update the `gen/` folder of examples  independently during the migration phase I would prefer us to keep it. It would obligate the need to update `src/app/attribute-size.cpp` as suggested by #3346 

For reference the change is:
```
--- a/src/app/util/attribute-size.cpp
+++ b/src/app/util/attribute-size.cpp
@@ -42,10 +42,9 @@
 //#include PLATFORM_HEADER
 
 #include "af.h"
+#include "gen/attribute-type.h"
 
-static const uint8_t attributeSizes[] = {
-#include "gen/attribute-size.h"
-};
+static const uint8_t attributeSizes[] = ZAP_GENERATED_ATTRIBUTE_SIZES;
```

This change means `gen/` folder generated from AppBuilder and `gen/folder` generated from `ZAP` won't be able to lives at the same time into the tree. 

I would prefer us to not have to change all the `gen/` folder at the same time, just in case something is wrong in one of the cluster used by the `all-clusters-app` but that is unused for others examples such as `lighting-app`, `lock-app` and `temperature-measurement-app`

 #### Summary of Changes
 * Split back `attribute-type.zapt` into 2 different files. `attribute-type.zapt` and `attribute-size.zapt`
