### PR TITLE
Remove 'emberAfClusterSecurityCustomCallback' from src/app

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/callback-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/gen/callback-stub.cpp
@@ -166,25 +166,6 @@ bool emberAfKeyEstablishmentClusterClientCommandReceivedCallback(EmberAfClusterC
  */
 void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId) {}
 
-/** @brief Cluster Security Custom
- *
- * This callback is fired when determining if APS encryption is required for a
- * cluster outside of the specification's required clusters.  In other words,
- * for the Smart Energy profile this would be a cluster beyond the list that
- * normally requires APS encryption.
- *
- * @param profileId The profile ID  Ver.: always
- * @param clusterId The cluster ID  Ver.: always
- * @param incoming Whether this is an incoming or outgoing message.  Ver.:
- * always
- * @param commandId The ZCL command ID being sent/received.  Ver.: always
- */
-bool emberAfClusterSecurityCustomCallback(EmberAfProfileId profileId, EmberAfClusterId clusterId, bool incoming, uint8_t commandId)
-{
-    // By default, assume APS encryption is not required.
-    return false;
-}
-
 /** @brief Default Response
  *
  * This function is called by the application framework when a Default Response
@@ -1323,20 +1304,6 @@ bool emberAfReportAttributesCallback(EmberAfClusterId clusterId, uint8_t * buffe
  */
 void emberAfScanErrorCallback(EmberStatus status) {}
 
-/** @brief Security Init
- *
- * This callback is called by the framework to give the application a chance to
- * modify the security settings of the node during network initialization.
- * Depending on the context when this callback is called, the pointer to the
- * initial security state may be NULL, which means the initial security state
- * can no longer be modified as the node is already operating on the network.
- *
- * @param state   Ver.: always
- * @param extended   Ver.: always
- * @param trustCenter   Ver.: always
- */
-void emberAfSecurityInitCallback(EmberInitialSecurityState * state, EmberExtendedSecurityBitmask * extended, bool trustCenter) {}
-
 /** @brief Key Establishment Cluster Server Command Received
  *
  * This function is called by the application framework when a client-to-server
@@ -1513,32 +1480,6 @@ EmberStatus emberAfStartSearchForJoinableNetworkCallback(void)
  *
  */
 void emberAfStopMoveCallback(void) {}
-
-/** @brief Trust Center Join
- *
- * This callback is called from within the application framework's
- * implementation of emberTrustCenterJoinHandler or ezspTrustCenterJoinHandler.
- * This callback provides the same arguments passed to the
- * TrustCenterJoinHandler. For more information about the TrustCenterJoinHandler
- * please see documentation included in stack/include/trust-center.h.
- *
- * @param newNodeId   Ver.: always
- * @param newNodeEui64   Ver.: always
- * @param parentOfNewNode   Ver.: always
- * @param status   Ver.: always
- * @param decision   Ver.: always
- */
-void emberAfTrustCenterJoinCallback(EmberNodeId newNodeId, EmberEUI64 newNodeEui64, EmberNodeId parentOfNewNode,
-                                    EmberDeviceUpdate status, EmberJoinDecision decision)
-{}
-
-/** @brief Trust Center Keepalive Abort
- *
- * This callback is called when the device should abort the trust center
- * keepalive process.
- *
- */
-void emberAfTrustCenterKeepaliveAbortCallback(void) {}
 
 /** @brief Trust Center Keepalive Update
  *

--- a/examples/all-clusters-app/all-clusters-common/gen/callback.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/callback.h
@@ -141,20 +141,6 @@ EmberStatus emberAfClearReportTableCallback(void);
  * @param clusterId   Ver.: always
  */
 void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId);
-/** @brief Cluster Security Custom
- *
- * This callback is fired when determining if APS encryption is required for a
- * cluster outside of the specification's required clusters.  In other words,
- * for the Smart Energy profile this would be a cluster beyond the list that
- * normally requires APS encryption.
- *
- * @param profileId The profile ID  Ver.: always
- * @param clusterId The cluster ID  Ver.: always
- * @param incoming Whether this is an incoming or outgoing message.  Ver.:
- * always
- * @param commandId The ZCL command ID being sent/received.  Ver.: always
- */
-bool emberAfClusterSecurityCustomCallback(EmberAfProfileId profileId, EmberAfClusterId clusterId, bool incoming, uint8_t commandId);
 /** @brief Default Response
  *
  * This function is called by the application framework when a Default Response
@@ -1088,19 +1074,6 @@ void emberAfScanCompleteCallback(uint8_t channel, EmberStatus status);
  * @param status The status of the scan.  Ver.: always
  */
 void emberAfScanErrorCallback(EmberStatus status);
-/** @brief Security Init
- *
- * This callback is called by the framework to give the application a chance to
- * modify the security settings of the node during network initialization.
- * Depending on the context when this callback is called, the pointer to the
- * initial security state may be NULL, which means the initial security state
- * can no longer be modified as the node is already operating on the network.
- *
- * @param state   Ver.: always
- * @param extended   Ver.: always
- * @param trustCenter   Ver.: always
- */
-void emberAfSecurityInitCallback(EmberInitialSecurityState * state, EmberExtendedSecurityBitmask * extended, bool trustCenter);
 /** @brief Set Default Poll Control
  *
  * This function will set the default poll control for the current network to
@@ -1253,29 +1226,6 @@ EmberStatus emberAfStartSearchForJoinableNetworkCallback(void);
  *
  */
 void emberAfStopMoveCallback(void);
-/** @brief Trust Center Join
- *
- * This callback is called from within the application framework's
- * implementation of emberTrustCenterJoinHandler or ezspTrustCenterJoinHandler.
- * This callback provides the same arguments passed to the
- * TrustCenterJoinHandler. For more information about the TrustCenterJoinHandler
- * please see documentation included in stack/include/trust-center.h.
- *
- * @param newNodeId   Ver.: always
- * @param newNodeEui64   Ver.: always
- * @param parentOfNewNode   Ver.: always
- * @param status   Ver.: always
- * @param decision   Ver.: always
- */
-void emberAfTrustCenterJoinCallback(EmberNodeId newNodeId, EmberEUI64 newNodeEui64, EmberNodeId parentOfNewNode,
-                                    EmberDeviceUpdate status, EmberJoinDecision decision);
-/** @brief Trust Center Keepalive Abort
- *
- * This callback is called when the device should abort the trust center
- * keepalive process.
- *
- */
-void emberAfTrustCenterKeepaliveAbortCallback(void);
 /** @brief Trust Center Keepalive Update
  *
  * This callback is called when the device finishes registration (successfully

--- a/examples/lighting-app/lighting-common/gen/callback-stub.cpp
+++ b/examples/lighting-app/lighting-common/gen/callback-stub.cpp
@@ -163,25 +163,6 @@ bool emberAfKeyEstablishmentClusterClientCommandReceivedCallback(EmberAfClusterC
  */
 void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId) {}
 
