### PR TITLE
Add missing '#ifdef EMBER_AF_PLUGIN_REPORTING' to src/app/util/util.cpp

### DIFF
--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -52,6 +52,10 @@
 #include <app/clusters/groups-server/groups-server.h>
 #endif // EMBER_AF_PLUGIN_GROUPS_SERVER
 
+#ifdef EMBER_AF_PLUGIN_REPORTING
+#include <app/reporting/reporting.h>
+#endif // EMBER_AF_PLUGIN_REPORTING
+
 using namespace chip;
 
 // TODO: Need to figure out what needs to happen wrt HAL tokens here, but for
@@ -311,10 +315,12 @@ void emberAfStackDown(void)
         // && emberNetworkState() == EMBER_NO_NETWORK
     )
     {
+#ifdef EMBER_AF_PLUGIN_REPORTING
         // the report table should be cleared when the stack comes down.
         // going to a new network means new report devices should be discovered.
         // if the table isnt cleared the device keeps trying to send messages.
         emberAfClearReportTableCallback();
+#endif // EMBER_AF_PLUGIN_REPORTING
     }
 
     emberAfRegistrationAbortCallback();


### PR DESCRIPTION

 #### Problem

While trying to generate a working ZAP `gen/` folder for the `temperature-measurement-app` I noticed that I forgot to add a `#ifdef EMBER_AF_PLUGIN_REPORTING` in `src/app/util/util.cpp`...

 #### Summary of Changes
 * Add the missing `#include` and the missing `#ifdef`