### PR TITLE
Remove hardcoded node IDs for devices

### DIFF
--- a/examples/all-clusters-app/esp32/main/EchoServer.cpp
+++ b/examples/all-clusters-app/esp32/main/EchoServer.cpp
@@ -232,17 +232,11 @@ SecureSessionMgrBase & SessionManager()
 }
 } // namespace chip
 
-void PairingComplete(SecurePairingSession * pairing)
-{
-    Optional<Transport::PeerAddress> peer(Transport::Type::kUndefined);
-    sessions.NewPairing(peer, pairing);
-}
-
 // The echo server assumes the platform's networking has been setup already
-void startServer()
+void startServer(NodeId localNodeId)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    err            = sessions.Init(kLocalNodeId, &DeviceLayer::SystemLayer,
+    err            = sessions.Init(localNodeId, &DeviceLayer::SystemLayer,
                         UdpListenParameters(&DeviceLayer::InetLayer).SetAddressType(kIPAddressType_IPv6).SetInterfaceId(NULL),
                         UdpListenParameters(&DeviceLayer::InetLayer).SetAddressType(kIPAddressType_IPv4));
     SuccessOrExit(err);
@@ -258,4 +252,11 @@ exit:
     {
         ESP_LOGI(TAG, "Echo Server Listening...");
     }
+}
+
+void PairingComplete(NodeId assignedNodeId, NodeId peerNodeId, SecurePairingSession * pairing)
+{
+    Optional<Transport::PeerAddress> peer(Transport::Type::kUndefined);
+    startServer(assignedNodeId);
+    sessions.NewPairing(peer, peerNodeId, pairing);
 }

--- a/examples/all-clusters-app/esp32/main/Globals.cpp
+++ b/examples/all-clusters-app/esp32/main/Globals.cpp
@@ -21,4 +21,3 @@ LEDWidget statusLED1;
 LEDWidget statusLED2;
 BluetoothWidget bluetoothLED;
 WiFiWidget wifiLED;
-const chip::NodeId kLocalNodeId = 12344321;

--- a/examples/all-clusters-app/esp32/main/RendezvousDeviceDelegate.cpp
+++ b/examples/all-clusters-app/esp32/main/RendezvousDeviceDelegate.cpp
@@ -30,7 +30,7 @@ using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
 
-extern void PairingComplete(SecurePairingSession * pairing);
+extern void PairingComplete(NodeId assignedNodeId, NodeId peerNodeId, SecurePairingSession * pairing);
 
 static const char * TAG = "rendezvous-devicedelegate";
 
@@ -43,7 +43,7 @@ RendezvousDeviceDelegate::RendezvousDeviceDelegate()
     err = DeviceLayer::ConfigurationMgr().GetSetupPinCode(setupPINCode);
     SuccessOrExit(err);
 
-    params.SetSetupPINCode(setupPINCode).SetLocalNodeId(kLocalNodeId).SetBleLayer(DeviceLayer::ConnectivityMgr().GetBleLayer());
+    params.SetSetupPINCode(setupPINCode).SetBleLayer(DeviceLayer::ConnectivityMgr().GetBleLayer());
 
     mRendezvousSession = chip::Platform::New<RendezvousSession>(this);
     err                = mRendezvousSession->Init(params);
@@ -52,6 +52,20 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ESP_LOGE(TAG, "RendezvousDeviceDelegate Init failure: %s", ErrorStr(err));
+    }
+}
+
+void RendezvousDeviceDelegate::OnRendezvousComplete()
+{
+    ESP_LOGI(TAG, "Device completed Rendezvous process\n");
+    if (mRendezvousSession->GetLocalNodeId().HasValue() && mRendezvousSession->GetRemoteNodeId().HasValue())
+    {
+        PairingComplete(mRendezvousSession->GetLocalNodeId().Value(), mRendezvousSession->GetRemoteNodeId().Value(),
+                        &mRendezvousSession->GetPairingSession());
+    }
+    else
+    {
+        ESP_LOGI(TAG, "Commissioner did not assign a node ID to the device!!!\n");
     }
 }
 