-/** @brief Cluster Security Custom
- *
- * This callback is fired when determining if APS encryption is required for a
- * cluster outside of the specification's required clusters.  In other words,
- * for the Smart Energy profile this would be a cluster beyond the list that
- * normally requires APS encryption.
- *
- * @param profileId The profile ID  Ver.: always
- * @param clusterId The cluster ID  Ver.: always
- * @param incoming Whether this is an incoming or outgoing message.  Ver.:
- * always
- * @param commandId The ZCL command ID being sent/received.  Ver.: always
- */
-bool emberAfClusterSecurityCustomCallback(EmberAfProfileId profileId, EmberAfClusterId clusterId, bool incoming, uint8_t commandId)
-{
-    // By default, assume APS encryption is not required.
-    return false;
-}
-
 /** @brief Default Response
  *
  * This function is called by the application framework when a Default Response
@@ -1343,20 +1324,6 @@ bool emberAfReportAttributesCallback(EmberAfClusterId clusterId, uint8_t * buffe
  */
 void emberAfScanErrorCallback(EmberStatus status) {}
 
-/** @brief Security Init
- *
- * This callback is called by the framework to give the application a chance to
- * modify the security settings of the node during network initialization.
- * Depending on the context when this callback is called, the pointer to the
- * initial security state may be NULL, which means the initial security state
- * can no longer be modified as the node is already operating on the network.
- *
- * @param state   Ver.: always
- * @param extended   Ver.: always
- * @param trustCenter   Ver.: always
- */
-void emberAfSecurityInitCallback(EmberInitialSecurityState * state, EmberExtendedSecurityBitmask * extended, bool trustCenter) {}
-
 /** @brief Key Establishment Cluster Server Command Received
  *
  * This function is called by the application framework when a client-to-server
@@ -1534,32 +1501,6 @@ EmberStatus emberAfStartSearchForJoinableNetworkCallback(void)
  */
 void emberAfStopMoveCallback(void) {}
 
-/** @brief Trust Center Join
- *
- * This callback is called from within the application framework's
- * implementation of emberTrustCenterJoinHandler or ezspTrustCenterJoinHandler.
- * This callback provides the same arguments passed to the
- * TrustCenterJoinHandler. For more information about the TrustCenterJoinHandler
- * please see documentation included in stack/include/trust-center.h.
- *
- * @param newNodeId   Ver.: always
- * @param newNodeEui64   Ver.: always
- * @param parentOfNewNode   Ver.: always
- * @param status   Ver.: always
- * @param decision   Ver.: always
- */
-void emberAfTrustCenterJoinCallback(EmberNodeId newNodeId, EmberEUI64 newNodeEui64, EmberNodeId parentOfNewNode,
-                                    EmberDeviceUpdate status, EmberJoinDecision decision)
-{}
-
-/** @brief Trust Center Keepalive Abort
- *
- * This callback is called when the device should abort the trust center
- * keepalive process.
- *
- */
-void emberAfTrustCenterKeepaliveAbortCallback(void) {}
-
 /** @brief Trust Center Keepalive Update
  *
  * This callback is called when the device finishes registration (successfully
@@ -1628,13 +1569,6 @@ void halRadioPowerUpHandler(void) {}
  * @param sleepMode    Idle/sleep mode
  */
 void halSleepCallback(bool enter, SleepModes sleepMode) {}
-
-// These functions / constants are added to avoid ld failure when building with GN
-// They should be removed if we have zcl updates and nolonger need this or causing other errors
-bool emberAfIsCurrentSecurityProfileSmartEnergy(void)
-{
-    return false;
-}
 
 void emberAfPluginUpdateTcLinkKeyZigbeeKeyEstablishmentCallback(EmberEUI64 partner, EmberKeyStatus status) {}
 

--- a/examples/lighting-app/lighting-common/gen/callback.h
+++ b/examples/lighting-app/lighting-common/gen/callback.h
@@ -141,20 +141,6 @@ EmberStatus emberAfClearReportTableCallback(void);
  * @param clusterId   Ver.: always
  */
 void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId);
-/** @brief Cluster Security Custom
- *
- * This callback is fired when determining if APS encryption is required for a
- * cluster outside of the specification's required clusters.  In other words,
- * for the Smart Energy profile this would be a cluster beyond the list that
- * normally requires APS encryption.
- *
- * @param profileId The profile ID  Ver.: always
- * @param clusterId The cluster ID  Ver.: always
- * @param incoming Whether this is an incoming or outgoing message.  Ver.:
- * always
- * @param commandId The ZCL command ID being sent/received.  Ver.: always
- */
-bool emberAfClusterSecurityCustomCallback(EmberAfProfileId profileId, EmberAfClusterId clusterId, bool incoming, uint8_t commandId);
 /** @brief Default Response
  *
  * This function is called by the application framework when a Default Response
@@ -1088,19 +1074,6 @@ void emberAfScanCompleteCallback(uint8_t channel, EmberStatus status);
  * @param status The status of the scan.  Ver.: always
  */
 void emberAfScanErrorCallback(EmberStatus status);
-/** @brief Security Init
- *
- * This callback is called by the framework to give the application a chance to
- * modify the security settings of the node during network initialization.
- * Depending on the context when this callback is called, the pointer to the
- * initial security state may be NULL, which means the initial security state
- * can no longer be modified as the node is already operating on the network.
- *
- * @param state   Ver.: always
- * @param extended   Ver.: always
- * @param trustCenter   Ver.: always
- */
-void emberAfSecurityInitCallback(EmberInitialSecurityState * state, EmberExtendedSecurityBitmask * extended, bool trustCenter);
 /** @brief Set Default Poll Control
  *
  * This function will set the default poll control for the current network to
@@ -1253,29 +1226,6 @@ EmberStatus emberAfStartSearchForJoinableNetworkCallback(void);
  *
  */
 void emberAfStopMoveCallback(void);
-/** @brief Trust Center Join
- *
- * This callback is called from within the application framework's
- * implementation of emberTrustCenterJoinHandler or ezspTrustCenterJoinHandler.
- * This callback provides the same arguments passed to the
- * TrustCenterJoinHandler. For more information about the TrustCenterJoinHandler
- * please see documentation included in stack/include/trust-center.h.
- *
- * @param newNodeId   Ver.: always
- * @param newNodeEui64   Ver.: always
- * @param parentOfNewNode   Ver.: always
- * @param status   Ver.: always
- * @param decision   Ver.: always
- */
-void emberAfTrustCenterJoinCallback(EmberNodeId newNodeId, EmberEUI64 newNodeEui64, EmberNodeId parentOfNewNode,
-                                    EmberDeviceUpdate status, EmberJoinDecision decision);
-/** @brief Trust Center Keepalive Abort
- *
- * This callback is called when the device should abort the trust center
- * keepalive process.
- *
- */
-void emberAfTrustCenterKeepaliveAbortCallback(void);
 /** @brief Trust Center Keepalive Update
  *
  * This callback is called when the device finishes registration (successfully

--- a/examples/lock-app/lock-common/gen/callback-stub.cpp
+++ b/examples/lock-app/lock-common/gen/callback-stub.cpp
@@ -164,25 +164,6 @@ bool emberAfKeyEstablishmentClusterClientCommandReceivedCallback(EmberAfClusterC
  */
 void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId) {}
 
