### PR TITLE
Move 'emberAfPluginColorControlServerComputePwmFrom*Callback' to src/…

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/callback-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/gen/callback-stub.cpp
@@ -1608,30 +1608,3 @@ void halRadioPowerUpHandler(void) {}
  * @param sleepMode    Idle/sleep mode
  */
 void halSleepCallback(bool enter, SleepModes sleepMode) {}
-
-/** @brief Compute Pwm from HSV
- *
- * This function is called from the color server when it is time for the PWMs to
- * be driven with a new value from the HSV values.
- *
- * @param endpoint The identifying endpoint Ver.: always
- */
-void emberAfPluginColorControlServerComputePwmFromHsvCallback(uint8_t endpoint) {}
-
-/** @brief Compute Pwm from HSV
- *
- * This function is called from the color server when it is time for the PWMs to
- * be driven with a new value from the color temperature.
- *
- * @param endpoint The identifying endpoint Ver.: always
- */
-void emberAfPluginColorControlServerComputePwmFromTempCallback(uint8_t endpoint) {}
-
-/** @brief Compute Pwm from HSV
- *
- * This function is called from the color server when it is time for the PWMs to
- * be driven with a new value from the color X and color Y values.
- *
- * @param endpoint The identifying endpoint Ver.: always
- */
-void emberAfPluginColorControlServerComputePwmFromXyCallback(uint8_t endpoint) {}

--- a/examples/all-clusters-app/all-clusters-common/gen/callback.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/callback.h
@@ -8074,31 +8074,6 @@ bool emberAfColorControlClusterStepSaturationCallback(uint8_t stepMode, uint8_t 
  */
 bool emberAfColorControlClusterStopMoveStepCallback(uint8_t optionsMask, uint8_t optionsOverride);
 
-/** @brief Compute Pwm from HSV
- *
- * This function is called from the color server when it is time for the PWMs to
- * be driven with a new value from the HSV values.
- *
- * @param endpoint The identifying endpoint Ver.: always
- */
-void emberAfPluginColorControlServerComputePwmFromHsvCallback(uint8_t endpoint);
-/** @brief Compute Pwm from HSV
- *
- * This function is called from the color server when it is time for the PWMs to
- * be driven with a new value from the color X and color Y values.
- *
- * @param endpoint The identifying endpoint Ver.: always
- */
-void emberAfPluginColorControlServerComputePwmFromXyCallback(uint8_t endpoint);
-/** @brief Compute Pwm from HSV
- *
- * This function is called from the color server when it is time for the PWMs to
- * be driven with a new value from the color temperature.
- *
- * @param endpoint The identifying endpoint Ver.: always
- */
-void emberAfPluginColorControlServerComputePwmFromTempCallback(uint8_t endpoint);
-
 /** @} END Color Control Cluster Callbacks */
 
 /** @name Ballast Configuration Cluster Callbacks */

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -37,6 +37,7 @@
  *plugin.
  *******************************************************************************
  ******************************************************************************/
+#include "color-control-server.h"
 
 #include <app/util/af.h>
 
@@ -1855,3 +1856,9 @@ void emberAfColorControlClusterServerInitCallback(EndpointId endpoint)
     }
 #endif
 }
+
+void emberAfPluginColorControlServerComputePwmFromHsvCallback(EndpointId endpoint) {}
+
+void emberAfPluginColorControlServerComputePwmFromTempCallback(EndpointId endpoint) {}
+
+void emberAfPluginColorControlServerComputePwmFromXyCallback(EndpointId endpoint) {}

--- a/src/app/clusters/color-control-server/color-control-server.h
+++ b/src/app/clusters/color-control-server/color-control-server.h
@@ -1,0 +1,47 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/util/basic-types.h>
+
+/** @brief Compute Pwm from HSV
+ *
+ * This function is called from the color server when it is time for the PWMs to
+ * be driven with a new value from the HSV values.
+ *
+ * @param endpoint The identifying endpoint Ver.: always
+ */
+void emberAfPluginColorControlServerComputePwmFromHsvCallback(CHIPEndpointId endpoint);
+
+/** @brief Compute Pwm from HSV
+ *
+ * This function is called from the color server when it is time for the PWMs to
+ * be driven with a new value from the color temperature.
+ *
+ * @param endpoint The identifying endpoint Ver.: always
+ */
+void emberAfPluginColorControlServerComputePwmFromTempCallback(CHIPEndpointId endpoint);
+
+/** @brief Compute Pwm from HSV
+ *
+ * This function is called from the color server when it is time for the PWMs to
+ * be driven with a new value from the color X and color Y values.
+ *
+ * @param endpoint The identifying endpoint Ver.: always
+ */
+void emberAfPluginColorControlServerComputePwmFromXyCallback(CHIPEndpointId endpoint);


### PR DESCRIPTION
…app/clusters/color-control-server


 #### Problem
#3464 does not have any informations about plugins and will not generate definitions or stubs for the Color Control server methods.

 #### Summary of Changes
  * Move `emberAfPluginColorControlServerComputePwmFrom*Callback` into `src/app/clusters/color-control-server`
  * Remove the related definitions/stubs from `gen/` folders