@@ -66,7 +80,6 @@ void RendezvousDeviceDelegate::OnRendezvousStatusUpdate(RendezvousSessionDelegat
     {
     case RendezvousSessionDelegate::SecurePairingSuccess:
         ESP_LOGI(TAG, "Device completed SPAKE2+ handshake\n");
-        PairingComplete(&mRendezvousSession->GetPairingSession());
         bluetoothLED.Set(true);
         break;
 

--- a/examples/all-clusters-app/esp32/main/include/RendezvousDeviceDelegate.h
+++ b/examples/all-clusters-app/esp32/main/include/RendezvousDeviceDelegate.h
@@ -26,6 +26,7 @@ public:
     RendezvousDeviceDelegate();
 
     //////////// RendezvousSession callback Implementation ///////////////
+    void OnRendezvousComplete() override;
     void OnRendezvousStatusUpdate(RendezvousSessionDelegate::Status status, CHIP_ERROR err) override;
 
 private:

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -56,8 +56,6 @@ using namespace ::chip;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
 
-extern void startServer();
-
 #define QRCODE_BASE_URL "https://dhrishi.github.io/connectedhomeip/qrcode.html"
 
 #if CONFIG_DEVICE_TYPE_M5STACK
@@ -84,7 +82,7 @@ extern void startServer();
 // Used to indicate that an IP address has been added to the QRCode
 #define EXAMPLE_VENDOR_TAG_IP 1
 
-extern void PairingComplete(SecurePairingSession * pairing);
+extern void PairingComplete(NodeId assignedNodeId, NodeId peerNodeId, SecurePairingSession * pairing);
 
 const char * TAG = "all-clusters-app";
 
@@ -529,7 +527,6 @@ extern "C" void app_main()
 
     // Start the Echo Server
     InitDataModelHandler();
-    startServer();
 
     if (isRendezvousBLE())
     {
@@ -538,7 +535,7 @@ extern "C" void app_main()
     else if (isRendezvousBypassed())
     {
         ChipLogProgress(Ble, "Rendezvous and Secure Pairing skipped. Using test secret.");
-        PairingComplete(&gTestPairing);
+        PairingComplete(chip::kTestDeviceNodeId, chip::kTestControllerNodeId, &gTestPairing);
     }
 
     std::string qrCodeText = createSetupPayload();

--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -21,11 +21,7 @@
 #include "commands/clusters/Commands.h"
 #include "commands/echo/Commands.h"
 
-// NOTE: Remote device ID is in sync with the echo server device id
-//       At some point, we may want to add an option to connect to a device without
-//       knowing its id, because the ID can be learned on the first response that is received.
-constexpr chip::NodeId kLocalDeviceId  = 112233;
-constexpr chip::NodeId kRemoteDeviceId = 12344321;
+#include <transport/SecurePairingSession.h>
 
 // ================================================================================
 // Main Code
@@ -37,5 +33,5 @@ int main(int argc, char * argv[])
     registerCommandsEcho(commands);
     registerClusters(commands);
 
-    return commands.Run(kLocalDeviceId, kRemoteDeviceId, argc, argv);
+    return commands.Run(chip::kTestControllerNodeId, chip::kTestDeviceNodeId, argc, argv);
 }

--- a/examples/common/chip-app-server/RendezvousServer.cpp
+++ b/examples/common/chip-app-server/RendezvousServer.cpp
@@ -61,6 +61,13 @@ void RendezvousServer::OnRendezvousMessageReceived(PacketBuffer * buffer)
     chip::System::PacketBuffer::Free(buffer);
 }
 
+void RendezvousServer::OnRendezvousComplete()
+{
+    ChipLogProgress(AppServer, "Device completed Rendezvous process");
+    SessionManager().NewPairing(Optional<Transport::PeerAddress>{}, mRendezvousSession.GetRemoteNodeId().Value(),
+                                &mRendezvousSession.GetPairingSession());
+}
+
 void RendezvousServer::OnRendezvousStatusUpdate(Status status, CHIP_ERROR err)
 {
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(AppServer, "OnRendezvousStatusUpdate: %s", chip::ErrorStr(err)));
@@ -69,7 +76,6 @@ void RendezvousServer::OnRendezvousStatusUpdate(Status status, CHIP_ERROR err)
     {
     case RendezvousSessionDelegate::SecurePairingSuccess:
         ChipLogProgress(AppServer, "Device completed SPAKE2+ handshake");
-        SessionManager().NewPairing(Optional<Transport::PeerAddress>{}, &mRendezvousSession.GetPairingSession());
         break;
     case RendezvousSessionDelegate::NetworkProvisioningSuccess:
         ChipLogProgress(AppServer, "Device was assigned network credentials");

--- a/examples/common/chip-app-server/Server.cpp
+++ b/examples/common/chip-app-server/Server.cpp
@@ -40,10 +40,6 @@ using namespace ::chip::Inet;
 using namespace ::chip::Transport;
 using namespace ::chip::DeviceLayer;
 
-#ifndef EXAMPLE_SERVER_NODEID
-#define EXAMPLE_SERVER_NODEID 12344321
-#endif // EXAMPLE_SERVER_NODEID
-
 namespace {
 
 class ServerCallback : public SecureSessionMgrDelegate
@@ -104,7 +100,7 @@ void InitServer()
 
     InitDataModelHandler();
 
-    err = gSessions.Init(EXAMPLE_SERVER_NODEID, &DeviceLayer::SystemLayer,
+    err = gSessions.Init(chip::kTestDeviceNodeId, &DeviceLayer::SystemLayer,
                          UdpListenParameters(&DeviceLayer::InetLayer).SetAddressType(kIPAddressType_IPv6));
     SuccessOrExit(err);
 
@@ -117,13 +113,13 @@ void InitServer()
 
         SuccessOrExit(err = DeviceLayer::ConfigurationMgr().GetSetupPinCode(pinCode));
         params.SetSetupPINCode(pinCode)
-            .SetLocalNodeId(EXAMPLE_SERVER_NODEID)
+            .SetLocalNodeId(chip::kTestDeviceNodeId)
             .SetBleLayer(DeviceLayer::ConnectivityMgr().GetBleLayer());
         SuccessOrExit(err = gRendezvousServer.Init(params));
     }
 #endif
 
-    err = gSessions.NewPairing(peer, &gTestPairing);
+    err = gSessions.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing);
     SuccessOrExit(err);
 
     gSessions.SetDelegate(&gCallbacks);

--- a/examples/common/chip-app-server/include/RendezvousServer.h
+++ b/examples/common/chip-app-server/include/RendezvousServer.h
@@ -35,6 +35,7 @@ public:
     void OnRendezvousConnectionClosed() override;
     void OnRendezvousError(CHIP_ERROR err) override;
     void OnRendezvousMessageReceived(System::PacketBuffer * buffer) override;
+    void OnRendezvousComplete() override;
     void OnRendezvousStatusUpdate(Status status, CHIP_ERROR err) override;
 
 private:

--- a/examples/temperature-measurement-app/esp32/main/ResponseServer.cpp
+++ b/examples/temperature-measurement-app/esp32/main/ResponseServer.cpp
@@ -142,17 +142,11 @@ SecureSessionMgrBase & SessionManager()
 }
 } // namespace chip
 