-/** @brief Cluster Security Custom
- *
- * This callback is fired when determining if APS encryption is required for a
- * cluster outside of the specification's required clusters.  In other words,
- * for the Smart Energy profile this would be a cluster beyond the list that
- * normally requires APS encryption.
- *
- * @param profileId The profile ID  Ver.: always
- * @param clusterId The cluster ID  Ver.: always
- * @param incoming Whether this is an incoming or outgoing message.  Ver.:
- * always
- * @param commandId The ZCL command ID being sent/received.  Ver.: always
- */
-bool emberAfClusterSecurityCustomCallback(EmberAfProfileId profileId, EmberAfClusterId clusterId, bool incoming, uint8_t commandId)
-{
-    // By default, assume APS encryption is not required.
-    return false;
-}
-
 /** @brief Default Response
  *
  * This function is called by the application framework when a Default Response
@@ -1344,20 +1325,6 @@ bool emberAfReportAttributesCallback(EmberAfClusterId clusterId, uint8_t * buffe
  */
 void emberAfScanErrorCallback(EmberStatus status) {}
 
-/** @brief Security Init
- *
- * This callback is called by the framework to give the application a chance to
- * modify the security settings of the node during network initialization.
- * Depending on the context when this callback is called, the pointer to the
- * initial security state may be NULL, which means the initial security state
- * can no longer be modified as the node is already operating on the network.
- *
- * @param state   Ver.: always
- * @param extended   Ver.: always
- * @param trustCenter   Ver.: always
- */
-void emberAfSecurityInitCallback(EmberInitialSecurityState * state, EmberExtendedSecurityBitmask * extended, bool trustCenter) {}
-
 /** @brief Key Establishment Cluster Server Command Received
  *
  * This function is called by the application framework when a client-to-server
@@ -1534,32 +1501,6 @@ EmberStatus emberAfStartSearchForJoinableNetworkCallback(void)
  *
  */
 void emberAfStopMoveCallback(void) {}
-
-/** @brief Trust Center Join
- *
- * This callback is called from within the application framework's
- * implementation of emberTrustCenterJoinHandler or ezspTrustCenterJoinHandler.
- * This callback provides the same arguments passed to the
- * TrustCenterJoinHandler. For more information about the TrustCenterJoinHandler
- * please see documentation included in stack/include/trust-center.h.
- *
- * @param newNodeId   Ver.: always
- * @param newNodeEui64   Ver.: always
- * @param parentOfNewNode   Ver.: always
- * @param status   Ver.: always
- * @param decision   Ver.: always
- */
-void emberAfTrustCenterJoinCallback(EmberNodeId newNodeId, EmberEUI64 newNodeEui64, EmberNodeId parentOfNewNode,
-                                    EmberDeviceUpdate status, EmberJoinDecision decision)
-{}
-
-/** @brief Trust Center Keepalive Abort
- *
- * This callback is called when the device should abort the trust center
- * keepalive process.
- *
- */
-void emberAfTrustCenterKeepaliveAbortCallback(void) {}
 
 /** @brief Trust Center Keepalive Update
  *

--- a/examples/lock-app/lock-common/gen/callback.h
+++ b/examples/lock-app/lock-common/gen/callback.h
@@ -141,20 +141,6 @@ EmberStatus emberAfClearReportTableCallback(void);
  * @param clusterId   Ver.: always
  */
 void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId);
-/** @brief Cluster Security Custom
- *
- * This callback is fired when determining if APS encryption is required for a
- * cluster outside of the specification's required clusters.  In other words,
- * for the Smart Energy profile this would be a cluster beyond the list that
- * normally requires APS encryption.
- *
- * @param profileId The profile ID  Ver.: always
- * @param clusterId The cluster ID  Ver.: always
- * @param incoming Whether this is an incoming or outgoing message.  Ver.:
- * always
- * @param commandId The ZCL command ID being sent/received.  Ver.: always
- */
-bool emberAfClusterSecurityCustomCallback(EmberAfProfileId profileId, EmberAfClusterId clusterId, bool incoming, uint8_t commandId);
 /** @brief Default Response
  *
  * This function is called by the application framework when a Default Response
@@ -1088,19 +1074,6 @@ void emberAfScanCompleteCallback(uint8_t channel, EmberStatus status);
  * @param status The status of the scan.  Ver.: always
  */
 void emberAfScanErrorCallback(EmberStatus status);
-/** @brief Security Init
- *
- * This callback is called by the framework to give the application a chance to
- * modify the security settings of the node during network initialization.
- * Depending on the context when this callback is called, the pointer to the
- * initial security state may be NULL, which means the initial security state
- * can no longer be modified as the node is already operating on the network.
- *
- * @param state   Ver.: always
- * @param extended   Ver.: always
- * @param trustCenter   Ver.: always
- */
-void emberAfSecurityInitCallback(EmberInitialSecurityState * state, EmberExtendedSecurityBitmask * extended, bool trustCenter);
 /** @brief Set Default Poll Control
  *
  * This function will set the default poll control for the current network to
@@ -1253,29 +1226,6 @@ EmberStatus emberAfStartSearchForJoinableNetworkCallback(void);
  *
  */
 void emberAfStopMoveCallback(void);
-/** @brief Trust Center Join
- *
- * This callback is called from within the application framework's
- * implementation of emberTrustCenterJoinHandler or ezspTrustCenterJoinHandler.
- * This callback provides the same arguments passed to the
- * TrustCenterJoinHandler. For more information about the TrustCenterJoinHandler
- * please see documentation included in stack/include/trust-center.h.
- *
- * @param newNodeId   Ver.: always
- * @param newNodeEui64   Ver.: always
- * @param parentOfNewNode   Ver.: always
- * @param status   Ver.: always
- * @param decision   Ver.: always
- */
-void emberAfTrustCenterJoinCallback(EmberNodeId newNodeId, EmberEUI64 newNodeEui64, EmberNodeId parentOfNewNode,
-                                    EmberDeviceUpdate status, EmberJoinDecision decision);
-/** @brief Trust Center Keepalive Abort
- *
- * This callback is called when the device should abort the trust center
- * keepalive process.
- *
- */
-void emberAfTrustCenterKeepaliveAbortCallback(void);
 /** @brief Trust Center Keepalive Update
  *
  * This callback is called when the device finishes registration (successfully

--- a/examples/temperature-measurement-app/esp32/main/gen/callback-stub.cpp
+++ b/examples/temperature-measurement-app/esp32/main/gen/callback-stub.cpp
@@ -145,25 +145,6 @@ bool emberAfKeyEstablishmentClusterClientCommandReceivedCallback(EmberAfClusterC
  */
 void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId) {}
 
-/** @brief Cluster Security Custom
- *
- * This callback is fired when determining if APS encryption is required for a
- * cluster outside of the specification's required clusters.  In other words,
- * for the Smart Energy profile this would be a cluster beyond the list that
- * normally requires APS encryption.
- *
- * @param profileId The profile ID  Ver.: always
- * @param clusterId The cluster ID  Ver.: always
- * @param incoming Whether this is an incoming or outgoing message.  Ver.:
- * always
- * @param commandId The ZCL command ID being sent/received.  Ver.: always
- */
-bool emberAfClusterSecurityCustomCallback(EmberAfProfileId profileId, EmberAfClusterId clusterId, bool incoming, uint8_t commandId)
-{
-    // By default, assume APS encryption is not required.
-    return false;
-}
-
 /** @brief Default Response
  *
  * This function is called by the application framework when a Default Response
@@ -1348,20 +1329,6 @@ void emberAfScanCompleteCallback(uint8_t channel, EmberStatus status) {}
  */
 void emberAfScanErrorCallback(EmberStatus status) {}
 
