### PR TITLE
[nrfconnect] Don't pass Zephyr optimization flags to CHIP build scripts

### DIFF
--- a/build/config/compiler/compiler.gni
+++ b/build/config/compiler/compiler.gni
@@ -20,7 +20,7 @@ declare_args() {
   optimize_for_size = true
 
   # Optimize debug builds with -Og.
-  optimize_debug = current_os == "freertos"
+  optimize_debug = current_os == "freertos" || current_os == "zephyr"
 
   # Symbol level for debugging.
   symbol_level = 2


### PR DESCRIPTION
 #### Problem
Currently, CMake scripts for nRF Connect examples pass all Zephyr flags to CHIP build system via GN's `target_cflags_c`/`target_cflags_cc` arguments. As a result there can be duplicated or conflicting flags passed to the compiler.

 #### Summary of Changes
Add filter_exclude() to generated `args.gn` to filter out unnecessary flags before running CHIP build

 Fixes #3685