-void PairingComplete(SecurePairingSession * pairing)
-{
-    Optional<Transport::PeerAddress> peer(Transport::Type::kUndefined);
-    sessions.NewPairing(peer, pairing);
-}
-
 // The echo server assumes the platform's networking has been setup already
-void startServer()
+void startServer(NodeId localNodeId)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    err            = sessions.Init(kLocalNodeId, &DeviceLayer::SystemLayer,
+    err            = sessions.Init(localNodeId, &DeviceLayer::SystemLayer,
                         UdpListenParameters(&DeviceLayer::InetLayer).SetAddressType(kIPAddressType_IPv6).SetInterfaceId(nullptr),
                         UdpListenParameters(&DeviceLayer::InetLayer).SetAddressType(kIPAddressType_IPv4));
     SuccessOrExit(err);
@@ -168,4 +162,11 @@ exit:
     {
         ESP_LOGI(TAG, "Echo Server Listening...");
     }
+}
+
+void PairingComplete(NodeId assignedNodeId, NodeId peerNodeId, SecurePairingSession * pairing)
+{
+    Optional<Transport::PeerAddress> peer(Transport::Type::kUndefined);
+    startServer(assignedNodeId);
+    sessions.NewPairing(peer, peerNodeId, pairing);
 }

--- a/examples/temperature-measurement-app/esp32/main/include/RendezvousDeviceDelegate.h
+++ b/examples/temperature-measurement-app/esp32/main/include/RendezvousDeviceDelegate.h
@@ -27,6 +27,7 @@ public:
     RendezvousDeviceDelegate();
 
     //////////// RendezvousSession callback Implementation ///////////////