-/** @brief Security Init
- *
- * This callback is called by the framework to give the application a chance to
- * modify the security settings of the node during network initialization.
- * Depending on the context when this callback is called, the pointer to the
- * initial security state may be NULL, which means the initial security state
- * can no longer be modified as the node is already operating on the network.
- *
- * @param state   Ver.: always
- * @param extended   Ver.: always
- * @param trustCenter   Ver.: always
- */
-void emberAfSecurityInitCallback(EmberInitialSecurityState * state, EmberExtendedSecurityBitmask * extended, bool trustCenter) {}
-
 /** @brief Key Establishment Cluster Server Command Received
  *
  * This function is called by the application framework when a client-to-server
@@ -1538,32 +1505,6 @@ EmberStatus emberAfStartSearchForJoinableNetworkCallback(void)
  *
  */
 void emberAfStopMoveCallback(void) {}
-
-/** @brief Trust Center Join
- *
- * This callback is called from within the application framework's
- * implementation of emberTrustCenterJoinHandler or ezspTrustCenterJoinHandler.
- * This callback provides the same arguments passed to the
- * TrustCenterJoinHandler. For more information about the TrustCenterJoinHandler
- * please see documentation included in stack/include/trust-center.h.
- *
- * @param newNodeId   Ver.: always
- * @param newNodeEui64   Ver.: always
- * @param parentOfNewNode   Ver.: always
- * @param status   Ver.: always
- * @param decision   Ver.: always
- */
-void emberAfTrustCenterJoinCallback(EmberNodeId newNodeId, EmberEUI64 newNodeEui64, EmberNodeId parentOfNewNode,
-                                    EmberDeviceUpdate status, EmberJoinDecision decision)
-{}
-
-/** @brief Trust Center Keepalive Abort
- *
- * This callback is called when the device should abort the trust center
- * keepalive process.
- *
- */
-void emberAfTrustCenterKeepaliveAbortCallback(void) {}
 
 /** @brief Trust Center Keepalive Update
  *

--- a/examples/temperature-measurement-app/esp32/main/gen/callback.h
+++ b/examples/temperature-measurement-app/esp32/main/gen/callback.h
@@ -126,20 +126,6 @@ EmberStatus emberAfClearReportTableCallback(void);
  * @param clusterId   Ver.: always
  */
 void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId);
-/** @brief Cluster Security Custom
- *
- * This callback is fired when determining if APS encryption is required for a
- * cluster outside of the specification's required clusters.  In other words,
- * for the Smart Energy profile this would be a cluster beyond the list that
- * normally requires APS encryption.
- *
- * @param profileId The profile ID  Ver.: always
- * @param clusterId The cluster ID  Ver.: always
- * @param incoming Whether this is an incoming or outgoing message.  Ver.:
- * always
- * @param commandId The ZCL command ID being sent/received.  Ver.: always
- */
-bool emberAfClusterSecurityCustomCallback(EmberAfProfileId profileId, EmberAfClusterId clusterId, bool incoming, uint8_t commandId);
 /** @brief Default Response
  *
  * This function is called by the application framework when a Default Response
@@ -1073,19 +1059,6 @@ void emberAfScanCompleteCallback(uint8_t channel, EmberStatus status);
  * @param status The status of the scan.  Ver.: always
  */
 void emberAfScanErrorCallback(EmberStatus status);
-/** @brief Security Init
- *
- * This callback is called by the framework to give the application a chance to
- * modify the security settings of the node during network initialization.
- * Depending on the context when this callback is called, the pointer to the
- * initial security state may be NULL, which means the initial security state
- * can no longer be modified as the node is already operating on the network.
- *
- * @param state   Ver.: always
- * @param extended   Ver.: always
- * @param trustCenter   Ver.: always
- */
-void emberAfSecurityInitCallback(EmberInitialSecurityState * state, EmberExtendedSecurityBitmask * extended, bool trustCenter);
 /** @brief Set Default Poll Control
  *
  * This function will set the default poll control for the current network to
@@ -1238,29 +1211,6 @@ EmberStatus emberAfStartSearchForJoinableNetworkCallback(void);
  *
  */
 void emberAfStopMoveCallback(void);
