### PR TITLE
Issue a 'WakeSelect' after marking the system for shutdown.

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
@@ -229,6 +229,7 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_Shutdown()
     mShouldRunEventLoop.store(false, std::memory_order_relaxed);
     if (mChipTask)
     {
+        SystemLayer.WakeSelect();
         SuccessOrExit(err = pthread_join(mChipTask, nullptr));
     }
 


### PR DESCRIPTION
 #### Problem
chip-tool occasionally takes 5 seconds to finish even though a reply is received within ms.

Apparently the CHIP main loop waits for events and the PairingSession has an expiry timer of 5 seconds (otherwise the select would hang for the default of one month). This is due to the 'Shutdown' method marking that the main thread should stop but never waking it up.

 #### Summary of Changes
Issue a wakeselect in the POSIX implementation of the platform.