+    void OnRendezvousComplete() override;
     void OnRendezvousStatusUpdate(RendezvousSessionDelegate::Status status, CHIP_ERROR err) override;
 
 private:

--- a/examples/temperature-measurement-app/esp32/main/main.cpp
+++ b/examples/temperature-measurement-app/esp32/main/main.cpp
@@ -44,8 +44,6 @@ using namespace ::chip;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
 
-extern void startServer();
-
 // Used to indicate that an IP address has been added to the QRCode
 #define EXAMPLE_VENDOR_TAG_IP 1
 
@@ -113,7 +111,6 @@ extern "C" void app_main()
     }
 
     InitDataModelHandler();
-    startServer();
 
     if (isRendezvousBLE())
     {
@@ -122,7 +119,7 @@ extern "C" void app_main()
     else if (isRendezvousBypassed())
     {
         ChipLogProgress(Ble, "Rendezvous and Secure Pairing skipped. Using test secret.");
-        PairingComplete(&gTestPairing);
+        PairingComplete(chip::kTestDeviceNodeId, chip::kTestControllerNodeId, &gTestPairing);
     }
 
     // Run the UI Loop

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -190,7 +190,7 @@ CHIP_ERROR Device::LoadSecureSessionParameters()
     SuccessOrExit(err);
 
     err = mSessionManager->NewPairing(
-        Optional<Transport::PeerAddress>::Value(Transport::PeerAddress::UDP(mDeviceAddr, mDevicePort, mInterface)),
+        Optional<Transport::PeerAddress>::Value(Transport::PeerAddress::UDP(mDeviceAddr, mDevicePort, mInterface)), mDeviceId,
         &pairingSession);
     SuccessOrExit(err);
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -467,7 +467,7 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, RendezvousParam
 
     mRendezvousSession = chip::Platform::New<RendezvousSession>(this);
     VerifyOrExit(mRendezvousSession != nullptr, err = CHIP_ERROR_NO_MEMORY);
-    err = mRendezvousSession->Init(params.SetLocalNodeId(mLocalDeviceId));
+    err = mRendezvousSession->Init(params.SetLocalNodeId(mLocalDeviceId).SetRemoteNodeId(remoteDeviceId));
     SuccessOrExit(err);
 
     device->Init(mSessionManager, mInetLayer, remoteDeviceId, remotePort, interfaceId);

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -146,8 +146,8 @@ private:
 // NOTE: Remote device ID is in sync with the echo server device id
 // At some point, we may want to add an option to connect to a device without
 // knowing its id, because the ID can be learned on the first response that is received.
-chip::NodeId kLocalDeviceId  = 112233;
-chip::NodeId kRemoteDeviceId = 12344321;
+chip::NodeId kLocalDeviceId  = chip::kTestControllerNodeId;
+chip::NodeId kRemoteDeviceId = chip::kTestDeviceNodeId;
 
 jint JNI_OnLoad(JavaVM * jvm, void * reserved)
 {

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -129,8 +129,8 @@ static chip::Inet::InetLayer sInetLayer;
 // NOTE: Remote device ID is in sync with the echo server device id
 // At some point, we may want to add an option to connect to a device without
 // knowing its id, because the ID can be learned on the first response that is received.
-chip::NodeId kLocalDeviceId  = 112233;
-chip::NodeId kRemoteDeviceId = 12344321;
+chip::NodeId kLocalDeviceId  = chip::kTestControllerNodeId;
+chip::NodeId kRemoteDeviceId = chip::kTestDeviceNodeId;
 
 #if CONFIG_NETWORK_LAYER_BLE
 static BleLayer sBle;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -35,8 +35,8 @@ static const char * const CHIP_SELECT_QUEUE = "com.zigbee.chip.select";
 // NOTE: Remote device ID is in sync with the echo server device id
 //       At some point, we may want to add an option to connect to a device without
 //       knowing its id, because the ID can be learned on the first response that is received.
-constexpr chip::NodeId kLocalDeviceId = 112233;
-constexpr chip::NodeId kRemoteDeviceId = 12344321;
+constexpr chip::NodeId kLocalDeviceId = chip::kTestControllerNodeId;
+constexpr chip::NodeId kRemoteDeviceId = chip::kTestDeviceNodeId;
 
 @implementation AddressInfo
 - (instancetype)initWithIP:(NSString *)ip

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
@@ -104,14 +104,18 @@ CHIP_ERROR CHIPPersistentStorageDelegateBridge::GetKeyValue(const char * key, ch
         valueString = [mDefaultPersistentStorage objectForKey:keyString];
     }
 
-    if (value != nullptr) {
-        size = strlcpy(value, [valueString UTF8String], size);
+    if (valueString != nil) {
+        if (value != nullptr) {
+            size = strlcpy(value, [valueString UTF8String], size);
+        } else {
+            size = [valueString length];
+        }
+        // Increment size to account for null termination
+        size += 1;
+        return CHIP_NO_ERROR;
     } else {
-        size = [valueString length];
+        return CHIP_ERROR_INVALID_ARGUMENT;
     }
-    // Increment size to account for null termination
-    size += 1;
-    return CHIP_NO_ERROR;
 }
 
 void CHIPPersistentStorageDelegateBridge::SetKeyValue(const char * key, const char * value)

--- a/src/lib/support/SerializableIntegerSet.cpp
+++ b/src/lib/support/SerializableIntegerSet.cpp
@@ -32,8 +32,9 @@ const char * SerializableU64SetBase::SerializeBase64(char * buf, uint16_t & bufl
     // Swap to little endian order if needed.
     SwapByteOrderIfNeeded();
 
-    buflen = Base64Encode(reinterpret_cast<const uint8_t *>(mData), static_cast<uint16_t>(len), buf);
-    out    = buf;
+    buflen      = Base64Encode(reinterpret_cast<const uint8_t *>(mData), static_cast<uint16_t>(len), buf);
+    buf[buflen] = '\0';
+    out         = buf;
 
     // Swap back to the original order
     SwapByteOrderIfNeeded();

--- a/src/lib/support/SerializableIntegerSet.h
+++ b/src/lib/support/SerializableIntegerSet.h
@@ -34,7 +34,9 @@
 #include <support/Base64.h>
 #include <support/CodeUtils.h>
 
-#define CHIP_MAX_SERIALIZED_SIZE_U64(count) static_cast<uint16_t>(BASE64_ENCODED_LEN(sizeof(uint64_t) * (count)))
+// BASE64_ENCODED_LEN doesn't account for null termination of the string.
+// So, we are adding 1 extra byte to the size requirement.
+#define CHIP_MAX_SERIALIZED_SIZE_U64(count) static_cast<uint16_t>(BASE64_ENCODED_LEN(sizeof(uint64_t) * (count)) + 1)
 
 namespace chip {
 

--- a/src/lib/support/tests/TestSerializableIntegerSet.cpp
+++ b/src/lib/support/tests/TestSerializableIntegerSet.cpp
@@ -63,7 +63,7 @@ void TestSerializableIntegerSet(nlTestSuite * inSuite, void * inContext)
     }
 
     set.Remove(8);
-    NL_TEST_ASSERT(inSuite, set.SerializedSize() == 0);
+    NL_TEST_ASSERT(inSuite, set.SerializedSize() == CHIP_MAX_SERIALIZED_SIZE_U64(0));
 }
 
 void TestSerializableIntegerSetNonZero(nlTestSuite * inSuite, void * inContext)
@@ -109,7 +109,7 @@ void TestSerializableIntegerSetNonZero(nlTestSuite * inSuite, void * inContext)
     }
 
     set.Remove(7);
-    NL_TEST_ASSERT(inSuite, set.SerializedSize() == 0);
+    NL_TEST_ASSERT(inSuite, set.SerializedSize() == CHIP_MAX_SERIALIZED_SIZE_U64(0));
 }
 
 void TestSerializableIntegerSetSerialize(nlTestSuite * inSuite, void * inContext)