-/** @brief Trust Center Join
- *
- * This callback is called from within the application framework's
- * implementation of emberTrustCenterJoinHandler or ezspTrustCenterJoinHandler.
- * This callback provides the same arguments passed to the
- * TrustCenterJoinHandler. For more information about the TrustCenterJoinHandler
- * please see documentation included in stack/include/trust-center.h.
- *
- * @param newNodeId   Ver.: always
- * @param newNodeEui64   Ver.: always
- * @param parentOfNewNode   Ver.: always
- * @param status   Ver.: always
- * @param decision   Ver.: always
- */
-void emberAfTrustCenterJoinCallback(EmberNodeId newNodeId, EmberEUI64 newNodeEui64, EmberNodeId parentOfNewNode,
-                                    EmberDeviceUpdate status, EmberJoinDecision decision);
-/** @brief Trust Center Keepalive Abort
- *
- * This callback is called when the device should abort the trust center
- * keepalive process.
- *
- */
-void emberAfTrustCenterKeepaliveAbortCallback(void);
 /** @brief Trust Center Keepalive Update
  *
  * This callback is called when the device finishes registration (successfully

--- a/src/app/util/af-main.h
+++ b/src/app/util/af-main.h
@@ -69,8 +69,6 @@ void emberAfGetMfgString(uint8_t * returnData);
 // Functions common to both SOC and Host versions of the application.
 void emAfInitializeMessageSentCallbackArray(void);
 
-EmberAfCbkeKeyEstablishmentSuite emberAfIsFullSmartEnergySecurityPresent(void);
-
 #if defined(EZSP_HOST)
 void emAfClearNetworkCache(uint8_t networkIndex);
 #else
@@ -95,7 +93,6 @@ bool emberAfNcpNeedsReset(void);
 
 void emAfPrintStatus(const char * task, EmberStatus status);
 
-uint8_t emberAfGetSecurityLevel(void);
 uint8_t emberAfGetKeyTableSize(void);
 uint8_t emberAfGetBindingTableSize(void);
 uint8_t emberAfGetAddressTableSize(void);

--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -489,34 +489,6 @@ typedef EmberAppLinkKeyRequestPolicy EmberAfAppLinkKeyRequestPolicy;
 #endif
 
 #ifdef DOXYGEN_SHOULD_SKIP_THIS
-enum EmberAfSecurityProfile
-#else
-typedef uint8_t EmberAfSecurityProfile;
-enum
-#endif
-{
-    EMBER_AF_SECURITY_PROFILE_NONE    = 0x00,
-    EMBER_AF_SECURITY_PROFILE_HA      = 0x01,
-    EMBER_AF_SECURITY_PROFILE_HA12    = 0x02,
-    EMBER_AF_SECURITY_PROFILE_SE_TEST = 0x03,
-    EMBER_AF_SECURITY_PROFILE_SE_FULL = 0x04,
-    EMBER_AF_SECURITY_PROFILE_Z3      = 0x05,
-    EMBER_AF_SECURITY_PROFILE_CUSTOM  = 0xFF,
-};
-
-typedef struct
-{
-    EmberAfSecurityProfile securityProfile;
-    uint16_t tcBitmask;
-    EmberExtendedSecurityBitmask tcExtendedBitmask;
-    uint16_t nodeBitmask;
-    EmberExtendedSecurityBitmask nodeExtendedBitmask;
-    EmberAfTcLinkKeyRequestPolicy tcLinkKeyRequestPolicy;
-    EmberAfAppLinkKeyRequestPolicy appLinkKeyRequestPolicy;
-    EmberKeyData preconfiguredKey;
-} EmberAfSecurityProfileData;
-
-#ifdef DOXYGEN_SHOULD_SKIP_THIS
 enum EmberAfEndpointBitmask;
 #else
 typedef uint8_t EmberAfEndpointBitmask;
@@ -1475,21 +1447,6 @@ typedef struct
 #define EMBER_AF_METERING_NF5_UPDATE_SITE_ID 0x00000040
 #define EMBER_AF_METERING_NF5_RESET_BATTERY_COUNTER 0x00000080
 #define EMBER_AF_METERING_NF5_UPDATE_CIN 0x00000100
-
-/**
- * @brief CBKE Library types
- */
-#ifdef DOXYGEN_SHOULD_SKIP_THIS
-enum EmberAfCbkeKeyEstablishmentSuite
-#else
-typedef uint16_t EmberAfCbkeKeyEstablishmentSuite;
-enum
-#endif
-{
-    EMBER_AF_INVALID_KEY_ESTABLISHMENT_SUITE    = 0x0000,
-    EMBER_AF_CBKE_KEY_ESTABLISHMENT_SUITE_163K1 = 0x0001,
-    EMBER_AF_CBKE_KEY_ESTABLISHMENT_SUITE_283K1 = 0x0002,
-};
 
 /**
  * @brief Device Management plugin types

--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -1702,13 +1702,6 @@ EmberStatus emberAfInitiatePartnerLinkKeyExchange(EmberNodeId target, CHIPEndpoi
     emberAfInitiatePartnerLinkKeyExchangeCallback(target, endpoint, callback)
 #endif
 
-/** @brief Use this function to determine if the security profile of the
- * current network was set to Smart Energy.  The security profile is configured
- * in AppBuilder.
-   @ return true if the security profile is Smart Energy or false otherwise.
- */
-bool emberAfIsCurrentSecurityProfileSmartEnergy(void);
-
 /** @} END Messaging */
 
 /** @name ZCL macros */

--- a/src/app/util/config.h
+++ b/src/app/util/config.h
@@ -126,11 +126,7 @@
 // the max source route overhead and broadcast radius
 // if we havent defined MAX_HOPS then define based on profile ID
 #ifndef ZA_MAX_HOPS
-#ifdef EMBER_AF_HAS_SECURITY_PROFILE_SE
-#define ZA_MAX_HOPS 6
-#else
 #define ZA_MAX_HOPS 12
-#endif
 #endif
 
 #ifndef EMBER_AF_SOURCE_ROUTING_RESERVED_PAYLOAD_LENGTH

--- a/src/app/util/debug-printing.h
+++ b/src/app/util/debug-printing.h
@@ -2725,29 +2725,6 @@
 #define emberAfAppPrintString(buffer)
 #endif // defined(EMBER_AF_PRINT_ENABLE) && defined(EMBER_AF_PRINT_APP)
 
-// Printing macros for Security
-// Prints messages related to security
-#if defined(EMBER_AF_PRINT_ENABLE) && defined(EMBER_AF_PRINT_SECURITY)
-#define emberAfSecurityPrint(...) emberAfPrint(EMBER_AF_PRINT_SECURITY, __VA_ARGS__)
-#define emberAfSecurityPrintln(...) emberAfPrintln(EMBER_AF_PRINT_SECURITY, __VA_ARGS__)
-// Blocking IO is enabled for all serial ports, therefore flush calls are unnecessary.
-#define emberAfSecurityFlush()
-#define emberAfSecurityDebugExec(x)                                                                                                \
-    if (emberAfPrintEnabled(EMBER_AF_PRINT_SECURITY))                                                                              \
-    {                                                                                                                              \
-        x;                                                                                                                         \
-    }
-#define emberAfSecurityPrintBuffer(buffer, len, withSpace) emberAfPrintBuffer(EMBER_AF_PRINT_SECURITY, (buffer), (len), (withSpace))
-#define emberAfSecurityPrintString(buffer) emberAfPrintString(EMBER_AF_PRINT_SECURITY, (buffer))
-#else
-#define emberAfSecurityPrint(...)
-#define emberAfSecurityPrintln(...)
-#define emberAfSecurityFlush()
-#define emberAfSecurityDebugExec(x)
-#define emberAfSecurityPrintBuffer(buffer, len, withSpace)
-#define emberAfSecurityPrintString(buffer)
-#endif // defined(EMBER_AF_PRINT_ENABLE) && defined(EMBER_AF_PRINT_SECURITY)
-
 // Printing macros for Attributes
 // Prints messages related to attributes
 #if defined(EMBER_AF_PRINT_ENABLE) && defined(EMBER_AF_PRINT_ATTRIBUTES)

--- a/src/app/util/types_stub.h
+++ b/src/app/util/types_stub.h
@@ -216,9 +216,6 @@ enum
         details about this requirement.
      */
     EMBER_APS_OPTION_DSA_SIGN = 0x0010,
-    /** Send the message using APS Encryption using the Link Key shared
-        with the destination node to encrypt the data at the APS Level. */
-    EMBER_APS_OPTION_ENCRYPTION = 0x0020,
     /** Resend the message using the APS retry mechanism.
         This option and the enable route discovery option must be enabled for
         an existing route to be repaired automatically. */
