### PR TITLE
[QPG6100] Extension lock-app UI/control state machine

### DIFF
--- a/examples/lock-app/qpg6100/BUILD.gn
+++ b/examples/lock-app/qpg6100/BUILD.gn
@@ -22,6 +22,7 @@ assert(current_os == "freertos")
 
 qpg6100_project_dir = "${chip_root}/examples/lock-app/qpg6100"
 examples_plat_dir = "${chip_root}/examples/platform/qpg6100"
+examples_common_dir = "${chip_root}/examples/common"
 
 qpg6100_sdk("sdk") {
   include_dirs = [
@@ -48,6 +49,7 @@ qpg6100_executable("lock_app") {
     ":sdk",
     "${chip_root}/src/lib",
     "${chip_root}/src/setup_payload",
+    "${examples_common_dir}/chip-app-server:chip-app-server",
 
     #    OpenThread to be enabled
     #    https://github.com/project-chip/connectedhomeip/issues/293
@@ -58,12 +60,25 @@ qpg6100_executable("lock_app") {
   ]
 
   include_dirs += [
-    "${qpg6100_project_dir}/src/",
+    "${qpg6100_project_dir}/include/",
     "${chip_root}/src/app/util",
     "${examples_plat_dir}/",
   ]
 
-  sources = [ "src/main.cpp" ]
+  sources = [
+    "${examples_common_dir}/chip-app-server/QRCodeUtil.cpp",
+    "src/AppTask.cpp",
+    "src/BoltLockManager.cpp",
+    "src/ZclCallbacks.cpp",
+    "src/main.cpp",
+  ]
+
+  deps = [
+    "${chip_root}/examples/common/chip-app-server:chip-app-server",
+    "${chip_root}/examples/lock-app/lock-common",
+    "${chip_root}/src/lib",
+    "${chip_root}/src/setup_payload",
+  ]
 
   output_dir = root_out_dir
 

--- a/examples/lock-app/qpg6100/README.md
+++ b/examples/lock-app/qpg6100/README.md
@@ -26,18 +26,19 @@ with separate updates.
 
 Current status of implementation:
 
+-   Button and LED control
 -   Initialization of the CHIP stack.
 -   CHIP Logging, PlatformManager and ConfigurationManager enabled.
 -   BLE: CHIPoBLE advertisement and connection available for provisioning
+-   CHIP ZCL cluster control for the Lock mechanism through CHIP tool.
 
 Pending:
 
--   Button and LED control
 -   Thread: Linking QPG6100 OpenThread implementation to CHIP build
--   Intake CHIP ZCL cluster control for the Lock mechanism through CHIP tool.
 
 For more information on Qorvo and the platforms, please visit
-[the Qorvo website](www.qorvo.com) or contact us on LPW.support@qorvo.com.
+[the Qorvo website](http://www.qorvo.com) or contact us on
+LPW.support@qorvo.com.
 
 ## Building
 

--- a/examples/lock-app/qpg6100/include/AppConfig.h
+++ b/examples/lock-app/qpg6100/include/AppConfig.h
@@ -1,0 +1,42 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef APP_CONFIG_H
+#define APP_CONFIG_H
+
+// ---- Lock Example App Config ----
+
+#define APP_LOCK_BUTTON BTN_LOCK
+#define APP_FUNCTION_BUTTON BTN_FUNCTION
+
+#define SYSTEM_STATE_LED LED_GREEN
+#define LOCK_STATE_LED LED_RED
+
+// Time it takes in ms for the simulated actuator to move from one
+// state to another.
+#define ACTUATOR_MOVEMENT_PERIOS_MS 2000
+
+// ---- Lock Example SWU Config ----
+#define SWU_INTERVAl_WINDOW_MIN_MS (23 * 60 * 60 * 1000) // 23 hours
+#define SWU_INTERVAl_WINDOW_MAX_MS (24 * 60 * 60 * 1000) // 24 hours
+
+// ---- Thread Polling Config ----
+#define THREAD_ACTIVE_POLLING_INTERVAL_MS 100
+#define THREAD_INACTIVE_POLLING_INTERVAL_MS 1000
+
+#endif // APP_CONFIG_H

--- a/examples/lock-app/qpg6100/include/AppEvent.h
+++ b/examples/lock-app/qpg6100/include/AppEvent.h
@@ -1,0 +1,58 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef APP_EVENT_H
+#define APP_EVENT_H
+
+struct AppEvent;
+typedef void (*EventHandler)(AppEvent *);
+
+struct AppEvent
+{
+    enum AppEventTypes
+    {
+        kEventType_Button = 0,
+        kEventType_Timer,
+        kEventType_Lock,
+        kEventType_Install,
+    };
+
+    uint16_t Type;
+
+    union
+    {
+        struct
+        {
+            uint8_t ButtonIdx;
+            uint8_t Action;
+        } ButtonEvent;
+        struct
+        {
+            void * Context;
+        } TimerEvent;
+        struct
+        {
+            uint8_t Action;
+            int32_t Actor;
+        } LockEvent;
+    };
+
+    EventHandler Handler;
+};
+
+#endif // APP_EVENT_H

--- a/examples/lock-app/qpg6100/include/AppTask.h
+++ b/examples/lock-app/qpg6100/include/AppTask.h
@@ -1,0 +1,88 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef APP_TASK_H
+#define APP_TASK_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "AppEvent.h"
+#include "BoltLockManager.h"
+
+#include "FreeRTOS.h"
+#include "timers.h" // provides FreeRTOS timer support
+#include <ble/BLEEndPoint.h>
+#include <platform/CHIPDeviceLayer.h>
+
+class AppTask
+{
+
+public:
+    int StartAppTask();
+    static void AppTaskMain(void * pvParameter);
+
+    void PostLockActionRequest(int32_t aActor, BoltLockManager::Action_t aAction);
+    void PostEvent(const AppEvent * event);
+    void UpdateClusterState();
+
+    static void ButtonEventHandler(uint8_t btnIdx, bool btnPressed);
+
+private:
+    friend AppTask & GetAppTask(void);
+
+    int Init();
+
+    static void ActionInitiated(BoltLockManager::Action_t aAction, int32_t aActor);
+    static void ActionCompleted(BoltLockManager::Action_t aAction);
+
+    void CancelTimer(void);
+
+    void DispatchEvent(AppEvent * event);
+
+    static void FunctionTimerEventHandler(AppEvent * aEvent);
+    static void FunctionHandler(AppEvent * aEvent);
+    static void LockActionEventHandler(AppEvent * aEvent);
+    static void TimerEventHandler(chip::System::Layer * aLayer, void * aAppState, chip::System::Error aError);
+
+    void StartTimer(uint32_t aTimeoutMs);
+
+    enum Function_t
+    {
+        kFunction_NoneSelected   = 0,
+        kFunction_SoftwareUpdate = 0,
+        kFunction_Joiner         = 1,
+        kFunction_FactoryReset   = 2,
+
+        kFunction_Invalid
+    } Function;
+
+    Function_t mFunction;
+    bool mFunctionTimerActive;
+    bool mSyncClusterToButtonAction;
+    chip::Ble::BLEEndPoint * mBLEEndPoint;
+
+    static AppTask sAppTask;
+};
+
+inline AppTask & GetAppTask(void)
+{
+    return AppTask::sAppTask;
+}
+
+#endif // APP_TASK_H

--- a/examples/lock-app/qpg6100/include/BoltLockManager.h
+++ b/examples/lock-app/qpg6100/include/BoltLockManager.h
@@ -1,0 +1,86 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef LOCK_MANAGER_H
+#define LOCK_MANAGER_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "AppEvent.h"
+
+#include "FreeRTOS.h"
+#include "timers.h" // provides FreeRTOS timer support
+
+class BoltLockManager
+{
+public:
+    enum Action_t
+    {
+        LOCK_ACTION = 0,
+        UNLOCK_ACTION,
+
+        INVALID_ACTION
+    } Action;
+
+    enum State_t
+    {
+        kState_LockingInitiated = 0,
+        kState_LockingCompleted,
+        kState_UnlockingInitiated,
+        kState_UnlockingCompleted,
+    } State;
+
+    int Init();
+    bool IsUnlocked();
+    void EnableAutoRelock(bool aOn);
+    void SetAutoLockDuration(uint32_t aDurationInSecs);
+    bool IsActionInProgress();
+    bool InitiateAction(int32_t aActor, Action_t aAction);
+
+    typedef void (*Callback_fn_initiated)(Action_t, int32_t aActor);
+    typedef void (*Callback_fn_completed)(Action_t);
+    void SetCallbacks(Callback_fn_initiated aActionInitiated_CB, Callback_fn_completed aActionCompleted_CB);
+
+private:
+    friend BoltLockManager & BoltLockMgr(void);
+    State_t mState;
+
+    Callback_fn_initiated mActionInitiated_CB;
+    Callback_fn_completed mActionCompleted_CB;
+
+    bool mAutoRelock;
+    uint32_t mAutoLockDuration;
+    bool mAutoLockTimerArmed;
+
+    void CancelTimer(void);
+    void StartTimer(uint32_t aTimeoutMs);
+
+    static void TimerEventHandler(TimerHandle_t xTimer);
+    static void AutoReLockTimerEventHandler(AppEvent * aEvent);
+    static void ActuatorMovementTimerEventHandler(AppEvent * aEvent);
+
+    static BoltLockManager sLock;
+};
+
+inline BoltLockManager & BoltLockMgr(void)
+{
+    return BoltLockManager::sLock;
+}
+
+#endif // LOCK_MANAGER_H

--- a/examples/lock-app/qpg6100/src/AppTask.cpp
+++ b/examples/lock-app/qpg6100/src/AppTask.cpp
@@ -1,0 +1,496 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2019 Google LLC.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "qvCHIP.h"
+
+#include "AppConfig.h"
+#include "AppEvent.h"
+#include "AppTask.h"
+
+#include "QRCodeUtil.h"
+
+#include "Server.h"
+#include "attribute-storage.h"
+#include "gen/cluster-id.h"
+
+#include <setup_payload/QRCodeSetupPayloadGenerator.h>
+#include <setup_payload/SetupPayload.h>
+
+using namespace chip::TLV;
+using namespace chip::DeviceLayer;
+
+#include <platform/CHIPDeviceLayer.h>
+#if CHIP_ENABLE_OPENTHREAD
+#include <platform/OpenThread/OpenThreadUtils.h>
+#include <platform/ThreadStackManager.h>
+#include <platform/internal/DeviceNetworkInfo.h>
+#include <platform/qpg6100/ThreadStackManagerImpl.h>
+#define JOINER_START_TRIGGER_TIMEOUT 1500
+#endif
+
+#define FACTORY_RESET_TRIGGER_TIMEOUT 3000
+#define FACTORY_RESET_CANCEL_WINDOW_TIMEOUT 3000
+#define APP_TASK_STACK_SIZE (4096)
+#define APP_TASK_PRIORITY 2
+#define APP_EVENT_QUEUE_SIZE 10
+
+static TaskHandle_t sAppTaskHandle;
+static QueueHandle_t sAppEventQueue;
+
+static bool sIsThreadProvisioned     = false;
+static bool sIsThreadEnabled         = false;
+static bool sIsThreadAttached        = false;
+static bool sIsPairedToAccount       = false;
+static bool sHaveBLEConnections      = false;
+static bool sHaveServiceConnectivity = false;
+
+AppTask AppTask::sAppTask;
+
+int AppTask::StartAppTask()
+{
+    sAppEventQueue = xQueueCreate(APP_EVENT_QUEUE_SIZE, sizeof(AppEvent));
+    if (sAppEventQueue == NULL)
+    {
+        ChipLogError(NotSpecified, "Failed to allocate app event queue");
+        return CHIP_ERROR_NO_MEMORY;
+    }
+
+    // Start App task.
+    if (xTaskCreate(AppTaskMain, "APP", APP_TASK_STACK_SIZE / sizeof(StackType_t), NULL, 1, &sAppTaskHandle) != pdPASS)
+    {
+        return CHIP_ERROR_NO_MEMORY;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+int AppTask::Init()
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    ChipLogProgress(NotSpecified, "Current Firmware Version: %s", CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION);
+
+    err = BoltLockMgr().Init();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(NotSpecified, "BoltLockMgr().Init() failed");
+        return err;
+    }
+    BoltLockMgr().SetCallbacks(ActionInitiated, ActionCompleted);
+
+    // Subscribe with our button callback to the qvCHIP button handler.
+    qvCHIP_SetBtnCallback(ButtonEventHandler);
+
+    qvCHIP_LedSet(LOCK_STATE_LED, !BoltLockMgr().IsUnlocked());
+
+    // Init ZCL Data Model
+    InitServer();
+    UpdateClusterState();
+
+    PrintQRCode(chip::RendezvousInformationFlags::kBLE);
+
+    return err;
+}
+
+void AppTask::AppTaskMain(void * pvParameter)
+{
+    int err;
+    AppEvent event;
+    uint64_t mLastChangeTimeUS = 0;
+
+    err = sAppTask.Init();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(NotSpecified, "AppTask.Init() failed");
+        // appError(err);
+    }
+
+    ChipLogProgress(NotSpecified, "App Task started");
+    // TODO: PR # 2939 - OT support
+    // SetDeviceName("QPG6100LockDemo._chip._udp.local.");
+
+    while (true)
+    {
+        BaseType_t eventReceived = xQueueReceive(sAppEventQueue, &event, pdMS_TO_TICKS(10));
+        while (eventReceived == pdTRUE)
+        {
+            sAppTask.DispatchEvent(&event);
+            eventReceived = xQueueReceive(sAppEventQueue, &event, 0);
+        }
+
+        // Collect connectivity and configuration state from the CHIP stack. Because
+        // the CHIP event loop is being run in a separate task, the stack must be
+        // locked while these values are queried.  However we use a non-blocking
+        // lock request (TryLockCHIPStack()) to avoid blocking other UI activities
+        // when the CHIP task is busy (e.g. with a long crypto operation).
+        if (PlatformMgr().TryLockChipStack())
+        {
+            sIsThreadProvisioned     = ConnectivityMgr().IsThreadProvisioned();
+            sIsThreadEnabled         = ConnectivityMgr().IsThreadEnabled();
+            sIsThreadAttached        = ConnectivityMgr().IsThreadAttached();
+            sHaveBLEConnections      = (ConnectivityMgr().NumBLEConnections() != 0);
+            sHaveServiceConnectivity = ConnectivityMgr().HaveServiceConnectivity();
+            PlatformMgr().UnlockChipStack();
+        }
+
+        // Update the status LED if factory reset has not been initiated.
+        //
+        // If system has "full connectivity", keep the LED On constantly.
+        //
+        // If thread and service provisioned, but not attached to the thread network
+        // yet OR no connectivity to the service OR subscriptions are not fully
+        // established THEN blink the LED Off for a short period of time.
+        //
+        // If the system has ble connection(s) uptill the stage above, THEN blink
+        // the LEDs at an even rate of 100ms.
+        //
+        // Otherwise, blink the LED ON for a very short time.
+        if (sAppTask.mFunction != kFunction_FactoryReset)
+        {
+            // Consider the system to be "fully connected" if it has service
+            // connectivity
+            if (sHaveServiceConnectivity)
+            {
+                qvCHIP_LedSet(SYSTEM_STATE_LED, true);
+            }
+            else if (sIsThreadProvisioned && sIsThreadEnabled && sIsPairedToAccount &&
+                     (!sIsThreadAttached || !sHaveServiceConnectivity))
+            {
+                qvCHIP_LedBlink(SYSTEM_STATE_LED, 950, 50);
+            }
+            else if (sHaveBLEConnections)
+            {
+                qvCHIP_LedBlink(SYSTEM_STATE_LED, 100, 100);
+            }
+            else
+            {
+                qvCHIP_LedBlink(SYSTEM_STATE_LED, 50, 950);
+            }
+        }
+
+        uint64_t nowUS            = chip::System::Layer::GetClock_Monotonic();
+        uint64_t nextChangeTimeUS = mLastChangeTimeUS + 5 * 1000 * 1000UL;
+
+        if (nowUS > nextChangeTimeUS)
+        {
+            // TODO: PR # 2939 - OT support
+            /*
+            PublishService();
+            */
+            mLastChangeTimeUS = nowUS;
+        }
+    }
+}
+
+void AppTask::LockActionEventHandler(AppEvent * aEvent)
+{
+    bool initiated = false;
+    BoltLockManager::Action_t action;
+    int32_t actor;
+    int err = CHIP_NO_ERROR;
+
+    if (aEvent->Type == AppEvent::kEventType_Lock)
+    {
+        action = static_cast<BoltLockManager::Action_t>(aEvent->LockEvent.Action);
+        actor  = aEvent->LockEvent.Actor;
+    }
+    else if (aEvent->Type == AppEvent::kEventType_Button)
+    {
+        if (BoltLockMgr().IsUnlocked())
+        {
+            action = BoltLockManager::LOCK_ACTION;
+        }
+        else
+        {
+            action = BoltLockManager::UNLOCK_ACTION;
+        }
+        actor = AppEvent::kEventType_Button;
+    }
+    else
+    {
+        err = CHIP_ERROR_MAX;
+    }
+
+    if (err == CHIP_NO_ERROR)
+    {
+        initiated = BoltLockMgr().InitiateAction(actor, action);
+
+        if (!initiated)
+        {
+            ChipLogProgress(NotSpecified, "Action is already in progress or active.");
+        }
+    }
+}
+
+void AppTask::ButtonEventHandler(uint8_t btnIdx, bool btnPressed)
+{
+    if (btnIdx != APP_LOCK_BUTTON && btnIdx != APP_FUNCTION_BUTTON)
+    {
+        return;
+    }
+
+    AppEvent button_event              = {};
+    button_event.Type                  = AppEvent::kEventType_Button;
+    button_event.ButtonEvent.ButtonIdx = btnIdx;
+    button_event.ButtonEvent.Action    = btnPressed;
+
+    if (btnIdx == APP_LOCK_BUTTON && btnPressed == true)
+    {
+        button_event.Handler = LockActionEventHandler;
+        sAppTask.PostEvent(&button_event);
+    }
+    else if (btnIdx == APP_FUNCTION_BUTTON)
+    {
+        button_event.Handler = FunctionHandler;
+        sAppTask.PostEvent(&button_event);
+    }
+}
+
+void AppTask::TimerEventHandler(chip::System::Layer * aLayer, void * aAppState, chip::System::Error aError)
+{
+    AppEvent event;
+    event.Type               = AppEvent::kEventType_Timer;
+    event.TimerEvent.Context = aAppState;
+    event.Handler            = FunctionTimerEventHandler;
+    sAppTask.PostEvent(&event);
+}
+
+void AppTask::FunctionTimerEventHandler(AppEvent * aEvent)
+{
+    if (aEvent->Type != AppEvent::kEventType_Timer)
+    {
+        return;
+    }
+
+    // If we reached here, the button was held past FACTORY_RESET_TRIGGER_TIMEOUT,
+    // initiate factory reset
+    if (sAppTask.mFunctionTimerActive && sAppTask.mFunction == kFunction_SoftwareUpdate)
+    {
+#if CHIP_ENABLE_OPENTHREAD
+        ChipLogProgress(NotSpecified, "Release button now to Start Thread Joiner");
+        ChipLogProgress(NotSpecified, "Hold to trigger Factory Reset");
+        sAppTask.mFunction = kFunction_Joiner;
+        sAppTask.StartTimer(FACTORY_RESET_TRIGGER_TIMEOUT);
+    }
+    else if (sAppTask.mFunctionTimerActive && sAppTask.mFunction == kFunction_Joiner)
+    {
+#endif
+        ChipLogProgress(NotSpecified, "Factory Reset Triggered. Release button within %ums to cancel.",
+                        FACTORY_RESET_CANCEL_WINDOW_TIMEOUT);
+
+        // Start timer for FACTORY_RESET_CANCEL_WINDOW_TIMEOUT to allow user to
+        // cancel, if required.
+        sAppTask.StartTimer(FACTORY_RESET_CANCEL_WINDOW_TIMEOUT);
+
+        sAppTask.mFunction = kFunction_FactoryReset;
+
+        // Turn off all LEDs before starting blink to make sure blink is
+        // co-ordinated.
+        qvCHIP_LedSet(SYSTEM_STATE_LED, false);
+        qvCHIP_LedSet(LOCK_STATE_LED, false);
+
+        qvCHIP_LedBlink(SYSTEM_STATE_LED, 500, 500);
+        qvCHIP_LedBlink(LOCK_STATE_LED, 500, 500);
+    }
+    else if (sAppTask.mFunctionTimerActive && sAppTask.mFunction == kFunction_FactoryReset)
+    {
+        // Actually trigger Factory Reset
+        sAppTask.mFunction = kFunction_NoneSelected;
+        ConfigurationMgr().InitiateFactoryReset();
+    }
+}
+
+void AppTask::FunctionHandler(AppEvent * aEvent)
+{
+    if (aEvent->ButtonEvent.ButtonIdx != APP_FUNCTION_BUTTON)
+    {
+        return;
+    }
+
+    // To trigger software update: press the APP_FUNCTION_BUTTON button briefly (<
+    // FACTORY_RESET_TRIGGER_TIMEOUT) To initiate factory reset: press the
+    // APP_FUNCTION_BUTTON for FACTORY_RESET_TRIGGER_TIMEOUT +
+    // FACTORY_RESET_CANCEL_WINDOW_TIMEOUT All LEDs start blinking after
+    // FACTORY_RESET_TRIGGER_TIMEOUT to signal factory reset has been initiated.
+    // To cancel factory reset: release the APP_FUNCTION_BUTTON once all LEDs
+    // start blinking within the FACTORY_RESET_CANCEL_WINDOW_TIMEOUT
+    if (aEvent->ButtonEvent.Action == true)
+    {
+        if (!sAppTask.mFunctionTimerActive && sAppTask.mFunction == kFunction_NoneSelected)
+        {
+#if CHIP_ENABLE_OPENTHREAD
+            sAppTask.StartTimer(JOINER_START_TRIGGER_TIMEOUT);
+#else
+            sAppTask.StartTimer(FACTORY_RESET_TRIGGER_TIMEOUT);
+#endif
+
+            sAppTask.mFunction = kFunction_SoftwareUpdate;
+        }
+    }
+    else
+    {
+        // If the button was released before factory reset got initiated, trigger a
+        // software update.
+        if (sAppTask.mFunctionTimerActive && sAppTask.mFunction == kFunction_SoftwareUpdate)
+        {
+            sAppTask.CancelTimer();
+
+            sAppTask.mFunction = kFunction_NoneSelected;
+
+            ChipLogError(NotSpecified, "Software Update currently not supported.");
+        }
+#if CHIP_ENABLE_OPENTHREAD
+        else if (sAppTask.mFunctionTimerActive && sAppTask.mFunction == kFunction_Joiner)
+        {
+            sAppTask.CancelTimer();
+            sAppTask.mFunction = kFunction_NoneSelected;
+
+            CHIP_ERROR error = ThreadStackMgr().JoinerStart();
+            ChipLogProgress(NotSpecified, "Thread joiner triggered: %s", chip::ErrorStr(error));
+        }
+#endif
+        else if (sAppTask.mFunctionTimerActive && sAppTask.mFunction == kFunction_FactoryReset)
+        {
+            // Set lock status LED back to show state of lock.
+            qvCHIP_LedSet(LOCK_STATE_LED, !BoltLockMgr().IsUnlocked());
+
+            sAppTask.CancelTimer();
+
+            // Change the function to none selected since factory reset has been
+            // canceled.
+            sAppTask.mFunction = kFunction_NoneSelected;
+
+            ChipLogProgress(NotSpecified, "Factory Reset has been Canceled");
+        }
+    }
+}
+
+void AppTask::CancelTimer()
+{
+    SystemLayer.CancelTimer(TimerEventHandler, this);
+    mFunctionTimerActive = false;
+}
+
+void AppTask::StartTimer(uint32_t aTimeoutInMs)
+{
+    CHIP_ERROR err;
+
+    SystemLayer.CancelTimer(TimerEventHandler, this);
+    err = SystemLayer.StartTimer(aTimeoutInMs, TimerEventHandler, this);
+    SuccessOrExit(err);
+
+    mFunctionTimerActive = true;
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(NotSpecified, "StartTimer failed %s: ", chip::ErrorStr(err));
+    }
+}
+
+void AppTask::ActionInitiated(BoltLockManager::Action_t aAction, int32_t aActor)
+{
+    // If the action has been initiated by the lock, update the bolt lock trait
+    // and start flashing the LEDs rapidly to indicate action initiation.
+    if (aAction == BoltLockManager::LOCK_ACTION)
+    {
+        ChipLogProgress(NotSpecified, "Lock Action has been initiated");
+    }
+    else if (aAction == BoltLockManager::UNLOCK_ACTION)
+    {
+        ChipLogProgress(NotSpecified, "Unlock Action has been initiated");
+    }
+
+    if (aActor == AppEvent::kEventType_Button)
+    {
+        sAppTask.mSyncClusterToButtonAction = true;
+    }
+
+    qvCHIP_LedBlink(LOCK_STATE_LED, 50, 50);
+}
+
+void AppTask::ActionCompleted(BoltLockManager::Action_t aAction)
+{
+    // if the action has been completed by the lock, update the bolt lock trait.
+    // Turn on the lock LED if in a LOCKED state OR
+    // Turn off the lock LED if in an UNLOCKED state.
+    if (aAction == BoltLockManager::LOCK_ACTION)
+    {
+        ChipLogProgress(NotSpecified, "Lock Action has been completed");
+
+        qvCHIP_LedSet(LOCK_STATE_LED, true);
+    }
+    else if (aAction == BoltLockManager::UNLOCK_ACTION)
+    {
+        ChipLogProgress(NotSpecified, "Unlock Action has been completed");
+
+        qvCHIP_LedSet(LOCK_STATE_LED, false);
+    }
+
+    if (sAppTask.mSyncClusterToButtonAction)
+    {
+        sAppTask.UpdateClusterState();
+        sAppTask.mSyncClusterToButtonAction = false;
+    }
+}
+
+void AppTask::PostLockActionRequest(int32_t aActor, BoltLockManager::Action_t aAction)
+{
+    AppEvent event;
+    event.Type             = AppEvent::kEventType_Lock;
+    event.LockEvent.Actor  = aActor;
+    event.LockEvent.Action = aAction;
+    event.Handler          = LockActionEventHandler;
+    PostEvent(&event);
+}
+
+void AppTask::PostEvent(const AppEvent * aEvent)
+{
+    if (sAppEventQueue != NULL)
+    {
+        if (!xQueueSend(sAppEventQueue, aEvent, 1))
+        {
+            ChipLogError(NotSpecified, "Failed to post event to app task event queue");
+        }
+    }
+}
+
+void AppTask::DispatchEvent(AppEvent * aEvent)
+{
+    if (aEvent->Handler)
+    {
+        aEvent->Handler(aEvent);
+    }
+    else
+    {
+        ChipLogError(NotSpecified, "Event received with no handler. Dropping event.");
+    }
+}
+
+void AppTask::UpdateClusterState(void)
+{
+    uint8_t newValue = !BoltLockMgr().IsUnlocked();
+
+    // write the new on/off value
+    EmberAfStatus status = emberAfWriteAttribute(1, ZCL_ON_OFF_CLUSTER_ID, ZCL_ON_OFF_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
+                                                 (uint8_t *) &newValue, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    {
+        ChipLogError(NotSpecified, "ERR: updating on/off %x", status);
+    }
+}

--- a/examples/lock-app/qpg6100/src/BoltLockManager.cpp
+++ b/examples/lock-app/qpg6100/src/BoltLockManager.cpp
@@ -1,0 +1,226 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2019 Google LLC.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "BoltLockManager.h"
+
+#include "AppConfig.h"
+#include "AppTask.h"
+#include <FreeRTOS.h>
+
+BoltLockManager BoltLockManager::sLock;
+
+TimerHandle_t sLockTimer;
+
+int BoltLockManager::Init()
+{
+    // Create FreeRTOS sw timer for lock timer.
+    sLockTimer = xTimerCreate("lockTmr",        // Just a text name, not used by the RTOS kernel
+                              1,                // == default timer period (mS)
+                              false,            // no timer reload (==one-shot)
+                              (void *) this,    // init timer id = lock obj context
+                              TimerEventHandler // timer callback handler
+    );
+
+    if (sLockTimer == NULL)
+    {
+        ChipLogProgress(NotSpecified, "sLockTimer timer create failed");
+        // TODO:
+        // appError(CHIP_ERROR_MAX);
+    }
+
+    mState              = kState_LockingCompleted;
+    mAutoLockTimerArmed = false;
+    mAutoRelock         = false;
+    mAutoLockDuration   = 0;
+
+    return CHIP_NO_ERROR;
+}
+
+void BoltLockManager::SetCallbacks(Callback_fn_initiated aActionInitiated_CB, Callback_fn_completed aActionCompleted_CB)
+{
+    mActionInitiated_CB = aActionInitiated_CB;
+    mActionCompleted_CB = aActionCompleted_CB;
+}
+
+bool BoltLockManager::IsActionInProgress()
+{
+    return (mState == kState_LockingInitiated || mState == kState_UnlockingInitiated);
+}
+
+bool BoltLockManager::IsUnlocked()
+{
+    return (mState == kState_UnlockingCompleted);
+}
+
+void BoltLockManager::EnableAutoRelock(bool aOn)
+{
+    mAutoRelock = aOn;
+}
+
+void BoltLockManager::SetAutoLockDuration(uint32_t aDurationInSecs)
+{
+    mAutoLockDuration = aDurationInSecs;
+}
+
+bool BoltLockManager::InitiateAction(int32_t aActor, Action_t aAction)
+{
+    bool action_initiated = false;
+    State_t new_state;
+
+    // Initiate Lock/Unlock Action only when the previous one is complete.
+    if (mState == kState_LockingCompleted && aAction == UNLOCK_ACTION)
+    {
+        action_initiated = true;
+
+        new_state = kState_UnlockingInitiated;
+    }
+    else if (mState == kState_UnlockingCompleted && aAction == LOCK_ACTION)
+    {
+        action_initiated = true;
+
+        new_state = kState_LockingInitiated;
+    }
+
+    if (action_initiated)
+    {
+        if (mAutoLockTimerArmed && new_state == kState_LockingInitiated)
+        {
+            // If auto lock timer has been armed and someone initiates locking,
+            // cancel the timer and continue as normal.
+            mAutoLockTimerArmed = false;
+
+            CancelTimer();
+        }
+
+        StartTimer(ACTUATOR_MOVEMENT_PERIOS_MS);
+
+        // Since the timer started successfully, update the state and trigger callback
+        mState = new_state;
+
+        if (mActionInitiated_CB)
+        {
+            mActionInitiated_CB(aAction, aActor);
+        }
+    }
+
+    return action_initiated;
+}
+
+void BoltLockManager::StartTimer(uint32_t aTimeoutMs)
+{
+    if (xTimerIsTimerActive(sLockTimer))
+    {
+        ChipLogError(NotSpecified, "app timer already started!");
+        CancelTimer();
+    }
+
+    // timer is not active, change its period to required value (== restart).
+    // FreeRTOS- Block for a maximum of 100 ticks if the change period command
+    // cannot immediately be sent to the timer command queue.
+    if (xTimerChangePeriod(sLockTimer, (aTimeoutMs / portTICK_PERIOD_MS), 100) != pdPASS)
+    {
+        ChipLogError(NotSpecified, "sLockTimer timer start() failed");
+        // appError(CHIP_ERROR_MAX);
+    }
+}
+
+void BoltLockManager::CancelTimer(void)
+{
+    if (xTimerStop(sLockTimer, 0) == pdFAIL)
+    {
+        ChipLogError(NotSpecified, "Lock timer timer stop() failed");
+        // appError(CHIP_ERROR_MAX);
+    }
+}
+
+void BoltLockManager::TimerEventHandler(TimerHandle_t xTimer)
+{
+    // Get lock obj context from timer id.
+    BoltLockManager * lock = static_cast<BoltLockManager *>(pvTimerGetTimerID(xTimer));
+
+    // The timer event handler will be called in the context of the timer task
+    // once sLockTimer expires. Post an event to apptask queue with the actual handler
+    // so that the event can be handled in the context of the apptask.
+    AppEvent event;
+    event.Type               = AppEvent::kEventType_Timer;
+    event.TimerEvent.Context = lock;
+    if (lock->mAutoLockTimerArmed)
+    {
+        event.Handler = AutoReLockTimerEventHandler;
+    }
+    else
+    {
+        event.Handler = ActuatorMovementTimerEventHandler;
+    }
+    GetAppTask().PostEvent(&event);
+}
+
+void BoltLockManager::AutoReLockTimerEventHandler(AppEvent * aEvent)
+{
+    BoltLockManager * lock = static_cast<BoltLockManager *>(aEvent->TimerEvent.Context);
+    int32_t actor          = 0;
+
+    // Make sure auto lock timer is still armed.
+    if (!lock->mAutoLockTimerArmed)
+    {
+        return;
+    }
+
+    lock->mAutoLockTimerArmed = false;
+
+    ChipLogProgress(NotSpecified, "Auto Re-Lock has been triggered!");
+
+    lock->InitiateAction(actor, LOCK_ACTION);
+}
+
+void BoltLockManager::ActuatorMovementTimerEventHandler(AppEvent * aEvent)
+{
+    Action_t actionCompleted = INVALID_ACTION;
+
+    BoltLockManager * lock = static_cast<BoltLockManager *>(aEvent->TimerEvent.Context);
+
+    if (lock->mState == kState_LockingInitiated)
+    {
+        lock->mState    = kState_LockingCompleted;
+        actionCompleted = LOCK_ACTION;
+    }
+    else if (lock->mState == kState_UnlockingInitiated)
+    {
+        lock->mState    = kState_UnlockingCompleted;
+        actionCompleted = UNLOCK_ACTION;
+    }
+
+    if (actionCompleted != INVALID_ACTION)
+    {
+        if (lock->mActionCompleted_CB)
+        {
+            lock->mActionCompleted_CB(actionCompleted);
+        }
+
+        if (lock->mAutoRelock && actionCompleted == UNLOCK_ACTION)
+        {
+            // Start the timer for auto relock
+            lock->StartTimer(lock->mAutoLockDuration * 1000);
+
+            lock->mAutoLockTimerArmed = true;
+
+            ChipLogProgress(NotSpecified, "Auto Re-lock enabled. Will be triggered in %u seconds", lock->mAutoLockDuration);
+        }
+    }
+}

--- a/examples/lock-app/qpg6100/src/ZclCallbacks.cpp
+++ b/examples/lock-app/qpg6100/src/ZclCallbacks.cpp
@@ -1,0 +1,69 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <support/logging/CHIPLogging.h>
+
+#include "AppTask.h"
+#include "BoltLockManager.h"
+
+#include "gen/attribute-id.h"
+#include "gen/cluster-id.h"
+#include <app/chip-zcl-zpro-codec.h>
+#include <app/util/af-types.h>
+#include <app/util/attribute-storage.h>
+#include <app/util/util.h>
+
+using namespace ::chip;
+
+void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,
+                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+{
+    if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
+    {
+        ChipLogProgress(Zcl, "Unknown cluster ID: %d", clusterId);
+        return;
+    }
+
+    if (attributeId != ZCL_ON_OFF_ATTRIBUTE_ID)
+    {
+        ChipLogProgress(Zcl, "Unknown attribute ID: %d", attributeId);
+        return;
+    }
+
+    if (*value)
+    {
+        BoltLockMgr().InitiateAction(0, BoltLockManager::LOCK_ACTION);
+    }
+    else
+    {
+        BoltLockMgr().InitiateAction(0, BoltLockManager::UNLOCK_ACTION);
+    }
+}
+
+/** @brief On/off Cluster Server Post Init
+ *
+ * Following resolution of the On/Off state at startup for this endpoint,
+ * perform any additional initialization needed; e.g., synchronize hardware
+ * state.
+ *
+ * @param endpoint Endpoint that is being initialized  Ver.: always
+ */
+void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint)
+{
+    GetAppTask().UpdateClusterState();
+}

--- a/examples/lock-app/qpg6100/src/main.cpp
+++ b/examples/lock-app/qpg6100/src/main.cpp
@@ -53,8 +53,7 @@
  *                    Includes Definitions
  *****************************************************************************/
 
-#define GP_COMPONENT_ID GP_COMPONENT_ID_APP
-
+// FreeRTOS
 #include "FreeRTOS.h"
 #include "task.h"
 
@@ -64,6 +63,9 @@
 // CHIP includes
 #include <platform/CHIPDeviceLayer.h>
 #include <support/logging/CHIPLogging.h>
+
+// Application level logic
+#include "AppTask.h"
 
 using namespace ::chip;
 using namespace ::chip::Inet;
@@ -86,10 +88,19 @@ using namespace ::chip::DeviceLayer::Internal;
 
 int Application_Init(void)
 {
+    int ret = CHIP_ERROR_MAX;
+
     /* Launch application task */
     ChipLogProgress(NotSpecified, "============================");
     ChipLogProgress(NotSpecified, "Qorvo " APP_NAME " Launching");
     ChipLogProgress(NotSpecified, "============================");
+
+    ret = GetAppTask().StartAppTask();
+    if (ret != CHIP_NO_ERROR)
+    {
+        ChipLogError(NotSpecified, "GetAppTask().Init() failed");
+        return -1;
+    }
 
     return 0;
 }

--- a/examples/platform/qpg6100/project_include/CHIPProjectConfig.h
+++ b/examples/platform/qpg6100/project_include/CHIPProjectConfig.h
@@ -38,6 +38,10 @@
  */
 #define CHIP_DEVICE_CONFIG_ENABLE_TEST_DEVICE_IDENTITY 34
 
+// Use a default setup PIN code if one hasn't been provisioned in flash.
+#define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 12345678
+#define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR 0xF00
+
 // Use a default pairing code if one hasn't been provisioned in flash.
 #define CHIP_DEVICE_CONFIG_USE_TEST_PAIRING_CODE "CHIPUS"
 

--- a/src/platform/qpg6100/args.gni
+++ b/src/platform/qpg6100/args.gni
@@ -19,6 +19,7 @@ import("//build_overrides/qpg6100_sdk.gni")
 arm_platform_config = "${qpg6100_sdk_build_root}/qpg6100_arm.gni"
 
 mbedtls_target = "${qpg6100_sdk_build_root}:qpg6100_sdk"
+openthread_external_mbedtls = mbedtls_target
 
 chip_device_platform = "qpg6100"
 

--- a/third_party/qpg_sdk/qpg6100_sdk.gni
+++ b/third_party/qpg_sdk/qpg6100_sdk.gni
@@ -58,14 +58,26 @@ template("qpg6100_sdk") {
       "${qpg6100_sdk_root}/qpg6100/comps/gpFreeRTOS/config",
       "${qpg6100_sdk_root}/qpg6100/comps/gpFreeRTOS/Source/include",
       "${qpg6100_sdk_root}/qpg6100/comps/gpFreeRTOS/Source/Portable/GCC/ARM_CM3",
+      "${qpg6100_sdk_root}/qpg6100/comps/libmbedtls",
       "${mbedtls_root}/repo/include",
     ]
 
     lib_dirs = []
 
-    libs += [ "${qpg6100_sdk_root}/qpg6100/lib/libCHIP_qpg6100.a" ]
+    libs += [
+      "${qpg6100_sdk_root}/qpg6100/lib/libCHIP_qpg6100.a",
+      "${qpg6100_sdk_root}/qpg6100/lib/libmbedtls_alt_qpg6100.a",
+    ]
 
-    defines = []
+    defines = [
+      "QORVO_CRYPTO_ENGINE",
+      "MBEDTLS_CONFIG_FILE=\"qpg6100-mbedtls-config.h\"",
+    ]
+
+    cflags = []
+
+    # Allow warning due to mbedtls
+    cflags += [ "-Wno-maybe-uninitialized" ]
 
     if (defined(invoker.defines)) {
       defines += invoker.defines
@@ -75,6 +87,71 @@ template("qpg6100_sdk") {
   source_set(sdk_target_name) {
     sources = [
       "${chip_root}/third_party/mbedtls/repo/include/mbedtls/platform.h",
+      "${chip_root}/third_party/mbedtls/repo/library/aes.c",
+      "${chip_root}/third_party/mbedtls/repo/library/aesni.c",
+      "${chip_root}/third_party/mbedtls/repo/library/arc4.c",
+      "${chip_root}/third_party/mbedtls/repo/library/asn1parse.c",
+      "${chip_root}/third_party/mbedtls/repo/library/asn1write.c",
+      "${chip_root}/third_party/mbedtls/repo/library/base64.c",
+      "${chip_root}/third_party/mbedtls/repo/library/bignum.c",
+      "${chip_root}/third_party/mbedtls/repo/library/blowfish.c",
+      "${chip_root}/third_party/mbedtls/repo/library/camellia.c",
+      "${chip_root}/third_party/mbedtls/repo/library/ccm.c",
+      "${chip_root}/third_party/mbedtls/repo/library/certs.c",
+      "${chip_root}/third_party/mbedtls/repo/library/cipher.c",
+      "${chip_root}/third_party/mbedtls/repo/library/cipher_wrap.c",
+      "${chip_root}/third_party/mbedtls/repo/library/ctr_drbg.c",
+      "${chip_root}/third_party/mbedtls/repo/library/debug.c",
+      "${chip_root}/third_party/mbedtls/repo/library/des.c",
+      "${chip_root}/third_party/mbedtls/repo/library/dhm.c",
+      "${chip_root}/third_party/mbedtls/repo/library/ecdh.c",
+      "${chip_root}/third_party/mbedtls/repo/library/ecdsa.c",
+      "${chip_root}/third_party/mbedtls/repo/library/ecjpake.c",
+      "${chip_root}/third_party/mbedtls/repo/library/ecp.c",
+      "${chip_root}/third_party/mbedtls/repo/library/ecp_curves.c",
+      "${chip_root}/third_party/mbedtls/repo/library/entropy.c",
+      "${chip_root}/third_party/mbedtls/repo/library/entropy_poll.c",
+      "${chip_root}/third_party/mbedtls/repo/library/error.c",
+      "${chip_root}/third_party/mbedtls/repo/library/gcm.c",
+      "${chip_root}/third_party/mbedtls/repo/library/hkdf.c",
+      "${chip_root}/third_party/mbedtls/repo/library/hmac_drbg.c",
+      "${chip_root}/third_party/mbedtls/repo/library/md.c",
+      "${chip_root}/third_party/mbedtls/repo/library/md5.c",
+      "${chip_root}/third_party/mbedtls/repo/library/md_wrap.c",
+      "${chip_root}/third_party/mbedtls/repo/library/oid.c",
+      "${chip_root}/third_party/mbedtls/repo/library/pem.c",
+      "${chip_root}/third_party/mbedtls/repo/library/pk.c",
+      "${chip_root}/third_party/mbedtls/repo/library/pk_wrap.c",
+      "${chip_root}/third_party/mbedtls/repo/library/pkcs12.c",
+      "${chip_root}/third_party/mbedtls/repo/library/pkcs5.c",
+      "${chip_root}/third_party/mbedtls/repo/library/pkparse.c",
+      "${chip_root}/third_party/mbedtls/repo/library/pkwrite.c",
+      "${chip_root}/third_party/mbedtls/repo/library/platform.c",
+      "${chip_root}/third_party/mbedtls/repo/library/platform_util.c",
+      "${chip_root}/third_party/mbedtls/repo/library/ripemd160.c",
+      "${chip_root}/third_party/mbedtls/repo/library/rsa.c",
+      "${chip_root}/third_party/mbedtls/repo/library/rsa_internal.c",
+      "${chip_root}/third_party/mbedtls/repo/library/sha1.c",
+      "${chip_root}/third_party/mbedtls/repo/library/sha256.c",
+      "${chip_root}/third_party/mbedtls/repo/library/sha512.c",
+      "${chip_root}/third_party/mbedtls/repo/library/ssl_cache.c",
+      "${chip_root}/third_party/mbedtls/repo/library/ssl_ciphersuites.c",
+      "${chip_root}/third_party/mbedtls/repo/library/ssl_cli.c",
+      "${chip_root}/third_party/mbedtls/repo/library/ssl_cookie.c",
+      "${chip_root}/third_party/mbedtls/repo/library/ssl_srv.c",
+      "${chip_root}/third_party/mbedtls/repo/library/ssl_ticket.c",
+      "${chip_root}/third_party/mbedtls/repo/library/ssl_tls.c",
+      "${chip_root}/third_party/mbedtls/repo/library/threading.c",
+      "${chip_root}/third_party/mbedtls/repo/library/timing.c",
+      "${chip_root}/third_party/mbedtls/repo/library/version.c",
+      "${chip_root}/third_party/mbedtls/repo/library/version_features.c",
+      "${chip_root}/third_party/mbedtls/repo/library/x509.c",
+      "${chip_root}/third_party/mbedtls/repo/library/x509_create.c",
+      "${chip_root}/third_party/mbedtls/repo/library/x509_crl.c",
+      "${chip_root}/third_party/mbedtls/repo/library/x509_csr.c",
+      "${chip_root}/third_party/mbedtls/repo/library/x509write_crt.c",
+      "${chip_root}/third_party/mbedtls/repo/library/x509write_csr.c",
+      "${chip_root}/third_party/mbedtls/repo/library/xtea.c",
       "${qpg6100_sdk_root}/qpg6100/comps/gpFreeRTOS/Source/Portable/GCC/ARM_CM3/portmacro.h",
       "${qpg6100_sdk_root}/qpg6100/comps/gpFreeRTOS/Source/include/FreeRTOS.h",
       "${qpg6100_sdk_root}/qpg6100/comps/gpFreeRTOS/Source/include/deprecated_definitions.h",
@@ -89,13 +166,15 @@ template("qpg6100_sdk") {
       "${qpg6100_sdk_root}/qpg6100/comps/gpFreeRTOS/Source/include/timers.h",
       "${qpg6100_sdk_root}/qpg6100/comps/gpFreeRTOS/config/FreeRTOSConfig.h",
       "${qpg6100_sdk_root}/qpg6100/comps/gpFreeRTOS/config/hooks.c",
+      "${qpg6100_sdk_root}/qpg6100/comps/libmbedtls/aes_alt.h",
+      "${qpg6100_sdk_root}/qpg6100/comps/libmbedtls/ccm_alt.h",
+      "${qpg6100_sdk_root}/qpg6100/comps/libmbedtls/ecjpake_alt.h",
+      "${qpg6100_sdk_root}/qpg6100/comps/libmbedtls/ecp_alt.h",
+      "${qpg6100_sdk_root}/qpg6100/comps/libmbedtls/qpg6100-mbedtls-config.h",
+      "${qpg6100_sdk_root}/qpg6100/comps/libmbedtls/sha256_alt.h",
+      "${qpg6100_sdk_root}/qpg6100/comps/libmbedtls/trng.c",  #add this for
+                                                              # mbedtls_hardware_poll
       "${qpg6100_sdk_root}/qpg6100/comps/qvCHIP/inc/qvCHIP.h",
-    ]
-
-    public_deps = [
-      #      "${segger_rtt_root}:segger_rtt",
-      #      "${segger_rtt_root}:segger_rtt_printf",
-      #      "${segger_rtt_root}:segger_rtt_syscalls",
     ]
 
     if (defined(invoker.sources)) {


### PR DESCRIPTION
 #### Problem
Initial Lock application port did not hold any application logic with Buttons/LEDs

 #### Summary of Changes
Adding existing state machine implementation + coupling in ZCL cluster code.

* Addition application level state machine
  * Using SystemLayer timer more generic code
* LED and Button control
* Addition ZCL clusters
* Use of mbedtls alt (crypto functionality pulled in by ZCL code)

Fixes #3485
Fixes #3486 