### PR TITLE
Add a work queue for thread safety in CHIP's Storage Delegate Bridge

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
@@ -48,7 +48,7 @@ private:
     SendKeyValue mCompletionHandler;
     SendStatus mStatusHandler;
     NSUserDefaults * mDefaultPersistentStorage;
-    dispatch_queue_t mDefaultCallbackQueue;
+    dispatch_queue_t mWorkQueue;
 };
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
@@ -23,134 +23,145 @@ CHIPPersistentStorageDelegateBridge::CHIPPersistentStorageDelegateBridge(void)
     : mDelegate(nil)
 {
     mDefaultPersistentStorage = [[NSUserDefaults alloc] init];
-    mDefaultCallbackQueue = dispatch_queue_create("com.zigbee.chip.framework.callback", DISPATCH_QUEUE_SERIAL);
+    mWorkQueue = dispatch_queue_create("com.zigbee.chip.framework.storage.workqueue", DISPATCH_QUEUE_SERIAL);
 }
 
 CHIPPersistentStorageDelegateBridge::~CHIPPersistentStorageDelegateBridge(void) {}
 
 void CHIPPersistentStorageDelegateBridge::setFrameworkDelegate(id<CHIPPersistentStorageDelegate> delegate, dispatch_queue_t queue)
 {
-    if (delegate && queue) {
-        mDelegate = delegate;
-        mQueue = queue;
-    } else {
-        mDelegate = nil;
-        mQueue = nil;
-    }
+    dispatch_async(mWorkQueue, ^{
+        if (delegate && queue) {
+            mDelegate = delegate;
+            mQueue = queue;
+        } else {
+            mDelegate = nil;
+            mQueue = nil;
+        }
+    });
 }
 
 void CHIPPersistentStorageDelegateBridge::SetDelegate(chip::Controller::PersistentStorageResultDelegate * delegate)
 {
-    if (delegate) {
-        mCallback = delegate;
+    dispatch_async(mWorkQueue, ^{
+        if (delegate) {
+            mCallback = delegate;
 
-        mCompletionHandler = ^(NSString * key, NSString * value) {
-            mCallback->OnValue([key UTF8String], [value UTF8String]);
-        };
+            mCompletionHandler = ^(NSString * key, NSString * value) {
+                dispatch_async(mWorkQueue, ^{
+                    mCallback->OnValue([key UTF8String], [value UTF8String]);
+                });
+            };
 
-        mStatusHandler = ^(NSString * key, Operation operation, NSError * status) {
-            chip::Controller::PersistentStorageResultDelegate::Operation op
-                = chip::Controller::PersistentStorageResultDelegate::Operation::kGET;
-            switch (operation) {
-            case kGet:
-                op = chip::Controller::PersistentStorageResultDelegate::Operation::kGET;
-                break;
-            case kSet:
-                op = chip::Controller::PersistentStorageResultDelegate::Operation::kSET;
-                break;
-            case kDelete:
-                op = chip::Controller::PersistentStorageResultDelegate::Operation::kDELETE;
-                break;
-            }
-            mCallback->OnStatus([key UTF8String], op, [CHIPError errorToCHIPErrorCode:status]);
-        };
-    } else {
-        mCallback = nil;
-        mCompletionHandler = nil;
-        mStatusHandler = nil;
-    }
+            mStatusHandler = ^(NSString * key, Operation operation, NSError * status) {
+                dispatch_async(mWorkQueue, ^{
+                    chip::Controller::PersistentStorageResultDelegate::Operation op
+                        = chip::Controller::PersistentStorageResultDelegate::Operation::kGET;
+                    switch (operation) {
+                    case kGet:
+                        op = chip::Controller::PersistentStorageResultDelegate::Operation::kGET;
+                        break;
+                    case kSet:
+                        op = chip::Controller::PersistentStorageResultDelegate::Operation::kSET;
+                        break;
+                    case kDelete:
+                        op = chip::Controller::PersistentStorageResultDelegate::Operation::kDELETE;
+                        break;
+                    }
+                    mCallback->OnStatus([key UTF8String], op, [CHIPError errorToCHIPErrorCode:status]);
+                });
+            };
+        } else {
+            mCallback = nil;
+            mCompletionHandler = nil;
+            mStatusHandler = nil;
+        }
+    });
 }
 
 void CHIPPersistentStorageDelegateBridge::GetKeyValue(const char * key)
 {
-    NSString * keyString = [NSString stringWithUTF8String:key];
-    NSLog(@"PersistentStorageDelegate Get Value for Key: %@", keyString);
+    dispatch_async(mWorkQueue, ^{
+        NSString * keyString = [NSString stringWithUTF8String:key];
+        NSLog(@"PersistentStorageDelegate Get Value for Key: %@", keyString);
 
-    id<CHIPPersistentStorageDelegate> strongDelegate = mDelegate;
-    if (strongDelegate && mQueue) {
-        dispatch_async(mQueue, ^{
-            [strongDelegate GetKeyValue:keyString handler:mCompletionHandler];
-        });
-    } else {
-        dispatch_async(mDefaultCallbackQueue, ^{
+        id<CHIPPersistentStorageDelegate> strongDelegate = mDelegate;
+        if (strongDelegate && mQueue) {
+            dispatch_async(mQueue, ^{
+                [strongDelegate GetKeyValue:keyString handler:mCompletionHandler];
+            });
+        } else {
             NSString * value = [mDefaultPersistentStorage objectForKey:keyString];
             NSLog(@"PersistentStorageDelegate Get Value for Key: %@, value %@", keyString, value);
             mCompletionHandler(keyString, value);
-        });
-    }
+        }
+    });
 }
 
 CHIP_ERROR CHIPPersistentStorageDelegateBridge::GetKeyValue(const char * key, char * value, uint16_t & size)
 {
-    NSString * keyString = [NSString stringWithUTF8String:key];
-    NSLog(@"PersistentStorageDelegate Sync Get Value for Key: %@", keyString);
+    __block CHIP_ERROR error = CHIP_NO_ERROR;
+    dispatch_sync(mWorkQueue, ^{
+        NSString * keyString = [NSString stringWithUTF8String:key];
+        NSLog(@"PersistentStorageDelegate Sync Get Value for Key: %@", keyString);
 
-    NSString * valueString = nil;
+        NSString * valueString = nil;
 
-    id<CHIPPersistentStorageDelegate> strongDelegate = mDelegate;
-    if (strongDelegate) {
-        valueString = [strongDelegate GetKeyValue:keyString];
-    } else {
-        valueString = [mDefaultPersistentStorage objectForKey:keyString];
-    }
-
-    if (valueString != nil) {
-        if (value != nullptr) {
-            size = strlcpy(value, [valueString UTF8String], size);
+        id<CHIPPersistentStorageDelegate> strongDelegate = mDelegate;
+        if (strongDelegate) {
+            valueString = [strongDelegate GetKeyValue:keyString];
         } else {
-            size = [valueString length];
+            valueString = [mDefaultPersistentStorage objectForKey:keyString];
         }
-        // Increment size to account for null termination
-        size += 1;
-        return CHIP_NO_ERROR;
-    } else {
-        return CHIP_ERROR_INVALID_ARGUMENT;
-    }
+
+        if (valueString != nil) {
+            if (value != nullptr) {
+                size = strlcpy(value, [valueString UTF8String], size);
+            } else {
+                size = [valueString length];
+            }
+            // Increment size to account for null termination
+            size += 1;
+        } else {
+            error = CHIP_ERROR_INVALID_ARGUMENT;
+        }
+    });
+    return error;
 }
 
 void CHIPPersistentStorageDelegateBridge::SetKeyValue(const char * key, const char * value)
 {
-    NSString * keyString = [NSString stringWithUTF8String:key];
-    NSString * valueString = [NSString stringWithUTF8String:value];
-    NSLog(@"PersistentStorageDelegate Set Key %@, Value %@", keyString, valueString);
+    dispatch_async(mWorkQueue, ^{
+        NSString * keyString = [NSString stringWithUTF8String:key];
+        NSString * valueString = [NSString stringWithUTF8String:value];
+        NSLog(@"PersistentStorageDelegate Set Key %@, Value %@", keyString, valueString);
 
-    id<CHIPPersistentStorageDelegate> strongDelegate = mDelegate;
-    if (strongDelegate && mQueue) {
-        dispatch_async(mQueue, ^{
-            [strongDelegate SetKeyValue:keyString value:valueString handler:mStatusHandler];
-        });
-    } else {
-        dispatch_async(mDefaultCallbackQueue, ^{
+        id<CHIPPersistentStorageDelegate> strongDelegate = mDelegate;
+        if (strongDelegate && mQueue) {
+            dispatch_async(mQueue, ^{
+                [strongDelegate SetKeyValue:keyString value:valueString handler:mStatusHandler];
+            });
+        } else {
             [mDefaultPersistentStorage setObject:valueString forKey:keyString];
             mStatusHandler(keyString, kSet, [CHIPError errorForCHIPErrorCode:0]);
-        });
-    }
+        }
+    });
 }
 
 void CHIPPersistentStorageDelegateBridge::DeleteKeyValue(const char * key)
 {
-    NSString * keyString = [NSString stringWithUTF8String:key];
-    NSLog(@"PersistentStorageDelegate Delete Key: %@", keyString);
+    dispatch_async(mWorkQueue, ^{
+        NSString * keyString = [NSString stringWithUTF8String:key];
+        NSLog(@"PersistentStorageDelegate Delete Key: %@", keyString);
 
-    id<CHIPPersistentStorageDelegate> strongDelegate = mDelegate;
-    if (strongDelegate && mQueue) {
-        dispatch_async(mQueue, ^{
-            [strongDelegate DeleteKeyValue:keyString handler:mStatusHandler];
-        });
-    } else {
-        dispatch_async(mDefaultCallbackQueue, ^{
+        id<CHIPPersistentStorageDelegate> strongDelegate = mDelegate;
+        if (strongDelegate && mQueue) {
+            dispatch_async(mQueue, ^{
+                [strongDelegate DeleteKeyValue:keyString handler:mStatusHandler];
+            });
+        } else {
             [mDefaultPersistentStorage removeObjectForKey:keyString];
             mStatusHandler(keyString, kDelete, [CHIPError errorForCHIPErrorCode:0]);
-        });
-    }
+        }
+    });
 }


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
The CHIP Storage Delegate Bridge has methods that might execute on arbitrary threads while accessing member variables. 
<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Added a workqueue and made sure every operation is queued up either async or in sync as necessary.
<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