@@ -319,63 +316,6 @@ enum
 {
     EMBER_DENY_APP_LINK_KEY_REQUESTS = 0x00,
     EMBER_ALLOW_APP_LINK_KEY_REQUEST = 0x01
-};
-
-/** @brief This is the Extended Security Bitmask that controls the use
- *  of various extended security features.
- */
-#ifdef DOXYGEN_SHOULD_SKIP_THIS
-enum EmberExtendedSecurityBitmask
-#else
-typedef uint16_t EmberExtendedSecurityBitmask;
-enum
-#endif
-{
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-    // If this bit is set, the 'key token data' field is set in the Initial
-    // Security Bitmask to 0 (No Preconfig Key token). Otherwise, the
-    // field is left as is.
-    EMBER_PRECONFIG_KEY_NOT_VALID = 0x0001,
-#endif
-
-    // bits 2-3 are unused.
-    /** This denotes that the network key update can only happen if the network
-        key update request is unicast and encrypted i.e. broadcast network key update
-        requests will not be processed if bit 1 is set*/
-    EMBER_SECURE_NETWORK_KEY_ROTATION = 0x0002,
-
-    /** This denotes whether a joiner node (router or end-device) uses a Global
-        Link Key or a Unique Link Key. */
-    EMBER_JOINER_GLOBAL_LINK_KEY = 0x0010,
-
-    /** This denotes whether the device's outgoing frame counter is allowed to
-        be reset during forming or joining. If the flag is set, the outgoing frame
-        counter is not allowed to be reset. If the flag is not set, the frame
-        counter is allowed to be reset. */
-
-    EMBER_EXT_NO_FRAME_COUNTER_RESET = 0x0020,
-
-    /** This denotes whether a device should discard or accept network leave
-        without rejoin commands. */
-    EMBER_NWK_LEAVE_WITHOUT_REJOIN_NOT_ALLOWED = 0x0040,
-
-    // Bit 7 reserved for future use (stored in TOKEN).
-
-    /** This denotes whether a router node should discard or accept network Leave
-        Commands. */
-    EMBER_NWK_LEAVE_REQUEST_NOT_ALLOWED = 0x0100,
-
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-    /** This denotes whether a node is running the latest stack specification or
-        is emulating R18 specs behavior. If this flag is enabled, a router
-        node should only send encrypted Update Device messages while the TC should
-        only accept encrypted Updated Device messages.*/
-    EMBER_R18_STACK_BEHAVIOR = 0x0200,
-#endif
-
-    // Bit 10 is reserved for future use (stored in TOKEN).
-    // Bit 11 is reserved for future use(stored in RAM).
-    // Bits 12-15 are unused.
 };
 
 /** @brief This data structure contains the key data that is passed
@@ -624,67 +564,6 @@ typedef struct
     /** The index of the network the binding belongs to. */
     uint8_t networkIndex;
 } EmberBindingTableEntry;