--- a/src/transport/RendezvousParameters.h
+++ b/src/transport/RendezvousParameters.h
@@ -61,6 +61,14 @@ public:
         return *this;
     }
 
+    bool HasRemoteNodeId() const { return mRemoteNodeId.HasValue(); }
+    const Optional<NodeId> GetRemoteNodeId() const { return mRemoteNodeId; }
+    RendezvousParameters & SetRemoteNodeId(NodeId nodeId)
+    {
+        mRemoteNodeId.SetValue(nodeId);
+        return *this;
+    }
+
 #if CONFIG_NETWORK_LAYER_BLE
     bool HasBleLayer() const { return mBleLayer != nullptr; }
     Ble::BleLayer * GetBleLayer() const { return mBleLayer; }
@@ -83,6 +91,7 @@ public:
 
 private:
     Optional<NodeId> mLocalNodeId;        ///< the local node id
+    Optional<NodeId> mRemoteNodeId;       ///< the remote node id
     uint32_t mSetupPINCode  = 0;          ///< the target peripheral setup PIN Code
     uint16_t mDiscriminator = UINT16_MAX; ///< the target peripheral discriminator
 

--- a/src/transport/RendezvousSession.h
+++ b/src/transport/RendezvousSession.h
@@ -91,6 +91,9 @@ public:
      */
     SecurePairingSession & GetPairingSession() { return mPairingSession; }
 
