### PR TITLE
Add some method on a BufferReader to test how much buffer is left.

### DIFF
--- a/src/lib/support/BufferReader.h
+++ b/src/lib/support/BufferReader.h
@@ -59,6 +59,18 @@ public:
     uint16_t OctetsRead() const { return static_cast<uint16_t>(mReadPtr - mBufStart); }
 
     /**
+     * Number of octets we have remaining to read.  Can be useful for logging.
+     */
+    uint16_t Remaining() const { return mAvailable; }
+
+    /**
+     * Test whether we have at least the given number of octets left to read.
+     * This takes a size_t, not uint16_t, to make life a bit simpler for
+     * consumers and avoid casting.
+     */
+    bool HasAtLeast(size_t octets) const { return octets <= Remaining(); }
+
+    /**
      * The reader status.  Once the status becomes a failure status, all later
      * read operations become no-ops and the status continues to be a failure
      * status.

--- a/src/lib/support/tests/BUILD.gn
+++ b/src/lib/support/tests/BUILD.gn
@@ -22,6 +22,7 @@ chip_test_suite("tests") {
 
   sources = [
     "TestBufBound.cpp",
+    "TestBufferReader.cpp",
     "TestCHIPArgParser.cpp",
     "TestCHIPCounter.cpp",
     "TestCHIPMem.cpp",
@@ -46,6 +47,7 @@ chip_test_suite("tests") {
 
   tests = [
     "TestBufBound",
+    "TestBufferReader",
     "TestErrorStr",
     "TestCHIPArgParser",
     "TestTimeUtils",

--- a/src/lib/support/tests/TestBufferReader.cpp
+++ b/src/lib/support/tests/TestBufferReader.cpp
@@ -1,0 +1,107 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a unit test suite for CHIP BufferReader
+ *
+ */
+
+#include "TestSupport.h"
+
+#include <support/BufferReader.h>
+#include <support/TestUtils.h>
+#include <type_traits>
+
+#include <nlunit-test.h>
+
+using namespace chip;
+using namespace chip::Encoding::LittleEndian;
+
+static const uint8_t test_buffer[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18 };
+
+struct TestReader : public Reader
+{
+    TestReader() : Reader(test_buffer, std::extent<typeof(test_buffer)>::value) {}
+};
+
+static void TestBufferReader_Basic(nlTestSuite * inSuite, void * inContext)
+{
+    TestReader reader;
+    uint8_t first;
+    uint16_t second;
+    uint32_t third;
+    uint64_t fourth;
+    CHIP_ERROR err = reader.Read8(&first).Read16(&second).Read32(&third).Read64(&fourth).StatusCode();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, first == 0x01);
+    NL_TEST_ASSERT(inSuite, second == 0x0302);
+    NL_TEST_ASSERT(inSuite, third == 0x07060504);
+    NL_TEST_ASSERT(inSuite, fourth == 0x0f0e0d0c0b0a0908);
+    NL_TEST_ASSERT(inSuite, reader.OctetsRead() == 15);
+    NL_TEST_ASSERT(inSuite, reader.Remaining() == 3);
+    NL_TEST_ASSERT(inSuite, reader.HasAtLeast(2));
+    NL_TEST_ASSERT(inSuite, reader.HasAtLeast(3));
+    NL_TEST_ASSERT(inSuite, !reader.HasAtLeast(4));
+
+    uint32_t fourMore;
+    err = reader.Read32(&fourMore).StatusCode();
+    NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
+}
+
+static void TestBufferReader_Saturation(nlTestSuite * inSuite, void * inContext)
+{
+    TestReader reader;
+    uint64_t temp;
+    // Read some bytes out so we can get to the end of the buffer.
+    CHIP_ERROR err = reader.Read64(&temp).StatusCode();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    err = reader.Read64(&temp).StatusCode();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, reader.HasAtLeast(2));
+    NL_TEST_ASSERT(inSuite, !reader.HasAtLeast(3));
+    uint32_t tooBig;
+    err = reader.Read32(&tooBig).StatusCode();
+    NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, !reader.HasAtLeast(1));
+
+    // Check that even though we only really read out 16 bytes, we can't read
+    // out one more bytes, because our previous read failed.
+    uint8_t small;
+    err = reader.Read8(&small).StatusCode();
+    NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
+}
+
+#define NL_TEST_DEF_FN(fn) NL_TEST_DEF("Test " #fn, fn)
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+static const nlTest sTests[] = { NL_TEST_DEF_FN(TestBufferReader_Basic), NL_TEST_DEF_FN(TestBufferReader_Saturation),
+                                 NL_TEST_SENTINEL() };
+
+int TestBufferReader(void)
+{
+    nlTestSuite theSuite = { "CHIP BufferReader tests", &sTests[0], nullptr, nullptr };
+
+    // Run test suit againt one context.
+    nlTestRunner(&theSuite, nullptr);
+    return nlTestRunnerStats(&theSuite);
+}
+
+CHIP_REGISTER_TEST_SUITE(TestBufferReader)

--- a/src/lib/support/tests/TestBufferReaderDriver.cpp
+++ b/src/lib/support/tests/TestBufferReaderDriver.cpp
@@ -18,7 +18,7 @@
 /**
  *    @file
  *      This file implements a standalone/native program executable
- *      test driver for the support library BufBound unit
+ *      test driver for the support library buffer reader unit
  *      tests.
  *
  */
@@ -27,5 +27,5 @@
 
 int main()
 {
-    return TestBufBound();
+    return TestBufferReader();
 }

--- a/src/lib/support/tests/TestScopedBuffer.cpp
+++ b/src/lib/support/tests/TestScopedBuffer.cpp
@@ -160,4 +160,4 @@ int TestScopedBuffer(void)
     return nlTestRunnerStats(&theSuite);
 }
 
-CHIP_REGISTER_TEST_SUITE(TestBufBound)
+CHIP_REGISTER_TEST_SUITE(TestScopedBuffer)

--- a/src/lib/support/tests/TestSerializableIntegerSet.cpp
+++ b/src/lib/support/tests/TestSerializableIntegerSet.cpp
@@ -182,4 +182,4 @@ int TestSerializableIntegerSet(void)
     return nlTestRunnerStats(&theSuite);
 }
 
-CHIP_REGISTER_TEST_SUITE(TestBufBound)
+CHIP_REGISTER_TEST_SUITE(TestSerializableIntegerSet)

--- a/src/lib/support/tests/TestSupport.h
+++ b/src/lib/support/tests/TestSupport.h
@@ -38,6 +38,7 @@ int TestPersistedCounter(int argc, char * argv[]);
 int TestScopedBuffer(void);
 int TestSafeInt();
 int TestSerializableIntegerSet(void);
+int TestBufferReader();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The non-BufferReader test changes are just a drive-by fix for a
problem I found when writing the BufferReader tests: some tests were
registering the wrong function.

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
There's no way to ask a buffer reader how much there is left to read.  I had thought this would not be needed, since the idea was to just try reading stuff and see whether it succeeds, but two things came up:

1. Some code wants to log the number of octets it's planning to work with, and it can't do that right now if it gets handed a buffer reader.
2. Some code wants to read out pascal strings, effectively (length, followed by a chunk of buffer) from the buffer reader.  We could expose an API for saying "I want a pointer to N `uint8_t`" or something, and have it fit with the overall reader API, but I'm not completely happy about making this pattern of reading out a pointer into the reader's internal buffer something we encourage.
<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Add two function: one that returns how many octets we have left in the reader, and one that takes a count and returns whether we have that many octets.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->


<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