-
-/** @brief This describes the Initial Security features and requirements that
- *  will be used when forming or joining the network.  */
-typedef struct
-{
-    /** This bitmask enumerates which security features should be used
-        and the presence of valid data within other elements of the
-        ::EmberInitialSecurityState data structure.  For more details, see the
-        ::EmberInitialSecurityBitmask. */
-    uint16_t bitmask;
-    /** This is the pre-configured key that can be used by devices when joining the
-     *  network if the Trust Center does not send the initial security data
-     *  in-the-clear.
-     *  For the Trust Center, it will be the global link key and <b>must</b> be set
-     *  regardless of whether joining devices are expected to have a pre-configured
-     *  Link Key.
-     *  This parameter will only be used if the EmberInitialSecurityState::bitmask
-     *  sets the bit indicating ::EMBER_HAVE_PRECONFIGURED_KEY. */
-    EmberKeyData preconfiguredKey;
-    /** This is the Network Key used when initially forming the network.
-     *  It must be set on the Trust Center and is not needed for devices
-     *  joining the network.  This parameter will only be used if the
-     *  EmberInitialSecurityState::bitmask sets the bit indicating
-     *  ::EMBER_HAVE_NETWORK_KEY.  */
-    EmberKeyData networkKey;
-    /** This is the sequence number associated with the network key.  It must
-     *  be set if the Network Key is set and is used to indicate a particular
-     *  of the network key for updating and switching.  This parameter will
-     *  only be used if the ::EMBER_HAVE_NETWORK_KEY is set. Generally, it should
-     *  be set to 0 when forming the network; joining devices can ignore
-     *  this value.  */
-    uint8_t networkKeySequenceNumber;
-    /** This is the long address of the trust center on the network that will
-     *  be joined.  It is usually NOT set prior to joining the network and
-     *  is learned during the joining message exchange.  This field
-     *  is only examined if ::EMBER_HAVE_TRUST_CENTER_EUI64 is set in the
-     *  EmberInitialSecurityState::bitmask.  Most devices should clear that
-     *  bit and leave this field alone.  This field must be set when using
-     *  commissioning mode.  It is required to be in little-endian format. */
-    EmberEUI64 preconfiguredTrustCenterEui64;
-} EmberInitialSecurityState;
-
-/** @brief The Status of the Update Device message sent to the Trust Center.
- *  The device may have joined or rejoined insecurely, rejoined securely, or
- *  left.  MAC Security has been deprecated and therefore there is no secure
- *  join.
- */
-// These map to the actual values within the APS Command frame so they cannot
-// be arbitrarily changed.
-#ifdef DOXYGEN_SHOULD_SKIP_THIS
-enum EmberDeviceUpdate
-#else
-typedef uint8_t EmberDeviceUpdate;
-enum
-#endif
-{
-    EMBER_STANDARD_SECURITY_SECURED_REJOIN   = 0,
-    EMBER_STANDARD_SECURITY_UNSECURED_JOIN   = 1,
-    EMBER_DEVICE_LEFT                        = 2,
-    EMBER_STANDARD_SECURITY_UNSECURED_REJOIN = 3,
-};
 
 /**
  * @brief The decision made by the Trust Center when a node attempts to join.

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -91,13 +91,8 @@ EmberAfClusterCommand curCmd;
 // to NULL when the function exits.
 EmberAfClusterCommand * emAfCurrentCommand;
 
-// variable used for toggling Aps Link security. Set by the CLI
-uint8_t emAfTestApsSecurityOverride = APS_TEST_SECURITY_DEFAULT;
-
 // DEPRECATED.
 uint8_t emberAfIncomingZclSequenceNumber = 0xFF;
-
-static bool afNoSecurityForDefaultResponse = false;
 
 // Sequence used for outgoing messages if they are
 // not responses.
@@ -231,10 +226,6 @@ static void prepareForResponse(const EmberAfClusterCommand * cmd)
     // sender of the request cares about some aspects of the delivery, so we as
     // the receiver should make equal effort for the response.
     emberAfResponseApsFrame.options = EMBER_AF_DEFAULT_APS_OPTIONS;
-    if ((cmd->apsFrame->options & EMBER_APS_OPTION_ENCRYPTION) != 0U)
-    {
-        emberAfResponseApsFrame.options |= EMBER_APS_OPTION_ENCRYPTION;
-    }
     if ((cmd->apsFrame->options & EMBER_APS_OPTION_RETRY) != 0U)
     {
         emberAfResponseApsFrame.options |= EMBER_APS_OPTION_RETRY;
@@ -324,7 +315,6 @@ void emberAfStackDown(void)
     }
 
     emberAfRegistrationAbortCallback();
-    emberAfTrustCenterKeepaliveAbortCallback();
 }
 
 // ****************************************
@@ -515,7 +505,6 @@ bool emberAfProcessMessageIntoZclCmd(EmberApsFrame * apsFrame, EmberIncomingMess
 bool emberAfProcessMessage(EmberApsFrame * apsFrame, EmberIncomingMessageType type, uint8_t * message, uint16_t msgLen,
                            ChipNodeId source, InterPanHeader * interPanHeader)
 {
-    EmberStatus sendStatus;
     bool msgHandled = false;
     // reset/reinitialize curCmd
     curCmd = staticCmd;
@@ -539,44 +528,12 @@ bool emberAfProcessMessage(EmberApsFrame * apsFrame, EmberIncomingMessageType ty
         goto kickout;
     }
 
-    if (interPanHeader == NULL)
-    {
-        bool broadcast = (type == EMBER_INCOMING_BROADCAST || type == EMBER_INCOMING_BROADCAST_LOOPBACK ||
-                          type == EMBER_INCOMING_MULTICAST || type == EMBER_INCOMING_MULTICAST_LOOPBACK);
-
-        // if the cluster for the incoming message requires security and
-        // doesnt have it return default response STATUS_FAILURE
-        if (emberAfDetermineIfLinkSecurityIsRequired(curCmd.commandId,
-                                                     true, // incoming
-                                                     broadcast, curCmd.apsFrame->profileId, curCmd.apsFrame->clusterId,
-                                                     curCmd.source) &&
-            (!(curCmd.apsFrame->options & EMBER_APS_OPTION_ENCRYPTION)))
-        {
-            emberAfDebugPrintln("Drop clus %2x due to no aps security", curCmd.apsFrame->clusterId);
-            afNoSecurityForDefaultResponse = true;
-            sendStatus                     = emberAfSendDefaultResponse(&curCmd, EMBER_ZCL_STATUS_NOT_AUTHORIZED);
-            if (EMBER_SUCCESS != sendStatus)
-            {
-                emberAfDebugPrintln("Util: failed to send %s response: 0x%x", "default", sendStatus);
-            }
-            afNoSecurityForDefaultResponse = false;
-
-            // Mark the message as processed.  It failed security processing, so no
-            // other parts of the code should act upon it.
-            msgHandled = true;
-            goto kickout;
-        }
-    }
-    else if (!(interPanHeader->options & EMBER_AF_INTERPAN_OPTION_MAC_HAS_LONG_ADDRESS))
+    if (interPanHeader != NULL && !(interPanHeader->options & EMBER_AF_INTERPAN_OPTION_MAC_HAS_LONG_ADDRESS))
     {
         // For safety, dump all interpan messages that don't have a long
         // source in the MAC layer.  In theory they should not get past
         // the MAC filters but this is insures they will not get processed.
         goto kickout;
-    }
-    else
-    {
-        // MISRA requires ..else if.. to have terminating else.
     }
 
     if (curCmd.apsFrame->destinationEndpoint == EMBER_BROADCAST_ENDPOINT)
@@ -734,10 +691,6 @@ EmberStatus emberAfSendResponseWithCallback(EmberAfMessageSentFunction callback)
     //  which leads to a bad memory reference - AHilton
     if (emberAfCurrentCommand() != NULL)
     {
-        if ((emberAfCurrentCommand()->apsFrame->options & EMBER_APS_OPTION_ENCRYPTION) != 0U)
-        {
-            emberAfResponseApsFrame.options |= EMBER_APS_OPTION_ENCRYPTION;
-        }
         if ((emberAfCurrentCommand()->apsFrame->options & EMBER_APS_OPTION_RETRY) != 0U)
         {
             emberAfResponseApsFrame.options |= EMBER_APS_OPTION_RETRY;
@@ -783,8 +736,7 @@ EmberStatus emberAfSendResponseWithCallback(EmberAfMessageSentFunction callback)
 #endif
     }
     UNUSED_VAR(label);
-    emberAfDebugPrintln("T%4x:TX (%p) %ccast 0x%x%p", 0, "resp", label, status,
-                        ((emberAfResponseApsFrame.options & EMBER_APS_OPTION_ENCRYPTION) ? " w/ link key" : ""));
+    emberAfDebugPrintln("T%4x:TX (%p) %ccast 0x%x%p", 0, "resp", label, status, "");
     emberAfDebugPrint("TX buffer: [");
     emberAfDebugFlush();
     emberAfDebugPrintBuffer(appResponseData, appResponseLength, true);
@@ -869,120 +821,11 @@ EmberStatus emberAfSendDefaultResponse(const EmberAfClusterCommand * cmd, EmberA
     return emberAfSendDefaultResponseWithCallback(cmd, status, NULL);
 }
 
-bool emberAfDetermineIfLinkSecurityIsRequired(CommandId commandId, bool incoming, bool broadcast, EmberAfProfileId profileId,
-                                              EmberAfClusterId clusterId, ChipNodeId remoteNodeId)
-{
-    (void) afNoSecurityForDefaultResponse; // remove warning if not used
-
-    // If we have turned off all APS security (needed for testing), then just
-    // always return false.
-    if ((emAfTestApsSecurityOverride == APS_TEST_SECURITY_DISABLED) || afNoSecurityForDefaultResponse)
-    {
-        afNoSecurityForDefaultResponse = false;
-        return false;
-    }
-
-    // NOTE: In general if it is a unicast, and one of the SE clusters, it
-    // requires APS encryption.  A few special cases exists that we allow for
-    // but those must be explicitly spelled out here.
-
-    // Assume that if the local device is broadcasting, even if it is using one
-    // of the SE clusters, this is okay.
-    if (!incoming && broadcast)
-    {
-        return false;
-    }
-
-    // At this point if the CLI command has been issued, it's safe to over any other settings
-    // and return.
-    // This change allows HA applications to use the CLI option to enable APS security.
-    if (emAfTestApsSecurityOverride == APS_TEST_SECURITY_ENABLED)
-    {
-        return true;
-    }
-    else if (emAfTestApsSecurityOverride == APS_TEST_SECURITY_DISABLED)
-    {
-        // The default return value before this change.
-        return false;
-    }
-    else
-    {
-        // MISRA requires ..else if.. to have terminating else.
-    }
-
-#ifdef EMBER_AF_HAS_SECURITY_PROFILE_SE
-    if (emberAfIsCurrentSecurityProfileSmartEnergy())
-    {
-        // Check against profile IDs that use APS security on these clusters.
-        if (profileId != SE_PROFILE_ID && profileId != EMBER_WILDCARD_PROFILE_ID)
-        {
-            return false;
-        }
-
-        // Loopback packets do not require security
-        if (emberGetNodeId() == remoteNodeId)
-        {
-            return false;
-        }
-
-        // This list comes from Section 5.4.6 of the SE spec.
-        switch (clusterId)
-        {
-        case ZCL_TIME_CLUSTER_ID:
-        case ZCL_COMMISSIONING_CLUSTER_ID:
-        case ZCL_PRICE_CLUSTER_ID:
-        case ZCL_DEMAND_RESPONSE_LOAD_CONTROL_CLUSTER_ID:
-        case ZCL_SIMPLE_METERING_CLUSTER_ID:
-        case ZCL_MESSAGING_CLUSTER_ID:
-        case ZCL_TUNNELING_CLUSTER_ID:
-        case ZCL_GENERIC_TUNNEL_CLUSTER_ID:
-        case ZCL_PREPAYMENT_CLUSTER_ID:
-        case ZCL_CALENDAR_CLUSTER_ID:
-        case ZCL_DEVICE_MANAGEMENT_CLUSTER_ID:
-        case ZCL_EVENTS_CLUSTER_ID:
-        case ZCL_MDU_PAIRING_CLUSTER_ID:
-        case ZCL_ENERGY_MANAGEMENT_CLUSTER_ID:
-        case ZCL_SUB_GHZ_CLUSTER_ID:
-            return true;
-        case ZCL_OTA_BOOTLOAD_CLUSTER_ID:
-            if (commandId == ZCL_IMAGE_NOTIFY_COMMAND_ID && broadcast)
-            {
-                return false;
-            }
-            else
-            {
-                return true;
-            }
-        default:
-            break;
-        }
-    }
-#endif // EMBER_AF_HAS_SECURITY_PROFILE_SE
-
-    // All works with all hubs commands require aps link key authorization
-    if (clusterId == ZCL_SL_WWAH_CLUSTER_ID)
-    {
-        return true;
-    }
-
-    if (emberAfClusterSecurityCustomCallback(profileId, clusterId, incoming, commandId))
-    {
-        return true;
-    }
-
-    // APS_TEST_SECURITY_DEFAULT at this point returns false.
-    return false;
-}
-
 uint8_t emberAfMaximumApsPayloadLength(EmberOutgoingMessageType type, uint64_t indexOrDestination, EmberApsFrame * apsFrame)
 {
     ChipNodeId destination = EMBER_UNKNOWN_NODE_ID;
     uint8_t max            = EMBER_AF_MAXIMUM_APS_PAYLOAD_LENGTH;
 
-    if ((apsFrame->options & EMBER_APS_OPTION_ENCRYPTION) != 0U)
-    {
-        max = static_cast<uint8_t>(max - EMBER_AF_APS_ENCRYPTION_OVERHEAD);
-    }
     if ((apsFrame->options & EMBER_APS_OPTION_SOURCE_EUI64) != 0U)
     {
         max = static_cast<uint8_t>(max - EUI64_SIZE);

--- a/src/app/util/util.h
+++ b/src/app/util/util.h
@@ -188,16 +188,6 @@ uint8_t * emberAfPutDateInResp(EmberAfDate * value);
 
 bool emberAfIsThisMyEui64(EmberEUI64 eui64);
 
-// If the variable has not been set, APS_TEST_SECURITY_DEFAULT will
-// eventually return false.
-enum
-{
-    APS_TEST_SECURITY_ENABLED  = 0,
-    APS_TEST_SECURITY_DISABLED = 1,
-    APS_TEST_SECURITY_DEFAULT  = 2,
-};
-extern uint8_t emAfTestApsSecurityOverride;
-
 #ifdef EZSP_HOST
 // the EM260 host application is expected to provide these functions if using
 // a cluster that needs it.
@@ -214,12 +204,6 @@ extern uint8_t emberAfIncomingZclSequenceNumber;
 // reply (in the case where the app disables it and then doesnt send a
 // message that gets parsed).
 void emberAfSetNoReplyForNextMessage(bool set);
-
-// this function determines if APS Link key should be used to secure
-// the message. It is based on the clusterId and specified in the SE
-// app profile.  If the message is outgoing then the
-bool emberAfDetermineIfLinkSecurityIsRequired(CHIPCommandId commandId, bool incoming, bool broadcast, EmberAfProfileId profileId,
-                                              EmberAfClusterId clusterId, ChipNodeId remoteNodeId);
 
 #define isThisDataTypeSentLittleEndianOTA(dataType) (!(emberAfIsThisDataTypeAStringType(dataType)))
 

--- a/src/app/zap-templates/callback-stub-src.zapt
+++ b/src/app/zap-templates/callback-stub-src.zapt
@@ -169,25 +169,6 @@ bool emberAfAttributeWriteAccessCallback(CHIPEndpointId endpoint, CHIPClusterId 
     return true;
 }
 
-/** @brief Cluster Security Custom
- *
- * This callback is fired when determining if APS encryption is required for a
- * cluster outside of the specification's required clusters.  In other words,
- * for the Smart Energy profile this would be a cluster beyond the list that
- * normally requires APS encryption.
- *
- * @param profileId The profile ID  Ver.: always
- * @param clusterId The cluster ID  Ver.: always
- * @param incoming Whether this is an incoming or outgoing message.  Ver.:
- * always
- * @param commandId The ZCL command ID being sent/received.  Ver.: always
- */
-bool emberAfClusterSecurityCustomCallback(EmberAfProfileId profileId, CHIPClusterId clusterId, bool incoming, CHIPCommandId commandId)
-{
-    // By default, assume APS encryption is not required.
-    return false;
-}
-
 /** @brief Default Response
  *
  * This function is called by the application framework when a Default Response
@@ -558,14 +539,6 @@ bool emberAfGetEndpointInfoCallback(CHIPEndpointId endpoint, uint8_t * returnNet
 {
     return false;
 }
-
-/** @brief Trust Center Keepalive Abort
- *
- * This callback is called when the device should abort the trust center
- * keepalive process.
- *
- */
-void emberAfTrustCenterKeepaliveAbortCallback() {}
 
 /** @brief Get Source Route Overhead
  *

--- a/src/app/zap-templates/callback.zapt
+++ b/src/app/zap-templates/callback.zapt
@@ -218,21 +218,6 @@ bool emberAfAttributeReadAccessCallback(CHIPEndpointId endpoint, CHIPClusterId c
 bool emberAfAttributeWriteAccessCallback(CHIPEndpointId endpoint, CHIPClusterId clusterId, uint16_t manufacturerCode,
                                          CHIPAttributeId attributeId);
 
-/** @brief Cluster Security Custom
- *
- * This callback is fired when determining if APS encryption is required for a
- * cluster outside of the specification's required clusters.  In other words,
- * for the Smart Energy profile this would be a cluster beyond the list that
- * normally requires APS encryption.
- *
- * @param profileId The profile ID  Ver.: always
- * @param clusterId The cluster ID  Ver.: always
- * @param incoming Whether this is an incoming or outgoing message.  Ver.:
- * always
- * @param commandId The ZCL command ID being sent/received.  Ver.: always
- */
-bool emberAfClusterSecurityCustomCallback(EmberAfProfileId profileId, CHIPClusterId clusterId, bool incoming, CHIPCommandId commandId);
-
 /** @brief Default Response
  *
  * This function is called by the application framework when a Default Response
@@ -560,14 +545,6 @@ uint32_t emberAfGetCurrentTimeCallback();
  * with information about the endpoint.  Ver.: always
  */
 bool emberAfGetEndpointInfoCallback(CHIPEndpointId endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo);
-
-/** @brief Trust Center Keepalive Abort
- *
- * This callback is called when the device should abort the trust center
- * keepalive process.
- *
- */
-void emberAfTrustCenterKeepaliveAbortCallback();
 
 /** @brief Get Source Route Overhead
  *


### PR DESCRIPTION
 #### Problem

#3809 list all the callbacks that are kept when migrating to ZAP in #3464. While some definitively makes senses, some others may be some dependencies that does not make sense.

One example of such callback is `emberAfClusterSecurityCustomCallback` since security is not optional in CHIP.

This patch has some intersection with #3462 but this is just because `EmberAfProfileId` is used in `emberAfClusterSecurityCustomCallback`

 #### Summary of Changes
 * Remove `emberAfClusterSecurityCustomCallback` callbacks from `gen/`
 * Remove the only usage of `emberAfClusterSecurityCustomCallback` that was leading to a stub anyway
 * Remove a bunch of some other security related code into `src/app/util`. My understanding is that the secure layer is on top of this code, so security features will not be managed by it.