+    Optional<NodeId> GetLocalNodeId() const { return mParams.GetLocalNodeId(); }
+    Optional<NodeId> GetRemoteNodeId() const { return mParams.GetRemoteNodeId(); }
+
     //////////// SecurePairingSessionDelegate Implementation ///////////////
     CHIP_ERROR SendPairingMessage(const PacketHeader & header, Header::Flags payloadFlags, System::PacketBuffer * msgBuf) override;
     void OnPairingError(CHIP_ERROR err) override;

--- a/src/transport/SecurePairingSession.h
+++ b/src/transport/SecurePairingSession.h
@@ -249,6 +249,14 @@ protected:
 };
 
 /*
+ * The following constants are node IDs that test devices and test
+ * controllers use while using the SecurePairingUsingTestSecret to
+ * establish secure channel
+ */
+constexpr chip::NodeId kTestControllerNodeId = 112233;
+constexpr chip::NodeId kTestDeviceNodeId     = 12344321;
+
+/*
  * The following class should only be used for test usecases.
  * The class is currently also used for devices that do no yet support
  * rendezvous. Once all the non-test usecases start supporting

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -135,7 +135,7 @@ public:
      *   establishes the security keys for secure communication with the
      *   peer node.
      */
-    CHIP_ERROR NewPairing(const Optional<Transport::PeerAddress> & peerAddr, SecurePairingSession * pairing);
+    CHIP_ERROR NewPairing(const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId, SecurePairingSession * pairing);
 
     /**
      * @brief

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -133,11 +133,11 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
     SecurePairingUsingTestSecret pairing1(Optional<NodeId>::Value(kSourceNodeId), 1, 2);
     Optional<Transport::PeerAddress> peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));
 
-    err = conn.NewPairing(peer, &pairing1);
+    err = conn.NewPairing(peer, kDestinationNodeId, &pairing1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     SecurePairingUsingTestSecret pairing2(Optional<NodeId>::Value(kDestinationNodeId), 2, 1);
-    err = conn.NewPairing(peer, &pairing2);
+    err = conn.NewPairing(peer, kSourceNodeId, &pairing2);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     // Should be able to send a message to itself by just calling send.


### PR DESCRIPTION
 #### Problem
The example devices are using hardcoded node IDs. This prevents commissioner from assigning node ID, and have multiple devices paired simultaneously.

 #### Summary of Changes
The problem seems to be more involved. The node ID was not configurable for Rendezvous state machine. So, just removing the hard coded value from the example apps was not sufficient.

The peer node ID received in message header during spake2p handshake can not be used, as these messages are not encrypted and integrity protected. So the new code relies on messages that are received post spake2p handshake (which are encrypted and integrity protected). The node ID is updated only after the received message can be decrypted.

This change updates the initialization logic for Rendezvous (specifically on device side) to not expect a node ID at start. The state machine detects when the commissioner sends a valid node ID, and it bootstraps the secure channel and connections using this node ID.

Also, different example apps and controllers had copies of hardcoded values (which are still useful when Rendezvous is bypassed, and test pairing is used). This PR moves the hardcoded value next to the test secret. 

