### PR TITLE
Use chip::* types from src/app/util/basic-types.h instead of EmberAf*…

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/af-gen-event.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/af-gen-event.h
@@ -63,7 +63,7 @@
     extern void emberAfPluginIasZoneServerManageQueueEventHandler(void);                                                           \
     extern void emberAfPluginReportingTickEventHandler(void);                                                                      \
     extern void emberAfPluginTemperatureMeasurementServerReadEventHandler(void);                                                   \
-    static void clusterTickWrapper(EmberEventControl * control, EmberAfTickFunction callback, uint8_t endpoint)                    \
+    static void clusterTickWrapper(EmberEventControl * control, EmberAfTickFunction callback, chip::EndpointId endpoint)           \
     {                                                                                                                              \
         /* emberAfPushEndpointNetworkIndex(endpoint); */                                                                           \
         emberEventControlSetInactive(control);                                                                                     \

--- a/examples/all-clusters-app/all-clusters-common/gen/af-structs.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/af-structs.h
@@ -39,6 +39,8 @@
 #ifndef SILABS_EMBER_AF_STRUCTS
 #define SILABS_EMBER_AF_STRUCTS
 
+#include "basic-types.h"
+
 // Generated structs from the metadata
 // Struct for IasAceZoneStatusResult
 typedef struct _IasAceZoneStatusResult
@@ -50,7 +52,7 @@ typedef struct _IasAceZoneStatusResult
 // Struct for ReadAttributeStatusRecord
 typedef struct _ReadAttributeStatusRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t status;
     uint8_t attributeType;
     uint8_t * attributeLocation;
@@ -59,7 +61,7 @@ typedef struct _ReadAttributeStatusRecord
 // Struct for WriteAttributeRecord
 typedef struct _WriteAttributeRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t attributeType;
     uint8_t * attributeLocation;
 } WriteAttributeRecord;
@@ -68,14 +70,14 @@ typedef struct _WriteAttributeRecord
 typedef struct _WriteAttributeStatusRecord
 {
     uint8_t status;
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
 } WriteAttributeStatusRecord;
 
 // Struct for ConfigureReportingRecord
 typedef struct _ConfigureReportingRecord
 {
     uint8_t direction;
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t attributeType;
     uint16_t minimumReportingInterval;
     uint16_t maximumReportingInterval;
@@ -88,7 +90,7 @@ typedef struct _ConfigureReportingStatusRecord
 {
     uint8_t status;
     uint8_t direction;
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
 } ConfigureReportingStatusRecord;
 
 // Struct for ReadReportingConfigurationRecord
@@ -96,7 +98,7 @@ typedef struct _ReadReportingConfigurationRecord
 {
     uint8_t status;
     uint8_t direction;
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t attributeType;
     uint16_t minimumReportingInterval;
     uint16_t maximumReportingInterval;
@@ -108,13 +110,13 @@ typedef struct _ReadReportingConfigurationRecord
 typedef struct _ReadReportingConfigurationAttributeRecord
 {
     uint8_t direction;
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
 } ReadReportingConfigurationAttributeRecord;
 
 // Struct for ReportAttributeRecord
 typedef struct _ReportAttributeRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t attributeType;
     uint8_t * attributeLocation;
 } ReportAttributeRecord;
@@ -122,14 +124,14 @@ typedef struct _ReportAttributeRecord
 // Struct for DiscoverAttributesInfoRecord
 typedef struct _DiscoverAttributesInfoRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t attributeType;
 } DiscoverAttributesInfoRecord;
 
 // Struct for ExtendedDiscoverAttributesInfoRecord
 typedef struct _ExtendedDiscoverAttributesInfoRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t attributeType;
     uint8_t attributeAccessControl;
 } ExtendedDiscoverAttributesInfoRecord;
@@ -137,7 +139,7 @@ typedef struct _ExtendedDiscoverAttributesInfoRecord
 // Struct for ReadStructuredAttributeRecord
 typedef struct _ReadStructuredAttributeRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t indicator;
     uint16_t indicies;
 } ReadStructuredAttributeRecord;
@@ -145,7 +147,7 @@ typedef struct _ReadStructuredAttributeRecord
 // Struct for WriteStructuredAttributeRecord
 typedef struct _WriteStructuredAttributeRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t indicator;
     uint16_t indicies;
     uint8_t attributeType;
@@ -156,7 +158,7 @@ typedef struct _WriteStructuredAttributeRecord
 typedef struct _WriteStructuredAttributeStatusRecord
 {
     uint8_t status;
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t indicator;
     uint16_t indicies;
 } WriteStructuredAttributeStatusRecord;
@@ -406,7 +408,7 @@ typedef struct _DeviceInformationRecord
 // Struct for GroupInformationRecord
 typedef struct _GroupInformationRecord
 {
-    uint16_t groupId;
+    chip::GroupId groupId;
     uint8_t groupType;
 } GroupInformationRecord;
 

--- a/examples/all-clusters-app/all-clusters-common/gen/call-command-handler.cpp
+++ b/examples/all-clusters-app/all-clusters-common/gen/call-command-handler.cpp
@@ -60,6 +60,8 @@
 #include "command-id.h"
 #include "util.h"
 
+using namespace chip;
+
 static EmberAfStatus status(bool wasHandled, bool clusterExists, bool mfgSpecific)
 {
     if (wasHandled)
@@ -274,8 +276,8 @@ EmberAfStatus emberAfGroupsClusterClientCommandParse(EmberAfClusterCommand * cmd
         {
         case ZCL_ADD_GROUP_RESPONSE_COMMAND_ID: {
             uint16_t payloadOffset = cmd->payloadStartIndex;
-            uint8_t status;   // Ver.: always
-            uint16_t groupId; // Ver.: always
+            uint8_t status;  // Ver.: always
+            GroupId groupId; // Ver.: always
             // Command is fixed length: 3
             if (cmd->bufLen < payloadOffset + 3u)
             {
@@ -290,7 +292,7 @@ EmberAfStatus emberAfGroupsClusterClientCommandParse(EmberAfClusterCommand * cmd
         case ZCL_VIEW_GROUP_RESPONSE_COMMAND_ID: {
             uint16_t payloadOffset = cmd->payloadStartIndex;
             uint8_t status;      // Ver.: always
-            uint16_t groupId;    // Ver.: always
+            GroupId groupId;     // Ver.: always
             uint8_t * groupName; // Ver.: always
             // Command is not a fixed length
             if (cmd->bufLen < payloadOffset + 1u)
@@ -333,8 +335,8 @@ EmberAfStatus emberAfGroupsClusterClientCommandParse(EmberAfClusterCommand * cmd
         }
         case ZCL_REMOVE_GROUP_RESPONSE_COMMAND_ID: {
             uint16_t payloadOffset = cmd->payloadStartIndex;
-            uint8_t status;   // Ver.: always
-            uint16_t groupId; // Ver.: always
+            uint8_t status;  // Ver.: always
+            GroupId groupId; // Ver.: always
             // Command is fixed length: 3
             if (cmd->bufLen < payloadOffset + 3u)
             {
@@ -365,7 +367,7 @@ EmberAfStatus emberAfGroupsClusterServerCommandParse(EmberAfClusterCommand * cmd
         {
         case ZCL_ADD_GROUP_COMMAND_ID: {
             uint16_t payloadOffset = cmd->payloadStartIndex;
-            uint16_t groupId;    // Ver.: always
+            GroupId groupId;     // Ver.: always
             uint8_t * groupName; // Ver.: always
             // Command is not a fixed length
             if (cmd->bufLen < payloadOffset + 2u)
@@ -384,7 +386,7 @@ EmberAfStatus emberAfGroupsClusterServerCommandParse(EmberAfClusterCommand * cmd
         }
         case ZCL_VIEW_GROUP_COMMAND_ID: {
             uint16_t payloadOffset = cmd->payloadStartIndex;
-            uint16_t groupId; // Ver.: always
+            GroupId groupId; // Ver.: always
             // Command is fixed length: 2
             if (cmd->bufLen < payloadOffset + 2u)
             {
@@ -411,7 +413,7 @@ EmberAfStatus emberAfGroupsClusterServerCommandParse(EmberAfClusterCommand * cmd
         }
         case ZCL_REMOVE_GROUP_COMMAND_ID: {
             uint16_t payloadOffset = cmd->payloadStartIndex;
-            uint16_t groupId; // Ver.: always
+            GroupId groupId; // Ver.: always
             // Command is fixed length: 2
             if (cmd->bufLen < payloadOffset + 2u)
             {
@@ -428,7 +430,7 @@ EmberAfStatus emberAfGroupsClusterServerCommandParse(EmberAfClusterCommand * cmd
         }
         case ZCL_ADD_GROUP_IF_IDENTIFYING_COMMAND_ID: {
             uint16_t payloadOffset = cmd->payloadStartIndex;
-            uint16_t groupId;    // Ver.: always
+            GroupId groupId;     // Ver.: always
             uint8_t * groupName; // Ver.: always
             // Command is not a fixed length
             if (cmd->bufLen < payloadOffset + 2u)
@@ -464,9 +466,9 @@ EmberAfStatus emberAfScenesClusterClientCommandParse(EmberAfClusterCommand * cmd
         {
         case ZCL_ADD_SCENE_RESPONSE_COMMAND_ID: {
             uint16_t payloadOffset = cmd->payloadStartIndex;
-            uint8_t status;   // Ver.: always
-            uint16_t groupId; // Ver.: always
-            uint8_t sceneId;  // Ver.: always
+            uint8_t status;  // Ver.: always
+            GroupId groupId; // Ver.: always
+            uint8_t sceneId; // Ver.: always
             // Command is fixed length: 4
             if (cmd->bufLen < payloadOffset + 4u)
             {
@@ -483,7 +485,7 @@ EmberAfStatus emberAfScenesClusterClientCommandParse(EmberAfClusterCommand * cmd
         case ZCL_VIEW_SCENE_RESPONSE_COMMAND_ID: {
             uint16_t payloadOffset = cmd->payloadStartIndex;
             uint8_t status;               // Ver.: always
-            uint16_t groupId;             // Ver.: always
+            GroupId groupId;              // Ver.: always
             uint8_t sceneId;              // Ver.: always
             uint16_t transitionTime;      // Ver.: always
             uint8_t * sceneName;          // Ver.: always
@@ -544,9 +546,9 @@ EmberAfStatus emberAfScenesClusterClientCommandParse(EmberAfClusterCommand * cmd
         }
         case ZCL_REMOVE_SCENE_RESPONSE_COMMAND_ID: {
             uint16_t payloadOffset = cmd->payloadStartIndex;
-            uint8_t status;   // Ver.: always
-            uint16_t groupId; // Ver.: always
-            uint8_t sceneId;  // Ver.: always
+            uint8_t status;  // Ver.: always
+            GroupId groupId; // Ver.: always
+            uint8_t sceneId; // Ver.: always
             // Command is fixed length: 4
             if (cmd->bufLen < payloadOffset + 4u)
             {
@@ -562,8 +564,8 @@ EmberAfStatus emberAfScenesClusterClientCommandParse(EmberAfClusterCommand * cmd
         }
         case ZCL_REMOVE_ALL_SCENES_RESPONSE_COMMAND_ID: {
             uint16_t payloadOffset = cmd->payloadStartIndex;
-            uint8_t status;   // Ver.: always
-            uint16_t groupId; // Ver.: always
+            uint8_t status;  // Ver.: always
+            GroupId groupId; // Ver.: always
             // Command is fixed length: 3
             if (cmd->bufLen < payloadOffset + 3u)
             {
@@ -577,9 +579,9 @@ EmberAfStatus emberAfScenesClusterClientCommandParse(EmberAfClusterCommand * cmd
         }
         case ZCL_STORE_SCENE_RESPONSE_COMMAND_ID: {
             uint16_t payloadOffset = cmd->payloadStartIndex;
-            uint8_t status;   // Ver.: always
-            uint16_t groupId; // Ver.: always
-            uint8_t sceneId;  // Ver.: always
+            uint8_t status;  // Ver.: always
+            GroupId groupId; // Ver.: always
+            uint8_t sceneId; // Ver.: always
             // Command is fixed length: 4
             if (cmd->bufLen < payloadOffset + 4u)
             {
@@ -597,7 +599,7 @@ EmberAfStatus emberAfScenesClusterClientCommandParse(EmberAfClusterCommand * cmd
             uint16_t payloadOffset = cmd->payloadStartIndex;
             uint8_t status;      // Ver.: always
             uint8_t capacity;    // Ver.: always
-            uint16_t groupId;    // Ver.: always
+            GroupId groupId;     // Ver.: always
             uint8_t sceneCount;  // Ver.: always
             uint8_t * sceneList; // Ver.: always
             // Command is not a fixed length
@@ -661,7 +663,7 @@ EmberAfStatus emberAfScenesClusterServerCommandParse(EmberAfClusterCommand * cmd
         {
         case ZCL_ADD_SCENE_COMMAND_ID: {
             uint16_t payloadOffset = cmd->payloadStartIndex;
-            uint16_t groupId;             // Ver.: always
+            GroupId groupId;              // Ver.: always
             uint8_t sceneId;              // Ver.: always
             uint16_t transitionTime;      // Ver.: always
             uint8_t * sceneName;          // Ver.: always
@@ -697,8 +699,8 @@ EmberAfStatus emberAfScenesClusterServerCommandParse(EmberAfClusterCommand * cmd
         }
         case ZCL_VIEW_SCENE_COMMAND_ID: {
             uint16_t payloadOffset = cmd->payloadStartIndex;
-            uint16_t groupId; // Ver.: always
-            uint8_t sceneId;  // Ver.: always
+            GroupId groupId; // Ver.: always
+            uint8_t sceneId; // Ver.: always
             // Command is fixed length: 3
             if (cmd->bufLen < payloadOffset + 3u)
             {
@@ -712,8 +714,8 @@ EmberAfStatus emberAfScenesClusterServerCommandParse(EmberAfClusterCommand * cmd
         }
         case ZCL_REMOVE_SCENE_COMMAND_ID: {
             uint16_t payloadOffset = cmd->payloadStartIndex;
-            uint16_t groupId; // Ver.: always
-            uint8_t sceneId;  // Ver.: always
+            GroupId groupId; // Ver.: always
+            uint8_t sceneId; // Ver.: always
             // Command is fixed length: 3
             if (cmd->bufLen < payloadOffset + 3u)
             {
@@ -727,7 +729,7 @@ EmberAfStatus emberAfScenesClusterServerCommandParse(EmberAfClusterCommand * cmd
         }
         case ZCL_REMOVE_ALL_SCENES_COMMAND_ID: {
             uint16_t payloadOffset = cmd->payloadStartIndex;
-            uint16_t groupId; // Ver.: always
+            GroupId groupId; // Ver.: always
             // Command is fixed length: 2
             if (cmd->bufLen < payloadOffset + 2u)
             {
@@ -739,8 +741,8 @@ EmberAfStatus emberAfScenesClusterServerCommandParse(EmberAfClusterCommand * cmd
         }
         case ZCL_STORE_SCENE_COMMAND_ID: {
             uint16_t payloadOffset = cmd->payloadStartIndex;
-            uint16_t groupId; // Ver.: always
-            uint8_t sceneId;  // Ver.: always
+            GroupId groupId; // Ver.: always
+            uint8_t sceneId; // Ver.: always
             // Command is fixed length: 3
             if (cmd->bufLen < payloadOffset + 3u)
             {
@@ -754,7 +756,7 @@ EmberAfStatus emberAfScenesClusterServerCommandParse(EmberAfClusterCommand * cmd
         }
         case ZCL_RECALL_SCENE_COMMAND_ID: {
             uint16_t payloadOffset = cmd->payloadStartIndex;
-            uint16_t groupId;        // Ver.: always
+            GroupId groupId;         // Ver.: always
             uint8_t sceneId;         // Ver.: always
             uint16_t transitionTime; // Ver.: since zcl-7.0-07-5123-07
             // Command is not a fixed length
@@ -785,7 +787,7 @@ EmberAfStatus emberAfScenesClusterServerCommandParse(EmberAfClusterCommand * cmd
         }
         case ZCL_GET_SCENE_MEMBERSHIP_COMMAND_ID: {
             uint16_t payloadOffset = cmd->payloadStartIndex;
-            uint16_t groupId; // Ver.: always
+            GroupId groupId; // Ver.: always
             // Command is fixed length: 2
             if (cmd->bufLen < payloadOffset + 2u)
             {

--- a/examples/all-clusters-app/all-clusters-common/gen/callback-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/gen/callback-stub.cpp
@@ -45,6 +45,8 @@
 //#include "hal/hal.h"
 //#include EMBER_AF_API_NETWORK_STEERING
 
+using namespace chip;
+
 /** @brief On/off Cluster Server Post Init
  *
  * Following resolution of the On/Off state at startup for this endpoint,
@@ -53,7 +55,7 @@
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint) {}
+void emberAfPluginOnOffClusterServerPostInitCallback(EndpointId endpoint) {}
 
 /** @brief Add To Current App Tasks
  *
@@ -101,8 +103,8 @@ void emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
  * @param value   Ver.: always
  * @param type   Ver.: always
  */
-EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(uint8_t endpoint, EmberAfClusterId clusterId,
-                                                                          EmberAfAttributeId attributeId, uint8_t mask,
+EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId clusterId,
+                                                                          AttributeId attributeId, uint8_t mask,
                                                                           uint16_t manufacturerCode, uint8_t * value, uint8_t type)
 {
     return EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_NORMAL; // Default
@@ -118,8 +120,8 @@ EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(uint8_
  * @param manufacturerCode   Ver.: always
  * @param attributeId   Ver.: always
  */
-bool emberAfAttributeReadAccessCallback(uint8_t endpoint, EmberAfClusterId clusterId, uint16_t manufacturerCode,
-                                        uint16_t attributeId)
+bool emberAfAttributeReadAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode,
+                                        AttributeId attributeId)
 {
     return true;
 }
@@ -134,8 +136,8 @@ bool emberAfAttributeReadAccessCallback(uint8_t endpoint, EmberAfClusterId clust
  * @param manufacturerCode   Ver.: always
  * @param attributeId   Ver.: always
  */
-bool emberAfAttributeWriteAccessCallback(uint8_t endpoint, EmberAfClusterId clusterId, uint16_t manufacturerCode,
-                                         uint16_t attributeId)
+bool emberAfAttributeWriteAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode,
+                                         AttributeId attributeId)
 {
     return true;
 }
@@ -164,7 +166,7 @@ bool emberAfKeyEstablishmentClusterClientCommandReceivedCallback(EmberAfClusterC
  * @param endpoint   Ver.: always
  * @param clusterId   Ver.: always
  */
-void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId) {}
+void emberAfClusterInitCallback(EndpointId endpoint, ClusterId clusterId) {}
 
 /** @brief Default Response
  *
@@ -178,7 +180,7 @@ void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId) {}
  * @param status Specifies either SUCCESS or the nature of the error that was
  * detected in the received command.  Ver.: always
  */
-bool emberAfDefaultResponseCallback(EmberAfClusterId clusterId, uint8_t commandId, EmberAfStatus status)
+bool emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, EmberAfStatus status)
 {
     return false;
 }
@@ -203,8 +205,8 @@ bool emberAfDefaultResponseCallback(EmberAfClusterId clusterId, uint8_t commandI
  * @param extended Indicates whether the response is in the extended format or
  * not.  Ver.: always
  */
-bool emberAfDiscoverAttributesResponseCallback(EmberAfClusterId clusterId, bool discoveryComplete, uint8_t * buffer,
-                                               uint16_t bufLen, bool extended)
+bool emberAfDiscoverAttributesResponseCallback(ClusterId clusterId, bool discoveryComplete, uint8_t * buffer, uint16_t bufLen,
+                                               bool extended)
 {
     return false;
 }
@@ -223,8 +225,8 @@ bool emberAfDiscoverAttributesResponseCallback(EmberAfClusterId clusterId, bool 
  * @param commandIdCount The length of bytes of the list, whish is the same as
  * the number of identifiers.  Ver.: always
  */
-bool emberAfDiscoverCommandsGeneratedResponseCallback(EmberAfClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
-                                                      uint8_t * commandIds, uint16_t commandIdCount)
+bool emberAfDiscoverCommandsGeneratedResponseCallback(ClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
+                                                      CommandId * commandIds, uint16_t commandIdCount)
 {
     return false;
 }
@@ -243,8 +245,8 @@ bool emberAfDiscoverCommandsGeneratedResponseCallback(EmberAfClusterId clusterId
  * @param commandIdCount The length of bytes of the list, whish is the same as
  * the number of identifiers.  Ver.: always
  */
-bool emberAfDiscoverCommandsReceivedResponseCallback(EmberAfClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
-                                                     uint8_t * commandIds, uint16_t commandIdCount)
+bool emberAfDiscoverCommandsReceivedResponseCallback(ClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
+                                                     CommandId * commandIds, uint16_t commandIdCount)
 {
     return false;
 }
@@ -309,7 +311,7 @@ void emberAfEepromShutdownCallback(void) {}
  * @param buffer   Ver.: always
  * @param maxReadLength   Ver.: always
  */
-EmberAfStatus emberAfExternalAttributeReadCallback(uint8_t endpoint, EmberAfClusterId clusterId,
+EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
                                                    EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
                                                    uint8_t * buffer, uint16_t maxReadLength)
 {
@@ -362,7 +364,7 @@ EmberAfStatus emberAfExternalAttributeReadCallback(uint8_t endpoint, EmberAfClus
  * @param manufacturerCode   Ver.: always
  * @param buffer   Ver.: always
  */
-EmberAfStatus emberAfExternalAttributeWriteCallback(uint8_t endpoint, EmberAfClusterId clusterId,
+EmberAfStatus emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId,
                                                     EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
                                                     uint8_t * buffer)
 {
@@ -522,7 +524,7 @@ bool emberAfGetEndpointByIndexCallback(uint8_t index, uint8_t * endpointReturn)
  * information is written if the callback is providing the information.  Ver.:
  * always
  */
-bool emberAfGetEndpointDescriptionCallback(uint8_t endpoint, EmberEndpointDescription * result)
+bool emberAfGetEndpointDescriptionCallback(EndpointId endpoint, EmberEndpointDescription * result)
 {
     return false;
 }
@@ -544,7 +546,8 @@ bool emberAfGetEndpointDescriptionCallback(uint8_t endpoint, EmberEndpointDescri
  * @param returnEndpointInfo A pointer to a data struct that will be written
  * with information about the endpoint.  Ver.: always
  */
-bool emberAfGetEndpointInfoCallback(uint8_t endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo)
+bool emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex,
+                                    EmberAfEndpointInfoStruct * returnEndpointInfo)
 {
     return false;
 }
@@ -733,7 +736,7 @@ EmberStatus emberAfInitiateInterPanKeyEstablishmentCallback(EmberPanId panId, co
  * @param nodeId The node id of the remote device.  Ver.: always
  * @param endpoint The endpoint on the remote device.  Ver.: always
  */
-EmberStatus emberAfInitiateKeyEstablishmentCallback(EmberNodeId nodeId, uint8_t endpoint)
+EmberStatus emberAfInitiateKeyEstablishmentCallback(EmberNodeId nodeId, EndpointId endpoint)
 {
     return EMBER_LIBRARY_NOT_PRESENT;
 }
@@ -1065,9 +1068,8 @@ void emberAfPostEm4ResetCallback(void)
  * @param size   Ver.: always
  * @param value   Ver.: always
  */
-EmberAfStatus emberAfPreAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
-                                                uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size,
-                                                uint8_t * value)
+EmberAfStatus emberAfPreAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
+                                                uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
 {
     return EMBER_ZCL_STATUS_SUCCESS;
 }
@@ -1200,7 +1202,7 @@ bool emberAfPreZDOMessageReceivedCallback(EmberNodeId emberNodeId, EmberApsFrame
  * Ver.: always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
     return false;
 }
@@ -1289,7 +1291,7 @@ void emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
  * always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfReportAttributesCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+bool emberAfReportAttributesCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
     return false;
 }
@@ -1516,7 +1518,7 @@ void emberAfUnusedPanIdFoundCallback(EmberPanId panId, uint8_t channel) {}
  * Ver.: always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfWriteAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+bool emberAfWriteAttributesResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
     return false;
 }

--- a/examples/all-clusters-app/all-clusters-common/gen/callback.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/callback.h
@@ -97,8 +97,8 @@ void emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks);
  * @param value   Ver.: always
  * @param type   Ver.: always
  */
-EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(uint8_t endpoint, EmberAfClusterId clusterId,
-                                                                          EmberAfAttributeId attributeId, uint8_t mask,
+EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
+                                                                          chip::AttributeId attributeId, uint8_t mask,
                                                                           uint16_t manufacturerCode, uint8_t * value, uint8_t type);
 /** @brief Attribute Read Access
  *
@@ -110,8 +110,8 @@ EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(uint8_
  * @param manufacturerCode   Ver.: always
  * @param attributeId   Ver.: always
  */
-bool emberAfAttributeReadAccessCallback(uint8_t endpoint, EmberAfClusterId clusterId, uint16_t manufacturerCode,
-                                        uint16_t attributeId);
+bool emberAfAttributeReadAccessCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode,
+                                        chip::AttributeId attributeId);
 /** @brief Attribute Write Access
  *
  * This function is called whenever the Application Framework needs to check
@@ -122,8 +122,8 @@ bool emberAfAttributeReadAccessCallback(uint8_t endpoint, EmberAfClusterId clust
  * @param manufacturerCode   Ver.: always
  * @param attributeId   Ver.: always
  */
-bool emberAfAttributeWriteAccessCallback(uint8_t endpoint, EmberAfClusterId clusterId, uint16_t manufacturerCode,
-                                         uint16_t attributeId);
+bool emberAfAttributeWriteAccessCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode,
+                                         chip::AttributeId attributeId);
 /** @brief Clear Report Table
  *
  * This function is called by the framework when the application should clear
@@ -140,7 +140,7 @@ EmberStatus emberAfClearReportTableCallback(void);
  * @param endpoint   Ver.: always
  * @param clusterId   Ver.: always
  */
-void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId);
+void emberAfClusterInitCallback(chip::EndpointId endpoint, chip::ClusterId clusterId);
 /** @brief Default Response
  *
  * This function is called by the application framework when a Default Response
@@ -153,7 +153,7 @@ void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId);
  * @param status Specifies either SUCCESS or the nature of the error that was
  * detected in the received command.  Ver.: always
  */
-bool emberAfDefaultResponseCallback(EmberAfClusterId clusterId, uint8_t commandId, EmberAfStatus status);
+bool emberAfDefaultResponseCallback(chip::ClusterId clusterId, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Discover Attributes Response
  *
  * This function is called by the application framework when a Discover
@@ -174,8 +174,8 @@ bool emberAfDefaultResponseCallback(EmberAfClusterId clusterId, uint8_t commandI
  * @param extended Indicates whether the response is in the extended format or
  * not.  Ver.: always
  */
-bool emberAfDiscoverAttributesResponseCallback(EmberAfClusterId clusterId, bool discoveryComplete, uint8_t * buffer,
-                                               uint16_t bufLen, bool extended);
+bool emberAfDiscoverAttributesResponseCallback(chip::ClusterId clusterId, bool discoveryComplete, uint8_t * buffer, uint16_t bufLen,
+                                               bool extended);
 /** @brief Discover Commands Generated Response
  *
  * This function is called by the framework when Discover Commands Generated
@@ -190,8 +190,8 @@ bool emberAfDiscoverAttributesResponseCallback(EmberAfClusterId clusterId, bool 
  * @param commandIdCount The length of bytes of the list, whish is the same as
  * the number of identifiers.  Ver.: always
  */
-bool emberAfDiscoverCommandsGeneratedResponseCallback(EmberAfClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
-                                                      uint8_t * commandIds, uint16_t commandIdCount);
+bool emberAfDiscoverCommandsGeneratedResponseCallback(chip::ClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
+                                                      chip::CommandId * commandIds, uint16_t commandIdCount);
 /** @brief Discover Commands Received Response
  *
  * This function is called by the framework when Discover Commands Received
@@ -206,8 +206,8 @@ bool emberAfDiscoverCommandsGeneratedResponseCallback(EmberAfClusterId clusterId
  * @param commandIdCount The length of bytes of the list, whish is the same as
  * the number of identifiers.  Ver.: always
  */
-bool emberAfDiscoverCommandsReceivedResponseCallback(EmberAfClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
-                                                     uint8_t * commandIds, uint16_t commandIdCount);
+bool emberAfDiscoverCommandsReceivedResponseCallback(chip::ClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
+                                                     chip::CommandId * commandIds, uint16_t commandIdCount);
 /** @brief Eeprom Init
  *
  * Tells the system to initialize the EEPROM if it is not already initialized.
@@ -275,7 +275,7 @@ void emberAfEnergyScanResultCallback(uint8_t channel, int8_t rssi);
  * @param buffer   Ver.: always
  * @param maxReadLength   Ver.: always
  */
-EmberAfStatus emberAfExternalAttributeReadCallback(uint8_t endpoint, EmberAfClusterId clusterId,
+EmberAfStatus emberAfExternalAttributeReadCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
                                                    EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
                                                    uint8_t * buffer, uint16_t maxReadLength);
 /** @brief External Attribute Write
@@ -324,7 +324,7 @@ EmberAfStatus emberAfExternalAttributeReadCallback(uint8_t endpoint, EmberAfClus
  * @param manufacturerCode   Ver.: always
  * @param buffer   Ver.: always
  */
-EmberAfStatus emberAfExternalAttributeWriteCallback(uint8_t endpoint, EmberAfClusterId clusterId,
+EmberAfStatus emberAfExternalAttributeWriteCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
                                                     EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
                                                     uint8_t * buffer);
 /** @brief Find Unused Pan Id And Form
@@ -440,7 +440,7 @@ bool emberAfGetEndpointByIndexCallback(uint8_t index, uint8_t * endpointReturn);
  * information is written if the callback is providing the information.  Ver.:
  * always
  */
-bool emberAfGetEndpointDescriptionCallback(uint8_t endpoint, EmberEndpointDescription * result);
+bool emberAfGetEndpointDescriptionCallback(chip::EndpointId endpoint, EmberEndpointDescription * result);
 /** @brief Get Endpoint Info
  *
  * This function is a callback to an application implemented endpoint that
@@ -458,7 +458,8 @@ bool emberAfGetEndpointDescriptionCallback(uint8_t endpoint, EmberEndpointDescri
  * @param returnEndpointInfo A pointer to a data struct that will be written
  * with information about the endpoint.  Ver.: always
  */
-bool emberAfGetEndpointInfoCallback(uint8_t endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo);
+bool emberAfGetEndpointInfoCallback(chip::EndpointId endpoint, uint8_t * returnNetworkIndex,
+                                    EmberAfEndpointInfoStruct * returnEndpointInfo);
 /** @brief Get Form And Join Extended Pan Id
  *
  * This callback is called by the framework to get the extended PAN ID used by
@@ -601,7 +602,7 @@ EmberStatus emberAfInitiateInterPanKeyEstablishmentCallback(EmberPanId panId, co
  * @param nodeId The node id of the remote device.  Ver.: always
  * @param endpoint The endpoint on the remote device.  Ver.: always
  */
-EmberStatus emberAfInitiateKeyEstablishmentCallback(EmberNodeId nodeId, uint8_t endpoint);
+EmberStatus emberAfInitiateKeyEstablishmentCallback(EmberNodeId nodeId, chip::EndpointId endpoint);
 /** @brief Initiate Partner Link Key Exchange
  *
  * This function is called by the framework to initiate a partner link key
@@ -849,8 +850,8 @@ bool emberAfPerformingKeyEstablishmentCallback(void);
  * @param size   Ver.: always
  * @param value   Ver.: always
  */
-void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value);
+void emberAfPostAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
+                                        uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value);
 /** @brief Post Em4 Reset
  *
  * A callback called by application framework, and implemented by em4 plugin
@@ -874,7 +875,7 @@ void emberAfPostEm4ResetCallback(void);
  * @param size   Ver.: always
  * @param value   Ver.: always
  */
-EmberAfStatus emberAfPreAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPreAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
                                                 uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size,
                                                 uint8_t * value);
 /** @brief Pre Cli Send
@@ -984,7 +985,7 @@ bool emberAfPreZDOMessageReceivedCallback(EmberNodeId emberNodeId, EmberApsFrame
  * Ver.: always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+bool emberAfReadAttributesResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration
@@ -1054,7 +1055,7 @@ void emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks);
  * always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfReportAttributesCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+bool emberAfReportAttributesCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 /** @brief Scan Complete
  *
  * This is called by the low-level stack code when an 802.15.4 active scan
@@ -1259,7 +1260,7 @@ void emberAfUnusedPanIdFoundCallback(EmberPanId panId, uint8_t channel);
  * Ver.: always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfWriteAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+bool emberAfWriteAttributesResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 /** @brief Zigbee Key Establishment
  *
  * A callback to the application to notify it of the status of the request for a
@@ -1282,7 +1283,7 @@ void emberAfZigbeeKeyEstablishmentCallback(EmberEUI64 partner, EmberKeyStatus st
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBasicClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBasicClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Basic Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -1292,14 +1293,14 @@ void emberAfBasicClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBasicClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBasicClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Basic Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBasicClusterClientInitCallback(uint8_t endpoint);
+void emberAfBasicClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Basic Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -1309,7 +1310,7 @@ void emberAfBasicClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBasicClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfBasicClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief Basic Cluster Client Message Sent
  *
@@ -1335,7 +1336,7 @@ void emberAfBasicClusterClientMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBasicClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBasicClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief Basic Cluster Client Tick
@@ -1344,7 +1345,7 @@ EmberAfStatus emberAfBasicClusterClientPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBasicClusterClientTickCallback(uint8_t endpoint);
+void emberAfBasicClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Basic Cluster Get Locales Supported
  *
  *
@@ -1374,7 +1375,7 @@ bool emberAfBasicClusterResetToFactoryDefaultsCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBasicClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBasicClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Basic Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -1384,14 +1385,14 @@ void emberAfBasicClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBasicClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBasicClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Basic Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBasicClusterServerInitCallback(uint8_t endpoint);
+void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Basic Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -1401,7 +1402,7 @@ void emberAfBasicClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBasicClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfBasicClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief Basic Cluster Server Message Sent
  *
@@ -1427,7 +1428,7 @@ void emberAfBasicClusterServerMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBasicClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBasicClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief Basic Cluster Server Tick
@@ -1436,7 +1437,7 @@ EmberAfStatus emberAfBasicClusterServerPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBasicClusterServerTickCallback(uint8_t endpoint);
+void emberAfBasicClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Basic Cluster Callbacks */
 
@@ -1450,7 +1451,7 @@ void emberAfBasicClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPowerConfigClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPowerConfigClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Power Configuration Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -1460,14 +1461,15 @@ void emberAfPowerConfigClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPowerConfigClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPowerConfigClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Power Configuration Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPowerConfigClusterClientInitCallback(uint8_t endpoint);
+void emberAfPowerConfigClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Power Configuration Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -1477,7 +1479,8 @@ void emberAfPowerConfigClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPowerConfigClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPowerConfigClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Power Configuration Cluster Client Message Sent
  *
@@ -1504,7 +1507,7 @@ void emberAfPowerConfigClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPowerConfigClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPowerConfigClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Power Configuration Cluster Client Tick
@@ -1513,7 +1516,7 @@ EmberAfStatus emberAfPowerConfigClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPowerConfigClusterClientTickCallback(uint8_t endpoint);
+void emberAfPowerConfigClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Power Configuration Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -1521,7 +1524,7 @@ void emberAfPowerConfigClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPowerConfigClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPowerConfigClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Power Configuration Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -1531,14 +1534,15 @@ void emberAfPowerConfigClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPowerConfigClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPowerConfigClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Power Configuration Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPowerConfigClusterServerInitCallback(uint8_t endpoint);
+void emberAfPowerConfigClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Power Configuration Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -1548,7 +1552,8 @@ void emberAfPowerConfigClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPowerConfigClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPowerConfigClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Power Configuration Cluster Server Message Sent
  *
@@ -1575,7 +1580,7 @@ void emberAfPowerConfigClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPowerConfigClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPowerConfigClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Power Configuration Cluster Server Tick
@@ -1584,7 +1589,7 @@ EmberAfStatus emberAfPowerConfigClusterServerPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPowerConfigClusterServerTickCallback(uint8_t endpoint);
+void emberAfPowerConfigClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Power Configuration Cluster Callbacks */
 
@@ -1598,7 +1603,7 @@ void emberAfPowerConfigClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDeviceTempClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDeviceTempClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Device Temperature Configuration Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -1608,14 +1613,15 @@ void emberAfDeviceTempClusterClientAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDeviceTempClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDeviceTempClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Device Temperature Configuration Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDeviceTempClusterClientInitCallback(uint8_t endpoint);
+void emberAfDeviceTempClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Device Temperature Configuration Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -1625,7 +1631,8 @@ void emberAfDeviceTempClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDeviceTempClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDeviceTempClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Device Temperature Configuration Cluster Client Message Sent
  *
@@ -1652,7 +1659,7 @@ void emberAfDeviceTempClusterClientMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDeviceTempClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDeviceTempClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Device Temperature Configuration Cluster Client Tick
@@ -1661,7 +1668,7 @@ EmberAfStatus emberAfDeviceTempClusterClientPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDeviceTempClusterClientTickCallback(uint8_t endpoint);
+void emberAfDeviceTempClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Device Temperature Configuration Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -1669,7 +1676,7 @@ void emberAfDeviceTempClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDeviceTempClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDeviceTempClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Device Temperature Configuration Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -1679,14 +1686,15 @@ void emberAfDeviceTempClusterServerAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDeviceTempClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDeviceTempClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Device Temperature Configuration Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDeviceTempClusterServerInitCallback(uint8_t endpoint);
+void emberAfDeviceTempClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Device Temperature Configuration Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -1696,7 +1704,8 @@ void emberAfDeviceTempClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDeviceTempClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDeviceTempClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Device Temperature Configuration Cluster Server Message Sent
  *
@@ -1723,7 +1732,7 @@ void emberAfDeviceTempClusterServerMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDeviceTempClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDeviceTempClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Device Temperature Configuration Cluster Server Tick
@@ -1732,7 +1741,7 @@ EmberAfStatus emberAfDeviceTempClusterServerPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDeviceTempClusterServerTickCallback(uint8_t endpoint);
+void emberAfDeviceTempClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Device Temperature Configuration Cluster Callbacks */
 
@@ -1746,7 +1755,7 @@ void emberAfDeviceTempClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIdentifyClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIdentifyClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Identify Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -1756,14 +1765,15 @@ void emberAfIdentifyClusterClientAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIdentifyClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIdentifyClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Identify Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIdentifyClusterClientInitCallback(uint8_t endpoint);
+void emberAfIdentifyClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Identify Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -1773,7 +1783,8 @@ void emberAfIdentifyClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIdentifyClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIdentifyClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Identify Cluster Client Message Sent
  *
@@ -1800,7 +1811,7 @@ void emberAfIdentifyClusterClientMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIdentifyClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIdentifyClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Identify Cluster Client Tick
@@ -1809,7 +1820,7 @@ EmberAfStatus emberAfIdentifyClusterClientPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIdentifyClusterClientTickCallback(uint8_t endpoint);
+void emberAfIdentifyClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Identify Cluster E Z Mode Invoke
  *
  *
@@ -1844,7 +1855,7 @@ bool emberAfIdentifyClusterIdentifyQueryResponseCallback(uint16_t timeout);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIdentifyClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIdentifyClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Identify Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -1854,14 +1865,15 @@ void emberAfIdentifyClusterServerAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIdentifyClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIdentifyClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Identify Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIdentifyClusterServerInitCallback(uint8_t endpoint);
+void emberAfIdentifyClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Identify Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -1871,7 +1883,8 @@ void emberAfIdentifyClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIdentifyClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIdentifyClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Identify Cluster Server Message Sent
  *
@@ -1898,7 +1911,7 @@ void emberAfIdentifyClusterServerMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIdentifyClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIdentifyClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Identify Cluster Server Tick
@@ -1907,7 +1920,7 @@ EmberAfStatus emberAfIdentifyClusterServerPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIdentifyClusterServerTickCallback(uint8_t endpoint);
+void emberAfIdentifyClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Identify Cluster Trigger Effect
  *
  *
@@ -1937,7 +1950,7 @@ bool emberAfIdentifyClusterUpdateCommissionStateCallback(uint8_t action, uint8_t
  *
  * @param endpoint The endpoint.  Ver.: always
  */
-void emberAfGroupsClusterClearGroupTableCallback(uint8_t endpoint);
+void emberAfGroupsClusterClearGroupTableCallback(chip::EndpointId endpoint);
 /** @brief Groups Cluster Add Group
  *
  *
@@ -1945,7 +1958,7 @@ void emberAfGroupsClusterClearGroupTableCallback(uint8_t endpoint);
  * @param groupId   Ver.: always
  * @param groupName   Ver.: always
  */
-bool emberAfGroupsClusterAddGroupCallback(uint16_t groupId, uint8_t * groupName);
+bool emberAfGroupsClusterAddGroupCallback(chip::GroupId groupId, uint8_t * groupName);
 /** @brief Groups Cluster Add Group If Identifying
  *
  *
@@ -1953,7 +1966,7 @@ bool emberAfGroupsClusterAddGroupCallback(uint16_t groupId, uint8_t * groupName)
  * @param groupId   Ver.: always
  * @param groupName   Ver.: always
  */
-bool emberAfGroupsClusterAddGroupIfIdentifyingCallback(uint16_t groupId, uint8_t * groupName);
+bool emberAfGroupsClusterAddGroupIfIdentifyingCallback(chip::GroupId groupId, uint8_t * groupName);
 /** @brief Groups Cluster Add Group Response
  *
  *
@@ -1961,7 +1974,7 @@ bool emberAfGroupsClusterAddGroupIfIdentifyingCallback(uint16_t groupId, uint8_t
  * @param status   Ver.: always
  * @param groupId   Ver.: always
  */
-bool emberAfGroupsClusterAddGroupResponseCallback(uint8_t status, uint16_t groupId);
+bool emberAfGroupsClusterAddGroupResponseCallback(uint8_t status, chip::GroupId groupId);
 /** @brief Groups Cluster Client Attribute Changed
  *
  * Client Attribute Changed
@@ -1969,7 +1982,7 @@ bool emberAfGroupsClusterAddGroupResponseCallback(uint8_t status, uint16_t group
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGroupsClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGroupsClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Groups Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -1979,14 +1992,14 @@ void emberAfGroupsClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGroupsClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGroupsClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Groups Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGroupsClusterClientInitCallback(uint8_t endpoint);
+void emberAfGroupsClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Groups Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -1996,7 +2009,8 @@ void emberAfGroupsClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGroupsClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGroupsClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Groups Cluster Client Message Sent
  *
@@ -2023,7 +2037,7 @@ void emberAfGroupsClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGroupsClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGroupsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Groups Cluster Client Tick
@@ -2032,7 +2046,7 @@ EmberAfStatus emberAfGroupsClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGroupsClusterClientTickCallback(uint8_t endpoint);
+void emberAfGroupsClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Groups Cluster Get Group Membership
  *
  *
@@ -2062,7 +2076,7 @@ bool emberAfGroupsClusterRemoveAllGroupsCallback(void);
  *
  * @param groupId   Ver.: always
  */
-bool emberAfGroupsClusterRemoveGroupCallback(uint16_t groupId);
+bool emberAfGroupsClusterRemoveGroupCallback(chip::GroupId groupId);
 /** @brief Groups Cluster Remove Group Response
  *
  *
@@ -2070,7 +2084,7 @@ bool emberAfGroupsClusterRemoveGroupCallback(uint16_t groupId);
  * @param status   Ver.: always
  * @param groupId   Ver.: always
  */
-bool emberAfGroupsClusterRemoveGroupResponseCallback(uint8_t status, uint16_t groupId);
+bool emberAfGroupsClusterRemoveGroupResponseCallback(uint8_t status, chip::GroupId groupId);
 /** @brief Groups Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -2078,7 +2092,7 @@ bool emberAfGroupsClusterRemoveGroupResponseCallback(uint8_t status, uint16_t gr
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGroupsClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGroupsClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Groups Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -2088,14 +2102,14 @@ void emberAfGroupsClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGroupsClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGroupsClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Groups Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGroupsClusterServerInitCallback(uint8_t endpoint);
+void emberAfGroupsClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Groups Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -2105,7 +2119,8 @@ void emberAfGroupsClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGroupsClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGroupsClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Groups Cluster Server Message Sent
  *
@@ -2132,7 +2147,7 @@ void emberAfGroupsClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGroupsClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGroupsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Groups Cluster Server Tick
@@ -2141,14 +2156,14 @@ EmberAfStatus emberAfGroupsClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGroupsClusterServerTickCallback(uint8_t endpoint);
+void emberAfGroupsClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Groups Cluster View Group
  *
  *
  *
  * @param groupId   Ver.: always
  */
-bool emberAfGroupsClusterViewGroupCallback(uint16_t groupId);
+bool emberAfGroupsClusterViewGroupCallback(chip::GroupId groupId);
 /** @brief Groups Cluster View Group Response
  *
  *
@@ -2157,7 +2172,7 @@ bool emberAfGroupsClusterViewGroupCallback(uint16_t groupId);
  * @param groupId   Ver.: always
  * @param groupName   Ver.: always
  */
-bool emberAfGroupsClusterViewGroupResponseCallback(uint8_t status, uint16_t groupId, uint8_t * groupName);
+bool emberAfGroupsClusterViewGroupResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t * groupName);
 
 /** @} END Groups Cluster Callbacks */
 
@@ -2171,7 +2186,7 @@ bool emberAfGroupsClusterViewGroupResponseCallback(uint8_t status, uint16_t grou
  *
  * @param endpoint The endpoint.  Ver.: always
  */
-void emberAfScenesClusterClearSceneTableCallback(uint8_t endpoint);
+void emberAfScenesClusterClearSceneTableCallback(chip::EndpointId endpoint);
 /** @brief Scenes Cluster Add Scene
  *
  *
@@ -2182,7 +2197,7 @@ void emberAfScenesClusterClearSceneTableCallback(uint8_t endpoint);
  * @param sceneName   Ver.: always
  * @param extensionFieldSets   Ver.: always
  */
-bool emberAfScenesClusterAddSceneCallback(uint16_t groupId, uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
+bool emberAfScenesClusterAddSceneCallback(chip::GroupId groupId, uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
                                           uint8_t * extensionFieldSets);
 /** @brief Scenes Cluster Add Scene Response
  *
@@ -2192,7 +2207,7 @@ bool emberAfScenesClusterAddSceneCallback(uint16_t groupId, uint8_t sceneId, uin
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterAddSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterAddSceneResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster Client Attribute Changed
  *
  * Client Attribute Changed
@@ -2200,7 +2215,7 @@ bool emberAfScenesClusterAddSceneResponseCallback(uint8_t status, uint16_t group
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfScenesClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfScenesClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Scenes Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -2210,14 +2225,14 @@ void emberAfScenesClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfScenesClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfScenesClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Scenes Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfScenesClusterClientInitCallback(uint8_t endpoint);
+void emberAfScenesClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Scenes Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -2227,7 +2242,8 @@ void emberAfScenesClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfScenesClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfScenesClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Scenes Cluster Client Message Sent
  *
@@ -2254,7 +2270,7 @@ void emberAfScenesClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfScenesClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfScenesClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Scenes Cluster Client Tick
@@ -2263,7 +2279,7 @@ EmberAfStatus emberAfScenesClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfScenesClusterClientTickCallback(uint8_t endpoint);
+void emberAfScenesClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Scenes Cluster Copy Scene
  *
  *
@@ -2295,8 +2311,8 @@ bool emberAfScenesClusterCopySceneResponseCallback(uint8_t status, uint16_t grou
  * @param sceneName   Ver.: always
  * @param extensionFieldSets   Ver.: always
  */
-bool emberAfScenesClusterEnhancedAddSceneCallback(uint16_t groupId, uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
-                                                  uint8_t * extensionFieldSets);
+bool emberAfScenesClusterEnhancedAddSceneCallback(chip::GroupId groupId, uint8_t sceneId, uint16_t transitionTime,
+                                                  uint8_t * sceneName, uint8_t * extensionFieldSets);
 /** @brief Scenes Cluster Enhanced Add Scene Response
  *
  *
@@ -2305,7 +2321,7 @@ bool emberAfScenesClusterEnhancedAddSceneCallback(uint16_t groupId, uint8_t scen
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterEnhancedAddSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterEnhancedAddSceneResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster Enhanced View Scene
  *
  *
@@ -2313,7 +2329,7 @@ bool emberAfScenesClusterEnhancedAddSceneResponseCallback(uint8_t status, uint16
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterEnhancedViewSceneCallback(uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterEnhancedViewSceneCallback(chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster Enhanced View Scene Response
  *
  *
@@ -2325,7 +2341,7 @@ bool emberAfScenesClusterEnhancedViewSceneCallback(uint16_t groupId, uint8_t sce
  * @param sceneName   Ver.: always
  * @param extensionFieldSets   Ver.: always
  */
-bool emberAfScenesClusterEnhancedViewSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId,
+bool emberAfScenesClusterEnhancedViewSceneResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t sceneId,
                                                            uint16_t transitionTime, uint8_t * sceneName,
                                                            uint8_t * extensionFieldSets);
 /** @brief Scenes Cluster Get Scene Membership
@@ -2334,7 +2350,7 @@ bool emberAfScenesClusterEnhancedViewSceneResponseCallback(uint8_t status, uint1
  *
  * @param groupId   Ver.: always
  */
-bool emberAfScenesClusterGetSceneMembershipCallback(uint16_t groupId);
+bool emberAfScenesClusterGetSceneMembershipCallback(chip::GroupId groupId);
 /** @brief Scenes Cluster Get Scene Membership Response
  *
  *
@@ -2345,8 +2361,8 @@ bool emberAfScenesClusterGetSceneMembershipCallback(uint16_t groupId);
  * @param sceneCount   Ver.: always
  * @param sceneList   Ver.: always
  */
-bool emberAfScenesClusterGetSceneMembershipResponseCallback(uint8_t status, uint8_t capacity, uint16_t groupId, uint8_t sceneCount,
-                                                            uint8_t * sceneList);
+bool emberAfScenesClusterGetSceneMembershipResponseCallback(uint8_t status, uint8_t capacity, chip::GroupId groupId,
+                                                            uint8_t sceneCount, uint8_t * sceneList);
 /** @brief Scenes Cluster Recall Scene
  *
  *
@@ -2355,14 +2371,14 @@ bool emberAfScenesClusterGetSceneMembershipResponseCallback(uint8_t status, uint
  * @param sceneId   Ver.: always
  * @param transitionTime   Ver.: since zcl-7.0-07-5123-07
  */
-bool emberAfScenesClusterRecallSceneCallback(uint16_t groupId, uint8_t sceneId, uint16_t transitionTime);
+bool emberAfScenesClusterRecallSceneCallback(chip::GroupId groupId, uint8_t sceneId, uint16_t transitionTime);
 /** @brief Scenes Cluster Remove All Scenes
  *
  *
  *
  * @param groupId   Ver.: always
  */
-bool emberAfScenesClusterRemoveAllScenesCallback(uint16_t groupId);
+bool emberAfScenesClusterRemoveAllScenesCallback(chip::GroupId groupId);
 /** @brief Scenes Cluster Remove All Scenes Response
  *
  *
@@ -2370,7 +2386,7 @@ bool emberAfScenesClusterRemoveAllScenesCallback(uint16_t groupId);
  * @param status   Ver.: always
  * @param groupId   Ver.: always
  */
-bool emberAfScenesClusterRemoveAllScenesResponseCallback(uint8_t status, uint16_t groupId);
+bool emberAfScenesClusterRemoveAllScenesResponseCallback(uint8_t status, chip::GroupId groupId);
 /** @brief Scenes Cluster Remove Scene
  *
  *
@@ -2378,7 +2394,7 @@ bool emberAfScenesClusterRemoveAllScenesResponseCallback(uint8_t status, uint16_
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterRemoveSceneCallback(uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterRemoveSceneCallback(chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster Remove Scene Response
  *
  *
@@ -2387,7 +2403,7 @@ bool emberAfScenesClusterRemoveSceneCallback(uint16_t groupId, uint8_t sceneId);
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterRemoveSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterRemoveSceneResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -2395,7 +2411,7 @@ bool emberAfScenesClusterRemoveSceneResponseCallback(uint8_t status, uint16_t gr
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfScenesClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfScenesClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Scenes Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -2405,14 +2421,14 @@ void emberAfScenesClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfScenesClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfScenesClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Scenes Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfScenesClusterServerInitCallback(uint8_t endpoint);
+void emberAfScenesClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Scenes Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -2422,7 +2438,8 @@ void emberAfScenesClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfScenesClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfScenesClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Scenes Cluster Server Message Sent
  *
@@ -2449,7 +2466,7 @@ void emberAfScenesClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfScenesClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfScenesClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Scenes Cluster Server Tick
@@ -2458,7 +2475,7 @@ EmberAfStatus emberAfScenesClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfScenesClusterServerTickCallback(uint8_t endpoint);
+void emberAfScenesClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Scenes Cluster Store Scene
  *
  *
@@ -2466,7 +2483,7 @@ void emberAfScenesClusterServerTickCallback(uint8_t endpoint);
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterStoreSceneCallback(uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterStoreSceneCallback(chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster Store Scene Response
  *
  *
@@ -2475,7 +2492,7 @@ bool emberAfScenesClusterStoreSceneCallback(uint16_t groupId, uint8_t sceneId);
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterStoreSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterStoreSceneResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster View Scene
  *
  *
@@ -2483,7 +2500,7 @@ bool emberAfScenesClusterStoreSceneResponseCallback(uint8_t status, uint16_t gro
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterViewSceneCallback(uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterViewSceneCallback(chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster View Scene Response
  *
  *
@@ -2495,7 +2512,7 @@ bool emberAfScenesClusterViewSceneCallback(uint16_t groupId, uint8_t sceneId);
  * @param sceneName   Ver.: always
  * @param extensionFieldSets   Ver.: always
  */
-bool emberAfScenesClusterViewSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
+bool emberAfScenesClusterViewSceneResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t sceneId, uint16_t transitionTime,
                                                    uint8_t * sceneName, uint8_t * extensionFieldSets);
 /** @} END Scenes Cluster Callbacks */
 
@@ -2509,7 +2526,7 @@ bool emberAfScenesClusterViewSceneResponseCallback(uint8_t status, uint16_t grou
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOnOffClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOnOffClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief On/off Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -2519,14 +2536,14 @@ void emberAfOnOffClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOnOffClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOnOffClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief On/off Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOnOffClusterClientInitCallback(uint8_t endpoint);
+void emberAfOnOffClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief On/off Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -2536,7 +2553,7 @@ void emberAfOnOffClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOnOffClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfOnOffClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief On/off Cluster Client Message Sent
  *
@@ -2562,7 +2579,7 @@ void emberAfOnOffClusterClientMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOnOffClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOnOffClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief On/off Cluster Client Tick
@@ -2571,7 +2588,7 @@ EmberAfStatus emberAfOnOffClusterClientPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOnOffClusterClientTickCallback(uint8_t endpoint);
+void emberAfOnOffClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief On/off Cluster Off
  *
  *
@@ -2644,7 +2661,7 @@ bool emberAfOnOffClusterSampleMfgSpecificToggleWithTransitionCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOnOffClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOnOffClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief On/off Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -2654,14 +2671,14 @@ void emberAfOnOffClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOnOffClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOnOffClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief On/off Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOnOffClusterServerInitCallback(uint8_t endpoint);
+void emberAfOnOffClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief On/off Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -2671,7 +2688,7 @@ void emberAfOnOffClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOnOffClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfOnOffClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief On/off Cluster Server Message Sent
  *
@@ -2697,7 +2714,7 @@ void emberAfOnOffClusterServerMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOnOffClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOnOffClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief On/off Cluster Server Tick
@@ -2706,7 +2723,7 @@ EmberAfStatus emberAfOnOffClusterServerPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOnOffClusterServerTickCallback(uint8_t endpoint);
+void emberAfOnOffClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief On/off Cluster Toggle
  *
  *
@@ -2721,7 +2738,7 @@ bool emberAfOnOffClusterToggleCallback(void);
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint);
+void emberAfPluginOnOffClusterServerPostInitCallback(chip::EndpointId endpoint);
 
 /** @} END On/off Cluster Callbacks */
 
@@ -2735,7 +2752,7 @@ void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOnOffSwitchConfigClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief On/off Switch Configuration Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -2745,14 +2762,15 @@ void emberAfOnOffSwitchConfigClusterClientAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOnOffSwitchConfigClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief On/off Switch Configuration Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterClientInitCallback(uint8_t endpoint);
+void emberAfOnOffSwitchConfigClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief On/off Switch Configuration Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -2763,7 +2781,7 @@ void emberAfOnOffSwitchConfigClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfOnOffSwitchConfigClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief On/off Switch Configuration Cluster Client Message Sent
  *
@@ -2790,7 +2808,8 @@ void emberAfOnOffSwitchConfigClusterClientMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOnOffSwitchConfigClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOnOffSwitchConfigClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief On/off Switch Configuration Cluster Client Tick
@@ -2799,7 +2818,7 @@ EmberAfStatus emberAfOnOffSwitchConfigClusterClientPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterClientTickCallback(uint8_t endpoint);
+void emberAfOnOffSwitchConfigClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief On/off Switch Configuration Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -2807,7 +2826,7 @@ void emberAfOnOffSwitchConfigClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOnOffSwitchConfigClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief On/off Switch Configuration Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -2817,14 +2836,15 @@ void emberAfOnOffSwitchConfigClusterServerAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOnOffSwitchConfigClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief On/off Switch Configuration Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterServerInitCallback(uint8_t endpoint);
+void emberAfOnOffSwitchConfigClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief On/off Switch Configuration Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -2835,7 +2855,7 @@ void emberAfOnOffSwitchConfigClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfOnOffSwitchConfigClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief On/off Switch Configuration Cluster Server Message Sent
  *
@@ -2862,7 +2882,8 @@ void emberAfOnOffSwitchConfigClusterServerMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOnOffSwitchConfigClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOnOffSwitchConfigClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief On/off Switch Configuration Cluster Server Tick
@@ -2871,7 +2892,7 @@ EmberAfStatus emberAfOnOffSwitchConfigClusterServerPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterServerTickCallback(uint8_t endpoint);
+void emberAfOnOffSwitchConfigClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END On/off Switch Configuration Cluster Callbacks */
 
@@ -2885,7 +2906,7 @@ void emberAfOnOffSwitchConfigClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfLevelControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfLevelControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Level Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -2895,14 +2916,15 @@ void emberAfLevelControlClusterClientAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfLevelControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfLevelControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief Level Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfLevelControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfLevelControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Level Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -2912,7 +2934,8 @@ void emberAfLevelControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfLevelControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfLevelControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief Level Control Cluster Client Message Sent
  *
@@ -2939,7 +2962,7 @@ void emberAfLevelControlClusterClientMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfLevelControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfLevelControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief Level Control Cluster Client Tick
@@ -2948,7 +2971,7 @@ EmberAfStatus emberAfLevelControlClusterClientPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfLevelControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfLevelControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Level Control Cluster Move
  *
  *
@@ -2993,7 +3016,7 @@ bool emberAfLevelControlClusterMoveWithOnOffCallback(uint8_t moveMode, uint8_t r
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfLevelControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfLevelControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Level Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -3003,14 +3026,15 @@ void emberAfLevelControlClusterServerAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfLevelControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfLevelControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief Level Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfLevelControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfLevelControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Level Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -3020,7 +3044,8 @@ void emberAfLevelControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfLevelControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfLevelControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief Level Control Cluster Server Message Sent
  *
@@ -3047,7 +3072,7 @@ void emberAfLevelControlClusterServerMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfLevelControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfLevelControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief Level Control Cluster Server Tick
@@ -3056,7 +3081,7 @@ EmberAfStatus emberAfLevelControlClusterServerPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfLevelControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfLevelControlClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Level Control Cluster Step
  *
  *
@@ -3105,7 +3130,7 @@ bool emberAfLevelControlClusterStopWithOnOffCallback(void);
  * @param alarmCode   Ver.: always
  * @param clusterId   Ver.: always
  */
-bool emberAfAlarmClusterAlarmCallback(uint8_t alarmCode, uint16_t clusterId);
+bool emberAfAlarmClusterAlarmCallback(uint8_t alarmCode, chip::ClusterId clusterId);
 /** @brief Alarms Cluster Client Attribute Changed
  *
  * Client Attribute Changed
@@ -3113,7 +3138,7 @@ bool emberAfAlarmClusterAlarmCallback(uint8_t alarmCode, uint16_t clusterId);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfAlarmClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfAlarmClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Alarms Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -3123,14 +3148,14 @@ void emberAfAlarmClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfAlarmClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfAlarmClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Alarms Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfAlarmClusterClientInitCallback(uint8_t endpoint);
+void emberAfAlarmClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Alarms Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -3140,7 +3165,7 @@ void emberAfAlarmClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfAlarmClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfAlarmClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief Alarms Cluster Client Message Sent
  *
@@ -3166,7 +3191,7 @@ void emberAfAlarmClusterClientMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfAlarmClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfAlarmClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief Alarms Cluster Client Tick
@@ -3175,7 +3200,7 @@ EmberAfStatus emberAfAlarmClusterClientPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfAlarmClusterClientTickCallback(uint8_t endpoint);
+void emberAfAlarmClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Alarms Cluster Get Alarm
  *
  *
@@ -3191,7 +3216,7 @@ bool emberAfAlarmClusterGetAlarmCallback(void);
  * @param clusterId   Ver.: always
  * @param timeStamp   Ver.: always
  */
-bool emberAfAlarmClusterGetAlarmResponseCallback(uint8_t status, uint8_t alarmCode, uint16_t clusterId, uint32_t timeStamp);
+bool emberAfAlarmClusterGetAlarmResponseCallback(uint8_t status, uint8_t alarmCode, chip::ClusterId clusterId, uint32_t timeStamp);
 /** @brief Alarms Cluster Reset Alarm
  *
  *
@@ -3199,7 +3224,7 @@ bool emberAfAlarmClusterGetAlarmResponseCallback(uint8_t status, uint8_t alarmCo
  * @param alarmCode   Ver.: always
  * @param clusterId   Ver.: always
  */
-bool emberAfAlarmClusterResetAlarmCallback(uint8_t alarmCode, uint16_t clusterId);
+bool emberAfAlarmClusterResetAlarmCallback(uint8_t alarmCode, chip::ClusterId clusterId);
 /** @brief Alarms Cluster Reset Alarm Log
  *
  *
@@ -3219,7 +3244,7 @@ bool emberAfAlarmClusterResetAllAlarmsCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfAlarmClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfAlarmClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Alarms Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -3229,14 +3254,14 @@ void emberAfAlarmClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfAlarmClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfAlarmClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Alarms Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfAlarmClusterServerInitCallback(uint8_t endpoint);
+void emberAfAlarmClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Alarms Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -3246,7 +3271,7 @@ void emberAfAlarmClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfAlarmClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfAlarmClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief Alarms Cluster Server Message Sent
  *
@@ -3272,7 +3297,7 @@ void emberAfAlarmClusterServerMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfAlarmClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfAlarmClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief Alarms Cluster Server Tick
@@ -3281,7 +3306,7 @@ EmberAfStatus emberAfAlarmClusterServerPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfAlarmClusterServerTickCallback(uint8_t endpoint);
+void emberAfAlarmClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Alarms Cluster Callbacks */
 
@@ -3295,7 +3320,7 @@ void emberAfAlarmClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTimeClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfTimeClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Time Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -3305,14 +3330,14 @@ void emberAfTimeClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTimeClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfTimeClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Time Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTimeClusterClientInitCallback(uint8_t endpoint);
+void emberAfTimeClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Time Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -3322,7 +3347,7 @@ void emberAfTimeClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfTimeClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfTimeClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           uint16_t manufacturerCode);
 /** @brief Time Cluster Client Message Sent
  *
@@ -3348,7 +3373,7 @@ void emberAfTimeClusterClientMessageSentCallback(EmberOutgoingMessageType type, 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfTimeClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfTimeClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                   EmberAfAttributeType attributeType, uint8_t size,
                                                                   uint8_t * value);
 /** @brief Time Cluster Client Tick
@@ -3357,7 +3382,7 @@ EmberAfStatus emberAfTimeClusterClientPreAttributeChangedCallback(uint8_t endpoi
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTimeClusterClientTickCallback(uint8_t endpoint);
+void emberAfTimeClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Time Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -3365,7 +3390,7 @@ void emberAfTimeClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTimeClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfTimeClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Time Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -3375,14 +3400,14 @@ void emberAfTimeClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTimeClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfTimeClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Time Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTimeClusterServerInitCallback(uint8_t endpoint);
+void emberAfTimeClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Time Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -3392,7 +3417,7 @@ void emberAfTimeClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfTimeClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfTimeClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           uint16_t manufacturerCode);
 /** @brief Time Cluster Server Message Sent
  *
@@ -3418,7 +3443,7 @@ void emberAfTimeClusterServerMessageSentCallback(EmberOutgoingMessageType type, 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfTimeClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfTimeClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                   EmberAfAttributeType attributeType, uint8_t size,
                                                                   uint8_t * value);
 /** @brief Time Cluster Server Tick
@@ -3427,7 +3452,7 @@ EmberAfStatus emberAfTimeClusterServerPreAttributeChangedCallback(uint8_t endpoi
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTimeClusterServerTickCallback(uint8_t endpoint);
+void emberAfTimeClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Time Cluster Callbacks */
 
@@ -3452,7 +3477,7 @@ bool emberAfRssiLocationClusterAnchorNodeAnnounceCallback(uint8_t * anchorNodeIe
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfRssiLocationClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfRssiLocationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief RSSI Location Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -3462,14 +3487,15 @@ void emberAfRssiLocationClusterClientAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfRssiLocationClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfRssiLocationClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief RSSI Location Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfRssiLocationClusterClientInitCallback(uint8_t endpoint);
+void emberAfRssiLocationClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief RSSI Location Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -3479,7 +3505,8 @@ void emberAfRssiLocationClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfRssiLocationClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfRssiLocationClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief RSSI Location Cluster Client Message Sent
  *
@@ -3506,7 +3533,7 @@ void emberAfRssiLocationClusterClientMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfRssiLocationClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfRssiLocationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief RSSI Location Cluster Client Tick
@@ -3515,7 +3542,7 @@ EmberAfStatus emberAfRssiLocationClusterClientPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfRssiLocationClusterClientTickCallback(uint8_t endpoint);
+void emberAfRssiLocationClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief RSSI Location Cluster Compact Location Data Notification
  *
  *
@@ -3657,7 +3684,7 @@ bool emberAfRssiLocationClusterSendPingsCallback(uint8_t * targetAddress, uint8_
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfRssiLocationClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfRssiLocationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief RSSI Location Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -3667,14 +3694,15 @@ void emberAfRssiLocationClusterServerAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfRssiLocationClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfRssiLocationClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief RSSI Location Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfRssiLocationClusterServerInitCallback(uint8_t endpoint);
+void emberAfRssiLocationClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief RSSI Location Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -3684,7 +3712,8 @@ void emberAfRssiLocationClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfRssiLocationClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfRssiLocationClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief RSSI Location Cluster Server Message Sent
  *
@@ -3711,7 +3740,7 @@ void emberAfRssiLocationClusterServerMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfRssiLocationClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfRssiLocationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief RSSI Location Cluster Server Tick
@@ -3720,7 +3749,7 @@ EmberAfStatus emberAfRssiLocationClusterServerPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfRssiLocationClusterServerTickCallback(uint8_t endpoint);
+void emberAfRssiLocationClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief RSSI Location Cluster Set Absolute Location
  *
  *
@@ -3758,7 +3787,7 @@ bool emberAfRssiLocationClusterSetDeviceConfigurationCallback(int16_t power, uin
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBinaryInputBasicClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBinaryInputBasicClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Binary Input (Basic) Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -3768,14 +3797,15 @@ void emberAfBinaryInputBasicClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBinaryInputBasicClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBinaryInputBasicClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Binary Input (Basic) Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBinaryInputBasicClusterClientInitCallback(uint8_t endpoint);
+void emberAfBinaryInputBasicClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Binary Input (Basic) Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -3785,8 +3815,8 @@ void emberAfBinaryInputBasicClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBinaryInputBasicClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfBinaryInputBasicClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Binary Input (Basic) Cluster Client Message Sent
  *
@@ -3813,7 +3843,8 @@ void emberAfBinaryInputBasicClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBinaryInputBasicClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBinaryInputBasicClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Binary Input (Basic) Cluster Client Tick
@@ -3822,7 +3853,7 @@ EmberAfStatus emberAfBinaryInputBasicClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBinaryInputBasicClusterClientTickCallback(uint8_t endpoint);
+void emberAfBinaryInputBasicClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Binary Input (Basic) Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -3830,7 +3861,7 @@ void emberAfBinaryInputBasicClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBinaryInputBasicClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBinaryInputBasicClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Binary Input (Basic) Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -3840,14 +3871,15 @@ void emberAfBinaryInputBasicClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBinaryInputBasicClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBinaryInputBasicClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Binary Input (Basic) Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBinaryInputBasicClusterServerInitCallback(uint8_t endpoint);
+void emberAfBinaryInputBasicClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Binary Input (Basic) Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -3857,8 +3889,8 @@ void emberAfBinaryInputBasicClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBinaryInputBasicClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfBinaryInputBasicClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Binary Input (Basic) Cluster Server Message Sent
  *
@@ -3885,7 +3917,8 @@ void emberAfBinaryInputBasicClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBinaryInputBasicClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBinaryInputBasicClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Binary Input (Basic) Cluster Server Tick
@@ -3894,7 +3927,7 @@ EmberAfStatus emberAfBinaryInputBasicClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBinaryInputBasicClusterServerTickCallback(uint8_t endpoint);
+void emberAfBinaryInputBasicClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Binary Input (Basic) Cluster Callbacks */
 
@@ -3908,7 +3941,7 @@ void emberAfBinaryInputBasicClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfCommissioningClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfCommissioningClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Commissioning Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -3918,14 +3951,15 @@ void emberAfCommissioningClusterClientAttributeChangedCallback(uint8_t endpoint,
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCommissioningClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfCommissioningClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                              EmberAfStatus status);
 /** @brief Commissioning Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCommissioningClusterClientInitCallback(uint8_t endpoint);
+void emberAfCommissioningClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Commissioning Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -3935,7 +3969,8 @@ void emberAfCommissioningClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfCommissioningClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfCommissioningClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    uint16_t manufacturerCode);
 /** @brief Commissioning Cluster Client Message Sent
  *
@@ -3962,7 +3997,7 @@ void emberAfCommissioningClusterClientMessageSentCallback(EmberOutgoingMessageTy
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfCommissioningClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfCommissioningClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            EmberAfAttributeType attributeType, uint8_t size,
                                                                            uint8_t * value);
 /** @brief Commissioning Cluster Client Tick
@@ -3971,7 +4006,7 @@ EmberAfStatus emberAfCommissioningClusterClientPreAttributeChangedCallback(uint8
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCommissioningClusterClientTickCallback(uint8_t endpoint);
+void emberAfCommissioningClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Commissioning Cluster Reset Startup Parameters
  *
  *
@@ -4040,7 +4075,7 @@ bool emberAfCommissioningClusterSaveStartupParametersResponseCallback(uint8_t st
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfCommissioningClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfCommissioningClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Commissioning Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -4050,14 +4085,15 @@ void emberAfCommissioningClusterServerAttributeChangedCallback(uint8_t endpoint,
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCommissioningClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfCommissioningClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                              EmberAfStatus status);
 /** @brief Commissioning Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCommissioningClusterServerInitCallback(uint8_t endpoint);
+void emberAfCommissioningClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Commissioning Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -4067,7 +4103,8 @@ void emberAfCommissioningClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfCommissioningClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfCommissioningClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    uint16_t manufacturerCode);
 /** @brief Commissioning Cluster Server Message Sent
  *
@@ -4094,7 +4131,7 @@ void emberAfCommissioningClusterServerMessageSentCallback(EmberOutgoingMessageTy
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfCommissioningClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfCommissioningClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            EmberAfAttributeType attributeType, uint8_t size,
                                                                            uint8_t * value);
 /** @brief Commissioning Cluster Server Tick
@@ -4103,7 +4140,7 @@ EmberAfStatus emberAfCommissioningClusterServerPreAttributeChangedCallback(uint8
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCommissioningClusterServerTickCallback(uint8_t endpoint);
+void emberAfCommissioningClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Commissioning Cluster Callbacks */
 
@@ -4117,7 +4154,7 @@ void emberAfCommissioningClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPartitionClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPartitionClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Partition Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -4127,14 +4164,15 @@ void emberAfPartitionClusterClientAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPartitionClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPartitionClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Partition Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPartitionClusterClientInitCallback(uint8_t endpoint);
+void emberAfPartitionClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Partition Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -4144,7 +4182,8 @@ void emberAfPartitionClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPartitionClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPartitionClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Partition Cluster Client Message Sent
  *
@@ -4171,7 +4210,7 @@ void emberAfPartitionClusterClientMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPartitionClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPartitionClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Partition Cluster Client Tick
@@ -4180,7 +4219,7 @@ EmberAfStatus emberAfPartitionClusterClientPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPartitionClusterClientTickCallback(uint8_t endpoint);
+void emberAfPartitionClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Partition Cluster Multiple Ack
  *
  *
@@ -4212,7 +4251,7 @@ bool emberAfPartitionClusterReadHandshakeParamResponseCallback(uint16_t partitio
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPartitionClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPartitionClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Partition Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -4222,14 +4261,15 @@ void emberAfPartitionClusterServerAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPartitionClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPartitionClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Partition Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPartitionClusterServerInitCallback(uint8_t endpoint);
+void emberAfPartitionClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Partition Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -4239,7 +4279,8 @@ void emberAfPartitionClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPartitionClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPartitionClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Partition Cluster Server Message Sent
  *
@@ -4266,7 +4307,7 @@ void emberAfPartitionClusterServerMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPartitionClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPartitionClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Partition Cluster Server Tick
@@ -4275,7 +4316,7 @@ EmberAfStatus emberAfPartitionClusterServerPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPartitionClusterServerTickCallback(uint8_t endpoint);
+void emberAfPartitionClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Partition Cluster Transfer Partitioned Frame
  *
  *
@@ -4305,7 +4346,7 @@ bool emberAfPartitionClusterWriteHandshakeParamCallback(uint16_t partitionedClus
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOtaBootloadClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOtaBootloadClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Over the Air Bootloading Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -4315,14 +4356,15 @@ void emberAfOtaBootloadClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOtaBootloadClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOtaBootloadClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Over the Air Bootloading Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOtaBootloadClusterClientInitCallback(uint8_t endpoint);
+void emberAfOtaBootloadClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Over the Air Bootloading Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -4332,7 +4374,8 @@ void emberAfOtaBootloadClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOtaBootloadClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfOtaBootloadClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Over the Air Bootloading Cluster Client Message Sent
  *
@@ -4359,7 +4402,7 @@ void emberAfOtaBootloadClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOtaBootloadClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOtaBootloadClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Over the Air Bootloading Cluster Client Tick
@@ -4368,7 +4411,7 @@ EmberAfStatus emberAfOtaBootloadClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOtaBootloadClusterClientTickCallback(uint8_t endpoint);
+void emberAfOtaBootloadClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Over the Air Bootloading Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -4376,7 +4419,7 @@ void emberAfOtaBootloadClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOtaBootloadClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOtaBootloadClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Over the Air Bootloading Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -4386,14 +4429,15 @@ void emberAfOtaBootloadClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOtaBootloadClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOtaBootloadClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Over the Air Bootloading Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOtaBootloadClusterServerInitCallback(uint8_t endpoint);
+void emberAfOtaBootloadClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Over the Air Bootloading Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -4403,7 +4447,8 @@ void emberAfOtaBootloadClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOtaBootloadClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfOtaBootloadClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Over the Air Bootloading Cluster Server Message Sent
  *
@@ -4430,7 +4475,7 @@ void emberAfOtaBootloadClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOtaBootloadClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOtaBootloadClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Over the Air Bootloading Cluster Server Tick
@@ -4439,7 +4484,7 @@ EmberAfStatus emberAfOtaBootloadClusterServerPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOtaBootloadClusterServerTickCallback(uint8_t endpoint);
+void emberAfOtaBootloadClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Over the Air Bootloading Cluster Callbacks */
 
@@ -4453,7 +4498,7 @@ void emberAfOtaBootloadClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPowerProfileClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPowerProfileClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Power Profile Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -4463,14 +4508,15 @@ void emberAfPowerProfileClusterClientAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPowerProfileClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPowerProfileClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief Power Profile Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPowerProfileClusterClientInitCallback(uint8_t endpoint);
+void emberAfPowerProfileClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Power Profile Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -4480,7 +4526,8 @@ void emberAfPowerProfileClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPowerProfileClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPowerProfileClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief Power Profile Cluster Client Message Sent
  *
@@ -4507,7 +4554,7 @@ void emberAfPowerProfileClusterClientMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPowerProfileClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPowerProfileClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief Power Profile Cluster Client Tick
@@ -4516,7 +4563,7 @@ EmberAfStatus emberAfPowerProfileClusterClientPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPowerProfileClusterClientTickCallback(uint8_t endpoint);
+void emberAfPowerProfileClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Power Profile Cluster Energy Phases Schedule Notification
  *
  *
@@ -4711,7 +4758,7 @@ bool emberAfPowerProfileClusterPowerProfilesStateNotificationCallback(uint8_t po
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPowerProfileClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPowerProfileClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Power Profile Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -4721,14 +4768,15 @@ void emberAfPowerProfileClusterServerAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPowerProfileClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPowerProfileClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief Power Profile Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPowerProfileClusterServerInitCallback(uint8_t endpoint);
+void emberAfPowerProfileClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Power Profile Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -4738,7 +4786,8 @@ void emberAfPowerProfileClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPowerProfileClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPowerProfileClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief Power Profile Cluster Server Message Sent
  *
@@ -4765,7 +4814,7 @@ void emberAfPowerProfileClusterServerMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPowerProfileClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPowerProfileClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief Power Profile Cluster Server Tick
@@ -4774,7 +4823,7 @@ EmberAfStatus emberAfPowerProfileClusterServerPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPowerProfileClusterServerTickCallback(uint8_t endpoint);
+void emberAfPowerProfileClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Power Profile Cluster Callbacks */
 
@@ -4788,7 +4837,7 @@ void emberAfPowerProfileClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -4798,14 +4847,15 @@ void emberAfApplianceControlClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Appliance Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfApplianceControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -4815,8 +4865,8 @@ void emberAfApplianceControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfApplianceControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfApplianceControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Appliance Control Cluster Client Message Sent
  *
@@ -4843,7 +4893,8 @@ void emberAfApplianceControlClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Appliance Control Cluster Client Tick
@@ -4852,14 +4903,14 @@ EmberAfStatus emberAfApplianceControlClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfApplianceControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Appliance Control Cluster Execution Of A Command
  *
  *
  *
  * @param commandId   Ver.: always
  */
-bool emberAfApplianceControlClusterExecutionOfACommandCallback(uint8_t commandId);
+bool emberAfApplianceControlClusterExecutionOfACommandCallback(chip::CommandId commandId);
 /** @brief Appliance Control Cluster Overload Pause
  *
  *
@@ -4886,7 +4937,7 @@ bool emberAfApplianceControlClusterOverloadWarningCallback(uint8_t warningEvent)
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -4896,14 +4947,15 @@ void emberAfApplianceControlClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Appliance Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfApplianceControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -4913,8 +4965,8 @@ void emberAfApplianceControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfApplianceControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfApplianceControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Appliance Control Cluster Server Message Sent
  *
@@ -4941,7 +4993,8 @@ void emberAfApplianceControlClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Appliance Control Cluster Server Tick
@@ -4950,7 +5003,7 @@ EmberAfStatus emberAfApplianceControlClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfApplianceControlClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Appliance Control Cluster Signal State
  *
  *
@@ -5014,7 +5067,7 @@ bool emberAfPollControlClusterCheckInResponseCallback(uint8_t startFastPolling, 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPollControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPollControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Poll Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -5024,14 +5077,15 @@ void emberAfPollControlClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPollControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPollControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Poll Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPollControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfPollControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Poll Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -5041,7 +5095,8 @@ void emberAfPollControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPollControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPollControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Poll Control Cluster Client Message Sent
  *
@@ -5068,7 +5123,7 @@ void emberAfPollControlClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPollControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPollControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Poll Control Cluster Client Tick
@@ -5077,7 +5132,7 @@ EmberAfStatus emberAfPollControlClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPollControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfPollControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Poll Control Cluster Fast Poll Stop
  *
  *
@@ -5091,7 +5146,7 @@ bool emberAfPollControlClusterFastPollStopCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPollControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPollControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Poll Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -5101,14 +5156,15 @@ void emberAfPollControlClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPollControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPollControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Poll Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPollControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfPollControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Poll Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -5118,7 +5174,8 @@ void emberAfPollControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPollControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPollControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Poll Control Cluster Server Message Sent
  *
@@ -5145,7 +5202,7 @@ void emberAfPollControlClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPollControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPollControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Poll Control Cluster Server Tick
@@ -5154,7 +5211,7 @@ EmberAfStatus emberAfPollControlClusterServerPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPollControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfPollControlClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Poll Control Cluster Set Long Poll Interval
  *
  *
@@ -5182,7 +5239,7 @@ bool emberAfPollControlClusterSetShortPollIntervalCallback(uint16_t newShortPoll
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGreenPowerClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGreenPowerClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Green Power Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -5192,14 +5249,15 @@ void emberAfGreenPowerClusterClientAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGreenPowerClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGreenPowerClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Green Power Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGreenPowerClusterClientInitCallback(uint8_t endpoint);
+void emberAfGreenPowerClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Green Power Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -5209,7 +5267,8 @@ void emberAfGreenPowerClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGreenPowerClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGreenPowerClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Green Power Cluster Client Message Sent
  *
@@ -5236,7 +5295,7 @@ void emberAfGreenPowerClusterClientMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGreenPowerClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGreenPowerClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Green Power Cluster Client Tick
@@ -5245,7 +5304,7 @@ EmberAfStatus emberAfGreenPowerClusterClientPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGreenPowerClusterClientTickCallback(uint8_t endpoint);
+void emberAfGreenPowerClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Green Power Cluster Gp Commissioning Notification
  *
  *
@@ -5262,7 +5321,7 @@ void emberAfGreenPowerClusterClientTickCallback(uint8_t endpoint);
  * @param mic   Ver.: since gp-1.0-09-5499-24
  */
 bool emberAfGreenPowerClusterGpCommissioningNotificationCallback(uint16_t options, uint32_t gpdSrcId, uint8_t * gpdIeee,
-                                                                 uint8_t endpoint, uint32_t gpdSecurityFrameCounter,
+                                                                 chip::EndpointId endpoint, uint32_t gpdSecurityFrameCounter,
                                                                  uint8_t gpdCommandId, uint8_t * gpdCommandPayload,
                                                                  uint16_t gppShortAddress, uint8_t gppLink, uint32_t mic);
 /** @brief Green Power Cluster Gp Notification
@@ -5350,7 +5409,7 @@ bool emberAfGreenPowerClusterGpPairingCallback(uint32_t options, uint32_t gpdSrc
  * @param reportDescriptor   Ver.: always
  */
 bool emberAfGreenPowerClusterGpPairingConfigurationCallback(
-    uint8_t actions, uint16_t options, uint32_t gpdSrcId, uint8_t * gpdIeee, uint8_t endpoint, uint8_t deviceId,
+    uint8_t actions, uint16_t options, uint32_t gpdSrcId, uint8_t * gpdIeee, chip::EndpointId endpoint, uint8_t deviceId,
     uint8_t groupListCount, uint8_t * groupList, uint16_t gpdAssignedAlias, uint8_t groupcastRadius, uint8_t securityOptions,
     uint32_t gpdSecurityFrameCounter, uint8_t * gpdSecurityKey, uint8_t numberOfPairedEndpoints, uint8_t * pairedEndpoints,
     uint8_t applicationInformation, uint16_t manufacturerId, uint16_t modeId, uint8_t numberOfGpdCommands,
@@ -5366,7 +5425,8 @@ bool emberAfGreenPowerClusterGpPairingConfigurationCallback(
  * @param gpdIeee   Ver.: since gp-1.0-09-5499-24
  * @param endpoint   Ver.: always
  */
-bool emberAfGreenPowerClusterGpPairingSearchCallback(uint16_t options, uint32_t gpdSrcId, uint8_t * gpdIeee, uint8_t endpoint);
+bool emberAfGreenPowerClusterGpPairingSearchCallback(uint16_t options, uint32_t gpdSrcId, uint8_t * gpdIeee,
+                                                     chip::EndpointId endpoint);
 /** @brief Green Power Cluster Gp Proxy Commissioning Mode
  *
  *
@@ -5414,8 +5474,8 @@ bool emberAfGreenPowerClusterGpProxyTableResponseCallback(uint8_t status, uint8_
  * @param gpdCommandPayload   Ver.: always
  */
 bool emberAfGreenPowerClusterGpResponseCallback(uint8_t options, uint16_t tempMasterShortAddress, uint8_t tempMasterTxChannel,
-                                                uint32_t gpdSrcId, uint8_t * gpdIeee, uint8_t endpoint, uint8_t gpdCommandId,
-                                                uint8_t * gpdCommandPayload);
+                                                uint32_t gpdSrcId, uint8_t * gpdIeee, chip::EndpointId endpoint,
+                                                uint8_t gpdCommandId, uint8_t * gpdCommandPayload);
 /** @brief Green Power Cluster Gp Sink Commissioning Mode
  *
  *
@@ -5484,7 +5544,7 @@ bool emberAfGreenPowerClusterGpTranslationTableResponseCallback(uint8_t status, 
  * @param translations   Ver.: since gp-1.0-09-5499-24
  */
 bool emberAfGreenPowerClusterGpTranslationTableUpdateCallback(uint16_t options, uint32_t gpdSrcId, uint8_t * gpdIeee,
-                                                              uint8_t endpoint, uint8_t * translations);
+                                                              chip::EndpointId endpoint, uint8_t * translations);
 /** @brief Green Power Cluster Gp Tunneling Stop
  *
  *
@@ -5507,7 +5567,7 @@ bool emberAfGreenPowerClusterGpTunnelingStopCallback(uint8_t options, uint32_t g
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGreenPowerClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGreenPowerClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Green Power Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -5517,14 +5577,15 @@ void emberAfGreenPowerClusterServerAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGreenPowerClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGreenPowerClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Green Power Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGreenPowerClusterServerInitCallback(uint8_t endpoint);
+void emberAfGreenPowerClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Green Power Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -5534,7 +5595,8 @@ void emberAfGreenPowerClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGreenPowerClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGreenPowerClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Green Power Cluster Server Message Sent
  *
@@ -5561,7 +5623,7 @@ void emberAfGreenPowerClusterServerMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGreenPowerClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGreenPowerClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Green Power Cluster Server Tick
@@ -5570,7 +5632,7 @@ EmberAfStatus emberAfGreenPowerClusterServerPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGreenPowerClusterServerTickCallback(uint8_t endpoint);
+void emberAfGreenPowerClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Green Power Cluster Callbacks */
 
@@ -5584,7 +5646,7 @@ void emberAfGreenPowerClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfKeepaliveClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfKeepaliveClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Keep-Alive Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -5594,14 +5656,15 @@ void emberAfKeepaliveClusterClientAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfKeepaliveClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfKeepaliveClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Keep-Alive Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfKeepaliveClusterClientInitCallback(uint8_t endpoint);
+void emberAfKeepaliveClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Keep-Alive Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -5611,7 +5674,8 @@ void emberAfKeepaliveClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfKeepaliveClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfKeepaliveClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Keep-Alive Cluster Client Message Sent
  *
@@ -5638,7 +5702,7 @@ void emberAfKeepaliveClusterClientMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfKeepaliveClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfKeepaliveClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Keep-Alive Cluster Client Tick
@@ -5647,7 +5711,7 @@ EmberAfStatus emberAfKeepaliveClusterClientPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfKeepaliveClusterClientTickCallback(uint8_t endpoint);
+void emberAfKeepaliveClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Keep-Alive Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -5655,7 +5719,7 @@ void emberAfKeepaliveClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfKeepaliveClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfKeepaliveClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Keep-Alive Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -5665,14 +5729,15 @@ void emberAfKeepaliveClusterServerAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfKeepaliveClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfKeepaliveClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Keep-Alive Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfKeepaliveClusterServerInitCallback(uint8_t endpoint);
+void emberAfKeepaliveClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Keep-Alive Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -5682,7 +5747,8 @@ void emberAfKeepaliveClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfKeepaliveClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfKeepaliveClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Keep-Alive Cluster Server Message Sent
  *
@@ -5709,7 +5775,7 @@ void emberAfKeepaliveClusterServerMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfKeepaliveClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfKeepaliveClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Keep-Alive Cluster Server Tick
@@ -5718,7 +5784,7 @@ EmberAfStatus emberAfKeepaliveClusterServerPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfKeepaliveClusterServerTickCallback(uint8_t endpoint);
+void emberAfKeepaliveClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Keep-Alive Cluster Callbacks */
 
@@ -5732,7 +5798,7 @@ void emberAfKeepaliveClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfShadeConfigClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfShadeConfigClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Shade Configuration Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -5742,14 +5808,15 @@ void emberAfShadeConfigClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfShadeConfigClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfShadeConfigClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Shade Configuration Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfShadeConfigClusterClientInitCallback(uint8_t endpoint);
+void emberAfShadeConfigClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Shade Configuration Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -5759,7 +5826,8 @@ void emberAfShadeConfigClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfShadeConfigClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfShadeConfigClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Shade Configuration Cluster Client Message Sent
  *
@@ -5786,7 +5854,7 @@ void emberAfShadeConfigClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfShadeConfigClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfShadeConfigClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Shade Configuration Cluster Client Tick
@@ -5795,7 +5863,7 @@ EmberAfStatus emberAfShadeConfigClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfShadeConfigClusterClientTickCallback(uint8_t endpoint);
+void emberAfShadeConfigClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Shade Configuration Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -5803,7 +5871,7 @@ void emberAfShadeConfigClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfShadeConfigClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfShadeConfigClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Shade Configuration Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -5813,14 +5881,15 @@ void emberAfShadeConfigClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfShadeConfigClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfShadeConfigClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Shade Configuration Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfShadeConfigClusterServerInitCallback(uint8_t endpoint);
+void emberAfShadeConfigClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Shade Configuration Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -5830,7 +5899,8 @@ void emberAfShadeConfigClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfShadeConfigClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfShadeConfigClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Shade Configuration Cluster Server Message Sent
  *
@@ -5857,7 +5927,7 @@ void emberAfShadeConfigClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfShadeConfigClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfShadeConfigClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Shade Configuration Cluster Server Tick
@@ -5866,7 +5936,7 @@ EmberAfStatus emberAfShadeConfigClusterServerPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfShadeConfigClusterServerTickCallback(uint8_t endpoint);
+void emberAfShadeConfigClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Shade Configuration Cluster Callbacks */
 
@@ -5978,7 +6048,7 @@ bool emberAfDoorLockClusterClearYeardayScheduleResponseCallback(uint8_t status);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDoorLockClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDoorLockClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Door Lock Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -5988,14 +6058,15 @@ void emberAfDoorLockClusterClientAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDoorLockClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDoorLockClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Door Lock Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDoorLockClusterClientInitCallback(uint8_t endpoint);
+void emberAfDoorLockClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Door Lock Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -6005,7 +6076,8 @@ void emberAfDoorLockClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDoorLockClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDoorLockClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Door Lock Cluster Client Message Sent
  *
@@ -6032,7 +6104,7 @@ void emberAfDoorLockClusterClientMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDoorLockClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDoorLockClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Door Lock Cluster Client Tick
@@ -6041,7 +6113,7 @@ EmberAfStatus emberAfDoorLockClusterClientPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDoorLockClusterClientTickCallback(uint8_t endpoint);
+void emberAfDoorLockClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Door Lock Cluster Get Holiday Schedule
  *
  *
@@ -6240,7 +6312,7 @@ bool emberAfDoorLockClusterProgrammingEventNotificationCallback(uint8_t source, 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDoorLockClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDoorLockClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Door Lock Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -6250,14 +6322,15 @@ void emberAfDoorLockClusterServerAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDoorLockClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDoorLockClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Door Lock Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDoorLockClusterServerInitCallback(uint8_t endpoint);
+void emberAfDoorLockClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Door Lock Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -6267,7 +6340,8 @@ void emberAfDoorLockClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDoorLockClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDoorLockClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Door Lock Cluster Server Message Sent
  *
@@ -6294,7 +6368,7 @@ void emberAfDoorLockClusterServerMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDoorLockClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDoorLockClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Door Lock Cluster Server Tick
@@ -6303,7 +6377,7 @@ EmberAfStatus emberAfDoorLockClusterServerPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDoorLockClusterServerTickCallback(uint8_t endpoint);
+void emberAfDoorLockClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Door Lock Cluster Set Holiday Schedule
  *
  *
@@ -6481,7 +6555,7 @@ bool emberAfDoorLockClusterUnlockWithTimeoutResponseCallback(uint8_t status);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfWindowCoveringClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfWindowCoveringClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Window Covering Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -6491,14 +6565,15 @@ void emberAfWindowCoveringClusterClientAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfWindowCoveringClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfWindowCoveringClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Window Covering Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfWindowCoveringClusterClientInitCallback(uint8_t endpoint);
+void emberAfWindowCoveringClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Window Covering Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -6508,8 +6583,8 @@ void emberAfWindowCoveringClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfWindowCoveringClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfWindowCoveringClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Window Covering Cluster Client Message Sent
  *
@@ -6536,7 +6611,8 @@ void emberAfWindowCoveringClusterClientMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfWindowCoveringClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfWindowCoveringClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Window Covering Cluster Client Tick
@@ -6545,7 +6621,7 @@ EmberAfStatus emberAfWindowCoveringClusterClientPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfWindowCoveringClusterClientTickCallback(uint8_t endpoint);
+void emberAfWindowCoveringClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Window Covering Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -6553,7 +6629,7 @@ void emberAfWindowCoveringClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfWindowCoveringClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfWindowCoveringClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Window Covering Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -6563,14 +6639,15 @@ void emberAfWindowCoveringClusterServerAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfWindowCoveringClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfWindowCoveringClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Window Covering Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfWindowCoveringClusterServerInitCallback(uint8_t endpoint);
+void emberAfWindowCoveringClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Window Covering Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -6580,8 +6657,8 @@ void emberAfWindowCoveringClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfWindowCoveringClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfWindowCoveringClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Window Covering Cluster Server Message Sent
  *
@@ -6608,7 +6685,8 @@ void emberAfWindowCoveringClusterServerMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfWindowCoveringClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfWindowCoveringClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Window Covering Cluster Server Tick
@@ -6617,7 +6695,7 @@ EmberAfStatus emberAfWindowCoveringClusterServerPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfWindowCoveringClusterServerTickCallback(uint8_t endpoint);
+void emberAfWindowCoveringClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Window Covering Cluster Window Covering Down Close
  *
  *
@@ -6690,7 +6768,7 @@ bool emberAfBarrierControlClusterBarrierControlStopCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBarrierControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBarrierControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Barrier Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -6700,14 +6778,15 @@ void emberAfBarrierControlClusterClientAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBarrierControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBarrierControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Barrier Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBarrierControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfBarrierControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Barrier Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -6717,8 +6796,8 @@ void emberAfBarrierControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBarrierControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfBarrierControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Barrier Control Cluster Client Message Sent
  *
@@ -6745,7 +6824,8 @@ void emberAfBarrierControlClusterClientMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBarrierControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBarrierControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Barrier Control Cluster Client Tick
@@ -6754,7 +6834,7 @@ EmberAfStatus emberAfBarrierControlClusterClientPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBarrierControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfBarrierControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Barrier Control Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -6762,7 +6842,7 @@ void emberAfBarrierControlClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBarrierControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBarrierControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Barrier Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -6772,14 +6852,15 @@ void emberAfBarrierControlClusterServerAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBarrierControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBarrierControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Barrier Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBarrierControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfBarrierControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Barrier Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -6789,8 +6870,8 @@ void emberAfBarrierControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBarrierControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfBarrierControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Barrier Control Cluster Server Message Sent
  *
@@ -6817,7 +6898,8 @@ void emberAfBarrierControlClusterServerMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBarrierControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBarrierControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Barrier Control Cluster Server Tick
@@ -6826,7 +6908,7 @@ EmberAfStatus emberAfBarrierControlClusterServerPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBarrierControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfBarrierControlClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Barrier Control Cluster Callbacks */
 
@@ -6840,7 +6922,7 @@ void emberAfBarrierControlClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPumpConfigControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPumpConfigControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Pump Configuration and Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -6850,14 +6932,15 @@ void emberAfPumpConfigControlClusterClientAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPumpConfigControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPumpConfigControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief Pump Configuration and Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPumpConfigControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfPumpConfigControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Pump Configuration and Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -6868,7 +6951,7 @@ void emberAfPumpConfigControlClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfPumpConfigControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief Pump Configuration and Control Cluster Client Message Sent
  *
@@ -6895,7 +6978,8 @@ void emberAfPumpConfigControlClusterClientMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPumpConfigControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPumpConfigControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief Pump Configuration and Control Cluster Client Tick
@@ -6904,7 +6988,7 @@ EmberAfStatus emberAfPumpConfigControlClusterClientPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPumpConfigControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfPumpConfigControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Pump Configuration and Control Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -6912,7 +6996,7 @@ void emberAfPumpConfigControlClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPumpConfigControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPumpConfigControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Pump Configuration and Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -6922,14 +7006,15 @@ void emberAfPumpConfigControlClusterServerAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPumpConfigControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPumpConfigControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief Pump Configuration and Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPumpConfigControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfPumpConfigControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Pump Configuration and Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -6940,7 +7025,7 @@ void emberAfPumpConfigControlClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfPumpConfigControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief Pump Configuration and Control Cluster Server Message Sent
  *
@@ -6967,7 +7052,8 @@ void emberAfPumpConfigControlClusterServerMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPumpConfigControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPumpConfigControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief Pump Configuration and Control Cluster Server Tick
@@ -6976,7 +7062,7 @@ EmberAfStatus emberAfPumpConfigControlClusterServerPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPumpConfigControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfPumpConfigControlClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Pump Configuration and Control Cluster Callbacks */
 
@@ -6996,7 +7082,7 @@ bool emberAfThermostatClusterClearWeeklyScheduleCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfThermostatClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfThermostatClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Thermostat Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -7006,14 +7092,15 @@ void emberAfThermostatClusterClientAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfThermostatClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfThermostatClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Thermostat Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfThermostatClusterClientInitCallback(uint8_t endpoint);
+void emberAfThermostatClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Thermostat Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -7023,7 +7110,8 @@ void emberAfThermostatClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfThermostatClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfThermostatClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Thermostat Cluster Client Message Sent
  *
@@ -7050,7 +7138,7 @@ void emberAfThermostatClusterClientMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfThermostatClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfThermostatClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Thermostat Cluster Client Tick
@@ -7059,7 +7147,7 @@ EmberAfStatus emberAfThermostatClusterClientPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfThermostatClusterClientTickCallback(uint8_t endpoint);
+void emberAfThermostatClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Thermostat Cluster Current Weekly Schedule
  *
  *
@@ -7105,7 +7193,7 @@ bool emberAfThermostatClusterRelayStatusLogCallback(uint16_t timeOfDay, uint16_t
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfThermostatClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfThermostatClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Thermostat Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -7115,14 +7203,15 @@ void emberAfThermostatClusterServerAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfThermostatClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfThermostatClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Thermostat Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfThermostatClusterServerInitCallback(uint8_t endpoint);
+void emberAfThermostatClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Thermostat Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -7132,7 +7221,8 @@ void emberAfThermostatClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfThermostatClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfThermostatClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Thermostat Cluster Server Message Sent
  *
@@ -7159,7 +7249,7 @@ void emberAfThermostatClusterServerMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Thermostat Cluster Server Tick
@@ -7168,7 +7258,7 @@ EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfThermostatClusterServerTickCallback(uint8_t endpoint);
+void emberAfThermostatClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Thermostat Cluster Set Weekly Schedule
  *
  *
@@ -7201,7 +7291,7 @@ bool emberAfThermostatClusterSetpointRaiseLowerCallback(uint8_t mode, int8_t amo
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfFanControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfFanControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Fan Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -7211,14 +7301,15 @@ void emberAfFanControlClusterClientAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFanControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfFanControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Fan Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFanControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfFanControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Fan Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -7228,7 +7319,8 @@ void emberAfFanControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfFanControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfFanControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Fan Control Cluster Client Message Sent
  *
@@ -7255,7 +7347,7 @@ void emberAfFanControlClusterClientMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfFanControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfFanControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Fan Control Cluster Client Tick
@@ -7264,7 +7356,7 @@ EmberAfStatus emberAfFanControlClusterClientPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFanControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfFanControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Fan Control Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -7272,7 +7364,7 @@ void emberAfFanControlClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfFanControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfFanControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Fan Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -7282,14 +7374,15 @@ void emberAfFanControlClusterServerAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFanControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfFanControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Fan Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFanControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfFanControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Fan Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -7299,7 +7392,8 @@ void emberAfFanControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfFanControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfFanControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Fan Control Cluster Server Message Sent
  *
@@ -7326,7 +7420,7 @@ void emberAfFanControlClusterServerMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfFanControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfFanControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Fan Control Cluster Server Tick
@@ -7335,7 +7429,7 @@ EmberAfStatus emberAfFanControlClusterServerPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFanControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfFanControlClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Fan Control Cluster Callbacks */
 
@@ -7349,7 +7443,7 @@ void emberAfFanControlClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDehumidControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDehumidControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Dehumidification Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -7359,14 +7453,15 @@ void emberAfDehumidControlClusterClientAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDehumidControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDehumidControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Dehumidification Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDehumidControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfDehumidControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Dehumidification Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -7376,8 +7471,8 @@ void emberAfDehumidControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDehumidControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfDehumidControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Dehumidification Control Cluster Client Message Sent
  *
@@ -7404,7 +7499,8 @@ void emberAfDehumidControlClusterClientMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDehumidControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDehumidControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Dehumidification Control Cluster Client Tick
@@ -7413,7 +7509,7 @@ EmberAfStatus emberAfDehumidControlClusterClientPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDehumidControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfDehumidControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Dehumidification Control Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -7421,7 +7517,7 @@ void emberAfDehumidControlClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDehumidControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDehumidControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Dehumidification Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -7431,14 +7527,15 @@ void emberAfDehumidControlClusterServerAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDehumidControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDehumidControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Dehumidification Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDehumidControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfDehumidControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Dehumidification Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -7448,8 +7545,8 @@ void emberAfDehumidControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDehumidControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfDehumidControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Dehumidification Control Cluster Server Message Sent
  *
@@ -7476,7 +7573,8 @@ void emberAfDehumidControlClusterServerMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDehumidControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDehumidControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Dehumidification Control Cluster Server Tick
@@ -7485,7 +7583,7 @@ EmberAfStatus emberAfDehumidControlClusterServerPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDehumidControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfDehumidControlClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Dehumidification Control Cluster Callbacks */
 
@@ -7499,7 +7597,7 @@ void emberAfDehumidControlClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfThermostatUiConfigClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfThermostatUiConfigClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Thermostat User Interface Configuration Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -7509,14 +7607,15 @@ void emberAfThermostatUiConfigClusterClientAttributeChangedCallback(uint8_t endp
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfThermostatUiConfigClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfThermostatUiConfigClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                   EmberAfStatus status);
 /** @brief Thermostat User Interface Configuration Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfThermostatUiConfigClusterClientInitCallback(uint8_t endpoint);
+void emberAfThermostatUiConfigClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Thermostat User Interface Configuration Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -7527,7 +7626,7 @@ void emberAfThermostatUiConfigClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfThermostatUiConfigClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                        EmberAfAttributeId attributeId,
+                                                                                        chip::AttributeId attributeId,
                                                                                         uint16_t manufacturerCode);
 /** @brief Thermostat User Interface Configuration Cluster Client Message Sent
  *
@@ -7554,7 +7653,8 @@ void emberAfThermostatUiConfigClusterClientMessageSentCallback(EmberOutgoingMess
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfThermostatUiConfigClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfThermostatUiConfigClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 EmberAfAttributeType attributeType, uint8_t size,
                                                                                 uint8_t * value);
 /** @brief Thermostat User Interface Configuration Cluster Client Tick
@@ -7563,7 +7663,7 @@ EmberAfStatus emberAfThermostatUiConfigClusterClientPreAttributeChangedCallback(
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfThermostatUiConfigClusterClientTickCallback(uint8_t endpoint);
+void emberAfThermostatUiConfigClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Thermostat User Interface Configuration Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -7571,7 +7671,7 @@ void emberAfThermostatUiConfigClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfThermostatUiConfigClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfThermostatUiConfigClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Thermostat User Interface Configuration Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -7581,14 +7681,15 @@ void emberAfThermostatUiConfigClusterServerAttributeChangedCallback(uint8_t endp
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfThermostatUiConfigClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfThermostatUiConfigClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                   EmberAfStatus status);
 /** @brief Thermostat User Interface Configuration Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfThermostatUiConfigClusterServerInitCallback(uint8_t endpoint);
+void emberAfThermostatUiConfigClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Thermostat User Interface Configuration Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -7599,7 +7700,7 @@ void emberAfThermostatUiConfigClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfThermostatUiConfigClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                        EmberAfAttributeId attributeId,
+                                                                                        chip::AttributeId attributeId,
                                                                                         uint16_t manufacturerCode);
 /** @brief Thermostat User Interface Configuration Cluster Server Message Sent
  *
@@ -7626,7 +7727,8 @@ void emberAfThermostatUiConfigClusterServerMessageSentCallback(EmberOutgoingMess
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfThermostatUiConfigClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfThermostatUiConfigClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 EmberAfAttributeType attributeType, uint8_t size,
                                                                                 uint8_t * value);
 /** @brief Thermostat User Interface Configuration Cluster Server Tick
@@ -7635,7 +7737,7 @@ EmberAfStatus emberAfThermostatUiConfigClusterServerPreAttributeChangedCallback(
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfThermostatUiConfigClusterServerTickCallback(uint8_t endpoint);
+void emberAfThermostatUiConfigClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Thermostat User Interface Configuration Cluster Callbacks */
 
@@ -7649,7 +7751,7 @@ void emberAfThermostatUiConfigClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfColorControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfColorControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Color Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -7659,14 +7761,15 @@ void emberAfColorControlClusterClientAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfColorControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfColorControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief Color Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfColorControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfColorControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Color Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -7676,7 +7779,8 @@ void emberAfColorControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfColorControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfColorControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief Color Control Cluster Client Message Sent
  *
@@ -7703,7 +7807,7 @@ void emberAfColorControlClusterClientMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfColorControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfColorControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief Color Control Cluster Client Tick
@@ -7712,7 +7816,7 @@ EmberAfStatus emberAfColorControlClusterClientPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfColorControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfColorControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Color Control Cluster Color Loop Set
  *
  *
@@ -7870,7 +7974,7 @@ bool emberAfColorControlClusterMoveToSaturationCallback(uint8_t saturation, uint
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfColorControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfColorControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Color Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -7880,14 +7984,15 @@ void emberAfColorControlClusterServerAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfColorControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfColorControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief Color Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfColorControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfColorControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Color Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -7897,7 +8002,8 @@ void emberAfColorControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfColorControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfColorControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief Color Control Cluster Server Message Sent
  *
@@ -7924,7 +8030,7 @@ void emberAfColorControlClusterServerMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfColorControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfColorControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief Color Control Cluster Server Tick
@@ -7933,7 +8039,7 @@ EmberAfStatus emberAfColorControlClusterServerPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfColorControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfColorControlClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Color Control Cluster Step Color
  *
  *
@@ -8006,7 +8112,7 @@ bool emberAfColorControlClusterStopMoveStepCallback(uint8_t optionsMask, uint8_t
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBallastConfigurationClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBallastConfigurationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Ballast Configuration Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8016,14 +8122,15 @@ void emberAfBallastConfigurationClusterClientAttributeChangedCallback(uint8_t en
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBallastConfigurationClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBallastConfigurationClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                     EmberAfStatus status);
 /** @brief Ballast Configuration Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBallastConfigurationClusterClientInitCallback(uint8_t endpoint);
+void emberAfBallastConfigurationClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Ballast Configuration Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8034,7 +8141,7 @@ void emberAfBallastConfigurationClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfBallastConfigurationClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId,
+                                                                                          chip::AttributeId attributeId,
                                                                                           uint16_t manufacturerCode);
 /** @brief Ballast Configuration Cluster Client Message Sent
  *
@@ -8061,7 +8168,8 @@ void emberAfBallastConfigurationClusterClientMessageSentCallback(EmberOutgoingMe
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBallastConfigurationClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBallastConfigurationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   EmberAfAttributeType attributeType, uint8_t size,
                                                                                   uint8_t * value);
 /** @brief Ballast Configuration Cluster Client Tick
@@ -8070,7 +8178,7 @@ EmberAfStatus emberAfBallastConfigurationClusterClientPreAttributeChangedCallbac
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBallastConfigurationClusterClientTickCallback(uint8_t endpoint);
+void emberAfBallastConfigurationClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Ballast Configuration Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8078,7 +8186,7 @@ void emberAfBallastConfigurationClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBallastConfigurationClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBallastConfigurationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Ballast Configuration Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8088,14 +8196,15 @@ void emberAfBallastConfigurationClusterServerAttributeChangedCallback(uint8_t en
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBallastConfigurationClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBallastConfigurationClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                     EmberAfStatus status);
 /** @brief Ballast Configuration Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBallastConfigurationClusterServerInitCallback(uint8_t endpoint);
+void emberAfBallastConfigurationClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Ballast Configuration Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -8106,7 +8215,7 @@ void emberAfBallastConfigurationClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfBallastConfigurationClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId,
+                                                                                          chip::AttributeId attributeId,
                                                                                           uint16_t manufacturerCode);
 /** @brief Ballast Configuration Cluster Server Message Sent
  *
@@ -8133,7 +8242,8 @@ void emberAfBallastConfigurationClusterServerMessageSentCallback(EmberOutgoingMe
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBallastConfigurationClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBallastConfigurationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   EmberAfAttributeType attributeType, uint8_t size,
                                                                                   uint8_t * value);
 /** @brief Ballast Configuration Cluster Server Tick
@@ -8142,7 +8252,7 @@ EmberAfStatus emberAfBallastConfigurationClusterServerPreAttributeChangedCallbac
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBallastConfigurationClusterServerTickCallback(uint8_t endpoint);
+void emberAfBallastConfigurationClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Ballast Configuration Cluster Callbacks */
 
@@ -8156,7 +8266,7 @@ void emberAfBallastConfigurationClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIllumMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIllumMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Illuminance Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8166,14 +8276,15 @@ void emberAfIllumMeasurementClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIllumMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIllumMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Illuminance Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIllumMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfIllumMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Illuminance Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8183,8 +8294,8 @@ void emberAfIllumMeasurementClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIllumMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfIllumMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Illuminance Measurement Cluster Client Message Sent
  *
@@ -8211,7 +8322,8 @@ void emberAfIllumMeasurementClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIllumMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIllumMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Illuminance Measurement Cluster Client Tick
@@ -8220,7 +8332,7 @@ EmberAfStatus emberAfIllumMeasurementClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIllumMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfIllumMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Illuminance Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8228,7 +8340,7 @@ void emberAfIllumMeasurementClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIllumMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIllumMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Illuminance Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8238,14 +8350,15 @@ void emberAfIllumMeasurementClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIllumMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIllumMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Illuminance Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIllumMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfIllumMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Illuminance Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -8255,8 +8368,8 @@ void emberAfIllumMeasurementClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIllumMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfIllumMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Illuminance Measurement Cluster Server Message Sent
  *
@@ -8283,7 +8396,8 @@ void emberAfIllumMeasurementClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIllumMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIllumMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Illuminance Measurement Cluster Server Tick
@@ -8292,7 +8406,7 @@ EmberAfStatus emberAfIllumMeasurementClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIllumMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfIllumMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Illuminance Measurement Cluster Callbacks */
 
@@ -8306,7 +8420,7 @@ void emberAfIllumMeasurementClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIllumLevelSensingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIllumLevelSensingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Illuminance Level Sensing Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8316,14 +8430,15 @@ void emberAfIllumLevelSensingClusterClientAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIllumLevelSensingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIllumLevelSensingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief Illuminance Level Sensing Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIllumLevelSensingClusterClientInitCallback(uint8_t endpoint);
+void emberAfIllumLevelSensingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Illuminance Level Sensing Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8334,7 +8449,7 @@ void emberAfIllumLevelSensingClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfIllumLevelSensingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief Illuminance Level Sensing Cluster Client Message Sent
  *
@@ -8361,7 +8476,8 @@ void emberAfIllumLevelSensingClusterClientMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIllumLevelSensingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIllumLevelSensingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief Illuminance Level Sensing Cluster Client Tick
@@ -8370,7 +8486,7 @@ EmberAfStatus emberAfIllumLevelSensingClusterClientPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIllumLevelSensingClusterClientTickCallback(uint8_t endpoint);
+void emberAfIllumLevelSensingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Illuminance Level Sensing Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8378,7 +8494,7 @@ void emberAfIllumLevelSensingClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIllumLevelSensingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIllumLevelSensingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Illuminance Level Sensing Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8388,14 +8504,15 @@ void emberAfIllumLevelSensingClusterServerAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIllumLevelSensingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIllumLevelSensingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief Illuminance Level Sensing Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIllumLevelSensingClusterServerInitCallback(uint8_t endpoint);
+void emberAfIllumLevelSensingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Illuminance Level Sensing Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -8406,7 +8523,7 @@ void emberAfIllumLevelSensingClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfIllumLevelSensingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief Illuminance Level Sensing Cluster Server Message Sent
  *
@@ -8433,7 +8550,8 @@ void emberAfIllumLevelSensingClusterServerMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIllumLevelSensingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIllumLevelSensingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief Illuminance Level Sensing Cluster Server Tick
@@ -8442,7 +8560,7 @@ EmberAfStatus emberAfIllumLevelSensingClusterServerPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIllumLevelSensingClusterServerTickCallback(uint8_t endpoint);
+void emberAfIllumLevelSensingClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Illuminance Level Sensing Cluster Callbacks */
 
@@ -8456,7 +8574,7 @@ void emberAfIllumLevelSensingClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTempMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfTempMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Temperature Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8466,14 +8584,15 @@ void emberAfTempMeasurementClusterClientAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTempMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfTempMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Temperature Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTempMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfTempMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Temperature Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8483,8 +8602,8 @@ void emberAfTempMeasurementClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfTempMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfTempMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Temperature Measurement Cluster Client Message Sent
  *
@@ -8511,7 +8630,8 @@ void emberAfTempMeasurementClusterClientMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfTempMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfTempMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Temperature Measurement Cluster Client Tick
@@ -8520,7 +8640,7 @@ EmberAfStatus emberAfTempMeasurementClusterClientPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTempMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfTempMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Temperature Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8528,7 +8648,7 @@ void emberAfTempMeasurementClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTempMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfTempMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Temperature Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8538,14 +8658,15 @@ void emberAfTempMeasurementClusterServerAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTempMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfTempMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Temperature Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTempMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfTempMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Temperature Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -8555,8 +8676,8 @@ void emberAfTempMeasurementClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfTempMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfTempMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Temperature Measurement Cluster Server Message Sent
  *
@@ -8583,7 +8704,8 @@ void emberAfTempMeasurementClusterServerMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfTempMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfTempMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Temperature Measurement Cluster Server Tick
@@ -8592,7 +8714,7 @@ EmberAfStatus emberAfTempMeasurementClusterServerPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTempMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfTempMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Temperature Measurement Cluster Callbacks */
 
@@ -8606,7 +8728,7 @@ void emberAfTempMeasurementClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPressureMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPressureMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Pressure Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8616,14 +8738,15 @@ void emberAfPressureMeasurementClusterClientAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPressureMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPressureMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief Pressure Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPressureMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfPressureMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Pressure Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8634,7 +8757,7 @@ void emberAfPressureMeasurementClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfPressureMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief Pressure Measurement Cluster Client Message Sent
  *
@@ -8661,7 +8784,8 @@ void emberAfPressureMeasurementClusterClientMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPressureMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPressureMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief Pressure Measurement Cluster Client Tick
@@ -8670,7 +8794,7 @@ EmberAfStatus emberAfPressureMeasurementClusterClientPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPressureMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfPressureMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Pressure Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8678,7 +8802,7 @@ void emberAfPressureMeasurementClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPressureMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPressureMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Pressure Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8688,14 +8812,15 @@ void emberAfPressureMeasurementClusterServerAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPressureMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPressureMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief Pressure Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPressureMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfPressureMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Pressure Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -8706,7 +8831,7 @@ void emberAfPressureMeasurementClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfPressureMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief Pressure Measurement Cluster Server Message Sent
  *
@@ -8733,7 +8858,8 @@ void emberAfPressureMeasurementClusterServerMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPressureMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPressureMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief Pressure Measurement Cluster Server Tick
@@ -8742,7 +8868,7 @@ EmberAfStatus emberAfPressureMeasurementClusterServerPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPressureMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfPressureMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Pressure Measurement Cluster Callbacks */
 
@@ -8756,7 +8882,7 @@ void emberAfPressureMeasurementClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfFlowMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfFlowMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Flow Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8766,14 +8892,15 @@ void emberAfFlowMeasurementClusterClientAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFlowMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfFlowMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Flow Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFlowMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfFlowMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Flow Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8783,8 +8910,8 @@ void emberAfFlowMeasurementClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfFlowMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfFlowMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Flow Measurement Cluster Client Message Sent
  *
@@ -8811,7 +8938,8 @@ void emberAfFlowMeasurementClusterClientMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfFlowMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfFlowMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Flow Measurement Cluster Client Tick
@@ -8820,7 +8948,7 @@ EmberAfStatus emberAfFlowMeasurementClusterClientPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFlowMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfFlowMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Flow Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8828,7 +8956,7 @@ void emberAfFlowMeasurementClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfFlowMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfFlowMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Flow Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8838,14 +8966,15 @@ void emberAfFlowMeasurementClusterServerAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFlowMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfFlowMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Flow Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFlowMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfFlowMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Flow Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -8855,8 +8984,8 @@ void emberAfFlowMeasurementClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfFlowMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfFlowMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Flow Measurement Cluster Server Message Sent
  *
@@ -8883,7 +9012,8 @@ void emberAfFlowMeasurementClusterServerMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfFlowMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfFlowMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Flow Measurement Cluster Server Tick
@@ -8892,7 +9022,7 @@ EmberAfStatus emberAfFlowMeasurementClusterServerPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFlowMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfFlowMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Flow Measurement Cluster Callbacks */
 
@@ -8906,7 +9036,8 @@ void emberAfFlowMeasurementClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfRelativeHumidityMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId);
 /** @brief Relative Humidity Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8916,7 +9047,7 @@ void emberAfRelativeHumidityMeasurementClusterClientAttributeChangedCallback(uin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfRelativeHumidityMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                             EmberAfStatus status);
 /** @brief Relative Humidity Measurement Cluster Client Init
  *
@@ -8924,7 +9055,7 @@ void emberAfRelativeHumidityMeasurementClusterClientDefaultResponseCallback(uint
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfRelativeHumidityMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Relative Humidity Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8935,7 +9066,7 @@ void emberAfRelativeHumidityMeasurementClusterClientInitCallback(uint8_t endpoin
  * Ver.: always
  */
 void emberAfRelativeHumidityMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                 EmberAfAttributeId attributeId,
+                                                                                                 chip::AttributeId attributeId,
                                                                                                  uint16_t manufacturerCode);
 /** @brief Relative Humidity Measurement Cluster Client Message Sent
  *
@@ -8963,7 +9094,7 @@ void emberAfRelativeHumidityMeasurementClusterClientMessageSentCallback(EmberOut
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfRelativeHumidityMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          EmberAfAttributeType attributeType,
                                                                                          uint8_t size, uint8_t * value);
 /** @brief Relative Humidity Measurement Cluster Client Tick
@@ -8972,7 +9103,7 @@ EmberAfStatus emberAfRelativeHumidityMeasurementClusterClientPreAttributeChanged
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfRelativeHumidityMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Relative Humidity Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8980,7 +9111,8 @@ void emberAfRelativeHumidityMeasurementClusterClientTickCallback(uint8_t endpoin
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfRelativeHumidityMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId);
 /** @brief Relative Humidity Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8990,7 +9122,7 @@ void emberAfRelativeHumidityMeasurementClusterServerAttributeChangedCallback(uin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfRelativeHumidityMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                             EmberAfStatus status);
 /** @brief Relative Humidity Measurement Cluster Server Init
  *
@@ -8998,7 +9130,7 @@ void emberAfRelativeHumidityMeasurementClusterServerDefaultResponseCallback(uint
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfRelativeHumidityMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Relative Humidity Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9009,7 +9141,7 @@ void emberAfRelativeHumidityMeasurementClusterServerInitCallback(uint8_t endpoin
  * Ver.: always
  */
 void emberAfRelativeHumidityMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                 EmberAfAttributeId attributeId,
+                                                                                                 chip::AttributeId attributeId,
                                                                                                  uint16_t manufacturerCode);
 /** @brief Relative Humidity Measurement Cluster Server Message Sent
  *
@@ -9037,7 +9169,7 @@ void emberAfRelativeHumidityMeasurementClusterServerMessageSentCallback(EmberOut
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfRelativeHumidityMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          EmberAfAttributeType attributeType,
                                                                                          uint8_t size, uint8_t * value);
 /** @brief Relative Humidity Measurement Cluster Server Tick
@@ -9046,7 +9178,7 @@ EmberAfStatus emberAfRelativeHumidityMeasurementClusterServerPreAttributeChanged
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfRelativeHumidityMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Relative Humidity Measurement Cluster Callbacks */
 
@@ -9060,7 +9192,7 @@ void emberAfRelativeHumidityMeasurementClusterServerTickCallback(uint8_t endpoin
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOccupancySensingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOccupancySensingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Occupancy Sensing Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9070,14 +9202,15 @@ void emberAfOccupancySensingClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOccupancySensingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOccupancySensingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Occupancy Sensing Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOccupancySensingClusterClientInitCallback(uint8_t endpoint);
+void emberAfOccupancySensingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Occupancy Sensing Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -9087,8 +9220,8 @@ void emberAfOccupancySensingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOccupancySensingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfOccupancySensingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Occupancy Sensing Cluster Client Message Sent
  *
@@ -9115,7 +9248,8 @@ void emberAfOccupancySensingClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOccupancySensingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOccupancySensingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Occupancy Sensing Cluster Client Tick
@@ -9124,7 +9258,7 @@ EmberAfStatus emberAfOccupancySensingClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOccupancySensingClusterClientTickCallback(uint8_t endpoint);
+void emberAfOccupancySensingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Occupancy Sensing Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -9132,7 +9266,7 @@ void emberAfOccupancySensingClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOccupancySensingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOccupancySensingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Occupancy Sensing Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -9142,14 +9276,15 @@ void emberAfOccupancySensingClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOccupancySensingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOccupancySensingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Occupancy Sensing Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOccupancySensingClusterServerInitCallback(uint8_t endpoint);
+void emberAfOccupancySensingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Occupancy Sensing Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9159,8 +9294,8 @@ void emberAfOccupancySensingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOccupancySensingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfOccupancySensingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Occupancy Sensing Cluster Server Message Sent
  *
@@ -9187,7 +9322,8 @@ void emberAfOccupancySensingClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOccupancySensingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOccupancySensingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Occupancy Sensing Cluster Server Tick
@@ -9196,7 +9332,7 @@ EmberAfStatus emberAfOccupancySensingClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOccupancySensingClusterServerTickCallback(uint8_t endpoint);
+void emberAfOccupancySensingClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Occupancy Sensing Cluster Callbacks */
 
@@ -9211,7 +9347,7 @@ void emberAfOccupancySensingClusterServerTickCallback(uint8_t endpoint);
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfCarbonMonoxideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                        EmberAfAttributeId attributeId);
+                                                                                        chip::AttributeId attributeId);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9221,7 +9357,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterClientAttributeChangedC
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfCarbonMonoxideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                        EmberAfStatus status);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Client Init
  *
@@ -9229,7 +9365,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterClientDefaultResponseCa
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfCarbonMonoxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -9240,7 +9376,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterClientInitCallback(uint
  * Ver.: always
  */
 void emberAfCarbonMonoxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -9268,14 +9404,14 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterClientMessageSentCallba
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfCarbonMonoxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfCarbonMonoxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -9284,7 +9420,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterClientTickCallback(uint
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfCarbonMonoxideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                        EmberAfAttributeId attributeId);
+                                                                                        chip::AttributeId attributeId);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -9294,7 +9430,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterServerAttributeChangedC
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfCarbonMonoxideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                        EmberAfStatus status);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Init
  *
@@ -9302,7 +9438,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterServerDefaultResponseCa
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfCarbonMonoxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9313,7 +9449,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterServerInitCallback(uint
  * Ver.: always
  */
 void emberAfCarbonMonoxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -9341,14 +9477,14 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterServerMessageSentCallba
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfCarbonMonoxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfCarbonMonoxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Carbon Monoxide Concentration Measurement Cluster Callbacks */
 
@@ -9363,7 +9499,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterServerTickCallback(uint
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfCarbonDioxideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId);
+                                                                                       chip::AttributeId attributeId);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9373,7 +9509,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterClientAttributeChangedCa
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfCarbonDioxideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                       EmberAfStatus status);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Client Init
  *
@@ -9381,7 +9517,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterClientDefaultResponseCal
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfCarbonDioxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -9392,7 +9528,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterClientInitCallback(uint8
  * Ver.: always
  */
 void emberAfCarbonDioxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -9420,14 +9556,14 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterClientMessageSentCallbac
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfCarbonDioxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfCarbonDioxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -9436,7 +9572,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterClientTickCallback(uint8
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfCarbonDioxideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId);
+                                                                                       chip::AttributeId attributeId);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -9446,7 +9582,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterServerAttributeChangedCa
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfCarbonDioxideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                       EmberAfStatus status);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Init
  *
@@ -9454,7 +9590,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterServerDefaultResponseCal
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfCarbonDioxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9465,7 +9601,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterServerInitCallback(uint8
  * Ver.: always
  */
 void emberAfCarbonDioxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -9493,14 +9629,14 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterServerMessageSentCallbac
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfCarbonDioxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfCarbonDioxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Carbon Dioxide Concentration Measurement Cluster Callbacks */
 
@@ -9514,7 +9650,8 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterServerTickCallback(uint8
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfEthyleneConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Ethylene Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9524,7 +9661,7 @@ void emberAfEthyleneConcentrationMeasurementClusterClientAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfEthyleneConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Ethylene Concentration Measurement Cluster Client Init
  *
@@ -9532,7 +9669,7 @@ void emberAfEthyleneConcentrationMeasurementClusterClientDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfEthyleneConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Ethylene Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -9542,8 +9679,9 @@ void emberAfEthyleneConcentrationMeasurementClusterClientInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfEthyleneConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Ethylene Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -9571,7 +9709,7 @@ void emberAfEthyleneConcentrationMeasurementClusterClientMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfEthyleneConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Ethylene Concentration Measurement Cluster Client Tick
@@ -9580,7 +9718,7 @@ EmberAfStatus emberAfEthyleneConcentrationMeasurementClusterClientPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfEthyleneConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Ethylene Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -9588,7 +9726,8 @@ void emberAfEthyleneConcentrationMeasurementClusterClientTickCallback(uint8_t en
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfEthyleneConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Ethylene Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -9598,7 +9737,7 @@ void emberAfEthyleneConcentrationMeasurementClusterServerAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfEthyleneConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Ethylene Concentration Measurement Cluster Server Init
  *
@@ -9606,7 +9745,7 @@ void emberAfEthyleneConcentrationMeasurementClusterServerDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfEthyleneConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Ethylene Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9616,8 +9755,9 @@ void emberAfEthyleneConcentrationMeasurementClusterServerInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfEthyleneConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Ethylene Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -9645,7 +9785,7 @@ void emberAfEthyleneConcentrationMeasurementClusterServerMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfEthyleneConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Ethylene Concentration Measurement Cluster Server Tick
@@ -9654,7 +9794,7 @@ EmberAfStatus emberAfEthyleneConcentrationMeasurementClusterServerPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfEthyleneConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Ethylene Concentration Measurement Cluster Callbacks */
 
@@ -9669,7 +9809,7 @@ void emberAfEthyleneConcentrationMeasurementClusterServerTickCallback(uint8_t en
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfEthyleneOxideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId);
+                                                                                       chip::AttributeId attributeId);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9679,7 +9819,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterClientAttributeChangedCa
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfEthyleneOxideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                       EmberAfStatus status);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Client Init
  *
@@ -9687,7 +9827,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterClientDefaultResponseCal
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfEthyleneOxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -9698,7 +9838,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterClientInitCallback(uint8
  * Ver.: always
  */
 void emberAfEthyleneOxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -9726,14 +9866,14 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterClientMessageSentCallbac
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfEthyleneOxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfEthyleneOxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -9742,7 +9882,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterClientTickCallback(uint8
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfEthyleneOxideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId);
+                                                                                       chip::AttributeId attributeId);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -9752,7 +9892,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterServerAttributeChangedCa
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfEthyleneOxideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                       EmberAfStatus status);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Init
  *
@@ -9760,7 +9900,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterServerDefaultResponseCal
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfEthyleneOxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9771,7 +9911,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterServerInitCallback(uint8
  * Ver.: always
  */
 void emberAfEthyleneOxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -9799,14 +9939,14 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterServerMessageSentCallbac
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfEthyleneOxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfEthyleneOxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Ethylene Oxide Concentration Measurement Cluster Callbacks */
 
@@ -9820,7 +9960,8 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterServerTickCallback(uint8
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfHydrogenConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Hydrogen Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9830,7 +9971,7 @@ void emberAfHydrogenConcentrationMeasurementClusterClientAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfHydrogenConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Hydrogen Concentration Measurement Cluster Client Init
  *
@@ -9838,7 +9979,7 @@ void emberAfHydrogenConcentrationMeasurementClusterClientDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfHydrogenConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Hydrogen Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -9848,8 +9989,9 @@ void emberAfHydrogenConcentrationMeasurementClusterClientInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfHydrogenConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Hydrogen Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -9877,7 +10019,7 @@ void emberAfHydrogenConcentrationMeasurementClusterClientMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfHydrogenConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Hydrogen Concentration Measurement Cluster Client Tick
@@ -9886,7 +10028,7 @@ EmberAfStatus emberAfHydrogenConcentrationMeasurementClusterClientPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfHydrogenConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Hydrogen Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -9894,7 +10036,8 @@ void emberAfHydrogenConcentrationMeasurementClusterClientTickCallback(uint8_t en
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfHydrogenConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Hydrogen Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -9904,7 +10047,7 @@ void emberAfHydrogenConcentrationMeasurementClusterServerAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfHydrogenConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Hydrogen Concentration Measurement Cluster Server Init
  *
@@ -9912,7 +10055,7 @@ void emberAfHydrogenConcentrationMeasurementClusterServerDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfHydrogenConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Hydrogen Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9922,8 +10065,9 @@ void emberAfHydrogenConcentrationMeasurementClusterServerInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfHydrogenConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Hydrogen Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -9951,7 +10095,7 @@ void emberAfHydrogenConcentrationMeasurementClusterServerMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfHydrogenConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Hydrogen Concentration Measurement Cluster Server Tick
@@ -9960,7 +10104,7 @@ EmberAfStatus emberAfHydrogenConcentrationMeasurementClusterServerPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfHydrogenConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Hydrogen Concentration Measurement Cluster Callbacks */
 
@@ -9975,7 +10119,7 @@ void emberAfHydrogenConcentrationMeasurementClusterServerTickCallback(uint8_t en
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfHydrogenSulphideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId);
+                                                                                          chip::AttributeId attributeId);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9985,15 +10129,15 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterClientAttributeChange
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                         EmberAfStatus status);
+void emberAfHydrogenSulphideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                         uint8_t commandId, EmberAfStatus status);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfHydrogenSulphideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10004,7 +10148,7 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterClientInitCallback(ui
  * Ver.: always
  */
 void emberAfHydrogenSulphideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -10032,14 +10176,14 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterClientMessageSentCall
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfHydrogenSulphideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfHydrogenSulphideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10048,7 +10192,7 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterClientTickCallback(ui
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfHydrogenSulphideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId);
+                                                                                          chip::AttributeId attributeId);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10058,15 +10202,15 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterServerAttributeChange
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                         EmberAfStatus status);
+void emberAfHydrogenSulphideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                         uint8_t commandId, EmberAfStatus status);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfHydrogenSulphideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10077,7 +10221,7 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterServerInitCallback(ui
  * Ver.: always
  */
 void emberAfHydrogenSulphideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -10105,14 +10249,14 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterServerMessageSentCall
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfHydrogenSulphideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfHydrogenSulphideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Hydrogen Sulphide Concentration Measurement Cluster Callbacks */
 
@@ -10126,8 +10270,8 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterServerTickCallback(ui
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId);
+void emberAfNitricOxideConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId);
 /** @brief Nitric Oxide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -10137,7 +10281,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterClientAttributeChangedCall
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfNitricOxideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                     EmberAfStatus status);
 /** @brief Nitric Oxide Concentration Measurement Cluster Client Init
  *
@@ -10145,7 +10289,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterClientDefaultResponseCallb
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfNitricOxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Nitric Oxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10156,7 +10300,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterClientInitCallback(uint8_t
  * Ver.: always
  */
 void emberAfNitricOxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Nitric Oxide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -10184,7 +10328,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterClientMessageSentCallback(
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfNitricOxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                                 EmberAfAttributeId attributeId,
+                                                                                                 chip::AttributeId attributeId,
                                                                                                  EmberAfAttributeType attributeType,
                                                                                                  uint8_t size, uint8_t * value);
 /** @brief Nitric Oxide Concentration Measurement Cluster Client Tick
@@ -10193,7 +10337,7 @@ EmberAfStatus emberAfNitricOxideConcentrationMeasurementClusterClientPreAttribut
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfNitricOxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10201,8 +10345,8 @@ void emberAfNitricOxideConcentrationMeasurementClusterClientTickCallback(uint8_t
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId);
+void emberAfNitricOxideConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId);
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10212,7 +10356,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterServerAttributeChangedCall
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfNitricOxideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                     EmberAfStatus status);
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Init
  *
@@ -10220,7 +10364,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterServerDefaultResponseCallb
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfNitricOxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10231,7 +10375,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterServerInitCallback(uint8_t
  * Ver.: always
  */
 void emberAfNitricOxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -10259,7 +10403,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterServerMessageSentCallback(
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfNitricOxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                                 EmberAfAttributeId attributeId,
+                                                                                                 chip::AttributeId attributeId,
                                                                                                  EmberAfAttributeType attributeType,
                                                                                                  uint8_t size, uint8_t * value);
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Tick
@@ -10268,7 +10412,7 @@ EmberAfStatus emberAfNitricOxideConcentrationMeasurementClusterServerPreAttribut
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfNitricOxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Nitric Oxide Concentration Measurement Cluster Callbacks */
 
@@ -10283,7 +10427,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterServerTickCallback(uint8_t
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfNitrogenDioxideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId);
+                                                                                         chip::AttributeId attributeId);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -10293,15 +10437,15 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterClientAttributeChanged
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                        EmberAfStatus status);
+void emberAfNitrogenDioxideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                        uint8_t commandId, EmberAfStatus status);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfNitrogenDioxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10312,7 +10456,7 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterClientInitCallback(uin
  * Ver.: always
  */
 void emberAfNitrogenDioxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -10340,14 +10484,14 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterClientMessageSentCallb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfNitrogenDioxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfNitrogenDioxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10356,7 +10500,7 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterClientTickCallback(uin
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfNitrogenDioxideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId);
+                                                                                         chip::AttributeId attributeId);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10366,15 +10510,15 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterServerAttributeChanged
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                        EmberAfStatus status);
+void emberAfNitrogenDioxideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                        uint8_t commandId, EmberAfStatus status);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfNitrogenDioxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10385,7 +10529,7 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterServerInitCallback(uin
  * Ver.: always
  */
 void emberAfNitrogenDioxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -10413,14 +10557,14 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterServerMessageSentCallb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfNitrogenDioxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfNitrogenDioxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Nitrogen Dioxide Concentration Measurement Cluster Callbacks */
 
@@ -10434,7 +10578,8 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterServerTickCallback(uin
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOxygenConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId);
 /** @brief Oxygen Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -10444,7 +10589,7 @@ void emberAfOxygenConcentrationMeasurementClusterClientAttributeChangedCallback(
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfOxygenConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                EmberAfStatus status);
 /** @brief Oxygen Concentration Measurement Cluster Client Init
  *
@@ -10452,7 +10597,7 @@ void emberAfOxygenConcentrationMeasurementClusterClientDefaultResponseCallback(u
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfOxygenConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Oxygen Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10463,7 +10608,7 @@ void emberAfOxygenConcentrationMeasurementClusterClientInitCallback(uint8_t endp
  * Ver.: always
  */
 void emberAfOxygenConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                    EmberAfAttributeId attributeId,
+                                                                                                    chip::AttributeId attributeId,
                                                                                                     uint16_t manufacturerCode);
 /** @brief Oxygen Concentration Measurement Cluster Client Message Sent
  *
@@ -10491,7 +10636,7 @@ void emberAfOxygenConcentrationMeasurementClusterClientMessageSentCallback(Ember
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfOxygenConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                            EmberAfAttributeId attributeId,
+                                                                                            chip::AttributeId attributeId,
                                                                                             EmberAfAttributeType attributeType,
                                                                                             uint8_t size, uint8_t * value);
 /** @brief Oxygen Concentration Measurement Cluster Client Tick
@@ -10500,7 +10645,7 @@ EmberAfStatus emberAfOxygenConcentrationMeasurementClusterClientPreAttributeChan
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfOxygenConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Oxygen Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10508,7 +10653,8 @@ void emberAfOxygenConcentrationMeasurementClusterClientTickCallback(uint8_t endp
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOxygenConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId);
 /** @brief Oxygen Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10518,7 +10664,7 @@ void emberAfOxygenConcentrationMeasurementClusterServerAttributeChangedCallback(
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfOxygenConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                EmberAfStatus status);
 /** @brief Oxygen Concentration Measurement Cluster Server Init
  *
@@ -10526,7 +10672,7 @@ void emberAfOxygenConcentrationMeasurementClusterServerDefaultResponseCallback(u
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfOxygenConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Oxygen Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10537,7 +10683,7 @@ void emberAfOxygenConcentrationMeasurementClusterServerInitCallback(uint8_t endp
  * Ver.: always
  */
 void emberAfOxygenConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                    EmberAfAttributeId attributeId,
+                                                                                                    chip::AttributeId attributeId,
                                                                                                     uint16_t manufacturerCode);
 /** @brief Oxygen Concentration Measurement Cluster Server Message Sent
  *
@@ -10565,7 +10711,7 @@ void emberAfOxygenConcentrationMeasurementClusterServerMessageSentCallback(Ember
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfOxygenConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                            EmberAfAttributeId attributeId,
+                                                                                            chip::AttributeId attributeId,
                                                                                             EmberAfAttributeType attributeType,
                                                                                             uint8_t size, uint8_t * value);
 /** @brief Oxygen Concentration Measurement Cluster Server Tick
@@ -10574,7 +10720,7 @@ EmberAfStatus emberAfOxygenConcentrationMeasurementClusterServerPreAttributeChan
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfOxygenConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Oxygen Concentration Measurement Cluster Callbacks */
 
@@ -10588,7 +10734,8 @@ void emberAfOxygenConcentrationMeasurementClusterServerTickCallback(uint8_t endp
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOzoneConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId);
 /** @brief Ozone Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -10598,7 +10745,7 @@ void emberAfOzoneConcentrationMeasurementClusterClientAttributeChangedCallback(u
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfOzoneConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                               EmberAfStatus status);
 /** @brief Ozone Concentration Measurement Cluster Client Init
  *
@@ -10606,7 +10753,7 @@ void emberAfOzoneConcentrationMeasurementClusterClientDefaultResponseCallback(ui
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfOzoneConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Ozone Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10617,7 +10764,7 @@ void emberAfOzoneConcentrationMeasurementClusterClientInitCallback(uint8_t endpo
  * Ver.: always
  */
 void emberAfOzoneConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                   EmberAfAttributeId attributeId,
+                                                                                                   chip::AttributeId attributeId,
                                                                                                    uint16_t manufacturerCode);
 /** @brief Ozone Concentration Measurement Cluster Client Message Sent
  *
@@ -10645,7 +10792,7 @@ void emberAfOzoneConcentrationMeasurementClusterClientMessageSentCallback(EmberO
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfOzoneConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                           EmberAfAttributeId attributeId,
+                                                                                           chip::AttributeId attributeId,
                                                                                            EmberAfAttributeType attributeType,
                                                                                            uint8_t size, uint8_t * value);
 /** @brief Ozone Concentration Measurement Cluster Client Tick
@@ -10654,7 +10801,7 @@ EmberAfStatus emberAfOzoneConcentrationMeasurementClusterClientPreAttributeChang
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfOzoneConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Ozone Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10662,7 +10809,8 @@ void emberAfOzoneConcentrationMeasurementClusterClientTickCallback(uint8_t endpo
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOzoneConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId);
 /** @brief Ozone Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10672,7 +10820,7 @@ void emberAfOzoneConcentrationMeasurementClusterServerAttributeChangedCallback(u
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfOzoneConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                               EmberAfStatus status);
 /** @brief Ozone Concentration Measurement Cluster Server Init
  *
@@ -10680,7 +10828,7 @@ void emberAfOzoneConcentrationMeasurementClusterServerDefaultResponseCallback(ui
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfOzoneConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Ozone Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10691,7 +10839,7 @@ void emberAfOzoneConcentrationMeasurementClusterServerInitCallback(uint8_t endpo
  * Ver.: always
  */
 void emberAfOzoneConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                   EmberAfAttributeId attributeId,
+                                                                                                   chip::AttributeId attributeId,
                                                                                                    uint16_t manufacturerCode);
 /** @brief Ozone Concentration Measurement Cluster Server Message Sent
  *
@@ -10719,7 +10867,7 @@ void emberAfOzoneConcentrationMeasurementClusterServerMessageSentCallback(EmberO
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfOzoneConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                           EmberAfAttributeId attributeId,
+                                                                                           chip::AttributeId attributeId,
                                                                                            EmberAfAttributeType attributeType,
                                                                                            uint8_t size, uint8_t * value);
 /** @brief Ozone Concentration Measurement Cluster Server Tick
@@ -10728,7 +10876,7 @@ EmberAfStatus emberAfOzoneConcentrationMeasurementClusterServerPreAttributeChang
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfOzoneConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Ozone Concentration Measurement Cluster Callbacks */
 
@@ -10743,7 +10891,7 @@ void emberAfOzoneConcentrationMeasurementClusterServerTickCallback(uint8_t endpo
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfSulfurDioxideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId);
+                                                                                       chip::AttributeId attributeId);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -10753,7 +10901,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterClientAttributeChangedCa
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfSulfurDioxideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                       EmberAfStatus status);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Client Init
  *
@@ -10761,7 +10909,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterClientDefaultResponseCal
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfSulfurDioxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10772,7 +10920,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterClientInitCallback(uint8
  * Ver.: always
  */
 void emberAfSulfurDioxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -10800,14 +10948,14 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterClientMessageSentCallbac
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfSulfurDioxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfSulfurDioxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10816,7 +10964,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterClientTickCallback(uint8
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfSulfurDioxideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId);
+                                                                                       chip::AttributeId attributeId);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10826,7 +10974,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterServerAttributeChangedCa
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfSulfurDioxideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                       EmberAfStatus status);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Init
  *
@@ -10834,7 +10982,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterServerDefaultResponseCal
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfSulfurDioxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10845,7 +10993,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterServerInitCallback(uint8
  * Ver.: always
  */
 void emberAfSulfurDioxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -10873,14 +11021,14 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterServerMessageSentCallbac
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfSulfurDioxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfSulfurDioxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Sulfur Dioxide Concentration Measurement Cluster Callbacks */
 
@@ -10895,7 +11043,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterServerTickCallback(uint8
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfDissolvedOxygenConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId);
+                                                                                         chip::AttributeId attributeId);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -10905,15 +11053,15 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterClientAttributeChanged
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                        EmberAfStatus status);
+void emberAfDissolvedOxygenConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                        uint8_t commandId, EmberAfStatus status);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfDissolvedOxygenConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10924,7 +11072,7 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterClientInitCallback(uin
  * Ver.: always
  */
 void emberAfDissolvedOxygenConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -10952,14 +11100,14 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterClientMessageSentCallb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfDissolvedOxygenConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfDissolvedOxygenConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10968,7 +11116,7 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterClientTickCallback(uin
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfDissolvedOxygenConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId);
+                                                                                         chip::AttributeId attributeId);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10978,15 +11126,15 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterServerAttributeChanged
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                        EmberAfStatus status);
+void emberAfDissolvedOxygenConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                        uint8_t commandId, EmberAfStatus status);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfDissolvedOxygenConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10997,7 +11145,7 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterServerInitCallback(uin
  * Ver.: always
  */
 void emberAfDissolvedOxygenConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -11025,14 +11173,14 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterServerMessageSentCallb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfDissolvedOxygenConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfDissolvedOxygenConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Dissolved Oxygen Concentration Measurement Cluster Callbacks */
 
@@ -11046,7 +11194,8 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterServerTickCallback(uin
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBromateConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId);
 /** @brief Bromate Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11056,7 +11205,7 @@ void emberAfBromateConcentrationMeasurementClusterClientAttributeChangedCallback
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfBromateConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                 EmberAfStatus status);
 /** @brief Bromate Concentration Measurement Cluster Client Init
  *
@@ -11064,7 +11213,7 @@ void emberAfBromateConcentrationMeasurementClusterClientDefaultResponseCallback(
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfBromateConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Bromate Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11075,7 +11224,7 @@ void emberAfBromateConcentrationMeasurementClusterClientInitCallback(uint8_t end
  * Ver.: always
  */
 void emberAfBromateConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                     EmberAfAttributeId attributeId,
+                                                                                                     chip::AttributeId attributeId,
                                                                                                      uint16_t manufacturerCode);
 /** @brief Bromate Concentration Measurement Cluster Client Message Sent
  *
@@ -11103,7 +11252,7 @@ void emberAfBromateConcentrationMeasurementClusterClientMessageSentCallback(Embe
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfBromateConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              EmberAfAttributeType attributeType,
                                                                                              uint8_t size, uint8_t * value);
 /** @brief Bromate Concentration Measurement Cluster Client Tick
@@ -11112,7 +11261,7 @@ EmberAfStatus emberAfBromateConcentrationMeasurementClusterClientPreAttributeCha
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfBromateConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Bromate Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -11120,7 +11269,8 @@ void emberAfBromateConcentrationMeasurementClusterClientTickCallback(uint8_t end
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBromateConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId);
 /** @brief Bromate Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -11130,7 +11280,7 @@ void emberAfBromateConcentrationMeasurementClusterServerAttributeChangedCallback
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfBromateConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                 EmberAfStatus status);
 /** @brief Bromate Concentration Measurement Cluster Server Init
  *
@@ -11138,7 +11288,7 @@ void emberAfBromateConcentrationMeasurementClusterServerDefaultResponseCallback(
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfBromateConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Bromate Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -11149,7 +11299,7 @@ void emberAfBromateConcentrationMeasurementClusterServerInitCallback(uint8_t end
  * Ver.: always
  */
 void emberAfBromateConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                     EmberAfAttributeId attributeId,
+                                                                                                     chip::AttributeId attributeId,
                                                                                                      uint16_t manufacturerCode);
 /** @brief Bromate Concentration Measurement Cluster Server Message Sent
  *
@@ -11177,7 +11327,7 @@ void emberAfBromateConcentrationMeasurementClusterServerMessageSentCallback(Embe
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfBromateConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              EmberAfAttributeType attributeType,
                                                                                              uint8_t size, uint8_t * value);
 /** @brief Bromate Concentration Measurement Cluster Server Tick
@@ -11186,7 +11336,7 @@ EmberAfStatus emberAfBromateConcentrationMeasurementClusterServerPreAttributeCha
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfBromateConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Bromate Concentration Measurement Cluster Callbacks */
 
@@ -11200,8 +11350,8 @@ void emberAfBromateConcentrationMeasurementClusterServerTickCallback(uint8_t end
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId);
+void emberAfChloraminesConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId);
 /** @brief Chloramines Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11211,7 +11361,7 @@ void emberAfChloraminesConcentrationMeasurementClusterClientAttributeChangedCall
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChloraminesConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                     EmberAfStatus status);
 /** @brief Chloramines Concentration Measurement Cluster Client Init
  *
@@ -11219,7 +11369,7 @@ void emberAfChloraminesConcentrationMeasurementClusterClientDefaultResponseCallb
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfChloraminesConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Chloramines Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11230,7 +11380,7 @@ void emberAfChloraminesConcentrationMeasurementClusterClientInitCallback(uint8_t
  * Ver.: always
  */
 void emberAfChloraminesConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Chloramines Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -11258,7 +11408,7 @@ void emberAfChloraminesConcentrationMeasurementClusterClientMessageSentCallback(
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChloraminesConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                                 EmberAfAttributeId attributeId,
+                                                                                                 chip::AttributeId attributeId,
                                                                                                  EmberAfAttributeType attributeType,
                                                                                                  uint8_t size, uint8_t * value);
 /** @brief Chloramines Concentration Measurement Cluster Client Tick
@@ -11267,7 +11417,7 @@ EmberAfStatus emberAfChloraminesConcentrationMeasurementClusterClientPreAttribut
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfChloraminesConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Chloramines Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -11275,8 +11425,8 @@ void emberAfChloraminesConcentrationMeasurementClusterClientTickCallback(uint8_t
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId);
+void emberAfChloraminesConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId);
 /** @brief Chloramines Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -11286,7 +11436,7 @@ void emberAfChloraminesConcentrationMeasurementClusterServerAttributeChangedCall
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChloraminesConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                     EmberAfStatus status);
 /** @brief Chloramines Concentration Measurement Cluster Server Init
  *
@@ -11294,7 +11444,7 @@ void emberAfChloraminesConcentrationMeasurementClusterServerDefaultResponseCallb
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfChloraminesConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Chloramines Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -11305,7 +11455,7 @@ void emberAfChloraminesConcentrationMeasurementClusterServerInitCallback(uint8_t
  * Ver.: always
  */
 void emberAfChloraminesConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Chloramines Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -11333,7 +11483,7 @@ void emberAfChloraminesConcentrationMeasurementClusterServerMessageSentCallback(
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChloraminesConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                                 EmberAfAttributeId attributeId,
+                                                                                                 chip::AttributeId attributeId,
                                                                                                  EmberAfAttributeType attributeType,
                                                                                                  uint8_t size, uint8_t * value);
 /** @brief Chloramines Concentration Measurement Cluster Server Tick
@@ -11342,7 +11492,7 @@ EmberAfStatus emberAfChloraminesConcentrationMeasurementClusterServerPreAttribut
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfChloraminesConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Chloramines Concentration Measurement Cluster Callbacks */
 
@@ -11356,7 +11506,8 @@ void emberAfChloraminesConcentrationMeasurementClusterServerTickCallback(uint8_t
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfChlorineConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Chlorine Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11366,7 +11517,7 @@ void emberAfChlorineConcentrationMeasurementClusterClientAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChlorineConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Chlorine Concentration Measurement Cluster Client Init
  *
@@ -11374,7 +11525,7 @@ void emberAfChlorineConcentrationMeasurementClusterClientDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfChlorineConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Chlorine Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11384,8 +11535,9 @@ void emberAfChlorineConcentrationMeasurementClusterClientInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfChlorineConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Chlorine Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -11413,7 +11565,7 @@ void emberAfChlorineConcentrationMeasurementClusterClientMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChlorineConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Chlorine Concentration Measurement Cluster Client Tick
@@ -11422,7 +11574,7 @@ EmberAfStatus emberAfChlorineConcentrationMeasurementClusterClientPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfChlorineConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Chlorine Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -11430,7 +11582,8 @@ void emberAfChlorineConcentrationMeasurementClusterClientTickCallback(uint8_t en
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfChlorineConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Chlorine Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -11440,7 +11593,7 @@ void emberAfChlorineConcentrationMeasurementClusterServerAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChlorineConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Chlorine Concentration Measurement Cluster Server Init
  *
@@ -11448,7 +11601,7 @@ void emberAfChlorineConcentrationMeasurementClusterServerDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfChlorineConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Chlorine Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -11458,8 +11611,9 @@ void emberAfChlorineConcentrationMeasurementClusterServerInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfChlorineConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Chlorine Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -11487,7 +11641,7 @@ void emberAfChlorineConcentrationMeasurementClusterServerMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChlorineConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Chlorine Concentration Measurement Cluster Server Tick
@@ -11496,7 +11650,7 @@ EmberAfStatus emberAfChlorineConcentrationMeasurementClusterServerPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfChlorineConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Chlorine Concentration Measurement Cluster Callbacks */
 
@@ -11511,7 +11665,7 @@ void emberAfChlorineConcentrationMeasurementClusterServerTickCallback(uint8_t en
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId);
+                                                                                               chip::AttributeId attributeId);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11521,7 +11675,8 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientAttributeC
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                              uint8_t commandId,
                                                                                               EmberAfStatus status);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Client Init
  *
@@ -11529,7 +11684,7 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientDefaultRes
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11540,7 +11695,7 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientInitCallba
  * Ver.: always
  */
 void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -11568,14 +11723,14 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientMessageSen
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -11584,7 +11739,7 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientTickCallba
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId);
+                                                                                               chip::AttributeId attributeId);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -11594,7 +11749,8 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerAttributeC
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                              uint8_t commandId,
                                                                                               EmberAfStatus status);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Init
  *
@@ -11602,7 +11758,7 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerDefaultRes
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -11613,7 +11769,7 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerInitCallba
  * Ver.: always
  */
 void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -11641,14 +11797,14 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerMessageSen
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Fecal coliform and E. Coli Concentration Measurement Cluster Callbacks */
 
@@ -11662,7 +11818,8 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerTickCallba
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfFluorideConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Fluoride Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11672,7 +11829,7 @@ void emberAfFluorideConcentrationMeasurementClusterClientAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfFluorideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Fluoride Concentration Measurement Cluster Client Init
  *
@@ -11680,7 +11837,7 @@ void emberAfFluorideConcentrationMeasurementClusterClientDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfFluorideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Fluoride Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11690,8 +11847,9 @@ void emberAfFluorideConcentrationMeasurementClusterClientInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfFluorideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Fluoride Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -11719,7 +11877,7 @@ void emberAfFluorideConcentrationMeasurementClusterClientMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfFluorideConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Fluoride Concentration Measurement Cluster Client Tick
@@ -11728,7 +11886,7 @@ EmberAfStatus emberAfFluorideConcentrationMeasurementClusterClientPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfFluorideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Fluoride Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -11736,7 +11894,8 @@ void emberAfFluorideConcentrationMeasurementClusterClientTickCallback(uint8_t en
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfFluorideConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Fluoride Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -11746,7 +11905,7 @@ void emberAfFluorideConcentrationMeasurementClusterServerAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfFluorideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Fluoride Concentration Measurement Cluster Server Init
  *
@@ -11754,7 +11913,7 @@ void emberAfFluorideConcentrationMeasurementClusterServerDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfFluorideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Fluoride Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -11764,8 +11923,9 @@ void emberAfFluorideConcentrationMeasurementClusterServerInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfFluorideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Fluoride Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -11793,7 +11953,7 @@ void emberAfFluorideConcentrationMeasurementClusterServerMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfFluorideConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Fluoride Concentration Measurement Cluster Server Tick
@@ -11802,7 +11962,7 @@ EmberAfStatus emberAfFluorideConcentrationMeasurementClusterServerPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfFluorideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Fluoride Concentration Measurement Cluster Callbacks */
 
@@ -11817,7 +11977,7 @@ void emberAfFluorideConcentrationMeasurementClusterServerTickCallback(uint8_t en
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId);
+                                                                                         chip::AttributeId attributeId);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11827,15 +11987,15 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientAttributeChanged
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                        EmberAfStatus status);
+void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                        uint8_t commandId, EmberAfStatus status);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11846,7 +12006,7 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientInitCallback(uin
  * Ver.: always
  */
 void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -11874,14 +12034,14 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientMessageSentCallb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfHaloaceticAcidsConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -11890,7 +12050,7 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientTickCallback(uin
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId);
+                                                                                         chip::AttributeId attributeId);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -11900,15 +12060,15 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerAttributeChanged
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                        EmberAfStatus status);
+void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                        uint8_t commandId, EmberAfStatus status);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -11919,7 +12079,7 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerInitCallback(uin
  * Ver.: always
  */
 void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -11947,14 +12107,14 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerMessageSentCallb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfHaloaceticAcidsConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Haloacetic Acids Concentration Measurement Cluster Callbacks */
 
@@ -11969,7 +12129,7 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerTickCallback(uin
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId);
+                                                                                              chip::AttributeId attributeId);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11979,7 +12139,8 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientAttributeCh
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                             uint8_t commandId,
                                                                                              EmberAfStatus status);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Client Init
  *
@@ -11987,7 +12148,7 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientDefaultResp
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11998,7 +12159,7 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientInitCallbac
  * Ver.: always
  */
 void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -12026,14 +12187,14 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientMessageSent
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12042,7 +12203,7 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientTickCallbac
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId);
+                                                                                              chip::AttributeId attributeId);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12052,7 +12213,8 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerAttributeCh
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                             uint8_t commandId,
                                                                                              EmberAfStatus status);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Init
  *
@@ -12060,7 +12222,7 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerDefaultResp
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12071,7 +12233,7 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerInitCallbac
  * Ver.: always
  */
 void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -12099,14 +12261,14 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerMessageSent
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Total Trihalomethanes Concentration Measurement Cluster Callbacks */
 
@@ -12121,7 +12283,7 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerTickCallbac
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId);
+                                                                                               chip::AttributeId attributeId);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -12131,7 +12293,8 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientAttributeC
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                              uint8_t commandId,
                                                                                               EmberAfStatus status);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Client Init
  *
@@ -12139,7 +12302,7 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientDefaultRes
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -12150,7 +12313,7 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientInitCallba
  * Ver.: always
  */
 void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -12178,14 +12341,14 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientMessageSen
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12194,7 +12357,7 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientTickCallba
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId);
+                                                                                               chip::AttributeId attributeId);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12204,7 +12367,8 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerAttributeC
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                              uint8_t commandId,
                                                                                               EmberAfStatus status);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Init
  *
@@ -12212,7 +12376,7 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerDefaultRes
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12223,7 +12387,7 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerInitCallba
  * Ver.: always
  */
 void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -12251,14 +12415,14 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerMessageSen
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Total Coliform Bacteria Concentration Measurement Cluster Callbacks */
 
@@ -12272,8 +12436,8 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerTickCallba
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                   EmberAfAttributeId attributeId);
+void emberAfTurbidityConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId);
 /** @brief Turbidity Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -12283,7 +12447,7 @@ void emberAfTurbidityConcentrationMeasurementClusterClientAttributeChangedCallba
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfTurbidityConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                   EmberAfStatus status);
 /** @brief Turbidity Concentration Measurement Cluster Client Init
  *
@@ -12291,7 +12455,7 @@ void emberAfTurbidityConcentrationMeasurementClusterClientDefaultResponseCallbac
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfTurbidityConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Turbidity Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -12302,7 +12466,7 @@ void emberAfTurbidityConcentrationMeasurementClusterClientInitCallback(uint8_t e
  * Ver.: always
  */
 void emberAfTurbidityConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Turbidity Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -12330,7 +12494,7 @@ void emberAfTurbidityConcentrationMeasurementClusterClientMessageSentCallback(Em
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfTurbidityConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                EmberAfAttributeType attributeType,
                                                                                                uint8_t size, uint8_t * value);
 /** @brief Turbidity Concentration Measurement Cluster Client Tick
@@ -12339,7 +12503,7 @@ EmberAfStatus emberAfTurbidityConcentrationMeasurementClusterClientPreAttributeC
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfTurbidityConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Turbidity Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12347,8 +12511,8 @@ void emberAfTurbidityConcentrationMeasurementClusterClientTickCallback(uint8_t e
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                   EmberAfAttributeId attributeId);
+void emberAfTurbidityConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId);
 /** @brief Turbidity Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12358,7 +12522,7 @@ void emberAfTurbidityConcentrationMeasurementClusterServerAttributeChangedCallba
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfTurbidityConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                   EmberAfStatus status);
 /** @brief Turbidity Concentration Measurement Cluster Server Init
  *
@@ -12366,7 +12530,7 @@ void emberAfTurbidityConcentrationMeasurementClusterServerDefaultResponseCallbac
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfTurbidityConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Turbidity Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12377,7 +12541,7 @@ void emberAfTurbidityConcentrationMeasurementClusterServerInitCallback(uint8_t e
  * Ver.: always
  */
 void emberAfTurbidityConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Turbidity Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -12405,7 +12569,7 @@ void emberAfTurbidityConcentrationMeasurementClusterServerMessageSentCallback(Em
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfTurbidityConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                EmberAfAttributeType attributeType,
                                                                                                uint8_t size, uint8_t * value);
 /** @brief Turbidity Concentration Measurement Cluster Server Tick
@@ -12414,7 +12578,7 @@ EmberAfStatus emberAfTurbidityConcentrationMeasurementClusterServerPreAttributeC
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfTurbidityConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Turbidity Concentration Measurement Cluster Callbacks */
 
@@ -12428,7 +12592,8 @@ void emberAfTurbidityConcentrationMeasurementClusterServerTickCallback(uint8_t e
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfCopperConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId);
 /** @brief Copper Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -12438,7 +12603,7 @@ void emberAfCopperConcentrationMeasurementClusterClientAttributeChangedCallback(
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfCopperConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                EmberAfStatus status);
 /** @brief Copper Concentration Measurement Cluster Client Init
  *
@@ -12446,7 +12611,7 @@ void emberAfCopperConcentrationMeasurementClusterClientDefaultResponseCallback(u
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfCopperConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Copper Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -12457,7 +12622,7 @@ void emberAfCopperConcentrationMeasurementClusterClientInitCallback(uint8_t endp
  * Ver.: always
  */
 void emberAfCopperConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                    EmberAfAttributeId attributeId,
+                                                                                                    chip::AttributeId attributeId,
                                                                                                     uint16_t manufacturerCode);
 /** @brief Copper Concentration Measurement Cluster Client Message Sent
  *
@@ -12485,7 +12650,7 @@ void emberAfCopperConcentrationMeasurementClusterClientMessageSentCallback(Ember
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfCopperConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                            EmberAfAttributeId attributeId,
+                                                                                            chip::AttributeId attributeId,
                                                                                             EmberAfAttributeType attributeType,
                                                                                             uint8_t size, uint8_t * value);
 /** @brief Copper Concentration Measurement Cluster Client Tick
@@ -12494,7 +12659,7 @@ EmberAfStatus emberAfCopperConcentrationMeasurementClusterClientPreAttributeChan
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfCopperConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Copper Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12502,7 +12667,8 @@ void emberAfCopperConcentrationMeasurementClusterClientTickCallback(uint8_t endp
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfCopperConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId);
 /** @brief Copper Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12512,7 +12678,7 @@ void emberAfCopperConcentrationMeasurementClusterServerAttributeChangedCallback(
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfCopperConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                EmberAfStatus status);
 /** @brief Copper Concentration Measurement Cluster Server Init
  *
@@ -12520,7 +12686,7 @@ void emberAfCopperConcentrationMeasurementClusterServerDefaultResponseCallback(u
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfCopperConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Copper Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12531,7 +12697,7 @@ void emberAfCopperConcentrationMeasurementClusterServerInitCallback(uint8_t endp
  * Ver.: always
  */
 void emberAfCopperConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                    EmberAfAttributeId attributeId,
+                                                                                                    chip::AttributeId attributeId,
                                                                                                     uint16_t manufacturerCode);
 /** @brief Copper Concentration Measurement Cluster Server Message Sent
  *
@@ -12559,7 +12725,7 @@ void emberAfCopperConcentrationMeasurementClusterServerMessageSentCallback(Ember
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfCopperConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                            EmberAfAttributeId attributeId,
+                                                                                            chip::AttributeId attributeId,
                                                                                             EmberAfAttributeType attributeType,
                                                                                             uint8_t size, uint8_t * value);
 /** @brief Copper Concentration Measurement Cluster Server Tick
@@ -12568,7 +12734,7 @@ EmberAfStatus emberAfCopperConcentrationMeasurementClusterServerPreAttributeChan
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfCopperConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Copper Concentration Measurement Cluster Callbacks */
 
@@ -12582,7 +12748,8 @@ void emberAfCopperConcentrationMeasurementClusterServerTickCallback(uint8_t endp
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfLeadConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId);
 /** @brief Lead Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -12592,7 +12759,7 @@ void emberAfLeadConcentrationMeasurementClusterClientAttributeChangedCallback(ui
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfLeadConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                              EmberAfStatus status);
 /** @brief Lead Concentration Measurement Cluster Client Init
  *
@@ -12600,7 +12767,7 @@ void emberAfLeadConcentrationMeasurementClusterClientDefaultResponseCallback(uin
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfLeadConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Lead Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -12611,7 +12778,7 @@ void emberAfLeadConcentrationMeasurementClusterClientInitCallback(uint8_t endpoi
  * Ver.: always
  */
 void emberAfLeadConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                  EmberAfAttributeId attributeId,
+                                                                                                  chip::AttributeId attributeId,
                                                                                                   uint16_t manufacturerCode);
 /** @brief Lead Concentration Measurement Cluster Client Message Sent
  *
@@ -12639,7 +12806,7 @@ void emberAfLeadConcentrationMeasurementClusterClientMessageSentCallback(EmberOu
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfLeadConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId,
+                                                                                          chip::AttributeId attributeId,
                                                                                           EmberAfAttributeType attributeType,
                                                                                           uint8_t size, uint8_t * value);
 /** @brief Lead Concentration Measurement Cluster Client Tick
@@ -12648,7 +12815,7 @@ EmberAfStatus emberAfLeadConcentrationMeasurementClusterClientPreAttributeChange
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfLeadConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Lead Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12656,7 +12823,8 @@ void emberAfLeadConcentrationMeasurementClusterClientTickCallback(uint8_t endpoi
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfLeadConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId);
 /** @brief Lead Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12666,7 +12834,7 @@ void emberAfLeadConcentrationMeasurementClusterServerAttributeChangedCallback(ui
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfLeadConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                              EmberAfStatus status);
 /** @brief Lead Concentration Measurement Cluster Server Init
  *
@@ -12674,7 +12842,7 @@ void emberAfLeadConcentrationMeasurementClusterServerDefaultResponseCallback(uin
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfLeadConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Lead Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12685,7 +12853,7 @@ void emberAfLeadConcentrationMeasurementClusterServerInitCallback(uint8_t endpoi
  * Ver.: always
  */
 void emberAfLeadConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                  EmberAfAttributeId attributeId,
+                                                                                                  chip::AttributeId attributeId,
                                                                                                   uint16_t manufacturerCode);
 /** @brief Lead Concentration Measurement Cluster Server Message Sent
  *
@@ -12713,7 +12881,7 @@ void emberAfLeadConcentrationMeasurementClusterServerMessageSentCallback(EmberOu
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfLeadConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId,
+                                                                                          chip::AttributeId attributeId,
                                                                                           EmberAfAttributeType attributeType,
                                                                                           uint8_t size, uint8_t * value);
 /** @brief Lead Concentration Measurement Cluster Server Tick
@@ -12722,7 +12890,7 @@ EmberAfStatus emberAfLeadConcentrationMeasurementClusterServerPreAttributeChange
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfLeadConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Lead Concentration Measurement Cluster Callbacks */
 
@@ -12736,8 +12904,8 @@ void emberAfLeadConcentrationMeasurementClusterServerTickCallback(uint8_t endpoi
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                   EmberAfAttributeId attributeId);
+void emberAfManganeseConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId);
 /** @brief Manganese Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -12747,7 +12915,7 @@ void emberAfManganeseConcentrationMeasurementClusterClientAttributeChangedCallba
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfManganeseConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                   EmberAfStatus status);
 /** @brief Manganese Concentration Measurement Cluster Client Init
  *
@@ -12755,7 +12923,7 @@ void emberAfManganeseConcentrationMeasurementClusterClientDefaultResponseCallbac
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfManganeseConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Manganese Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -12766,7 +12934,7 @@ void emberAfManganeseConcentrationMeasurementClusterClientInitCallback(uint8_t e
  * Ver.: always
  */
 void emberAfManganeseConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Manganese Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -12794,7 +12962,7 @@ void emberAfManganeseConcentrationMeasurementClusterClientMessageSentCallback(Em
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfManganeseConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                EmberAfAttributeType attributeType,
                                                                                                uint8_t size, uint8_t * value);
 /** @brief Manganese Concentration Measurement Cluster Client Tick
@@ -12803,7 +12971,7 @@ EmberAfStatus emberAfManganeseConcentrationMeasurementClusterClientPreAttributeC
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfManganeseConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Manganese Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12811,8 +12979,8 @@ void emberAfManganeseConcentrationMeasurementClusterClientTickCallback(uint8_t e
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                   EmberAfAttributeId attributeId);
+void emberAfManganeseConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId);
 /** @brief Manganese Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12822,7 +12990,7 @@ void emberAfManganeseConcentrationMeasurementClusterServerAttributeChangedCallba
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfManganeseConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                   EmberAfStatus status);
 /** @brief Manganese Concentration Measurement Cluster Server Init
  *
@@ -12830,7 +12998,7 @@ void emberAfManganeseConcentrationMeasurementClusterServerDefaultResponseCallbac
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfManganeseConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Manganese Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12841,7 +13009,7 @@ void emberAfManganeseConcentrationMeasurementClusterServerInitCallback(uint8_t e
  * Ver.: always
  */
 void emberAfManganeseConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Manganese Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -12869,7 +13037,7 @@ void emberAfManganeseConcentrationMeasurementClusterServerMessageSentCallback(Em
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfManganeseConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                EmberAfAttributeType attributeType,
                                                                                                uint8_t size, uint8_t * value);
 /** @brief Manganese Concentration Measurement Cluster Server Tick
@@ -12878,7 +13046,7 @@ EmberAfStatus emberAfManganeseConcentrationMeasurementClusterServerPreAttributeC
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfManganeseConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Manganese Concentration Measurement Cluster Callbacks */
 
@@ -12892,7 +13060,8 @@ void emberAfManganeseConcentrationMeasurementClusterServerTickCallback(uint8_t e
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSulfateConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId);
 /** @brief Sulfate Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -12902,7 +13071,7 @@ void emberAfSulfateConcentrationMeasurementClusterClientAttributeChangedCallback
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfSulfateConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                 EmberAfStatus status);
 /** @brief Sulfate Concentration Measurement Cluster Client Init
  *
@@ -12910,7 +13079,7 @@ void emberAfSulfateConcentrationMeasurementClusterClientDefaultResponseCallback(
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfSulfateConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Sulfate Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -12921,7 +13090,7 @@ void emberAfSulfateConcentrationMeasurementClusterClientInitCallback(uint8_t end
  * Ver.: always
  */
 void emberAfSulfateConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                     EmberAfAttributeId attributeId,
+                                                                                                     chip::AttributeId attributeId,
                                                                                                      uint16_t manufacturerCode);
 /** @brief Sulfate Concentration Measurement Cluster Client Message Sent
  *
@@ -12949,7 +13118,7 @@ void emberAfSulfateConcentrationMeasurementClusterClientMessageSentCallback(Embe
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfSulfateConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              EmberAfAttributeType attributeType,
                                                                                              uint8_t size, uint8_t * value);
 /** @brief Sulfate Concentration Measurement Cluster Client Tick
@@ -12958,7 +13127,7 @@ EmberAfStatus emberAfSulfateConcentrationMeasurementClusterClientPreAttributeCha
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfSulfateConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Sulfate Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12966,7 +13135,8 @@ void emberAfSulfateConcentrationMeasurementClusterClientTickCallback(uint8_t end
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSulfateConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId);
 /** @brief Sulfate Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12976,7 +13146,7 @@ void emberAfSulfateConcentrationMeasurementClusterServerAttributeChangedCallback
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfSulfateConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                 EmberAfStatus status);
 /** @brief Sulfate Concentration Measurement Cluster Server Init
  *
@@ -12984,7 +13154,7 @@ void emberAfSulfateConcentrationMeasurementClusterServerDefaultResponseCallback(
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfSulfateConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Sulfate Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12995,7 +13165,7 @@ void emberAfSulfateConcentrationMeasurementClusterServerInitCallback(uint8_t end
  * Ver.: always
  */
 void emberAfSulfateConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                     EmberAfAttributeId attributeId,
+                                                                                                     chip::AttributeId attributeId,
                                                                                                      uint16_t manufacturerCode);
 /** @brief Sulfate Concentration Measurement Cluster Server Message Sent
  *
@@ -13023,7 +13193,7 @@ void emberAfSulfateConcentrationMeasurementClusterServerMessageSentCallback(Embe
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfSulfateConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              EmberAfAttributeType attributeType,
                                                                                              uint8_t size, uint8_t * value);
 /** @brief Sulfate Concentration Measurement Cluster Server Tick
@@ -13032,7 +13202,7 @@ EmberAfStatus emberAfSulfateConcentrationMeasurementClusterServerPreAttributeCha
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfSulfateConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Sulfate Concentration Measurement Cluster Callbacks */
 
@@ -13047,7 +13217,7 @@ void emberAfSulfateConcentrationMeasurementClusterServerTickCallback(uint8_t end
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfBromodichloromethaneConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId);
+                                                                                              chip::AttributeId attributeId);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -13057,7 +13227,8 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterClientAttributeCh
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfBromodichloromethaneConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                             uint8_t commandId,
                                                                                              EmberAfStatus status);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Client Init
  *
@@ -13065,7 +13236,7 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterClientDefaultResp
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfBromodichloromethaneConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -13076,7 +13247,7 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterClientInitCallbac
  * Ver.: always
  */
 void emberAfBromodichloromethaneConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -13104,14 +13275,14 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterClientMessageSent
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfBromodichloromethaneConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfBromodichloromethaneConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -13120,7 +13291,7 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterClientTickCallbac
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfBromodichloromethaneConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId);
+                                                                                              chip::AttributeId attributeId);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -13130,7 +13301,8 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterServerAttributeCh
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfBromodichloromethaneConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                             uint8_t commandId,
                                                                                              EmberAfStatus status);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Init
  *
@@ -13138,7 +13310,7 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterServerDefaultResp
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfBromodichloromethaneConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -13149,7 +13321,7 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterServerInitCallbac
  * Ver.: always
  */
 void emberAfBromodichloromethaneConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -13177,14 +13349,14 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterServerMessageSent
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfBromodichloromethaneConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfBromodichloromethaneConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Bromodichloromethane Concentration Measurement Cluster Callbacks */
 
@@ -13198,8 +13370,8 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterServerTickCallbac
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                   EmberAfAttributeId attributeId);
+void emberAfBromoformConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId);
 /** @brief Bromoform Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -13209,7 +13381,7 @@ void emberAfBromoformConcentrationMeasurementClusterClientAttributeChangedCallba
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfBromoformConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                   EmberAfStatus status);
 /** @brief Bromoform Concentration Measurement Cluster Client Init
  *
@@ -13217,7 +13389,7 @@ void emberAfBromoformConcentrationMeasurementClusterClientDefaultResponseCallbac
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfBromoformConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Bromoform Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -13228,7 +13400,7 @@ void emberAfBromoformConcentrationMeasurementClusterClientInitCallback(uint8_t e
  * Ver.: always
  */
 void emberAfBromoformConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Bromoform Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -13256,7 +13428,7 @@ void emberAfBromoformConcentrationMeasurementClusterClientMessageSentCallback(Em
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfBromoformConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                EmberAfAttributeType attributeType,
                                                                                                uint8_t size, uint8_t * value);
 /** @brief Bromoform Concentration Measurement Cluster Client Tick
@@ -13265,7 +13437,7 @@ EmberAfStatus emberAfBromoformConcentrationMeasurementClusterClientPreAttributeC
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfBromoformConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Bromoform Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -13273,8 +13445,8 @@ void emberAfBromoformConcentrationMeasurementClusterClientTickCallback(uint8_t e
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                   EmberAfAttributeId attributeId);
+void emberAfBromoformConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId);
 /** @brief Bromoform Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -13284,7 +13456,7 @@ void emberAfBromoformConcentrationMeasurementClusterServerAttributeChangedCallba
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfBromoformConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                   EmberAfStatus status);
 /** @brief Bromoform Concentration Measurement Cluster Server Init
  *
@@ -13292,7 +13464,7 @@ void emberAfBromoformConcentrationMeasurementClusterServerDefaultResponseCallbac
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfBromoformConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Bromoform Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -13303,7 +13475,7 @@ void emberAfBromoformConcentrationMeasurementClusterServerInitCallback(uint8_t e
  * Ver.: always
  */
 void emberAfBromoformConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Bromoform Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -13331,7 +13503,7 @@ void emberAfBromoformConcentrationMeasurementClusterServerMessageSentCallback(Em
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfBromoformConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                EmberAfAttributeType attributeType,
                                                                                                uint8_t size, uint8_t * value);
 /** @brief Bromoform Concentration Measurement Cluster Server Tick
@@ -13340,7 +13512,7 @@ EmberAfStatus emberAfBromoformConcentrationMeasurementClusterServerPreAttributeC
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfBromoformConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Bromoform Concentration Measurement Cluster Callbacks */
 
@@ -13355,7 +13527,7 @@ void emberAfBromoformConcentrationMeasurementClusterServerTickCallback(uint8_t e
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId);
+                                                                                              chip::AttributeId attributeId);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -13365,7 +13537,8 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientAttributeCh
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                             uint8_t commandId,
                                                                                              EmberAfStatus status);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Client Init
  *
@@ -13373,7 +13546,7 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientDefaultResp
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -13384,7 +13557,7 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientInitCallbac
  * Ver.: always
  */
 void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -13412,14 +13585,14 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientMessageSent
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChlorodibromomethaneConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -13428,7 +13601,7 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientTickCallbac
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId);
+                                                                                              chip::AttributeId attributeId);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -13438,7 +13611,8 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerAttributeCh
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                             uint8_t commandId,
                                                                                              EmberAfStatus status);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Init
  *
@@ -13446,7 +13620,7 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerDefaultResp
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -13457,7 +13631,7 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerInitCallbac
  * Ver.: always
  */
 void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -13485,14 +13659,14 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerMessageSent
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChlorodibromomethaneConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Chlorodibromomethane Concentration Measurement Cluster Callbacks */
 
@@ -13506,8 +13680,8 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerTickCallbac
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId);
+void emberAfChloroformConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId);
 /** @brief Chloroform Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -13517,7 +13691,7 @@ void emberAfChloroformConcentrationMeasurementClusterClientAttributeChangedCallb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChloroformConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                    EmberAfStatus status);
 /** @brief Chloroform Concentration Measurement Cluster Client Init
  *
@@ -13525,7 +13699,7 @@ void emberAfChloroformConcentrationMeasurementClusterClientDefaultResponseCallba
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfChloroformConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Chloroform Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -13536,7 +13710,7 @@ void emberAfChloroformConcentrationMeasurementClusterClientInitCallback(uint8_t 
  * Ver.: always
  */
 void emberAfChloroformConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Chloroform Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -13564,7 +13738,7 @@ void emberAfChloroformConcentrationMeasurementClusterClientMessageSentCallback(E
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChloroformConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                                EmberAfAttributeId attributeId,
+                                                                                                chip::AttributeId attributeId,
                                                                                                 EmberAfAttributeType attributeType,
                                                                                                 uint8_t size, uint8_t * value);
 /** @brief Chloroform Concentration Measurement Cluster Client Tick
@@ -13573,7 +13747,7 @@ EmberAfStatus emberAfChloroformConcentrationMeasurementClusterClientPreAttribute
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfChloroformConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Chloroform Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -13581,8 +13755,8 @@ void emberAfChloroformConcentrationMeasurementClusterClientTickCallback(uint8_t 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId);
+void emberAfChloroformConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId);
 /** @brief Chloroform Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -13592,7 +13766,7 @@ void emberAfChloroformConcentrationMeasurementClusterServerAttributeChangedCallb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChloroformConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                    EmberAfStatus status);
 /** @brief Chloroform Concentration Measurement Cluster Server Init
  *
@@ -13600,7 +13774,7 @@ void emberAfChloroformConcentrationMeasurementClusterServerDefaultResponseCallba
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfChloroformConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Chloroform Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -13611,7 +13785,7 @@ void emberAfChloroformConcentrationMeasurementClusterServerInitCallback(uint8_t 
  * Ver.: always
  */
 void emberAfChloroformConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Chloroform Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -13639,7 +13813,7 @@ void emberAfChloroformConcentrationMeasurementClusterServerMessageSentCallback(E
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChloroformConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                                EmberAfAttributeId attributeId,
+                                                                                                chip::AttributeId attributeId,
                                                                                                 EmberAfAttributeType attributeType,
                                                                                                 uint8_t size, uint8_t * value);
 /** @brief Chloroform Concentration Measurement Cluster Server Tick
@@ -13648,7 +13822,7 @@ EmberAfStatus emberAfChloroformConcentrationMeasurementClusterServerPreAttribute
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfChloroformConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Chloroform Concentration Measurement Cluster Callbacks */
 
@@ -13662,7 +13836,8 @@ void emberAfChloroformConcentrationMeasurementClusterServerTickCallback(uint8_t 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSodiumConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId);
 /** @brief Sodium Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -13672,7 +13847,7 @@ void emberAfSodiumConcentrationMeasurementClusterClientAttributeChangedCallback(
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfSodiumConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                EmberAfStatus status);
 /** @brief Sodium Concentration Measurement Cluster Client Init
  *
@@ -13680,7 +13855,7 @@ void emberAfSodiumConcentrationMeasurementClusterClientDefaultResponseCallback(u
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfSodiumConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Sodium Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -13691,7 +13866,7 @@ void emberAfSodiumConcentrationMeasurementClusterClientInitCallback(uint8_t endp
  * Ver.: always
  */
 void emberAfSodiumConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                    EmberAfAttributeId attributeId,
+                                                                                                    chip::AttributeId attributeId,
                                                                                                     uint16_t manufacturerCode);
 /** @brief Sodium Concentration Measurement Cluster Client Message Sent
  *
@@ -13719,7 +13894,7 @@ void emberAfSodiumConcentrationMeasurementClusterClientMessageSentCallback(Ember
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfSodiumConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                            EmberAfAttributeId attributeId,
+                                                                                            chip::AttributeId attributeId,
                                                                                             EmberAfAttributeType attributeType,
                                                                                             uint8_t size, uint8_t * value);
 /** @brief Sodium Concentration Measurement Cluster Client Tick
@@ -13728,7 +13903,7 @@ EmberAfStatus emberAfSodiumConcentrationMeasurementClusterClientPreAttributeChan
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfSodiumConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Sodium Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -13736,7 +13911,8 @@ void emberAfSodiumConcentrationMeasurementClusterClientTickCallback(uint8_t endp
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSodiumConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId);
 /** @brief Sodium Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -13746,7 +13922,7 @@ void emberAfSodiumConcentrationMeasurementClusterServerAttributeChangedCallback(
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfSodiumConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                EmberAfStatus status);
 /** @brief Sodium Concentration Measurement Cluster Server Init
  *
@@ -13754,7 +13930,7 @@ void emberAfSodiumConcentrationMeasurementClusterServerDefaultResponseCallback(u
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfSodiumConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Sodium Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -13765,7 +13941,7 @@ void emberAfSodiumConcentrationMeasurementClusterServerInitCallback(uint8_t endp
  * Ver.: always
  */
 void emberAfSodiumConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                    EmberAfAttributeId attributeId,
+                                                                                                    chip::AttributeId attributeId,
                                                                                                     uint16_t manufacturerCode);
 /** @brief Sodium Concentration Measurement Cluster Server Message Sent
  *
@@ -13793,7 +13969,7 @@ void emberAfSodiumConcentrationMeasurementClusterServerMessageSentCallback(Ember
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfSodiumConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                            EmberAfAttributeId attributeId,
+                                                                                            chip::AttributeId attributeId,
                                                                                             EmberAfAttributeType attributeType,
                                                                                             uint8_t size, uint8_t * value);
 /** @brief Sodium Concentration Measurement Cluster Server Tick
@@ -13802,7 +13978,7 @@ EmberAfStatus emberAfSodiumConcentrationMeasurementClusterServerPreAttributeChan
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfSodiumConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Sodium Concentration Measurement Cluster Callbacks */
 
@@ -13816,7 +13992,7 @@ void emberAfSodiumConcentrationMeasurementClusterServerTickCallback(uint8_t endp
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIasZoneClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIasZoneClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief IAS Zone Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -13826,14 +14002,14 @@ void emberAfIasZoneClusterClientAttributeChangedCallback(uint8_t endpoint, Ember
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIasZoneClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIasZoneClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief IAS Zone Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIasZoneClusterClientInitCallback(uint8_t endpoint);
+void emberAfIasZoneClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief IAS Zone Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -13843,7 +14019,8 @@ void emberAfIasZoneClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIasZoneClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIasZoneClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              uint16_t manufacturerCode);
 /** @brief IAS Zone Cluster Client Message Sent
  *
@@ -13870,7 +14047,7 @@ void emberAfIasZoneClusterClientMessageSentCallback(EmberOutgoingMessageType typ
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIasZoneClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIasZoneClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                      EmberAfAttributeType attributeType, uint8_t size,
                                                                      uint8_t * value);
 /** @brief IAS Zone Cluster Client Tick
@@ -13879,7 +14056,7 @@ EmberAfStatus emberAfIasZoneClusterClientPreAttributeChangedCallback(uint8_t end
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIasZoneClusterClientTickCallback(uint8_t endpoint);
+void emberAfIasZoneClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief IAS Zone Cluster Initiate Normal Operation Mode
  *
  *
@@ -13913,7 +14090,7 @@ bool emberAfIasZoneClusterInitiateTestModeResponseCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIasZoneClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIasZoneClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief IAS Zone Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -13923,14 +14100,14 @@ void emberAfIasZoneClusterServerAttributeChangedCallback(uint8_t endpoint, Ember
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIasZoneClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIasZoneClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief IAS Zone Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIasZoneClusterServerInitCallback(uint8_t endpoint);
+void emberAfIasZoneClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief IAS Zone Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -13940,7 +14117,8 @@ void emberAfIasZoneClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIasZoneClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIasZoneClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              uint16_t manufacturerCode);
 /** @brief IAS Zone Cluster Server Message Sent
  *
@@ -13967,7 +14145,7 @@ void emberAfIasZoneClusterServerMessageSentCallback(EmberOutgoingMessageType typ
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIasZoneClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIasZoneClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                      EmberAfAttributeType attributeType, uint8_t size,
                                                                      uint8_t * value);
 /** @brief IAS Zone Cluster Server Tick
@@ -13976,7 +14154,7 @@ EmberAfStatus emberAfIasZoneClusterServerPreAttributeChangedCallback(uint8_t end
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIasZoneClusterServerTickCallback(uint8_t endpoint);
+void emberAfIasZoneClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief IAS Zone Cluster Zone Enroll Request
  *
  *
@@ -14050,7 +14228,7 @@ bool emberAfIasAceClusterBypassResponseCallback(uint8_t numberOfZones, uint8_t *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIasAceClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIasAceClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief IAS ACE Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -14060,14 +14238,14 @@ void emberAfIasAceClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIasAceClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIasAceClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief IAS ACE Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIasAceClusterClientInitCallback(uint8_t endpoint);
+void emberAfIasAceClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief IAS ACE Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -14077,7 +14255,8 @@ void emberAfIasAceClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIasAceClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIasAceClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief IAS ACE Cluster Client Message Sent
  *
@@ -14104,7 +14283,7 @@ void emberAfIasAceClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIasAceClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIasAceClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief IAS ACE Cluster Client Tick
@@ -14113,7 +14292,7 @@ EmberAfStatus emberAfIasAceClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIasAceClusterClientTickCallback(uint8_t endpoint);
+void emberAfIasAceClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief IAS ACE Cluster Emergency
  *
  *
@@ -14244,7 +14423,7 @@ bool emberAfIasAceClusterPanicCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIasAceClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIasAceClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief IAS ACE Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -14254,14 +14433,14 @@ void emberAfIasAceClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIasAceClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIasAceClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief IAS ACE Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIasAceClusterServerInitCallback(uint8_t endpoint);
+void emberAfIasAceClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief IAS ACE Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -14271,7 +14450,8 @@ void emberAfIasAceClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIasAceClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIasAceClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief IAS ACE Cluster Server Message Sent
  *
@@ -14298,7 +14478,7 @@ void emberAfIasAceClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIasAceClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIasAceClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief IAS ACE Cluster Server Tick
@@ -14307,7 +14487,7 @@ EmberAfStatus emberAfIasAceClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIasAceClusterServerTickCallback(uint8_t endpoint);
+void emberAfIasAceClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief IAS ACE Cluster Set Bypassed Zone List
  *
  *
@@ -14340,7 +14520,7 @@ bool emberAfIasAceClusterZoneStatusChangedCallback(uint8_t zoneId, uint16_t zone
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIasWdClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIasWdClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief IAS WD Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -14350,14 +14530,14 @@ void emberAfIasWdClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIasWdClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIasWdClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief IAS WD Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIasWdClusterClientInitCallback(uint8_t endpoint);
+void emberAfIasWdClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief IAS WD Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -14367,7 +14547,7 @@ void emberAfIasWdClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIasWdClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIasWdClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief IAS WD Cluster Client Message Sent
  *
@@ -14393,7 +14573,7 @@ void emberAfIasWdClusterClientMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIasWdClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIasWdClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief IAS WD Cluster Client Tick
@@ -14402,7 +14582,7 @@ EmberAfStatus emberAfIasWdClusterClientPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIasWdClusterClientTickCallback(uint8_t endpoint);
+void emberAfIasWdClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief IAS WD Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -14410,7 +14590,7 @@ void emberAfIasWdClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIasWdClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIasWdClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief IAS WD Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -14420,14 +14600,14 @@ void emberAfIasWdClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIasWdClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIasWdClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief IAS WD Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIasWdClusterServerInitCallback(uint8_t endpoint);
+void emberAfIasWdClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief IAS WD Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -14437,7 +14617,7 @@ void emberAfIasWdClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIasWdClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIasWdClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief IAS WD Cluster Server Message Sent
  *
@@ -14463,7 +14643,7 @@ void emberAfIasWdClusterServerMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIasWdClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIasWdClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief IAS WD Cluster Server Tick
@@ -14472,7 +14652,7 @@ EmberAfStatus emberAfIasWdClusterServerPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIasWdClusterServerTickCallback(uint8_t endpoint);
+void emberAfIasWdClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief IAS WD Cluster Squawk
  *
  *
@@ -14511,7 +14691,7 @@ bool emberAfGenericTunnelClusterAdvertiseProtocolAddressCallback(uint8_t * proto
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGenericTunnelClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGenericTunnelClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Generic Tunnel Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -14521,14 +14701,15 @@ void emberAfGenericTunnelClusterClientAttributeChangedCallback(uint8_t endpoint,
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGenericTunnelClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGenericTunnelClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                              EmberAfStatus status);
 /** @brief Generic Tunnel Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGenericTunnelClusterClientInitCallback(uint8_t endpoint);
+void emberAfGenericTunnelClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Generic Tunnel Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -14538,7 +14719,8 @@ void emberAfGenericTunnelClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGenericTunnelClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGenericTunnelClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    uint16_t manufacturerCode);
 /** @brief Generic Tunnel Cluster Client Message Sent
  *
@@ -14565,7 +14747,7 @@ void emberAfGenericTunnelClusterClientMessageSentCallback(EmberOutgoingMessageTy
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGenericTunnelClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGenericTunnelClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            EmberAfAttributeType attributeType, uint8_t size,
                                                                            uint8_t * value);
 /** @brief Generic Tunnel Cluster Client Tick
@@ -14574,7 +14756,7 @@ EmberAfStatus emberAfGenericTunnelClusterClientPreAttributeChangedCallback(uint8
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGenericTunnelClusterClientTickCallback(uint8_t endpoint);
+void emberAfGenericTunnelClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Generic Tunnel Cluster Match Protocol Address
  *
  *
@@ -14597,7 +14779,7 @@ bool emberAfGenericTunnelClusterMatchProtocolAddressResponseCallback(uint8_t * d
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGenericTunnelClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGenericTunnelClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Generic Tunnel Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -14607,14 +14789,15 @@ void emberAfGenericTunnelClusterServerAttributeChangedCallback(uint8_t endpoint,
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGenericTunnelClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGenericTunnelClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                              EmberAfStatus status);
 /** @brief Generic Tunnel Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGenericTunnelClusterServerInitCallback(uint8_t endpoint);
+void emberAfGenericTunnelClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Generic Tunnel Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -14624,7 +14807,8 @@ void emberAfGenericTunnelClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGenericTunnelClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGenericTunnelClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    uint16_t manufacturerCode);
 /** @brief Generic Tunnel Cluster Server Message Sent
  *
@@ -14651,7 +14835,7 @@ void emberAfGenericTunnelClusterServerMessageSentCallback(EmberOutgoingMessageTy
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGenericTunnelClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGenericTunnelClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            EmberAfAttributeType attributeType, uint8_t size,
                                                                            uint8_t * value);
 /** @brief Generic Tunnel Cluster Server Tick
@@ -14660,7 +14844,7 @@ EmberAfStatus emberAfGenericTunnelClusterServerPreAttributeChangedCallback(uint8
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGenericTunnelClusterServerTickCallback(uint8_t endpoint);
+void emberAfGenericTunnelClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Generic Tunnel Cluster Callbacks */
 
@@ -14674,7 +14858,7 @@ void emberAfGenericTunnelClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBacnetProtocolTunnelClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief BACnet Protocol Tunnel Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -14684,14 +14868,15 @@ void emberAfBacnetProtocolTunnelClusterClientAttributeChangedCallback(uint8_t en
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBacnetProtocolTunnelClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                     EmberAfStatus status);
 /** @brief BACnet Protocol Tunnel Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterClientInitCallback(uint8_t endpoint);
+void emberAfBacnetProtocolTunnelClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief BACnet Protocol Tunnel Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -14702,7 +14887,7 @@ void emberAfBacnetProtocolTunnelClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfBacnetProtocolTunnelClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId,
+                                                                                          chip::AttributeId attributeId,
                                                                                           uint16_t manufacturerCode);
 /** @brief BACnet Protocol Tunnel Cluster Client Message Sent
  *
@@ -14729,7 +14914,8 @@ void emberAfBacnetProtocolTunnelClusterClientMessageSentCallback(EmberOutgoingMe
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBacnetProtocolTunnelClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBacnetProtocolTunnelClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   EmberAfAttributeType attributeType, uint8_t size,
                                                                                   uint8_t * value);
 /** @brief BACnet Protocol Tunnel Cluster Client Tick
@@ -14738,7 +14924,7 @@ EmberAfStatus emberAfBacnetProtocolTunnelClusterClientPreAttributeChangedCallbac
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterClientTickCallback(uint8_t endpoint);
+void emberAfBacnetProtocolTunnelClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief BACnet Protocol Tunnel Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -14746,7 +14932,7 @@ void emberAfBacnetProtocolTunnelClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBacnetProtocolTunnelClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief BACnet Protocol Tunnel Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -14756,14 +14942,15 @@ void emberAfBacnetProtocolTunnelClusterServerAttributeChangedCallback(uint8_t en
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBacnetProtocolTunnelClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                     EmberAfStatus status);
 /** @brief BACnet Protocol Tunnel Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterServerInitCallback(uint8_t endpoint);
+void emberAfBacnetProtocolTunnelClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief BACnet Protocol Tunnel Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -14774,7 +14961,7 @@ void emberAfBacnetProtocolTunnelClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfBacnetProtocolTunnelClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId,
+                                                                                          chip::AttributeId attributeId,
                                                                                           uint16_t manufacturerCode);
 /** @brief BACnet Protocol Tunnel Cluster Server Message Sent
  *
@@ -14801,7 +14988,8 @@ void emberAfBacnetProtocolTunnelClusterServerMessageSentCallback(EmberOutgoingMe
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBacnetProtocolTunnelClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBacnetProtocolTunnelClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   EmberAfAttributeType attributeType, uint8_t size,
                                                                                   uint8_t * value);
 /** @brief BACnet Protocol Tunnel Cluster Server Tick
@@ -14810,7 +14998,7 @@ EmberAfStatus emberAfBacnetProtocolTunnelClusterServerPreAttributeChangedCallbac
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterServerTickCallback(uint8_t endpoint);
+void emberAfBacnetProtocolTunnelClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief BACnet Protocol Tunnel Cluster Transfer Npdu
  *
  *
@@ -14831,7 +15019,7 @@ bool emberAfBacnetProtocolTunnelClusterTransferNpduCallback(uint8_t * npdu);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAf11073ProtocolTunnelClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief 11073 Protocol Tunnel Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -14841,14 +15029,15 @@ void emberAf11073ProtocolTunnelClusterClientAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAf11073ProtocolTunnelClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief 11073 Protocol Tunnel Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterClientInitCallback(uint8_t endpoint);
+void emberAf11073ProtocolTunnelClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief 11073 Protocol Tunnel Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -14859,7 +15048,7 @@ void emberAf11073ProtocolTunnelClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAf11073ProtocolTunnelClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief 11073 Protocol Tunnel Cluster Client Message Sent
  *
@@ -14886,7 +15075,8 @@ void emberAf11073ProtocolTunnelClusterClientMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAf11073ProtocolTunnelClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAf11073ProtocolTunnelClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief 11073 Protocol Tunnel Cluster Client Tick
@@ -14895,7 +15085,7 @@ EmberAfStatus emberAf11073ProtocolTunnelClusterClientPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterClientTickCallback(uint8_t endpoint);
+void emberAf11073ProtocolTunnelClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief 11073 Protocol Tunnel Cluster Connect Request
  *
  *
@@ -14928,7 +15118,7 @@ bool emberAf11073ProtocolTunnelClusterDisconnectRequestCallback(uint8_t * manage
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAf11073ProtocolTunnelClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief 11073 Protocol Tunnel Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -14938,14 +15128,15 @@ void emberAf11073ProtocolTunnelClusterServerAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAf11073ProtocolTunnelClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief 11073 Protocol Tunnel Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterServerInitCallback(uint8_t endpoint);
+void emberAf11073ProtocolTunnelClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief 11073 Protocol Tunnel Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -14956,7 +15147,7 @@ void emberAf11073ProtocolTunnelClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAf11073ProtocolTunnelClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief 11073 Protocol Tunnel Cluster Server Message Sent
  *
@@ -14983,7 +15174,8 @@ void emberAf11073ProtocolTunnelClusterServerMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAf11073ProtocolTunnelClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAf11073ProtocolTunnelClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief 11073 Protocol Tunnel Cluster Server Tick
@@ -14992,7 +15184,7 @@ EmberAfStatus emberAf11073ProtocolTunnelClusterServerPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterServerTickCallback(uint8_t endpoint);
+void emberAf11073ProtocolTunnelClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief 11073 Protocol Tunnel Cluster Transfer A P D U
  *
  *
@@ -15013,7 +15205,7 @@ bool emberAf11073ProtocolTunnelClusterTransferAPDUCallback(uint8_t * apdu);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIso7816ProtocolTunnelClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief ISO 7816 Protocol Tunnel Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -15023,14 +15215,15 @@ void emberAfIso7816ProtocolTunnelClusterClientAttributeChangedCallback(uint8_t e
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIso7816ProtocolTunnelClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                      EmberAfStatus status);
 /** @brief ISO 7816 Protocol Tunnel Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterClientInitCallback(uint8_t endpoint);
+void emberAfIso7816ProtocolTunnelClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief ISO 7816 Protocol Tunnel Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -15041,7 +15234,7 @@ void emberAfIso7816ProtocolTunnelClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfIso7816ProtocolTunnelClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                           EmberAfAttributeId attributeId,
+                                                                                           chip::AttributeId attributeId,
                                                                                            uint16_t manufacturerCode);
 /** @brief ISO 7816 Protocol Tunnel Cluster Client Message Sent
  *
@@ -15068,7 +15261,8 @@ void emberAfIso7816ProtocolTunnelClusterClientMessageSentCallback(EmberOutgoingM
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIso7816ProtocolTunnelClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIso7816ProtocolTunnelClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                                    uint8_t * value);
 /** @brief ISO 7816 Protocol Tunnel Cluster Client Tick
@@ -15077,7 +15271,7 @@ EmberAfStatus emberAfIso7816ProtocolTunnelClusterClientPreAttributeChangedCallba
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterClientTickCallback(uint8_t endpoint);
+void emberAfIso7816ProtocolTunnelClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief ISO 7816 Protocol Tunnel Cluster Extract Smart Card
  *
  *
@@ -15097,7 +15291,7 @@ bool emberAfIso7816ProtocolTunnelClusterInsertSmartCardCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIso7816ProtocolTunnelClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief ISO 7816 Protocol Tunnel Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -15107,14 +15301,15 @@ void emberAfIso7816ProtocolTunnelClusterServerAttributeChangedCallback(uint8_t e
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIso7816ProtocolTunnelClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                      EmberAfStatus status);
 /** @brief ISO 7816 Protocol Tunnel Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterServerInitCallback(uint8_t endpoint);
+void emberAfIso7816ProtocolTunnelClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief ISO 7816 Protocol Tunnel Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -15125,7 +15320,7 @@ void emberAfIso7816ProtocolTunnelClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfIso7816ProtocolTunnelClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                           EmberAfAttributeId attributeId,
+                                                                                           chip::AttributeId attributeId,
                                                                                            uint16_t manufacturerCode);
 /** @brief ISO 7816 Protocol Tunnel Cluster Server Message Sent
  *
@@ -15152,7 +15347,8 @@ void emberAfIso7816ProtocolTunnelClusterServerMessageSentCallback(EmberOutgoingM
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIso7816ProtocolTunnelClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIso7816ProtocolTunnelClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                                    uint8_t * value);
 /** @brief ISO 7816 Protocol Tunnel Cluster Server Tick
@@ -15161,7 +15357,7 @@ EmberAfStatus emberAfIso7816ProtocolTunnelClusterServerPreAttributeChangedCallba
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterServerTickCallback(uint8_t endpoint);
+void emberAfIso7816ProtocolTunnelClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief ISO 7816 Protocol Tunnel Cluster Transfer Apdu
  *
  *
@@ -15191,7 +15387,7 @@ bool emberAfPriceClusterCancelTariffCallback(uint32_t providerId, uint32_t issue
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPriceClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPriceClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Price Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -15201,14 +15397,14 @@ void emberAfPriceClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPriceClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPriceClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Price Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPriceClusterClientInitCallback(uint8_t endpoint);
+void emberAfPriceClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Price Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -15218,7 +15414,7 @@ void emberAfPriceClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPriceClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPriceClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief Price Cluster Client Message Sent
  *
@@ -15244,7 +15440,7 @@ void emberAfPriceClusterClientMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPriceClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPriceClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief Price Cluster Client Tick
@@ -15253,7 +15449,7 @@ EmberAfStatus emberAfPriceClusterClientPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPriceClusterClientTickCallback(uint8_t endpoint);
+void emberAfPriceClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Price Cluster Cpp Event Response
  *
  *
@@ -15653,7 +15849,7 @@ bool emberAfPriceClusterPublishTierLabelsCallback(uint32_t providerId, uint32_t 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPriceClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPriceClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Price Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -15663,14 +15859,14 @@ void emberAfPriceClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPriceClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPriceClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Price Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPriceClusterServerInitCallback(uint8_t endpoint);
+void emberAfPriceClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Price Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -15680,7 +15876,7 @@ void emberAfPriceClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPriceClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPriceClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief Price Cluster Server Message Sent
  *
@@ -15706,7 +15902,7 @@ void emberAfPriceClusterServerMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPriceClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPriceClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief Price Cluster Server Tick
@@ -15715,7 +15911,7 @@ EmberAfStatus emberAfPriceClusterServerPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPriceClusterServerTickCallback(uint8_t endpoint);
+void emberAfPriceClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Price Cluster Callbacks */
 
@@ -15749,7 +15945,8 @@ bool emberAfDemandResponseLoadControlClusterCancelLoadControlEventCallback(uint3
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDemandResponseLoadControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                           chip::AttributeId attributeId);
 /** @brief Demand Response and Load Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -15759,7 +15956,7 @@ void emberAfDemandResponseLoadControlClusterClientAttributeChangedCallback(uint8
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfDemandResponseLoadControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                           EmberAfStatus status);
 /** @brief Demand Response and Load Control Cluster Client Init
  *
@@ -15767,7 +15964,7 @@ void emberAfDemandResponseLoadControlClusterClientDefaultResponseCallback(uint8_
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfDemandResponseLoadControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Demand Response and Load Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -15778,7 +15975,7 @@ void emberAfDemandResponseLoadControlClusterClientInitCallback(uint8_t endpoint)
  * Ver.: always
  */
 void emberAfDemandResponseLoadControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                uint16_t manufacturerCode);
 /** @brief Demand Response and Load Control Cluster Client Message Sent
  *
@@ -15806,7 +16003,7 @@ void emberAfDemandResponseLoadControlClusterClientMessageSentCallback(EmberOutgo
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfDemandResponseLoadControlClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        EmberAfAttributeType attributeType,
                                                                                        uint8_t size, uint8_t * value);
 /** @brief Demand Response and Load Control Cluster Client Tick
@@ -15815,7 +16012,7 @@ EmberAfStatus emberAfDemandResponseLoadControlClusterClientPreAttributeChangedCa
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfDemandResponseLoadControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Demand Response and Load Control Cluster Get Scheduled Events
  *
  *
@@ -15879,7 +16076,8 @@ bool emberAfDemandResponseLoadControlClusterReportEventStatusCallback(uint32_t i
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDemandResponseLoadControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                           chip::AttributeId attributeId);
 /** @brief Demand Response and Load Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -15889,7 +16087,7 @@ void emberAfDemandResponseLoadControlClusterServerAttributeChangedCallback(uint8
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfDemandResponseLoadControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                           EmberAfStatus status);
 /** @brief Demand Response and Load Control Cluster Server Init
  *
@@ -15897,7 +16095,7 @@ void emberAfDemandResponseLoadControlClusterServerDefaultResponseCallback(uint8_
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfDemandResponseLoadControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Demand Response and Load Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -15908,7 +16106,7 @@ void emberAfDemandResponseLoadControlClusterServerInitCallback(uint8_t endpoint)
  * Ver.: always
  */
 void emberAfDemandResponseLoadControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                uint16_t manufacturerCode);
 /** @brief Demand Response and Load Control Cluster Server Message Sent
  *
@@ -15936,7 +16134,7 @@ void emberAfDemandResponseLoadControlClusterServerMessageSentCallback(EmberOutgo
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfDemandResponseLoadControlClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        EmberAfAttributeType attributeType,
                                                                                        uint8_t size, uint8_t * value);
 /** @brief Demand Response and Load Control Cluster Server Tick
@@ -15945,7 +16143,7 @@ EmberAfStatus emberAfDemandResponseLoadControlClusterServerPreAttributeChangedCa
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfDemandResponseLoadControlClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Demand Response and Load Control Cluster Callbacks */
 
@@ -15973,7 +16171,7 @@ bool emberAfSimpleMeteringClusterChangeSupplyCallback(uint32_t providerId, uint3
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSimpleMeteringClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSimpleMeteringClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Simple Metering Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -15983,14 +16181,15 @@ void emberAfSimpleMeteringClusterClientAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSimpleMeteringClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSimpleMeteringClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Simple Metering Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSimpleMeteringClusterClientInitCallback(uint8_t endpoint);
+void emberAfSimpleMeteringClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Simple Metering Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -16000,8 +16199,8 @@ void emberAfSimpleMeteringClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfSimpleMeteringClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfSimpleMeteringClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Simple Metering Cluster Client Message Sent
  *
@@ -16028,7 +16227,8 @@ void emberAfSimpleMeteringClusterClientMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSimpleMeteringClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSimpleMeteringClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Simple Metering Cluster Client Tick
@@ -16037,7 +16237,7 @@ EmberAfStatus emberAfSimpleMeteringClusterClientPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSimpleMeteringClusterClientTickCallback(uint8_t endpoint);
+void emberAfSimpleMeteringClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Simple Metering Cluster Configure Mirror
  *
  *
@@ -16064,7 +16264,7 @@ bool emberAfSimpleMeteringClusterConfigureMirrorCallback(uint32_t issuerEventId,
 bool emberAfSimpleMeteringClusterConfigureNotificationFlagsCallback(uint32_t issuerEventId, uint8_t notificationScheme,
                                                                     uint16_t notificationFlagAttributeId, uint16_t clusterId,
                                                                     uint16_t manufacturerCode, uint8_t numberOfCommands,
-                                                                    uint8_t * commandIds);
+                                                                    chip::CommandId * commandIds);
 /** @brief Simple Metering Cluster Configure Notification Scheme
  *
  *
@@ -16249,7 +16449,7 @@ bool emberAfSimpleMeteringClusterScheduleSnapshotResponseCallback(uint32_t issue
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSimpleMeteringClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSimpleMeteringClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Simple Metering Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -16259,14 +16459,15 @@ void emberAfSimpleMeteringClusterServerAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSimpleMeteringClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSimpleMeteringClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Simple Metering Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSimpleMeteringClusterServerInitCallback(uint8_t endpoint);
+void emberAfSimpleMeteringClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Simple Metering Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -16276,8 +16477,8 @@ void emberAfSimpleMeteringClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfSimpleMeteringClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfSimpleMeteringClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Simple Metering Cluster Server Message Sent
  *
@@ -16304,7 +16505,8 @@ void emberAfSimpleMeteringClusterServerMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSimpleMeteringClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSimpleMeteringClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Simple Metering Cluster Server Tick
@@ -16313,7 +16515,7 @@ EmberAfStatus emberAfSimpleMeteringClusterServerPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSimpleMeteringClusterServerTickCallback(uint8_t endpoint);
+void emberAfSimpleMeteringClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Simple Metering Cluster Set Supply Status
  *
  *
@@ -16417,7 +16619,7 @@ bool emberAfMessagingClusterCancelMessageCallback(uint32_t messageId, uint8_t me
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMessagingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMessagingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Messaging Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -16427,14 +16629,15 @@ void emberAfMessagingClusterClientAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMessagingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMessagingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Messaging Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMessagingClusterClientInitCallback(uint8_t endpoint);
+void emberAfMessagingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Messaging Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -16444,7 +16647,8 @@ void emberAfMessagingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfMessagingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfMessagingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Messaging Cluster Client Message Sent
  *
@@ -16471,7 +16675,7 @@ void emberAfMessagingClusterClientMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMessagingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMessagingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Messaging Cluster Client Tick
@@ -16480,7 +16684,7 @@ EmberAfStatus emberAfMessagingClusterClientPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMessagingClusterClientTickCallback(uint8_t endpoint);
+void emberAfMessagingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Messaging Cluster Display Message
  *
  *
@@ -16540,7 +16744,7 @@ bool emberAfMessagingClusterMessageConfirmationCallback(uint32_t messageId, uint
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMessagingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMessagingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Messaging Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -16550,14 +16754,15 @@ void emberAfMessagingClusterServerAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMessagingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMessagingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Messaging Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMessagingClusterServerInitCallback(uint8_t endpoint);
+void emberAfMessagingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Messaging Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -16567,7 +16772,8 @@ void emberAfMessagingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfMessagingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfMessagingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Messaging Cluster Server Message Sent
  *
@@ -16594,7 +16800,7 @@ void emberAfMessagingClusterServerMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMessagingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMessagingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Messaging Cluster Server Tick
@@ -16603,7 +16809,7 @@ EmberAfStatus emberAfMessagingClusterServerPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMessagingClusterServerTickCallback(uint8_t endpoint);
+void emberAfMessagingClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Messaging Cluster Callbacks */
 
@@ -16633,7 +16839,7 @@ bool emberAfTunnelingClusterAckTransferDataServerToClientCallback(uint16_t tunne
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTunnelingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfTunnelingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Tunneling Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -16643,14 +16849,15 @@ void emberAfTunnelingClusterClientAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTunnelingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfTunnelingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Tunneling Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTunnelingClusterClientInitCallback(uint8_t endpoint);
+void emberAfTunnelingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Tunneling Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -16660,7 +16867,8 @@ void emberAfTunnelingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfTunnelingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfTunnelingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Tunneling Cluster Client Message Sent
  *
@@ -16687,7 +16895,7 @@ void emberAfTunnelingClusterClientMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfTunnelingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfTunnelingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Tunneling Cluster Client Tick
@@ -16696,7 +16904,7 @@ EmberAfStatus emberAfTunnelingClusterClientPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTunnelingClusterClientTickCallback(uint8_t endpoint);
+void emberAfTunnelingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Tunneling Cluster Close Tunnel
  *
  *
@@ -16755,7 +16963,7 @@ bool emberAfTunnelingClusterRequestTunnelResponseCallback(uint16_t tunnelId, uin
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTunnelingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfTunnelingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Tunneling Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -16765,14 +16973,15 @@ void emberAfTunnelingClusterServerAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTunnelingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfTunnelingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Tunneling Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTunnelingClusterServerInitCallback(uint8_t endpoint);
+void emberAfTunnelingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Tunneling Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -16782,7 +16991,8 @@ void emberAfTunnelingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfTunnelingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfTunnelingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Tunneling Cluster Server Message Sent
  *
@@ -16809,7 +17019,7 @@ void emberAfTunnelingClusterServerMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfTunnelingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfTunnelingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Tunneling Cluster Server Tick
@@ -16818,7 +17028,7 @@ EmberAfStatus emberAfTunnelingClusterServerPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTunnelingClusterServerTickCallback(uint8_t endpoint);
+void emberAfTunnelingClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Tunneling Cluster Supported Tunnel Protocols Response
  *
  *
@@ -16923,7 +17133,7 @@ bool emberAfPrepaymentClusterChangePaymentModeResponseCallback(uint8_t friendlyC
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPrepaymentClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPrepaymentClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Prepayment Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -16933,14 +17143,15 @@ void emberAfPrepaymentClusterClientAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPrepaymentClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPrepaymentClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Prepayment Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPrepaymentClusterClientInitCallback(uint8_t endpoint);
+void emberAfPrepaymentClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Prepayment Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -16950,7 +17161,8 @@ void emberAfPrepaymentClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPrepaymentClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPrepaymentClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Prepayment Cluster Client Message Sent
  *
@@ -16977,7 +17189,7 @@ void emberAfPrepaymentClusterClientMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPrepaymentClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPrepaymentClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Prepayment Cluster Client Tick
@@ -16986,7 +17198,7 @@ EmberAfStatus emberAfPrepaymentClusterClientPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPrepaymentClusterClientTickCallback(uint8_t endpoint);
+void emberAfPrepaymentClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Prepayment Cluster Consumer Top Up
  *
  *
@@ -17106,7 +17318,7 @@ bool emberAfPrepaymentClusterSelectAvailableEmergencyCreditCallback(uint32_t com
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPrepaymentClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPrepaymentClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Prepayment Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -17116,14 +17328,15 @@ void emberAfPrepaymentClusterServerAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPrepaymentClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPrepaymentClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Prepayment Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPrepaymentClusterServerInitCallback(uint8_t endpoint);
+void emberAfPrepaymentClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Prepayment Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -17133,7 +17346,8 @@ void emberAfPrepaymentClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPrepaymentClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPrepaymentClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Prepayment Cluster Server Message Sent
  *
@@ -17160,7 +17374,7 @@ void emberAfPrepaymentClusterServerMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPrepaymentClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPrepaymentClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Prepayment Cluster Server Tick
@@ -17169,7 +17383,7 @@ EmberAfStatus emberAfPrepaymentClusterServerPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPrepaymentClusterServerTickCallback(uint8_t endpoint);
+void emberAfPrepaymentClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Prepayment Cluster Set Low Credit Warning Level
  *
  *
@@ -17214,7 +17428,7 @@ bool emberAfPrepaymentClusterSetOverallDebtCapCallback(uint32_t providerId, uint
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfEnergyManagementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfEnergyManagementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Energy Management Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -17224,14 +17438,15 @@ void emberAfEnergyManagementClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEnergyManagementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfEnergyManagementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Energy Management Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEnergyManagementClusterClientInitCallback(uint8_t endpoint);
+void emberAfEnergyManagementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Energy Management Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -17241,8 +17456,8 @@ void emberAfEnergyManagementClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfEnergyManagementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfEnergyManagementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Energy Management Cluster Client Message Sent
  *
@@ -17269,7 +17484,8 @@ void emberAfEnergyManagementClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfEnergyManagementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfEnergyManagementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Energy Management Cluster Client Tick
@@ -17278,7 +17494,7 @@ EmberAfStatus emberAfEnergyManagementClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEnergyManagementClusterClientTickCallback(uint8_t endpoint);
+void emberAfEnergyManagementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Energy Management Cluster Manage Event
  *
  *
@@ -17317,7 +17533,7 @@ bool emberAfEnergyManagementClusterReportEventStatusCallback(uint32_t issuerEven
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfEnergyManagementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfEnergyManagementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Energy Management Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -17327,14 +17543,15 @@ void emberAfEnergyManagementClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEnergyManagementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfEnergyManagementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Energy Management Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEnergyManagementClusterServerInitCallback(uint8_t endpoint);
+void emberAfEnergyManagementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Energy Management Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -17344,8 +17561,8 @@ void emberAfEnergyManagementClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfEnergyManagementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfEnergyManagementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Energy Management Cluster Server Message Sent
  *
@@ -17372,7 +17589,8 @@ void emberAfEnergyManagementClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfEnergyManagementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfEnergyManagementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Energy Management Cluster Server Tick
@@ -17381,7 +17599,7 @@ EmberAfStatus emberAfEnergyManagementClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEnergyManagementClusterServerTickCallback(uint8_t endpoint);
+void emberAfEnergyManagementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Energy Management Cluster Callbacks */
 
@@ -17404,7 +17622,7 @@ bool emberAfCalendarClusterCancelCalendarCallback(uint32_t providerId, uint32_t 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfCalendarClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfCalendarClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Calendar Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -17414,14 +17632,15 @@ void emberAfCalendarClusterClientAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCalendarClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfCalendarClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Calendar Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCalendarClusterClientInitCallback(uint8_t endpoint);
+void emberAfCalendarClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Calendar Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -17431,7 +17650,8 @@ void emberAfCalendarClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfCalendarClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfCalendarClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Calendar Cluster Client Message Sent
  *
@@ -17458,7 +17678,7 @@ void emberAfCalendarClusterClientMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfCalendarClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfCalendarClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Calendar Cluster Client Tick
@@ -17467,7 +17687,7 @@ EmberAfStatus emberAfCalendarClusterClientPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCalendarClusterClientTickCallback(uint8_t endpoint);
+void emberAfCalendarClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Calendar Cluster Get Calendar
  *
  *
@@ -17623,7 +17843,7 @@ bool emberAfCalendarClusterPublishWeekProfileCallback(uint32_t providerId, uint3
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfCalendarClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfCalendarClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Calendar Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -17633,14 +17853,15 @@ void emberAfCalendarClusterServerAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCalendarClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfCalendarClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Calendar Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCalendarClusterServerInitCallback(uint8_t endpoint);
+void emberAfCalendarClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Calendar Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -17650,7 +17871,8 @@ void emberAfCalendarClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfCalendarClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfCalendarClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Calendar Cluster Server Message Sent
  *
@@ -17677,7 +17899,7 @@ void emberAfCalendarClusterServerMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfCalendarClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfCalendarClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Calendar Cluster Server Tick
@@ -17686,7 +17908,7 @@ EmberAfStatus emberAfCalendarClusterServerPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCalendarClusterServerTickCallback(uint8_t endpoint);
+void emberAfCalendarClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Calendar Cluster Callbacks */
 
@@ -17700,7 +17922,7 @@ void emberAfCalendarClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDeviceManagementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDeviceManagementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Device Management Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -17710,14 +17932,15 @@ void emberAfDeviceManagementClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDeviceManagementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDeviceManagementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Device Management Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDeviceManagementClusterClientInitCallback(uint8_t endpoint);
+void emberAfDeviceManagementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Device Management Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -17727,8 +17950,8 @@ void emberAfDeviceManagementClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDeviceManagementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfDeviceManagementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Device Management Cluster Client Message Sent
  *
@@ -17755,7 +17978,8 @@ void emberAfDeviceManagementClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDeviceManagementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDeviceManagementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Device Management Cluster Client Tick
@@ -17764,7 +17988,7 @@ EmberAfStatus emberAfDeviceManagementClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDeviceManagementClusterClientTickCallback(uint8_t endpoint);
+void emberAfDeviceManagementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Device Management Cluster Get C I N
  *
  *
@@ -17864,7 +18088,7 @@ bool emberAfDeviceManagementClusterRequestNewPasswordResponseCallback(uint32_t i
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDeviceManagementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDeviceManagementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Device Management Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -17874,14 +18098,15 @@ void emberAfDeviceManagementClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDeviceManagementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDeviceManagementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Device Management Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDeviceManagementClusterServerInitCallback(uint8_t endpoint);
+void emberAfDeviceManagementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Device Management Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -17891,8 +18116,8 @@ void emberAfDeviceManagementClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDeviceManagementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfDeviceManagementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Device Management Cluster Server Message Sent
  *
@@ -17919,7 +18144,8 @@ void emberAfDeviceManagementClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDeviceManagementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDeviceManagementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Device Management Cluster Server Tick
@@ -17928,7 +18154,7 @@ EmberAfStatus emberAfDeviceManagementClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDeviceManagementClusterServerTickCallback(uint8_t endpoint);
+void emberAfDeviceManagementClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Device Management Cluster Set Event Configuration
  *
  *
@@ -17991,7 +18217,7 @@ bool emberAfEventsClusterClearEventLogResponseCallback(uint8_t clearedEventsLogs
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfEventsClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfEventsClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Events Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -18001,14 +18227,14 @@ void emberAfEventsClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEventsClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfEventsClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Events Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEventsClusterClientInitCallback(uint8_t endpoint);
+void emberAfEventsClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Events Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -18018,7 +18244,8 @@ void emberAfEventsClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfEventsClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfEventsClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Events Cluster Client Message Sent
  *
@@ -18045,7 +18272,7 @@ void emberAfEventsClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfEventsClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfEventsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Events Cluster Client Tick
@@ -18054,7 +18281,7 @@ EmberAfStatus emberAfEventsClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEventsClusterClientTickCallback(uint8_t endpoint);
+void emberAfEventsClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Events Cluster Get Event Log
  *
  *
@@ -18099,7 +18326,7 @@ bool emberAfEventsClusterPublishEventLogCallback(uint16_t totalNumberOfEvents, u
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfEventsClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfEventsClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Events Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -18109,14 +18336,14 @@ void emberAfEventsClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEventsClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfEventsClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Events Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEventsClusterServerInitCallback(uint8_t endpoint);
+void emberAfEventsClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Events Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -18126,7 +18353,8 @@ void emberAfEventsClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfEventsClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfEventsClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Events Cluster Server Message Sent
  *
@@ -18153,7 +18381,7 @@ void emberAfEventsClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfEventsClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfEventsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Events Cluster Server Tick
@@ -18162,7 +18390,7 @@ EmberAfStatus emberAfEventsClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEventsClusterServerTickCallback(uint8_t endpoint);
+void emberAfEventsClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Events Cluster Callbacks */
 
@@ -18176,7 +18404,7 @@ void emberAfEventsClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMduPairingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMduPairingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief MDU Pairing Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -18186,14 +18414,15 @@ void emberAfMduPairingClusterClientAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMduPairingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMduPairingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief MDU Pairing Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMduPairingClusterClientInitCallback(uint8_t endpoint);
+void emberAfMduPairingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief MDU Pairing Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -18203,7 +18432,8 @@ void emberAfMduPairingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfMduPairingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfMduPairingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief MDU Pairing Cluster Client Message Sent
  *
@@ -18230,7 +18460,7 @@ void emberAfMduPairingClusterClientMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMduPairingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMduPairingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief MDU Pairing Cluster Client Tick
@@ -18239,7 +18469,7 @@ EmberAfStatus emberAfMduPairingClusterClientPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMduPairingClusterClientTickCallback(uint8_t endpoint);
+void emberAfMduPairingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief MDU Pairing Cluster Pairing Request
  *
  *
@@ -18267,7 +18497,7 @@ bool emberAfMduPairingClusterPairingResponseCallback(uint32_t pairingInformation
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMduPairingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMduPairingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief MDU Pairing Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -18277,14 +18507,15 @@ void emberAfMduPairingClusterServerAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMduPairingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMduPairingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief MDU Pairing Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMduPairingClusterServerInitCallback(uint8_t endpoint);
+void emberAfMduPairingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief MDU Pairing Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -18294,7 +18525,8 @@ void emberAfMduPairingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfMduPairingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfMduPairingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief MDU Pairing Cluster Server Message Sent
  *
@@ -18321,7 +18553,7 @@ void emberAfMduPairingClusterServerMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMduPairingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMduPairingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief MDU Pairing Cluster Server Tick
@@ -18330,7 +18562,7 @@ EmberAfStatus emberAfMduPairingClusterServerPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMduPairingClusterServerTickCallback(uint8_t endpoint);
+void emberAfMduPairingClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END MDU Pairing Cluster Callbacks */
 
@@ -18344,7 +18576,7 @@ void emberAfMduPairingClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSubGhzClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSubGhzClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Sub-GHz Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -18354,14 +18586,14 @@ void emberAfSubGhzClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSubGhzClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSubGhzClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Sub-GHz Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSubGhzClusterClientInitCallback(uint8_t endpoint);
+void emberAfSubGhzClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Sub-GHz Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -18371,7 +18603,8 @@ void emberAfSubGhzClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfSubGhzClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfSubGhzClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Sub-GHz Cluster Client Message Sent
  *
@@ -18398,7 +18631,7 @@ void emberAfSubGhzClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSubGhzClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSubGhzClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Sub-GHz Cluster Client Tick
@@ -18407,7 +18640,7 @@ EmberAfStatus emberAfSubGhzClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSubGhzClusterClientTickCallback(uint8_t endpoint);
+void emberAfSubGhzClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Sub-GHz Cluster Get Suspend Zcl Messages Status
  *
  *
@@ -18421,7 +18654,7 @@ bool emberAfSubGhzClusterGetSuspendZclMessagesStatusCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSubGhzClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSubGhzClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Sub-GHz Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -18431,14 +18664,14 @@ void emberAfSubGhzClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSubGhzClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSubGhzClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Sub-GHz Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSubGhzClusterServerInitCallback(uint8_t endpoint);
+void emberAfSubGhzClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Sub-GHz Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -18448,7 +18681,8 @@ void emberAfSubGhzClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfSubGhzClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfSubGhzClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Sub-GHz Cluster Server Message Sent
  *
@@ -18475,7 +18709,7 @@ void emberAfSubGhzClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSubGhzClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSubGhzClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Sub-GHz Cluster Server Tick
@@ -18484,7 +18718,7 @@ EmberAfStatus emberAfSubGhzClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSubGhzClusterServerTickCallback(uint8_t endpoint);
+void emberAfSubGhzClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Sub-GHz Cluster Suspend Zcl Messages
  *
  *
@@ -18516,7 +18750,7 @@ bool emberAfKeyEstablishmentClusterClientCommandReceivedCallback(EmberAfClusterC
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfKeyEstablishmentClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfKeyEstablishmentClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Key Establishment Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -18526,14 +18760,15 @@ void emberAfKeyEstablishmentClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfKeyEstablishmentClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfKeyEstablishmentClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Key Establishment Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfKeyEstablishmentClusterClientInitCallback(uint8_t endpoint);
+void emberAfKeyEstablishmentClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Key Establishment Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -18543,8 +18778,8 @@ void emberAfKeyEstablishmentClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfKeyEstablishmentClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfKeyEstablishmentClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Key Establishment Cluster Client Message Sent
  *
@@ -18571,7 +18806,8 @@ void emberAfKeyEstablishmentClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfKeyEstablishmentClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfKeyEstablishmentClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Key Establishment Cluster Client Tick
@@ -18580,7 +18816,7 @@ EmberAfStatus emberAfKeyEstablishmentClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfKeyEstablishmentClusterClientTickCallback(uint8_t endpoint);
+void emberAfKeyEstablishmentClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Key Establishment Cluster Confirm Key Data Request
  *
  *
@@ -18640,7 +18876,7 @@ bool emberAfKeyEstablishmentClusterInitiateKeyEstablishmentResponseCallback(uint
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfKeyEstablishmentClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfKeyEstablishmentClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Key Establishment Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -18650,14 +18886,15 @@ void emberAfKeyEstablishmentClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfKeyEstablishmentClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfKeyEstablishmentClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Key Establishment Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfKeyEstablishmentClusterServerInitCallback(uint8_t endpoint);
+void emberAfKeyEstablishmentClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Key Establishment Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -18667,8 +18904,8 @@ void emberAfKeyEstablishmentClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfKeyEstablishmentClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfKeyEstablishmentClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Key Establishment Cluster Server Message Sent
  *
@@ -18695,7 +18932,8 @@ void emberAfKeyEstablishmentClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfKeyEstablishmentClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfKeyEstablishmentClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Key Establishment Cluster Server Tick
@@ -18704,7 +18942,7 @@ EmberAfStatus emberAfKeyEstablishmentClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfKeyEstablishmentClusterServerTickCallback(uint8_t endpoint);
+void emberAfKeyEstablishmentClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Key Establishment Cluster Terminate Key Establishment
  *
  *
@@ -18739,7 +18977,7 @@ bool emberAfKeyEstablishmentClusterServerCommandReceivedCallback(EmberAfClusterC
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfInformationClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfInformationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Information Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -18749,14 +18987,15 @@ void emberAfInformationClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfInformationClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfInformationClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Information Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfInformationClusterClientInitCallback(uint8_t endpoint);
+void emberAfInformationClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Information Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -18766,7 +19005,8 @@ void emberAfInformationClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfInformationClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfInformationClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Information Cluster Client Message Sent
  *
@@ -18793,7 +19033,7 @@ void emberAfInformationClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfInformationClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfInformationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Information Cluster Client Tick
@@ -18802,7 +19042,7 @@ EmberAfStatus emberAfInformationClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfInformationClusterClientTickCallback(uint8_t endpoint);
+void emberAfInformationClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Information Cluster Configure Delivery Enable
  *
  *
@@ -18917,7 +19157,7 @@ bool emberAfInformationClusterSendPreferenceResponseCallback(uint8_t * statusFee
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfInformationClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfInformationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Information Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -18927,14 +19167,15 @@ void emberAfInformationClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfInformationClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfInformationClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Information Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfInformationClusterServerInitCallback(uint8_t endpoint);
+void emberAfInformationClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Information Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -18944,7 +19185,8 @@ void emberAfInformationClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfInformationClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfInformationClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Information Cluster Server Message Sent
  *
@@ -18971,7 +19213,7 @@ void emberAfInformationClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfInformationClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfInformationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Information Cluster Server Request Preference
@@ -18986,7 +19228,7 @@ bool emberAfInformationClusterServerRequestPreferenceCallback(void);
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfInformationClusterServerTickCallback(uint8_t endpoint);
+void emberAfInformationClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Information Cluster Update
  *
  *
@@ -19016,7 +19258,7 @@ bool emberAfInformationClusterUpdateResponseCallback(uint8_t * notificationList)
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDataSharingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDataSharingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Data Sharing Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -19026,14 +19268,15 @@ void emberAfDataSharingClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDataSharingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDataSharingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Data Sharing Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDataSharingClusterClientInitCallback(uint8_t endpoint);
+void emberAfDataSharingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Data Sharing Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -19043,7 +19286,8 @@ void emberAfDataSharingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDataSharingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDataSharingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Data Sharing Cluster Client Message Sent
  *
@@ -19070,7 +19314,7 @@ void emberAfDataSharingClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDataSharingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDataSharingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Data Sharing Cluster Client Tick
@@ -19079,7 +19323,7 @@ EmberAfStatus emberAfDataSharingClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDataSharingClusterClientTickCallback(uint8_t endpoint);
+void emberAfDataSharingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Data Sharing Cluster File Transmission
  *
  *
@@ -19137,7 +19381,7 @@ bool emberAfDataSharingClusterRecordTransmissionCallback(uint8_t transmitOptions
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDataSharingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDataSharingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Data Sharing Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -19147,14 +19391,15 @@ void emberAfDataSharingClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDataSharingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDataSharingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Data Sharing Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDataSharingClusterServerInitCallback(uint8_t endpoint);
+void emberAfDataSharingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Data Sharing Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -19164,7 +19409,8 @@ void emberAfDataSharingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDataSharingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDataSharingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Data Sharing Cluster Server Message Sent
  *
@@ -19191,7 +19437,7 @@ void emberAfDataSharingClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDataSharingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDataSharingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Data Sharing Cluster Server Tick
@@ -19200,7 +19446,7 @@ EmberAfStatus emberAfDataSharingClusterServerPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDataSharingClusterServerTickCallback(uint8_t endpoint);
+void emberAfDataSharingClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Data Sharing Cluster Write File Request
  *
  *
@@ -19237,7 +19483,7 @@ bool emberAfGamingClusterActionControlCallback(uint32_t actions);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGamingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGamingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Gaming Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -19247,14 +19493,14 @@ void emberAfGamingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGamingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGamingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Gaming Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGamingClusterClientInitCallback(uint8_t endpoint);
+void emberAfGamingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Gaming Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -19264,7 +19510,8 @@ void emberAfGamingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGamingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGamingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Gaming Cluster Client Message Sent
  *
@@ -19291,7 +19538,7 @@ void emberAfGamingClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGamingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGamingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Gaming Cluster Client Tick
@@ -19300,7 +19547,7 @@ EmberAfStatus emberAfGamingClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGamingClusterClientTickCallback(uint8_t endpoint);
+void emberAfGamingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Gaming Cluster Download Game
  *
  *
@@ -19330,7 +19577,7 @@ bool emberAfGamingClusterGameAnnouncementCallback(uint16_t gameId, uint8_t gameM
  * @param status   Ver.: always
  * @param message   Ver.: always
  */
-bool emberAfGamingClusterGeneralResponseCallback(uint8_t commandId, uint8_t status, uint8_t * message);
+bool emberAfGamingClusterGeneralResponseCallback(chip::CommandId commandId, uint8_t status, uint8_t * message);
 /** @brief Gaming Cluster Join Game
  *
  *
@@ -19373,7 +19620,7 @@ bool emberAfGamingClusterSearchGameCallback(uint8_t specificGame, uint16_t gameI
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGamingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGamingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Gaming Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -19383,14 +19630,14 @@ void emberAfGamingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGamingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGamingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Gaming Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGamingClusterServerInitCallback(uint8_t endpoint);
+void emberAfGamingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Gaming Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -19400,7 +19647,8 @@ void emberAfGamingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGamingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGamingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Gaming Cluster Server Message Sent
  *
@@ -19427,7 +19675,7 @@ void emberAfGamingClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGamingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGamingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Gaming Cluster Server Tick
@@ -19436,7 +19684,7 @@ EmberAfStatus emberAfGamingClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGamingClusterServerTickCallback(uint8_t endpoint);
+void emberAfGamingClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Gaming Cluster Start Game
  *
  *
@@ -19462,7 +19710,7 @@ bool emberAfGamingClusterStartOverCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDataRateControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDataRateControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Data Rate Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -19472,14 +19720,15 @@ void emberAfDataRateControlClusterClientAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDataRateControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDataRateControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Data Rate Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDataRateControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfDataRateControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Data Rate Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -19489,8 +19738,8 @@ void emberAfDataRateControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDataRateControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfDataRateControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Data Rate Control Cluster Client Message Sent
  *
@@ -19517,7 +19766,8 @@ void emberAfDataRateControlClusterClientMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDataRateControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDataRateControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Data Rate Control Cluster Client Tick
@@ -19526,7 +19776,7 @@ EmberAfStatus emberAfDataRateControlClusterClientPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDataRateControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfDataRateControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Data Rate Control Cluster Data Rate Control
  *
  *
@@ -19571,7 +19821,7 @@ bool emberAfDataRateControlClusterPathDeletionCallback(uint16_t originatorAddres
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDataRateControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDataRateControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Data Rate Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -19581,14 +19831,15 @@ void emberAfDataRateControlClusterServerAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDataRateControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDataRateControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Data Rate Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDataRateControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfDataRateControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Data Rate Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -19598,8 +19849,8 @@ void emberAfDataRateControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDataRateControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfDataRateControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Data Rate Control Cluster Server Message Sent
  *
@@ -19626,7 +19877,8 @@ void emberAfDataRateControlClusterServerMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDataRateControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDataRateControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Data Rate Control Cluster Server Tick
@@ -19635,7 +19887,7 @@ EmberAfStatus emberAfDataRateControlClusterServerPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDataRateControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfDataRateControlClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Data Rate Control Cluster Callbacks */
 
@@ -19649,7 +19901,7 @@ void emberAfDataRateControlClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfVoiceOverZigbeeClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Voice over ZigBee Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -19659,14 +19911,15 @@ void emberAfVoiceOverZigbeeClusterClientAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfVoiceOverZigbeeClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Voice over ZigBee Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterClientInitCallback(uint8_t endpoint);
+void emberAfVoiceOverZigbeeClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Voice over ZigBee Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -19676,8 +19929,8 @@ void emberAfVoiceOverZigbeeClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfVoiceOverZigbeeClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Voice over ZigBee Cluster Client Message Sent
  *
@@ -19704,7 +19957,8 @@ void emberAfVoiceOverZigbeeClusterClientMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfVoiceOverZigbeeClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfVoiceOverZigbeeClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Voice over ZigBee Cluster Client Tick
@@ -19713,7 +19967,7 @@ EmberAfStatus emberAfVoiceOverZigbeeClusterClientPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterClientTickCallback(uint8_t endpoint);
+void emberAfVoiceOverZigbeeClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Voice over ZigBee Cluster Control
  *
  *
@@ -19756,7 +20010,7 @@ bool emberAfVoiceOverZigbeeClusterEstablishmentResponseCallback(uint8_t ackNack,
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfVoiceOverZigbeeClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Voice over ZigBee Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -19766,14 +20020,15 @@ void emberAfVoiceOverZigbeeClusterServerAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfVoiceOverZigbeeClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Voice over ZigBee Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterServerInitCallback(uint8_t endpoint);
+void emberAfVoiceOverZigbeeClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Voice over ZigBee Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -19783,8 +20038,8 @@ void emberAfVoiceOverZigbeeClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfVoiceOverZigbeeClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Voice over ZigBee Cluster Server Message Sent
  *
@@ -19811,7 +20066,8 @@ void emberAfVoiceOverZigbeeClusterServerMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfVoiceOverZigbeeClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfVoiceOverZigbeeClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Voice over ZigBee Cluster Server Tick
@@ -19820,7 +20076,7 @@ EmberAfStatus emberAfVoiceOverZigbeeClusterServerPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterServerTickCallback(uint8_t endpoint);
+void emberAfVoiceOverZigbeeClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Voice over ZigBee Cluster Voice Transmission
  *
  *
@@ -19867,7 +20123,7 @@ bool emberAfChattingClusterChatMessageCallback(uint16_t destinationUid, uint16_t
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChattingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfChattingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Chatting Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -19877,14 +20133,15 @@ void emberAfChattingClusterClientAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChattingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfChattingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Chatting Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChattingClusterClientInitCallback(uint8_t endpoint);
+void emberAfChattingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Chatting Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -19894,7 +20151,8 @@ void emberAfChattingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfChattingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfChattingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Chatting Cluster Client Message Sent
  *
@@ -19921,7 +20179,7 @@ void emberAfChattingClusterClientMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfChattingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfChattingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Chatting Cluster Client Tick
@@ -19930,7 +20188,7 @@ EmberAfStatus emberAfChattingClusterClientPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChattingClusterClientTickCallback(uint8_t endpoint);
+void emberAfChattingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Chatting Cluster Get Node Information Request
  *
  *
@@ -19997,7 +20255,7 @@ bool emberAfChattingClusterSearchChatResponseCallback(uint8_t options, uint8_t *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChattingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfChattingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Chatting Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -20007,14 +20265,15 @@ void emberAfChattingClusterServerAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChattingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfChattingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Chatting Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChattingClusterServerInitCallback(uint8_t endpoint);
+void emberAfChattingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Chatting Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -20024,7 +20283,8 @@ void emberAfChattingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfChattingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfChattingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Chatting Cluster Server Message Sent
  *
@@ -20051,7 +20311,7 @@ void emberAfChattingClusterServerMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfChattingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfChattingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Chatting Cluster Server Tick
@@ -20060,7 +20320,7 @@ EmberAfStatus emberAfChattingClusterServerPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChattingClusterServerTickCallback(uint8_t endpoint);
+void emberAfChattingClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Chatting Cluster Start Chat Request
  *
  *
@@ -20095,7 +20355,8 @@ bool emberAfChattingClusterSwitchChairmanConfirmCallback(uint16_t cid, uint8_t *
  * @param address   Ver.: always
  * @param endpoint   Ver.: always
  */
-bool emberAfChattingClusterSwitchChairmanNotificationCallback(uint16_t cid, uint16_t uid, uint16_t address, uint8_t endpoint);
+bool emberAfChattingClusterSwitchChairmanNotificationCallback(uint16_t cid, uint16_t uid, uint16_t address,
+                                                              chip::EndpointId endpoint);
 /** @brief Chatting Cluster Switch Chairman Request
  *
  *
@@ -20176,7 +20437,7 @@ bool emberAfPaymentClusterBuyRequestCallback(uint8_t * userId, uint16_t userType
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPaymentClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPaymentClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Payment Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -20186,14 +20447,14 @@ void emberAfPaymentClusterClientAttributeChangedCallback(uint8_t endpoint, Ember
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPaymentClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPaymentClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Payment Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPaymentClusterClientInitCallback(uint8_t endpoint);
+void emberAfPaymentClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Payment Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -20203,7 +20464,8 @@ void emberAfPaymentClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPaymentClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPaymentClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              uint16_t manufacturerCode);
 /** @brief Payment Cluster Client Message Sent
  *
@@ -20230,7 +20492,7 @@ void emberAfPaymentClusterClientMessageSentCallback(EmberOutgoingMessageType typ
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPaymentClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPaymentClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                      EmberAfAttributeType attributeType, uint8_t size,
                                                                      uint8_t * value);
 /** @brief Payment Cluster Client Tick
@@ -20239,7 +20501,7 @@ EmberAfStatus emberAfPaymentClusterClientPreAttributeChangedCallback(uint8_t end
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPaymentClusterClientTickCallback(uint8_t endpoint);
+void emberAfPaymentClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Payment Cluster Payment Confirm
  *
  *
@@ -20268,7 +20530,7 @@ bool emberAfPaymentClusterReceiptDeliveryCallback(uint8_t * serialNumber, uint32
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPaymentClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPaymentClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Payment Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -20278,14 +20540,14 @@ void emberAfPaymentClusterServerAttributeChangedCallback(uint8_t endpoint, Ember
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPaymentClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPaymentClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Payment Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPaymentClusterServerInitCallback(uint8_t endpoint);
+void emberAfPaymentClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Payment Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -20295,7 +20557,8 @@ void emberAfPaymentClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPaymentClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPaymentClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              uint16_t manufacturerCode);
 /** @brief Payment Cluster Server Message Sent
  *
@@ -20322,7 +20585,7 @@ void emberAfPaymentClusterServerMessageSentCallback(EmberOutgoingMessageType typ
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPaymentClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPaymentClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                      EmberAfAttributeType attributeType, uint8_t size,
                                                                      uint8_t * value);
 /** @brief Payment Cluster Server Tick
@@ -20331,7 +20594,7 @@ EmberAfStatus emberAfPaymentClusterServerPreAttributeChangedCallback(uint8_t end
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPaymentClusterServerTickCallback(uint8_t endpoint);
+void emberAfPaymentClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Payment Cluster Transaction End
  *
  *
@@ -20370,7 +20633,7 @@ bool emberAfBillingClusterCheckBillStatusCallback(uint8_t * userId, uint16_t ser
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBillingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBillingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Billing Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -20380,14 +20643,14 @@ void emberAfBillingClusterClientAttributeChangedCallback(uint8_t endpoint, Ember
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBillingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBillingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Billing Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBillingClusterClientInitCallback(uint8_t endpoint);
+void emberAfBillingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Billing Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -20397,7 +20660,8 @@ void emberAfBillingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBillingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfBillingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              uint16_t manufacturerCode);
 /** @brief Billing Cluster Client Message Sent
  *
@@ -20424,7 +20688,7 @@ void emberAfBillingClusterClientMessageSentCallback(EmberOutgoingMessageType typ
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBillingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBillingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                      EmberAfAttributeType attributeType, uint8_t size,
                                                                      uint8_t * value);
 /** @brief Billing Cluster Client Tick
@@ -20433,7 +20697,7 @@ EmberAfStatus emberAfBillingClusterClientPreAttributeChangedCallback(uint8_t end
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBillingClusterClientTickCallback(uint8_t endpoint);
+void emberAfBillingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Billing Cluster Send Bill Record
  *
  *
@@ -20453,7 +20717,7 @@ bool emberAfBillingClusterSendBillRecordCallback(uint8_t * userId, uint16_t serv
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBillingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBillingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Billing Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -20463,14 +20727,14 @@ void emberAfBillingClusterServerAttributeChangedCallback(uint8_t endpoint, Ember
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBillingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBillingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Billing Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBillingClusterServerInitCallback(uint8_t endpoint);
+void emberAfBillingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Billing Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -20480,7 +20744,8 @@ void emberAfBillingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBillingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfBillingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              uint16_t manufacturerCode);
 /** @brief Billing Cluster Server Message Sent
  *
@@ -20507,7 +20772,7 @@ void emberAfBillingClusterServerMessageSentCallback(EmberOutgoingMessageType typ
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBillingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBillingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                      EmberAfAttributeType attributeType, uint8_t size,
                                                                      uint8_t * value);
 /** @brief Billing Cluster Server Tick
@@ -20516,7 +20781,7 @@ EmberAfStatus emberAfBillingClusterServerPreAttributeChangedCallback(uint8_t end
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBillingClusterServerTickCallback(uint8_t endpoint);
+void emberAfBillingClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Billing Cluster Session Keep Alive
  *
  *
@@ -20575,7 +20840,7 @@ bool emberAfBillingClusterUnsubscribeCallback(uint8_t * userId, uint16_t service
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceIdentificationClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceIdentificationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Identification Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -20585,14 +20850,15 @@ void emberAfApplianceIdentificationClusterClientAttributeChangedCallback(uint8_t
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceIdentificationClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceIdentificationClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                        EmberAfStatus status);
 /** @brief Appliance Identification Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceIdentificationClusterClientInitCallback(uint8_t endpoint);
+void emberAfApplianceIdentificationClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Identification Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -20603,7 +20869,7 @@ void emberAfApplianceIdentificationClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfApplianceIdentificationClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              uint16_t manufacturerCode);
 /** @brief Appliance Identification Cluster Client Message Sent
  *
@@ -20630,8 +20896,8 @@ void emberAfApplianceIdentificationClusterClientMessageSentCallback(EmberOutgoin
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceIdentificationClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceIdentificationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      EmberAfAttributeType attributeType,
                                                                                      uint8_t size, uint8_t * value);
 /** @brief Appliance Identification Cluster Client Tick
@@ -20640,7 +20906,7 @@ EmberAfStatus emberAfApplianceIdentificationClusterClientPreAttributeChangedCall
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceIdentificationClusterClientTickCallback(uint8_t endpoint);
+void emberAfApplianceIdentificationClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Appliance Identification Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -20648,7 +20914,7 @@ void emberAfApplianceIdentificationClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceIdentificationClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceIdentificationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Identification Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -20658,14 +20924,15 @@ void emberAfApplianceIdentificationClusterServerAttributeChangedCallback(uint8_t
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceIdentificationClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceIdentificationClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                        EmberAfStatus status);
 /** @brief Appliance Identification Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceIdentificationClusterServerInitCallback(uint8_t endpoint);
+void emberAfApplianceIdentificationClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Identification Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -20676,7 +20943,7 @@ void emberAfApplianceIdentificationClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfApplianceIdentificationClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              uint16_t manufacturerCode);
 /** @brief Appliance Identification Cluster Server Message Sent
  *
@@ -20703,8 +20970,8 @@ void emberAfApplianceIdentificationClusterServerMessageSentCallback(EmberOutgoin
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceIdentificationClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceIdentificationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      EmberAfAttributeType attributeType,
                                                                                      uint8_t size, uint8_t * value);
 /** @brief Appliance Identification Cluster Server Tick
@@ -20713,7 +20980,7 @@ EmberAfStatus emberAfApplianceIdentificationClusterServerPreAttributeChangedCall
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceIdentificationClusterServerTickCallback(uint8_t endpoint);
+void emberAfApplianceIdentificationClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Appliance Identification Cluster Callbacks */
 
@@ -20727,7 +20994,7 @@ void emberAfApplianceIdentificationClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMeterIdentificationClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMeterIdentificationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Meter Identification Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -20737,14 +21004,15 @@ void emberAfMeterIdentificationClusterClientAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMeterIdentificationClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMeterIdentificationClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief Meter Identification Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMeterIdentificationClusterClientInitCallback(uint8_t endpoint);
+void emberAfMeterIdentificationClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Meter Identification Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -20755,7 +21023,7 @@ void emberAfMeterIdentificationClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfMeterIdentificationClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief Meter Identification Cluster Client Message Sent
  *
@@ -20782,7 +21050,8 @@ void emberAfMeterIdentificationClusterClientMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMeterIdentificationClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMeterIdentificationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief Meter Identification Cluster Client Tick
@@ -20791,7 +21060,7 @@ EmberAfStatus emberAfMeterIdentificationClusterClientPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMeterIdentificationClusterClientTickCallback(uint8_t endpoint);
+void emberAfMeterIdentificationClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Meter Identification Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -20799,7 +21068,7 @@ void emberAfMeterIdentificationClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMeterIdentificationClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMeterIdentificationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Meter Identification Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -20809,14 +21078,15 @@ void emberAfMeterIdentificationClusterServerAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMeterIdentificationClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMeterIdentificationClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief Meter Identification Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMeterIdentificationClusterServerInitCallback(uint8_t endpoint);
+void emberAfMeterIdentificationClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Meter Identification Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -20827,7 +21097,7 @@ void emberAfMeterIdentificationClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfMeterIdentificationClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief Meter Identification Cluster Server Message Sent
  *
@@ -20854,7 +21124,8 @@ void emberAfMeterIdentificationClusterServerMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMeterIdentificationClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMeterIdentificationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief Meter Identification Cluster Server Tick
@@ -20863,7 +21134,7 @@ EmberAfStatus emberAfMeterIdentificationClusterServerPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMeterIdentificationClusterServerTickCallback(uint8_t endpoint);
+void emberAfMeterIdentificationClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Meter Identification Cluster Callbacks */
 
@@ -20885,7 +21156,7 @@ bool emberAfApplianceEventsAndAlertClusterAlertsNotificationCallback(uint8_t ale
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceEventsAndAlertClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Events and Alert Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -20895,14 +21166,15 @@ void emberAfApplianceEventsAndAlertClusterClientAttributeChangedCallback(uint8_t
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceEventsAndAlertClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                        EmberAfStatus status);
 /** @brief Appliance Events and Alert Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterClientInitCallback(uint8_t endpoint);
+void emberAfApplianceEventsAndAlertClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Events and Alert Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -20913,7 +21185,7 @@ void emberAfApplianceEventsAndAlertClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfApplianceEventsAndAlertClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              uint16_t manufacturerCode);
 /** @brief Appliance Events and Alert Cluster Client Message Sent
  *
@@ -20940,8 +21212,8 @@ void emberAfApplianceEventsAndAlertClusterClientMessageSentCallback(EmberOutgoin
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceEventsAndAlertClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceEventsAndAlertClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      EmberAfAttributeType attributeType,
                                                                                      uint8_t size, uint8_t * value);
 /** @brief Appliance Events and Alert Cluster Client Tick
@@ -20950,7 +21222,7 @@ EmberAfStatus emberAfApplianceEventsAndAlertClusterClientPreAttributeChangedCall
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterClientTickCallback(uint8_t endpoint);
+void emberAfApplianceEventsAndAlertClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Appliance Events and Alert Cluster Events Notification
  *
  *
@@ -20980,7 +21252,7 @@ bool emberAfApplianceEventsAndAlertClusterGetAlertsResponseCallback(uint8_t aler
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceEventsAndAlertClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Events and Alert Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -20990,14 +21262,15 @@ void emberAfApplianceEventsAndAlertClusterServerAttributeChangedCallback(uint8_t
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceEventsAndAlertClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                        EmberAfStatus status);
 /** @brief Appliance Events and Alert Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterServerInitCallback(uint8_t endpoint);
+void emberAfApplianceEventsAndAlertClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Events and Alert Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -21008,7 +21281,7 @@ void emberAfApplianceEventsAndAlertClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfApplianceEventsAndAlertClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              uint16_t manufacturerCode);
 /** @brief Appliance Events and Alert Cluster Server Message Sent
  *
@@ -21035,8 +21308,8 @@ void emberAfApplianceEventsAndAlertClusterServerMessageSentCallback(EmberOutgoin
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceEventsAndAlertClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceEventsAndAlertClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      EmberAfAttributeType attributeType,
                                                                                      uint8_t size, uint8_t * value);
 /** @brief Appliance Events and Alert Cluster Server Tick
@@ -21045,7 +21318,7 @@ EmberAfStatus emberAfApplianceEventsAndAlertClusterServerPreAttributeChangedCall
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterServerTickCallback(uint8_t endpoint);
+void emberAfApplianceEventsAndAlertClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Appliance Events and Alert Cluster Callbacks */
 
@@ -21059,7 +21332,7 @@ void emberAfApplianceEventsAndAlertClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceStatisticsClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceStatisticsClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Statistics Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -21069,14 +21342,15 @@ void emberAfApplianceStatisticsClusterClientAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceStatisticsClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceStatisticsClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief Appliance Statistics Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceStatisticsClusterClientInitCallback(uint8_t endpoint);
+void emberAfApplianceStatisticsClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Statistics Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -21087,7 +21361,7 @@ void emberAfApplianceStatisticsClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfApplianceStatisticsClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief Appliance Statistics Cluster Client Message Sent
  *
@@ -21114,7 +21388,8 @@ void emberAfApplianceStatisticsClusterClientMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceStatisticsClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceStatisticsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief Appliance Statistics Cluster Client Tick
@@ -21123,7 +21398,7 @@ EmberAfStatus emberAfApplianceStatisticsClusterClientPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceStatisticsClusterClientTickCallback(uint8_t endpoint);
+void emberAfApplianceStatisticsClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Appliance Statistics Cluster Log Notification
  *
  *
@@ -21174,7 +21449,7 @@ bool emberAfApplianceStatisticsClusterLogResponseCallback(uint32_t timeStamp, ui
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceStatisticsClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceStatisticsClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Statistics Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -21184,14 +21459,15 @@ void emberAfApplianceStatisticsClusterServerAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceStatisticsClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceStatisticsClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief Appliance Statistics Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceStatisticsClusterServerInitCallback(uint8_t endpoint);
+void emberAfApplianceStatisticsClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Statistics Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -21202,7 +21478,7 @@ void emberAfApplianceStatisticsClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfApplianceStatisticsClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief Appliance Statistics Cluster Server Message Sent
  *
@@ -21229,7 +21505,8 @@ void emberAfApplianceStatisticsClusterServerMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceStatisticsClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceStatisticsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief Appliance Statistics Cluster Server Tick
@@ -21238,7 +21515,7 @@ EmberAfStatus emberAfApplianceStatisticsClusterServerPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceStatisticsClusterServerTickCallback(uint8_t endpoint);
+void emberAfApplianceStatisticsClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Appliance Statistics Cluster Statistics Available
  *
  *
@@ -21260,7 +21537,7 @@ bool emberAfApplianceStatisticsClusterStatisticsAvailableCallback(uint8_t logQue
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfElectricalMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfElectricalMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Electrical Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -21270,14 +21547,15 @@ void emberAfElectricalMeasurementClusterClientAttributeChangedCallback(uint8_t e
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfElectricalMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfElectricalMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                      EmberAfStatus status);
 /** @brief Electrical Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfElectricalMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfElectricalMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Electrical Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -21288,7 +21566,7 @@ void emberAfElectricalMeasurementClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfElectricalMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                           EmberAfAttributeId attributeId,
+                                                                                           chip::AttributeId attributeId,
                                                                                            uint16_t manufacturerCode);
 /** @brief Electrical Measurement Cluster Client Message Sent
  *
@@ -21315,7 +21593,8 @@ void emberAfElectricalMeasurementClusterClientMessageSentCallback(EmberOutgoingM
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfElectricalMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfElectricalMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                                    uint8_t * value);
 /** @brief Electrical Measurement Cluster Client Tick
@@ -21324,7 +21603,7 @@ EmberAfStatus emberAfElectricalMeasurementClusterClientPreAttributeChangedCallba
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfElectricalMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfElectricalMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Electrical Measurement Cluster Get Measurement Profile Command
  *
  *
@@ -21333,7 +21612,7 @@ void emberAfElectricalMeasurementClusterClientTickCallback(uint8_t endpoint);
  * @param startTime   Ver.: always
  * @param numberOfIntervals   Ver.: always
  */
-bool emberAfElectricalMeasurementClusterGetMeasurementProfileCommandCallback(uint16_t attributeId, uint32_t startTime,
+bool emberAfElectricalMeasurementClusterGetMeasurementProfileCommandCallback(chip::AttributeId attributeId, uint32_t startTime,
                                                                              uint8_t numberOfIntervals);
 /** @brief Electrical Measurement Cluster Get Measurement Profile Response Command
  *
@@ -21349,7 +21628,8 @@ bool emberAfElectricalMeasurementClusterGetMeasurementProfileCommandCallback(uin
 bool emberAfElectricalMeasurementClusterGetMeasurementProfileResponseCommandCallback(uint32_t startTime, uint8_t status,
                                                                                      uint8_t profileIntervalPeriod,
                                                                                      uint8_t numberOfIntervalsDelivered,
-                                                                                     uint16_t attributeId, uint8_t * intervals);
+                                                                                     chip::AttributeId attributeId,
+                                                                                     uint8_t * intervals);
 /** @brief Electrical Measurement Cluster Get Profile Info Command
  *
  *
@@ -21375,7 +21655,7 @@ bool emberAfElectricalMeasurementClusterGetProfileInfoResponseCommandCallback(ui
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfElectricalMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfElectricalMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Electrical Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -21385,14 +21665,15 @@ void emberAfElectricalMeasurementClusterServerAttributeChangedCallback(uint8_t e
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfElectricalMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfElectricalMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                      EmberAfStatus status);
 /** @brief Electrical Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfElectricalMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfElectricalMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Electrical Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -21403,7 +21684,7 @@ void emberAfElectricalMeasurementClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfElectricalMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                           EmberAfAttributeId attributeId,
+                                                                                           chip::AttributeId attributeId,
                                                                                            uint16_t manufacturerCode);
 /** @brief Electrical Measurement Cluster Server Message Sent
  *
@@ -21430,7 +21711,8 @@ void emberAfElectricalMeasurementClusterServerMessageSentCallback(EmberOutgoingM
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfElectricalMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfElectricalMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                                    uint8_t * value);
 /** @brief Electrical Measurement Cluster Server Tick
@@ -21439,7 +21721,7 @@ EmberAfStatus emberAfElectricalMeasurementClusterServerPreAttributeChangedCallba
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfElectricalMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfElectricalMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Electrical Measurement Cluster Callbacks */
 
@@ -21453,7 +21735,7 @@ void emberAfElectricalMeasurementClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDiagnosticsClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDiagnosticsClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Diagnostics Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -21463,14 +21745,15 @@ void emberAfDiagnosticsClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDiagnosticsClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDiagnosticsClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Diagnostics Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDiagnosticsClusterClientInitCallback(uint8_t endpoint);
+void emberAfDiagnosticsClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Diagnostics Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -21480,7 +21763,8 @@ void emberAfDiagnosticsClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDiagnosticsClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDiagnosticsClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Diagnostics Cluster Client Message Sent
  *
@@ -21507,7 +21791,7 @@ void emberAfDiagnosticsClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDiagnosticsClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDiagnosticsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Diagnostics Cluster Client Tick
@@ -21516,7 +21800,7 @@ EmberAfStatus emberAfDiagnosticsClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDiagnosticsClusterClientTickCallback(uint8_t endpoint);
+void emberAfDiagnosticsClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Diagnostics Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -21524,7 +21808,7 @@ void emberAfDiagnosticsClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDiagnosticsClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDiagnosticsClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Diagnostics Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -21534,14 +21818,15 @@ void emberAfDiagnosticsClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDiagnosticsClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDiagnosticsClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Diagnostics Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDiagnosticsClusterServerInitCallback(uint8_t endpoint);
+void emberAfDiagnosticsClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Diagnostics Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -21551,7 +21836,8 @@ void emberAfDiagnosticsClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDiagnosticsClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDiagnosticsClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Diagnostics Cluster Server Message Sent
  *
@@ -21578,7 +21864,7 @@ void emberAfDiagnosticsClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDiagnosticsClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDiagnosticsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Diagnostics Cluster Server Tick
@@ -21587,7 +21873,7 @@ EmberAfStatus emberAfDiagnosticsClusterServerPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDiagnosticsClusterServerTickCallback(uint8_t endpoint);
+void emberAfDiagnosticsClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Diagnostics Cluster Callbacks */
 
@@ -21601,7 +21887,7 @@ void emberAfDiagnosticsClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfZllCommissioningClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfZllCommissioningClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief ZLL Commissioning Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -21611,14 +21897,15 @@ void emberAfZllCommissioningClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfZllCommissioningClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfZllCommissioningClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief ZLL Commissioning Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfZllCommissioningClusterClientInitCallback(uint8_t endpoint);
+void emberAfZllCommissioningClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief ZLL Commissioning Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -21628,8 +21915,8 @@ void emberAfZllCommissioningClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfZllCommissioningClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfZllCommissioningClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief ZLL Commissioning Cluster Client Message Sent
  *
@@ -21656,7 +21943,8 @@ void emberAfZllCommissioningClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfZllCommissioningClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfZllCommissioningClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief ZLL Commissioning Cluster Client Tick
@@ -21665,7 +21953,7 @@ EmberAfStatus emberAfZllCommissioningClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfZllCommissioningClusterClientTickCallback(uint8_t endpoint);
+void emberAfZllCommissioningClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief ZLL Commissioning Cluster Device Information Request
  *
  *
@@ -21903,7 +22191,7 @@ bool emberAfZllCommissioningClusterScanResponseCallback(uint32_t transaction, ui
                                                         uint8_t zllInformation, uint16_t keyBitmask, uint32_t responseId,
                                                         uint8_t * extendedPanId, uint8_t networkUpdateId, uint8_t logicalChannel,
                                                         uint16_t panId, uint16_t networkAddress, uint8_t numberOfSubDevices,
-                                                        uint8_t totalGroupIds, uint8_t endpointId, uint16_t profileId,
+                                                        uint8_t totalGroupIds, chip::EndpointId endpointId, uint16_t profileId,
                                                         uint16_t deviceId, uint8_t version, uint8_t groupIdCount);
 /** @brief ZLL Commissioning Cluster Server Attribute Changed
  *
@@ -21912,7 +22200,7 @@ bool emberAfZllCommissioningClusterScanResponseCallback(uint32_t transaction, ui
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfZllCommissioningClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfZllCommissioningClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief ZLL Commissioning Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -21922,14 +22210,15 @@ void emberAfZllCommissioningClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfZllCommissioningClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfZllCommissioningClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief ZLL Commissioning Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfZllCommissioningClusterServerInitCallback(uint8_t endpoint);
+void emberAfZllCommissioningClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief ZLL Commissioning Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -21939,8 +22228,8 @@ void emberAfZllCommissioningClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfZllCommissioningClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfZllCommissioningClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief ZLL Commissioning Cluster Server Message Sent
  *
@@ -21967,7 +22256,8 @@ void emberAfZllCommissioningClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfZllCommissioningClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfZllCommissioningClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief ZLL Commissioning Cluster Server Tick
@@ -21976,7 +22266,7 @@ EmberAfStatus emberAfZllCommissioningClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfZllCommissioningClusterServerTickCallback(uint8_t endpoint);
+void emberAfZllCommissioningClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END ZLL Commissioning Cluster Callbacks */
 
@@ -21990,7 +22280,7 @@ void emberAfZllCommissioningClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSampleMfgSpecificClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Sample Mfg Specific Cluster Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -22000,14 +22290,15 @@ void emberAfSampleMfgSpecificClusterClientAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSampleMfgSpecificClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief Sample Mfg Specific Cluster Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterClientInitCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Sample Mfg Specific Cluster Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -22018,7 +22309,7 @@ void emberAfSampleMfgSpecificClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfSampleMfgSpecificClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief Sample Mfg Specific Cluster Cluster Client Message Sent
  *
@@ -22045,7 +22336,8 @@ void emberAfSampleMfgSpecificClusterClientMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSampleMfgSpecificClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSampleMfgSpecificClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief Sample Mfg Specific Cluster Cluster Client Tick
@@ -22054,7 +22346,7 @@ EmberAfStatus emberAfSampleMfgSpecificClusterClientPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterClientTickCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Sample Mfg Specific Cluster Cluster Command One
  *
  *
@@ -22069,7 +22361,7 @@ bool emberAfSampleMfgSpecificClusterCommandOneCallback(uint8_t argOne);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSampleMfgSpecificClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Sample Mfg Specific Cluster Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -22079,14 +22371,15 @@ void emberAfSampleMfgSpecificClusterServerAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSampleMfgSpecificClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief Sample Mfg Specific Cluster Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterServerInitCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Sample Mfg Specific Cluster Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -22097,7 +22390,7 @@ void emberAfSampleMfgSpecificClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfSampleMfgSpecificClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief Sample Mfg Specific Cluster Cluster Server Message Sent
  *
@@ -22124,7 +22417,8 @@ void emberAfSampleMfgSpecificClusterServerMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSampleMfgSpecificClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSampleMfgSpecificClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief Sample Mfg Specific Cluster Cluster Server Tick
@@ -22133,7 +22427,7 @@ EmberAfStatus emberAfSampleMfgSpecificClusterServerPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterServerTickCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Sample Mfg Specific Cluster Cluster Callbacks */
 
@@ -22147,7 +22441,7 @@ void emberAfSampleMfgSpecificClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSampleMfgSpecificCluster2ClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -22157,14 +22451,15 @@ void emberAfSampleMfgSpecificCluster2ClientAttributeChangedCallback(uint8_t endp
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSampleMfgSpecificCluster2ClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                   EmberAfStatus status);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ClientInitCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificCluster2ClientInitCallback(chip::EndpointId endpoint);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -22175,7 +22470,7 @@ void emberAfSampleMfgSpecificCluster2ClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfSampleMfgSpecificCluster2ClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                        EmberAfAttributeId attributeId,
+                                                                                        chip::AttributeId attributeId,
                                                                                         uint16_t manufacturerCode);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Client Message Sent
  *
@@ -22202,7 +22497,8 @@ void emberAfSampleMfgSpecificCluster2ClientMessageSentCallback(EmberOutgoingMess
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSampleMfgSpecificCluster2ClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSampleMfgSpecificCluster2ClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 EmberAfAttributeType attributeType, uint8_t size,
                                                                                 uint8_t * value);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Client Tick
@@ -22211,7 +22507,7 @@ EmberAfStatus emberAfSampleMfgSpecificCluster2ClientPreAttributeChangedCallback(
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ClientTickCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificCluster2ClientTickCallback(chip::EndpointId endpoint);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Command Two
  *
  *
@@ -22226,7 +22522,7 @@ bool emberAfSampleMfgSpecificCluster2CommandTwoCallback(uint8_t argOne);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSampleMfgSpecificCluster2ServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -22236,14 +22532,15 @@ void emberAfSampleMfgSpecificCluster2ServerAttributeChangedCallback(uint8_t endp
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSampleMfgSpecificCluster2ServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                   EmberAfStatus status);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ServerInitCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificCluster2ServerInitCallback(chip::EndpointId endpoint);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -22254,7 +22551,7 @@ void emberAfSampleMfgSpecificCluster2ServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfSampleMfgSpecificCluster2ServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                        EmberAfAttributeId attributeId,
+                                                                                        chip::AttributeId attributeId,
                                                                                         uint16_t manufacturerCode);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Server Message Sent
  *
@@ -22281,7 +22578,8 @@ void emberAfSampleMfgSpecificCluster2ServerMessageSentCallback(EmberOutgoingMess
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSampleMfgSpecificCluster2ServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSampleMfgSpecificCluster2ServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 EmberAfAttributeType attributeType, uint8_t size,
                                                                                 uint8_t * value);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Server Tick
@@ -22290,7 +22588,7 @@ EmberAfStatus emberAfSampleMfgSpecificCluster2ServerPreAttributeChangedCallback(
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ServerTickCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificCluster2ServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Sample Mfg Specific Cluster 2 Cluster Callbacks */
 
@@ -22304,7 +22602,7 @@ void emberAfSampleMfgSpecificCluster2ServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOtaConfigurationClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOtaConfigurationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Configuration Cluster Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -22314,14 +22612,15 @@ void emberAfOtaConfigurationClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOtaConfigurationClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOtaConfigurationClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Configuration Cluster Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOtaConfigurationClusterClientInitCallback(uint8_t endpoint);
+void emberAfOtaConfigurationClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Configuration Cluster Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -22331,8 +22630,8 @@ void emberAfOtaConfigurationClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOtaConfigurationClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfOtaConfigurationClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Configuration Cluster Cluster Client Message Sent
  *
@@ -22359,7 +22658,8 @@ void emberAfOtaConfigurationClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOtaConfigurationClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOtaConfigurationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Configuration Cluster Cluster Client Tick
@@ -22368,7 +22668,7 @@ EmberAfStatus emberAfOtaConfigurationClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOtaConfigurationClusterClientTickCallback(uint8_t endpoint);
+void emberAfOtaConfigurationClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Configuration Cluster Cluster Lock Tokens
  *
  *
@@ -22397,7 +22697,7 @@ bool emberAfOtaConfigurationClusterReturnTokenCallback(uint16_t token, uint8_t *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOtaConfigurationClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOtaConfigurationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Configuration Cluster Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -22407,14 +22707,15 @@ void emberAfOtaConfigurationClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOtaConfigurationClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOtaConfigurationClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Configuration Cluster Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOtaConfigurationClusterServerInitCallback(uint8_t endpoint);
+void emberAfOtaConfigurationClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Configuration Cluster Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -22424,8 +22725,8 @@ void emberAfOtaConfigurationClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOtaConfigurationClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfOtaConfigurationClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Configuration Cluster Cluster Server Message Sent
  *
@@ -22452,7 +22753,8 @@ void emberAfOtaConfigurationClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOtaConfigurationClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOtaConfigurationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Configuration Cluster Cluster Server Tick
@@ -22461,7 +22763,7 @@ EmberAfStatus emberAfOtaConfigurationClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOtaConfigurationClusterServerTickCallback(uint8_t endpoint);
+void emberAfOtaConfigurationClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Configuration Cluster Cluster Set Token
  *
  *
@@ -22490,7 +22792,7 @@ bool emberAfOtaConfigurationClusterUnlockTokensCallback(uint8_t * data);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMfglibClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMfglibClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief MFGLIB Cluster Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -22500,14 +22802,14 @@ void emberAfMfglibClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMfglibClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMfglibClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief MFGLIB Cluster Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMfglibClusterClientInitCallback(uint8_t endpoint);
+void emberAfMfglibClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief MFGLIB Cluster Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -22517,7 +22819,8 @@ void emberAfMfglibClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfMfglibClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfMfglibClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief MFGLIB Cluster Cluster Client Message Sent
  *
@@ -22544,7 +22847,7 @@ void emberAfMfglibClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMfglibClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMfglibClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief MFGLIB Cluster Cluster Client Tick
@@ -22553,7 +22856,7 @@ EmberAfStatus emberAfMfglibClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMfglibClusterClientTickCallback(uint8_t endpoint);
+void emberAfMfglibClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief MFGLIB Cluster Cluster Rx Mode
  *
  *
@@ -22570,7 +22873,7 @@ bool emberAfMfglibClusterRxModeCallback(uint8_t channel, int8_t power, uint16_t 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMfglibClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMfglibClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief MFGLIB Cluster Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -22580,14 +22883,14 @@ void emberAfMfglibClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMfglibClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMfglibClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief MFGLIB Cluster Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMfglibClusterServerInitCallback(uint8_t endpoint);
+void emberAfMfglibClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief MFGLIB Cluster Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -22597,7 +22900,8 @@ void emberAfMfglibClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfMfglibClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfMfglibClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief MFGLIB Cluster Cluster Server Message Sent
  *
@@ -22624,7 +22928,7 @@ void emberAfMfglibClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMfglibClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMfglibClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief MFGLIB Cluster Cluster Server Tick
@@ -22633,7 +22937,7 @@ EmberAfStatus emberAfMfglibClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMfglibClusterServerTickCallback(uint8_t endpoint);
+void emberAfMfglibClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief MFGLIB Cluster Cluster Stream
  *
  *
@@ -22678,7 +22982,7 @@ bool emberAfSlWwahClusterApsAckRequirementQueryCallback(void);
  *
  * @param clusterId   Ver.: always
  */
-bool emberAfSlWwahClusterApsLinkKeyAuthorizationQueryCallback(uint16_t clusterId);
+bool emberAfSlWwahClusterApsLinkKeyAuthorizationQueryCallback(chip::ClusterId clusterId);
 /** @brief SL Works With All Hubs Cluster Aps Link Key Authorization Query Response
  *
  *
@@ -22686,7 +22990,7 @@ bool emberAfSlWwahClusterApsLinkKeyAuthorizationQueryCallback(uint16_t clusterId
  * @param clusterId   Ver.: always
  * @param apsLinkKeyAuthStatus   Ver.: always
  */
-bool emberAfSlWwahClusterApsLinkKeyAuthorizationQueryResponseCallback(uint16_t clusterId, uint8_t apsLinkKeyAuthStatus);
+bool emberAfSlWwahClusterApsLinkKeyAuthorizationQueryResponseCallback(chip::ClusterId clusterId, uint8_t apsLinkKeyAuthStatus);
 /** @brief SL Works With All Hubs Cluster Clear Binding Table
  *
  *
@@ -22700,7 +23004,7 @@ bool emberAfSlWwahClusterClearBindingTableCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSlWwahClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSlWwahClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief SL Works With All Hubs Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -22710,14 +23014,14 @@ void emberAfSlWwahClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSlWwahClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSlWwahClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief SL Works With All Hubs Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSlWwahClusterClientInitCallback(uint8_t endpoint);
+void emberAfSlWwahClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief SL Works With All Hubs Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -22727,7 +23031,8 @@ void emberAfSlWwahClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfSlWwahClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfSlWwahClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief SL Works With All Hubs Cluster Client Message Sent
  *
@@ -22754,7 +23059,7 @@ void emberAfSlWwahClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSlWwahClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSlWwahClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief SL Works With All Hubs Cluster Client Tick
@@ -22763,7 +23068,7 @@ EmberAfStatus emberAfSlWwahClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSlWwahClusterClientTickCallback(uint8_t endpoint);
+void emberAfSlWwahClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief SL Works With All Hubs Cluster Debug Report Query
  *
  *
@@ -22979,7 +23284,7 @@ bool emberAfSlWwahClusterRequireApsAcksOnUnicastsCallback(uint8_t numberExemptCl
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSlWwahClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSlWwahClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief SL Works With All Hubs Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -22989,14 +23294,14 @@ void emberAfSlWwahClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSlWwahClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSlWwahClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief SL Works With All Hubs Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSlWwahClusterServerInitCallback(uint8_t endpoint);
+void emberAfSlWwahClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief SL Works With All Hubs Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -23006,7 +23311,8 @@ void emberAfSlWwahClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfSlWwahClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfSlWwahClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief SL Works With All Hubs Cluster Server Message Sent
  *
@@ -23033,7 +23339,7 @@ void emberAfSlWwahClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSlWwahClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSlWwahClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief SL Works With All Hubs Cluster Server Tick
@@ -23042,7 +23348,7 @@ EmberAfStatus emberAfSlWwahClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSlWwahClusterServerTickCallback(uint8_t endpoint);
+void emberAfSlWwahClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief SL Works With All Hubs Cluster Set Ias Zone Enrollment Method
  *
  *

--- a/examples/all-clusters-app/all-clusters-common/gen/clusters-callback-stubs.cpp
+++ b/examples/all-clusters-app/all-clusters-common/gen/clusters-callback-stubs.cpp
@@ -22,6 +22,8 @@
 
 #include "af.h"
 
+using namespace chip;
+
 /** @brief Identify Cluster Identify Query Response
  *
  *
@@ -62,12 +64,12 @@ bool emberAfIasZoneClusterZoneStatusChangeNotificationCallback(uint16_t zoneStat
 
 // endpoint_config.h callbacks, grep'd from SDK, comment these out as clusters come in
 
-void emberAfIasZoneClusterClientInitCallback(uint8_t endpoint) {}
+void emberAfIasZoneClusterClientInitCallback(EndpointId endpoint) {}
 
-void emberAfPollControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId) {}
-void emberAfPollControlClusterServerInitCallback(uint8_t endpoint) {}
+void emberAfPollControlClusterServerAttributeChangedCallback(EndpointId endpoint, AttributeId attributeId) {}
+void emberAfPollControlClusterServerInitCallback(EndpointId endpoint) {}
 void emberAfPluginPollControlServerStackStatusCallback(EmberStatus status) {}
-EmberAfStatus emberAfPollControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPollControlClusterServerPreAttributeChangedCallback(EndpointId endpoint, AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value)
 {

--- a/examples/all-clusters-app/esp32/main/include/CHIPDeviceManager.h
+++ b/examples/all-clusters-app/esp32/main/include/CHIPDeviceManager.h
@@ -72,7 +72,7 @@ public:
      * @param size               size of the attribute
      * @param value              pointer to the new value
      */
-    virtual void PostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
+    virtual void PostAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
                                              uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
     {}
     virtual ~CHIPDeviceManagerCallbacks() {}

--- a/examples/all-clusters-app/linux/main.cpp
+++ b/examples/all-clusters-app/linux/main.cpp
@@ -40,7 +40,7 @@ using namespace chip::Inet;
 using namespace chip::Transport;
 using namespace chip::DeviceLayer;
 
-void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,
+void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
 {}
 

--- a/examples/lighting-app/efr32/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/efr32/src/ZclCallbacks.cpp
@@ -29,9 +29,9 @@
 
 #include <app/util/af-types.h>
 
-// using namespace ::chip;
+using namespace ::chip;
 
-void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,
+void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
 {
     if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
@@ -64,7 +64,7 @@ void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clust
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint)
+void emberAfPluginOnOffClusterServerPostInitCallback(EndpointId endpoint)
 {
     // TODO: implement any additional On/off Cluster Server post init actions
 }

--- a/examples/lighting-app/lighting-common/gen/af-structs.h
+++ b/examples/lighting-app/lighting-common/gen/af-structs.h
@@ -39,6 +39,8 @@
 #ifndef SILABS_EMBER_AF_STRUCTS
 #define SILABS_EMBER_AF_STRUCTS
 
+#include "basic-types.h"
+
 // Generated structs from the metadata
 // Struct for IasAceZoneStatusResult
 typedef struct _IasAceZoneStatusResult
@@ -50,7 +52,7 @@ typedef struct _IasAceZoneStatusResult
 // Struct for ReadAttributeStatusRecord
 typedef struct _ReadAttributeStatusRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t status;
     uint8_t attributeType;
     uint8_t * attributeLocation;
@@ -59,7 +61,7 @@ typedef struct _ReadAttributeStatusRecord
 // Struct for WriteAttributeRecord
 typedef struct _WriteAttributeRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t attributeType;
     uint8_t * attributeLocation;
 } WriteAttributeRecord;
@@ -68,14 +70,14 @@ typedef struct _WriteAttributeRecord
 typedef struct _WriteAttributeStatusRecord
 {
     uint8_t status;
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
 } WriteAttributeStatusRecord;
 
 // Struct for ConfigureReportingRecord
 typedef struct _ConfigureReportingRecord
 {
     uint8_t direction;
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t attributeType;
     uint16_t minimumReportingInterval;
     uint16_t maximumReportingInterval;
@@ -88,7 +90,7 @@ typedef struct _ConfigureReportingStatusRecord
 {
     uint8_t status;
     uint8_t direction;
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
 } ConfigureReportingStatusRecord;
 
 // Struct for ReadReportingConfigurationRecord
@@ -96,7 +98,7 @@ typedef struct _ReadReportingConfigurationRecord
 {
     uint8_t status;
     uint8_t direction;
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t attributeType;
     uint16_t minimumReportingInterval;
     uint16_t maximumReportingInterval;
@@ -108,13 +110,13 @@ typedef struct _ReadReportingConfigurationRecord
 typedef struct _ReadReportingConfigurationAttributeRecord
 {
     uint8_t direction;
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
 } ReadReportingConfigurationAttributeRecord;
 
 // Struct for ReportAttributeRecord
 typedef struct _ReportAttributeRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t attributeType;
     uint8_t * attributeLocation;
 } ReportAttributeRecord;
@@ -122,14 +124,14 @@ typedef struct _ReportAttributeRecord
 // Struct for DiscoverAttributesInfoRecord
 typedef struct _DiscoverAttributesInfoRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t attributeType;
 } DiscoverAttributesInfoRecord;
 
 // Struct for ExtendedDiscoverAttributesInfoRecord
 typedef struct _ExtendedDiscoverAttributesInfoRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t attributeType;
     uint8_t attributeAccessControl;
 } ExtendedDiscoverAttributesInfoRecord;
@@ -137,7 +139,7 @@ typedef struct _ExtendedDiscoverAttributesInfoRecord
 // Struct for ReadStructuredAttributeRecord
 typedef struct _ReadStructuredAttributeRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t indicator;
     uint16_t indicies;
 } ReadStructuredAttributeRecord;
@@ -145,7 +147,7 @@ typedef struct _ReadStructuredAttributeRecord
 // Struct for WriteStructuredAttributeRecord
 typedef struct _WriteStructuredAttributeRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t indicator;
     uint16_t indicies;
     uint8_t attributeType;
@@ -156,7 +158,7 @@ typedef struct _WriteStructuredAttributeRecord
 typedef struct _WriteStructuredAttributeStatusRecord
 {
     uint8_t status;
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t indicator;
     uint16_t indicies;
 } WriteStructuredAttributeStatusRecord;
@@ -406,7 +408,7 @@ typedef struct _DeviceInformationRecord
 // Struct for GroupInformationRecord
 typedef struct _GroupInformationRecord
 {
-    uint16_t groupId;
+    chip::GroupId groupId;
     uint8_t groupType;
 } GroupInformationRecord;
 

--- a/examples/lighting-app/lighting-common/gen/call-command-handler.cpp
+++ b/examples/lighting-app/lighting-common/gen/call-command-handler.cpp
@@ -60,6 +60,8 @@
 #include "command-id.h"
 #include "util.h"
 
+using namespace chip;
+
 static EmberAfStatus status(bool wasHandled, bool clusterExists, bool mfgSpecific)
 {
     if (wasHandled)

--- a/examples/lighting-app/lighting-common/gen/callback-stub.cpp
+++ b/examples/lighting-app/lighting-common/gen/callback-stub.cpp
@@ -43,6 +43,8 @@
 //#include "hal/hal.h"
 //#include EMBER_AF_API_NETWORK_STEERING
 
+using namespace chip;
+
 /** @brief Add To Current App Tasks
  *
  * This function is only useful to sleepy end devices.  This function will note
@@ -89,8 +91,8 @@ void emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
  * @param value   Ver.: always
  * @param type   Ver.: always
  */
-EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(uint8_t endpoint, EmberAfClusterId clusterId,
-                                                                          EmberAfAttributeId attributeId, uint8_t mask,
+EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId clusterId,
+                                                                          AttributeId attributeId, uint8_t mask,
                                                                           uint16_t manufacturerCode, uint8_t * value, uint8_t type)
 {
     return EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_NORMAL; // Default
@@ -106,8 +108,8 @@ EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(uint8_
  * @param manufacturerCode   Ver.: always
  * @param attributeId   Ver.: always
  */
-bool emberAfAttributeReadAccessCallback(uint8_t endpoint, EmberAfClusterId clusterId, uint16_t manufacturerCode,
-                                        uint16_t attributeId)
+bool emberAfAttributeReadAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode,
+                                        AttributeId attributeId)
 {
     return true;
 }
@@ -122,8 +124,8 @@ bool emberAfAttributeReadAccessCallback(uint8_t endpoint, EmberAfClusterId clust
  * @param manufacturerCode   Ver.: always
  * @param attributeId   Ver.: always
  */
-bool emberAfAttributeWriteAccessCallback(uint8_t endpoint, EmberAfClusterId clusterId, uint16_t manufacturerCode,
-                                         uint16_t attributeId)
+bool emberAfAttributeWriteAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode,
+                                         AttributeId attributeId)
 {
     return true;
 }
@@ -135,7 +137,7 @@ bool emberAfAttributeWriteAccessCallback(uint8_t endpoint, EmberAfClusterId clus
  *
  * @param endpoint The endpoint.  Ver.: always
  */
-void emberAfGroupsClusterClearGroupTableCallback(uint8_t endpoint) {}
+void emberAfGroupsClusterClearGroupTableCallback(EndpointId endpoint) {}
 
 /** @brief Key Establishment Cluster Client Command Received
  *
@@ -161,7 +163,7 @@ bool emberAfKeyEstablishmentClusterClientCommandReceivedCallback(EmberAfClusterC
  * @param endpoint   Ver.: always
  * @param clusterId   Ver.: always
  */
-void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId) {}
+void emberAfClusterInitCallback(EndpointId endpoint, ClusterId clusterId) {}
 
 /** @brief Default Response
  *
@@ -175,7 +177,7 @@ void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId) {}
  * @param status Specifies either SUCCESS or the nature of the error that was
  * detected in the received command.  Ver.: always
  */
-bool emberAfDefaultResponseCallback(EmberAfClusterId clusterId, uint8_t commandId, EmberAfStatus status)
+bool emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, EmberAfStatus status)
 {
     return false;
 }
@@ -200,8 +202,8 @@ bool emberAfDefaultResponseCallback(EmberAfClusterId clusterId, uint8_t commandI
  * @param extended Indicates whether the response is in the extended format or
  * not.  Ver.: always
  */
-bool emberAfDiscoverAttributesResponseCallback(EmberAfClusterId clusterId, bool discoveryComplete, uint8_t * buffer,
-                                               uint16_t bufLen, bool extended)
+bool emberAfDiscoverAttributesResponseCallback(ClusterId clusterId, bool discoveryComplete, uint8_t * buffer, uint16_t bufLen,
+                                               bool extended)
 {
     return false;
 }
@@ -220,8 +222,8 @@ bool emberAfDiscoverAttributesResponseCallback(EmberAfClusterId clusterId, bool 
  * @param commandIdCount The length of bytes of the list, whish is the same as
  * the number of identifiers.  Ver.: always
  */
-bool emberAfDiscoverCommandsGeneratedResponseCallback(EmberAfClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
-                                                      uint8_t * commandIds, uint16_t commandIdCount)
+bool emberAfDiscoverCommandsGeneratedResponseCallback(ClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
+                                                      CommandId * commandIds, uint16_t commandIdCount)
 {
     return false;
 }
@@ -240,8 +242,8 @@ bool emberAfDiscoverCommandsGeneratedResponseCallback(EmberAfClusterId clusterId
  * @param commandIdCount The length of bytes of the list, whish is the same as
  * the number of identifiers.  Ver.: always
  */
-bool emberAfDiscoverCommandsReceivedResponseCallback(EmberAfClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
-                                                     uint8_t * commandIds, uint16_t commandIdCount)
+bool emberAfDiscoverCommandsReceivedResponseCallback(ClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
+                                                     CommandId * commandIds, uint16_t commandIdCount)
 {
     return false;
 }
@@ -306,7 +308,7 @@ void emberAfEepromShutdownCallback(void) {}
  * @param buffer   Ver.: always
  * @param maxReadLength   Ver.: always
  */
-EmberAfStatus emberAfExternalAttributeReadCallback(uint8_t endpoint, EmberAfClusterId clusterId,
+EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
                                                    EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
                                                    uint8_t * buffer, uint16_t maxReadLength)
 {
@@ -359,7 +361,7 @@ EmberAfStatus emberAfExternalAttributeReadCallback(uint8_t endpoint, EmberAfClus
  * @param manufacturerCode   Ver.: always
  * @param buffer   Ver.: always
  */
-EmberAfStatus emberAfExternalAttributeWriteCallback(uint8_t endpoint, EmberAfClusterId clusterId,
+EmberAfStatus emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId,
                                                     EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
                                                     uint8_t * buffer)
 {
@@ -519,7 +521,7 @@ bool emberAfGetEndpointByIndexCallback(uint8_t index, uint8_t * endpointReturn)
  * information is written if the callback is providing the information.  Ver.:
  * always
  */
-bool emberAfGetEndpointDescriptionCallback(uint8_t endpoint, EmberEndpointDescription * result)
+bool emberAfGetEndpointDescriptionCallback(EndpointId endpoint, EmberEndpointDescription * result)
 {
     return false;
 }
@@ -541,7 +543,8 @@ bool emberAfGetEndpointDescriptionCallback(uint8_t endpoint, EmberEndpointDescri
  * @param returnEndpointInfo A pointer to a data struct that will be written
  * with information about the endpoint.  Ver.: always
  */
-bool emberAfGetEndpointInfoCallback(uint8_t endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo)
+bool emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex,
+                                    EmberAfEndpointInfoStruct * returnEndpointInfo)
 {
     return false;
 }
@@ -730,7 +733,7 @@ EmberStatus emberAfInitiateInterPanKeyEstablishmentCallback(EmberPanId panId, co
  * @param nodeId The node id of the remote device.  Ver.: always
  * @param endpoint The endpoint on the remote device.  Ver.: always
  */
-EmberStatus emberAfInitiateKeyEstablishmentCallback(EmberNodeId nodeId, uint8_t endpoint)
+EmberStatus emberAfInitiateKeyEstablishmentCallback(EmberNodeId nodeId, EndpointId endpoint)
 {
     return EMBER_LIBRARY_NOT_PRESENT;
 }
@@ -1053,7 +1056,7 @@ int8_t emberAfPluginNetworkSteeringGetPowerForRadioChannelCallback(uint8_t chann
  * @param size   Ver.: always
  * @param value   Ver.: always
  */
-void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,
+void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
 {}
 #endif
@@ -1085,9 +1088,8 @@ void emberAfPostEm4ResetCallback(void)
  * @param size   Ver.: always
  * @param value   Ver.: always
  */
-EmberAfStatus emberAfPreAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
-                                                uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size,
-                                                uint8_t * value)
+EmberAfStatus emberAfPreAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
+                                                uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
 {
     return EMBER_ZCL_STATUS_SUCCESS;
 }
@@ -1220,7 +1222,7 @@ bool emberAfPreZDOMessageReceivedCallback(EmberNodeId emberNodeId, EmberApsFrame
  * Ver.: always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
     return false;
 }
@@ -1309,7 +1311,7 @@ void emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
  * always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfReportAttributesCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+bool emberAfReportAttributesCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
     return false;
 }
@@ -1536,7 +1538,7 @@ void emberAfUnusedPanIdFoundCallback(EmberPanId panId, uint8_t channel) {}
  * Ver.: always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfWriteAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+bool emberAfWriteAttributesResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
     return false;
 }

--- a/examples/lighting-app/lighting-common/gen/callback.h
+++ b/examples/lighting-app/lighting-common/gen/callback.h
@@ -97,8 +97,8 @@ void emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks);
  * @param value   Ver.: always
  * @param type   Ver.: always
  */
-EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(uint8_t endpoint, EmberAfClusterId clusterId,
-                                                                          EmberAfAttributeId attributeId, uint8_t mask,
+EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
+                                                                          chip::AttributeId attributeId, uint8_t mask,
                                                                           uint16_t manufacturerCode, uint8_t * value, uint8_t type);
 /** @brief Attribute Read Access
  *
@@ -110,8 +110,8 @@ EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(uint8_
  * @param manufacturerCode   Ver.: always
  * @param attributeId   Ver.: always
  */
-bool emberAfAttributeReadAccessCallback(uint8_t endpoint, EmberAfClusterId clusterId, uint16_t manufacturerCode,
-                                        uint16_t attributeId);
+bool emberAfAttributeReadAccessCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode,
+                                        chip::AttributeId attributeId);
 /** @brief Attribute Write Access
  *
  * This function is called whenever the Application Framework needs to check
@@ -122,8 +122,8 @@ bool emberAfAttributeReadAccessCallback(uint8_t endpoint, EmberAfClusterId clust
  * @param manufacturerCode   Ver.: always
  * @param attributeId   Ver.: always
  */
-bool emberAfAttributeWriteAccessCallback(uint8_t endpoint, EmberAfClusterId clusterId, uint16_t manufacturerCode,
-                                         uint16_t attributeId);
+bool emberAfAttributeWriteAccessCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode,
+                                         chip::AttributeId attributeId);
 /** @brief Clear Report Table
  *
  * This function is called by the framework when the application should clear
@@ -140,7 +140,7 @@ EmberStatus emberAfClearReportTableCallback(void);
  * @param endpoint   Ver.: always
  * @param clusterId   Ver.: always
  */
-void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId);
+void emberAfClusterInitCallback(chip::EndpointId endpoint, chip::ClusterId clusterId);
 /** @brief Default Response
  *
  * This function is called by the application framework when a Default Response
@@ -153,7 +153,7 @@ void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId);
  * @param status Specifies either SUCCESS or the nature of the error that was
  * detected in the received command.  Ver.: always
  */
-bool emberAfDefaultResponseCallback(EmberAfClusterId clusterId, uint8_t commandId, EmberAfStatus status);
+bool emberAfDefaultResponseCallback(chip::ClusterId clusterId, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Discover Attributes Response
  *
  * This function is called by the application framework when a Discover
@@ -174,8 +174,8 @@ bool emberAfDefaultResponseCallback(EmberAfClusterId clusterId, uint8_t commandI
  * @param extended Indicates whether the response is in the extended format or
  * not.  Ver.: always
  */
-bool emberAfDiscoverAttributesResponseCallback(EmberAfClusterId clusterId, bool discoveryComplete, uint8_t * buffer,
-                                               uint16_t bufLen, bool extended);
+bool emberAfDiscoverAttributesResponseCallback(chip::ClusterId clusterId, bool discoveryComplete, uint8_t * buffer, uint16_t bufLen,
+                                               bool extended);
 /** @brief Discover Commands Generated Response
  *
  * This function is called by the framework when Discover Commands Generated
@@ -190,8 +190,8 @@ bool emberAfDiscoverAttributesResponseCallback(EmberAfClusterId clusterId, bool 
  * @param commandIdCount The length of bytes of the list, whish is the same as
  * the number of identifiers.  Ver.: always
  */
-bool emberAfDiscoverCommandsGeneratedResponseCallback(EmberAfClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
-                                                      uint8_t * commandIds, uint16_t commandIdCount);
+bool emberAfDiscoverCommandsGeneratedResponseCallback(chip::ClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
+                                                      chip::CommandId * commandIds, uint16_t commandIdCount);
 /** @brief Discover Commands Received Response
  *
  * This function is called by the framework when Discover Commands Received
@@ -206,8 +206,8 @@ bool emberAfDiscoverCommandsGeneratedResponseCallback(EmberAfClusterId clusterId
  * @param commandIdCount The length of bytes of the list, whish is the same as
  * the number of identifiers.  Ver.: always
  */
-bool emberAfDiscoverCommandsReceivedResponseCallback(EmberAfClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
-                                                     uint8_t * commandIds, uint16_t commandIdCount);
+bool emberAfDiscoverCommandsReceivedResponseCallback(chip::ClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
+                                                     chip::CommandId * commandIds, uint16_t commandIdCount);
 /** @brief Eeprom Init
  *
  * Tells the system to initialize the EEPROM if it is not already initialized.
@@ -275,7 +275,7 @@ void emberAfEnergyScanResultCallback(uint8_t channel, int8_t rssi);
  * @param buffer   Ver.: always
  * @param maxReadLength   Ver.: always
  */
-EmberAfStatus emberAfExternalAttributeReadCallback(uint8_t endpoint, EmberAfClusterId clusterId,
+EmberAfStatus emberAfExternalAttributeReadCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
                                                    EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
                                                    uint8_t * buffer, uint16_t maxReadLength);
 /** @brief External Attribute Write
@@ -324,7 +324,7 @@ EmberAfStatus emberAfExternalAttributeReadCallback(uint8_t endpoint, EmberAfClus
  * @param manufacturerCode   Ver.: always
  * @param buffer   Ver.: always
  */
-EmberAfStatus emberAfExternalAttributeWriteCallback(uint8_t endpoint, EmberAfClusterId clusterId,
+EmberAfStatus emberAfExternalAttributeWriteCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
                                                     EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
                                                     uint8_t * buffer);
 /** @brief Find Unused Pan Id And Form
@@ -440,7 +440,7 @@ bool emberAfGetEndpointByIndexCallback(uint8_t index, uint8_t * endpointReturn);
  * information is written if the callback is providing the information.  Ver.:
  * always
  */
-bool emberAfGetEndpointDescriptionCallback(uint8_t endpoint, EmberEndpointDescription * result);
+bool emberAfGetEndpointDescriptionCallback(chip::EndpointId endpoint, EmberEndpointDescription * result);
 /** @brief Get Endpoint Info
  *
  * This function is a callback to an application implemented endpoint that
@@ -458,7 +458,8 @@ bool emberAfGetEndpointDescriptionCallback(uint8_t endpoint, EmberEndpointDescri
  * @param returnEndpointInfo A pointer to a data struct that will be written
  * with information about the endpoint.  Ver.: always
  */
-bool emberAfGetEndpointInfoCallback(uint8_t endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo);
+bool emberAfGetEndpointInfoCallback(chip::EndpointId endpoint, uint8_t * returnNetworkIndex,
+                                    EmberAfEndpointInfoStruct * returnEndpointInfo);
 /** @brief Get Form And Join Extended Pan Id
  *
  * This callback is called by the framework to get the extended PAN ID used by
@@ -601,7 +602,7 @@ EmberStatus emberAfInitiateInterPanKeyEstablishmentCallback(EmberPanId panId, co
  * @param nodeId The node id of the remote device.  Ver.: always
  * @param endpoint The endpoint on the remote device.  Ver.: always
  */
-EmberStatus emberAfInitiateKeyEstablishmentCallback(EmberNodeId nodeId, uint8_t endpoint);
+EmberStatus emberAfInitiateKeyEstablishmentCallback(EmberNodeId nodeId, chip::EndpointId endpoint);
 /** @brief Initiate Partner Link Key Exchange
  *
  * This function is called by the framework to initiate a partner link key
@@ -849,8 +850,8 @@ bool emberAfPerformingKeyEstablishmentCallback(void);
  * @param size   Ver.: always
  * @param value   Ver.: always
  */
-void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value);
+void emberAfPostAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
+                                        uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value);
 /** @brief Post Em4 Reset
  *
  * A callback called by application framework, and implemented by em4 plugin
@@ -874,7 +875,7 @@ void emberAfPostEm4ResetCallback(void);
  * @param size   Ver.: always
  * @param value   Ver.: always
  */
-EmberAfStatus emberAfPreAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPreAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
                                                 uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size,
                                                 uint8_t * value);
 /** @brief Pre Cli Send
@@ -984,7 +985,7 @@ bool emberAfPreZDOMessageReceivedCallback(EmberNodeId emberNodeId, EmberApsFrame
  * Ver.: always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+bool emberAfReadAttributesResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration
@@ -1054,7 +1055,7 @@ void emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks);
  * always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfReportAttributesCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+bool emberAfReportAttributesCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 /** @brief Scan Complete
  *
  * This is called by the low-level stack code when an 802.15.4 active scan
@@ -1259,7 +1260,7 @@ void emberAfUnusedPanIdFoundCallback(EmberPanId panId, uint8_t channel);
  * Ver.: always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfWriteAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+bool emberAfWriteAttributesResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 /** @brief Zigbee Key Establishment
  *
  * A callback to the application to notify it of the status of the request for a
@@ -1282,7 +1283,7 @@ void emberAfZigbeeKeyEstablishmentCallback(EmberEUI64 partner, EmberKeyStatus st
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBasicClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBasicClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Basic Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -1292,14 +1293,14 @@ void emberAfBasicClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBasicClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBasicClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Basic Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBasicClusterClientInitCallback(uint8_t endpoint);
+void emberAfBasicClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Basic Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -1309,7 +1310,7 @@ void emberAfBasicClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBasicClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfBasicClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief Basic Cluster Client Message Sent
  *
@@ -1335,7 +1336,7 @@ void emberAfBasicClusterClientMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBasicClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBasicClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief Basic Cluster Client Tick
@@ -1344,7 +1345,7 @@ EmberAfStatus emberAfBasicClusterClientPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBasicClusterClientTickCallback(uint8_t endpoint);
+void emberAfBasicClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Basic Cluster Get Locales Supported
  *
  *
@@ -1374,7 +1375,7 @@ bool emberAfBasicClusterResetToFactoryDefaultsCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBasicClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBasicClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Basic Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -1384,14 +1385,14 @@ void emberAfBasicClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBasicClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBasicClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Basic Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBasicClusterServerInitCallback(uint8_t endpoint);
+void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Basic Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -1401,7 +1402,7 @@ void emberAfBasicClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBasicClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfBasicClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief Basic Cluster Server Message Sent
  *
@@ -1427,7 +1428,7 @@ void emberAfBasicClusterServerMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBasicClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBasicClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief Basic Cluster Server Tick
@@ -1436,7 +1437,7 @@ EmberAfStatus emberAfBasicClusterServerPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBasicClusterServerTickCallback(uint8_t endpoint);
+void emberAfBasicClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Basic Cluster Callbacks */
 
@@ -1450,7 +1451,7 @@ void emberAfBasicClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPowerConfigClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPowerConfigClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Power Configuration Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -1460,14 +1461,15 @@ void emberAfPowerConfigClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPowerConfigClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPowerConfigClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Power Configuration Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPowerConfigClusterClientInitCallback(uint8_t endpoint);
+void emberAfPowerConfigClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Power Configuration Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -1477,7 +1479,8 @@ void emberAfPowerConfigClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPowerConfigClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPowerConfigClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Power Configuration Cluster Client Message Sent
  *
@@ -1504,7 +1507,7 @@ void emberAfPowerConfigClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPowerConfigClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPowerConfigClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Power Configuration Cluster Client Tick
@@ -1513,7 +1516,7 @@ EmberAfStatus emberAfPowerConfigClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPowerConfigClusterClientTickCallback(uint8_t endpoint);
+void emberAfPowerConfigClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Power Configuration Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -1521,7 +1524,7 @@ void emberAfPowerConfigClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPowerConfigClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPowerConfigClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Power Configuration Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -1531,14 +1534,15 @@ void emberAfPowerConfigClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPowerConfigClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPowerConfigClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Power Configuration Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPowerConfigClusterServerInitCallback(uint8_t endpoint);
+void emberAfPowerConfigClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Power Configuration Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -1548,7 +1552,8 @@ void emberAfPowerConfigClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPowerConfigClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPowerConfigClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Power Configuration Cluster Server Message Sent
  *
@@ -1575,7 +1580,7 @@ void emberAfPowerConfigClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPowerConfigClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPowerConfigClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Power Configuration Cluster Server Tick
@@ -1584,7 +1589,7 @@ EmberAfStatus emberAfPowerConfigClusterServerPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPowerConfigClusterServerTickCallback(uint8_t endpoint);
+void emberAfPowerConfigClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Power Configuration Cluster Callbacks */
 
@@ -1598,7 +1603,7 @@ void emberAfPowerConfigClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDeviceTempClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDeviceTempClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Device Temperature Configuration Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -1608,14 +1613,15 @@ void emberAfDeviceTempClusterClientAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDeviceTempClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDeviceTempClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Device Temperature Configuration Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDeviceTempClusterClientInitCallback(uint8_t endpoint);
+void emberAfDeviceTempClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Device Temperature Configuration Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -1625,7 +1631,8 @@ void emberAfDeviceTempClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDeviceTempClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDeviceTempClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Device Temperature Configuration Cluster Client Message Sent
  *
@@ -1652,7 +1659,7 @@ void emberAfDeviceTempClusterClientMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDeviceTempClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDeviceTempClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Device Temperature Configuration Cluster Client Tick
@@ -1661,7 +1668,7 @@ EmberAfStatus emberAfDeviceTempClusterClientPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDeviceTempClusterClientTickCallback(uint8_t endpoint);
+void emberAfDeviceTempClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Device Temperature Configuration Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -1669,7 +1676,7 @@ void emberAfDeviceTempClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDeviceTempClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDeviceTempClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Device Temperature Configuration Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -1679,14 +1686,15 @@ void emberAfDeviceTempClusterServerAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDeviceTempClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDeviceTempClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Device Temperature Configuration Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDeviceTempClusterServerInitCallback(uint8_t endpoint);
+void emberAfDeviceTempClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Device Temperature Configuration Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -1696,7 +1704,8 @@ void emberAfDeviceTempClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDeviceTempClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDeviceTempClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Device Temperature Configuration Cluster Server Message Sent
  *
@@ -1723,7 +1732,7 @@ void emberAfDeviceTempClusterServerMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDeviceTempClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDeviceTempClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Device Temperature Configuration Cluster Server Tick
@@ -1732,7 +1741,7 @@ EmberAfStatus emberAfDeviceTempClusterServerPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDeviceTempClusterServerTickCallback(uint8_t endpoint);
+void emberAfDeviceTempClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Device Temperature Configuration Cluster Callbacks */
 
@@ -1746,7 +1755,7 @@ void emberAfDeviceTempClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIdentifyClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIdentifyClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Identify Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -1756,14 +1765,15 @@ void emberAfIdentifyClusterClientAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIdentifyClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIdentifyClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Identify Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIdentifyClusterClientInitCallback(uint8_t endpoint);
+void emberAfIdentifyClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Identify Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -1773,7 +1783,8 @@ void emberAfIdentifyClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIdentifyClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIdentifyClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Identify Cluster Client Message Sent
  *
@@ -1800,7 +1811,7 @@ void emberAfIdentifyClusterClientMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIdentifyClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIdentifyClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Identify Cluster Client Tick
@@ -1809,7 +1820,7 @@ EmberAfStatus emberAfIdentifyClusterClientPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIdentifyClusterClientTickCallback(uint8_t endpoint);
+void emberAfIdentifyClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Identify Cluster E Z Mode Invoke
  *
  *
@@ -1844,7 +1855,7 @@ bool emberAfIdentifyClusterIdentifyQueryResponseCallback(uint16_t timeout);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIdentifyClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIdentifyClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Identify Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -1854,14 +1865,15 @@ void emberAfIdentifyClusterServerAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIdentifyClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIdentifyClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Identify Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIdentifyClusterServerInitCallback(uint8_t endpoint);
+void emberAfIdentifyClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Identify Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -1871,7 +1883,8 @@ void emberAfIdentifyClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIdentifyClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIdentifyClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Identify Cluster Server Message Sent
  *
@@ -1898,7 +1911,7 @@ void emberAfIdentifyClusterServerMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIdentifyClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIdentifyClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Identify Cluster Server Tick
@@ -1907,7 +1920,7 @@ EmberAfStatus emberAfIdentifyClusterServerPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIdentifyClusterServerTickCallback(uint8_t endpoint);
+void emberAfIdentifyClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Identify Cluster Trigger Effect
  *
  *
@@ -1937,7 +1950,7 @@ bool emberAfIdentifyClusterUpdateCommissionStateCallback(uint8_t action, uint8_t
  *
  * @param endpoint The endpoint.  Ver.: always
  */
-void emberAfGroupsClusterClearGroupTableCallback(uint8_t endpoint);
+void emberAfGroupsClusterClearGroupTableCallback(chip::EndpointId endpoint);
 /** @brief Groups Cluster Add Group
  *
  *
@@ -1945,7 +1958,7 @@ void emberAfGroupsClusterClearGroupTableCallback(uint8_t endpoint);
  * @param groupId   Ver.: always
  * @param groupName   Ver.: always
  */
-bool emberAfGroupsClusterAddGroupCallback(uint16_t groupId, uint8_t * groupName);
+bool emberAfGroupsClusterAddGroupCallback(chip::GroupId groupId, uint8_t * groupName);
 /** @brief Groups Cluster Add Group If Identifying
  *
  *
@@ -1953,7 +1966,7 @@ bool emberAfGroupsClusterAddGroupCallback(uint16_t groupId, uint8_t * groupName)
  * @param groupId   Ver.: always
  * @param groupName   Ver.: always
  */
-bool emberAfGroupsClusterAddGroupIfIdentifyingCallback(uint16_t groupId, uint8_t * groupName);
+bool emberAfGroupsClusterAddGroupIfIdentifyingCallback(chip::GroupId groupId, uint8_t * groupName);
 /** @brief Groups Cluster Add Group Response
  *
  *
@@ -1961,7 +1974,7 @@ bool emberAfGroupsClusterAddGroupIfIdentifyingCallback(uint16_t groupId, uint8_t
  * @param status   Ver.: always
  * @param groupId   Ver.: always
  */
-bool emberAfGroupsClusterAddGroupResponseCallback(uint8_t status, uint16_t groupId);
+bool emberAfGroupsClusterAddGroupResponseCallback(uint8_t status, chip::GroupId groupId);
 /** @brief Groups Cluster Client Attribute Changed
  *
  * Client Attribute Changed
@@ -1969,7 +1982,7 @@ bool emberAfGroupsClusterAddGroupResponseCallback(uint8_t status, uint16_t group
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGroupsClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGroupsClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Groups Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -1979,14 +1992,14 @@ void emberAfGroupsClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGroupsClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGroupsClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Groups Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGroupsClusterClientInitCallback(uint8_t endpoint);
+void emberAfGroupsClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Groups Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -1996,7 +2009,8 @@ void emberAfGroupsClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGroupsClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGroupsClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Groups Cluster Client Message Sent
  *
@@ -2023,7 +2037,7 @@ void emberAfGroupsClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGroupsClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGroupsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Groups Cluster Client Tick
@@ -2032,7 +2046,7 @@ EmberAfStatus emberAfGroupsClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGroupsClusterClientTickCallback(uint8_t endpoint);
+void emberAfGroupsClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Groups Cluster Get Group Membership
  *
  *
@@ -2062,7 +2076,7 @@ bool emberAfGroupsClusterRemoveAllGroupsCallback(void);
  *
  * @param groupId   Ver.: always
  */
-bool emberAfGroupsClusterRemoveGroupCallback(uint16_t groupId);
+bool emberAfGroupsClusterRemoveGroupCallback(chip::GroupId groupId);
 /** @brief Groups Cluster Remove Group Response
  *
  *
@@ -2070,7 +2084,7 @@ bool emberAfGroupsClusterRemoveGroupCallback(uint16_t groupId);
  * @param status   Ver.: always
  * @param groupId   Ver.: always
  */
-bool emberAfGroupsClusterRemoveGroupResponseCallback(uint8_t status, uint16_t groupId);
+bool emberAfGroupsClusterRemoveGroupResponseCallback(uint8_t status, chip::GroupId groupId);
 /** @brief Groups Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -2078,7 +2092,7 @@ bool emberAfGroupsClusterRemoveGroupResponseCallback(uint8_t status, uint16_t gr
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGroupsClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGroupsClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Groups Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -2088,14 +2102,14 @@ void emberAfGroupsClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGroupsClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGroupsClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Groups Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGroupsClusterServerInitCallback(uint8_t endpoint);
+void emberAfGroupsClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Groups Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -2105,7 +2119,8 @@ void emberAfGroupsClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGroupsClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGroupsClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Groups Cluster Server Message Sent
  *
@@ -2132,7 +2147,7 @@ void emberAfGroupsClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGroupsClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGroupsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Groups Cluster Server Tick
@@ -2141,14 +2156,14 @@ EmberAfStatus emberAfGroupsClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGroupsClusterServerTickCallback(uint8_t endpoint);
+void emberAfGroupsClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Groups Cluster View Group
  *
  *
  *
  * @param groupId   Ver.: always
  */
-bool emberAfGroupsClusterViewGroupCallback(uint16_t groupId);
+bool emberAfGroupsClusterViewGroupCallback(chip::GroupId groupId);
 /** @brief Groups Cluster View Group Response
  *
  *
@@ -2157,7 +2172,7 @@ bool emberAfGroupsClusterViewGroupCallback(uint16_t groupId);
  * @param groupId   Ver.: always
  * @param groupName   Ver.: always
  */
-bool emberAfGroupsClusterViewGroupResponseCallback(uint8_t status, uint16_t groupId, uint8_t * groupName);
+bool emberAfGroupsClusterViewGroupResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t * groupName);
 
 /** @} END Groups Cluster Callbacks */
 
@@ -2171,7 +2186,7 @@ bool emberAfGroupsClusterViewGroupResponseCallback(uint8_t status, uint16_t grou
  *
  * @param endpoint The endpoint.  Ver.: always
  */
-void emberAfScenesClusterClearSceneTableCallback(uint8_t endpoint);
+void emberAfScenesClusterClearSceneTableCallback(chip::EndpointId endpoint);
 /** @brief Scenes Cluster Add Scene
  *
  *
@@ -2182,7 +2197,7 @@ void emberAfScenesClusterClearSceneTableCallback(uint8_t endpoint);
  * @param sceneName   Ver.: always
  * @param extensionFieldSets   Ver.: always
  */
-bool emberAfScenesClusterAddSceneCallback(uint16_t groupId, uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
+bool emberAfScenesClusterAddSceneCallback(chip::GroupId groupId, uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
                                           uint8_t * extensionFieldSets);
 /** @brief Scenes Cluster Add Scene Response
  *
@@ -2192,7 +2207,7 @@ bool emberAfScenesClusterAddSceneCallback(uint16_t groupId, uint8_t sceneId, uin
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterAddSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterAddSceneResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster Client Attribute Changed
  *
  * Client Attribute Changed
@@ -2200,7 +2215,7 @@ bool emberAfScenesClusterAddSceneResponseCallback(uint8_t status, uint16_t group
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfScenesClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfScenesClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Scenes Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -2210,14 +2225,14 @@ void emberAfScenesClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfScenesClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfScenesClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Scenes Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfScenesClusterClientInitCallback(uint8_t endpoint);
+void emberAfScenesClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Scenes Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -2227,7 +2242,8 @@ void emberAfScenesClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfScenesClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfScenesClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Scenes Cluster Client Message Sent
  *
@@ -2254,7 +2270,7 @@ void emberAfScenesClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfScenesClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfScenesClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Scenes Cluster Client Tick
@@ -2263,7 +2279,7 @@ EmberAfStatus emberAfScenesClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfScenesClusterClientTickCallback(uint8_t endpoint);
+void emberAfScenesClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Scenes Cluster Copy Scene
  *
  *
@@ -2295,8 +2311,8 @@ bool emberAfScenesClusterCopySceneResponseCallback(uint8_t status, uint16_t grou
  * @param sceneName   Ver.: always
  * @param extensionFieldSets   Ver.: always
  */
-bool emberAfScenesClusterEnhancedAddSceneCallback(uint16_t groupId, uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
-                                                  uint8_t * extensionFieldSets);
+bool emberAfScenesClusterEnhancedAddSceneCallback(chip::GroupId groupId, uint8_t sceneId, uint16_t transitionTime,
+                                                  uint8_t * sceneName, uint8_t * extensionFieldSets);
 /** @brief Scenes Cluster Enhanced Add Scene Response
  *
  *
@@ -2305,7 +2321,7 @@ bool emberAfScenesClusterEnhancedAddSceneCallback(uint16_t groupId, uint8_t scen
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterEnhancedAddSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterEnhancedAddSceneResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster Enhanced View Scene
  *
  *
@@ -2313,7 +2329,7 @@ bool emberAfScenesClusterEnhancedAddSceneResponseCallback(uint8_t status, uint16
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterEnhancedViewSceneCallback(uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterEnhancedViewSceneCallback(chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster Enhanced View Scene Response
  *
  *
@@ -2325,7 +2341,7 @@ bool emberAfScenesClusterEnhancedViewSceneCallback(uint16_t groupId, uint8_t sce
  * @param sceneName   Ver.: always
  * @param extensionFieldSets   Ver.: always
  */
-bool emberAfScenesClusterEnhancedViewSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId,
+bool emberAfScenesClusterEnhancedViewSceneResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t sceneId,
                                                            uint16_t transitionTime, uint8_t * sceneName,
                                                            uint8_t * extensionFieldSets);
 /** @brief Scenes Cluster Get Scene Membership
@@ -2334,7 +2350,7 @@ bool emberAfScenesClusterEnhancedViewSceneResponseCallback(uint8_t status, uint1
  *
  * @param groupId   Ver.: always
  */
-bool emberAfScenesClusterGetSceneMembershipCallback(uint16_t groupId);
+bool emberAfScenesClusterGetSceneMembershipCallback(chip::GroupId groupId);
 /** @brief Scenes Cluster Get Scene Membership Response
  *
  *
@@ -2345,8 +2361,8 @@ bool emberAfScenesClusterGetSceneMembershipCallback(uint16_t groupId);
  * @param sceneCount   Ver.: always
  * @param sceneList   Ver.: always
  */
-bool emberAfScenesClusterGetSceneMembershipResponseCallback(uint8_t status, uint8_t capacity, uint16_t groupId, uint8_t sceneCount,
-                                                            uint8_t * sceneList);
+bool emberAfScenesClusterGetSceneMembershipResponseCallback(uint8_t status, uint8_t capacity, chip::GroupId groupId,
+                                                            uint8_t sceneCount, uint8_t * sceneList);
 /** @brief Scenes Cluster Recall Scene
  *
  *
@@ -2355,14 +2371,14 @@ bool emberAfScenesClusterGetSceneMembershipResponseCallback(uint8_t status, uint
  * @param sceneId   Ver.: always
  * @param transitionTime   Ver.: since zcl-7.0-07-5123-07
  */
-bool emberAfScenesClusterRecallSceneCallback(uint16_t groupId, uint8_t sceneId, uint16_t transitionTime);
+bool emberAfScenesClusterRecallSceneCallback(chip::GroupId groupId, uint8_t sceneId, uint16_t transitionTime);
 /** @brief Scenes Cluster Remove All Scenes
  *
  *
  *
  * @param groupId   Ver.: always
  */
-bool emberAfScenesClusterRemoveAllScenesCallback(uint16_t groupId);
+bool emberAfScenesClusterRemoveAllScenesCallback(chip::GroupId groupId);
 /** @brief Scenes Cluster Remove All Scenes Response
  *
  *
@@ -2370,7 +2386,7 @@ bool emberAfScenesClusterRemoveAllScenesCallback(uint16_t groupId);
  * @param status   Ver.: always
  * @param groupId   Ver.: always
  */
-bool emberAfScenesClusterRemoveAllScenesResponseCallback(uint8_t status, uint16_t groupId);
+bool emberAfScenesClusterRemoveAllScenesResponseCallback(uint8_t status, chip::GroupId groupId);
 /** @brief Scenes Cluster Remove Scene
  *
  *
@@ -2378,7 +2394,7 @@ bool emberAfScenesClusterRemoveAllScenesResponseCallback(uint8_t status, uint16_
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterRemoveSceneCallback(uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterRemoveSceneCallback(chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster Remove Scene Response
  *
  *
@@ -2387,7 +2403,7 @@ bool emberAfScenesClusterRemoveSceneCallback(uint16_t groupId, uint8_t sceneId);
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterRemoveSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterRemoveSceneResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -2395,7 +2411,7 @@ bool emberAfScenesClusterRemoveSceneResponseCallback(uint8_t status, uint16_t gr
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfScenesClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfScenesClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Scenes Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -2405,14 +2421,14 @@ void emberAfScenesClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfScenesClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfScenesClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Scenes Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfScenesClusterServerInitCallback(uint8_t endpoint);
+void emberAfScenesClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Scenes Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -2422,7 +2438,8 @@ void emberAfScenesClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfScenesClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfScenesClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Scenes Cluster Server Message Sent
  *
@@ -2449,7 +2466,7 @@ void emberAfScenesClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfScenesClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfScenesClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Scenes Cluster Server Tick
@@ -2458,7 +2475,7 @@ EmberAfStatus emberAfScenesClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfScenesClusterServerTickCallback(uint8_t endpoint);
+void emberAfScenesClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Scenes Cluster Store Scene
  *
  *
@@ -2466,7 +2483,7 @@ void emberAfScenesClusterServerTickCallback(uint8_t endpoint);
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterStoreSceneCallback(uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterStoreSceneCallback(chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster Store Scene Response
  *
  *
@@ -2475,7 +2492,7 @@ bool emberAfScenesClusterStoreSceneCallback(uint16_t groupId, uint8_t sceneId);
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterStoreSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterStoreSceneResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster View Scene
  *
  *
@@ -2483,7 +2500,7 @@ bool emberAfScenesClusterStoreSceneResponseCallback(uint8_t status, uint16_t gro
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterViewSceneCallback(uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterViewSceneCallback(chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster View Scene Response
  *
  *
@@ -2495,7 +2512,7 @@ bool emberAfScenesClusterViewSceneCallback(uint16_t groupId, uint8_t sceneId);
  * @param sceneName   Ver.: always
  * @param extensionFieldSets   Ver.: always
  */
-bool emberAfScenesClusterViewSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
+bool emberAfScenesClusterViewSceneResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t sceneId, uint16_t transitionTime,
                                                    uint8_t * sceneName, uint8_t * extensionFieldSets);
 /** @} END Scenes Cluster Callbacks */
 
@@ -2508,7 +2525,7 @@ bool emberAfScenesClusterViewSceneResponseCallback(uint8_t status, uint16_t grou
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOnOffClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOnOffClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief On/off Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -2518,14 +2535,14 @@ void emberAfOnOffClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOnOffClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOnOffClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief On/off Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOnOffClusterClientInitCallback(uint8_t endpoint);
+void emberAfOnOffClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief On/off Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -2535,7 +2552,7 @@ void emberAfOnOffClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOnOffClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfOnOffClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief On/off Cluster Client Message Sent
  *
@@ -2561,7 +2578,7 @@ void emberAfOnOffClusterClientMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOnOffClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOnOffClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief On/off Cluster Client Tick
@@ -2570,7 +2587,7 @@ EmberAfStatus emberAfOnOffClusterClientPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOnOffClusterClientTickCallback(uint8_t endpoint);
+void emberAfOnOffClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief On/off Cluster Off
  *
  *
@@ -2643,7 +2660,7 @@ bool emberAfOnOffClusterSampleMfgSpecificToggleWithTransitionCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOnOffClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOnOffClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief On/off Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -2653,14 +2670,14 @@ void emberAfOnOffClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOnOffClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOnOffClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief On/off Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOnOffClusterServerInitCallback(uint8_t endpoint);
+void emberAfOnOffClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief On/off Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -2670,7 +2687,7 @@ void emberAfOnOffClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOnOffClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfOnOffClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief On/off Cluster Server Message Sent
  *
@@ -2696,7 +2713,7 @@ void emberAfOnOffClusterServerMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOnOffClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOnOffClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief On/off Cluster Server Tick
@@ -2705,7 +2722,7 @@ EmberAfStatus emberAfOnOffClusterServerPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOnOffClusterServerTickCallback(uint8_t endpoint);
+void emberAfOnOffClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief On/off Cluster Toggle
  *
  *
@@ -2719,7 +2736,7 @@ bool emberAfOnOffClusterToggleCallback(void);
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint);
+void emberAfPluginOnOffClusterServerPostInitCallback(chip::EndpointId endpoint);
 
 /** @} END On/off Cluster Callbacks */
 
@@ -2733,7 +2750,7 @@ void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOnOffSwitchConfigClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief On/off Switch Configuration Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -2743,14 +2760,15 @@ void emberAfOnOffSwitchConfigClusterClientAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOnOffSwitchConfigClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief On/off Switch Configuration Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterClientInitCallback(uint8_t endpoint);
+void emberAfOnOffSwitchConfigClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief On/off Switch Configuration Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -2761,7 +2779,7 @@ void emberAfOnOffSwitchConfigClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfOnOffSwitchConfigClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief On/off Switch Configuration Cluster Client Message Sent
  *
@@ -2788,7 +2806,8 @@ void emberAfOnOffSwitchConfigClusterClientMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOnOffSwitchConfigClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOnOffSwitchConfigClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief On/off Switch Configuration Cluster Client Tick
@@ -2797,7 +2816,7 @@ EmberAfStatus emberAfOnOffSwitchConfigClusterClientPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterClientTickCallback(uint8_t endpoint);
+void emberAfOnOffSwitchConfigClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief On/off Switch Configuration Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -2805,7 +2824,7 @@ void emberAfOnOffSwitchConfigClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOnOffSwitchConfigClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief On/off Switch Configuration Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -2815,14 +2834,15 @@ void emberAfOnOffSwitchConfigClusterServerAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOnOffSwitchConfigClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief On/off Switch Configuration Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterServerInitCallback(uint8_t endpoint);
+void emberAfOnOffSwitchConfigClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief On/off Switch Configuration Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -2833,7 +2853,7 @@ void emberAfOnOffSwitchConfigClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfOnOffSwitchConfigClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief On/off Switch Configuration Cluster Server Message Sent
  *
@@ -2860,7 +2880,8 @@ void emberAfOnOffSwitchConfigClusterServerMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOnOffSwitchConfigClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOnOffSwitchConfigClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief On/off Switch Configuration Cluster Server Tick
@@ -2869,7 +2890,7 @@ EmberAfStatus emberAfOnOffSwitchConfigClusterServerPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterServerTickCallback(uint8_t endpoint);
+void emberAfOnOffSwitchConfigClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END On/off Switch Configuration Cluster Callbacks */
 
@@ -2883,7 +2904,7 @@ void emberAfOnOffSwitchConfigClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfLevelControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfLevelControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Level Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -2893,14 +2914,15 @@ void emberAfLevelControlClusterClientAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfLevelControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfLevelControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief Level Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfLevelControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfLevelControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Level Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -2910,7 +2932,8 @@ void emberAfLevelControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfLevelControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfLevelControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief Level Control Cluster Client Message Sent
  *
@@ -2937,7 +2960,7 @@ void emberAfLevelControlClusterClientMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfLevelControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfLevelControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief Level Control Cluster Client Tick
@@ -2946,7 +2969,7 @@ EmberAfStatus emberAfLevelControlClusterClientPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfLevelControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfLevelControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Level Control Cluster Move
  *
  *
@@ -2991,7 +3014,7 @@ bool emberAfLevelControlClusterMoveWithOnOffCallback(uint8_t moveMode, uint8_t r
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfLevelControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfLevelControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Level Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -3001,14 +3024,15 @@ void emberAfLevelControlClusterServerAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfLevelControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfLevelControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief Level Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfLevelControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfLevelControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Level Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -3018,7 +3042,8 @@ void emberAfLevelControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfLevelControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfLevelControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief Level Control Cluster Server Message Sent
  *
@@ -3045,7 +3070,7 @@ void emberAfLevelControlClusterServerMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfLevelControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfLevelControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief Level Control Cluster Server Tick
@@ -3054,7 +3079,7 @@ EmberAfStatus emberAfLevelControlClusterServerPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfLevelControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfLevelControlClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Level Control Cluster Step
  *
  *
@@ -3103,7 +3128,7 @@ bool emberAfLevelControlClusterStopWithOnOffCallback(void);
  * @param alarmCode   Ver.: always
  * @param clusterId   Ver.: always
  */
-bool emberAfAlarmClusterAlarmCallback(uint8_t alarmCode, uint16_t clusterId);
+bool emberAfAlarmClusterAlarmCallback(uint8_t alarmCode, chip::ClusterId clusterId);
 /** @brief Alarms Cluster Client Attribute Changed
  *
  * Client Attribute Changed
@@ -3111,7 +3136,7 @@ bool emberAfAlarmClusterAlarmCallback(uint8_t alarmCode, uint16_t clusterId);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfAlarmClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfAlarmClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Alarms Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -3121,14 +3146,14 @@ void emberAfAlarmClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfAlarmClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfAlarmClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Alarms Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfAlarmClusterClientInitCallback(uint8_t endpoint);
+void emberAfAlarmClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Alarms Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -3138,7 +3163,7 @@ void emberAfAlarmClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfAlarmClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfAlarmClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief Alarms Cluster Client Message Sent
  *
@@ -3164,7 +3189,7 @@ void emberAfAlarmClusterClientMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfAlarmClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfAlarmClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief Alarms Cluster Client Tick
@@ -3173,7 +3198,7 @@ EmberAfStatus emberAfAlarmClusterClientPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfAlarmClusterClientTickCallback(uint8_t endpoint);
+void emberAfAlarmClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Alarms Cluster Get Alarm
  *
  *
@@ -3189,7 +3214,7 @@ bool emberAfAlarmClusterGetAlarmCallback(void);
  * @param clusterId   Ver.: always
  * @param timeStamp   Ver.: always
  */
-bool emberAfAlarmClusterGetAlarmResponseCallback(uint8_t status, uint8_t alarmCode, uint16_t clusterId, uint32_t timeStamp);
+bool emberAfAlarmClusterGetAlarmResponseCallback(uint8_t status, uint8_t alarmCode, chip::ClusterId clusterId, uint32_t timeStamp);
 /** @brief Alarms Cluster Reset Alarm
  *
  *
@@ -3197,7 +3222,7 @@ bool emberAfAlarmClusterGetAlarmResponseCallback(uint8_t status, uint8_t alarmCo
  * @param alarmCode   Ver.: always
  * @param clusterId   Ver.: always
  */
-bool emberAfAlarmClusterResetAlarmCallback(uint8_t alarmCode, uint16_t clusterId);
+bool emberAfAlarmClusterResetAlarmCallback(uint8_t alarmCode, chip::ClusterId clusterId);
 /** @brief Alarms Cluster Reset Alarm Log
  *
  *
@@ -3217,7 +3242,7 @@ bool emberAfAlarmClusterResetAllAlarmsCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfAlarmClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfAlarmClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Alarms Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -3227,14 +3252,14 @@ void emberAfAlarmClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfAlarmClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfAlarmClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Alarms Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfAlarmClusterServerInitCallback(uint8_t endpoint);
+void emberAfAlarmClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Alarms Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -3244,7 +3269,7 @@ void emberAfAlarmClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfAlarmClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfAlarmClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief Alarms Cluster Server Message Sent
  *
@@ -3270,7 +3295,7 @@ void emberAfAlarmClusterServerMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfAlarmClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfAlarmClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief Alarms Cluster Server Tick
@@ -3279,7 +3304,7 @@ EmberAfStatus emberAfAlarmClusterServerPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfAlarmClusterServerTickCallback(uint8_t endpoint);
+void emberAfAlarmClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Alarms Cluster Callbacks */
 
@@ -3293,7 +3318,7 @@ void emberAfAlarmClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTimeClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfTimeClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Time Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -3303,14 +3328,14 @@ void emberAfTimeClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTimeClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfTimeClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Time Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTimeClusterClientInitCallback(uint8_t endpoint);
+void emberAfTimeClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Time Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -3320,7 +3345,7 @@ void emberAfTimeClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfTimeClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfTimeClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           uint16_t manufacturerCode);
 /** @brief Time Cluster Client Message Sent
  *
@@ -3346,7 +3371,7 @@ void emberAfTimeClusterClientMessageSentCallback(EmberOutgoingMessageType type, 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfTimeClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfTimeClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                   EmberAfAttributeType attributeType, uint8_t size,
                                                                   uint8_t * value);
 /** @brief Time Cluster Client Tick
@@ -3355,7 +3380,7 @@ EmberAfStatus emberAfTimeClusterClientPreAttributeChangedCallback(uint8_t endpoi
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTimeClusterClientTickCallback(uint8_t endpoint);
+void emberAfTimeClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Time Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -3363,7 +3388,7 @@ void emberAfTimeClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTimeClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfTimeClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Time Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -3373,14 +3398,14 @@ void emberAfTimeClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTimeClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfTimeClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Time Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTimeClusterServerInitCallback(uint8_t endpoint);
+void emberAfTimeClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Time Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -3390,7 +3415,7 @@ void emberAfTimeClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfTimeClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfTimeClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           uint16_t manufacturerCode);
 /** @brief Time Cluster Server Message Sent
  *
@@ -3416,7 +3441,7 @@ void emberAfTimeClusterServerMessageSentCallback(EmberOutgoingMessageType type, 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfTimeClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfTimeClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                   EmberAfAttributeType attributeType, uint8_t size,
                                                                   uint8_t * value);
 /** @brief Time Cluster Server Tick
@@ -3425,7 +3450,7 @@ EmberAfStatus emberAfTimeClusterServerPreAttributeChangedCallback(uint8_t endpoi
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTimeClusterServerTickCallback(uint8_t endpoint);
+void emberAfTimeClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Time Cluster Callbacks */
 
@@ -3450,7 +3475,7 @@ bool emberAfRssiLocationClusterAnchorNodeAnnounceCallback(uint8_t * anchorNodeIe
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfRssiLocationClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfRssiLocationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief RSSI Location Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -3460,14 +3485,15 @@ void emberAfRssiLocationClusterClientAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfRssiLocationClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfRssiLocationClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief RSSI Location Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfRssiLocationClusterClientInitCallback(uint8_t endpoint);
+void emberAfRssiLocationClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief RSSI Location Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -3477,7 +3503,8 @@ void emberAfRssiLocationClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfRssiLocationClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfRssiLocationClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief RSSI Location Cluster Client Message Sent
  *
@@ -3504,7 +3531,7 @@ void emberAfRssiLocationClusterClientMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfRssiLocationClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfRssiLocationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief RSSI Location Cluster Client Tick
@@ -3513,7 +3540,7 @@ EmberAfStatus emberAfRssiLocationClusterClientPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfRssiLocationClusterClientTickCallback(uint8_t endpoint);
+void emberAfRssiLocationClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief RSSI Location Cluster Compact Location Data Notification
  *
  *
@@ -3655,7 +3682,7 @@ bool emberAfRssiLocationClusterSendPingsCallback(uint8_t * targetAddress, uint8_
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfRssiLocationClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfRssiLocationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief RSSI Location Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -3665,14 +3692,15 @@ void emberAfRssiLocationClusterServerAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfRssiLocationClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfRssiLocationClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief RSSI Location Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfRssiLocationClusterServerInitCallback(uint8_t endpoint);
+void emberAfRssiLocationClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief RSSI Location Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -3682,7 +3710,8 @@ void emberAfRssiLocationClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfRssiLocationClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfRssiLocationClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief RSSI Location Cluster Server Message Sent
  *
@@ -3709,7 +3738,7 @@ void emberAfRssiLocationClusterServerMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfRssiLocationClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfRssiLocationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief RSSI Location Cluster Server Tick
@@ -3718,7 +3747,7 @@ EmberAfStatus emberAfRssiLocationClusterServerPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfRssiLocationClusterServerTickCallback(uint8_t endpoint);
+void emberAfRssiLocationClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief RSSI Location Cluster Set Absolute Location
  *
  *
@@ -3756,7 +3785,7 @@ bool emberAfRssiLocationClusterSetDeviceConfigurationCallback(int16_t power, uin
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBinaryInputBasicClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBinaryInputBasicClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Binary Input (Basic) Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -3766,14 +3795,15 @@ void emberAfBinaryInputBasicClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBinaryInputBasicClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBinaryInputBasicClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Binary Input (Basic) Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBinaryInputBasicClusterClientInitCallback(uint8_t endpoint);
+void emberAfBinaryInputBasicClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Binary Input (Basic) Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -3783,8 +3813,8 @@ void emberAfBinaryInputBasicClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBinaryInputBasicClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfBinaryInputBasicClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Binary Input (Basic) Cluster Client Message Sent
  *
@@ -3811,7 +3841,8 @@ void emberAfBinaryInputBasicClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBinaryInputBasicClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBinaryInputBasicClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Binary Input (Basic) Cluster Client Tick
@@ -3820,7 +3851,7 @@ EmberAfStatus emberAfBinaryInputBasicClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBinaryInputBasicClusterClientTickCallback(uint8_t endpoint);
+void emberAfBinaryInputBasicClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Binary Input (Basic) Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -3828,7 +3859,7 @@ void emberAfBinaryInputBasicClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBinaryInputBasicClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBinaryInputBasicClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Binary Input (Basic) Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -3838,14 +3869,15 @@ void emberAfBinaryInputBasicClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBinaryInputBasicClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBinaryInputBasicClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Binary Input (Basic) Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBinaryInputBasicClusterServerInitCallback(uint8_t endpoint);
+void emberAfBinaryInputBasicClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Binary Input (Basic) Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -3855,8 +3887,8 @@ void emberAfBinaryInputBasicClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBinaryInputBasicClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfBinaryInputBasicClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Binary Input (Basic) Cluster Server Message Sent
  *
@@ -3883,7 +3915,8 @@ void emberAfBinaryInputBasicClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBinaryInputBasicClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBinaryInputBasicClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Binary Input (Basic) Cluster Server Tick
@@ -3892,7 +3925,7 @@ EmberAfStatus emberAfBinaryInputBasicClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBinaryInputBasicClusterServerTickCallback(uint8_t endpoint);
+void emberAfBinaryInputBasicClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Binary Input (Basic) Cluster Callbacks */
 
@@ -3906,7 +3939,7 @@ void emberAfBinaryInputBasicClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfCommissioningClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfCommissioningClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Commissioning Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -3916,14 +3949,15 @@ void emberAfCommissioningClusterClientAttributeChangedCallback(uint8_t endpoint,
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCommissioningClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfCommissioningClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                              EmberAfStatus status);
 /** @brief Commissioning Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCommissioningClusterClientInitCallback(uint8_t endpoint);
+void emberAfCommissioningClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Commissioning Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -3933,7 +3967,8 @@ void emberAfCommissioningClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfCommissioningClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfCommissioningClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    uint16_t manufacturerCode);
 /** @brief Commissioning Cluster Client Message Sent
  *
@@ -3960,7 +3995,7 @@ void emberAfCommissioningClusterClientMessageSentCallback(EmberOutgoingMessageTy
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfCommissioningClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfCommissioningClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            EmberAfAttributeType attributeType, uint8_t size,
                                                                            uint8_t * value);
 /** @brief Commissioning Cluster Client Tick
@@ -3969,7 +4004,7 @@ EmberAfStatus emberAfCommissioningClusterClientPreAttributeChangedCallback(uint8
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCommissioningClusterClientTickCallback(uint8_t endpoint);
+void emberAfCommissioningClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Commissioning Cluster Reset Startup Parameters
  *
  *
@@ -4038,7 +4073,7 @@ bool emberAfCommissioningClusterSaveStartupParametersResponseCallback(uint8_t st
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfCommissioningClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfCommissioningClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Commissioning Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -4048,14 +4083,15 @@ void emberAfCommissioningClusterServerAttributeChangedCallback(uint8_t endpoint,
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCommissioningClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfCommissioningClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                              EmberAfStatus status);
 /** @brief Commissioning Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCommissioningClusterServerInitCallback(uint8_t endpoint);
+void emberAfCommissioningClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Commissioning Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -4065,7 +4101,8 @@ void emberAfCommissioningClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfCommissioningClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfCommissioningClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    uint16_t manufacturerCode);
 /** @brief Commissioning Cluster Server Message Sent
  *
@@ -4092,7 +4129,7 @@ void emberAfCommissioningClusterServerMessageSentCallback(EmberOutgoingMessageTy
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfCommissioningClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfCommissioningClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            EmberAfAttributeType attributeType, uint8_t size,
                                                                            uint8_t * value);
 /** @brief Commissioning Cluster Server Tick
@@ -4101,7 +4138,7 @@ EmberAfStatus emberAfCommissioningClusterServerPreAttributeChangedCallback(uint8
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCommissioningClusterServerTickCallback(uint8_t endpoint);
+void emberAfCommissioningClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Commissioning Cluster Callbacks */
 
@@ -4115,7 +4152,7 @@ void emberAfCommissioningClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPartitionClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPartitionClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Partition Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -4125,14 +4162,15 @@ void emberAfPartitionClusterClientAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPartitionClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPartitionClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Partition Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPartitionClusterClientInitCallback(uint8_t endpoint);
+void emberAfPartitionClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Partition Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -4142,7 +4180,8 @@ void emberAfPartitionClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPartitionClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPartitionClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Partition Cluster Client Message Sent
  *
@@ -4169,7 +4208,7 @@ void emberAfPartitionClusterClientMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPartitionClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPartitionClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Partition Cluster Client Tick
@@ -4178,7 +4217,7 @@ EmberAfStatus emberAfPartitionClusterClientPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPartitionClusterClientTickCallback(uint8_t endpoint);
+void emberAfPartitionClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Partition Cluster Multiple Ack
  *
  *
@@ -4210,7 +4249,7 @@ bool emberAfPartitionClusterReadHandshakeParamResponseCallback(uint16_t partitio
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPartitionClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPartitionClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Partition Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -4220,14 +4259,15 @@ void emberAfPartitionClusterServerAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPartitionClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPartitionClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Partition Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPartitionClusterServerInitCallback(uint8_t endpoint);
+void emberAfPartitionClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Partition Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -4237,7 +4277,8 @@ void emberAfPartitionClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPartitionClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPartitionClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Partition Cluster Server Message Sent
  *
@@ -4264,7 +4305,7 @@ void emberAfPartitionClusterServerMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPartitionClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPartitionClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Partition Cluster Server Tick
@@ -4273,7 +4314,7 @@ EmberAfStatus emberAfPartitionClusterServerPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPartitionClusterServerTickCallback(uint8_t endpoint);
+void emberAfPartitionClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Partition Cluster Transfer Partitioned Frame
  *
  *
@@ -4303,7 +4344,7 @@ bool emberAfPartitionClusterWriteHandshakeParamCallback(uint16_t partitionedClus
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOtaBootloadClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOtaBootloadClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Over the Air Bootloading Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -4313,14 +4354,15 @@ void emberAfOtaBootloadClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOtaBootloadClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOtaBootloadClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Over the Air Bootloading Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOtaBootloadClusterClientInitCallback(uint8_t endpoint);
+void emberAfOtaBootloadClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Over the Air Bootloading Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -4330,7 +4372,8 @@ void emberAfOtaBootloadClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOtaBootloadClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfOtaBootloadClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Over the Air Bootloading Cluster Client Message Sent
  *
@@ -4357,7 +4400,7 @@ void emberAfOtaBootloadClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOtaBootloadClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOtaBootloadClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Over the Air Bootloading Cluster Client Tick
@@ -4366,7 +4409,7 @@ EmberAfStatus emberAfOtaBootloadClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOtaBootloadClusterClientTickCallback(uint8_t endpoint);
+void emberAfOtaBootloadClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Over the Air Bootloading Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -4374,7 +4417,7 @@ void emberAfOtaBootloadClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOtaBootloadClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOtaBootloadClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Over the Air Bootloading Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -4384,14 +4427,15 @@ void emberAfOtaBootloadClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOtaBootloadClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOtaBootloadClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Over the Air Bootloading Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOtaBootloadClusterServerInitCallback(uint8_t endpoint);
+void emberAfOtaBootloadClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Over the Air Bootloading Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -4401,7 +4445,8 @@ void emberAfOtaBootloadClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOtaBootloadClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfOtaBootloadClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Over the Air Bootloading Cluster Server Message Sent
  *
@@ -4428,7 +4473,7 @@ void emberAfOtaBootloadClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOtaBootloadClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOtaBootloadClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Over the Air Bootloading Cluster Server Tick
@@ -4437,7 +4482,7 @@ EmberAfStatus emberAfOtaBootloadClusterServerPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOtaBootloadClusterServerTickCallback(uint8_t endpoint);
+void emberAfOtaBootloadClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Over the Air Bootloading Cluster Callbacks */
 
@@ -4451,7 +4496,7 @@ void emberAfOtaBootloadClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPowerProfileClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPowerProfileClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Power Profile Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -4461,14 +4506,15 @@ void emberAfPowerProfileClusterClientAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPowerProfileClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPowerProfileClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief Power Profile Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPowerProfileClusterClientInitCallback(uint8_t endpoint);
+void emberAfPowerProfileClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Power Profile Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -4478,7 +4524,8 @@ void emberAfPowerProfileClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPowerProfileClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPowerProfileClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief Power Profile Cluster Client Message Sent
  *
@@ -4505,7 +4552,7 @@ void emberAfPowerProfileClusterClientMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPowerProfileClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPowerProfileClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief Power Profile Cluster Client Tick
@@ -4514,7 +4561,7 @@ EmberAfStatus emberAfPowerProfileClusterClientPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPowerProfileClusterClientTickCallback(uint8_t endpoint);
+void emberAfPowerProfileClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Power Profile Cluster Energy Phases Schedule Notification
  *
  *
@@ -4709,7 +4756,7 @@ bool emberAfPowerProfileClusterPowerProfilesStateNotificationCallback(uint8_t po
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPowerProfileClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPowerProfileClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Power Profile Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -4719,14 +4766,15 @@ void emberAfPowerProfileClusterServerAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPowerProfileClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPowerProfileClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief Power Profile Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPowerProfileClusterServerInitCallback(uint8_t endpoint);
+void emberAfPowerProfileClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Power Profile Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -4736,7 +4784,8 @@ void emberAfPowerProfileClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPowerProfileClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPowerProfileClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief Power Profile Cluster Server Message Sent
  *
@@ -4763,7 +4812,7 @@ void emberAfPowerProfileClusterServerMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPowerProfileClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPowerProfileClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief Power Profile Cluster Server Tick
@@ -4772,7 +4821,7 @@ EmberAfStatus emberAfPowerProfileClusterServerPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPowerProfileClusterServerTickCallback(uint8_t endpoint);
+void emberAfPowerProfileClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Power Profile Cluster Callbacks */
 
@@ -4786,7 +4835,7 @@ void emberAfPowerProfileClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -4796,14 +4845,15 @@ void emberAfApplianceControlClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Appliance Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfApplianceControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -4813,8 +4863,8 @@ void emberAfApplianceControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfApplianceControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfApplianceControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Appliance Control Cluster Client Message Sent
  *
@@ -4841,7 +4891,8 @@ void emberAfApplianceControlClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Appliance Control Cluster Client Tick
@@ -4850,14 +4901,14 @@ EmberAfStatus emberAfApplianceControlClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfApplianceControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Appliance Control Cluster Execution Of A Command
  *
  *
  *
  * @param commandId   Ver.: always
  */
-bool emberAfApplianceControlClusterExecutionOfACommandCallback(uint8_t commandId);
+bool emberAfApplianceControlClusterExecutionOfACommandCallback(chip::CommandId commandId);
 /** @brief Appliance Control Cluster Overload Pause
  *
  *
@@ -4884,7 +4935,7 @@ bool emberAfApplianceControlClusterOverloadWarningCallback(uint8_t warningEvent)
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -4894,14 +4945,15 @@ void emberAfApplianceControlClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Appliance Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfApplianceControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -4911,8 +4963,8 @@ void emberAfApplianceControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfApplianceControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfApplianceControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Appliance Control Cluster Server Message Sent
  *
@@ -4939,7 +4991,8 @@ void emberAfApplianceControlClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Appliance Control Cluster Server Tick
@@ -4948,7 +5001,7 @@ EmberAfStatus emberAfApplianceControlClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfApplianceControlClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Appliance Control Cluster Signal State
  *
  *
@@ -5012,7 +5065,7 @@ bool emberAfPollControlClusterCheckInResponseCallback(uint8_t startFastPolling, 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPollControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPollControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Poll Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -5022,14 +5075,15 @@ void emberAfPollControlClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPollControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPollControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Poll Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPollControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfPollControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Poll Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -5039,7 +5093,8 @@ void emberAfPollControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPollControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPollControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Poll Control Cluster Client Message Sent
  *
@@ -5066,7 +5121,7 @@ void emberAfPollControlClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPollControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPollControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Poll Control Cluster Client Tick
@@ -5075,7 +5130,7 @@ EmberAfStatus emberAfPollControlClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPollControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfPollControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Poll Control Cluster Fast Poll Stop
  *
  *
@@ -5089,7 +5144,7 @@ bool emberAfPollControlClusterFastPollStopCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPollControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPollControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Poll Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -5099,14 +5154,15 @@ void emberAfPollControlClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPollControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPollControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Poll Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPollControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfPollControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Poll Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -5116,7 +5172,8 @@ void emberAfPollControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPollControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPollControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Poll Control Cluster Server Message Sent
  *
@@ -5143,7 +5200,7 @@ void emberAfPollControlClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPollControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPollControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Poll Control Cluster Server Tick
@@ -5152,7 +5209,7 @@ EmberAfStatus emberAfPollControlClusterServerPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPollControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfPollControlClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Poll Control Cluster Set Long Poll Interval
  *
  *
@@ -5180,7 +5237,7 @@ bool emberAfPollControlClusterSetShortPollIntervalCallback(uint16_t newShortPoll
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGreenPowerClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGreenPowerClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Green Power Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -5190,14 +5247,15 @@ void emberAfGreenPowerClusterClientAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGreenPowerClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGreenPowerClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Green Power Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGreenPowerClusterClientInitCallback(uint8_t endpoint);
+void emberAfGreenPowerClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Green Power Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -5207,7 +5265,8 @@ void emberAfGreenPowerClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGreenPowerClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGreenPowerClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Green Power Cluster Client Message Sent
  *
@@ -5234,7 +5293,7 @@ void emberAfGreenPowerClusterClientMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGreenPowerClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGreenPowerClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Green Power Cluster Client Tick
@@ -5243,7 +5302,7 @@ EmberAfStatus emberAfGreenPowerClusterClientPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGreenPowerClusterClientTickCallback(uint8_t endpoint);
+void emberAfGreenPowerClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Green Power Cluster Gp Commissioning Notification
  *
  *
@@ -5260,7 +5319,7 @@ void emberAfGreenPowerClusterClientTickCallback(uint8_t endpoint);
  * @param mic   Ver.: since gp-1.0-09-5499-24
  */
 bool emberAfGreenPowerClusterGpCommissioningNotificationCallback(uint16_t options, uint32_t gpdSrcId, uint8_t * gpdIeee,
-                                                                 uint8_t endpoint, uint32_t gpdSecurityFrameCounter,
+                                                                 chip::EndpointId endpoint, uint32_t gpdSecurityFrameCounter,
                                                                  uint8_t gpdCommandId, uint8_t * gpdCommandPayload,
                                                                  uint16_t gppShortAddress, uint8_t gppLink, uint32_t mic);
 /** @brief Green Power Cluster Gp Notification
@@ -5348,7 +5407,7 @@ bool emberAfGreenPowerClusterGpPairingCallback(uint32_t options, uint32_t gpdSrc
  * @param reportDescriptor   Ver.: always
  */
 bool emberAfGreenPowerClusterGpPairingConfigurationCallback(
-    uint8_t actions, uint16_t options, uint32_t gpdSrcId, uint8_t * gpdIeee, uint8_t endpoint, uint8_t deviceId,
+    uint8_t actions, uint16_t options, uint32_t gpdSrcId, uint8_t * gpdIeee, chip::EndpointId endpoint, uint8_t deviceId,
     uint8_t groupListCount, uint8_t * groupList, uint16_t gpdAssignedAlias, uint8_t groupcastRadius, uint8_t securityOptions,
     uint32_t gpdSecurityFrameCounter, uint8_t * gpdSecurityKey, uint8_t numberOfPairedEndpoints, uint8_t * pairedEndpoints,
     uint8_t applicationInformation, uint16_t manufacturerId, uint16_t modeId, uint8_t numberOfGpdCommands,
@@ -5364,7 +5423,8 @@ bool emberAfGreenPowerClusterGpPairingConfigurationCallback(
  * @param gpdIeee   Ver.: since gp-1.0-09-5499-24
  * @param endpoint   Ver.: always
  */
-bool emberAfGreenPowerClusterGpPairingSearchCallback(uint16_t options, uint32_t gpdSrcId, uint8_t * gpdIeee, uint8_t endpoint);
+bool emberAfGreenPowerClusterGpPairingSearchCallback(uint16_t options, uint32_t gpdSrcId, uint8_t * gpdIeee,
+                                                     chip::EndpointId endpoint);
 /** @brief Green Power Cluster Gp Proxy Commissioning Mode
  *
  *
@@ -5412,8 +5472,8 @@ bool emberAfGreenPowerClusterGpProxyTableResponseCallback(uint8_t status, uint8_
  * @param gpdCommandPayload   Ver.: always
  */
 bool emberAfGreenPowerClusterGpResponseCallback(uint8_t options, uint16_t tempMasterShortAddress, uint8_t tempMasterTxChannel,
-                                                uint32_t gpdSrcId, uint8_t * gpdIeee, uint8_t endpoint, uint8_t gpdCommandId,
-                                                uint8_t * gpdCommandPayload);
+                                                uint32_t gpdSrcId, uint8_t * gpdIeee, chip::EndpointId endpoint,
+                                                uint8_t gpdCommandId, uint8_t * gpdCommandPayload);
 /** @brief Green Power Cluster Gp Sink Commissioning Mode
  *
  *
@@ -5482,7 +5542,7 @@ bool emberAfGreenPowerClusterGpTranslationTableResponseCallback(uint8_t status, 
  * @param translations   Ver.: since gp-1.0-09-5499-24
  */
 bool emberAfGreenPowerClusterGpTranslationTableUpdateCallback(uint16_t options, uint32_t gpdSrcId, uint8_t * gpdIeee,
-                                                              uint8_t endpoint, uint8_t * translations);
+                                                              chip::EndpointId endpoint, uint8_t * translations);
 /** @brief Green Power Cluster Gp Tunneling Stop
  *
  *
@@ -5505,7 +5565,7 @@ bool emberAfGreenPowerClusterGpTunnelingStopCallback(uint8_t options, uint32_t g
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGreenPowerClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGreenPowerClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Green Power Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -5515,14 +5575,15 @@ void emberAfGreenPowerClusterServerAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGreenPowerClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGreenPowerClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Green Power Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGreenPowerClusterServerInitCallback(uint8_t endpoint);
+void emberAfGreenPowerClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Green Power Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -5532,7 +5593,8 @@ void emberAfGreenPowerClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGreenPowerClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGreenPowerClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Green Power Cluster Server Message Sent
  *
@@ -5559,7 +5621,7 @@ void emberAfGreenPowerClusterServerMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGreenPowerClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGreenPowerClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Green Power Cluster Server Tick
@@ -5568,7 +5630,7 @@ EmberAfStatus emberAfGreenPowerClusterServerPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGreenPowerClusterServerTickCallback(uint8_t endpoint);
+void emberAfGreenPowerClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Green Power Cluster Callbacks */
 
@@ -5582,7 +5644,7 @@ void emberAfGreenPowerClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfKeepaliveClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfKeepaliveClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Keep-Alive Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -5592,14 +5654,15 @@ void emberAfKeepaliveClusterClientAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfKeepaliveClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfKeepaliveClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Keep-Alive Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfKeepaliveClusterClientInitCallback(uint8_t endpoint);
+void emberAfKeepaliveClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Keep-Alive Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -5609,7 +5672,8 @@ void emberAfKeepaliveClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfKeepaliveClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfKeepaliveClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Keep-Alive Cluster Client Message Sent
  *
@@ -5636,7 +5700,7 @@ void emberAfKeepaliveClusterClientMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfKeepaliveClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfKeepaliveClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Keep-Alive Cluster Client Tick
@@ -5645,7 +5709,7 @@ EmberAfStatus emberAfKeepaliveClusterClientPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfKeepaliveClusterClientTickCallback(uint8_t endpoint);
+void emberAfKeepaliveClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Keep-Alive Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -5653,7 +5717,7 @@ void emberAfKeepaliveClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfKeepaliveClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfKeepaliveClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Keep-Alive Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -5663,14 +5727,15 @@ void emberAfKeepaliveClusterServerAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfKeepaliveClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfKeepaliveClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Keep-Alive Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfKeepaliveClusterServerInitCallback(uint8_t endpoint);
+void emberAfKeepaliveClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Keep-Alive Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -5680,7 +5745,8 @@ void emberAfKeepaliveClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfKeepaliveClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfKeepaliveClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Keep-Alive Cluster Server Message Sent
  *
@@ -5707,7 +5773,7 @@ void emberAfKeepaliveClusterServerMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfKeepaliveClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfKeepaliveClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Keep-Alive Cluster Server Tick
@@ -5716,7 +5782,7 @@ EmberAfStatus emberAfKeepaliveClusterServerPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfKeepaliveClusterServerTickCallback(uint8_t endpoint);
+void emberAfKeepaliveClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Keep-Alive Cluster Callbacks */
 
@@ -5730,7 +5796,7 @@ void emberAfKeepaliveClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfShadeConfigClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfShadeConfigClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Shade Configuration Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -5740,14 +5806,15 @@ void emberAfShadeConfigClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfShadeConfigClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfShadeConfigClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Shade Configuration Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfShadeConfigClusterClientInitCallback(uint8_t endpoint);
+void emberAfShadeConfigClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Shade Configuration Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -5757,7 +5824,8 @@ void emberAfShadeConfigClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfShadeConfigClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfShadeConfigClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Shade Configuration Cluster Client Message Sent
  *
@@ -5784,7 +5852,7 @@ void emberAfShadeConfigClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfShadeConfigClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfShadeConfigClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Shade Configuration Cluster Client Tick
@@ -5793,7 +5861,7 @@ EmberAfStatus emberAfShadeConfigClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfShadeConfigClusterClientTickCallback(uint8_t endpoint);
+void emberAfShadeConfigClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Shade Configuration Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -5801,7 +5869,7 @@ void emberAfShadeConfigClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfShadeConfigClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfShadeConfigClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Shade Configuration Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -5811,14 +5879,15 @@ void emberAfShadeConfigClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfShadeConfigClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfShadeConfigClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Shade Configuration Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfShadeConfigClusterServerInitCallback(uint8_t endpoint);
+void emberAfShadeConfigClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Shade Configuration Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -5828,7 +5897,8 @@ void emberAfShadeConfigClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfShadeConfigClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfShadeConfigClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Shade Configuration Cluster Server Message Sent
  *
@@ -5855,7 +5925,7 @@ void emberAfShadeConfigClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfShadeConfigClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfShadeConfigClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Shade Configuration Cluster Server Tick
@@ -5864,7 +5934,7 @@ EmberAfStatus emberAfShadeConfigClusterServerPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfShadeConfigClusterServerTickCallback(uint8_t endpoint);
+void emberAfShadeConfigClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Shade Configuration Cluster Callbacks */
 
@@ -5976,7 +6046,7 @@ bool emberAfDoorLockClusterClearYeardayScheduleResponseCallback(uint8_t status);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDoorLockClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDoorLockClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Door Lock Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -5986,14 +6056,15 @@ void emberAfDoorLockClusterClientAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDoorLockClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDoorLockClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Door Lock Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDoorLockClusterClientInitCallback(uint8_t endpoint);
+void emberAfDoorLockClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Door Lock Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -6003,7 +6074,8 @@ void emberAfDoorLockClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDoorLockClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDoorLockClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Door Lock Cluster Client Message Sent
  *
@@ -6030,7 +6102,7 @@ void emberAfDoorLockClusterClientMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDoorLockClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDoorLockClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Door Lock Cluster Client Tick
@@ -6039,7 +6111,7 @@ EmberAfStatus emberAfDoorLockClusterClientPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDoorLockClusterClientTickCallback(uint8_t endpoint);
+void emberAfDoorLockClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Door Lock Cluster Get Holiday Schedule
  *
  *
@@ -6238,7 +6310,7 @@ bool emberAfDoorLockClusterProgrammingEventNotificationCallback(uint8_t source, 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDoorLockClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDoorLockClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Door Lock Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -6248,14 +6320,15 @@ void emberAfDoorLockClusterServerAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDoorLockClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDoorLockClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Door Lock Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDoorLockClusterServerInitCallback(uint8_t endpoint);
+void emberAfDoorLockClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Door Lock Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -6265,7 +6338,8 @@ void emberAfDoorLockClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDoorLockClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDoorLockClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Door Lock Cluster Server Message Sent
  *
@@ -6292,7 +6366,7 @@ void emberAfDoorLockClusterServerMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDoorLockClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDoorLockClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Door Lock Cluster Server Tick
@@ -6301,7 +6375,7 @@ EmberAfStatus emberAfDoorLockClusterServerPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDoorLockClusterServerTickCallback(uint8_t endpoint);
+void emberAfDoorLockClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Door Lock Cluster Set Holiday Schedule
  *
  *
@@ -6479,7 +6553,7 @@ bool emberAfDoorLockClusterUnlockWithTimeoutResponseCallback(uint8_t status);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfWindowCoveringClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfWindowCoveringClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Window Covering Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -6489,14 +6563,15 @@ void emberAfWindowCoveringClusterClientAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfWindowCoveringClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfWindowCoveringClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Window Covering Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfWindowCoveringClusterClientInitCallback(uint8_t endpoint);
+void emberAfWindowCoveringClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Window Covering Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -6506,8 +6581,8 @@ void emberAfWindowCoveringClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfWindowCoveringClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfWindowCoveringClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Window Covering Cluster Client Message Sent
  *
@@ -6534,7 +6609,8 @@ void emberAfWindowCoveringClusterClientMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfWindowCoveringClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfWindowCoveringClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Window Covering Cluster Client Tick
@@ -6543,7 +6619,7 @@ EmberAfStatus emberAfWindowCoveringClusterClientPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfWindowCoveringClusterClientTickCallback(uint8_t endpoint);
+void emberAfWindowCoveringClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Window Covering Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -6551,7 +6627,7 @@ void emberAfWindowCoveringClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfWindowCoveringClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfWindowCoveringClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Window Covering Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -6561,14 +6637,15 @@ void emberAfWindowCoveringClusterServerAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfWindowCoveringClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfWindowCoveringClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Window Covering Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfWindowCoveringClusterServerInitCallback(uint8_t endpoint);
+void emberAfWindowCoveringClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Window Covering Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -6578,8 +6655,8 @@ void emberAfWindowCoveringClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfWindowCoveringClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfWindowCoveringClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Window Covering Cluster Server Message Sent
  *
@@ -6606,7 +6683,8 @@ void emberAfWindowCoveringClusterServerMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfWindowCoveringClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfWindowCoveringClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Window Covering Cluster Server Tick
@@ -6615,7 +6693,7 @@ EmberAfStatus emberAfWindowCoveringClusterServerPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfWindowCoveringClusterServerTickCallback(uint8_t endpoint);
+void emberAfWindowCoveringClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Window Covering Cluster Window Covering Down Close
  *
  *
@@ -6688,7 +6766,7 @@ bool emberAfBarrierControlClusterBarrierControlStopCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBarrierControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBarrierControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Barrier Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -6698,14 +6776,15 @@ void emberAfBarrierControlClusterClientAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBarrierControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBarrierControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Barrier Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBarrierControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfBarrierControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Barrier Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -6715,8 +6794,8 @@ void emberAfBarrierControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBarrierControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfBarrierControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Barrier Control Cluster Client Message Sent
  *
@@ -6743,7 +6822,8 @@ void emberAfBarrierControlClusterClientMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBarrierControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBarrierControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Barrier Control Cluster Client Tick
@@ -6752,7 +6832,7 @@ EmberAfStatus emberAfBarrierControlClusterClientPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBarrierControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfBarrierControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Barrier Control Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -6760,7 +6840,7 @@ void emberAfBarrierControlClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBarrierControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBarrierControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Barrier Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -6770,14 +6850,15 @@ void emberAfBarrierControlClusterServerAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBarrierControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBarrierControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Barrier Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBarrierControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfBarrierControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Barrier Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -6787,8 +6868,8 @@ void emberAfBarrierControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBarrierControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfBarrierControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Barrier Control Cluster Server Message Sent
  *
@@ -6815,7 +6896,8 @@ void emberAfBarrierControlClusterServerMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBarrierControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBarrierControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Barrier Control Cluster Server Tick
@@ -6824,7 +6906,7 @@ EmberAfStatus emberAfBarrierControlClusterServerPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBarrierControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfBarrierControlClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Barrier Control Cluster Callbacks */
 
@@ -6838,7 +6920,7 @@ void emberAfBarrierControlClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPumpConfigControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPumpConfigControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Pump Configuration and Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -6848,14 +6930,15 @@ void emberAfPumpConfigControlClusterClientAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPumpConfigControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPumpConfigControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief Pump Configuration and Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPumpConfigControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfPumpConfigControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Pump Configuration and Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -6866,7 +6949,7 @@ void emberAfPumpConfigControlClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfPumpConfigControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief Pump Configuration and Control Cluster Client Message Sent
  *
@@ -6893,7 +6976,8 @@ void emberAfPumpConfigControlClusterClientMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPumpConfigControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPumpConfigControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief Pump Configuration and Control Cluster Client Tick
@@ -6902,7 +6986,7 @@ EmberAfStatus emberAfPumpConfigControlClusterClientPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPumpConfigControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfPumpConfigControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Pump Configuration and Control Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -6910,7 +6994,7 @@ void emberAfPumpConfigControlClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPumpConfigControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPumpConfigControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Pump Configuration and Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -6920,14 +7004,15 @@ void emberAfPumpConfigControlClusterServerAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPumpConfigControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPumpConfigControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief Pump Configuration and Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPumpConfigControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfPumpConfigControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Pump Configuration and Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -6938,7 +7023,7 @@ void emberAfPumpConfigControlClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfPumpConfigControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief Pump Configuration and Control Cluster Server Message Sent
  *
@@ -6965,7 +7050,8 @@ void emberAfPumpConfigControlClusterServerMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPumpConfigControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPumpConfigControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief Pump Configuration and Control Cluster Server Tick
@@ -6974,7 +7060,7 @@ EmberAfStatus emberAfPumpConfigControlClusterServerPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPumpConfigControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfPumpConfigControlClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Pump Configuration and Control Cluster Callbacks */
 
@@ -6994,7 +7080,7 @@ bool emberAfThermostatClusterClearWeeklyScheduleCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfThermostatClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfThermostatClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Thermostat Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -7004,14 +7090,15 @@ void emberAfThermostatClusterClientAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfThermostatClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfThermostatClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Thermostat Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfThermostatClusterClientInitCallback(uint8_t endpoint);
+void emberAfThermostatClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Thermostat Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -7021,7 +7108,8 @@ void emberAfThermostatClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfThermostatClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfThermostatClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Thermostat Cluster Client Message Sent
  *
@@ -7048,7 +7136,7 @@ void emberAfThermostatClusterClientMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfThermostatClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfThermostatClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Thermostat Cluster Client Tick
@@ -7057,7 +7145,7 @@ EmberAfStatus emberAfThermostatClusterClientPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfThermostatClusterClientTickCallback(uint8_t endpoint);
+void emberAfThermostatClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Thermostat Cluster Current Weekly Schedule
  *
  *
@@ -7103,7 +7191,7 @@ bool emberAfThermostatClusterRelayStatusLogCallback(uint16_t timeOfDay, uint16_t
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfThermostatClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfThermostatClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Thermostat Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -7113,14 +7201,15 @@ void emberAfThermostatClusterServerAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfThermostatClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfThermostatClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Thermostat Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfThermostatClusterServerInitCallback(uint8_t endpoint);
+void emberAfThermostatClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Thermostat Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -7130,7 +7219,8 @@ void emberAfThermostatClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfThermostatClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfThermostatClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Thermostat Cluster Server Message Sent
  *
@@ -7157,7 +7247,7 @@ void emberAfThermostatClusterServerMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Thermostat Cluster Server Tick
@@ -7166,7 +7256,7 @@ EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfThermostatClusterServerTickCallback(uint8_t endpoint);
+void emberAfThermostatClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Thermostat Cluster Set Weekly Schedule
  *
  *
@@ -7199,7 +7289,7 @@ bool emberAfThermostatClusterSetpointRaiseLowerCallback(uint8_t mode, int8_t amo
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfFanControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfFanControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Fan Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -7209,14 +7299,15 @@ void emberAfFanControlClusterClientAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFanControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfFanControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Fan Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFanControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfFanControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Fan Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -7226,7 +7317,8 @@ void emberAfFanControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfFanControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfFanControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Fan Control Cluster Client Message Sent
  *
@@ -7253,7 +7345,7 @@ void emberAfFanControlClusterClientMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfFanControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfFanControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Fan Control Cluster Client Tick
@@ -7262,7 +7354,7 @@ EmberAfStatus emberAfFanControlClusterClientPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFanControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfFanControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Fan Control Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -7270,7 +7362,7 @@ void emberAfFanControlClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfFanControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfFanControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Fan Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -7280,14 +7372,15 @@ void emberAfFanControlClusterServerAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFanControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfFanControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Fan Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFanControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfFanControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Fan Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -7297,7 +7390,8 @@ void emberAfFanControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfFanControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfFanControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Fan Control Cluster Server Message Sent
  *
@@ -7324,7 +7418,7 @@ void emberAfFanControlClusterServerMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfFanControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfFanControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Fan Control Cluster Server Tick
@@ -7333,7 +7427,7 @@ EmberAfStatus emberAfFanControlClusterServerPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFanControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfFanControlClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Fan Control Cluster Callbacks */
 
@@ -7347,7 +7441,7 @@ void emberAfFanControlClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDehumidControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDehumidControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Dehumidification Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -7357,14 +7451,15 @@ void emberAfDehumidControlClusterClientAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDehumidControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDehumidControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Dehumidification Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDehumidControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfDehumidControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Dehumidification Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -7374,8 +7469,8 @@ void emberAfDehumidControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDehumidControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfDehumidControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Dehumidification Control Cluster Client Message Sent
  *
@@ -7402,7 +7497,8 @@ void emberAfDehumidControlClusterClientMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDehumidControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDehumidControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Dehumidification Control Cluster Client Tick
@@ -7411,7 +7507,7 @@ EmberAfStatus emberAfDehumidControlClusterClientPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDehumidControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfDehumidControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Dehumidification Control Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -7419,7 +7515,7 @@ void emberAfDehumidControlClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDehumidControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDehumidControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Dehumidification Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -7429,14 +7525,15 @@ void emberAfDehumidControlClusterServerAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDehumidControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDehumidControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Dehumidification Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDehumidControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfDehumidControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Dehumidification Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -7446,8 +7543,8 @@ void emberAfDehumidControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDehumidControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfDehumidControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Dehumidification Control Cluster Server Message Sent
  *
@@ -7474,7 +7571,8 @@ void emberAfDehumidControlClusterServerMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDehumidControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDehumidControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Dehumidification Control Cluster Server Tick
@@ -7483,7 +7581,7 @@ EmberAfStatus emberAfDehumidControlClusterServerPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDehumidControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfDehumidControlClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Dehumidification Control Cluster Callbacks */
 
@@ -7497,7 +7595,7 @@ void emberAfDehumidControlClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfThermostatUiConfigClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfThermostatUiConfigClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Thermostat User Interface Configuration Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -7507,14 +7605,15 @@ void emberAfThermostatUiConfigClusterClientAttributeChangedCallback(uint8_t endp
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfThermostatUiConfigClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfThermostatUiConfigClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                   EmberAfStatus status);
 /** @brief Thermostat User Interface Configuration Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfThermostatUiConfigClusterClientInitCallback(uint8_t endpoint);
+void emberAfThermostatUiConfigClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Thermostat User Interface Configuration Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -7525,7 +7624,7 @@ void emberAfThermostatUiConfigClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfThermostatUiConfigClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                        EmberAfAttributeId attributeId,
+                                                                                        chip::AttributeId attributeId,
                                                                                         uint16_t manufacturerCode);
 /** @brief Thermostat User Interface Configuration Cluster Client Message Sent
  *
@@ -7552,7 +7651,8 @@ void emberAfThermostatUiConfigClusterClientMessageSentCallback(EmberOutgoingMess
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfThermostatUiConfigClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfThermostatUiConfigClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 EmberAfAttributeType attributeType, uint8_t size,
                                                                                 uint8_t * value);
 /** @brief Thermostat User Interface Configuration Cluster Client Tick
@@ -7561,7 +7661,7 @@ EmberAfStatus emberAfThermostatUiConfigClusterClientPreAttributeChangedCallback(
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfThermostatUiConfigClusterClientTickCallback(uint8_t endpoint);
+void emberAfThermostatUiConfigClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Thermostat User Interface Configuration Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -7569,7 +7669,7 @@ void emberAfThermostatUiConfigClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfThermostatUiConfigClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfThermostatUiConfigClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Thermostat User Interface Configuration Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -7579,14 +7679,15 @@ void emberAfThermostatUiConfigClusterServerAttributeChangedCallback(uint8_t endp
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfThermostatUiConfigClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfThermostatUiConfigClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                   EmberAfStatus status);
 /** @brief Thermostat User Interface Configuration Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfThermostatUiConfigClusterServerInitCallback(uint8_t endpoint);
+void emberAfThermostatUiConfigClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Thermostat User Interface Configuration Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -7597,7 +7698,7 @@ void emberAfThermostatUiConfigClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfThermostatUiConfigClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                        EmberAfAttributeId attributeId,
+                                                                                        chip::AttributeId attributeId,
                                                                                         uint16_t manufacturerCode);
 /** @brief Thermostat User Interface Configuration Cluster Server Message Sent
  *
@@ -7624,7 +7725,8 @@ void emberAfThermostatUiConfigClusterServerMessageSentCallback(EmberOutgoingMess
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfThermostatUiConfigClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfThermostatUiConfigClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 EmberAfAttributeType attributeType, uint8_t size,
                                                                                 uint8_t * value);
 /** @brief Thermostat User Interface Configuration Cluster Server Tick
@@ -7633,7 +7735,7 @@ EmberAfStatus emberAfThermostatUiConfigClusterServerPreAttributeChangedCallback(
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfThermostatUiConfigClusterServerTickCallback(uint8_t endpoint);
+void emberAfThermostatUiConfigClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Thermostat User Interface Configuration Cluster Callbacks */
 
@@ -7647,7 +7749,7 @@ void emberAfThermostatUiConfigClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfColorControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfColorControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Color Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -7657,14 +7759,15 @@ void emberAfColorControlClusterClientAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfColorControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfColorControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief Color Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfColorControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfColorControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Color Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -7674,7 +7777,8 @@ void emberAfColorControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfColorControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfColorControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief Color Control Cluster Client Message Sent
  *
@@ -7701,7 +7805,7 @@ void emberAfColorControlClusterClientMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfColorControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfColorControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief Color Control Cluster Client Tick
@@ -7710,7 +7814,7 @@ EmberAfStatus emberAfColorControlClusterClientPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfColorControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfColorControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Color Control Cluster Color Loop Set
  *
  *
@@ -7868,7 +7972,7 @@ bool emberAfColorControlClusterMoveToSaturationCallback(uint8_t saturation, uint
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfColorControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfColorControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Color Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -7878,14 +7982,15 @@ void emberAfColorControlClusterServerAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfColorControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfColorControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief Color Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfColorControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfColorControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Color Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -7895,7 +8000,8 @@ void emberAfColorControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfColorControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfColorControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief Color Control Cluster Server Message Sent
  *
@@ -7922,7 +8028,7 @@ void emberAfColorControlClusterServerMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfColorControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfColorControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief Color Control Cluster Server Tick
@@ -7931,7 +8037,7 @@ EmberAfStatus emberAfColorControlClusterServerPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfColorControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfColorControlClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Color Control Cluster Step Color
  *
  *
@@ -8004,7 +8110,7 @@ bool emberAfColorControlClusterStopMoveStepCallback(uint8_t optionsMask, uint8_t
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBallastConfigurationClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBallastConfigurationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Ballast Configuration Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8014,14 +8120,15 @@ void emberAfBallastConfigurationClusterClientAttributeChangedCallback(uint8_t en
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBallastConfigurationClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBallastConfigurationClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                     EmberAfStatus status);
 /** @brief Ballast Configuration Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBallastConfigurationClusterClientInitCallback(uint8_t endpoint);
+void emberAfBallastConfigurationClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Ballast Configuration Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8032,7 +8139,7 @@ void emberAfBallastConfigurationClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfBallastConfigurationClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId,
+                                                                                          chip::AttributeId attributeId,
                                                                                           uint16_t manufacturerCode);
 /** @brief Ballast Configuration Cluster Client Message Sent
  *
@@ -8059,7 +8166,8 @@ void emberAfBallastConfigurationClusterClientMessageSentCallback(EmberOutgoingMe
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBallastConfigurationClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBallastConfigurationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   EmberAfAttributeType attributeType, uint8_t size,
                                                                                   uint8_t * value);
 /** @brief Ballast Configuration Cluster Client Tick
@@ -8068,7 +8176,7 @@ EmberAfStatus emberAfBallastConfigurationClusterClientPreAttributeChangedCallbac
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBallastConfigurationClusterClientTickCallback(uint8_t endpoint);
+void emberAfBallastConfigurationClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Ballast Configuration Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8076,7 +8184,7 @@ void emberAfBallastConfigurationClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBallastConfigurationClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBallastConfigurationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Ballast Configuration Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8086,14 +8194,15 @@ void emberAfBallastConfigurationClusterServerAttributeChangedCallback(uint8_t en
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBallastConfigurationClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBallastConfigurationClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                     EmberAfStatus status);
 /** @brief Ballast Configuration Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBallastConfigurationClusterServerInitCallback(uint8_t endpoint);
+void emberAfBallastConfigurationClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Ballast Configuration Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -8104,7 +8213,7 @@ void emberAfBallastConfigurationClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfBallastConfigurationClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId,
+                                                                                          chip::AttributeId attributeId,
                                                                                           uint16_t manufacturerCode);
 /** @brief Ballast Configuration Cluster Server Message Sent
  *
@@ -8131,7 +8240,8 @@ void emberAfBallastConfigurationClusterServerMessageSentCallback(EmberOutgoingMe
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBallastConfigurationClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBallastConfigurationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   EmberAfAttributeType attributeType, uint8_t size,
                                                                                   uint8_t * value);
 /** @brief Ballast Configuration Cluster Server Tick
@@ -8140,7 +8250,7 @@ EmberAfStatus emberAfBallastConfigurationClusterServerPreAttributeChangedCallbac
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBallastConfigurationClusterServerTickCallback(uint8_t endpoint);
+void emberAfBallastConfigurationClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Ballast Configuration Cluster Callbacks */
 
@@ -8154,7 +8264,7 @@ void emberAfBallastConfigurationClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIllumMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIllumMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Illuminance Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8164,14 +8274,15 @@ void emberAfIllumMeasurementClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIllumMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIllumMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Illuminance Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIllumMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfIllumMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Illuminance Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8181,8 +8292,8 @@ void emberAfIllumMeasurementClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIllumMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfIllumMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Illuminance Measurement Cluster Client Message Sent
  *
@@ -8209,7 +8320,8 @@ void emberAfIllumMeasurementClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIllumMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIllumMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Illuminance Measurement Cluster Client Tick
@@ -8218,7 +8330,7 @@ EmberAfStatus emberAfIllumMeasurementClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIllumMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfIllumMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Illuminance Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8226,7 +8338,7 @@ void emberAfIllumMeasurementClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIllumMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIllumMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Illuminance Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8236,14 +8348,15 @@ void emberAfIllumMeasurementClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIllumMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIllumMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Illuminance Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIllumMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfIllumMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Illuminance Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -8253,8 +8366,8 @@ void emberAfIllumMeasurementClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIllumMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfIllumMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Illuminance Measurement Cluster Server Message Sent
  *
@@ -8281,7 +8394,8 @@ void emberAfIllumMeasurementClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIllumMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIllumMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Illuminance Measurement Cluster Server Tick
@@ -8290,7 +8404,7 @@ EmberAfStatus emberAfIllumMeasurementClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIllumMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfIllumMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Illuminance Measurement Cluster Callbacks */
 
@@ -8304,7 +8418,7 @@ void emberAfIllumMeasurementClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIllumLevelSensingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIllumLevelSensingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Illuminance Level Sensing Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8314,14 +8428,15 @@ void emberAfIllumLevelSensingClusterClientAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIllumLevelSensingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIllumLevelSensingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief Illuminance Level Sensing Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIllumLevelSensingClusterClientInitCallback(uint8_t endpoint);
+void emberAfIllumLevelSensingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Illuminance Level Sensing Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8332,7 +8447,7 @@ void emberAfIllumLevelSensingClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfIllumLevelSensingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief Illuminance Level Sensing Cluster Client Message Sent
  *
@@ -8359,7 +8474,8 @@ void emberAfIllumLevelSensingClusterClientMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIllumLevelSensingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIllumLevelSensingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief Illuminance Level Sensing Cluster Client Tick
@@ -8368,7 +8484,7 @@ EmberAfStatus emberAfIllumLevelSensingClusterClientPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIllumLevelSensingClusterClientTickCallback(uint8_t endpoint);
+void emberAfIllumLevelSensingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Illuminance Level Sensing Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8376,7 +8492,7 @@ void emberAfIllumLevelSensingClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIllumLevelSensingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIllumLevelSensingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Illuminance Level Sensing Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8386,14 +8502,15 @@ void emberAfIllumLevelSensingClusterServerAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIllumLevelSensingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIllumLevelSensingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief Illuminance Level Sensing Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIllumLevelSensingClusterServerInitCallback(uint8_t endpoint);
+void emberAfIllumLevelSensingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Illuminance Level Sensing Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -8404,7 +8521,7 @@ void emberAfIllumLevelSensingClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfIllumLevelSensingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief Illuminance Level Sensing Cluster Server Message Sent
  *
@@ -8431,7 +8548,8 @@ void emberAfIllumLevelSensingClusterServerMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIllumLevelSensingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIllumLevelSensingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief Illuminance Level Sensing Cluster Server Tick
@@ -8440,7 +8558,7 @@ EmberAfStatus emberAfIllumLevelSensingClusterServerPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIllumLevelSensingClusterServerTickCallback(uint8_t endpoint);
+void emberAfIllumLevelSensingClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Illuminance Level Sensing Cluster Callbacks */
 
@@ -8454,7 +8572,7 @@ void emberAfIllumLevelSensingClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTempMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfTempMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Temperature Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8464,14 +8582,15 @@ void emberAfTempMeasurementClusterClientAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTempMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfTempMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Temperature Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTempMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfTempMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Temperature Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8481,8 +8600,8 @@ void emberAfTempMeasurementClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfTempMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfTempMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Temperature Measurement Cluster Client Message Sent
  *
@@ -8509,7 +8628,8 @@ void emberAfTempMeasurementClusterClientMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfTempMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfTempMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Temperature Measurement Cluster Client Tick
@@ -8518,7 +8638,7 @@ EmberAfStatus emberAfTempMeasurementClusterClientPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTempMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfTempMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Temperature Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8526,7 +8646,7 @@ void emberAfTempMeasurementClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTempMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfTempMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Temperature Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8536,14 +8656,15 @@ void emberAfTempMeasurementClusterServerAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTempMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfTempMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Temperature Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTempMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfTempMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Temperature Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -8553,8 +8674,8 @@ void emberAfTempMeasurementClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfTempMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfTempMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Temperature Measurement Cluster Server Message Sent
  *
@@ -8581,7 +8702,8 @@ void emberAfTempMeasurementClusterServerMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfTempMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfTempMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Temperature Measurement Cluster Server Tick
@@ -8590,7 +8712,7 @@ EmberAfStatus emberAfTempMeasurementClusterServerPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTempMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfTempMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Temperature Measurement Cluster Callbacks */
 
@@ -8604,7 +8726,7 @@ void emberAfTempMeasurementClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPressureMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPressureMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Pressure Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8614,14 +8736,15 @@ void emberAfPressureMeasurementClusterClientAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPressureMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPressureMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief Pressure Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPressureMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfPressureMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Pressure Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8632,7 +8755,7 @@ void emberAfPressureMeasurementClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfPressureMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief Pressure Measurement Cluster Client Message Sent
  *
@@ -8659,7 +8782,8 @@ void emberAfPressureMeasurementClusterClientMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPressureMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPressureMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief Pressure Measurement Cluster Client Tick
@@ -8668,7 +8792,7 @@ EmberAfStatus emberAfPressureMeasurementClusterClientPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPressureMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfPressureMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Pressure Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8676,7 +8800,7 @@ void emberAfPressureMeasurementClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPressureMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPressureMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Pressure Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8686,14 +8810,15 @@ void emberAfPressureMeasurementClusterServerAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPressureMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPressureMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief Pressure Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPressureMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfPressureMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Pressure Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -8704,7 +8829,7 @@ void emberAfPressureMeasurementClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfPressureMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief Pressure Measurement Cluster Server Message Sent
  *
@@ -8731,7 +8856,8 @@ void emberAfPressureMeasurementClusterServerMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPressureMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPressureMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief Pressure Measurement Cluster Server Tick
@@ -8740,7 +8866,7 @@ EmberAfStatus emberAfPressureMeasurementClusterServerPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPressureMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfPressureMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Pressure Measurement Cluster Callbacks */
 
@@ -8754,7 +8880,7 @@ void emberAfPressureMeasurementClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfFlowMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfFlowMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Flow Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8764,14 +8890,15 @@ void emberAfFlowMeasurementClusterClientAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFlowMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfFlowMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Flow Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFlowMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfFlowMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Flow Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8781,8 +8908,8 @@ void emberAfFlowMeasurementClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfFlowMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfFlowMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Flow Measurement Cluster Client Message Sent
  *
@@ -8809,7 +8936,8 @@ void emberAfFlowMeasurementClusterClientMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfFlowMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfFlowMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Flow Measurement Cluster Client Tick
@@ -8818,7 +8946,7 @@ EmberAfStatus emberAfFlowMeasurementClusterClientPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFlowMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfFlowMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Flow Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8826,7 +8954,7 @@ void emberAfFlowMeasurementClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfFlowMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfFlowMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Flow Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8836,14 +8964,15 @@ void emberAfFlowMeasurementClusterServerAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFlowMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfFlowMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Flow Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFlowMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfFlowMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Flow Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -8853,8 +8982,8 @@ void emberAfFlowMeasurementClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfFlowMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfFlowMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Flow Measurement Cluster Server Message Sent
  *
@@ -8881,7 +9010,8 @@ void emberAfFlowMeasurementClusterServerMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfFlowMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfFlowMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Flow Measurement Cluster Server Tick
@@ -8890,7 +9020,7 @@ EmberAfStatus emberAfFlowMeasurementClusterServerPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFlowMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfFlowMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Flow Measurement Cluster Callbacks */
 
@@ -8904,7 +9034,8 @@ void emberAfFlowMeasurementClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfRelativeHumidityMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId);
 /** @brief Relative Humidity Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8914,7 +9045,7 @@ void emberAfRelativeHumidityMeasurementClusterClientAttributeChangedCallback(uin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfRelativeHumidityMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                             EmberAfStatus status);
 /** @brief Relative Humidity Measurement Cluster Client Init
  *
@@ -8922,7 +9053,7 @@ void emberAfRelativeHumidityMeasurementClusterClientDefaultResponseCallback(uint
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfRelativeHumidityMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Relative Humidity Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8933,7 +9064,7 @@ void emberAfRelativeHumidityMeasurementClusterClientInitCallback(uint8_t endpoin
  * Ver.: always
  */
 void emberAfRelativeHumidityMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                 EmberAfAttributeId attributeId,
+                                                                                                 chip::AttributeId attributeId,
                                                                                                  uint16_t manufacturerCode);
 /** @brief Relative Humidity Measurement Cluster Client Message Sent
  *
@@ -8961,7 +9092,7 @@ void emberAfRelativeHumidityMeasurementClusterClientMessageSentCallback(EmberOut
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfRelativeHumidityMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          EmberAfAttributeType attributeType,
                                                                                          uint8_t size, uint8_t * value);
 /** @brief Relative Humidity Measurement Cluster Client Tick
@@ -8970,7 +9101,7 @@ EmberAfStatus emberAfRelativeHumidityMeasurementClusterClientPreAttributeChanged
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfRelativeHumidityMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Relative Humidity Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8978,7 +9109,8 @@ void emberAfRelativeHumidityMeasurementClusterClientTickCallback(uint8_t endpoin
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfRelativeHumidityMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId);
 /** @brief Relative Humidity Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8988,7 +9120,7 @@ void emberAfRelativeHumidityMeasurementClusterServerAttributeChangedCallback(uin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfRelativeHumidityMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                             EmberAfStatus status);
 /** @brief Relative Humidity Measurement Cluster Server Init
  *
@@ -8996,7 +9128,7 @@ void emberAfRelativeHumidityMeasurementClusterServerDefaultResponseCallback(uint
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfRelativeHumidityMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Relative Humidity Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9007,7 +9139,7 @@ void emberAfRelativeHumidityMeasurementClusterServerInitCallback(uint8_t endpoin
  * Ver.: always
  */
 void emberAfRelativeHumidityMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                 EmberAfAttributeId attributeId,
+                                                                                                 chip::AttributeId attributeId,
                                                                                                  uint16_t manufacturerCode);
 /** @brief Relative Humidity Measurement Cluster Server Message Sent
  *
@@ -9035,7 +9167,7 @@ void emberAfRelativeHumidityMeasurementClusterServerMessageSentCallback(EmberOut
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfRelativeHumidityMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          EmberAfAttributeType attributeType,
                                                                                          uint8_t size, uint8_t * value);
 /** @brief Relative Humidity Measurement Cluster Server Tick
@@ -9044,7 +9176,7 @@ EmberAfStatus emberAfRelativeHumidityMeasurementClusterServerPreAttributeChanged
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfRelativeHumidityMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Relative Humidity Measurement Cluster Callbacks */
 
@@ -9058,7 +9190,7 @@ void emberAfRelativeHumidityMeasurementClusterServerTickCallback(uint8_t endpoin
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOccupancySensingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOccupancySensingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Occupancy Sensing Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9068,14 +9200,15 @@ void emberAfOccupancySensingClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOccupancySensingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOccupancySensingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Occupancy Sensing Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOccupancySensingClusterClientInitCallback(uint8_t endpoint);
+void emberAfOccupancySensingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Occupancy Sensing Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -9085,8 +9218,8 @@ void emberAfOccupancySensingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOccupancySensingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfOccupancySensingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Occupancy Sensing Cluster Client Message Sent
  *
@@ -9113,7 +9246,8 @@ void emberAfOccupancySensingClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOccupancySensingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOccupancySensingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Occupancy Sensing Cluster Client Tick
@@ -9122,7 +9256,7 @@ EmberAfStatus emberAfOccupancySensingClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOccupancySensingClusterClientTickCallback(uint8_t endpoint);
+void emberAfOccupancySensingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Occupancy Sensing Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -9130,7 +9264,7 @@ void emberAfOccupancySensingClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOccupancySensingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOccupancySensingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Occupancy Sensing Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -9140,14 +9274,15 @@ void emberAfOccupancySensingClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOccupancySensingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOccupancySensingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Occupancy Sensing Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOccupancySensingClusterServerInitCallback(uint8_t endpoint);
+void emberAfOccupancySensingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Occupancy Sensing Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9157,8 +9292,8 @@ void emberAfOccupancySensingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOccupancySensingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfOccupancySensingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Occupancy Sensing Cluster Server Message Sent
  *
@@ -9185,7 +9320,8 @@ void emberAfOccupancySensingClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOccupancySensingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOccupancySensingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Occupancy Sensing Cluster Server Tick
@@ -9194,7 +9330,7 @@ EmberAfStatus emberAfOccupancySensingClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOccupancySensingClusterServerTickCallback(uint8_t endpoint);
+void emberAfOccupancySensingClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Occupancy Sensing Cluster Callbacks */
 
@@ -9209,7 +9345,7 @@ void emberAfOccupancySensingClusterServerTickCallback(uint8_t endpoint);
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfCarbonMonoxideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                        EmberAfAttributeId attributeId);
+                                                                                        chip::AttributeId attributeId);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9219,7 +9355,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterClientAttributeChangedC
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfCarbonMonoxideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                        EmberAfStatus status);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Client Init
  *
@@ -9227,7 +9363,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterClientDefaultResponseCa
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfCarbonMonoxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -9238,7 +9374,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterClientInitCallback(uint
  * Ver.: always
  */
 void emberAfCarbonMonoxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -9266,14 +9402,14 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterClientMessageSentCallba
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfCarbonMonoxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfCarbonMonoxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -9282,7 +9418,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterClientTickCallback(uint
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfCarbonMonoxideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                        EmberAfAttributeId attributeId);
+                                                                                        chip::AttributeId attributeId);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -9292,7 +9428,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterServerAttributeChangedC
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfCarbonMonoxideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                        EmberAfStatus status);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Init
  *
@@ -9300,7 +9436,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterServerDefaultResponseCa
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfCarbonMonoxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9311,7 +9447,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterServerInitCallback(uint
  * Ver.: always
  */
 void emberAfCarbonMonoxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -9339,14 +9475,14 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterServerMessageSentCallba
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfCarbonMonoxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfCarbonMonoxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Carbon Monoxide Concentration Measurement Cluster Callbacks */
 
@@ -9361,7 +9497,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterServerTickCallback(uint
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfCarbonDioxideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId);
+                                                                                       chip::AttributeId attributeId);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9371,7 +9507,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterClientAttributeChangedCa
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfCarbonDioxideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                       EmberAfStatus status);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Client Init
  *
@@ -9379,7 +9515,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterClientDefaultResponseCal
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfCarbonDioxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -9390,7 +9526,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterClientInitCallback(uint8
  * Ver.: always
  */
 void emberAfCarbonDioxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -9418,14 +9554,14 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterClientMessageSentCallbac
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfCarbonDioxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfCarbonDioxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -9434,7 +9570,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterClientTickCallback(uint8
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfCarbonDioxideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId);
+                                                                                       chip::AttributeId attributeId);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -9444,7 +9580,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterServerAttributeChangedCa
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfCarbonDioxideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                       EmberAfStatus status);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Init
  *
@@ -9452,7 +9588,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterServerDefaultResponseCal
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfCarbonDioxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9463,7 +9599,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterServerInitCallback(uint8
  * Ver.: always
  */
 void emberAfCarbonDioxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -9491,14 +9627,14 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterServerMessageSentCallbac
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfCarbonDioxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfCarbonDioxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Carbon Dioxide Concentration Measurement Cluster Callbacks */
 
@@ -9512,7 +9648,8 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterServerTickCallback(uint8
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfEthyleneConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Ethylene Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9522,7 +9659,7 @@ void emberAfEthyleneConcentrationMeasurementClusterClientAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfEthyleneConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Ethylene Concentration Measurement Cluster Client Init
  *
@@ -9530,7 +9667,7 @@ void emberAfEthyleneConcentrationMeasurementClusterClientDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfEthyleneConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Ethylene Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -9540,8 +9677,9 @@ void emberAfEthyleneConcentrationMeasurementClusterClientInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfEthyleneConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Ethylene Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -9569,7 +9707,7 @@ void emberAfEthyleneConcentrationMeasurementClusterClientMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfEthyleneConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Ethylene Concentration Measurement Cluster Client Tick
@@ -9578,7 +9716,7 @@ EmberAfStatus emberAfEthyleneConcentrationMeasurementClusterClientPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfEthyleneConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Ethylene Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -9586,7 +9724,8 @@ void emberAfEthyleneConcentrationMeasurementClusterClientTickCallback(uint8_t en
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfEthyleneConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Ethylene Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -9596,7 +9735,7 @@ void emberAfEthyleneConcentrationMeasurementClusterServerAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfEthyleneConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Ethylene Concentration Measurement Cluster Server Init
  *
@@ -9604,7 +9743,7 @@ void emberAfEthyleneConcentrationMeasurementClusterServerDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfEthyleneConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Ethylene Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9614,8 +9753,9 @@ void emberAfEthyleneConcentrationMeasurementClusterServerInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfEthyleneConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Ethylene Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -9643,7 +9783,7 @@ void emberAfEthyleneConcentrationMeasurementClusterServerMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfEthyleneConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Ethylene Concentration Measurement Cluster Server Tick
@@ -9652,7 +9792,7 @@ EmberAfStatus emberAfEthyleneConcentrationMeasurementClusterServerPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfEthyleneConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Ethylene Concentration Measurement Cluster Callbacks */
 
@@ -9667,7 +9807,7 @@ void emberAfEthyleneConcentrationMeasurementClusterServerTickCallback(uint8_t en
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfEthyleneOxideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId);
+                                                                                       chip::AttributeId attributeId);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9677,7 +9817,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterClientAttributeChangedCa
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfEthyleneOxideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                       EmberAfStatus status);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Client Init
  *
@@ -9685,7 +9825,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterClientDefaultResponseCal
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfEthyleneOxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -9696,7 +9836,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterClientInitCallback(uint8
  * Ver.: always
  */
 void emberAfEthyleneOxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -9724,14 +9864,14 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterClientMessageSentCallbac
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfEthyleneOxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfEthyleneOxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -9740,7 +9880,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterClientTickCallback(uint8
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfEthyleneOxideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId);
+                                                                                       chip::AttributeId attributeId);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -9750,7 +9890,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterServerAttributeChangedCa
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfEthyleneOxideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                       EmberAfStatus status);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Init
  *
@@ -9758,7 +9898,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterServerDefaultResponseCal
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfEthyleneOxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9769,7 +9909,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterServerInitCallback(uint8
  * Ver.: always
  */
 void emberAfEthyleneOxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -9797,14 +9937,14 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterServerMessageSentCallbac
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfEthyleneOxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfEthyleneOxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Ethylene Oxide Concentration Measurement Cluster Callbacks */
 
@@ -9818,7 +9958,8 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterServerTickCallback(uint8
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfHydrogenConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Hydrogen Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9828,7 +9969,7 @@ void emberAfHydrogenConcentrationMeasurementClusterClientAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfHydrogenConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Hydrogen Concentration Measurement Cluster Client Init
  *
@@ -9836,7 +9977,7 @@ void emberAfHydrogenConcentrationMeasurementClusterClientDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfHydrogenConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Hydrogen Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -9846,8 +9987,9 @@ void emberAfHydrogenConcentrationMeasurementClusterClientInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfHydrogenConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Hydrogen Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -9875,7 +10017,7 @@ void emberAfHydrogenConcentrationMeasurementClusterClientMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfHydrogenConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Hydrogen Concentration Measurement Cluster Client Tick
@@ -9884,7 +10026,7 @@ EmberAfStatus emberAfHydrogenConcentrationMeasurementClusterClientPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfHydrogenConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Hydrogen Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -9892,7 +10034,8 @@ void emberAfHydrogenConcentrationMeasurementClusterClientTickCallback(uint8_t en
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfHydrogenConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Hydrogen Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -9902,7 +10045,7 @@ void emberAfHydrogenConcentrationMeasurementClusterServerAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfHydrogenConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Hydrogen Concentration Measurement Cluster Server Init
  *
@@ -9910,7 +10053,7 @@ void emberAfHydrogenConcentrationMeasurementClusterServerDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfHydrogenConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Hydrogen Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9920,8 +10063,9 @@ void emberAfHydrogenConcentrationMeasurementClusterServerInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfHydrogenConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Hydrogen Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -9949,7 +10093,7 @@ void emberAfHydrogenConcentrationMeasurementClusterServerMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfHydrogenConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Hydrogen Concentration Measurement Cluster Server Tick
@@ -9958,7 +10102,7 @@ EmberAfStatus emberAfHydrogenConcentrationMeasurementClusterServerPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfHydrogenConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Hydrogen Concentration Measurement Cluster Callbacks */
 
@@ -9973,7 +10117,7 @@ void emberAfHydrogenConcentrationMeasurementClusterServerTickCallback(uint8_t en
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfHydrogenSulphideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId);
+                                                                                          chip::AttributeId attributeId);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9983,15 +10127,15 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterClientAttributeChange
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                         EmberAfStatus status);
+void emberAfHydrogenSulphideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                         uint8_t commandId, EmberAfStatus status);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfHydrogenSulphideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10002,7 +10146,7 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterClientInitCallback(ui
  * Ver.: always
  */
 void emberAfHydrogenSulphideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -10030,14 +10174,14 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterClientMessageSentCall
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfHydrogenSulphideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfHydrogenSulphideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10046,7 +10190,7 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterClientTickCallback(ui
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfHydrogenSulphideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId);
+                                                                                          chip::AttributeId attributeId);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10056,15 +10200,15 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterServerAttributeChange
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                         EmberAfStatus status);
+void emberAfHydrogenSulphideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                         uint8_t commandId, EmberAfStatus status);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfHydrogenSulphideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10075,7 +10219,7 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterServerInitCallback(ui
  * Ver.: always
  */
 void emberAfHydrogenSulphideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -10103,14 +10247,14 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterServerMessageSentCall
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfHydrogenSulphideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfHydrogenSulphideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Hydrogen Sulphide Concentration Measurement Cluster Callbacks */
 
@@ -10124,8 +10268,8 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterServerTickCallback(ui
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId);
+void emberAfNitricOxideConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId);
 /** @brief Nitric Oxide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -10135,7 +10279,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterClientAttributeChangedCall
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfNitricOxideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                     EmberAfStatus status);
 /** @brief Nitric Oxide Concentration Measurement Cluster Client Init
  *
@@ -10143,7 +10287,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterClientDefaultResponseCallb
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfNitricOxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Nitric Oxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10154,7 +10298,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterClientInitCallback(uint8_t
  * Ver.: always
  */
 void emberAfNitricOxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Nitric Oxide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -10182,7 +10326,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterClientMessageSentCallback(
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfNitricOxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                                 EmberAfAttributeId attributeId,
+                                                                                                 chip::AttributeId attributeId,
                                                                                                  EmberAfAttributeType attributeType,
                                                                                                  uint8_t size, uint8_t * value);
 /** @brief Nitric Oxide Concentration Measurement Cluster Client Tick
@@ -10191,7 +10335,7 @@ EmberAfStatus emberAfNitricOxideConcentrationMeasurementClusterClientPreAttribut
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfNitricOxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10199,8 +10343,8 @@ void emberAfNitricOxideConcentrationMeasurementClusterClientTickCallback(uint8_t
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId);
+void emberAfNitricOxideConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId);
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10210,7 +10354,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterServerAttributeChangedCall
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfNitricOxideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                     EmberAfStatus status);
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Init
  *
@@ -10218,7 +10362,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterServerDefaultResponseCallb
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfNitricOxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10229,7 +10373,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterServerInitCallback(uint8_t
  * Ver.: always
  */
 void emberAfNitricOxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -10257,7 +10401,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterServerMessageSentCallback(
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfNitricOxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                                 EmberAfAttributeId attributeId,
+                                                                                                 chip::AttributeId attributeId,
                                                                                                  EmberAfAttributeType attributeType,
                                                                                                  uint8_t size, uint8_t * value);
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Tick
@@ -10266,7 +10410,7 @@ EmberAfStatus emberAfNitricOxideConcentrationMeasurementClusterServerPreAttribut
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfNitricOxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Nitric Oxide Concentration Measurement Cluster Callbacks */
 
@@ -10281,7 +10425,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterServerTickCallback(uint8_t
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfNitrogenDioxideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId);
+                                                                                         chip::AttributeId attributeId);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -10291,15 +10435,15 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterClientAttributeChanged
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                        EmberAfStatus status);
+void emberAfNitrogenDioxideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                        uint8_t commandId, EmberAfStatus status);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfNitrogenDioxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10310,7 +10454,7 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterClientInitCallback(uin
  * Ver.: always
  */
 void emberAfNitrogenDioxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -10338,14 +10482,14 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterClientMessageSentCallb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfNitrogenDioxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfNitrogenDioxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10354,7 +10498,7 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterClientTickCallback(uin
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfNitrogenDioxideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId);
+                                                                                         chip::AttributeId attributeId);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10364,15 +10508,15 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterServerAttributeChanged
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                        EmberAfStatus status);
+void emberAfNitrogenDioxideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                        uint8_t commandId, EmberAfStatus status);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfNitrogenDioxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10383,7 +10527,7 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterServerInitCallback(uin
  * Ver.: always
  */
 void emberAfNitrogenDioxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -10411,14 +10555,14 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterServerMessageSentCallb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfNitrogenDioxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfNitrogenDioxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Nitrogen Dioxide Concentration Measurement Cluster Callbacks */
 
@@ -10432,7 +10576,8 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterServerTickCallback(uin
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOxygenConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId);
 /** @brief Oxygen Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -10442,7 +10587,7 @@ void emberAfOxygenConcentrationMeasurementClusterClientAttributeChangedCallback(
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfOxygenConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                EmberAfStatus status);
 /** @brief Oxygen Concentration Measurement Cluster Client Init
  *
@@ -10450,7 +10595,7 @@ void emberAfOxygenConcentrationMeasurementClusterClientDefaultResponseCallback(u
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfOxygenConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Oxygen Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10461,7 +10606,7 @@ void emberAfOxygenConcentrationMeasurementClusterClientInitCallback(uint8_t endp
  * Ver.: always
  */
 void emberAfOxygenConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                    EmberAfAttributeId attributeId,
+                                                                                                    chip::AttributeId attributeId,
                                                                                                     uint16_t manufacturerCode);
 /** @brief Oxygen Concentration Measurement Cluster Client Message Sent
  *
@@ -10489,7 +10634,7 @@ void emberAfOxygenConcentrationMeasurementClusterClientMessageSentCallback(Ember
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfOxygenConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                            EmberAfAttributeId attributeId,
+                                                                                            chip::AttributeId attributeId,
                                                                                             EmberAfAttributeType attributeType,
                                                                                             uint8_t size, uint8_t * value);
 /** @brief Oxygen Concentration Measurement Cluster Client Tick
@@ -10498,7 +10643,7 @@ EmberAfStatus emberAfOxygenConcentrationMeasurementClusterClientPreAttributeChan
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfOxygenConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Oxygen Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10506,7 +10651,8 @@ void emberAfOxygenConcentrationMeasurementClusterClientTickCallback(uint8_t endp
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOxygenConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId);
 /** @brief Oxygen Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10516,7 +10662,7 @@ void emberAfOxygenConcentrationMeasurementClusterServerAttributeChangedCallback(
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfOxygenConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                EmberAfStatus status);
 /** @brief Oxygen Concentration Measurement Cluster Server Init
  *
@@ -10524,7 +10670,7 @@ void emberAfOxygenConcentrationMeasurementClusterServerDefaultResponseCallback(u
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfOxygenConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Oxygen Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10535,7 +10681,7 @@ void emberAfOxygenConcentrationMeasurementClusterServerInitCallback(uint8_t endp
  * Ver.: always
  */
 void emberAfOxygenConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                    EmberAfAttributeId attributeId,
+                                                                                                    chip::AttributeId attributeId,
                                                                                                     uint16_t manufacturerCode);
 /** @brief Oxygen Concentration Measurement Cluster Server Message Sent
  *
@@ -10563,7 +10709,7 @@ void emberAfOxygenConcentrationMeasurementClusterServerMessageSentCallback(Ember
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfOxygenConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                            EmberAfAttributeId attributeId,
+                                                                                            chip::AttributeId attributeId,
                                                                                             EmberAfAttributeType attributeType,
                                                                                             uint8_t size, uint8_t * value);
 /** @brief Oxygen Concentration Measurement Cluster Server Tick
@@ -10572,7 +10718,7 @@ EmberAfStatus emberAfOxygenConcentrationMeasurementClusterServerPreAttributeChan
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfOxygenConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Oxygen Concentration Measurement Cluster Callbacks */
 
@@ -10586,7 +10732,8 @@ void emberAfOxygenConcentrationMeasurementClusterServerTickCallback(uint8_t endp
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOzoneConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId);
 /** @brief Ozone Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -10596,7 +10743,7 @@ void emberAfOzoneConcentrationMeasurementClusterClientAttributeChangedCallback(u
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfOzoneConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                               EmberAfStatus status);
 /** @brief Ozone Concentration Measurement Cluster Client Init
  *
@@ -10604,7 +10751,7 @@ void emberAfOzoneConcentrationMeasurementClusterClientDefaultResponseCallback(ui
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfOzoneConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Ozone Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10615,7 +10762,7 @@ void emberAfOzoneConcentrationMeasurementClusterClientInitCallback(uint8_t endpo
  * Ver.: always
  */
 void emberAfOzoneConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                   EmberAfAttributeId attributeId,
+                                                                                                   chip::AttributeId attributeId,
                                                                                                    uint16_t manufacturerCode);
 /** @brief Ozone Concentration Measurement Cluster Client Message Sent
  *
@@ -10643,7 +10790,7 @@ void emberAfOzoneConcentrationMeasurementClusterClientMessageSentCallback(EmberO
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfOzoneConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                           EmberAfAttributeId attributeId,
+                                                                                           chip::AttributeId attributeId,
                                                                                            EmberAfAttributeType attributeType,
                                                                                            uint8_t size, uint8_t * value);
 /** @brief Ozone Concentration Measurement Cluster Client Tick
@@ -10652,7 +10799,7 @@ EmberAfStatus emberAfOzoneConcentrationMeasurementClusterClientPreAttributeChang
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfOzoneConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Ozone Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10660,7 +10807,8 @@ void emberAfOzoneConcentrationMeasurementClusterClientTickCallback(uint8_t endpo
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOzoneConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId);
 /** @brief Ozone Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10670,7 +10818,7 @@ void emberAfOzoneConcentrationMeasurementClusterServerAttributeChangedCallback(u
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfOzoneConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                               EmberAfStatus status);
 /** @brief Ozone Concentration Measurement Cluster Server Init
  *
@@ -10678,7 +10826,7 @@ void emberAfOzoneConcentrationMeasurementClusterServerDefaultResponseCallback(ui
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfOzoneConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Ozone Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10689,7 +10837,7 @@ void emberAfOzoneConcentrationMeasurementClusterServerInitCallback(uint8_t endpo
  * Ver.: always
  */
 void emberAfOzoneConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                   EmberAfAttributeId attributeId,
+                                                                                                   chip::AttributeId attributeId,
                                                                                                    uint16_t manufacturerCode);
 /** @brief Ozone Concentration Measurement Cluster Server Message Sent
  *
@@ -10717,7 +10865,7 @@ void emberAfOzoneConcentrationMeasurementClusterServerMessageSentCallback(EmberO
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfOzoneConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                           EmberAfAttributeId attributeId,
+                                                                                           chip::AttributeId attributeId,
                                                                                            EmberAfAttributeType attributeType,
                                                                                            uint8_t size, uint8_t * value);
 /** @brief Ozone Concentration Measurement Cluster Server Tick
@@ -10726,7 +10874,7 @@ EmberAfStatus emberAfOzoneConcentrationMeasurementClusterServerPreAttributeChang
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfOzoneConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Ozone Concentration Measurement Cluster Callbacks */
 
@@ -10741,7 +10889,7 @@ void emberAfOzoneConcentrationMeasurementClusterServerTickCallback(uint8_t endpo
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfSulfurDioxideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId);
+                                                                                       chip::AttributeId attributeId);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -10751,7 +10899,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterClientAttributeChangedCa
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfSulfurDioxideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                       EmberAfStatus status);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Client Init
  *
@@ -10759,7 +10907,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterClientDefaultResponseCal
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfSulfurDioxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10770,7 +10918,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterClientInitCallback(uint8
  * Ver.: always
  */
 void emberAfSulfurDioxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -10798,14 +10946,14 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterClientMessageSentCallbac
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfSulfurDioxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfSulfurDioxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10814,7 +10962,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterClientTickCallback(uint8
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfSulfurDioxideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId);
+                                                                                       chip::AttributeId attributeId);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10824,7 +10972,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterServerAttributeChangedCa
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfSulfurDioxideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                       EmberAfStatus status);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Init
  *
@@ -10832,7 +10980,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterServerDefaultResponseCal
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfSulfurDioxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10843,7 +10991,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterServerInitCallback(uint8
  * Ver.: always
  */
 void emberAfSulfurDioxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -10871,14 +11019,14 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterServerMessageSentCallbac
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfSulfurDioxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfSulfurDioxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Sulfur Dioxide Concentration Measurement Cluster Callbacks */
 
@@ -10893,7 +11041,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterServerTickCallback(uint8
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfDissolvedOxygenConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId);
+                                                                                         chip::AttributeId attributeId);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -10903,15 +11051,15 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterClientAttributeChanged
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                        EmberAfStatus status);
+void emberAfDissolvedOxygenConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                        uint8_t commandId, EmberAfStatus status);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfDissolvedOxygenConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10922,7 +11070,7 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterClientInitCallback(uin
  * Ver.: always
  */
 void emberAfDissolvedOxygenConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -10950,14 +11098,14 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterClientMessageSentCallb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfDissolvedOxygenConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfDissolvedOxygenConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10966,7 +11114,7 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterClientTickCallback(uin
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfDissolvedOxygenConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId);
+                                                                                         chip::AttributeId attributeId);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10976,15 +11124,15 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterServerAttributeChanged
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                        EmberAfStatus status);
+void emberAfDissolvedOxygenConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                        uint8_t commandId, EmberAfStatus status);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfDissolvedOxygenConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10995,7 +11143,7 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterServerInitCallback(uin
  * Ver.: always
  */
 void emberAfDissolvedOxygenConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -11023,14 +11171,14 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterServerMessageSentCallb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfDissolvedOxygenConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfDissolvedOxygenConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Dissolved Oxygen Concentration Measurement Cluster Callbacks */
 
@@ -11044,7 +11192,8 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterServerTickCallback(uin
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBromateConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId);
 /** @brief Bromate Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11054,7 +11203,7 @@ void emberAfBromateConcentrationMeasurementClusterClientAttributeChangedCallback
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfBromateConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                 EmberAfStatus status);
 /** @brief Bromate Concentration Measurement Cluster Client Init
  *
@@ -11062,7 +11211,7 @@ void emberAfBromateConcentrationMeasurementClusterClientDefaultResponseCallback(
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfBromateConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Bromate Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11073,7 +11222,7 @@ void emberAfBromateConcentrationMeasurementClusterClientInitCallback(uint8_t end
  * Ver.: always
  */
 void emberAfBromateConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                     EmberAfAttributeId attributeId,
+                                                                                                     chip::AttributeId attributeId,
                                                                                                      uint16_t manufacturerCode);
 /** @brief Bromate Concentration Measurement Cluster Client Message Sent
  *
@@ -11101,7 +11250,7 @@ void emberAfBromateConcentrationMeasurementClusterClientMessageSentCallback(Embe
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfBromateConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              EmberAfAttributeType attributeType,
                                                                                              uint8_t size, uint8_t * value);
 /** @brief Bromate Concentration Measurement Cluster Client Tick
@@ -11110,7 +11259,7 @@ EmberAfStatus emberAfBromateConcentrationMeasurementClusterClientPreAttributeCha
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfBromateConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Bromate Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -11118,7 +11267,8 @@ void emberAfBromateConcentrationMeasurementClusterClientTickCallback(uint8_t end
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBromateConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId);
 /** @brief Bromate Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -11128,7 +11278,7 @@ void emberAfBromateConcentrationMeasurementClusterServerAttributeChangedCallback
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfBromateConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                 EmberAfStatus status);
 /** @brief Bromate Concentration Measurement Cluster Server Init
  *
@@ -11136,7 +11286,7 @@ void emberAfBromateConcentrationMeasurementClusterServerDefaultResponseCallback(
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfBromateConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Bromate Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -11147,7 +11297,7 @@ void emberAfBromateConcentrationMeasurementClusterServerInitCallback(uint8_t end
  * Ver.: always
  */
 void emberAfBromateConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                     EmberAfAttributeId attributeId,
+                                                                                                     chip::AttributeId attributeId,
                                                                                                      uint16_t manufacturerCode);
 /** @brief Bromate Concentration Measurement Cluster Server Message Sent
  *
@@ -11175,7 +11325,7 @@ void emberAfBromateConcentrationMeasurementClusterServerMessageSentCallback(Embe
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfBromateConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              EmberAfAttributeType attributeType,
                                                                                              uint8_t size, uint8_t * value);
 /** @brief Bromate Concentration Measurement Cluster Server Tick
@@ -11184,7 +11334,7 @@ EmberAfStatus emberAfBromateConcentrationMeasurementClusterServerPreAttributeCha
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfBromateConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Bromate Concentration Measurement Cluster Callbacks */
 
@@ -11198,8 +11348,8 @@ void emberAfBromateConcentrationMeasurementClusterServerTickCallback(uint8_t end
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId);
+void emberAfChloraminesConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId);
 /** @brief Chloramines Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11209,7 +11359,7 @@ void emberAfChloraminesConcentrationMeasurementClusterClientAttributeChangedCall
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChloraminesConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                     EmberAfStatus status);
 /** @brief Chloramines Concentration Measurement Cluster Client Init
  *
@@ -11217,7 +11367,7 @@ void emberAfChloraminesConcentrationMeasurementClusterClientDefaultResponseCallb
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfChloraminesConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Chloramines Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11228,7 +11378,7 @@ void emberAfChloraminesConcentrationMeasurementClusterClientInitCallback(uint8_t
  * Ver.: always
  */
 void emberAfChloraminesConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Chloramines Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -11256,7 +11406,7 @@ void emberAfChloraminesConcentrationMeasurementClusterClientMessageSentCallback(
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChloraminesConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                                 EmberAfAttributeId attributeId,
+                                                                                                 chip::AttributeId attributeId,
                                                                                                  EmberAfAttributeType attributeType,
                                                                                                  uint8_t size, uint8_t * value);
 /** @brief Chloramines Concentration Measurement Cluster Client Tick
@@ -11265,7 +11415,7 @@ EmberAfStatus emberAfChloraminesConcentrationMeasurementClusterClientPreAttribut
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfChloraminesConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Chloramines Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -11273,8 +11423,8 @@ void emberAfChloraminesConcentrationMeasurementClusterClientTickCallback(uint8_t
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId);
+void emberAfChloraminesConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId);
 /** @brief Chloramines Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -11284,7 +11434,7 @@ void emberAfChloraminesConcentrationMeasurementClusterServerAttributeChangedCall
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChloraminesConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                     EmberAfStatus status);
 /** @brief Chloramines Concentration Measurement Cluster Server Init
  *
@@ -11292,7 +11442,7 @@ void emberAfChloraminesConcentrationMeasurementClusterServerDefaultResponseCallb
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfChloraminesConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Chloramines Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -11303,7 +11453,7 @@ void emberAfChloraminesConcentrationMeasurementClusterServerInitCallback(uint8_t
  * Ver.: always
  */
 void emberAfChloraminesConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Chloramines Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -11331,7 +11481,7 @@ void emberAfChloraminesConcentrationMeasurementClusterServerMessageSentCallback(
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChloraminesConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                                 EmberAfAttributeId attributeId,
+                                                                                                 chip::AttributeId attributeId,
                                                                                                  EmberAfAttributeType attributeType,
                                                                                                  uint8_t size, uint8_t * value);
 /** @brief Chloramines Concentration Measurement Cluster Server Tick
@@ -11340,7 +11490,7 @@ EmberAfStatus emberAfChloraminesConcentrationMeasurementClusterServerPreAttribut
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfChloraminesConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Chloramines Concentration Measurement Cluster Callbacks */
 
@@ -11354,7 +11504,8 @@ void emberAfChloraminesConcentrationMeasurementClusterServerTickCallback(uint8_t
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfChlorineConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Chlorine Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11364,7 +11515,7 @@ void emberAfChlorineConcentrationMeasurementClusterClientAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChlorineConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Chlorine Concentration Measurement Cluster Client Init
  *
@@ -11372,7 +11523,7 @@ void emberAfChlorineConcentrationMeasurementClusterClientDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfChlorineConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Chlorine Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11382,8 +11533,9 @@ void emberAfChlorineConcentrationMeasurementClusterClientInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfChlorineConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Chlorine Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -11411,7 +11563,7 @@ void emberAfChlorineConcentrationMeasurementClusterClientMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChlorineConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Chlorine Concentration Measurement Cluster Client Tick
@@ -11420,7 +11572,7 @@ EmberAfStatus emberAfChlorineConcentrationMeasurementClusterClientPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfChlorineConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Chlorine Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -11428,7 +11580,8 @@ void emberAfChlorineConcentrationMeasurementClusterClientTickCallback(uint8_t en
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfChlorineConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Chlorine Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -11438,7 +11591,7 @@ void emberAfChlorineConcentrationMeasurementClusterServerAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChlorineConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Chlorine Concentration Measurement Cluster Server Init
  *
@@ -11446,7 +11599,7 @@ void emberAfChlorineConcentrationMeasurementClusterServerDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfChlorineConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Chlorine Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -11456,8 +11609,9 @@ void emberAfChlorineConcentrationMeasurementClusterServerInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfChlorineConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Chlorine Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -11485,7 +11639,7 @@ void emberAfChlorineConcentrationMeasurementClusterServerMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChlorineConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Chlorine Concentration Measurement Cluster Server Tick
@@ -11494,7 +11648,7 @@ EmberAfStatus emberAfChlorineConcentrationMeasurementClusterServerPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfChlorineConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Chlorine Concentration Measurement Cluster Callbacks */
 
@@ -11509,7 +11663,7 @@ void emberAfChlorineConcentrationMeasurementClusterServerTickCallback(uint8_t en
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId);
+                                                                                               chip::AttributeId attributeId);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11519,7 +11673,8 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientAttributeC
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                              uint8_t commandId,
                                                                                               EmberAfStatus status);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Client Init
  *
@@ -11527,7 +11682,7 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientDefaultRes
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11538,7 +11693,7 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientInitCallba
  * Ver.: always
  */
 void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -11566,14 +11721,14 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientMessageSen
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -11582,7 +11737,7 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientTickCallba
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId);
+                                                                                               chip::AttributeId attributeId);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -11592,7 +11747,8 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerAttributeC
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                              uint8_t commandId,
                                                                                               EmberAfStatus status);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Init
  *
@@ -11600,7 +11756,7 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerDefaultRes
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -11611,7 +11767,7 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerInitCallba
  * Ver.: always
  */
 void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -11639,14 +11795,14 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerMessageSen
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Fecal coliform and E. Coli Concentration Measurement Cluster Callbacks */
 
@@ -11660,7 +11816,8 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerTickCallba
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfFluorideConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Fluoride Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11670,7 +11827,7 @@ void emberAfFluorideConcentrationMeasurementClusterClientAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfFluorideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Fluoride Concentration Measurement Cluster Client Init
  *
@@ -11678,7 +11835,7 @@ void emberAfFluorideConcentrationMeasurementClusterClientDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfFluorideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Fluoride Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11688,8 +11845,9 @@ void emberAfFluorideConcentrationMeasurementClusterClientInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfFluorideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Fluoride Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -11717,7 +11875,7 @@ void emberAfFluorideConcentrationMeasurementClusterClientMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfFluorideConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Fluoride Concentration Measurement Cluster Client Tick
@@ -11726,7 +11884,7 @@ EmberAfStatus emberAfFluorideConcentrationMeasurementClusterClientPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfFluorideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Fluoride Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -11734,7 +11892,8 @@ void emberAfFluorideConcentrationMeasurementClusterClientTickCallback(uint8_t en
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfFluorideConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Fluoride Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -11744,7 +11903,7 @@ void emberAfFluorideConcentrationMeasurementClusterServerAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfFluorideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Fluoride Concentration Measurement Cluster Server Init
  *
@@ -11752,7 +11911,7 @@ void emberAfFluorideConcentrationMeasurementClusterServerDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfFluorideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Fluoride Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -11762,8 +11921,9 @@ void emberAfFluorideConcentrationMeasurementClusterServerInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfFluorideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Fluoride Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -11791,7 +11951,7 @@ void emberAfFluorideConcentrationMeasurementClusterServerMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfFluorideConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Fluoride Concentration Measurement Cluster Server Tick
@@ -11800,7 +11960,7 @@ EmberAfStatus emberAfFluorideConcentrationMeasurementClusterServerPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfFluorideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Fluoride Concentration Measurement Cluster Callbacks */
 
@@ -11815,7 +11975,7 @@ void emberAfFluorideConcentrationMeasurementClusterServerTickCallback(uint8_t en
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId);
+                                                                                         chip::AttributeId attributeId);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11825,15 +11985,15 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientAttributeChanged
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                        EmberAfStatus status);
+void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                        uint8_t commandId, EmberAfStatus status);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11844,7 +12004,7 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientInitCallback(uin
  * Ver.: always
  */
 void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -11872,14 +12032,14 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientMessageSentCallb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfHaloaceticAcidsConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -11888,7 +12048,7 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientTickCallback(uin
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId);
+                                                                                         chip::AttributeId attributeId);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -11898,15 +12058,15 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerAttributeChanged
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                        EmberAfStatus status);
+void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                        uint8_t commandId, EmberAfStatus status);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -11917,7 +12077,7 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerInitCallback(uin
  * Ver.: always
  */
 void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -11945,14 +12105,14 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerMessageSentCallb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfHaloaceticAcidsConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Haloacetic Acids Concentration Measurement Cluster Callbacks */
 
@@ -11967,7 +12127,7 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerTickCallback(uin
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId);
+                                                                                              chip::AttributeId attributeId);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11977,7 +12137,8 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientAttributeCh
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                             uint8_t commandId,
                                                                                              EmberAfStatus status);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Client Init
  *
@@ -11985,7 +12146,7 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientDefaultResp
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11996,7 +12157,7 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientInitCallbac
  * Ver.: always
  */
 void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -12024,14 +12185,14 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientMessageSent
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12040,7 +12201,7 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientTickCallbac
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId);
+                                                                                              chip::AttributeId attributeId);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12050,7 +12211,8 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerAttributeCh
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                             uint8_t commandId,
                                                                                              EmberAfStatus status);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Init
  *
@@ -12058,7 +12220,7 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerDefaultResp
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12069,7 +12231,7 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerInitCallbac
  * Ver.: always
  */
 void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -12097,14 +12259,14 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerMessageSent
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Total Trihalomethanes Concentration Measurement Cluster Callbacks */
 
@@ -12119,7 +12281,7 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerTickCallbac
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId);
+                                                                                               chip::AttributeId attributeId);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -12129,7 +12291,8 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientAttributeC
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                              uint8_t commandId,
                                                                                               EmberAfStatus status);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Client Init
  *
@@ -12137,7 +12300,7 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientDefaultRes
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -12148,7 +12311,7 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientInitCallba
  * Ver.: always
  */
 void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -12176,14 +12339,14 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientMessageSen
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12192,7 +12355,7 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientTickCallba
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId);
+                                                                                               chip::AttributeId attributeId);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12202,7 +12365,8 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerAttributeC
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                              uint8_t commandId,
                                                                                               EmberAfStatus status);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Init
  *
@@ -12210,7 +12374,7 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerDefaultRes
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12221,7 +12385,7 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerInitCallba
  * Ver.: always
  */
 void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -12249,14 +12413,14 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerMessageSen
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Total Coliform Bacteria Concentration Measurement Cluster Callbacks */
 
@@ -12270,8 +12434,8 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerTickCallba
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                   EmberAfAttributeId attributeId);
+void emberAfTurbidityConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId);
 /** @brief Turbidity Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -12281,7 +12445,7 @@ void emberAfTurbidityConcentrationMeasurementClusterClientAttributeChangedCallba
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfTurbidityConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                   EmberAfStatus status);
 /** @brief Turbidity Concentration Measurement Cluster Client Init
  *
@@ -12289,7 +12453,7 @@ void emberAfTurbidityConcentrationMeasurementClusterClientDefaultResponseCallbac
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfTurbidityConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Turbidity Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -12300,7 +12464,7 @@ void emberAfTurbidityConcentrationMeasurementClusterClientInitCallback(uint8_t e
  * Ver.: always
  */
 void emberAfTurbidityConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Turbidity Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -12328,7 +12492,7 @@ void emberAfTurbidityConcentrationMeasurementClusterClientMessageSentCallback(Em
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfTurbidityConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                EmberAfAttributeType attributeType,
                                                                                                uint8_t size, uint8_t * value);
 /** @brief Turbidity Concentration Measurement Cluster Client Tick
@@ -12337,7 +12501,7 @@ EmberAfStatus emberAfTurbidityConcentrationMeasurementClusterClientPreAttributeC
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfTurbidityConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Turbidity Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12345,8 +12509,8 @@ void emberAfTurbidityConcentrationMeasurementClusterClientTickCallback(uint8_t e
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                   EmberAfAttributeId attributeId);
+void emberAfTurbidityConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId);
 /** @brief Turbidity Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12356,7 +12520,7 @@ void emberAfTurbidityConcentrationMeasurementClusterServerAttributeChangedCallba
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfTurbidityConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                   EmberAfStatus status);
 /** @brief Turbidity Concentration Measurement Cluster Server Init
  *
@@ -12364,7 +12528,7 @@ void emberAfTurbidityConcentrationMeasurementClusterServerDefaultResponseCallbac
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfTurbidityConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Turbidity Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12375,7 +12539,7 @@ void emberAfTurbidityConcentrationMeasurementClusterServerInitCallback(uint8_t e
  * Ver.: always
  */
 void emberAfTurbidityConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Turbidity Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -12403,7 +12567,7 @@ void emberAfTurbidityConcentrationMeasurementClusterServerMessageSentCallback(Em
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfTurbidityConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                EmberAfAttributeType attributeType,
                                                                                                uint8_t size, uint8_t * value);
 /** @brief Turbidity Concentration Measurement Cluster Server Tick
@@ -12412,7 +12576,7 @@ EmberAfStatus emberAfTurbidityConcentrationMeasurementClusterServerPreAttributeC
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfTurbidityConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Turbidity Concentration Measurement Cluster Callbacks */
 
@@ -12426,7 +12590,8 @@ void emberAfTurbidityConcentrationMeasurementClusterServerTickCallback(uint8_t e
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfCopperConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId);
 /** @brief Copper Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -12436,7 +12601,7 @@ void emberAfCopperConcentrationMeasurementClusterClientAttributeChangedCallback(
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfCopperConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                EmberAfStatus status);
 /** @brief Copper Concentration Measurement Cluster Client Init
  *
@@ -12444,7 +12609,7 @@ void emberAfCopperConcentrationMeasurementClusterClientDefaultResponseCallback(u
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfCopperConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Copper Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -12455,7 +12620,7 @@ void emberAfCopperConcentrationMeasurementClusterClientInitCallback(uint8_t endp
  * Ver.: always
  */
 void emberAfCopperConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                    EmberAfAttributeId attributeId,
+                                                                                                    chip::AttributeId attributeId,
                                                                                                     uint16_t manufacturerCode);
 /** @brief Copper Concentration Measurement Cluster Client Message Sent
  *
@@ -12483,7 +12648,7 @@ void emberAfCopperConcentrationMeasurementClusterClientMessageSentCallback(Ember
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfCopperConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                            EmberAfAttributeId attributeId,
+                                                                                            chip::AttributeId attributeId,
                                                                                             EmberAfAttributeType attributeType,
                                                                                             uint8_t size, uint8_t * value);
 /** @brief Copper Concentration Measurement Cluster Client Tick
@@ -12492,7 +12657,7 @@ EmberAfStatus emberAfCopperConcentrationMeasurementClusterClientPreAttributeChan
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfCopperConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Copper Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12500,7 +12665,8 @@ void emberAfCopperConcentrationMeasurementClusterClientTickCallback(uint8_t endp
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfCopperConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId);
 /** @brief Copper Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12510,7 +12676,7 @@ void emberAfCopperConcentrationMeasurementClusterServerAttributeChangedCallback(
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfCopperConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                EmberAfStatus status);
 /** @brief Copper Concentration Measurement Cluster Server Init
  *
@@ -12518,7 +12684,7 @@ void emberAfCopperConcentrationMeasurementClusterServerDefaultResponseCallback(u
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfCopperConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Copper Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12529,7 +12695,7 @@ void emberAfCopperConcentrationMeasurementClusterServerInitCallback(uint8_t endp
  * Ver.: always
  */
 void emberAfCopperConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                    EmberAfAttributeId attributeId,
+                                                                                                    chip::AttributeId attributeId,
                                                                                                     uint16_t manufacturerCode);
 /** @brief Copper Concentration Measurement Cluster Server Message Sent
  *
@@ -12557,7 +12723,7 @@ void emberAfCopperConcentrationMeasurementClusterServerMessageSentCallback(Ember
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfCopperConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                            EmberAfAttributeId attributeId,
+                                                                                            chip::AttributeId attributeId,
                                                                                             EmberAfAttributeType attributeType,
                                                                                             uint8_t size, uint8_t * value);
 /** @brief Copper Concentration Measurement Cluster Server Tick
@@ -12566,7 +12732,7 @@ EmberAfStatus emberAfCopperConcentrationMeasurementClusterServerPreAttributeChan
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfCopperConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Copper Concentration Measurement Cluster Callbacks */
 
@@ -12580,7 +12746,8 @@ void emberAfCopperConcentrationMeasurementClusterServerTickCallback(uint8_t endp
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfLeadConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId);
 /** @brief Lead Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -12590,7 +12757,7 @@ void emberAfLeadConcentrationMeasurementClusterClientAttributeChangedCallback(ui
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfLeadConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                              EmberAfStatus status);
 /** @brief Lead Concentration Measurement Cluster Client Init
  *
@@ -12598,7 +12765,7 @@ void emberAfLeadConcentrationMeasurementClusterClientDefaultResponseCallback(uin
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfLeadConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Lead Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -12609,7 +12776,7 @@ void emberAfLeadConcentrationMeasurementClusterClientInitCallback(uint8_t endpoi
  * Ver.: always
  */
 void emberAfLeadConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                  EmberAfAttributeId attributeId,
+                                                                                                  chip::AttributeId attributeId,
                                                                                                   uint16_t manufacturerCode);
 /** @brief Lead Concentration Measurement Cluster Client Message Sent
  *
@@ -12637,7 +12804,7 @@ void emberAfLeadConcentrationMeasurementClusterClientMessageSentCallback(EmberOu
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfLeadConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId,
+                                                                                          chip::AttributeId attributeId,
                                                                                           EmberAfAttributeType attributeType,
                                                                                           uint8_t size, uint8_t * value);
 /** @brief Lead Concentration Measurement Cluster Client Tick
@@ -12646,7 +12813,7 @@ EmberAfStatus emberAfLeadConcentrationMeasurementClusterClientPreAttributeChange
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfLeadConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Lead Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12654,7 +12821,8 @@ void emberAfLeadConcentrationMeasurementClusterClientTickCallback(uint8_t endpoi
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfLeadConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId);
 /** @brief Lead Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12664,7 +12832,7 @@ void emberAfLeadConcentrationMeasurementClusterServerAttributeChangedCallback(ui
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfLeadConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                              EmberAfStatus status);
 /** @brief Lead Concentration Measurement Cluster Server Init
  *
@@ -12672,7 +12840,7 @@ void emberAfLeadConcentrationMeasurementClusterServerDefaultResponseCallback(uin
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfLeadConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Lead Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12683,7 +12851,7 @@ void emberAfLeadConcentrationMeasurementClusterServerInitCallback(uint8_t endpoi
  * Ver.: always
  */
 void emberAfLeadConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                  EmberAfAttributeId attributeId,
+                                                                                                  chip::AttributeId attributeId,
                                                                                                   uint16_t manufacturerCode);
 /** @brief Lead Concentration Measurement Cluster Server Message Sent
  *
@@ -12711,7 +12879,7 @@ void emberAfLeadConcentrationMeasurementClusterServerMessageSentCallback(EmberOu
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfLeadConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId,
+                                                                                          chip::AttributeId attributeId,
                                                                                           EmberAfAttributeType attributeType,
                                                                                           uint8_t size, uint8_t * value);
 /** @brief Lead Concentration Measurement Cluster Server Tick
@@ -12720,7 +12888,7 @@ EmberAfStatus emberAfLeadConcentrationMeasurementClusterServerPreAttributeChange
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfLeadConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Lead Concentration Measurement Cluster Callbacks */
 
@@ -12734,8 +12902,8 @@ void emberAfLeadConcentrationMeasurementClusterServerTickCallback(uint8_t endpoi
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                   EmberAfAttributeId attributeId);
+void emberAfManganeseConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId);
 /** @brief Manganese Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -12745,7 +12913,7 @@ void emberAfManganeseConcentrationMeasurementClusterClientAttributeChangedCallba
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfManganeseConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                   EmberAfStatus status);
 /** @brief Manganese Concentration Measurement Cluster Client Init
  *
@@ -12753,7 +12921,7 @@ void emberAfManganeseConcentrationMeasurementClusterClientDefaultResponseCallbac
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfManganeseConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Manganese Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -12764,7 +12932,7 @@ void emberAfManganeseConcentrationMeasurementClusterClientInitCallback(uint8_t e
  * Ver.: always
  */
 void emberAfManganeseConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Manganese Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -12792,7 +12960,7 @@ void emberAfManganeseConcentrationMeasurementClusterClientMessageSentCallback(Em
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfManganeseConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                EmberAfAttributeType attributeType,
                                                                                                uint8_t size, uint8_t * value);
 /** @brief Manganese Concentration Measurement Cluster Client Tick
@@ -12801,7 +12969,7 @@ EmberAfStatus emberAfManganeseConcentrationMeasurementClusterClientPreAttributeC
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfManganeseConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Manganese Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12809,8 +12977,8 @@ void emberAfManganeseConcentrationMeasurementClusterClientTickCallback(uint8_t e
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                   EmberAfAttributeId attributeId);
+void emberAfManganeseConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId);
 /** @brief Manganese Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12820,7 +12988,7 @@ void emberAfManganeseConcentrationMeasurementClusterServerAttributeChangedCallba
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfManganeseConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                   EmberAfStatus status);
 /** @brief Manganese Concentration Measurement Cluster Server Init
  *
@@ -12828,7 +12996,7 @@ void emberAfManganeseConcentrationMeasurementClusterServerDefaultResponseCallbac
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfManganeseConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Manganese Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12839,7 +13007,7 @@ void emberAfManganeseConcentrationMeasurementClusterServerInitCallback(uint8_t e
  * Ver.: always
  */
 void emberAfManganeseConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Manganese Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -12867,7 +13035,7 @@ void emberAfManganeseConcentrationMeasurementClusterServerMessageSentCallback(Em
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfManganeseConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                EmberAfAttributeType attributeType,
                                                                                                uint8_t size, uint8_t * value);
 /** @brief Manganese Concentration Measurement Cluster Server Tick
@@ -12876,7 +13044,7 @@ EmberAfStatus emberAfManganeseConcentrationMeasurementClusterServerPreAttributeC
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfManganeseConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Manganese Concentration Measurement Cluster Callbacks */
 
@@ -12890,7 +13058,8 @@ void emberAfManganeseConcentrationMeasurementClusterServerTickCallback(uint8_t e
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSulfateConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId);
 /** @brief Sulfate Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -12900,7 +13069,7 @@ void emberAfSulfateConcentrationMeasurementClusterClientAttributeChangedCallback
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfSulfateConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                 EmberAfStatus status);
 /** @brief Sulfate Concentration Measurement Cluster Client Init
  *
@@ -12908,7 +13077,7 @@ void emberAfSulfateConcentrationMeasurementClusterClientDefaultResponseCallback(
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfSulfateConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Sulfate Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -12919,7 +13088,7 @@ void emberAfSulfateConcentrationMeasurementClusterClientInitCallback(uint8_t end
  * Ver.: always
  */
 void emberAfSulfateConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                     EmberAfAttributeId attributeId,
+                                                                                                     chip::AttributeId attributeId,
                                                                                                      uint16_t manufacturerCode);
 /** @brief Sulfate Concentration Measurement Cluster Client Message Sent
  *
@@ -12947,7 +13116,7 @@ void emberAfSulfateConcentrationMeasurementClusterClientMessageSentCallback(Embe
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfSulfateConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              EmberAfAttributeType attributeType,
                                                                                              uint8_t size, uint8_t * value);
 /** @brief Sulfate Concentration Measurement Cluster Client Tick
@@ -12956,7 +13125,7 @@ EmberAfStatus emberAfSulfateConcentrationMeasurementClusterClientPreAttributeCha
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfSulfateConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Sulfate Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12964,7 +13133,8 @@ void emberAfSulfateConcentrationMeasurementClusterClientTickCallback(uint8_t end
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSulfateConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId);
 /** @brief Sulfate Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12974,7 +13144,7 @@ void emberAfSulfateConcentrationMeasurementClusterServerAttributeChangedCallback
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfSulfateConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                 EmberAfStatus status);
 /** @brief Sulfate Concentration Measurement Cluster Server Init
  *
@@ -12982,7 +13152,7 @@ void emberAfSulfateConcentrationMeasurementClusterServerDefaultResponseCallback(
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfSulfateConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Sulfate Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12993,7 +13163,7 @@ void emberAfSulfateConcentrationMeasurementClusterServerInitCallback(uint8_t end
  * Ver.: always
  */
 void emberAfSulfateConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                     EmberAfAttributeId attributeId,
+                                                                                                     chip::AttributeId attributeId,
                                                                                                      uint16_t manufacturerCode);
 /** @brief Sulfate Concentration Measurement Cluster Server Message Sent
  *
@@ -13021,7 +13191,7 @@ void emberAfSulfateConcentrationMeasurementClusterServerMessageSentCallback(Embe
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfSulfateConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              EmberAfAttributeType attributeType,
                                                                                              uint8_t size, uint8_t * value);
 /** @brief Sulfate Concentration Measurement Cluster Server Tick
@@ -13030,7 +13200,7 @@ EmberAfStatus emberAfSulfateConcentrationMeasurementClusterServerPreAttributeCha
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfSulfateConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Sulfate Concentration Measurement Cluster Callbacks */
 
@@ -13045,7 +13215,7 @@ void emberAfSulfateConcentrationMeasurementClusterServerTickCallback(uint8_t end
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfBromodichloromethaneConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId);
+                                                                                              chip::AttributeId attributeId);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -13055,7 +13225,8 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterClientAttributeCh
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfBromodichloromethaneConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                             uint8_t commandId,
                                                                                              EmberAfStatus status);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Client Init
  *
@@ -13063,7 +13234,7 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterClientDefaultResp
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfBromodichloromethaneConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -13074,7 +13245,7 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterClientInitCallbac
  * Ver.: always
  */
 void emberAfBromodichloromethaneConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -13102,14 +13273,14 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterClientMessageSent
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfBromodichloromethaneConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfBromodichloromethaneConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -13118,7 +13289,7 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterClientTickCallbac
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfBromodichloromethaneConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId);
+                                                                                              chip::AttributeId attributeId);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -13128,7 +13299,8 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterServerAttributeCh
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfBromodichloromethaneConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                             uint8_t commandId,
                                                                                              EmberAfStatus status);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Init
  *
@@ -13136,7 +13308,7 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterServerDefaultResp
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfBromodichloromethaneConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -13147,7 +13319,7 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterServerInitCallbac
  * Ver.: always
  */
 void emberAfBromodichloromethaneConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -13175,14 +13347,14 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterServerMessageSent
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfBromodichloromethaneConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfBromodichloromethaneConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Bromodichloromethane Concentration Measurement Cluster Callbacks */
 
@@ -13196,8 +13368,8 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterServerTickCallbac
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                   EmberAfAttributeId attributeId);
+void emberAfBromoformConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId);
 /** @brief Bromoform Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -13207,7 +13379,7 @@ void emberAfBromoformConcentrationMeasurementClusterClientAttributeChangedCallba
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfBromoformConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                   EmberAfStatus status);
 /** @brief Bromoform Concentration Measurement Cluster Client Init
  *
@@ -13215,7 +13387,7 @@ void emberAfBromoformConcentrationMeasurementClusterClientDefaultResponseCallbac
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfBromoformConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Bromoform Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -13226,7 +13398,7 @@ void emberAfBromoformConcentrationMeasurementClusterClientInitCallback(uint8_t e
  * Ver.: always
  */
 void emberAfBromoformConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Bromoform Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -13254,7 +13426,7 @@ void emberAfBromoformConcentrationMeasurementClusterClientMessageSentCallback(Em
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfBromoformConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                EmberAfAttributeType attributeType,
                                                                                                uint8_t size, uint8_t * value);
 /** @brief Bromoform Concentration Measurement Cluster Client Tick
@@ -13263,7 +13435,7 @@ EmberAfStatus emberAfBromoformConcentrationMeasurementClusterClientPreAttributeC
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfBromoformConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Bromoform Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -13271,8 +13443,8 @@ void emberAfBromoformConcentrationMeasurementClusterClientTickCallback(uint8_t e
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                   EmberAfAttributeId attributeId);
+void emberAfBromoformConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId);
 /** @brief Bromoform Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -13282,7 +13454,7 @@ void emberAfBromoformConcentrationMeasurementClusterServerAttributeChangedCallba
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfBromoformConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                   EmberAfStatus status);
 /** @brief Bromoform Concentration Measurement Cluster Server Init
  *
@@ -13290,7 +13462,7 @@ void emberAfBromoformConcentrationMeasurementClusterServerDefaultResponseCallbac
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfBromoformConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Bromoform Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -13301,7 +13473,7 @@ void emberAfBromoformConcentrationMeasurementClusterServerInitCallback(uint8_t e
  * Ver.: always
  */
 void emberAfBromoformConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Bromoform Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -13329,7 +13501,7 @@ void emberAfBromoformConcentrationMeasurementClusterServerMessageSentCallback(Em
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfBromoformConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                EmberAfAttributeType attributeType,
                                                                                                uint8_t size, uint8_t * value);
 /** @brief Bromoform Concentration Measurement Cluster Server Tick
@@ -13338,7 +13510,7 @@ EmberAfStatus emberAfBromoformConcentrationMeasurementClusterServerPreAttributeC
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfBromoformConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Bromoform Concentration Measurement Cluster Callbacks */
 
@@ -13353,7 +13525,7 @@ void emberAfBromoformConcentrationMeasurementClusterServerTickCallback(uint8_t e
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId);
+                                                                                              chip::AttributeId attributeId);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -13363,7 +13535,8 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientAttributeCh
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                             uint8_t commandId,
                                                                                              EmberAfStatus status);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Client Init
  *
@@ -13371,7 +13544,7 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientDefaultResp
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -13382,7 +13555,7 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientInitCallbac
  * Ver.: always
  */
 void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -13410,14 +13583,14 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientMessageSent
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChlorodibromomethaneConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -13426,7 +13599,7 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientTickCallbac
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId);
+                                                                                              chip::AttributeId attributeId);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -13436,7 +13609,8 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerAttributeCh
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                             uint8_t commandId,
                                                                                              EmberAfStatus status);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Init
  *
@@ -13444,7 +13618,7 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerDefaultResp
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -13455,7 +13629,7 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerInitCallbac
  * Ver.: always
  */
 void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -13483,14 +13657,14 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerMessageSent
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChlorodibromomethaneConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Chlorodibromomethane Concentration Measurement Cluster Callbacks */
 
@@ -13504,8 +13678,8 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerTickCallbac
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId);
+void emberAfChloroformConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId);
 /** @brief Chloroform Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -13515,7 +13689,7 @@ void emberAfChloroformConcentrationMeasurementClusterClientAttributeChangedCallb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChloroformConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                    EmberAfStatus status);
 /** @brief Chloroform Concentration Measurement Cluster Client Init
  *
@@ -13523,7 +13697,7 @@ void emberAfChloroformConcentrationMeasurementClusterClientDefaultResponseCallba
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfChloroformConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Chloroform Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -13534,7 +13708,7 @@ void emberAfChloroformConcentrationMeasurementClusterClientInitCallback(uint8_t 
  * Ver.: always
  */
 void emberAfChloroformConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Chloroform Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -13562,7 +13736,7 @@ void emberAfChloroformConcentrationMeasurementClusterClientMessageSentCallback(E
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChloroformConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                                EmberAfAttributeId attributeId,
+                                                                                                chip::AttributeId attributeId,
                                                                                                 EmberAfAttributeType attributeType,
                                                                                                 uint8_t size, uint8_t * value);
 /** @brief Chloroform Concentration Measurement Cluster Client Tick
@@ -13571,7 +13745,7 @@ EmberAfStatus emberAfChloroformConcentrationMeasurementClusterClientPreAttribute
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfChloroformConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Chloroform Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -13579,8 +13753,8 @@ void emberAfChloroformConcentrationMeasurementClusterClientTickCallback(uint8_t 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId);
+void emberAfChloroformConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId);
 /** @brief Chloroform Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -13590,7 +13764,7 @@ void emberAfChloroformConcentrationMeasurementClusterServerAttributeChangedCallb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChloroformConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                    EmberAfStatus status);
 /** @brief Chloroform Concentration Measurement Cluster Server Init
  *
@@ -13598,7 +13772,7 @@ void emberAfChloroformConcentrationMeasurementClusterServerDefaultResponseCallba
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfChloroformConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Chloroform Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -13609,7 +13783,7 @@ void emberAfChloroformConcentrationMeasurementClusterServerInitCallback(uint8_t 
  * Ver.: always
  */
 void emberAfChloroformConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Chloroform Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -13637,7 +13811,7 @@ void emberAfChloroformConcentrationMeasurementClusterServerMessageSentCallback(E
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChloroformConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                                EmberAfAttributeId attributeId,
+                                                                                                chip::AttributeId attributeId,
                                                                                                 EmberAfAttributeType attributeType,
                                                                                                 uint8_t size, uint8_t * value);
 /** @brief Chloroform Concentration Measurement Cluster Server Tick
@@ -13646,7 +13820,7 @@ EmberAfStatus emberAfChloroformConcentrationMeasurementClusterServerPreAttribute
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfChloroformConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Chloroform Concentration Measurement Cluster Callbacks */
 
@@ -13660,7 +13834,8 @@ void emberAfChloroformConcentrationMeasurementClusterServerTickCallback(uint8_t 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSodiumConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId);
 /** @brief Sodium Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -13670,7 +13845,7 @@ void emberAfSodiumConcentrationMeasurementClusterClientAttributeChangedCallback(
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfSodiumConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                EmberAfStatus status);
 /** @brief Sodium Concentration Measurement Cluster Client Init
  *
@@ -13678,7 +13853,7 @@ void emberAfSodiumConcentrationMeasurementClusterClientDefaultResponseCallback(u
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfSodiumConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Sodium Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -13689,7 +13864,7 @@ void emberAfSodiumConcentrationMeasurementClusterClientInitCallback(uint8_t endp
  * Ver.: always
  */
 void emberAfSodiumConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                    EmberAfAttributeId attributeId,
+                                                                                                    chip::AttributeId attributeId,
                                                                                                     uint16_t manufacturerCode);
 /** @brief Sodium Concentration Measurement Cluster Client Message Sent
  *
@@ -13717,7 +13892,7 @@ void emberAfSodiumConcentrationMeasurementClusterClientMessageSentCallback(Ember
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfSodiumConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                            EmberAfAttributeId attributeId,
+                                                                                            chip::AttributeId attributeId,
                                                                                             EmberAfAttributeType attributeType,
                                                                                             uint8_t size, uint8_t * value);
 /** @brief Sodium Concentration Measurement Cluster Client Tick
@@ -13726,7 +13901,7 @@ EmberAfStatus emberAfSodiumConcentrationMeasurementClusterClientPreAttributeChan
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfSodiumConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Sodium Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -13734,7 +13909,8 @@ void emberAfSodiumConcentrationMeasurementClusterClientTickCallback(uint8_t endp
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSodiumConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId);
 /** @brief Sodium Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -13744,7 +13920,7 @@ void emberAfSodiumConcentrationMeasurementClusterServerAttributeChangedCallback(
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfSodiumConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                EmberAfStatus status);
 /** @brief Sodium Concentration Measurement Cluster Server Init
  *
@@ -13752,7 +13928,7 @@ void emberAfSodiumConcentrationMeasurementClusterServerDefaultResponseCallback(u
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfSodiumConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Sodium Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -13763,7 +13939,7 @@ void emberAfSodiumConcentrationMeasurementClusterServerInitCallback(uint8_t endp
  * Ver.: always
  */
 void emberAfSodiumConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                    EmberAfAttributeId attributeId,
+                                                                                                    chip::AttributeId attributeId,
                                                                                                     uint16_t manufacturerCode);
 /** @brief Sodium Concentration Measurement Cluster Server Message Sent
  *
@@ -13791,7 +13967,7 @@ void emberAfSodiumConcentrationMeasurementClusterServerMessageSentCallback(Ember
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfSodiumConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                            EmberAfAttributeId attributeId,
+                                                                                            chip::AttributeId attributeId,
                                                                                             EmberAfAttributeType attributeType,
                                                                                             uint8_t size, uint8_t * value);
 /** @brief Sodium Concentration Measurement Cluster Server Tick
@@ -13800,7 +13976,7 @@ EmberAfStatus emberAfSodiumConcentrationMeasurementClusterServerPreAttributeChan
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfSodiumConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Sodium Concentration Measurement Cluster Callbacks */
 
@@ -13814,7 +13990,7 @@ void emberAfSodiumConcentrationMeasurementClusterServerTickCallback(uint8_t endp
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIasZoneClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIasZoneClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief IAS Zone Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -13824,14 +14000,14 @@ void emberAfIasZoneClusterClientAttributeChangedCallback(uint8_t endpoint, Ember
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIasZoneClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIasZoneClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief IAS Zone Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIasZoneClusterClientInitCallback(uint8_t endpoint);
+void emberAfIasZoneClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief IAS Zone Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -13841,7 +14017,8 @@ void emberAfIasZoneClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIasZoneClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIasZoneClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              uint16_t manufacturerCode);
 /** @brief IAS Zone Cluster Client Message Sent
  *
@@ -13868,7 +14045,7 @@ void emberAfIasZoneClusterClientMessageSentCallback(EmberOutgoingMessageType typ
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIasZoneClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIasZoneClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                      EmberAfAttributeType attributeType, uint8_t size,
                                                                      uint8_t * value);
 /** @brief IAS Zone Cluster Client Tick
@@ -13877,7 +14054,7 @@ EmberAfStatus emberAfIasZoneClusterClientPreAttributeChangedCallback(uint8_t end
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIasZoneClusterClientTickCallback(uint8_t endpoint);
+void emberAfIasZoneClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief IAS Zone Cluster Initiate Normal Operation Mode
  *
  *
@@ -13911,7 +14088,7 @@ bool emberAfIasZoneClusterInitiateTestModeResponseCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIasZoneClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIasZoneClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief IAS Zone Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -13921,14 +14098,14 @@ void emberAfIasZoneClusterServerAttributeChangedCallback(uint8_t endpoint, Ember
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIasZoneClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIasZoneClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief IAS Zone Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIasZoneClusterServerInitCallback(uint8_t endpoint);
+void emberAfIasZoneClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief IAS Zone Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -13938,7 +14115,8 @@ void emberAfIasZoneClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIasZoneClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIasZoneClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              uint16_t manufacturerCode);
 /** @brief IAS Zone Cluster Server Message Sent
  *
@@ -13965,7 +14143,7 @@ void emberAfIasZoneClusterServerMessageSentCallback(EmberOutgoingMessageType typ
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIasZoneClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIasZoneClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                      EmberAfAttributeType attributeType, uint8_t size,
                                                                      uint8_t * value);
 /** @brief IAS Zone Cluster Server Tick
@@ -13974,7 +14152,7 @@ EmberAfStatus emberAfIasZoneClusterServerPreAttributeChangedCallback(uint8_t end
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIasZoneClusterServerTickCallback(uint8_t endpoint);
+void emberAfIasZoneClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief IAS Zone Cluster Zone Enroll Request
  *
  *
@@ -14048,7 +14226,7 @@ bool emberAfIasAceClusterBypassResponseCallback(uint8_t numberOfZones, uint8_t *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIasAceClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIasAceClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief IAS ACE Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -14058,14 +14236,14 @@ void emberAfIasAceClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIasAceClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIasAceClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief IAS ACE Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIasAceClusterClientInitCallback(uint8_t endpoint);
+void emberAfIasAceClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief IAS ACE Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -14075,7 +14253,8 @@ void emberAfIasAceClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIasAceClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIasAceClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief IAS ACE Cluster Client Message Sent
  *
@@ -14102,7 +14281,7 @@ void emberAfIasAceClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIasAceClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIasAceClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief IAS ACE Cluster Client Tick
@@ -14111,7 +14290,7 @@ EmberAfStatus emberAfIasAceClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIasAceClusterClientTickCallback(uint8_t endpoint);
+void emberAfIasAceClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief IAS ACE Cluster Emergency
  *
  *
@@ -14242,7 +14421,7 @@ bool emberAfIasAceClusterPanicCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIasAceClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIasAceClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief IAS ACE Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -14252,14 +14431,14 @@ void emberAfIasAceClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIasAceClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIasAceClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief IAS ACE Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIasAceClusterServerInitCallback(uint8_t endpoint);
+void emberAfIasAceClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief IAS ACE Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -14269,7 +14448,8 @@ void emberAfIasAceClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIasAceClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIasAceClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief IAS ACE Cluster Server Message Sent
  *
@@ -14296,7 +14476,7 @@ void emberAfIasAceClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIasAceClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIasAceClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief IAS ACE Cluster Server Tick
@@ -14305,7 +14485,7 @@ EmberAfStatus emberAfIasAceClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIasAceClusterServerTickCallback(uint8_t endpoint);
+void emberAfIasAceClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief IAS ACE Cluster Set Bypassed Zone List
  *
  *
@@ -14338,7 +14518,7 @@ bool emberAfIasAceClusterZoneStatusChangedCallback(uint8_t zoneId, uint16_t zone
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIasWdClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIasWdClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief IAS WD Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -14348,14 +14528,14 @@ void emberAfIasWdClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIasWdClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIasWdClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief IAS WD Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIasWdClusterClientInitCallback(uint8_t endpoint);
+void emberAfIasWdClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief IAS WD Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -14365,7 +14545,7 @@ void emberAfIasWdClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIasWdClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIasWdClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief IAS WD Cluster Client Message Sent
  *
@@ -14391,7 +14571,7 @@ void emberAfIasWdClusterClientMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIasWdClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIasWdClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief IAS WD Cluster Client Tick
@@ -14400,7 +14580,7 @@ EmberAfStatus emberAfIasWdClusterClientPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIasWdClusterClientTickCallback(uint8_t endpoint);
+void emberAfIasWdClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief IAS WD Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -14408,7 +14588,7 @@ void emberAfIasWdClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIasWdClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIasWdClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief IAS WD Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -14418,14 +14598,14 @@ void emberAfIasWdClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIasWdClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIasWdClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief IAS WD Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIasWdClusterServerInitCallback(uint8_t endpoint);
+void emberAfIasWdClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief IAS WD Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -14435,7 +14615,7 @@ void emberAfIasWdClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIasWdClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIasWdClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief IAS WD Cluster Server Message Sent
  *
@@ -14461,7 +14641,7 @@ void emberAfIasWdClusterServerMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIasWdClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIasWdClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief IAS WD Cluster Server Tick
@@ -14470,7 +14650,7 @@ EmberAfStatus emberAfIasWdClusterServerPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIasWdClusterServerTickCallback(uint8_t endpoint);
+void emberAfIasWdClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief IAS WD Cluster Squawk
  *
  *
@@ -14509,7 +14689,7 @@ bool emberAfGenericTunnelClusterAdvertiseProtocolAddressCallback(uint8_t * proto
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGenericTunnelClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGenericTunnelClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Generic Tunnel Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -14519,14 +14699,15 @@ void emberAfGenericTunnelClusterClientAttributeChangedCallback(uint8_t endpoint,
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGenericTunnelClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGenericTunnelClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                              EmberAfStatus status);
 /** @brief Generic Tunnel Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGenericTunnelClusterClientInitCallback(uint8_t endpoint);
+void emberAfGenericTunnelClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Generic Tunnel Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -14536,7 +14717,8 @@ void emberAfGenericTunnelClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGenericTunnelClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGenericTunnelClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    uint16_t manufacturerCode);
 /** @brief Generic Tunnel Cluster Client Message Sent
  *
@@ -14563,7 +14745,7 @@ void emberAfGenericTunnelClusterClientMessageSentCallback(EmberOutgoingMessageTy
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGenericTunnelClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGenericTunnelClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            EmberAfAttributeType attributeType, uint8_t size,
                                                                            uint8_t * value);
 /** @brief Generic Tunnel Cluster Client Tick
@@ -14572,7 +14754,7 @@ EmberAfStatus emberAfGenericTunnelClusterClientPreAttributeChangedCallback(uint8
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGenericTunnelClusterClientTickCallback(uint8_t endpoint);
+void emberAfGenericTunnelClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Generic Tunnel Cluster Match Protocol Address
  *
  *
@@ -14595,7 +14777,7 @@ bool emberAfGenericTunnelClusterMatchProtocolAddressResponseCallback(uint8_t * d
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGenericTunnelClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGenericTunnelClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Generic Tunnel Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -14605,14 +14787,15 @@ void emberAfGenericTunnelClusterServerAttributeChangedCallback(uint8_t endpoint,
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGenericTunnelClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGenericTunnelClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                              EmberAfStatus status);
 /** @brief Generic Tunnel Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGenericTunnelClusterServerInitCallback(uint8_t endpoint);
+void emberAfGenericTunnelClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Generic Tunnel Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -14622,7 +14805,8 @@ void emberAfGenericTunnelClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGenericTunnelClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGenericTunnelClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    uint16_t manufacturerCode);
 /** @brief Generic Tunnel Cluster Server Message Sent
  *
@@ -14649,7 +14833,7 @@ void emberAfGenericTunnelClusterServerMessageSentCallback(EmberOutgoingMessageTy
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGenericTunnelClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGenericTunnelClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            EmberAfAttributeType attributeType, uint8_t size,
                                                                            uint8_t * value);
 /** @brief Generic Tunnel Cluster Server Tick
@@ -14658,7 +14842,7 @@ EmberAfStatus emberAfGenericTunnelClusterServerPreAttributeChangedCallback(uint8
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGenericTunnelClusterServerTickCallback(uint8_t endpoint);
+void emberAfGenericTunnelClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Generic Tunnel Cluster Callbacks */
 
@@ -14672,7 +14856,7 @@ void emberAfGenericTunnelClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBacnetProtocolTunnelClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief BACnet Protocol Tunnel Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -14682,14 +14866,15 @@ void emberAfBacnetProtocolTunnelClusterClientAttributeChangedCallback(uint8_t en
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBacnetProtocolTunnelClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                     EmberAfStatus status);
 /** @brief BACnet Protocol Tunnel Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterClientInitCallback(uint8_t endpoint);
+void emberAfBacnetProtocolTunnelClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief BACnet Protocol Tunnel Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -14700,7 +14885,7 @@ void emberAfBacnetProtocolTunnelClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfBacnetProtocolTunnelClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId,
+                                                                                          chip::AttributeId attributeId,
                                                                                           uint16_t manufacturerCode);
 /** @brief BACnet Protocol Tunnel Cluster Client Message Sent
  *
@@ -14727,7 +14912,8 @@ void emberAfBacnetProtocolTunnelClusterClientMessageSentCallback(EmberOutgoingMe
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBacnetProtocolTunnelClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBacnetProtocolTunnelClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   EmberAfAttributeType attributeType, uint8_t size,
                                                                                   uint8_t * value);
 /** @brief BACnet Protocol Tunnel Cluster Client Tick
@@ -14736,7 +14922,7 @@ EmberAfStatus emberAfBacnetProtocolTunnelClusterClientPreAttributeChangedCallbac
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterClientTickCallback(uint8_t endpoint);
+void emberAfBacnetProtocolTunnelClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief BACnet Protocol Tunnel Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -14744,7 +14930,7 @@ void emberAfBacnetProtocolTunnelClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBacnetProtocolTunnelClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief BACnet Protocol Tunnel Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -14754,14 +14940,15 @@ void emberAfBacnetProtocolTunnelClusterServerAttributeChangedCallback(uint8_t en
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBacnetProtocolTunnelClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                     EmberAfStatus status);
 /** @brief BACnet Protocol Tunnel Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterServerInitCallback(uint8_t endpoint);
+void emberAfBacnetProtocolTunnelClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief BACnet Protocol Tunnel Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -14772,7 +14959,7 @@ void emberAfBacnetProtocolTunnelClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfBacnetProtocolTunnelClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId,
+                                                                                          chip::AttributeId attributeId,
                                                                                           uint16_t manufacturerCode);
 /** @brief BACnet Protocol Tunnel Cluster Server Message Sent
  *
@@ -14799,7 +14986,8 @@ void emberAfBacnetProtocolTunnelClusterServerMessageSentCallback(EmberOutgoingMe
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBacnetProtocolTunnelClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBacnetProtocolTunnelClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   EmberAfAttributeType attributeType, uint8_t size,
                                                                                   uint8_t * value);
 /** @brief BACnet Protocol Tunnel Cluster Server Tick
@@ -14808,7 +14996,7 @@ EmberAfStatus emberAfBacnetProtocolTunnelClusterServerPreAttributeChangedCallbac
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterServerTickCallback(uint8_t endpoint);
+void emberAfBacnetProtocolTunnelClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief BACnet Protocol Tunnel Cluster Transfer Npdu
  *
  *
@@ -14829,7 +15017,7 @@ bool emberAfBacnetProtocolTunnelClusterTransferNpduCallback(uint8_t * npdu);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAf11073ProtocolTunnelClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief 11073 Protocol Tunnel Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -14839,14 +15027,15 @@ void emberAf11073ProtocolTunnelClusterClientAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAf11073ProtocolTunnelClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief 11073 Protocol Tunnel Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterClientInitCallback(uint8_t endpoint);
+void emberAf11073ProtocolTunnelClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief 11073 Protocol Tunnel Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -14857,7 +15046,7 @@ void emberAf11073ProtocolTunnelClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAf11073ProtocolTunnelClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief 11073 Protocol Tunnel Cluster Client Message Sent
  *
@@ -14884,7 +15073,8 @@ void emberAf11073ProtocolTunnelClusterClientMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAf11073ProtocolTunnelClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAf11073ProtocolTunnelClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief 11073 Protocol Tunnel Cluster Client Tick
@@ -14893,7 +15083,7 @@ EmberAfStatus emberAf11073ProtocolTunnelClusterClientPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterClientTickCallback(uint8_t endpoint);
+void emberAf11073ProtocolTunnelClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief 11073 Protocol Tunnel Cluster Connect Request
  *
  *
@@ -14926,7 +15116,7 @@ bool emberAf11073ProtocolTunnelClusterDisconnectRequestCallback(uint8_t * manage
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAf11073ProtocolTunnelClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief 11073 Protocol Tunnel Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -14936,14 +15126,15 @@ void emberAf11073ProtocolTunnelClusterServerAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAf11073ProtocolTunnelClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief 11073 Protocol Tunnel Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterServerInitCallback(uint8_t endpoint);
+void emberAf11073ProtocolTunnelClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief 11073 Protocol Tunnel Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -14954,7 +15145,7 @@ void emberAf11073ProtocolTunnelClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAf11073ProtocolTunnelClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief 11073 Protocol Tunnel Cluster Server Message Sent
  *
@@ -14981,7 +15172,8 @@ void emberAf11073ProtocolTunnelClusterServerMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAf11073ProtocolTunnelClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAf11073ProtocolTunnelClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief 11073 Protocol Tunnel Cluster Server Tick
@@ -14990,7 +15182,7 @@ EmberAfStatus emberAf11073ProtocolTunnelClusterServerPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterServerTickCallback(uint8_t endpoint);
+void emberAf11073ProtocolTunnelClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief 11073 Protocol Tunnel Cluster Transfer A P D U
  *
  *
@@ -15011,7 +15203,7 @@ bool emberAf11073ProtocolTunnelClusterTransferAPDUCallback(uint8_t * apdu);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIso7816ProtocolTunnelClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief ISO 7816 Protocol Tunnel Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -15021,14 +15213,15 @@ void emberAfIso7816ProtocolTunnelClusterClientAttributeChangedCallback(uint8_t e
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIso7816ProtocolTunnelClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                      EmberAfStatus status);
 /** @brief ISO 7816 Protocol Tunnel Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterClientInitCallback(uint8_t endpoint);
+void emberAfIso7816ProtocolTunnelClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief ISO 7816 Protocol Tunnel Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -15039,7 +15232,7 @@ void emberAfIso7816ProtocolTunnelClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfIso7816ProtocolTunnelClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                           EmberAfAttributeId attributeId,
+                                                                                           chip::AttributeId attributeId,
                                                                                            uint16_t manufacturerCode);
 /** @brief ISO 7816 Protocol Tunnel Cluster Client Message Sent
  *
@@ -15066,7 +15259,8 @@ void emberAfIso7816ProtocolTunnelClusterClientMessageSentCallback(EmberOutgoingM
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIso7816ProtocolTunnelClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIso7816ProtocolTunnelClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                                    uint8_t * value);
 /** @brief ISO 7816 Protocol Tunnel Cluster Client Tick
@@ -15075,7 +15269,7 @@ EmberAfStatus emberAfIso7816ProtocolTunnelClusterClientPreAttributeChangedCallba
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterClientTickCallback(uint8_t endpoint);
+void emberAfIso7816ProtocolTunnelClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief ISO 7816 Protocol Tunnel Cluster Extract Smart Card
  *
  *
@@ -15095,7 +15289,7 @@ bool emberAfIso7816ProtocolTunnelClusterInsertSmartCardCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIso7816ProtocolTunnelClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief ISO 7816 Protocol Tunnel Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -15105,14 +15299,15 @@ void emberAfIso7816ProtocolTunnelClusterServerAttributeChangedCallback(uint8_t e
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIso7816ProtocolTunnelClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                      EmberAfStatus status);
 /** @brief ISO 7816 Protocol Tunnel Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterServerInitCallback(uint8_t endpoint);
+void emberAfIso7816ProtocolTunnelClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief ISO 7816 Protocol Tunnel Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -15123,7 +15318,7 @@ void emberAfIso7816ProtocolTunnelClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfIso7816ProtocolTunnelClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                           EmberAfAttributeId attributeId,
+                                                                                           chip::AttributeId attributeId,
                                                                                            uint16_t manufacturerCode);
 /** @brief ISO 7816 Protocol Tunnel Cluster Server Message Sent
  *
@@ -15150,7 +15345,8 @@ void emberAfIso7816ProtocolTunnelClusterServerMessageSentCallback(EmberOutgoingM
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIso7816ProtocolTunnelClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIso7816ProtocolTunnelClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                                    uint8_t * value);
 /** @brief ISO 7816 Protocol Tunnel Cluster Server Tick
@@ -15159,7 +15355,7 @@ EmberAfStatus emberAfIso7816ProtocolTunnelClusterServerPreAttributeChangedCallba
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterServerTickCallback(uint8_t endpoint);
+void emberAfIso7816ProtocolTunnelClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief ISO 7816 Protocol Tunnel Cluster Transfer Apdu
  *
  *
@@ -15189,7 +15385,7 @@ bool emberAfPriceClusterCancelTariffCallback(uint32_t providerId, uint32_t issue
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPriceClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPriceClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Price Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -15199,14 +15395,14 @@ void emberAfPriceClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPriceClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPriceClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Price Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPriceClusterClientInitCallback(uint8_t endpoint);
+void emberAfPriceClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Price Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -15216,7 +15412,7 @@ void emberAfPriceClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPriceClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPriceClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief Price Cluster Client Message Sent
  *
@@ -15242,7 +15438,7 @@ void emberAfPriceClusterClientMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPriceClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPriceClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief Price Cluster Client Tick
@@ -15251,7 +15447,7 @@ EmberAfStatus emberAfPriceClusterClientPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPriceClusterClientTickCallback(uint8_t endpoint);
+void emberAfPriceClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Price Cluster Cpp Event Response
  *
  *
@@ -15651,7 +15847,7 @@ bool emberAfPriceClusterPublishTierLabelsCallback(uint32_t providerId, uint32_t 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPriceClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPriceClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Price Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -15661,14 +15857,14 @@ void emberAfPriceClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPriceClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPriceClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Price Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPriceClusterServerInitCallback(uint8_t endpoint);
+void emberAfPriceClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Price Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -15678,7 +15874,7 @@ void emberAfPriceClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPriceClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPriceClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief Price Cluster Server Message Sent
  *
@@ -15704,7 +15900,7 @@ void emberAfPriceClusterServerMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPriceClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPriceClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief Price Cluster Server Tick
@@ -15713,7 +15909,7 @@ EmberAfStatus emberAfPriceClusterServerPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPriceClusterServerTickCallback(uint8_t endpoint);
+void emberAfPriceClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Price Cluster Callbacks */
 
@@ -15747,7 +15943,8 @@ bool emberAfDemandResponseLoadControlClusterCancelLoadControlEventCallback(uint3
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDemandResponseLoadControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                           chip::AttributeId attributeId);
 /** @brief Demand Response and Load Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -15757,7 +15954,7 @@ void emberAfDemandResponseLoadControlClusterClientAttributeChangedCallback(uint8
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfDemandResponseLoadControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                           EmberAfStatus status);
 /** @brief Demand Response and Load Control Cluster Client Init
  *
@@ -15765,7 +15962,7 @@ void emberAfDemandResponseLoadControlClusterClientDefaultResponseCallback(uint8_
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfDemandResponseLoadControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Demand Response and Load Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -15776,7 +15973,7 @@ void emberAfDemandResponseLoadControlClusterClientInitCallback(uint8_t endpoint)
  * Ver.: always
  */
 void emberAfDemandResponseLoadControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                uint16_t manufacturerCode);
 /** @brief Demand Response and Load Control Cluster Client Message Sent
  *
@@ -15804,7 +16001,7 @@ void emberAfDemandResponseLoadControlClusterClientMessageSentCallback(EmberOutgo
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfDemandResponseLoadControlClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        EmberAfAttributeType attributeType,
                                                                                        uint8_t size, uint8_t * value);
 /** @brief Demand Response and Load Control Cluster Client Tick
@@ -15813,7 +16010,7 @@ EmberAfStatus emberAfDemandResponseLoadControlClusterClientPreAttributeChangedCa
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfDemandResponseLoadControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Demand Response and Load Control Cluster Get Scheduled Events
  *
  *
@@ -15877,7 +16074,8 @@ bool emberAfDemandResponseLoadControlClusterReportEventStatusCallback(uint32_t i
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDemandResponseLoadControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                           chip::AttributeId attributeId);
 /** @brief Demand Response and Load Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -15887,7 +16085,7 @@ void emberAfDemandResponseLoadControlClusterServerAttributeChangedCallback(uint8
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfDemandResponseLoadControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                           EmberAfStatus status);
 /** @brief Demand Response and Load Control Cluster Server Init
  *
@@ -15895,7 +16093,7 @@ void emberAfDemandResponseLoadControlClusterServerDefaultResponseCallback(uint8_
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfDemandResponseLoadControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Demand Response and Load Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -15906,7 +16104,7 @@ void emberAfDemandResponseLoadControlClusterServerInitCallback(uint8_t endpoint)
  * Ver.: always
  */
 void emberAfDemandResponseLoadControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                uint16_t manufacturerCode);
 /** @brief Demand Response and Load Control Cluster Server Message Sent
  *
@@ -15934,7 +16132,7 @@ void emberAfDemandResponseLoadControlClusterServerMessageSentCallback(EmberOutgo
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfDemandResponseLoadControlClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        EmberAfAttributeType attributeType,
                                                                                        uint8_t size, uint8_t * value);
 /** @brief Demand Response and Load Control Cluster Server Tick
@@ -15943,7 +16141,7 @@ EmberAfStatus emberAfDemandResponseLoadControlClusterServerPreAttributeChangedCa
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfDemandResponseLoadControlClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Demand Response and Load Control Cluster Callbacks */
 
@@ -15971,7 +16169,7 @@ bool emberAfSimpleMeteringClusterChangeSupplyCallback(uint32_t providerId, uint3
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSimpleMeteringClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSimpleMeteringClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Simple Metering Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -15981,14 +16179,15 @@ void emberAfSimpleMeteringClusterClientAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSimpleMeteringClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSimpleMeteringClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Simple Metering Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSimpleMeteringClusterClientInitCallback(uint8_t endpoint);
+void emberAfSimpleMeteringClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Simple Metering Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -15998,8 +16197,8 @@ void emberAfSimpleMeteringClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfSimpleMeteringClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfSimpleMeteringClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Simple Metering Cluster Client Message Sent
  *
@@ -16026,7 +16225,8 @@ void emberAfSimpleMeteringClusterClientMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSimpleMeteringClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSimpleMeteringClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Simple Metering Cluster Client Tick
@@ -16035,7 +16235,7 @@ EmberAfStatus emberAfSimpleMeteringClusterClientPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSimpleMeteringClusterClientTickCallback(uint8_t endpoint);
+void emberAfSimpleMeteringClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Simple Metering Cluster Configure Mirror
  *
  *
@@ -16062,7 +16262,7 @@ bool emberAfSimpleMeteringClusterConfigureMirrorCallback(uint32_t issuerEventId,
 bool emberAfSimpleMeteringClusterConfigureNotificationFlagsCallback(uint32_t issuerEventId, uint8_t notificationScheme,
                                                                     uint16_t notificationFlagAttributeId, uint16_t clusterId,
                                                                     uint16_t manufacturerCode, uint8_t numberOfCommands,
-                                                                    uint8_t * commandIds);
+                                                                    chip::CommandId * commandIds);
 /** @brief Simple Metering Cluster Configure Notification Scheme
  *
  *
@@ -16247,7 +16447,7 @@ bool emberAfSimpleMeteringClusterScheduleSnapshotResponseCallback(uint32_t issue
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSimpleMeteringClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSimpleMeteringClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Simple Metering Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -16257,14 +16457,15 @@ void emberAfSimpleMeteringClusterServerAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSimpleMeteringClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSimpleMeteringClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Simple Metering Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSimpleMeteringClusterServerInitCallback(uint8_t endpoint);
+void emberAfSimpleMeteringClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Simple Metering Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -16274,8 +16475,8 @@ void emberAfSimpleMeteringClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfSimpleMeteringClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfSimpleMeteringClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Simple Metering Cluster Server Message Sent
  *
@@ -16302,7 +16503,8 @@ void emberAfSimpleMeteringClusterServerMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSimpleMeteringClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSimpleMeteringClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Simple Metering Cluster Server Tick
@@ -16311,7 +16513,7 @@ EmberAfStatus emberAfSimpleMeteringClusterServerPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSimpleMeteringClusterServerTickCallback(uint8_t endpoint);
+void emberAfSimpleMeteringClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Simple Metering Cluster Set Supply Status
  *
  *
@@ -16415,7 +16617,7 @@ bool emberAfMessagingClusterCancelMessageCallback(uint32_t messageId, uint8_t me
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMessagingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMessagingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Messaging Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -16425,14 +16627,15 @@ void emberAfMessagingClusterClientAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMessagingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMessagingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Messaging Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMessagingClusterClientInitCallback(uint8_t endpoint);
+void emberAfMessagingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Messaging Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -16442,7 +16645,8 @@ void emberAfMessagingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfMessagingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfMessagingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Messaging Cluster Client Message Sent
  *
@@ -16469,7 +16673,7 @@ void emberAfMessagingClusterClientMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMessagingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMessagingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Messaging Cluster Client Tick
@@ -16478,7 +16682,7 @@ EmberAfStatus emberAfMessagingClusterClientPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMessagingClusterClientTickCallback(uint8_t endpoint);
+void emberAfMessagingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Messaging Cluster Display Message
  *
  *
@@ -16538,7 +16742,7 @@ bool emberAfMessagingClusterMessageConfirmationCallback(uint32_t messageId, uint
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMessagingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMessagingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Messaging Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -16548,14 +16752,15 @@ void emberAfMessagingClusterServerAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMessagingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMessagingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Messaging Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMessagingClusterServerInitCallback(uint8_t endpoint);
+void emberAfMessagingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Messaging Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -16565,7 +16770,8 @@ void emberAfMessagingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfMessagingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfMessagingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Messaging Cluster Server Message Sent
  *
@@ -16592,7 +16798,7 @@ void emberAfMessagingClusterServerMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMessagingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMessagingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Messaging Cluster Server Tick
@@ -16601,7 +16807,7 @@ EmberAfStatus emberAfMessagingClusterServerPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMessagingClusterServerTickCallback(uint8_t endpoint);
+void emberAfMessagingClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Messaging Cluster Callbacks */
 
@@ -16631,7 +16837,7 @@ bool emberAfTunnelingClusterAckTransferDataServerToClientCallback(uint16_t tunne
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTunnelingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfTunnelingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Tunneling Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -16641,14 +16847,15 @@ void emberAfTunnelingClusterClientAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTunnelingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfTunnelingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Tunneling Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTunnelingClusterClientInitCallback(uint8_t endpoint);
+void emberAfTunnelingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Tunneling Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -16658,7 +16865,8 @@ void emberAfTunnelingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfTunnelingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfTunnelingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Tunneling Cluster Client Message Sent
  *
@@ -16685,7 +16893,7 @@ void emberAfTunnelingClusterClientMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfTunnelingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfTunnelingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Tunneling Cluster Client Tick
@@ -16694,7 +16902,7 @@ EmberAfStatus emberAfTunnelingClusterClientPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTunnelingClusterClientTickCallback(uint8_t endpoint);
+void emberAfTunnelingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Tunneling Cluster Close Tunnel
  *
  *
@@ -16753,7 +16961,7 @@ bool emberAfTunnelingClusterRequestTunnelResponseCallback(uint16_t tunnelId, uin
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTunnelingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfTunnelingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Tunneling Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -16763,14 +16971,15 @@ void emberAfTunnelingClusterServerAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTunnelingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfTunnelingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Tunneling Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTunnelingClusterServerInitCallback(uint8_t endpoint);
+void emberAfTunnelingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Tunneling Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -16780,7 +16989,8 @@ void emberAfTunnelingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfTunnelingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfTunnelingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Tunneling Cluster Server Message Sent
  *
@@ -16807,7 +17017,7 @@ void emberAfTunnelingClusterServerMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfTunnelingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfTunnelingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Tunneling Cluster Server Tick
@@ -16816,7 +17026,7 @@ EmberAfStatus emberAfTunnelingClusterServerPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTunnelingClusterServerTickCallback(uint8_t endpoint);
+void emberAfTunnelingClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Tunneling Cluster Supported Tunnel Protocols Response
  *
  *
@@ -16921,7 +17131,7 @@ bool emberAfPrepaymentClusterChangePaymentModeResponseCallback(uint8_t friendlyC
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPrepaymentClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPrepaymentClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Prepayment Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -16931,14 +17141,15 @@ void emberAfPrepaymentClusterClientAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPrepaymentClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPrepaymentClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Prepayment Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPrepaymentClusterClientInitCallback(uint8_t endpoint);
+void emberAfPrepaymentClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Prepayment Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -16948,7 +17159,8 @@ void emberAfPrepaymentClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPrepaymentClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPrepaymentClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Prepayment Cluster Client Message Sent
  *
@@ -16975,7 +17187,7 @@ void emberAfPrepaymentClusterClientMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPrepaymentClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPrepaymentClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Prepayment Cluster Client Tick
@@ -16984,7 +17196,7 @@ EmberAfStatus emberAfPrepaymentClusterClientPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPrepaymentClusterClientTickCallback(uint8_t endpoint);
+void emberAfPrepaymentClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Prepayment Cluster Consumer Top Up
  *
  *
@@ -17104,7 +17316,7 @@ bool emberAfPrepaymentClusterSelectAvailableEmergencyCreditCallback(uint32_t com
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPrepaymentClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPrepaymentClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Prepayment Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -17114,14 +17326,15 @@ void emberAfPrepaymentClusterServerAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPrepaymentClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPrepaymentClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Prepayment Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPrepaymentClusterServerInitCallback(uint8_t endpoint);
+void emberAfPrepaymentClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Prepayment Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -17131,7 +17344,8 @@ void emberAfPrepaymentClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPrepaymentClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPrepaymentClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Prepayment Cluster Server Message Sent
  *
@@ -17158,7 +17372,7 @@ void emberAfPrepaymentClusterServerMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPrepaymentClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPrepaymentClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Prepayment Cluster Server Tick
@@ -17167,7 +17381,7 @@ EmberAfStatus emberAfPrepaymentClusterServerPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPrepaymentClusterServerTickCallback(uint8_t endpoint);
+void emberAfPrepaymentClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Prepayment Cluster Set Low Credit Warning Level
  *
  *
@@ -17212,7 +17426,7 @@ bool emberAfPrepaymentClusterSetOverallDebtCapCallback(uint32_t providerId, uint
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfEnergyManagementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfEnergyManagementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Energy Management Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -17222,14 +17436,15 @@ void emberAfEnergyManagementClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEnergyManagementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfEnergyManagementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Energy Management Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEnergyManagementClusterClientInitCallback(uint8_t endpoint);
+void emberAfEnergyManagementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Energy Management Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -17239,8 +17454,8 @@ void emberAfEnergyManagementClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfEnergyManagementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfEnergyManagementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Energy Management Cluster Client Message Sent
  *
@@ -17267,7 +17482,8 @@ void emberAfEnergyManagementClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfEnergyManagementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfEnergyManagementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Energy Management Cluster Client Tick
@@ -17276,7 +17492,7 @@ EmberAfStatus emberAfEnergyManagementClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEnergyManagementClusterClientTickCallback(uint8_t endpoint);
+void emberAfEnergyManagementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Energy Management Cluster Manage Event
  *
  *
@@ -17315,7 +17531,7 @@ bool emberAfEnergyManagementClusterReportEventStatusCallback(uint32_t issuerEven
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfEnergyManagementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfEnergyManagementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Energy Management Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -17325,14 +17541,15 @@ void emberAfEnergyManagementClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEnergyManagementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfEnergyManagementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Energy Management Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEnergyManagementClusterServerInitCallback(uint8_t endpoint);
+void emberAfEnergyManagementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Energy Management Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -17342,8 +17559,8 @@ void emberAfEnergyManagementClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfEnergyManagementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfEnergyManagementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Energy Management Cluster Server Message Sent
  *
@@ -17370,7 +17587,8 @@ void emberAfEnergyManagementClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfEnergyManagementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfEnergyManagementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Energy Management Cluster Server Tick
@@ -17379,7 +17597,7 @@ EmberAfStatus emberAfEnergyManagementClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEnergyManagementClusterServerTickCallback(uint8_t endpoint);
+void emberAfEnergyManagementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Energy Management Cluster Callbacks */
 
@@ -17402,7 +17620,7 @@ bool emberAfCalendarClusterCancelCalendarCallback(uint32_t providerId, uint32_t 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfCalendarClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfCalendarClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Calendar Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -17412,14 +17630,15 @@ void emberAfCalendarClusterClientAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCalendarClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfCalendarClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Calendar Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCalendarClusterClientInitCallback(uint8_t endpoint);
+void emberAfCalendarClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Calendar Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -17429,7 +17648,8 @@ void emberAfCalendarClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfCalendarClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfCalendarClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Calendar Cluster Client Message Sent
  *
@@ -17456,7 +17676,7 @@ void emberAfCalendarClusterClientMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfCalendarClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfCalendarClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Calendar Cluster Client Tick
@@ -17465,7 +17685,7 @@ EmberAfStatus emberAfCalendarClusterClientPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCalendarClusterClientTickCallback(uint8_t endpoint);
+void emberAfCalendarClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Calendar Cluster Get Calendar
  *
  *
@@ -17621,7 +17841,7 @@ bool emberAfCalendarClusterPublishWeekProfileCallback(uint32_t providerId, uint3
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfCalendarClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfCalendarClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Calendar Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -17631,14 +17851,15 @@ void emberAfCalendarClusterServerAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCalendarClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfCalendarClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Calendar Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCalendarClusterServerInitCallback(uint8_t endpoint);
+void emberAfCalendarClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Calendar Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -17648,7 +17869,8 @@ void emberAfCalendarClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfCalendarClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfCalendarClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Calendar Cluster Server Message Sent
  *
@@ -17675,7 +17897,7 @@ void emberAfCalendarClusterServerMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfCalendarClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfCalendarClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Calendar Cluster Server Tick
@@ -17684,7 +17906,7 @@ EmberAfStatus emberAfCalendarClusterServerPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCalendarClusterServerTickCallback(uint8_t endpoint);
+void emberAfCalendarClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Calendar Cluster Callbacks */
 
@@ -17698,7 +17920,7 @@ void emberAfCalendarClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDeviceManagementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDeviceManagementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Device Management Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -17708,14 +17930,15 @@ void emberAfDeviceManagementClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDeviceManagementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDeviceManagementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Device Management Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDeviceManagementClusterClientInitCallback(uint8_t endpoint);
+void emberAfDeviceManagementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Device Management Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -17725,8 +17948,8 @@ void emberAfDeviceManagementClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDeviceManagementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfDeviceManagementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Device Management Cluster Client Message Sent
  *
@@ -17753,7 +17976,8 @@ void emberAfDeviceManagementClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDeviceManagementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDeviceManagementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Device Management Cluster Client Tick
@@ -17762,7 +17986,7 @@ EmberAfStatus emberAfDeviceManagementClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDeviceManagementClusterClientTickCallback(uint8_t endpoint);
+void emberAfDeviceManagementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Device Management Cluster Get C I N
  *
  *
@@ -17862,7 +18086,7 @@ bool emberAfDeviceManagementClusterRequestNewPasswordResponseCallback(uint32_t i
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDeviceManagementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDeviceManagementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Device Management Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -17872,14 +18096,15 @@ void emberAfDeviceManagementClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDeviceManagementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDeviceManagementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Device Management Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDeviceManagementClusterServerInitCallback(uint8_t endpoint);
+void emberAfDeviceManagementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Device Management Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -17889,8 +18114,8 @@ void emberAfDeviceManagementClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDeviceManagementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfDeviceManagementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Device Management Cluster Server Message Sent
  *
@@ -17917,7 +18142,8 @@ void emberAfDeviceManagementClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDeviceManagementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDeviceManagementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Device Management Cluster Server Tick
@@ -17926,7 +18152,7 @@ EmberAfStatus emberAfDeviceManagementClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDeviceManagementClusterServerTickCallback(uint8_t endpoint);
+void emberAfDeviceManagementClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Device Management Cluster Set Event Configuration
  *
  *
@@ -17989,7 +18215,7 @@ bool emberAfEventsClusterClearEventLogResponseCallback(uint8_t clearedEventsLogs
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfEventsClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfEventsClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Events Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -17999,14 +18225,14 @@ void emberAfEventsClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEventsClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfEventsClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Events Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEventsClusterClientInitCallback(uint8_t endpoint);
+void emberAfEventsClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Events Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -18016,7 +18242,8 @@ void emberAfEventsClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfEventsClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfEventsClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Events Cluster Client Message Sent
  *
@@ -18043,7 +18270,7 @@ void emberAfEventsClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfEventsClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfEventsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Events Cluster Client Tick
@@ -18052,7 +18279,7 @@ EmberAfStatus emberAfEventsClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEventsClusterClientTickCallback(uint8_t endpoint);
+void emberAfEventsClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Events Cluster Get Event Log
  *
  *
@@ -18097,7 +18324,7 @@ bool emberAfEventsClusterPublishEventLogCallback(uint16_t totalNumberOfEvents, u
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfEventsClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfEventsClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Events Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -18107,14 +18334,14 @@ void emberAfEventsClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEventsClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfEventsClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Events Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEventsClusterServerInitCallback(uint8_t endpoint);
+void emberAfEventsClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Events Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -18124,7 +18351,8 @@ void emberAfEventsClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfEventsClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfEventsClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Events Cluster Server Message Sent
  *
@@ -18151,7 +18379,7 @@ void emberAfEventsClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfEventsClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfEventsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Events Cluster Server Tick
@@ -18160,7 +18388,7 @@ EmberAfStatus emberAfEventsClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEventsClusterServerTickCallback(uint8_t endpoint);
+void emberAfEventsClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Events Cluster Callbacks */
 
@@ -18174,7 +18402,7 @@ void emberAfEventsClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMduPairingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMduPairingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief MDU Pairing Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -18184,14 +18412,15 @@ void emberAfMduPairingClusterClientAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMduPairingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMduPairingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief MDU Pairing Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMduPairingClusterClientInitCallback(uint8_t endpoint);
+void emberAfMduPairingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief MDU Pairing Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -18201,7 +18430,8 @@ void emberAfMduPairingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfMduPairingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfMduPairingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief MDU Pairing Cluster Client Message Sent
  *
@@ -18228,7 +18458,7 @@ void emberAfMduPairingClusterClientMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMduPairingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMduPairingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief MDU Pairing Cluster Client Tick
@@ -18237,7 +18467,7 @@ EmberAfStatus emberAfMduPairingClusterClientPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMduPairingClusterClientTickCallback(uint8_t endpoint);
+void emberAfMduPairingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief MDU Pairing Cluster Pairing Request
  *
  *
@@ -18265,7 +18495,7 @@ bool emberAfMduPairingClusterPairingResponseCallback(uint32_t pairingInformation
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMduPairingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMduPairingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief MDU Pairing Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -18275,14 +18505,15 @@ void emberAfMduPairingClusterServerAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMduPairingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMduPairingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief MDU Pairing Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMduPairingClusterServerInitCallback(uint8_t endpoint);
+void emberAfMduPairingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief MDU Pairing Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -18292,7 +18523,8 @@ void emberAfMduPairingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfMduPairingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfMduPairingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief MDU Pairing Cluster Server Message Sent
  *
@@ -18319,7 +18551,7 @@ void emberAfMduPairingClusterServerMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMduPairingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMduPairingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief MDU Pairing Cluster Server Tick
@@ -18328,7 +18560,7 @@ EmberAfStatus emberAfMduPairingClusterServerPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMduPairingClusterServerTickCallback(uint8_t endpoint);
+void emberAfMduPairingClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END MDU Pairing Cluster Callbacks */
 
@@ -18342,7 +18574,7 @@ void emberAfMduPairingClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSubGhzClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSubGhzClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Sub-GHz Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -18352,14 +18584,14 @@ void emberAfSubGhzClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSubGhzClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSubGhzClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Sub-GHz Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSubGhzClusterClientInitCallback(uint8_t endpoint);
+void emberAfSubGhzClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Sub-GHz Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -18369,7 +18601,8 @@ void emberAfSubGhzClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfSubGhzClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfSubGhzClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Sub-GHz Cluster Client Message Sent
  *
@@ -18396,7 +18629,7 @@ void emberAfSubGhzClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSubGhzClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSubGhzClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Sub-GHz Cluster Client Tick
@@ -18405,7 +18638,7 @@ EmberAfStatus emberAfSubGhzClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSubGhzClusterClientTickCallback(uint8_t endpoint);
+void emberAfSubGhzClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Sub-GHz Cluster Get Suspend Zcl Messages Status
  *
  *
@@ -18419,7 +18652,7 @@ bool emberAfSubGhzClusterGetSuspendZclMessagesStatusCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSubGhzClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSubGhzClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Sub-GHz Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -18429,14 +18662,14 @@ void emberAfSubGhzClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSubGhzClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSubGhzClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Sub-GHz Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSubGhzClusterServerInitCallback(uint8_t endpoint);
+void emberAfSubGhzClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Sub-GHz Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -18446,7 +18679,8 @@ void emberAfSubGhzClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfSubGhzClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfSubGhzClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Sub-GHz Cluster Server Message Sent
  *
@@ -18473,7 +18707,7 @@ void emberAfSubGhzClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSubGhzClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSubGhzClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Sub-GHz Cluster Server Tick
@@ -18482,7 +18716,7 @@ EmberAfStatus emberAfSubGhzClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSubGhzClusterServerTickCallback(uint8_t endpoint);
+void emberAfSubGhzClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Sub-GHz Cluster Suspend Zcl Messages
  *
  *
@@ -18514,7 +18748,7 @@ bool emberAfKeyEstablishmentClusterClientCommandReceivedCallback(EmberAfClusterC
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfKeyEstablishmentClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfKeyEstablishmentClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Key Establishment Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -18524,14 +18758,15 @@ void emberAfKeyEstablishmentClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfKeyEstablishmentClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfKeyEstablishmentClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Key Establishment Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfKeyEstablishmentClusterClientInitCallback(uint8_t endpoint);
+void emberAfKeyEstablishmentClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Key Establishment Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -18541,8 +18776,8 @@ void emberAfKeyEstablishmentClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfKeyEstablishmentClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfKeyEstablishmentClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Key Establishment Cluster Client Message Sent
  *
@@ -18569,7 +18804,8 @@ void emberAfKeyEstablishmentClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfKeyEstablishmentClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfKeyEstablishmentClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Key Establishment Cluster Client Tick
@@ -18578,7 +18814,7 @@ EmberAfStatus emberAfKeyEstablishmentClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfKeyEstablishmentClusterClientTickCallback(uint8_t endpoint);
+void emberAfKeyEstablishmentClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Key Establishment Cluster Confirm Key Data Request
  *
  *
@@ -18638,7 +18874,7 @@ bool emberAfKeyEstablishmentClusterInitiateKeyEstablishmentResponseCallback(uint
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfKeyEstablishmentClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfKeyEstablishmentClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Key Establishment Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -18648,14 +18884,15 @@ void emberAfKeyEstablishmentClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfKeyEstablishmentClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfKeyEstablishmentClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Key Establishment Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfKeyEstablishmentClusterServerInitCallback(uint8_t endpoint);
+void emberAfKeyEstablishmentClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Key Establishment Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -18665,8 +18902,8 @@ void emberAfKeyEstablishmentClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfKeyEstablishmentClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfKeyEstablishmentClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Key Establishment Cluster Server Message Sent
  *
@@ -18693,7 +18930,8 @@ void emberAfKeyEstablishmentClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfKeyEstablishmentClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfKeyEstablishmentClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Key Establishment Cluster Server Tick
@@ -18702,7 +18940,7 @@ EmberAfStatus emberAfKeyEstablishmentClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfKeyEstablishmentClusterServerTickCallback(uint8_t endpoint);
+void emberAfKeyEstablishmentClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Key Establishment Cluster Terminate Key Establishment
  *
  *
@@ -18737,7 +18975,7 @@ bool emberAfKeyEstablishmentClusterServerCommandReceivedCallback(EmberAfClusterC
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfInformationClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfInformationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Information Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -18747,14 +18985,15 @@ void emberAfInformationClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfInformationClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfInformationClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Information Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfInformationClusterClientInitCallback(uint8_t endpoint);
+void emberAfInformationClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Information Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -18764,7 +19003,8 @@ void emberAfInformationClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfInformationClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfInformationClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Information Cluster Client Message Sent
  *
@@ -18791,7 +19031,7 @@ void emberAfInformationClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfInformationClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfInformationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Information Cluster Client Tick
@@ -18800,7 +19040,7 @@ EmberAfStatus emberAfInformationClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfInformationClusterClientTickCallback(uint8_t endpoint);
+void emberAfInformationClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Information Cluster Configure Delivery Enable
  *
  *
@@ -18915,7 +19155,7 @@ bool emberAfInformationClusterSendPreferenceResponseCallback(uint8_t * statusFee
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfInformationClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfInformationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Information Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -18925,14 +19165,15 @@ void emberAfInformationClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfInformationClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfInformationClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Information Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfInformationClusterServerInitCallback(uint8_t endpoint);
+void emberAfInformationClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Information Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -18942,7 +19183,8 @@ void emberAfInformationClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfInformationClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfInformationClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Information Cluster Server Message Sent
  *
@@ -18969,7 +19211,7 @@ void emberAfInformationClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfInformationClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfInformationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Information Cluster Server Request Preference
@@ -18984,7 +19226,7 @@ bool emberAfInformationClusterServerRequestPreferenceCallback(void);
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfInformationClusterServerTickCallback(uint8_t endpoint);
+void emberAfInformationClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Information Cluster Update
  *
  *
@@ -19014,7 +19256,7 @@ bool emberAfInformationClusterUpdateResponseCallback(uint8_t * notificationList)
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDataSharingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDataSharingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Data Sharing Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -19024,14 +19266,15 @@ void emberAfDataSharingClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDataSharingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDataSharingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Data Sharing Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDataSharingClusterClientInitCallback(uint8_t endpoint);
+void emberAfDataSharingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Data Sharing Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -19041,7 +19284,8 @@ void emberAfDataSharingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDataSharingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDataSharingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Data Sharing Cluster Client Message Sent
  *
@@ -19068,7 +19312,7 @@ void emberAfDataSharingClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDataSharingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDataSharingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Data Sharing Cluster Client Tick
@@ -19077,7 +19321,7 @@ EmberAfStatus emberAfDataSharingClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDataSharingClusterClientTickCallback(uint8_t endpoint);
+void emberAfDataSharingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Data Sharing Cluster File Transmission
  *
  *
@@ -19135,7 +19379,7 @@ bool emberAfDataSharingClusterRecordTransmissionCallback(uint8_t transmitOptions
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDataSharingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDataSharingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Data Sharing Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -19145,14 +19389,15 @@ void emberAfDataSharingClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDataSharingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDataSharingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Data Sharing Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDataSharingClusterServerInitCallback(uint8_t endpoint);
+void emberAfDataSharingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Data Sharing Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -19162,7 +19407,8 @@ void emberAfDataSharingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDataSharingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDataSharingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Data Sharing Cluster Server Message Sent
  *
@@ -19189,7 +19435,7 @@ void emberAfDataSharingClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDataSharingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDataSharingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Data Sharing Cluster Server Tick
@@ -19198,7 +19444,7 @@ EmberAfStatus emberAfDataSharingClusterServerPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDataSharingClusterServerTickCallback(uint8_t endpoint);
+void emberAfDataSharingClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Data Sharing Cluster Write File Request
  *
  *
@@ -19235,7 +19481,7 @@ bool emberAfGamingClusterActionControlCallback(uint32_t actions);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGamingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGamingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Gaming Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -19245,14 +19491,14 @@ void emberAfGamingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGamingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGamingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Gaming Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGamingClusterClientInitCallback(uint8_t endpoint);
+void emberAfGamingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Gaming Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -19262,7 +19508,8 @@ void emberAfGamingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGamingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGamingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Gaming Cluster Client Message Sent
  *
@@ -19289,7 +19536,7 @@ void emberAfGamingClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGamingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGamingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Gaming Cluster Client Tick
@@ -19298,7 +19545,7 @@ EmberAfStatus emberAfGamingClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGamingClusterClientTickCallback(uint8_t endpoint);
+void emberAfGamingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Gaming Cluster Download Game
  *
  *
@@ -19328,7 +19575,7 @@ bool emberAfGamingClusterGameAnnouncementCallback(uint16_t gameId, uint8_t gameM
  * @param status   Ver.: always
  * @param message   Ver.: always
  */
-bool emberAfGamingClusterGeneralResponseCallback(uint8_t commandId, uint8_t status, uint8_t * message);
+bool emberAfGamingClusterGeneralResponseCallback(chip::CommandId commandId, uint8_t status, uint8_t * message);
 /** @brief Gaming Cluster Join Game
  *
  *
@@ -19371,7 +19618,7 @@ bool emberAfGamingClusterSearchGameCallback(uint8_t specificGame, uint16_t gameI
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGamingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGamingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Gaming Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -19381,14 +19628,14 @@ void emberAfGamingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGamingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGamingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Gaming Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGamingClusterServerInitCallback(uint8_t endpoint);
+void emberAfGamingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Gaming Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -19398,7 +19645,8 @@ void emberAfGamingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGamingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGamingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Gaming Cluster Server Message Sent
  *
@@ -19425,7 +19673,7 @@ void emberAfGamingClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGamingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGamingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Gaming Cluster Server Tick
@@ -19434,7 +19682,7 @@ EmberAfStatus emberAfGamingClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGamingClusterServerTickCallback(uint8_t endpoint);
+void emberAfGamingClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Gaming Cluster Start Game
  *
  *
@@ -19460,7 +19708,7 @@ bool emberAfGamingClusterStartOverCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDataRateControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDataRateControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Data Rate Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -19470,14 +19718,15 @@ void emberAfDataRateControlClusterClientAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDataRateControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDataRateControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Data Rate Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDataRateControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfDataRateControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Data Rate Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -19487,8 +19736,8 @@ void emberAfDataRateControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDataRateControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfDataRateControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Data Rate Control Cluster Client Message Sent
  *
@@ -19515,7 +19764,8 @@ void emberAfDataRateControlClusterClientMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDataRateControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDataRateControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Data Rate Control Cluster Client Tick
@@ -19524,7 +19774,7 @@ EmberAfStatus emberAfDataRateControlClusterClientPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDataRateControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfDataRateControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Data Rate Control Cluster Data Rate Control
  *
  *
@@ -19569,7 +19819,7 @@ bool emberAfDataRateControlClusterPathDeletionCallback(uint16_t originatorAddres
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDataRateControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDataRateControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Data Rate Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -19579,14 +19829,15 @@ void emberAfDataRateControlClusterServerAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDataRateControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDataRateControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Data Rate Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDataRateControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfDataRateControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Data Rate Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -19596,8 +19847,8 @@ void emberAfDataRateControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDataRateControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfDataRateControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Data Rate Control Cluster Server Message Sent
  *
@@ -19624,7 +19875,8 @@ void emberAfDataRateControlClusterServerMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDataRateControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDataRateControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Data Rate Control Cluster Server Tick
@@ -19633,7 +19885,7 @@ EmberAfStatus emberAfDataRateControlClusterServerPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDataRateControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfDataRateControlClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Data Rate Control Cluster Callbacks */
 
@@ -19647,7 +19899,7 @@ void emberAfDataRateControlClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfVoiceOverZigbeeClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Voice over ZigBee Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -19657,14 +19909,15 @@ void emberAfVoiceOverZigbeeClusterClientAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfVoiceOverZigbeeClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Voice over ZigBee Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterClientInitCallback(uint8_t endpoint);
+void emberAfVoiceOverZigbeeClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Voice over ZigBee Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -19674,8 +19927,8 @@ void emberAfVoiceOverZigbeeClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfVoiceOverZigbeeClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Voice over ZigBee Cluster Client Message Sent
  *
@@ -19702,7 +19955,8 @@ void emberAfVoiceOverZigbeeClusterClientMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfVoiceOverZigbeeClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfVoiceOverZigbeeClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Voice over ZigBee Cluster Client Tick
@@ -19711,7 +19965,7 @@ EmberAfStatus emberAfVoiceOverZigbeeClusterClientPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterClientTickCallback(uint8_t endpoint);
+void emberAfVoiceOverZigbeeClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Voice over ZigBee Cluster Control
  *
  *
@@ -19754,7 +20008,7 @@ bool emberAfVoiceOverZigbeeClusterEstablishmentResponseCallback(uint8_t ackNack,
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfVoiceOverZigbeeClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Voice over ZigBee Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -19764,14 +20018,15 @@ void emberAfVoiceOverZigbeeClusterServerAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfVoiceOverZigbeeClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Voice over ZigBee Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterServerInitCallback(uint8_t endpoint);
+void emberAfVoiceOverZigbeeClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Voice over ZigBee Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -19781,8 +20036,8 @@ void emberAfVoiceOverZigbeeClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfVoiceOverZigbeeClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Voice over ZigBee Cluster Server Message Sent
  *
@@ -19809,7 +20064,8 @@ void emberAfVoiceOverZigbeeClusterServerMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfVoiceOverZigbeeClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfVoiceOverZigbeeClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Voice over ZigBee Cluster Server Tick
@@ -19818,7 +20074,7 @@ EmberAfStatus emberAfVoiceOverZigbeeClusterServerPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterServerTickCallback(uint8_t endpoint);
+void emberAfVoiceOverZigbeeClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Voice over ZigBee Cluster Voice Transmission
  *
  *
@@ -19865,7 +20121,7 @@ bool emberAfChattingClusterChatMessageCallback(uint16_t destinationUid, uint16_t
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChattingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfChattingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Chatting Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -19875,14 +20131,15 @@ void emberAfChattingClusterClientAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChattingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfChattingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Chatting Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChattingClusterClientInitCallback(uint8_t endpoint);
+void emberAfChattingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Chatting Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -19892,7 +20149,8 @@ void emberAfChattingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfChattingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfChattingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Chatting Cluster Client Message Sent
  *
@@ -19919,7 +20177,7 @@ void emberAfChattingClusterClientMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfChattingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfChattingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Chatting Cluster Client Tick
@@ -19928,7 +20186,7 @@ EmberAfStatus emberAfChattingClusterClientPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChattingClusterClientTickCallback(uint8_t endpoint);
+void emberAfChattingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Chatting Cluster Get Node Information Request
  *
  *
@@ -19995,7 +20253,7 @@ bool emberAfChattingClusterSearchChatResponseCallback(uint8_t options, uint8_t *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChattingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfChattingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Chatting Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -20005,14 +20263,15 @@ void emberAfChattingClusterServerAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChattingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfChattingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Chatting Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChattingClusterServerInitCallback(uint8_t endpoint);
+void emberAfChattingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Chatting Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -20022,7 +20281,8 @@ void emberAfChattingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfChattingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfChattingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Chatting Cluster Server Message Sent
  *
@@ -20049,7 +20309,7 @@ void emberAfChattingClusterServerMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfChattingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfChattingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Chatting Cluster Server Tick
@@ -20058,7 +20318,7 @@ EmberAfStatus emberAfChattingClusterServerPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChattingClusterServerTickCallback(uint8_t endpoint);
+void emberAfChattingClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Chatting Cluster Start Chat Request
  *
  *
@@ -20093,7 +20353,8 @@ bool emberAfChattingClusterSwitchChairmanConfirmCallback(uint16_t cid, uint8_t *
  * @param address   Ver.: always
  * @param endpoint   Ver.: always
  */
-bool emberAfChattingClusterSwitchChairmanNotificationCallback(uint16_t cid, uint16_t uid, uint16_t address, uint8_t endpoint);
+bool emberAfChattingClusterSwitchChairmanNotificationCallback(uint16_t cid, uint16_t uid, uint16_t address,
+                                                              chip::EndpointId endpoint);
 /** @brief Chatting Cluster Switch Chairman Request
  *
  *
@@ -20174,7 +20435,7 @@ bool emberAfPaymentClusterBuyRequestCallback(uint8_t * userId, uint16_t userType
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPaymentClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPaymentClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Payment Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -20184,14 +20445,14 @@ void emberAfPaymentClusterClientAttributeChangedCallback(uint8_t endpoint, Ember
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPaymentClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPaymentClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Payment Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPaymentClusterClientInitCallback(uint8_t endpoint);
+void emberAfPaymentClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Payment Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -20201,7 +20462,8 @@ void emberAfPaymentClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPaymentClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPaymentClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              uint16_t manufacturerCode);
 /** @brief Payment Cluster Client Message Sent
  *
@@ -20228,7 +20490,7 @@ void emberAfPaymentClusterClientMessageSentCallback(EmberOutgoingMessageType typ
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPaymentClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPaymentClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                      EmberAfAttributeType attributeType, uint8_t size,
                                                                      uint8_t * value);
 /** @brief Payment Cluster Client Tick
@@ -20237,7 +20499,7 @@ EmberAfStatus emberAfPaymentClusterClientPreAttributeChangedCallback(uint8_t end
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPaymentClusterClientTickCallback(uint8_t endpoint);
+void emberAfPaymentClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Payment Cluster Payment Confirm
  *
  *
@@ -20266,7 +20528,7 @@ bool emberAfPaymentClusterReceiptDeliveryCallback(uint8_t * serialNumber, uint32
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPaymentClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPaymentClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Payment Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -20276,14 +20538,14 @@ void emberAfPaymentClusterServerAttributeChangedCallback(uint8_t endpoint, Ember
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPaymentClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPaymentClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Payment Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPaymentClusterServerInitCallback(uint8_t endpoint);
+void emberAfPaymentClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Payment Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -20293,7 +20555,8 @@ void emberAfPaymentClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPaymentClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPaymentClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              uint16_t manufacturerCode);
 /** @brief Payment Cluster Server Message Sent
  *
@@ -20320,7 +20583,7 @@ void emberAfPaymentClusterServerMessageSentCallback(EmberOutgoingMessageType typ
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPaymentClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPaymentClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                      EmberAfAttributeType attributeType, uint8_t size,
                                                                      uint8_t * value);
 /** @brief Payment Cluster Server Tick
@@ -20329,7 +20592,7 @@ EmberAfStatus emberAfPaymentClusterServerPreAttributeChangedCallback(uint8_t end
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPaymentClusterServerTickCallback(uint8_t endpoint);
+void emberAfPaymentClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Payment Cluster Transaction End
  *
  *
@@ -20368,7 +20631,7 @@ bool emberAfBillingClusterCheckBillStatusCallback(uint8_t * userId, uint16_t ser
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBillingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBillingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Billing Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -20378,14 +20641,14 @@ void emberAfBillingClusterClientAttributeChangedCallback(uint8_t endpoint, Ember
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBillingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBillingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Billing Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBillingClusterClientInitCallback(uint8_t endpoint);
+void emberAfBillingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Billing Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -20395,7 +20658,8 @@ void emberAfBillingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBillingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfBillingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              uint16_t manufacturerCode);
 /** @brief Billing Cluster Client Message Sent
  *
@@ -20422,7 +20686,7 @@ void emberAfBillingClusterClientMessageSentCallback(EmberOutgoingMessageType typ
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBillingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBillingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                      EmberAfAttributeType attributeType, uint8_t size,
                                                                      uint8_t * value);
 /** @brief Billing Cluster Client Tick
@@ -20431,7 +20695,7 @@ EmberAfStatus emberAfBillingClusterClientPreAttributeChangedCallback(uint8_t end
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBillingClusterClientTickCallback(uint8_t endpoint);
+void emberAfBillingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Billing Cluster Send Bill Record
  *
  *
@@ -20451,7 +20715,7 @@ bool emberAfBillingClusterSendBillRecordCallback(uint8_t * userId, uint16_t serv
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBillingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBillingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Billing Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -20461,14 +20725,14 @@ void emberAfBillingClusterServerAttributeChangedCallback(uint8_t endpoint, Ember
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBillingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBillingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Billing Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBillingClusterServerInitCallback(uint8_t endpoint);
+void emberAfBillingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Billing Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -20478,7 +20742,8 @@ void emberAfBillingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBillingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfBillingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              uint16_t manufacturerCode);
 /** @brief Billing Cluster Server Message Sent
  *
@@ -20505,7 +20770,7 @@ void emberAfBillingClusterServerMessageSentCallback(EmberOutgoingMessageType typ
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBillingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBillingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                      EmberAfAttributeType attributeType, uint8_t size,
                                                                      uint8_t * value);
 /** @brief Billing Cluster Server Tick
@@ -20514,7 +20779,7 @@ EmberAfStatus emberAfBillingClusterServerPreAttributeChangedCallback(uint8_t end
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBillingClusterServerTickCallback(uint8_t endpoint);
+void emberAfBillingClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Billing Cluster Session Keep Alive
  *
  *
@@ -20573,7 +20838,7 @@ bool emberAfBillingClusterUnsubscribeCallback(uint8_t * userId, uint16_t service
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceIdentificationClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceIdentificationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Identification Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -20583,14 +20848,15 @@ void emberAfApplianceIdentificationClusterClientAttributeChangedCallback(uint8_t
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceIdentificationClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceIdentificationClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                        EmberAfStatus status);
 /** @brief Appliance Identification Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceIdentificationClusterClientInitCallback(uint8_t endpoint);
+void emberAfApplianceIdentificationClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Identification Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -20601,7 +20867,7 @@ void emberAfApplianceIdentificationClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfApplianceIdentificationClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              uint16_t manufacturerCode);
 /** @brief Appliance Identification Cluster Client Message Sent
  *
@@ -20628,8 +20894,8 @@ void emberAfApplianceIdentificationClusterClientMessageSentCallback(EmberOutgoin
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceIdentificationClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceIdentificationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      EmberAfAttributeType attributeType,
                                                                                      uint8_t size, uint8_t * value);
 /** @brief Appliance Identification Cluster Client Tick
@@ -20638,7 +20904,7 @@ EmberAfStatus emberAfApplianceIdentificationClusterClientPreAttributeChangedCall
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceIdentificationClusterClientTickCallback(uint8_t endpoint);
+void emberAfApplianceIdentificationClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Appliance Identification Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -20646,7 +20912,7 @@ void emberAfApplianceIdentificationClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceIdentificationClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceIdentificationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Identification Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -20656,14 +20922,15 @@ void emberAfApplianceIdentificationClusterServerAttributeChangedCallback(uint8_t
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceIdentificationClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceIdentificationClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                        EmberAfStatus status);
 /** @brief Appliance Identification Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceIdentificationClusterServerInitCallback(uint8_t endpoint);
+void emberAfApplianceIdentificationClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Identification Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -20674,7 +20941,7 @@ void emberAfApplianceIdentificationClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfApplianceIdentificationClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              uint16_t manufacturerCode);
 /** @brief Appliance Identification Cluster Server Message Sent
  *
@@ -20701,8 +20968,8 @@ void emberAfApplianceIdentificationClusterServerMessageSentCallback(EmberOutgoin
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceIdentificationClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceIdentificationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      EmberAfAttributeType attributeType,
                                                                                      uint8_t size, uint8_t * value);
 /** @brief Appliance Identification Cluster Server Tick
@@ -20711,7 +20978,7 @@ EmberAfStatus emberAfApplianceIdentificationClusterServerPreAttributeChangedCall
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceIdentificationClusterServerTickCallback(uint8_t endpoint);
+void emberAfApplianceIdentificationClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Appliance Identification Cluster Callbacks */
 
@@ -20725,7 +20992,7 @@ void emberAfApplianceIdentificationClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMeterIdentificationClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMeterIdentificationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Meter Identification Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -20735,14 +21002,15 @@ void emberAfMeterIdentificationClusterClientAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMeterIdentificationClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMeterIdentificationClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief Meter Identification Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMeterIdentificationClusterClientInitCallback(uint8_t endpoint);
+void emberAfMeterIdentificationClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Meter Identification Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -20753,7 +21021,7 @@ void emberAfMeterIdentificationClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfMeterIdentificationClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief Meter Identification Cluster Client Message Sent
  *
@@ -20780,7 +21048,8 @@ void emberAfMeterIdentificationClusterClientMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMeterIdentificationClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMeterIdentificationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief Meter Identification Cluster Client Tick
@@ -20789,7 +21058,7 @@ EmberAfStatus emberAfMeterIdentificationClusterClientPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMeterIdentificationClusterClientTickCallback(uint8_t endpoint);
+void emberAfMeterIdentificationClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Meter Identification Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -20797,7 +21066,7 @@ void emberAfMeterIdentificationClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMeterIdentificationClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMeterIdentificationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Meter Identification Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -20807,14 +21076,15 @@ void emberAfMeterIdentificationClusterServerAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMeterIdentificationClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMeterIdentificationClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief Meter Identification Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMeterIdentificationClusterServerInitCallback(uint8_t endpoint);
+void emberAfMeterIdentificationClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Meter Identification Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -20825,7 +21095,7 @@ void emberAfMeterIdentificationClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfMeterIdentificationClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief Meter Identification Cluster Server Message Sent
  *
@@ -20852,7 +21122,8 @@ void emberAfMeterIdentificationClusterServerMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMeterIdentificationClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMeterIdentificationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief Meter Identification Cluster Server Tick
@@ -20861,7 +21132,7 @@ EmberAfStatus emberAfMeterIdentificationClusterServerPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMeterIdentificationClusterServerTickCallback(uint8_t endpoint);
+void emberAfMeterIdentificationClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Meter Identification Cluster Callbacks */
 
@@ -20883,7 +21154,7 @@ bool emberAfApplianceEventsAndAlertClusterAlertsNotificationCallback(uint8_t ale
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceEventsAndAlertClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Events and Alert Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -20893,14 +21164,15 @@ void emberAfApplianceEventsAndAlertClusterClientAttributeChangedCallback(uint8_t
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceEventsAndAlertClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                        EmberAfStatus status);
 /** @brief Appliance Events and Alert Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterClientInitCallback(uint8_t endpoint);
+void emberAfApplianceEventsAndAlertClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Events and Alert Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -20911,7 +21183,7 @@ void emberAfApplianceEventsAndAlertClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfApplianceEventsAndAlertClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              uint16_t manufacturerCode);
 /** @brief Appliance Events and Alert Cluster Client Message Sent
  *
@@ -20938,8 +21210,8 @@ void emberAfApplianceEventsAndAlertClusterClientMessageSentCallback(EmberOutgoin
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceEventsAndAlertClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceEventsAndAlertClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      EmberAfAttributeType attributeType,
                                                                                      uint8_t size, uint8_t * value);
 /** @brief Appliance Events and Alert Cluster Client Tick
@@ -20948,7 +21220,7 @@ EmberAfStatus emberAfApplianceEventsAndAlertClusterClientPreAttributeChangedCall
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterClientTickCallback(uint8_t endpoint);
+void emberAfApplianceEventsAndAlertClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Appliance Events and Alert Cluster Events Notification
  *
  *
@@ -20978,7 +21250,7 @@ bool emberAfApplianceEventsAndAlertClusterGetAlertsResponseCallback(uint8_t aler
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceEventsAndAlertClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Events and Alert Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -20988,14 +21260,15 @@ void emberAfApplianceEventsAndAlertClusterServerAttributeChangedCallback(uint8_t
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceEventsAndAlertClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                        EmberAfStatus status);
 /** @brief Appliance Events and Alert Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterServerInitCallback(uint8_t endpoint);
+void emberAfApplianceEventsAndAlertClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Events and Alert Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -21006,7 +21279,7 @@ void emberAfApplianceEventsAndAlertClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfApplianceEventsAndAlertClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              uint16_t manufacturerCode);
 /** @brief Appliance Events and Alert Cluster Server Message Sent
  *
@@ -21033,8 +21306,8 @@ void emberAfApplianceEventsAndAlertClusterServerMessageSentCallback(EmberOutgoin
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceEventsAndAlertClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceEventsAndAlertClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      EmberAfAttributeType attributeType,
                                                                                      uint8_t size, uint8_t * value);
 /** @brief Appliance Events and Alert Cluster Server Tick
@@ -21043,7 +21316,7 @@ EmberAfStatus emberAfApplianceEventsAndAlertClusterServerPreAttributeChangedCall
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterServerTickCallback(uint8_t endpoint);
+void emberAfApplianceEventsAndAlertClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Appliance Events and Alert Cluster Callbacks */
 
@@ -21057,7 +21330,7 @@ void emberAfApplianceEventsAndAlertClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceStatisticsClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceStatisticsClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Statistics Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -21067,14 +21340,15 @@ void emberAfApplianceStatisticsClusterClientAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceStatisticsClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceStatisticsClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief Appliance Statistics Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceStatisticsClusterClientInitCallback(uint8_t endpoint);
+void emberAfApplianceStatisticsClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Statistics Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -21085,7 +21359,7 @@ void emberAfApplianceStatisticsClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfApplianceStatisticsClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief Appliance Statistics Cluster Client Message Sent
  *
@@ -21112,7 +21386,8 @@ void emberAfApplianceStatisticsClusterClientMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceStatisticsClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceStatisticsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief Appliance Statistics Cluster Client Tick
@@ -21121,7 +21396,7 @@ EmberAfStatus emberAfApplianceStatisticsClusterClientPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceStatisticsClusterClientTickCallback(uint8_t endpoint);
+void emberAfApplianceStatisticsClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Appliance Statistics Cluster Log Notification
  *
  *
@@ -21172,7 +21447,7 @@ bool emberAfApplianceStatisticsClusterLogResponseCallback(uint32_t timeStamp, ui
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceStatisticsClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceStatisticsClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Statistics Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -21182,14 +21457,15 @@ void emberAfApplianceStatisticsClusterServerAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceStatisticsClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceStatisticsClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief Appliance Statistics Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceStatisticsClusterServerInitCallback(uint8_t endpoint);
+void emberAfApplianceStatisticsClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Statistics Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -21200,7 +21476,7 @@ void emberAfApplianceStatisticsClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfApplianceStatisticsClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief Appliance Statistics Cluster Server Message Sent
  *
@@ -21227,7 +21503,8 @@ void emberAfApplianceStatisticsClusterServerMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceStatisticsClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceStatisticsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief Appliance Statistics Cluster Server Tick
@@ -21236,7 +21513,7 @@ EmberAfStatus emberAfApplianceStatisticsClusterServerPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceStatisticsClusterServerTickCallback(uint8_t endpoint);
+void emberAfApplianceStatisticsClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Appliance Statistics Cluster Statistics Available
  *
  *
@@ -21258,7 +21535,7 @@ bool emberAfApplianceStatisticsClusterStatisticsAvailableCallback(uint8_t logQue
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfElectricalMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfElectricalMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Electrical Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -21268,14 +21545,15 @@ void emberAfElectricalMeasurementClusterClientAttributeChangedCallback(uint8_t e
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfElectricalMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfElectricalMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                      EmberAfStatus status);
 /** @brief Electrical Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfElectricalMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfElectricalMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Electrical Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -21286,7 +21564,7 @@ void emberAfElectricalMeasurementClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfElectricalMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                           EmberAfAttributeId attributeId,
+                                                                                           chip::AttributeId attributeId,
                                                                                            uint16_t manufacturerCode);
 /** @brief Electrical Measurement Cluster Client Message Sent
  *
@@ -21313,7 +21591,8 @@ void emberAfElectricalMeasurementClusterClientMessageSentCallback(EmberOutgoingM
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfElectricalMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfElectricalMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                                    uint8_t * value);
 /** @brief Electrical Measurement Cluster Client Tick
@@ -21322,7 +21601,7 @@ EmberAfStatus emberAfElectricalMeasurementClusterClientPreAttributeChangedCallba
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfElectricalMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfElectricalMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Electrical Measurement Cluster Get Measurement Profile Command
  *
  *
@@ -21331,7 +21610,7 @@ void emberAfElectricalMeasurementClusterClientTickCallback(uint8_t endpoint);
  * @param startTime   Ver.: always
  * @param numberOfIntervals   Ver.: always
  */
-bool emberAfElectricalMeasurementClusterGetMeasurementProfileCommandCallback(uint16_t attributeId, uint32_t startTime,
+bool emberAfElectricalMeasurementClusterGetMeasurementProfileCommandCallback(chip::AttributeId attributeId, uint32_t startTime,
                                                                              uint8_t numberOfIntervals);
 /** @brief Electrical Measurement Cluster Get Measurement Profile Response Command
  *
@@ -21347,7 +21626,8 @@ bool emberAfElectricalMeasurementClusterGetMeasurementProfileCommandCallback(uin
 bool emberAfElectricalMeasurementClusterGetMeasurementProfileResponseCommandCallback(uint32_t startTime, uint8_t status,
                                                                                      uint8_t profileIntervalPeriod,
                                                                                      uint8_t numberOfIntervalsDelivered,
-                                                                                     uint16_t attributeId, uint8_t * intervals);
+                                                                                     chip::AttributeId attributeId,
+                                                                                     uint8_t * intervals);
 /** @brief Electrical Measurement Cluster Get Profile Info Command
  *
  *
@@ -21373,7 +21653,7 @@ bool emberAfElectricalMeasurementClusterGetProfileInfoResponseCommandCallback(ui
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfElectricalMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfElectricalMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Electrical Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -21383,14 +21663,15 @@ void emberAfElectricalMeasurementClusterServerAttributeChangedCallback(uint8_t e
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfElectricalMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfElectricalMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                      EmberAfStatus status);
 /** @brief Electrical Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfElectricalMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfElectricalMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Electrical Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -21401,7 +21682,7 @@ void emberAfElectricalMeasurementClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfElectricalMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                           EmberAfAttributeId attributeId,
+                                                                                           chip::AttributeId attributeId,
                                                                                            uint16_t manufacturerCode);
 /** @brief Electrical Measurement Cluster Server Message Sent
  *
@@ -21428,7 +21709,8 @@ void emberAfElectricalMeasurementClusterServerMessageSentCallback(EmberOutgoingM
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfElectricalMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfElectricalMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                                    uint8_t * value);
 /** @brief Electrical Measurement Cluster Server Tick
@@ -21437,7 +21719,7 @@ EmberAfStatus emberAfElectricalMeasurementClusterServerPreAttributeChangedCallba
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfElectricalMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfElectricalMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Electrical Measurement Cluster Callbacks */
 
@@ -21451,7 +21733,7 @@ void emberAfElectricalMeasurementClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDiagnosticsClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDiagnosticsClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Diagnostics Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -21461,14 +21743,15 @@ void emberAfDiagnosticsClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDiagnosticsClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDiagnosticsClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Diagnostics Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDiagnosticsClusterClientInitCallback(uint8_t endpoint);
+void emberAfDiagnosticsClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Diagnostics Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -21478,7 +21761,8 @@ void emberAfDiagnosticsClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDiagnosticsClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDiagnosticsClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Diagnostics Cluster Client Message Sent
  *
@@ -21505,7 +21789,7 @@ void emberAfDiagnosticsClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDiagnosticsClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDiagnosticsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Diagnostics Cluster Client Tick
@@ -21514,7 +21798,7 @@ EmberAfStatus emberAfDiagnosticsClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDiagnosticsClusterClientTickCallback(uint8_t endpoint);
+void emberAfDiagnosticsClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Diagnostics Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -21522,7 +21806,7 @@ void emberAfDiagnosticsClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDiagnosticsClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDiagnosticsClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Diagnostics Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -21532,14 +21816,15 @@ void emberAfDiagnosticsClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDiagnosticsClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDiagnosticsClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Diagnostics Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDiagnosticsClusterServerInitCallback(uint8_t endpoint);
+void emberAfDiagnosticsClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Diagnostics Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -21549,7 +21834,8 @@ void emberAfDiagnosticsClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDiagnosticsClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDiagnosticsClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Diagnostics Cluster Server Message Sent
  *
@@ -21576,7 +21862,7 @@ void emberAfDiagnosticsClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDiagnosticsClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDiagnosticsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Diagnostics Cluster Server Tick
@@ -21585,7 +21871,7 @@ EmberAfStatus emberAfDiagnosticsClusterServerPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDiagnosticsClusterServerTickCallback(uint8_t endpoint);
+void emberAfDiagnosticsClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Diagnostics Cluster Callbacks */
 
@@ -21599,7 +21885,7 @@ void emberAfDiagnosticsClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfZllCommissioningClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfZllCommissioningClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief ZLL Commissioning Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -21609,14 +21895,15 @@ void emberAfZllCommissioningClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfZllCommissioningClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfZllCommissioningClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief ZLL Commissioning Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfZllCommissioningClusterClientInitCallback(uint8_t endpoint);
+void emberAfZllCommissioningClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief ZLL Commissioning Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -21626,8 +21913,8 @@ void emberAfZllCommissioningClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfZllCommissioningClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfZllCommissioningClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief ZLL Commissioning Cluster Client Message Sent
  *
@@ -21654,7 +21941,8 @@ void emberAfZllCommissioningClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfZllCommissioningClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfZllCommissioningClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief ZLL Commissioning Cluster Client Tick
@@ -21663,7 +21951,7 @@ EmberAfStatus emberAfZllCommissioningClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfZllCommissioningClusterClientTickCallback(uint8_t endpoint);
+void emberAfZllCommissioningClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief ZLL Commissioning Cluster Device Information Request
  *
  *
@@ -21901,7 +22189,7 @@ bool emberAfZllCommissioningClusterScanResponseCallback(uint32_t transaction, ui
                                                         uint8_t zllInformation, uint16_t keyBitmask, uint32_t responseId,
                                                         uint8_t * extendedPanId, uint8_t networkUpdateId, uint8_t logicalChannel,
                                                         uint16_t panId, uint16_t networkAddress, uint8_t numberOfSubDevices,
-                                                        uint8_t totalGroupIds, uint8_t endpointId, uint16_t profileId,
+                                                        uint8_t totalGroupIds, chip::EndpointId endpointId, uint16_t profileId,
                                                         uint16_t deviceId, uint8_t version, uint8_t groupIdCount);
 /** @brief ZLL Commissioning Cluster Server Attribute Changed
  *
@@ -21910,7 +22198,7 @@ bool emberAfZllCommissioningClusterScanResponseCallback(uint32_t transaction, ui
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfZllCommissioningClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfZllCommissioningClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief ZLL Commissioning Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -21920,14 +22208,15 @@ void emberAfZllCommissioningClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfZllCommissioningClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfZllCommissioningClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief ZLL Commissioning Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfZllCommissioningClusterServerInitCallback(uint8_t endpoint);
+void emberAfZllCommissioningClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief ZLL Commissioning Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -21937,8 +22226,8 @@ void emberAfZllCommissioningClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfZllCommissioningClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfZllCommissioningClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief ZLL Commissioning Cluster Server Message Sent
  *
@@ -21965,7 +22254,8 @@ void emberAfZllCommissioningClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfZllCommissioningClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfZllCommissioningClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief ZLL Commissioning Cluster Server Tick
@@ -21974,7 +22264,7 @@ EmberAfStatus emberAfZllCommissioningClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfZllCommissioningClusterServerTickCallback(uint8_t endpoint);
+void emberAfZllCommissioningClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END ZLL Commissioning Cluster Callbacks */
 
@@ -21988,7 +22278,7 @@ void emberAfZllCommissioningClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSampleMfgSpecificClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Sample Mfg Specific Cluster Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -21998,14 +22288,15 @@ void emberAfSampleMfgSpecificClusterClientAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSampleMfgSpecificClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief Sample Mfg Specific Cluster Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterClientInitCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Sample Mfg Specific Cluster Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -22016,7 +22307,7 @@ void emberAfSampleMfgSpecificClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfSampleMfgSpecificClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief Sample Mfg Specific Cluster Cluster Client Message Sent
  *
@@ -22043,7 +22334,8 @@ void emberAfSampleMfgSpecificClusterClientMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSampleMfgSpecificClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSampleMfgSpecificClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief Sample Mfg Specific Cluster Cluster Client Tick
@@ -22052,7 +22344,7 @@ EmberAfStatus emberAfSampleMfgSpecificClusterClientPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterClientTickCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Sample Mfg Specific Cluster Cluster Command One
  *
  *
@@ -22067,7 +22359,7 @@ bool emberAfSampleMfgSpecificClusterCommandOneCallback(uint8_t argOne);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSampleMfgSpecificClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Sample Mfg Specific Cluster Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -22077,14 +22369,15 @@ void emberAfSampleMfgSpecificClusterServerAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSampleMfgSpecificClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief Sample Mfg Specific Cluster Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterServerInitCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Sample Mfg Specific Cluster Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -22095,7 +22388,7 @@ void emberAfSampleMfgSpecificClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfSampleMfgSpecificClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief Sample Mfg Specific Cluster Cluster Server Message Sent
  *
@@ -22122,7 +22415,8 @@ void emberAfSampleMfgSpecificClusterServerMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSampleMfgSpecificClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSampleMfgSpecificClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief Sample Mfg Specific Cluster Cluster Server Tick
@@ -22131,7 +22425,7 @@ EmberAfStatus emberAfSampleMfgSpecificClusterServerPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterServerTickCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Sample Mfg Specific Cluster Cluster Callbacks */
 
@@ -22145,7 +22439,7 @@ void emberAfSampleMfgSpecificClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSampleMfgSpecificCluster2ClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -22155,14 +22449,15 @@ void emberAfSampleMfgSpecificCluster2ClientAttributeChangedCallback(uint8_t endp
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSampleMfgSpecificCluster2ClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                   EmberAfStatus status);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ClientInitCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificCluster2ClientInitCallback(chip::EndpointId endpoint);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -22173,7 +22468,7 @@ void emberAfSampleMfgSpecificCluster2ClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfSampleMfgSpecificCluster2ClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                        EmberAfAttributeId attributeId,
+                                                                                        chip::AttributeId attributeId,
                                                                                         uint16_t manufacturerCode);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Client Message Sent
  *
@@ -22200,7 +22495,8 @@ void emberAfSampleMfgSpecificCluster2ClientMessageSentCallback(EmberOutgoingMess
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSampleMfgSpecificCluster2ClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSampleMfgSpecificCluster2ClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 EmberAfAttributeType attributeType, uint8_t size,
                                                                                 uint8_t * value);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Client Tick
@@ -22209,7 +22505,7 @@ EmberAfStatus emberAfSampleMfgSpecificCluster2ClientPreAttributeChangedCallback(
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ClientTickCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificCluster2ClientTickCallback(chip::EndpointId endpoint);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Command Two
  *
  *
@@ -22224,7 +22520,7 @@ bool emberAfSampleMfgSpecificCluster2CommandTwoCallback(uint8_t argOne);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSampleMfgSpecificCluster2ServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -22234,14 +22530,15 @@ void emberAfSampleMfgSpecificCluster2ServerAttributeChangedCallback(uint8_t endp
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSampleMfgSpecificCluster2ServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                   EmberAfStatus status);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ServerInitCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificCluster2ServerInitCallback(chip::EndpointId endpoint);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -22252,7 +22549,7 @@ void emberAfSampleMfgSpecificCluster2ServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfSampleMfgSpecificCluster2ServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                        EmberAfAttributeId attributeId,
+                                                                                        chip::AttributeId attributeId,
                                                                                         uint16_t manufacturerCode);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Server Message Sent
  *
@@ -22279,7 +22576,8 @@ void emberAfSampleMfgSpecificCluster2ServerMessageSentCallback(EmberOutgoingMess
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSampleMfgSpecificCluster2ServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSampleMfgSpecificCluster2ServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 EmberAfAttributeType attributeType, uint8_t size,
                                                                                 uint8_t * value);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Server Tick
@@ -22288,7 +22586,7 @@ EmberAfStatus emberAfSampleMfgSpecificCluster2ServerPreAttributeChangedCallback(
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ServerTickCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificCluster2ServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Sample Mfg Specific Cluster 2 Cluster Callbacks */
 
@@ -22302,7 +22600,7 @@ void emberAfSampleMfgSpecificCluster2ServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOtaConfigurationClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOtaConfigurationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Configuration Cluster Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -22312,14 +22610,15 @@ void emberAfOtaConfigurationClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOtaConfigurationClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOtaConfigurationClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Configuration Cluster Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOtaConfigurationClusterClientInitCallback(uint8_t endpoint);
+void emberAfOtaConfigurationClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Configuration Cluster Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -22329,8 +22628,8 @@ void emberAfOtaConfigurationClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOtaConfigurationClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfOtaConfigurationClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Configuration Cluster Cluster Client Message Sent
  *
@@ -22357,7 +22656,8 @@ void emberAfOtaConfigurationClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOtaConfigurationClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOtaConfigurationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Configuration Cluster Cluster Client Tick
@@ -22366,7 +22666,7 @@ EmberAfStatus emberAfOtaConfigurationClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOtaConfigurationClusterClientTickCallback(uint8_t endpoint);
+void emberAfOtaConfigurationClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Configuration Cluster Cluster Lock Tokens
  *
  *
@@ -22395,7 +22695,7 @@ bool emberAfOtaConfigurationClusterReturnTokenCallback(uint16_t token, uint8_t *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOtaConfigurationClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOtaConfigurationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Configuration Cluster Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -22405,14 +22705,15 @@ void emberAfOtaConfigurationClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOtaConfigurationClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOtaConfigurationClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Configuration Cluster Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOtaConfigurationClusterServerInitCallback(uint8_t endpoint);
+void emberAfOtaConfigurationClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Configuration Cluster Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -22422,8 +22723,8 @@ void emberAfOtaConfigurationClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOtaConfigurationClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfOtaConfigurationClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Configuration Cluster Cluster Server Message Sent
  *
@@ -22450,7 +22751,8 @@ void emberAfOtaConfigurationClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOtaConfigurationClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOtaConfigurationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Configuration Cluster Cluster Server Tick
@@ -22459,7 +22761,7 @@ EmberAfStatus emberAfOtaConfigurationClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOtaConfigurationClusterServerTickCallback(uint8_t endpoint);
+void emberAfOtaConfigurationClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Configuration Cluster Cluster Set Token
  *
  *
@@ -22488,7 +22790,7 @@ bool emberAfOtaConfigurationClusterUnlockTokensCallback(uint8_t * data);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMfglibClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMfglibClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief MFGLIB Cluster Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -22498,14 +22800,14 @@ void emberAfMfglibClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMfglibClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMfglibClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief MFGLIB Cluster Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMfglibClusterClientInitCallback(uint8_t endpoint);
+void emberAfMfglibClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief MFGLIB Cluster Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -22515,7 +22817,8 @@ void emberAfMfglibClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfMfglibClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfMfglibClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief MFGLIB Cluster Cluster Client Message Sent
  *
@@ -22542,7 +22845,7 @@ void emberAfMfglibClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMfglibClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMfglibClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief MFGLIB Cluster Cluster Client Tick
@@ -22551,7 +22854,7 @@ EmberAfStatus emberAfMfglibClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMfglibClusterClientTickCallback(uint8_t endpoint);
+void emberAfMfglibClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief MFGLIB Cluster Cluster Rx Mode
  *
  *
@@ -22568,7 +22871,7 @@ bool emberAfMfglibClusterRxModeCallback(uint8_t channel, int8_t power, uint16_t 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMfglibClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMfglibClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief MFGLIB Cluster Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -22578,14 +22881,14 @@ void emberAfMfglibClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMfglibClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMfglibClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief MFGLIB Cluster Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMfglibClusterServerInitCallback(uint8_t endpoint);
+void emberAfMfglibClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief MFGLIB Cluster Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -22595,7 +22898,8 @@ void emberAfMfglibClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfMfglibClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfMfglibClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief MFGLIB Cluster Cluster Server Message Sent
  *
@@ -22622,7 +22926,7 @@ void emberAfMfglibClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMfglibClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMfglibClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief MFGLIB Cluster Cluster Server Tick
@@ -22631,7 +22935,7 @@ EmberAfStatus emberAfMfglibClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMfglibClusterServerTickCallback(uint8_t endpoint);
+void emberAfMfglibClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief MFGLIB Cluster Cluster Stream
  *
  *
@@ -22676,7 +22980,7 @@ bool emberAfSlWwahClusterApsAckRequirementQueryCallback(void);
  *
  * @param clusterId   Ver.: always
  */
-bool emberAfSlWwahClusterApsLinkKeyAuthorizationQueryCallback(uint16_t clusterId);
+bool emberAfSlWwahClusterApsLinkKeyAuthorizationQueryCallback(chip::ClusterId clusterId);
 /** @brief SL Works With All Hubs Cluster Aps Link Key Authorization Query Response
  *
  *
@@ -22684,7 +22988,7 @@ bool emberAfSlWwahClusterApsLinkKeyAuthorizationQueryCallback(uint16_t clusterId
  * @param clusterId   Ver.: always
  * @param apsLinkKeyAuthStatus   Ver.: always
  */
-bool emberAfSlWwahClusterApsLinkKeyAuthorizationQueryResponseCallback(uint16_t clusterId, uint8_t apsLinkKeyAuthStatus);
+bool emberAfSlWwahClusterApsLinkKeyAuthorizationQueryResponseCallback(chip::ClusterId clusterId, uint8_t apsLinkKeyAuthStatus);
 /** @brief SL Works With All Hubs Cluster Clear Binding Table
  *
  *
@@ -22698,7 +23002,7 @@ bool emberAfSlWwahClusterClearBindingTableCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSlWwahClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSlWwahClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief SL Works With All Hubs Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -22708,14 +23012,14 @@ void emberAfSlWwahClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSlWwahClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSlWwahClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief SL Works With All Hubs Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSlWwahClusterClientInitCallback(uint8_t endpoint);
+void emberAfSlWwahClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief SL Works With All Hubs Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -22725,7 +23029,8 @@ void emberAfSlWwahClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfSlWwahClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfSlWwahClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief SL Works With All Hubs Cluster Client Message Sent
  *
@@ -22752,7 +23057,7 @@ void emberAfSlWwahClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSlWwahClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSlWwahClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief SL Works With All Hubs Cluster Client Tick
@@ -22761,7 +23066,7 @@ EmberAfStatus emberAfSlWwahClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSlWwahClusterClientTickCallback(uint8_t endpoint);
+void emberAfSlWwahClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief SL Works With All Hubs Cluster Debug Report Query
  *
  *
@@ -22977,7 +23282,7 @@ bool emberAfSlWwahClusterRequireApsAcksOnUnicastsCallback(uint8_t numberExemptCl
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSlWwahClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSlWwahClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief SL Works With All Hubs Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -22987,14 +23292,14 @@ void emberAfSlWwahClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSlWwahClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSlWwahClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief SL Works With All Hubs Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSlWwahClusterServerInitCallback(uint8_t endpoint);
+void emberAfSlWwahClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief SL Works With All Hubs Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -23004,7 +23309,8 @@ void emberAfSlWwahClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfSlWwahClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfSlWwahClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief SL Works With All Hubs Cluster Server Message Sent
  *
@@ -23031,7 +23337,7 @@ void emberAfSlWwahClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSlWwahClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSlWwahClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief SL Works With All Hubs Cluster Server Tick
@@ -23040,7 +23346,7 @@ EmberAfStatus emberAfSlWwahClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSlWwahClusterServerTickCallback(uint8_t endpoint);
+void emberAfSlWwahClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief SL Works With All Hubs Cluster Set Ias Zone Enrollment Method
  *
  *

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -48,7 +48,7 @@ using namespace chip::DeviceLayer;
 
 constexpr uint32_t kDefaultSetupPinCode = 12345678; // TODO: Should be a macro in CHIPProjectConfig.h like other example apps.
 
-void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,
+void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
 {
     if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
@@ -81,7 +81,7 @@ void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clust
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint)
+void emberAfPluginOnOffClusterServerPostInitCallback(EndpointId endpoint)
 {
     // TODO: implement any additional On/off Cluster Server post init actions
 }

--- a/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
@@ -26,7 +26,9 @@
 #include "AppTask.h"
 #include "LightingManager.h"
 
-void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,
+using namespace chip;
+
+void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
 {
     if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
@@ -52,7 +54,7 @@ void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clust
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint)
+void emberAfPluginOnOffClusterServerPostInitCallback(EndpointId endpoint)
 {
     GetAppTask().UpdateClusterState();
 }

--- a/examples/lock-app/efr32/src/ZclCallbacks.cpp
+++ b/examples/lock-app/efr32/src/ZclCallbacks.cpp
@@ -30,9 +30,9 @@
 #include <app/util/attribute-storage.h>
 #include <app/util/util.h>
 
-// using namespace ::chip;
+using namespace ::chip;
 
-void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,
+void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
 {
     if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
@@ -65,7 +65,7 @@ void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clust
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint)
+void emberAfPluginOnOffClusterServerPostInitCallback(EndpointId endpoint)
 {
     // TODO: implement any additional On/off Cluster Server post init actions
 }

--- a/examples/lock-app/k32w/main/ZclCallbacks.cpp
+++ b/examples/lock-app/k32w/main/ZclCallbacks.cpp
@@ -27,7 +27,7 @@
 
 using namespace ::chip;
 
-void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,
+void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
 {
     if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
@@ -53,7 +53,7 @@ void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clust
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint)
+void emberAfPluginOnOffClusterServerPostInitCallback(EndpointId endpoint)
 {
     // TODO: implement any additional On/off Cluster Server post init actions
 }

--- a/examples/lock-app/lock-common/gen/af-structs.h
+++ b/examples/lock-app/lock-common/gen/af-structs.h
@@ -39,6 +39,8 @@
 #ifndef SILABS_EMBER_AF_STRUCTS
 #define SILABS_EMBER_AF_STRUCTS
 
+#include "basic-types.h"
+
 // Generated structs from the metadata
 // Struct for IasAceZoneStatusResult
 typedef struct _IasAceZoneStatusResult
@@ -50,7 +52,7 @@ typedef struct _IasAceZoneStatusResult
 // Struct for ReadAttributeStatusRecord
 typedef struct _ReadAttributeStatusRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t status;
     uint8_t attributeType;
     uint8_t * attributeLocation;
@@ -59,7 +61,7 @@ typedef struct _ReadAttributeStatusRecord
 // Struct for WriteAttributeRecord
 typedef struct _WriteAttributeRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t attributeType;
     uint8_t * attributeLocation;
 } WriteAttributeRecord;
@@ -68,14 +70,14 @@ typedef struct _WriteAttributeRecord
 typedef struct _WriteAttributeStatusRecord
 {
     uint8_t status;
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
 } WriteAttributeStatusRecord;
 
 // Struct for ConfigureReportingRecord
 typedef struct _ConfigureReportingRecord
 {
     uint8_t direction;
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t attributeType;
     uint16_t minimumReportingInterval;
     uint16_t maximumReportingInterval;
@@ -88,7 +90,7 @@ typedef struct _ConfigureReportingStatusRecord
 {
     uint8_t status;
     uint8_t direction;
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
 } ConfigureReportingStatusRecord;
 
 // Struct for ReadReportingConfigurationRecord
@@ -96,7 +98,7 @@ typedef struct _ReadReportingConfigurationRecord
 {
     uint8_t status;
     uint8_t direction;
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t attributeType;
     uint16_t minimumReportingInterval;
     uint16_t maximumReportingInterval;
@@ -108,13 +110,13 @@ typedef struct _ReadReportingConfigurationRecord
 typedef struct _ReadReportingConfigurationAttributeRecord
 {
     uint8_t direction;
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
 } ReadReportingConfigurationAttributeRecord;
 
 // Struct for ReportAttributeRecord
 typedef struct _ReportAttributeRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t attributeType;
     uint8_t * attributeLocation;
 } ReportAttributeRecord;
@@ -122,14 +124,14 @@ typedef struct _ReportAttributeRecord
 // Struct for DiscoverAttributesInfoRecord
 typedef struct _DiscoverAttributesInfoRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t attributeType;
 } DiscoverAttributesInfoRecord;
 
 // Struct for ExtendedDiscoverAttributesInfoRecord
 typedef struct _ExtendedDiscoverAttributesInfoRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t attributeType;
     uint8_t attributeAccessControl;
 } ExtendedDiscoverAttributesInfoRecord;
@@ -137,7 +139,7 @@ typedef struct _ExtendedDiscoverAttributesInfoRecord
 // Struct for ReadStructuredAttributeRecord
 typedef struct _ReadStructuredAttributeRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t indicator;
     uint16_t indicies;
 } ReadStructuredAttributeRecord;
@@ -145,7 +147,7 @@ typedef struct _ReadStructuredAttributeRecord
 // Struct for WriteStructuredAttributeRecord
 typedef struct _WriteStructuredAttributeRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t indicator;
     uint16_t indicies;
     uint8_t attributeType;
@@ -156,7 +158,7 @@ typedef struct _WriteStructuredAttributeRecord
 typedef struct _WriteStructuredAttributeStatusRecord
 {
     uint8_t status;
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t indicator;
     uint16_t indicies;
 } WriteStructuredAttributeStatusRecord;
@@ -406,7 +408,7 @@ typedef struct _DeviceInformationRecord
 // Struct for GroupInformationRecord
 typedef struct _GroupInformationRecord
 {
-    uint16_t groupId;
+    chip::GroupId groupId;
     uint8_t groupType;
 } GroupInformationRecord;
 

--- a/examples/lock-app/lock-common/gen/call-command-handler.cpp
+++ b/examples/lock-app/lock-common/gen/call-command-handler.cpp
@@ -60,6 +60,8 @@
 #include "command-id.h"
 #include "util.h"
 
+using namespace chip;
+
 static EmberAfStatus status(bool wasHandled, bool clusterExists, bool mfgSpecific)
 {
     if (wasHandled)

--- a/examples/lock-app/lock-common/gen/callback-stub.cpp
+++ b/examples/lock-app/lock-common/gen/callback-stub.cpp
@@ -44,6 +44,8 @@
 //#include "hal/hal.h"
 //#include EMBER_AF_API_NETWORK_STEERING
 
+using namespace chip;
+
 /** @brief Add To Current App Tasks
  *
  * This function is only useful to sleepy end devices.  This function will note
@@ -90,8 +92,8 @@ void emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
  * @param value   Ver.: always
  * @param type   Ver.: always
  */
-EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(uint8_t endpoint, EmberAfClusterId clusterId,
-                                                                          EmberAfAttributeId attributeId, uint8_t mask,
+EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId clusterId,
+                                                                          AttributeId attributeId, uint8_t mask,
                                                                           uint16_t manufacturerCode, uint8_t * value, uint8_t type)
 {
     return EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_NORMAL; // Default
@@ -107,8 +109,8 @@ EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(uint8_
  * @param manufacturerCode   Ver.: always
  * @param attributeId   Ver.: always
  */
-bool emberAfAttributeReadAccessCallback(uint8_t endpoint, EmberAfClusterId clusterId, uint16_t manufacturerCode,
-                                        uint16_t attributeId)
+bool emberAfAttributeReadAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode,
+                                        AttributeId attributeId)
 {
     return true;
 }
@@ -123,8 +125,8 @@ bool emberAfAttributeReadAccessCallback(uint8_t endpoint, EmberAfClusterId clust
  * @param manufacturerCode   Ver.: always
  * @param attributeId   Ver.: always
  */
-bool emberAfAttributeWriteAccessCallback(uint8_t endpoint, EmberAfClusterId clusterId, uint16_t manufacturerCode,
-                                         uint16_t attributeId)
+bool emberAfAttributeWriteAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode,
+                                         AttributeId attributeId)
 {
     return true;
 }
@@ -136,7 +138,7 @@ bool emberAfAttributeWriteAccessCallback(uint8_t endpoint, EmberAfClusterId clus
  *
  * @param endpoint The endpoint.  Ver.: always
  */
-void emberAfGroupsClusterClearGroupTableCallback(uint8_t endpoint) {}
+void emberAfGroupsClusterClearGroupTableCallback(EndpointId endpoint) {}
 
 /** @brief Key Establishment Cluster Client Command Received
  *
@@ -162,7 +164,7 @@ bool emberAfKeyEstablishmentClusterClientCommandReceivedCallback(EmberAfClusterC
  * @param endpoint   Ver.: always
  * @param clusterId   Ver.: always
  */
-void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId) {}
+void emberAfClusterInitCallback(EndpointId endpoint, ClusterId clusterId) {}
 
 /** @brief Default Response
  *
@@ -176,7 +178,7 @@ void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId) {}
  * @param status Specifies either SUCCESS or the nature of the error that was
  * detected in the received command.  Ver.: always
  */
-bool emberAfDefaultResponseCallback(EmberAfClusterId clusterId, uint8_t commandId, EmberAfStatus status)
+bool emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, EmberAfStatus status)
 {
     return false;
 }
@@ -201,8 +203,8 @@ bool emberAfDefaultResponseCallback(EmberAfClusterId clusterId, uint8_t commandI
  * @param extended Indicates whether the response is in the extended format or
  * not.  Ver.: always
  */
-bool emberAfDiscoverAttributesResponseCallback(EmberAfClusterId clusterId, bool discoveryComplete, uint8_t * buffer,
-                                               uint16_t bufLen, bool extended)
+bool emberAfDiscoverAttributesResponseCallback(ClusterId clusterId, bool discoveryComplete, uint8_t * buffer, uint16_t bufLen,
+                                               bool extended)
 {
     return false;
 }
@@ -221,8 +223,8 @@ bool emberAfDiscoverAttributesResponseCallback(EmberAfClusterId clusterId, bool 
  * @param commandIdCount The length of bytes of the list, whish is the same as
  * the number of identifiers.  Ver.: always
  */
-bool emberAfDiscoverCommandsGeneratedResponseCallback(EmberAfClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
-                                                      uint8_t * commandIds, uint16_t commandIdCount)
+bool emberAfDiscoverCommandsGeneratedResponseCallback(ClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
+                                                      CommandId * commandIds, uint16_t commandIdCount)
 {
     return false;
 }
@@ -241,8 +243,8 @@ bool emberAfDiscoverCommandsGeneratedResponseCallback(EmberAfClusterId clusterId
  * @param commandIdCount The length of bytes of the list, whish is the same as
  * the number of identifiers.  Ver.: always
  */
-bool emberAfDiscoverCommandsReceivedResponseCallback(EmberAfClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
-                                                     uint8_t * commandIds, uint16_t commandIdCount)
+bool emberAfDiscoverCommandsReceivedResponseCallback(ClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
+                                                     CommandId * commandIds, uint16_t commandIdCount)
 {
     return false;
 }
@@ -307,7 +309,7 @@ void emberAfEepromShutdownCallback(void) {}
  * @param buffer   Ver.: always
  * @param maxReadLength   Ver.: always
  */
-EmberAfStatus emberAfExternalAttributeReadCallback(uint8_t endpoint, EmberAfClusterId clusterId,
+EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
                                                    EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
                                                    uint8_t * buffer, uint16_t maxReadLength)
 {
@@ -360,7 +362,7 @@ EmberAfStatus emberAfExternalAttributeReadCallback(uint8_t endpoint, EmberAfClus
  * @param manufacturerCode   Ver.: always
  * @param buffer   Ver.: always
  */
-EmberAfStatus emberAfExternalAttributeWriteCallback(uint8_t endpoint, EmberAfClusterId clusterId,
+EmberAfStatus emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId,
                                                     EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
                                                     uint8_t * buffer)
 {
@@ -520,7 +522,7 @@ bool emberAfGetEndpointByIndexCallback(uint8_t index, uint8_t * endpointReturn)
  * information is written if the callback is providing the information.  Ver.:
  * always
  */
-bool emberAfGetEndpointDescriptionCallback(uint8_t endpoint, EmberEndpointDescription * result)
+bool emberAfGetEndpointDescriptionCallback(EndpointId endpoint, EmberEndpointDescription * result)
 {
     return false;
 }
@@ -542,7 +544,8 @@ bool emberAfGetEndpointDescriptionCallback(uint8_t endpoint, EmberEndpointDescri
  * @param returnEndpointInfo A pointer to a data struct that will be written
  * with information about the endpoint.  Ver.: always
  */
-bool emberAfGetEndpointInfoCallback(uint8_t endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo)
+bool emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex,
+                                    EmberAfEndpointInfoStruct * returnEndpointInfo)
 {
     return false;
 }
@@ -731,7 +734,7 @@ EmberStatus emberAfInitiateInterPanKeyEstablishmentCallback(EmberPanId panId, co
  * @param nodeId The node id of the remote device.  Ver.: always
  * @param endpoint The endpoint on the remote device.  Ver.: always
  */
-EmberStatus emberAfInitiateKeyEstablishmentCallback(EmberNodeId nodeId, uint8_t endpoint)
+EmberStatus emberAfInitiateKeyEstablishmentCallback(EmberNodeId nodeId, EndpointId endpoint)
 {
     return EMBER_LIBRARY_NOT_PRESENT;
 }
@@ -1054,7 +1057,7 @@ int8_t emberAfPluginNetworkSteeringGetPowerForRadioChannelCallback(uint8_t chann
  * @param size   Ver.: always
  * @param value   Ver.: always
  */
-void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,
+void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
 {}
 #endif
@@ -1086,9 +1089,8 @@ void emberAfPostEm4ResetCallback(void)
  * @param size   Ver.: always
  * @param value   Ver.: always
  */
-EmberAfStatus emberAfPreAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
-                                                uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size,
-                                                uint8_t * value)
+EmberAfStatus emberAfPreAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
+                                                uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
 {
     return EMBER_ZCL_STATUS_SUCCESS;
 }
@@ -1221,7 +1223,7 @@ bool emberAfPreZDOMessageReceivedCallback(EmberNodeId emberNodeId, EmberApsFrame
  * Ver.: always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
     return false;
 }
@@ -1310,7 +1312,7 @@ void emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
  * always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfReportAttributesCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+bool emberAfReportAttributesCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
     return false;
 }
@@ -1537,7 +1539,7 @@ void emberAfUnusedPanIdFoundCallback(EmberPanId panId, uint8_t channel) {}
  * Ver.: always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfWriteAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+bool emberAfWriteAttributesResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
     return false;
 }

--- a/examples/lock-app/lock-common/gen/callback.h
+++ b/examples/lock-app/lock-common/gen/callback.h
@@ -97,8 +97,8 @@ void emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks);
  * @param value   Ver.: always
  * @param type   Ver.: always
  */
-EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(uint8_t endpoint, EmberAfClusterId clusterId,
-                                                                          EmberAfAttributeId attributeId, uint8_t mask,
+EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
+                                                                          chip::AttributeId attributeId, uint8_t mask,
                                                                           uint16_t manufacturerCode, uint8_t * value, uint8_t type);
 /** @brief Attribute Read Access
  *
@@ -110,8 +110,8 @@ EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(uint8_
  * @param manufacturerCode   Ver.: always
  * @param attributeId   Ver.: always
  */
-bool emberAfAttributeReadAccessCallback(uint8_t endpoint, EmberAfClusterId clusterId, uint16_t manufacturerCode,
-                                        uint16_t attributeId);
+bool emberAfAttributeReadAccessCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode,
+                                        chip::AttributeId attributeId);
 /** @brief Attribute Write Access
  *
  * This function is called whenever the Application Framework needs to check
@@ -122,8 +122,8 @@ bool emberAfAttributeReadAccessCallback(uint8_t endpoint, EmberAfClusterId clust
  * @param manufacturerCode   Ver.: always
  * @param attributeId   Ver.: always
  */
-bool emberAfAttributeWriteAccessCallback(uint8_t endpoint, EmberAfClusterId clusterId, uint16_t manufacturerCode,
-                                         uint16_t attributeId);
+bool emberAfAttributeWriteAccessCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode,
+                                         chip::AttributeId attributeId);
 /** @brief Clear Report Table
  *
  * This function is called by the framework when the application should clear
@@ -140,7 +140,7 @@ EmberStatus emberAfClearReportTableCallback(void);
  * @param endpoint   Ver.: always
  * @param clusterId   Ver.: always
  */
-void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId);
+void emberAfClusterInitCallback(chip::EndpointId endpoint, chip::ClusterId clusterId);
 /** @brief Default Response
  *
  * This function is called by the application framework when a Default Response
@@ -153,7 +153,7 @@ void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId);
  * @param status Specifies either SUCCESS or the nature of the error that was
  * detected in the received command.  Ver.: always
  */
-bool emberAfDefaultResponseCallback(EmberAfClusterId clusterId, uint8_t commandId, EmberAfStatus status);
+bool emberAfDefaultResponseCallback(chip::ClusterId clusterId, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Discover Attributes Response
  *
  * This function is called by the application framework when a Discover
@@ -174,8 +174,8 @@ bool emberAfDefaultResponseCallback(EmberAfClusterId clusterId, uint8_t commandI
  * @param extended Indicates whether the response is in the extended format or
  * not.  Ver.: always
  */
-bool emberAfDiscoverAttributesResponseCallback(EmberAfClusterId clusterId, bool discoveryComplete, uint8_t * buffer,
-                                               uint16_t bufLen, bool extended);
+bool emberAfDiscoverAttributesResponseCallback(chip::ClusterId clusterId, bool discoveryComplete, uint8_t * buffer, uint16_t bufLen,
+                                               bool extended);
 /** @brief Discover Commands Generated Response
  *
  * This function is called by the framework when Discover Commands Generated
@@ -190,8 +190,8 @@ bool emberAfDiscoverAttributesResponseCallback(EmberAfClusterId clusterId, bool 
  * @param commandIdCount The length of bytes of the list, whish is the same as
  * the number of identifiers.  Ver.: always
  */
-bool emberAfDiscoverCommandsGeneratedResponseCallback(EmberAfClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
-                                                      uint8_t * commandIds, uint16_t commandIdCount);
+bool emberAfDiscoverCommandsGeneratedResponseCallback(chip::ClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
+                                                      chip::CommandId * commandIds, uint16_t commandIdCount);
 /** @brief Discover Commands Received Response
  *
  * This function is called by the framework when Discover Commands Received
@@ -206,8 +206,8 @@ bool emberAfDiscoverCommandsGeneratedResponseCallback(EmberAfClusterId clusterId
  * @param commandIdCount The length of bytes of the list, whish is the same as
  * the number of identifiers.  Ver.: always
  */
-bool emberAfDiscoverCommandsReceivedResponseCallback(EmberAfClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
-                                                     uint8_t * commandIds, uint16_t commandIdCount);
+bool emberAfDiscoverCommandsReceivedResponseCallback(chip::ClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
+                                                     chip::CommandId * commandIds, uint16_t commandIdCount);
 /** @brief Eeprom Init
  *
  * Tells the system to initialize the EEPROM if it is not already initialized.
@@ -275,7 +275,7 @@ void emberAfEnergyScanResultCallback(uint8_t channel, int8_t rssi);
  * @param buffer   Ver.: always
  * @param maxReadLength   Ver.: always
  */
-EmberAfStatus emberAfExternalAttributeReadCallback(uint8_t endpoint, EmberAfClusterId clusterId,
+EmberAfStatus emberAfExternalAttributeReadCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
                                                    EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
                                                    uint8_t * buffer, uint16_t maxReadLength);
 /** @brief External Attribute Write
@@ -324,7 +324,7 @@ EmberAfStatus emberAfExternalAttributeReadCallback(uint8_t endpoint, EmberAfClus
  * @param manufacturerCode   Ver.: always
  * @param buffer   Ver.: always
  */
-EmberAfStatus emberAfExternalAttributeWriteCallback(uint8_t endpoint, EmberAfClusterId clusterId,
+EmberAfStatus emberAfExternalAttributeWriteCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
                                                     EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
                                                     uint8_t * buffer);
 /** @brief Find Unused Pan Id And Form
@@ -440,7 +440,7 @@ bool emberAfGetEndpointByIndexCallback(uint8_t index, uint8_t * endpointReturn);
  * information is written if the callback is providing the information.  Ver.:
  * always
  */
-bool emberAfGetEndpointDescriptionCallback(uint8_t endpoint, EmberEndpointDescription * result);
+bool emberAfGetEndpointDescriptionCallback(chip::EndpointId endpoint, EmberEndpointDescription * result);
 /** @brief Get Endpoint Info
  *
  * This function is a callback to an application implemented endpoint that
@@ -458,7 +458,8 @@ bool emberAfGetEndpointDescriptionCallback(uint8_t endpoint, EmberEndpointDescri
  * @param returnEndpointInfo A pointer to a data struct that will be written
  * with information about the endpoint.  Ver.: always
  */
-bool emberAfGetEndpointInfoCallback(uint8_t endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo);
+bool emberAfGetEndpointInfoCallback(chip::EndpointId endpoint, uint8_t * returnNetworkIndex,
+                                    EmberAfEndpointInfoStruct * returnEndpointInfo);
 /** @brief Get Form And Join Extended Pan Id
  *
  * This callback is called by the framework to get the extended PAN ID used by
@@ -601,7 +602,7 @@ EmberStatus emberAfInitiateInterPanKeyEstablishmentCallback(EmberPanId panId, co
  * @param nodeId The node id of the remote device.  Ver.: always
  * @param endpoint The endpoint on the remote device.  Ver.: always
  */
-EmberStatus emberAfInitiateKeyEstablishmentCallback(EmberNodeId nodeId, uint8_t endpoint);
+EmberStatus emberAfInitiateKeyEstablishmentCallback(EmberNodeId nodeId, chip::EndpointId endpoint);
 /** @brief Initiate Partner Link Key Exchange
  *
  * This function is called by the framework to initiate a partner link key
@@ -849,8 +850,8 @@ bool emberAfPerformingKeyEstablishmentCallback(void);
  * @param size   Ver.: always
  * @param value   Ver.: always
  */
-void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value);
+void emberAfPostAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
+                                        uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value);
 /** @brief Post Em4 Reset
  *
  * A callback called by application framework, and implemented by em4 plugin
@@ -874,7 +875,7 @@ void emberAfPostEm4ResetCallback(void);
  * @param size   Ver.: always
  * @param value   Ver.: always
  */
-EmberAfStatus emberAfPreAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPreAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
                                                 uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size,
                                                 uint8_t * value);
 /** @brief Pre Cli Send
@@ -984,7 +985,7 @@ bool emberAfPreZDOMessageReceivedCallback(EmberNodeId emberNodeId, EmberApsFrame
  * Ver.: always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+bool emberAfReadAttributesResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration
@@ -1054,7 +1055,7 @@ void emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks);
  * always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfReportAttributesCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+bool emberAfReportAttributesCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 /** @brief Scan Complete
  *
  * This is called by the low-level stack code when an 802.15.4 active scan
@@ -1259,7 +1260,7 @@ void emberAfUnusedPanIdFoundCallback(EmberPanId panId, uint8_t channel);
  * Ver.: always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfWriteAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+bool emberAfWriteAttributesResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 /** @brief Zigbee Key Establishment
  *
  * A callback to the application to notify it of the status of the request for a
@@ -1282,7 +1283,7 @@ void emberAfZigbeeKeyEstablishmentCallback(EmberEUI64 partner, EmberKeyStatus st
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBasicClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBasicClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Basic Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -1292,14 +1293,14 @@ void emberAfBasicClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBasicClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBasicClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Basic Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBasicClusterClientInitCallback(uint8_t endpoint);
+void emberAfBasicClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Basic Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -1309,7 +1310,7 @@ void emberAfBasicClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBasicClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfBasicClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief Basic Cluster Client Message Sent
  *
@@ -1335,7 +1336,7 @@ void emberAfBasicClusterClientMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBasicClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBasicClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief Basic Cluster Client Tick
@@ -1344,7 +1345,7 @@ EmberAfStatus emberAfBasicClusterClientPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBasicClusterClientTickCallback(uint8_t endpoint);
+void emberAfBasicClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Basic Cluster Get Locales Supported
  *
  *
@@ -1374,7 +1375,7 @@ bool emberAfBasicClusterResetToFactoryDefaultsCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBasicClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBasicClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Basic Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -1384,14 +1385,14 @@ void emberAfBasicClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBasicClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBasicClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Basic Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBasicClusterServerInitCallback(uint8_t endpoint);
+void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Basic Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -1401,7 +1402,7 @@ void emberAfBasicClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBasicClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfBasicClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief Basic Cluster Server Message Sent
  *
@@ -1427,7 +1428,7 @@ void emberAfBasicClusterServerMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBasicClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBasicClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief Basic Cluster Server Tick
@@ -1436,7 +1437,7 @@ EmberAfStatus emberAfBasicClusterServerPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBasicClusterServerTickCallback(uint8_t endpoint);
+void emberAfBasicClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Basic Cluster Callbacks */
 
@@ -1450,7 +1451,7 @@ void emberAfBasicClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPowerConfigClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPowerConfigClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Power Configuration Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -1460,14 +1461,15 @@ void emberAfPowerConfigClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPowerConfigClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPowerConfigClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Power Configuration Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPowerConfigClusterClientInitCallback(uint8_t endpoint);
+void emberAfPowerConfigClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Power Configuration Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -1477,7 +1479,8 @@ void emberAfPowerConfigClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPowerConfigClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPowerConfigClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Power Configuration Cluster Client Message Sent
  *
@@ -1504,7 +1507,7 @@ void emberAfPowerConfigClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPowerConfigClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPowerConfigClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Power Configuration Cluster Client Tick
@@ -1513,7 +1516,7 @@ EmberAfStatus emberAfPowerConfigClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPowerConfigClusterClientTickCallback(uint8_t endpoint);
+void emberAfPowerConfigClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Power Configuration Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -1521,7 +1524,7 @@ void emberAfPowerConfigClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPowerConfigClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPowerConfigClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Power Configuration Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -1531,14 +1534,15 @@ void emberAfPowerConfigClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPowerConfigClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPowerConfigClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Power Configuration Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPowerConfigClusterServerInitCallback(uint8_t endpoint);
+void emberAfPowerConfigClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Power Configuration Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -1548,7 +1552,8 @@ void emberAfPowerConfigClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPowerConfigClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPowerConfigClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Power Configuration Cluster Server Message Sent
  *
@@ -1575,7 +1580,7 @@ void emberAfPowerConfigClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPowerConfigClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPowerConfigClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Power Configuration Cluster Server Tick
@@ -1584,7 +1589,7 @@ EmberAfStatus emberAfPowerConfigClusterServerPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPowerConfigClusterServerTickCallback(uint8_t endpoint);
+void emberAfPowerConfigClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Power Configuration Cluster Callbacks */
 
@@ -1598,7 +1603,7 @@ void emberAfPowerConfigClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDeviceTempClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDeviceTempClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Device Temperature Configuration Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -1608,14 +1613,15 @@ void emberAfDeviceTempClusterClientAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDeviceTempClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDeviceTempClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Device Temperature Configuration Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDeviceTempClusterClientInitCallback(uint8_t endpoint);
+void emberAfDeviceTempClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Device Temperature Configuration Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -1625,7 +1631,8 @@ void emberAfDeviceTempClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDeviceTempClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDeviceTempClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Device Temperature Configuration Cluster Client Message Sent
  *
@@ -1652,7 +1659,7 @@ void emberAfDeviceTempClusterClientMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDeviceTempClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDeviceTempClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Device Temperature Configuration Cluster Client Tick
@@ -1661,7 +1668,7 @@ EmberAfStatus emberAfDeviceTempClusterClientPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDeviceTempClusterClientTickCallback(uint8_t endpoint);
+void emberAfDeviceTempClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Device Temperature Configuration Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -1669,7 +1676,7 @@ void emberAfDeviceTempClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDeviceTempClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDeviceTempClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Device Temperature Configuration Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -1679,14 +1686,15 @@ void emberAfDeviceTempClusterServerAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDeviceTempClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDeviceTempClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Device Temperature Configuration Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDeviceTempClusterServerInitCallback(uint8_t endpoint);
+void emberAfDeviceTempClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Device Temperature Configuration Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -1696,7 +1704,8 @@ void emberAfDeviceTempClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDeviceTempClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDeviceTempClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Device Temperature Configuration Cluster Server Message Sent
  *
@@ -1723,7 +1732,7 @@ void emberAfDeviceTempClusterServerMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDeviceTempClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDeviceTempClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Device Temperature Configuration Cluster Server Tick
@@ -1732,7 +1741,7 @@ EmberAfStatus emberAfDeviceTempClusterServerPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDeviceTempClusterServerTickCallback(uint8_t endpoint);
+void emberAfDeviceTempClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Device Temperature Configuration Cluster Callbacks */
 
@@ -1746,7 +1755,7 @@ void emberAfDeviceTempClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIdentifyClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIdentifyClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Identify Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -1756,14 +1765,15 @@ void emberAfIdentifyClusterClientAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIdentifyClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIdentifyClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Identify Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIdentifyClusterClientInitCallback(uint8_t endpoint);
+void emberAfIdentifyClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Identify Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -1773,7 +1783,8 @@ void emberAfIdentifyClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIdentifyClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIdentifyClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Identify Cluster Client Message Sent
  *
@@ -1800,7 +1811,7 @@ void emberAfIdentifyClusterClientMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIdentifyClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIdentifyClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Identify Cluster Client Tick
@@ -1809,7 +1820,7 @@ EmberAfStatus emberAfIdentifyClusterClientPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIdentifyClusterClientTickCallback(uint8_t endpoint);
+void emberAfIdentifyClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Identify Cluster E Z Mode Invoke
  *
  *
@@ -1844,7 +1855,7 @@ bool emberAfIdentifyClusterIdentifyQueryResponseCallback(uint16_t timeout);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIdentifyClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIdentifyClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Identify Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -1854,14 +1865,15 @@ void emberAfIdentifyClusterServerAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIdentifyClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIdentifyClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Identify Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIdentifyClusterServerInitCallback(uint8_t endpoint);
+void emberAfIdentifyClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Identify Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -1871,7 +1883,8 @@ void emberAfIdentifyClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIdentifyClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIdentifyClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Identify Cluster Server Message Sent
  *
@@ -1898,7 +1911,7 @@ void emberAfIdentifyClusterServerMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIdentifyClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIdentifyClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Identify Cluster Server Tick
@@ -1907,7 +1920,7 @@ EmberAfStatus emberAfIdentifyClusterServerPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIdentifyClusterServerTickCallback(uint8_t endpoint);
+void emberAfIdentifyClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Identify Cluster Trigger Effect
  *
  *
@@ -1937,7 +1950,7 @@ bool emberAfIdentifyClusterUpdateCommissionStateCallback(uint8_t action, uint8_t
  *
  * @param endpoint The endpoint.  Ver.: always
  */
-void emberAfGroupsClusterClearGroupTableCallback(uint8_t endpoint);
+void emberAfGroupsClusterClearGroupTableCallback(chip::EndpointId endpoint);
 /** @brief Groups Cluster Add Group
  *
  *
@@ -1945,7 +1958,7 @@ void emberAfGroupsClusterClearGroupTableCallback(uint8_t endpoint);
  * @param groupId   Ver.: always
  * @param groupName   Ver.: always
  */
-bool emberAfGroupsClusterAddGroupCallback(uint16_t groupId, uint8_t * groupName);
+bool emberAfGroupsClusterAddGroupCallback(chip::GroupId groupId, uint8_t * groupName);
 /** @brief Groups Cluster Add Group If Identifying
  *
  *
@@ -1953,7 +1966,7 @@ bool emberAfGroupsClusterAddGroupCallback(uint16_t groupId, uint8_t * groupName)
  * @param groupId   Ver.: always
  * @param groupName   Ver.: always
  */
-bool emberAfGroupsClusterAddGroupIfIdentifyingCallback(uint16_t groupId, uint8_t * groupName);
+bool emberAfGroupsClusterAddGroupIfIdentifyingCallback(chip::GroupId groupId, uint8_t * groupName);
 /** @brief Groups Cluster Add Group Response
  *
  *
@@ -1961,7 +1974,7 @@ bool emberAfGroupsClusterAddGroupIfIdentifyingCallback(uint16_t groupId, uint8_t
  * @param status   Ver.: always
  * @param groupId   Ver.: always
  */
-bool emberAfGroupsClusterAddGroupResponseCallback(uint8_t status, uint16_t groupId);
+bool emberAfGroupsClusterAddGroupResponseCallback(uint8_t status, chip::GroupId groupId);
 /** @brief Groups Cluster Client Attribute Changed
  *
  * Client Attribute Changed
@@ -1969,7 +1982,7 @@ bool emberAfGroupsClusterAddGroupResponseCallback(uint8_t status, uint16_t group
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGroupsClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGroupsClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Groups Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -1979,14 +1992,14 @@ void emberAfGroupsClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGroupsClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGroupsClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Groups Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGroupsClusterClientInitCallback(uint8_t endpoint);
+void emberAfGroupsClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Groups Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -1996,7 +2009,8 @@ void emberAfGroupsClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGroupsClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGroupsClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Groups Cluster Client Message Sent
  *
@@ -2023,7 +2037,7 @@ void emberAfGroupsClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGroupsClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGroupsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Groups Cluster Client Tick
@@ -2032,7 +2046,7 @@ EmberAfStatus emberAfGroupsClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGroupsClusterClientTickCallback(uint8_t endpoint);
+void emberAfGroupsClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Groups Cluster Get Group Membership
  *
  *
@@ -2062,7 +2076,7 @@ bool emberAfGroupsClusterRemoveAllGroupsCallback(void);
  *
  * @param groupId   Ver.: always
  */
-bool emberAfGroupsClusterRemoveGroupCallback(uint16_t groupId);
+bool emberAfGroupsClusterRemoveGroupCallback(chip::GroupId groupId);
 /** @brief Groups Cluster Remove Group Response
  *
  *
@@ -2070,7 +2084,7 @@ bool emberAfGroupsClusterRemoveGroupCallback(uint16_t groupId);
  * @param status   Ver.: always
  * @param groupId   Ver.: always
  */
-bool emberAfGroupsClusterRemoveGroupResponseCallback(uint8_t status, uint16_t groupId);
+bool emberAfGroupsClusterRemoveGroupResponseCallback(uint8_t status, chip::GroupId groupId);
 /** @brief Groups Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -2078,7 +2092,7 @@ bool emberAfGroupsClusterRemoveGroupResponseCallback(uint8_t status, uint16_t gr
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGroupsClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGroupsClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Groups Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -2088,14 +2102,14 @@ void emberAfGroupsClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGroupsClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGroupsClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Groups Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGroupsClusterServerInitCallback(uint8_t endpoint);
+void emberAfGroupsClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Groups Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -2105,7 +2119,8 @@ void emberAfGroupsClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGroupsClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGroupsClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Groups Cluster Server Message Sent
  *
@@ -2132,7 +2147,7 @@ void emberAfGroupsClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGroupsClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGroupsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Groups Cluster Server Tick
@@ -2141,14 +2156,14 @@ EmberAfStatus emberAfGroupsClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGroupsClusterServerTickCallback(uint8_t endpoint);
+void emberAfGroupsClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Groups Cluster View Group
  *
  *
  *
  * @param groupId   Ver.: always
  */
-bool emberAfGroupsClusterViewGroupCallback(uint16_t groupId);
+bool emberAfGroupsClusterViewGroupCallback(chip::GroupId groupId);
 /** @brief Groups Cluster View Group Response
  *
  *
@@ -2157,7 +2172,7 @@ bool emberAfGroupsClusterViewGroupCallback(uint16_t groupId);
  * @param groupId   Ver.: always
  * @param groupName   Ver.: always
  */
-bool emberAfGroupsClusterViewGroupResponseCallback(uint8_t status, uint16_t groupId, uint8_t * groupName);
+bool emberAfGroupsClusterViewGroupResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t * groupName);
 
 /** @} END Groups Cluster Callbacks */
 
@@ -2171,7 +2186,7 @@ bool emberAfGroupsClusterViewGroupResponseCallback(uint8_t status, uint16_t grou
  *
  * @param endpoint The endpoint.  Ver.: always
  */
-void emberAfScenesClusterClearSceneTableCallback(uint8_t endpoint);
+void emberAfScenesClusterClearSceneTableCallback(chip::EndpointId endpoint);
 /** @brief Scenes Cluster Add Scene
  *
  *
@@ -2182,7 +2197,7 @@ void emberAfScenesClusterClearSceneTableCallback(uint8_t endpoint);
  * @param sceneName   Ver.: always
  * @param extensionFieldSets   Ver.: always
  */
-bool emberAfScenesClusterAddSceneCallback(uint16_t groupId, uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
+bool emberAfScenesClusterAddSceneCallback(chip::GroupId groupId, uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
                                           uint8_t * extensionFieldSets);
 /** @brief Scenes Cluster Add Scene Response
  *
@@ -2192,7 +2207,7 @@ bool emberAfScenesClusterAddSceneCallback(uint16_t groupId, uint8_t sceneId, uin
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterAddSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterAddSceneResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster Client Attribute Changed
  *
  * Client Attribute Changed
@@ -2200,7 +2215,7 @@ bool emberAfScenesClusterAddSceneResponseCallback(uint8_t status, uint16_t group
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfScenesClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfScenesClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Scenes Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -2210,14 +2225,14 @@ void emberAfScenesClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfScenesClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfScenesClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Scenes Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfScenesClusterClientInitCallback(uint8_t endpoint);
+void emberAfScenesClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Scenes Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -2227,7 +2242,8 @@ void emberAfScenesClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfScenesClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfScenesClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Scenes Cluster Client Message Sent
  *
@@ -2254,7 +2270,7 @@ void emberAfScenesClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfScenesClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfScenesClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Scenes Cluster Client Tick
@@ -2263,7 +2279,7 @@ EmberAfStatus emberAfScenesClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfScenesClusterClientTickCallback(uint8_t endpoint);
+void emberAfScenesClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Scenes Cluster Copy Scene
  *
  *
@@ -2295,8 +2311,8 @@ bool emberAfScenesClusterCopySceneResponseCallback(uint8_t status, uint16_t grou
  * @param sceneName   Ver.: always
  * @param extensionFieldSets   Ver.: always
  */
-bool emberAfScenesClusterEnhancedAddSceneCallback(uint16_t groupId, uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
-                                                  uint8_t * extensionFieldSets);
+bool emberAfScenesClusterEnhancedAddSceneCallback(chip::GroupId groupId, uint8_t sceneId, uint16_t transitionTime,
+                                                  uint8_t * sceneName, uint8_t * extensionFieldSets);
 /** @brief Scenes Cluster Enhanced Add Scene Response
  *
  *
@@ -2305,7 +2321,7 @@ bool emberAfScenesClusterEnhancedAddSceneCallback(uint16_t groupId, uint8_t scen
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterEnhancedAddSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterEnhancedAddSceneResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster Enhanced View Scene
  *
  *
@@ -2313,7 +2329,7 @@ bool emberAfScenesClusterEnhancedAddSceneResponseCallback(uint8_t status, uint16
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterEnhancedViewSceneCallback(uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterEnhancedViewSceneCallback(chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster Enhanced View Scene Response
  *
  *
@@ -2325,7 +2341,7 @@ bool emberAfScenesClusterEnhancedViewSceneCallback(uint16_t groupId, uint8_t sce
  * @param sceneName   Ver.: always
  * @param extensionFieldSets   Ver.: always
  */
-bool emberAfScenesClusterEnhancedViewSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId,
+bool emberAfScenesClusterEnhancedViewSceneResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t sceneId,
                                                            uint16_t transitionTime, uint8_t * sceneName,
                                                            uint8_t * extensionFieldSets);
 /** @brief Scenes Cluster Get Scene Membership
@@ -2334,7 +2350,7 @@ bool emberAfScenesClusterEnhancedViewSceneResponseCallback(uint8_t status, uint1
  *
  * @param groupId   Ver.: always
  */
-bool emberAfScenesClusterGetSceneMembershipCallback(uint16_t groupId);
+bool emberAfScenesClusterGetSceneMembershipCallback(chip::GroupId groupId);
 /** @brief Scenes Cluster Get Scene Membership Response
  *
  *
@@ -2345,8 +2361,8 @@ bool emberAfScenesClusterGetSceneMembershipCallback(uint16_t groupId);
  * @param sceneCount   Ver.: always
  * @param sceneList   Ver.: always
  */
-bool emberAfScenesClusterGetSceneMembershipResponseCallback(uint8_t status, uint8_t capacity, uint16_t groupId, uint8_t sceneCount,
-                                                            uint8_t * sceneList);
+bool emberAfScenesClusterGetSceneMembershipResponseCallback(uint8_t status, uint8_t capacity, chip::GroupId groupId,
+                                                            uint8_t sceneCount, uint8_t * sceneList);
 /** @brief Scenes Cluster Recall Scene
  *
  *
@@ -2355,14 +2371,14 @@ bool emberAfScenesClusterGetSceneMembershipResponseCallback(uint8_t status, uint
  * @param sceneId   Ver.: always
  * @param transitionTime   Ver.: since zcl-7.0-07-5123-07
  */
-bool emberAfScenesClusterRecallSceneCallback(uint16_t groupId, uint8_t sceneId, uint16_t transitionTime);
+bool emberAfScenesClusterRecallSceneCallback(chip::GroupId groupId, uint8_t sceneId, uint16_t transitionTime);
 /** @brief Scenes Cluster Remove All Scenes
  *
  *
  *
  * @param groupId   Ver.: always
  */
-bool emberAfScenesClusterRemoveAllScenesCallback(uint16_t groupId);
+bool emberAfScenesClusterRemoveAllScenesCallback(chip::GroupId groupId);
 /** @brief Scenes Cluster Remove All Scenes Response
  *
  *
@@ -2370,7 +2386,7 @@ bool emberAfScenesClusterRemoveAllScenesCallback(uint16_t groupId);
  * @param status   Ver.: always
  * @param groupId   Ver.: always
  */
-bool emberAfScenesClusterRemoveAllScenesResponseCallback(uint8_t status, uint16_t groupId);
+bool emberAfScenesClusterRemoveAllScenesResponseCallback(uint8_t status, chip::GroupId groupId);
 /** @brief Scenes Cluster Remove Scene
  *
  *
@@ -2378,7 +2394,7 @@ bool emberAfScenesClusterRemoveAllScenesResponseCallback(uint8_t status, uint16_
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterRemoveSceneCallback(uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterRemoveSceneCallback(chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster Remove Scene Response
  *
  *
@@ -2387,7 +2403,7 @@ bool emberAfScenesClusterRemoveSceneCallback(uint16_t groupId, uint8_t sceneId);
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterRemoveSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterRemoveSceneResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -2395,7 +2411,7 @@ bool emberAfScenesClusterRemoveSceneResponseCallback(uint8_t status, uint16_t gr
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfScenesClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfScenesClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Scenes Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -2405,14 +2421,14 @@ void emberAfScenesClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfScenesClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfScenesClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Scenes Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfScenesClusterServerInitCallback(uint8_t endpoint);
+void emberAfScenesClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Scenes Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -2422,7 +2438,8 @@ void emberAfScenesClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfScenesClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfScenesClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Scenes Cluster Server Message Sent
  *
@@ -2449,7 +2466,7 @@ void emberAfScenesClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfScenesClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfScenesClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Scenes Cluster Server Tick
@@ -2458,7 +2475,7 @@ EmberAfStatus emberAfScenesClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfScenesClusterServerTickCallback(uint8_t endpoint);
+void emberAfScenesClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Scenes Cluster Store Scene
  *
  *
@@ -2466,7 +2483,7 @@ void emberAfScenesClusterServerTickCallback(uint8_t endpoint);
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterStoreSceneCallback(uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterStoreSceneCallback(chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster Store Scene Response
  *
  *
@@ -2475,7 +2492,7 @@ bool emberAfScenesClusterStoreSceneCallback(uint16_t groupId, uint8_t sceneId);
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterStoreSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterStoreSceneResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster View Scene
  *
  *
@@ -2483,7 +2500,7 @@ bool emberAfScenesClusterStoreSceneResponseCallback(uint8_t status, uint16_t gro
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterViewSceneCallback(uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterViewSceneCallback(chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster View Scene Response
  *
  *
@@ -2495,7 +2512,7 @@ bool emberAfScenesClusterViewSceneCallback(uint16_t groupId, uint8_t sceneId);
  * @param sceneName   Ver.: always
  * @param extensionFieldSets   Ver.: always
  */
-bool emberAfScenesClusterViewSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
+bool emberAfScenesClusterViewSceneResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t sceneId, uint16_t transitionTime,
                                                    uint8_t * sceneName, uint8_t * extensionFieldSets);
 /** @} END Scenes Cluster Callbacks */
 
@@ -2509,7 +2526,7 @@ bool emberAfScenesClusterViewSceneResponseCallback(uint8_t status, uint16_t grou
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOnOffClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOnOffClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief On/off Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -2519,14 +2536,14 @@ void emberAfOnOffClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOnOffClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOnOffClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief On/off Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOnOffClusterClientInitCallback(uint8_t endpoint);
+void emberAfOnOffClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief On/off Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -2536,7 +2553,7 @@ void emberAfOnOffClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOnOffClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfOnOffClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief On/off Cluster Client Message Sent
  *
@@ -2562,7 +2579,7 @@ void emberAfOnOffClusterClientMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOnOffClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOnOffClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief On/off Cluster Client Tick
@@ -2571,7 +2588,7 @@ EmberAfStatus emberAfOnOffClusterClientPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOnOffClusterClientTickCallback(uint8_t endpoint);
+void emberAfOnOffClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief On/off Cluster Off
  *
  *
@@ -2644,7 +2661,7 @@ bool emberAfOnOffClusterSampleMfgSpecificToggleWithTransitionCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOnOffClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOnOffClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief On/off Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -2654,14 +2671,14 @@ void emberAfOnOffClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOnOffClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOnOffClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief On/off Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOnOffClusterServerInitCallback(uint8_t endpoint);
+void emberAfOnOffClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief On/off Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -2671,7 +2688,7 @@ void emberAfOnOffClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOnOffClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfOnOffClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief On/off Cluster Server Message Sent
  *
@@ -2697,7 +2714,7 @@ void emberAfOnOffClusterServerMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOnOffClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOnOffClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief On/off Cluster Server Tick
@@ -2706,7 +2723,7 @@ EmberAfStatus emberAfOnOffClusterServerPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOnOffClusterServerTickCallback(uint8_t endpoint);
+void emberAfOnOffClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief On/off Cluster Toggle
  *
  *
@@ -2720,7 +2737,7 @@ bool emberAfOnOffClusterToggleCallback(void);
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint);
+void emberAfPluginOnOffClusterServerPostInitCallback(chip::EndpointId endpoint);
 
 /** @} END On/off Cluster Callbacks */
 
@@ -2734,7 +2751,7 @@ void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOnOffSwitchConfigClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief On/off Switch Configuration Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -2744,14 +2761,15 @@ void emberAfOnOffSwitchConfigClusterClientAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOnOffSwitchConfigClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief On/off Switch Configuration Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterClientInitCallback(uint8_t endpoint);
+void emberAfOnOffSwitchConfigClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief On/off Switch Configuration Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -2762,7 +2780,7 @@ void emberAfOnOffSwitchConfigClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfOnOffSwitchConfigClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief On/off Switch Configuration Cluster Client Message Sent
  *
@@ -2789,7 +2807,8 @@ void emberAfOnOffSwitchConfigClusterClientMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOnOffSwitchConfigClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOnOffSwitchConfigClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief On/off Switch Configuration Cluster Client Tick
@@ -2798,7 +2817,7 @@ EmberAfStatus emberAfOnOffSwitchConfigClusterClientPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterClientTickCallback(uint8_t endpoint);
+void emberAfOnOffSwitchConfigClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief On/off Switch Configuration Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -2806,7 +2825,7 @@ void emberAfOnOffSwitchConfigClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOnOffSwitchConfigClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief On/off Switch Configuration Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -2816,14 +2835,15 @@ void emberAfOnOffSwitchConfigClusterServerAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOnOffSwitchConfigClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief On/off Switch Configuration Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterServerInitCallback(uint8_t endpoint);
+void emberAfOnOffSwitchConfigClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief On/off Switch Configuration Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -2834,7 +2854,7 @@ void emberAfOnOffSwitchConfigClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfOnOffSwitchConfigClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief On/off Switch Configuration Cluster Server Message Sent
  *
@@ -2861,7 +2881,8 @@ void emberAfOnOffSwitchConfigClusterServerMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOnOffSwitchConfigClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOnOffSwitchConfigClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief On/off Switch Configuration Cluster Server Tick
@@ -2870,7 +2891,7 @@ EmberAfStatus emberAfOnOffSwitchConfigClusterServerPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterServerTickCallback(uint8_t endpoint);
+void emberAfOnOffSwitchConfigClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END On/off Switch Configuration Cluster Callbacks */
 
@@ -2884,7 +2905,7 @@ void emberAfOnOffSwitchConfigClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfLevelControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfLevelControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Level Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -2894,14 +2915,15 @@ void emberAfLevelControlClusterClientAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfLevelControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfLevelControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief Level Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfLevelControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfLevelControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Level Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -2911,7 +2933,8 @@ void emberAfLevelControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfLevelControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfLevelControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief Level Control Cluster Client Message Sent
  *
@@ -2938,7 +2961,7 @@ void emberAfLevelControlClusterClientMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfLevelControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfLevelControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief Level Control Cluster Client Tick
@@ -2947,7 +2970,7 @@ EmberAfStatus emberAfLevelControlClusterClientPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfLevelControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfLevelControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Level Control Cluster Move
  *
  *
@@ -2992,7 +3015,7 @@ bool emberAfLevelControlClusterMoveWithOnOffCallback(uint8_t moveMode, uint8_t r
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfLevelControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfLevelControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Level Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -3002,14 +3025,15 @@ void emberAfLevelControlClusterServerAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfLevelControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfLevelControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief Level Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfLevelControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfLevelControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Level Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -3019,7 +3043,8 @@ void emberAfLevelControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfLevelControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfLevelControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief Level Control Cluster Server Message Sent
  *
@@ -3046,7 +3071,7 @@ void emberAfLevelControlClusterServerMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfLevelControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfLevelControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief Level Control Cluster Server Tick
@@ -3055,7 +3080,7 @@ EmberAfStatus emberAfLevelControlClusterServerPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfLevelControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfLevelControlClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Level Control Cluster Step
  *
  *
@@ -3104,7 +3129,7 @@ bool emberAfLevelControlClusterStopWithOnOffCallback(void);
  * @param alarmCode   Ver.: always
  * @param clusterId   Ver.: always
  */
-bool emberAfAlarmClusterAlarmCallback(uint8_t alarmCode, uint16_t clusterId);
+bool emberAfAlarmClusterAlarmCallback(uint8_t alarmCode, chip::ClusterId clusterId);
 /** @brief Alarms Cluster Client Attribute Changed
  *
  * Client Attribute Changed
@@ -3112,7 +3137,7 @@ bool emberAfAlarmClusterAlarmCallback(uint8_t alarmCode, uint16_t clusterId);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfAlarmClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfAlarmClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Alarms Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -3122,14 +3147,14 @@ void emberAfAlarmClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfAlarmClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfAlarmClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Alarms Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfAlarmClusterClientInitCallback(uint8_t endpoint);
+void emberAfAlarmClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Alarms Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -3139,7 +3164,7 @@ void emberAfAlarmClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfAlarmClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfAlarmClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief Alarms Cluster Client Message Sent
  *
@@ -3165,7 +3190,7 @@ void emberAfAlarmClusterClientMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfAlarmClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfAlarmClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief Alarms Cluster Client Tick
@@ -3174,7 +3199,7 @@ EmberAfStatus emberAfAlarmClusterClientPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfAlarmClusterClientTickCallback(uint8_t endpoint);
+void emberAfAlarmClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Alarms Cluster Get Alarm
  *
  *
@@ -3190,7 +3215,7 @@ bool emberAfAlarmClusterGetAlarmCallback(void);
  * @param clusterId   Ver.: always
  * @param timeStamp   Ver.: always
  */
-bool emberAfAlarmClusterGetAlarmResponseCallback(uint8_t status, uint8_t alarmCode, uint16_t clusterId, uint32_t timeStamp);
+bool emberAfAlarmClusterGetAlarmResponseCallback(uint8_t status, uint8_t alarmCode, chip::ClusterId clusterId, uint32_t timeStamp);
 /** @brief Alarms Cluster Reset Alarm
  *
  *
@@ -3198,7 +3223,7 @@ bool emberAfAlarmClusterGetAlarmResponseCallback(uint8_t status, uint8_t alarmCo
  * @param alarmCode   Ver.: always
  * @param clusterId   Ver.: always
  */
-bool emberAfAlarmClusterResetAlarmCallback(uint8_t alarmCode, uint16_t clusterId);
+bool emberAfAlarmClusterResetAlarmCallback(uint8_t alarmCode, chip::ClusterId clusterId);
 /** @brief Alarms Cluster Reset Alarm Log
  *
  *
@@ -3218,7 +3243,7 @@ bool emberAfAlarmClusterResetAllAlarmsCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfAlarmClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfAlarmClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Alarms Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -3228,14 +3253,14 @@ void emberAfAlarmClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfAlarmClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfAlarmClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Alarms Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfAlarmClusterServerInitCallback(uint8_t endpoint);
+void emberAfAlarmClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Alarms Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -3245,7 +3270,7 @@ void emberAfAlarmClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfAlarmClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfAlarmClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief Alarms Cluster Server Message Sent
  *
@@ -3271,7 +3296,7 @@ void emberAfAlarmClusterServerMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfAlarmClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfAlarmClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief Alarms Cluster Server Tick
@@ -3280,7 +3305,7 @@ EmberAfStatus emberAfAlarmClusterServerPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfAlarmClusterServerTickCallback(uint8_t endpoint);
+void emberAfAlarmClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Alarms Cluster Callbacks */
 
@@ -3294,7 +3319,7 @@ void emberAfAlarmClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTimeClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfTimeClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Time Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -3304,14 +3329,14 @@ void emberAfTimeClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTimeClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfTimeClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Time Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTimeClusterClientInitCallback(uint8_t endpoint);
+void emberAfTimeClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Time Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -3321,7 +3346,7 @@ void emberAfTimeClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfTimeClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfTimeClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           uint16_t manufacturerCode);
 /** @brief Time Cluster Client Message Sent
  *
@@ -3347,7 +3372,7 @@ void emberAfTimeClusterClientMessageSentCallback(EmberOutgoingMessageType type, 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfTimeClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfTimeClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                   EmberAfAttributeType attributeType, uint8_t size,
                                                                   uint8_t * value);
 /** @brief Time Cluster Client Tick
@@ -3356,7 +3381,7 @@ EmberAfStatus emberAfTimeClusterClientPreAttributeChangedCallback(uint8_t endpoi
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTimeClusterClientTickCallback(uint8_t endpoint);
+void emberAfTimeClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Time Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -3364,7 +3389,7 @@ void emberAfTimeClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTimeClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfTimeClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Time Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -3374,14 +3399,14 @@ void emberAfTimeClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTimeClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfTimeClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Time Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTimeClusterServerInitCallback(uint8_t endpoint);
+void emberAfTimeClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Time Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -3391,7 +3416,7 @@ void emberAfTimeClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfTimeClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfTimeClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           uint16_t manufacturerCode);
 /** @brief Time Cluster Server Message Sent
  *
@@ -3417,7 +3442,7 @@ void emberAfTimeClusterServerMessageSentCallback(EmberOutgoingMessageType type, 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfTimeClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfTimeClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                   EmberAfAttributeType attributeType, uint8_t size,
                                                                   uint8_t * value);
 /** @brief Time Cluster Server Tick
@@ -3426,7 +3451,7 @@ EmberAfStatus emberAfTimeClusterServerPreAttributeChangedCallback(uint8_t endpoi
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTimeClusterServerTickCallback(uint8_t endpoint);
+void emberAfTimeClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Time Cluster Callbacks */
 
@@ -3451,7 +3476,7 @@ bool emberAfRssiLocationClusterAnchorNodeAnnounceCallback(uint8_t * anchorNodeIe
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfRssiLocationClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfRssiLocationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief RSSI Location Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -3461,14 +3486,15 @@ void emberAfRssiLocationClusterClientAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfRssiLocationClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfRssiLocationClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief RSSI Location Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfRssiLocationClusterClientInitCallback(uint8_t endpoint);
+void emberAfRssiLocationClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief RSSI Location Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -3478,7 +3504,8 @@ void emberAfRssiLocationClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfRssiLocationClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfRssiLocationClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief RSSI Location Cluster Client Message Sent
  *
@@ -3505,7 +3532,7 @@ void emberAfRssiLocationClusterClientMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfRssiLocationClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfRssiLocationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief RSSI Location Cluster Client Tick
@@ -3514,7 +3541,7 @@ EmberAfStatus emberAfRssiLocationClusterClientPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfRssiLocationClusterClientTickCallback(uint8_t endpoint);
+void emberAfRssiLocationClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief RSSI Location Cluster Compact Location Data Notification
  *
  *
@@ -3656,7 +3683,7 @@ bool emberAfRssiLocationClusterSendPingsCallback(uint8_t * targetAddress, uint8_
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfRssiLocationClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfRssiLocationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief RSSI Location Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -3666,14 +3693,15 @@ void emberAfRssiLocationClusterServerAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfRssiLocationClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfRssiLocationClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief RSSI Location Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfRssiLocationClusterServerInitCallback(uint8_t endpoint);
+void emberAfRssiLocationClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief RSSI Location Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -3683,7 +3711,8 @@ void emberAfRssiLocationClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfRssiLocationClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfRssiLocationClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief RSSI Location Cluster Server Message Sent
  *
@@ -3710,7 +3739,7 @@ void emberAfRssiLocationClusterServerMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfRssiLocationClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfRssiLocationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief RSSI Location Cluster Server Tick
@@ -3719,7 +3748,7 @@ EmberAfStatus emberAfRssiLocationClusterServerPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfRssiLocationClusterServerTickCallback(uint8_t endpoint);
+void emberAfRssiLocationClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief RSSI Location Cluster Set Absolute Location
  *
  *
@@ -3757,7 +3786,7 @@ bool emberAfRssiLocationClusterSetDeviceConfigurationCallback(int16_t power, uin
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBinaryInputBasicClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBinaryInputBasicClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Binary Input (Basic) Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -3767,14 +3796,15 @@ void emberAfBinaryInputBasicClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBinaryInputBasicClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBinaryInputBasicClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Binary Input (Basic) Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBinaryInputBasicClusterClientInitCallback(uint8_t endpoint);
+void emberAfBinaryInputBasicClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Binary Input (Basic) Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -3784,8 +3814,8 @@ void emberAfBinaryInputBasicClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBinaryInputBasicClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfBinaryInputBasicClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Binary Input (Basic) Cluster Client Message Sent
  *
@@ -3812,7 +3842,8 @@ void emberAfBinaryInputBasicClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBinaryInputBasicClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBinaryInputBasicClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Binary Input (Basic) Cluster Client Tick
@@ -3821,7 +3852,7 @@ EmberAfStatus emberAfBinaryInputBasicClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBinaryInputBasicClusterClientTickCallback(uint8_t endpoint);
+void emberAfBinaryInputBasicClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Binary Input (Basic) Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -3829,7 +3860,7 @@ void emberAfBinaryInputBasicClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBinaryInputBasicClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBinaryInputBasicClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Binary Input (Basic) Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -3839,14 +3870,15 @@ void emberAfBinaryInputBasicClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBinaryInputBasicClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBinaryInputBasicClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Binary Input (Basic) Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBinaryInputBasicClusterServerInitCallback(uint8_t endpoint);
+void emberAfBinaryInputBasicClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Binary Input (Basic) Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -3856,8 +3888,8 @@ void emberAfBinaryInputBasicClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBinaryInputBasicClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfBinaryInputBasicClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Binary Input (Basic) Cluster Server Message Sent
  *
@@ -3884,7 +3916,8 @@ void emberAfBinaryInputBasicClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBinaryInputBasicClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBinaryInputBasicClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Binary Input (Basic) Cluster Server Tick
@@ -3893,7 +3926,7 @@ EmberAfStatus emberAfBinaryInputBasicClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBinaryInputBasicClusterServerTickCallback(uint8_t endpoint);
+void emberAfBinaryInputBasicClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Binary Input (Basic) Cluster Callbacks */
 
@@ -3907,7 +3940,7 @@ void emberAfBinaryInputBasicClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfCommissioningClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfCommissioningClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Commissioning Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -3917,14 +3950,15 @@ void emberAfCommissioningClusterClientAttributeChangedCallback(uint8_t endpoint,
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCommissioningClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfCommissioningClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                              EmberAfStatus status);
 /** @brief Commissioning Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCommissioningClusterClientInitCallback(uint8_t endpoint);
+void emberAfCommissioningClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Commissioning Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -3934,7 +3968,8 @@ void emberAfCommissioningClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfCommissioningClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfCommissioningClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    uint16_t manufacturerCode);
 /** @brief Commissioning Cluster Client Message Sent
  *
@@ -3961,7 +3996,7 @@ void emberAfCommissioningClusterClientMessageSentCallback(EmberOutgoingMessageTy
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfCommissioningClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfCommissioningClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            EmberAfAttributeType attributeType, uint8_t size,
                                                                            uint8_t * value);
 /** @brief Commissioning Cluster Client Tick
@@ -3970,7 +4005,7 @@ EmberAfStatus emberAfCommissioningClusterClientPreAttributeChangedCallback(uint8
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCommissioningClusterClientTickCallback(uint8_t endpoint);
+void emberAfCommissioningClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Commissioning Cluster Reset Startup Parameters
  *
  *
@@ -4039,7 +4074,7 @@ bool emberAfCommissioningClusterSaveStartupParametersResponseCallback(uint8_t st
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfCommissioningClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfCommissioningClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Commissioning Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -4049,14 +4084,15 @@ void emberAfCommissioningClusterServerAttributeChangedCallback(uint8_t endpoint,
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCommissioningClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfCommissioningClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                              EmberAfStatus status);
 /** @brief Commissioning Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCommissioningClusterServerInitCallback(uint8_t endpoint);
+void emberAfCommissioningClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Commissioning Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -4066,7 +4102,8 @@ void emberAfCommissioningClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfCommissioningClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfCommissioningClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    uint16_t manufacturerCode);
 /** @brief Commissioning Cluster Server Message Sent
  *
@@ -4093,7 +4130,7 @@ void emberAfCommissioningClusterServerMessageSentCallback(EmberOutgoingMessageTy
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfCommissioningClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfCommissioningClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            EmberAfAttributeType attributeType, uint8_t size,
                                                                            uint8_t * value);
 /** @brief Commissioning Cluster Server Tick
@@ -4102,7 +4139,7 @@ EmberAfStatus emberAfCommissioningClusterServerPreAttributeChangedCallback(uint8
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCommissioningClusterServerTickCallback(uint8_t endpoint);
+void emberAfCommissioningClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Commissioning Cluster Callbacks */
 
@@ -4116,7 +4153,7 @@ void emberAfCommissioningClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPartitionClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPartitionClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Partition Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -4126,14 +4163,15 @@ void emberAfPartitionClusterClientAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPartitionClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPartitionClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Partition Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPartitionClusterClientInitCallback(uint8_t endpoint);
+void emberAfPartitionClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Partition Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -4143,7 +4181,8 @@ void emberAfPartitionClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPartitionClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPartitionClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Partition Cluster Client Message Sent
  *
@@ -4170,7 +4209,7 @@ void emberAfPartitionClusterClientMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPartitionClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPartitionClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Partition Cluster Client Tick
@@ -4179,7 +4218,7 @@ EmberAfStatus emberAfPartitionClusterClientPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPartitionClusterClientTickCallback(uint8_t endpoint);
+void emberAfPartitionClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Partition Cluster Multiple Ack
  *
  *
@@ -4211,7 +4250,7 @@ bool emberAfPartitionClusterReadHandshakeParamResponseCallback(uint16_t partitio
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPartitionClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPartitionClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Partition Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -4221,14 +4260,15 @@ void emberAfPartitionClusterServerAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPartitionClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPartitionClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Partition Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPartitionClusterServerInitCallback(uint8_t endpoint);
+void emberAfPartitionClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Partition Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -4238,7 +4278,8 @@ void emberAfPartitionClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPartitionClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPartitionClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Partition Cluster Server Message Sent
  *
@@ -4265,7 +4306,7 @@ void emberAfPartitionClusterServerMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPartitionClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPartitionClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Partition Cluster Server Tick
@@ -4274,7 +4315,7 @@ EmberAfStatus emberAfPartitionClusterServerPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPartitionClusterServerTickCallback(uint8_t endpoint);
+void emberAfPartitionClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Partition Cluster Transfer Partitioned Frame
  *
  *
@@ -4304,7 +4345,7 @@ bool emberAfPartitionClusterWriteHandshakeParamCallback(uint16_t partitionedClus
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOtaBootloadClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOtaBootloadClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Over the Air Bootloading Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -4314,14 +4355,15 @@ void emberAfOtaBootloadClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOtaBootloadClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOtaBootloadClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Over the Air Bootloading Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOtaBootloadClusterClientInitCallback(uint8_t endpoint);
+void emberAfOtaBootloadClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Over the Air Bootloading Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -4331,7 +4373,8 @@ void emberAfOtaBootloadClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOtaBootloadClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfOtaBootloadClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Over the Air Bootloading Cluster Client Message Sent
  *
@@ -4358,7 +4401,7 @@ void emberAfOtaBootloadClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOtaBootloadClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOtaBootloadClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Over the Air Bootloading Cluster Client Tick
@@ -4367,7 +4410,7 @@ EmberAfStatus emberAfOtaBootloadClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOtaBootloadClusterClientTickCallback(uint8_t endpoint);
+void emberAfOtaBootloadClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Over the Air Bootloading Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -4375,7 +4418,7 @@ void emberAfOtaBootloadClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOtaBootloadClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOtaBootloadClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Over the Air Bootloading Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -4385,14 +4428,15 @@ void emberAfOtaBootloadClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOtaBootloadClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOtaBootloadClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Over the Air Bootloading Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOtaBootloadClusterServerInitCallback(uint8_t endpoint);
+void emberAfOtaBootloadClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Over the Air Bootloading Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -4402,7 +4446,8 @@ void emberAfOtaBootloadClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOtaBootloadClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfOtaBootloadClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Over the Air Bootloading Cluster Server Message Sent
  *
@@ -4429,7 +4474,7 @@ void emberAfOtaBootloadClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOtaBootloadClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOtaBootloadClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Over the Air Bootloading Cluster Server Tick
@@ -4438,7 +4483,7 @@ EmberAfStatus emberAfOtaBootloadClusterServerPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOtaBootloadClusterServerTickCallback(uint8_t endpoint);
+void emberAfOtaBootloadClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Over the Air Bootloading Cluster Callbacks */
 
@@ -4452,7 +4497,7 @@ void emberAfOtaBootloadClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPowerProfileClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPowerProfileClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Power Profile Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -4462,14 +4507,15 @@ void emberAfPowerProfileClusterClientAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPowerProfileClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPowerProfileClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief Power Profile Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPowerProfileClusterClientInitCallback(uint8_t endpoint);
+void emberAfPowerProfileClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Power Profile Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -4479,7 +4525,8 @@ void emberAfPowerProfileClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPowerProfileClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPowerProfileClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief Power Profile Cluster Client Message Sent
  *
@@ -4506,7 +4553,7 @@ void emberAfPowerProfileClusterClientMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPowerProfileClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPowerProfileClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief Power Profile Cluster Client Tick
@@ -4515,7 +4562,7 @@ EmberAfStatus emberAfPowerProfileClusterClientPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPowerProfileClusterClientTickCallback(uint8_t endpoint);
+void emberAfPowerProfileClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Power Profile Cluster Energy Phases Schedule Notification
  *
  *
@@ -4710,7 +4757,7 @@ bool emberAfPowerProfileClusterPowerProfilesStateNotificationCallback(uint8_t po
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPowerProfileClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPowerProfileClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Power Profile Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -4720,14 +4767,15 @@ void emberAfPowerProfileClusterServerAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPowerProfileClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPowerProfileClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief Power Profile Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPowerProfileClusterServerInitCallback(uint8_t endpoint);
+void emberAfPowerProfileClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Power Profile Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -4737,7 +4785,8 @@ void emberAfPowerProfileClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPowerProfileClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPowerProfileClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief Power Profile Cluster Server Message Sent
  *
@@ -4764,7 +4813,7 @@ void emberAfPowerProfileClusterServerMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPowerProfileClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPowerProfileClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief Power Profile Cluster Server Tick
@@ -4773,7 +4822,7 @@ EmberAfStatus emberAfPowerProfileClusterServerPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPowerProfileClusterServerTickCallback(uint8_t endpoint);
+void emberAfPowerProfileClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Power Profile Cluster Callbacks */
 
@@ -4787,7 +4836,7 @@ void emberAfPowerProfileClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -4797,14 +4846,15 @@ void emberAfApplianceControlClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Appliance Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfApplianceControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -4814,8 +4864,8 @@ void emberAfApplianceControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfApplianceControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfApplianceControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Appliance Control Cluster Client Message Sent
  *
@@ -4842,7 +4892,8 @@ void emberAfApplianceControlClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Appliance Control Cluster Client Tick
@@ -4851,14 +4902,14 @@ EmberAfStatus emberAfApplianceControlClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfApplianceControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Appliance Control Cluster Execution Of A Command
  *
  *
  *
  * @param commandId   Ver.: always
  */
-bool emberAfApplianceControlClusterExecutionOfACommandCallback(uint8_t commandId);
+bool emberAfApplianceControlClusterExecutionOfACommandCallback(chip::CommandId commandId);
 /** @brief Appliance Control Cluster Overload Pause
  *
  *
@@ -4885,7 +4936,7 @@ bool emberAfApplianceControlClusterOverloadWarningCallback(uint8_t warningEvent)
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -4895,14 +4946,15 @@ void emberAfApplianceControlClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Appliance Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfApplianceControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -4912,8 +4964,8 @@ void emberAfApplianceControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfApplianceControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfApplianceControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Appliance Control Cluster Server Message Sent
  *
@@ -4940,7 +4992,8 @@ void emberAfApplianceControlClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Appliance Control Cluster Server Tick
@@ -4949,7 +5002,7 @@ EmberAfStatus emberAfApplianceControlClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfApplianceControlClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Appliance Control Cluster Signal State
  *
  *
@@ -5013,7 +5066,7 @@ bool emberAfPollControlClusterCheckInResponseCallback(uint8_t startFastPolling, 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPollControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPollControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Poll Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -5023,14 +5076,15 @@ void emberAfPollControlClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPollControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPollControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Poll Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPollControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfPollControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Poll Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -5040,7 +5094,8 @@ void emberAfPollControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPollControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPollControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Poll Control Cluster Client Message Sent
  *
@@ -5067,7 +5122,7 @@ void emberAfPollControlClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPollControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPollControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Poll Control Cluster Client Tick
@@ -5076,7 +5131,7 @@ EmberAfStatus emberAfPollControlClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPollControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfPollControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Poll Control Cluster Fast Poll Stop
  *
  *
@@ -5090,7 +5145,7 @@ bool emberAfPollControlClusterFastPollStopCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPollControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPollControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Poll Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -5100,14 +5155,15 @@ void emberAfPollControlClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPollControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPollControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Poll Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPollControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfPollControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Poll Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -5117,7 +5173,8 @@ void emberAfPollControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPollControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPollControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Poll Control Cluster Server Message Sent
  *
@@ -5144,7 +5201,7 @@ void emberAfPollControlClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPollControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPollControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Poll Control Cluster Server Tick
@@ -5153,7 +5210,7 @@ EmberAfStatus emberAfPollControlClusterServerPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPollControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfPollControlClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Poll Control Cluster Set Long Poll Interval
  *
  *
@@ -5181,7 +5238,7 @@ bool emberAfPollControlClusterSetShortPollIntervalCallback(uint16_t newShortPoll
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGreenPowerClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGreenPowerClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Green Power Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -5191,14 +5248,15 @@ void emberAfGreenPowerClusterClientAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGreenPowerClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGreenPowerClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Green Power Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGreenPowerClusterClientInitCallback(uint8_t endpoint);
+void emberAfGreenPowerClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Green Power Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -5208,7 +5266,8 @@ void emberAfGreenPowerClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGreenPowerClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGreenPowerClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Green Power Cluster Client Message Sent
  *
@@ -5235,7 +5294,7 @@ void emberAfGreenPowerClusterClientMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGreenPowerClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGreenPowerClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Green Power Cluster Client Tick
@@ -5244,7 +5303,7 @@ EmberAfStatus emberAfGreenPowerClusterClientPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGreenPowerClusterClientTickCallback(uint8_t endpoint);
+void emberAfGreenPowerClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Green Power Cluster Gp Commissioning Notification
  *
  *
@@ -5261,7 +5320,7 @@ void emberAfGreenPowerClusterClientTickCallback(uint8_t endpoint);
  * @param mic   Ver.: since gp-1.0-09-5499-24
  */
 bool emberAfGreenPowerClusterGpCommissioningNotificationCallback(uint16_t options, uint32_t gpdSrcId, uint8_t * gpdIeee,
-                                                                 uint8_t endpoint, uint32_t gpdSecurityFrameCounter,
+                                                                 chip::EndpointId endpoint, uint32_t gpdSecurityFrameCounter,
                                                                  uint8_t gpdCommandId, uint8_t * gpdCommandPayload,
                                                                  uint16_t gppShortAddress, uint8_t gppLink, uint32_t mic);
 /** @brief Green Power Cluster Gp Notification
@@ -5349,7 +5408,7 @@ bool emberAfGreenPowerClusterGpPairingCallback(uint32_t options, uint32_t gpdSrc
  * @param reportDescriptor   Ver.: always
  */
 bool emberAfGreenPowerClusterGpPairingConfigurationCallback(
-    uint8_t actions, uint16_t options, uint32_t gpdSrcId, uint8_t * gpdIeee, uint8_t endpoint, uint8_t deviceId,
+    uint8_t actions, uint16_t options, uint32_t gpdSrcId, uint8_t * gpdIeee, chip::EndpointId endpoint, uint8_t deviceId,
     uint8_t groupListCount, uint8_t * groupList, uint16_t gpdAssignedAlias, uint8_t groupcastRadius, uint8_t securityOptions,
     uint32_t gpdSecurityFrameCounter, uint8_t * gpdSecurityKey, uint8_t numberOfPairedEndpoints, uint8_t * pairedEndpoints,
     uint8_t applicationInformation, uint16_t manufacturerId, uint16_t modeId, uint8_t numberOfGpdCommands,
@@ -5365,7 +5424,8 @@ bool emberAfGreenPowerClusterGpPairingConfigurationCallback(
  * @param gpdIeee   Ver.: since gp-1.0-09-5499-24
  * @param endpoint   Ver.: always
  */
-bool emberAfGreenPowerClusterGpPairingSearchCallback(uint16_t options, uint32_t gpdSrcId, uint8_t * gpdIeee, uint8_t endpoint);
+bool emberAfGreenPowerClusterGpPairingSearchCallback(uint16_t options, uint32_t gpdSrcId, uint8_t * gpdIeee,
+                                                     chip::EndpointId endpoint);
 /** @brief Green Power Cluster Gp Proxy Commissioning Mode
  *
  *
@@ -5413,8 +5473,8 @@ bool emberAfGreenPowerClusterGpProxyTableResponseCallback(uint8_t status, uint8_
  * @param gpdCommandPayload   Ver.: always
  */
 bool emberAfGreenPowerClusterGpResponseCallback(uint8_t options, uint16_t tempMasterShortAddress, uint8_t tempMasterTxChannel,
-                                                uint32_t gpdSrcId, uint8_t * gpdIeee, uint8_t endpoint, uint8_t gpdCommandId,
-                                                uint8_t * gpdCommandPayload);
+                                                uint32_t gpdSrcId, uint8_t * gpdIeee, chip::EndpointId endpoint,
+                                                uint8_t gpdCommandId, uint8_t * gpdCommandPayload);
 /** @brief Green Power Cluster Gp Sink Commissioning Mode
  *
  *
@@ -5483,7 +5543,7 @@ bool emberAfGreenPowerClusterGpTranslationTableResponseCallback(uint8_t status, 
  * @param translations   Ver.: since gp-1.0-09-5499-24
  */
 bool emberAfGreenPowerClusterGpTranslationTableUpdateCallback(uint16_t options, uint32_t gpdSrcId, uint8_t * gpdIeee,
-                                                              uint8_t endpoint, uint8_t * translations);
+                                                              chip::EndpointId endpoint, uint8_t * translations);
 /** @brief Green Power Cluster Gp Tunneling Stop
  *
  *
@@ -5506,7 +5566,7 @@ bool emberAfGreenPowerClusterGpTunnelingStopCallback(uint8_t options, uint32_t g
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGreenPowerClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGreenPowerClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Green Power Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -5516,14 +5576,15 @@ void emberAfGreenPowerClusterServerAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGreenPowerClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGreenPowerClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Green Power Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGreenPowerClusterServerInitCallback(uint8_t endpoint);
+void emberAfGreenPowerClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Green Power Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -5533,7 +5594,8 @@ void emberAfGreenPowerClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGreenPowerClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGreenPowerClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Green Power Cluster Server Message Sent
  *
@@ -5560,7 +5622,7 @@ void emberAfGreenPowerClusterServerMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGreenPowerClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGreenPowerClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Green Power Cluster Server Tick
@@ -5569,7 +5631,7 @@ EmberAfStatus emberAfGreenPowerClusterServerPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGreenPowerClusterServerTickCallback(uint8_t endpoint);
+void emberAfGreenPowerClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Green Power Cluster Callbacks */
 
@@ -5583,7 +5645,7 @@ void emberAfGreenPowerClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfKeepaliveClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfKeepaliveClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Keep-Alive Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -5593,14 +5655,15 @@ void emberAfKeepaliveClusterClientAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfKeepaliveClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfKeepaliveClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Keep-Alive Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfKeepaliveClusterClientInitCallback(uint8_t endpoint);
+void emberAfKeepaliveClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Keep-Alive Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -5610,7 +5673,8 @@ void emberAfKeepaliveClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfKeepaliveClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfKeepaliveClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Keep-Alive Cluster Client Message Sent
  *
@@ -5637,7 +5701,7 @@ void emberAfKeepaliveClusterClientMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfKeepaliveClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfKeepaliveClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Keep-Alive Cluster Client Tick
@@ -5646,7 +5710,7 @@ EmberAfStatus emberAfKeepaliveClusterClientPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfKeepaliveClusterClientTickCallback(uint8_t endpoint);
+void emberAfKeepaliveClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Keep-Alive Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -5654,7 +5718,7 @@ void emberAfKeepaliveClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfKeepaliveClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfKeepaliveClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Keep-Alive Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -5664,14 +5728,15 @@ void emberAfKeepaliveClusterServerAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfKeepaliveClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfKeepaliveClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Keep-Alive Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfKeepaliveClusterServerInitCallback(uint8_t endpoint);
+void emberAfKeepaliveClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Keep-Alive Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -5681,7 +5746,8 @@ void emberAfKeepaliveClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfKeepaliveClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfKeepaliveClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Keep-Alive Cluster Server Message Sent
  *
@@ -5708,7 +5774,7 @@ void emberAfKeepaliveClusterServerMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfKeepaliveClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfKeepaliveClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Keep-Alive Cluster Server Tick
@@ -5717,7 +5783,7 @@ EmberAfStatus emberAfKeepaliveClusterServerPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfKeepaliveClusterServerTickCallback(uint8_t endpoint);
+void emberAfKeepaliveClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Keep-Alive Cluster Callbacks */
 
@@ -5731,7 +5797,7 @@ void emberAfKeepaliveClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfShadeConfigClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfShadeConfigClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Shade Configuration Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -5741,14 +5807,15 @@ void emberAfShadeConfigClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfShadeConfigClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfShadeConfigClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Shade Configuration Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfShadeConfigClusterClientInitCallback(uint8_t endpoint);
+void emberAfShadeConfigClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Shade Configuration Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -5758,7 +5825,8 @@ void emberAfShadeConfigClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfShadeConfigClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfShadeConfigClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Shade Configuration Cluster Client Message Sent
  *
@@ -5785,7 +5853,7 @@ void emberAfShadeConfigClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfShadeConfigClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfShadeConfigClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Shade Configuration Cluster Client Tick
@@ -5794,7 +5862,7 @@ EmberAfStatus emberAfShadeConfigClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfShadeConfigClusterClientTickCallback(uint8_t endpoint);
+void emberAfShadeConfigClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Shade Configuration Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -5802,7 +5870,7 @@ void emberAfShadeConfigClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfShadeConfigClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfShadeConfigClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Shade Configuration Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -5812,14 +5880,15 @@ void emberAfShadeConfigClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfShadeConfigClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfShadeConfigClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Shade Configuration Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfShadeConfigClusterServerInitCallback(uint8_t endpoint);
+void emberAfShadeConfigClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Shade Configuration Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -5829,7 +5898,8 @@ void emberAfShadeConfigClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfShadeConfigClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfShadeConfigClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Shade Configuration Cluster Server Message Sent
  *
@@ -5856,7 +5926,7 @@ void emberAfShadeConfigClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfShadeConfigClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfShadeConfigClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Shade Configuration Cluster Server Tick
@@ -5865,7 +5935,7 @@ EmberAfStatus emberAfShadeConfigClusterServerPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfShadeConfigClusterServerTickCallback(uint8_t endpoint);
+void emberAfShadeConfigClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Shade Configuration Cluster Callbacks */
 
@@ -5977,7 +6047,7 @@ bool emberAfDoorLockClusterClearYeardayScheduleResponseCallback(uint8_t status);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDoorLockClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDoorLockClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Door Lock Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -5987,14 +6057,15 @@ void emberAfDoorLockClusterClientAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDoorLockClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDoorLockClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Door Lock Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDoorLockClusterClientInitCallback(uint8_t endpoint);
+void emberAfDoorLockClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Door Lock Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -6004,7 +6075,8 @@ void emberAfDoorLockClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDoorLockClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDoorLockClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Door Lock Cluster Client Message Sent
  *
@@ -6031,7 +6103,7 @@ void emberAfDoorLockClusterClientMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDoorLockClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDoorLockClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Door Lock Cluster Client Tick
@@ -6040,7 +6112,7 @@ EmberAfStatus emberAfDoorLockClusterClientPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDoorLockClusterClientTickCallback(uint8_t endpoint);
+void emberAfDoorLockClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Door Lock Cluster Get Holiday Schedule
  *
  *
@@ -6239,7 +6311,7 @@ bool emberAfDoorLockClusterProgrammingEventNotificationCallback(uint8_t source, 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDoorLockClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDoorLockClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Door Lock Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -6249,14 +6321,15 @@ void emberAfDoorLockClusterServerAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDoorLockClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDoorLockClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Door Lock Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDoorLockClusterServerInitCallback(uint8_t endpoint);
+void emberAfDoorLockClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Door Lock Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -6266,7 +6339,8 @@ void emberAfDoorLockClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDoorLockClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDoorLockClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Door Lock Cluster Server Message Sent
  *
@@ -6293,7 +6367,7 @@ void emberAfDoorLockClusterServerMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDoorLockClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDoorLockClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Door Lock Cluster Server Tick
@@ -6302,7 +6376,7 @@ EmberAfStatus emberAfDoorLockClusterServerPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDoorLockClusterServerTickCallback(uint8_t endpoint);
+void emberAfDoorLockClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Door Lock Cluster Set Holiday Schedule
  *
  *
@@ -6480,7 +6554,7 @@ bool emberAfDoorLockClusterUnlockWithTimeoutResponseCallback(uint8_t status);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfWindowCoveringClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfWindowCoveringClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Window Covering Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -6490,14 +6564,15 @@ void emberAfWindowCoveringClusterClientAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfWindowCoveringClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfWindowCoveringClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Window Covering Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfWindowCoveringClusterClientInitCallback(uint8_t endpoint);
+void emberAfWindowCoveringClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Window Covering Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -6507,8 +6582,8 @@ void emberAfWindowCoveringClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfWindowCoveringClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfWindowCoveringClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Window Covering Cluster Client Message Sent
  *
@@ -6535,7 +6610,8 @@ void emberAfWindowCoveringClusterClientMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfWindowCoveringClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfWindowCoveringClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Window Covering Cluster Client Tick
@@ -6544,7 +6620,7 @@ EmberAfStatus emberAfWindowCoveringClusterClientPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfWindowCoveringClusterClientTickCallback(uint8_t endpoint);
+void emberAfWindowCoveringClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Window Covering Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -6552,7 +6628,7 @@ void emberAfWindowCoveringClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfWindowCoveringClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfWindowCoveringClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Window Covering Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -6562,14 +6638,15 @@ void emberAfWindowCoveringClusterServerAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfWindowCoveringClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfWindowCoveringClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Window Covering Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfWindowCoveringClusterServerInitCallback(uint8_t endpoint);
+void emberAfWindowCoveringClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Window Covering Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -6579,8 +6656,8 @@ void emberAfWindowCoveringClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfWindowCoveringClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfWindowCoveringClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Window Covering Cluster Server Message Sent
  *
@@ -6607,7 +6684,8 @@ void emberAfWindowCoveringClusterServerMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfWindowCoveringClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfWindowCoveringClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Window Covering Cluster Server Tick
@@ -6616,7 +6694,7 @@ EmberAfStatus emberAfWindowCoveringClusterServerPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfWindowCoveringClusterServerTickCallback(uint8_t endpoint);
+void emberAfWindowCoveringClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Window Covering Cluster Window Covering Down Close
  *
  *
@@ -6689,7 +6767,7 @@ bool emberAfBarrierControlClusterBarrierControlStopCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBarrierControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBarrierControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Barrier Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -6699,14 +6777,15 @@ void emberAfBarrierControlClusterClientAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBarrierControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBarrierControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Barrier Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBarrierControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfBarrierControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Barrier Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -6716,8 +6795,8 @@ void emberAfBarrierControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBarrierControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfBarrierControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Barrier Control Cluster Client Message Sent
  *
@@ -6744,7 +6823,8 @@ void emberAfBarrierControlClusterClientMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBarrierControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBarrierControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Barrier Control Cluster Client Tick
@@ -6753,7 +6833,7 @@ EmberAfStatus emberAfBarrierControlClusterClientPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBarrierControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfBarrierControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Barrier Control Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -6761,7 +6841,7 @@ void emberAfBarrierControlClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBarrierControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBarrierControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Barrier Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -6771,14 +6851,15 @@ void emberAfBarrierControlClusterServerAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBarrierControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBarrierControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Barrier Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBarrierControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfBarrierControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Barrier Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -6788,8 +6869,8 @@ void emberAfBarrierControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBarrierControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfBarrierControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Barrier Control Cluster Server Message Sent
  *
@@ -6816,7 +6897,8 @@ void emberAfBarrierControlClusterServerMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBarrierControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBarrierControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Barrier Control Cluster Server Tick
@@ -6825,7 +6907,7 @@ EmberAfStatus emberAfBarrierControlClusterServerPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBarrierControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfBarrierControlClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Barrier Control Cluster Callbacks */
 
@@ -6839,7 +6921,7 @@ void emberAfBarrierControlClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPumpConfigControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPumpConfigControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Pump Configuration and Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -6849,14 +6931,15 @@ void emberAfPumpConfigControlClusterClientAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPumpConfigControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPumpConfigControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief Pump Configuration and Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPumpConfigControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfPumpConfigControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Pump Configuration and Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -6867,7 +6950,7 @@ void emberAfPumpConfigControlClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfPumpConfigControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief Pump Configuration and Control Cluster Client Message Sent
  *
@@ -6894,7 +6977,8 @@ void emberAfPumpConfigControlClusterClientMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPumpConfigControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPumpConfigControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief Pump Configuration and Control Cluster Client Tick
@@ -6903,7 +6987,7 @@ EmberAfStatus emberAfPumpConfigControlClusterClientPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPumpConfigControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfPumpConfigControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Pump Configuration and Control Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -6911,7 +6995,7 @@ void emberAfPumpConfigControlClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPumpConfigControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPumpConfigControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Pump Configuration and Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -6921,14 +7005,15 @@ void emberAfPumpConfigControlClusterServerAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPumpConfigControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPumpConfigControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief Pump Configuration and Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPumpConfigControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfPumpConfigControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Pump Configuration and Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -6939,7 +7024,7 @@ void emberAfPumpConfigControlClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfPumpConfigControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief Pump Configuration and Control Cluster Server Message Sent
  *
@@ -6966,7 +7051,8 @@ void emberAfPumpConfigControlClusterServerMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPumpConfigControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPumpConfigControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief Pump Configuration and Control Cluster Server Tick
@@ -6975,7 +7061,7 @@ EmberAfStatus emberAfPumpConfigControlClusterServerPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPumpConfigControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfPumpConfigControlClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Pump Configuration and Control Cluster Callbacks */
 
@@ -6995,7 +7081,7 @@ bool emberAfThermostatClusterClearWeeklyScheduleCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfThermostatClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfThermostatClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Thermostat Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -7005,14 +7091,15 @@ void emberAfThermostatClusterClientAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfThermostatClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfThermostatClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Thermostat Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfThermostatClusterClientInitCallback(uint8_t endpoint);
+void emberAfThermostatClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Thermostat Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -7022,7 +7109,8 @@ void emberAfThermostatClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfThermostatClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfThermostatClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Thermostat Cluster Client Message Sent
  *
@@ -7049,7 +7137,7 @@ void emberAfThermostatClusterClientMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfThermostatClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfThermostatClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Thermostat Cluster Client Tick
@@ -7058,7 +7146,7 @@ EmberAfStatus emberAfThermostatClusterClientPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfThermostatClusterClientTickCallback(uint8_t endpoint);
+void emberAfThermostatClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Thermostat Cluster Current Weekly Schedule
  *
  *
@@ -7104,7 +7192,7 @@ bool emberAfThermostatClusterRelayStatusLogCallback(uint16_t timeOfDay, uint16_t
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfThermostatClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfThermostatClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Thermostat Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -7114,14 +7202,15 @@ void emberAfThermostatClusterServerAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfThermostatClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfThermostatClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Thermostat Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfThermostatClusterServerInitCallback(uint8_t endpoint);
+void emberAfThermostatClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Thermostat Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -7131,7 +7220,8 @@ void emberAfThermostatClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfThermostatClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfThermostatClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Thermostat Cluster Server Message Sent
  *
@@ -7158,7 +7248,7 @@ void emberAfThermostatClusterServerMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Thermostat Cluster Server Tick
@@ -7167,7 +7257,7 @@ EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfThermostatClusterServerTickCallback(uint8_t endpoint);
+void emberAfThermostatClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Thermostat Cluster Set Weekly Schedule
  *
  *
@@ -7200,7 +7290,7 @@ bool emberAfThermostatClusterSetpointRaiseLowerCallback(uint8_t mode, int8_t amo
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfFanControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfFanControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Fan Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -7210,14 +7300,15 @@ void emberAfFanControlClusterClientAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFanControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfFanControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Fan Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFanControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfFanControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Fan Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -7227,7 +7318,8 @@ void emberAfFanControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfFanControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfFanControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Fan Control Cluster Client Message Sent
  *
@@ -7254,7 +7346,7 @@ void emberAfFanControlClusterClientMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfFanControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfFanControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Fan Control Cluster Client Tick
@@ -7263,7 +7355,7 @@ EmberAfStatus emberAfFanControlClusterClientPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFanControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfFanControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Fan Control Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -7271,7 +7363,7 @@ void emberAfFanControlClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfFanControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfFanControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Fan Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -7281,14 +7373,15 @@ void emberAfFanControlClusterServerAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFanControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfFanControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Fan Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFanControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfFanControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Fan Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -7298,7 +7391,8 @@ void emberAfFanControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfFanControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfFanControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Fan Control Cluster Server Message Sent
  *
@@ -7325,7 +7419,7 @@ void emberAfFanControlClusterServerMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfFanControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfFanControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Fan Control Cluster Server Tick
@@ -7334,7 +7428,7 @@ EmberAfStatus emberAfFanControlClusterServerPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFanControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfFanControlClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Fan Control Cluster Callbacks */
 
@@ -7348,7 +7442,7 @@ void emberAfFanControlClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDehumidControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDehumidControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Dehumidification Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -7358,14 +7452,15 @@ void emberAfDehumidControlClusterClientAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDehumidControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDehumidControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Dehumidification Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDehumidControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfDehumidControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Dehumidification Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -7375,8 +7470,8 @@ void emberAfDehumidControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDehumidControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfDehumidControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Dehumidification Control Cluster Client Message Sent
  *
@@ -7403,7 +7498,8 @@ void emberAfDehumidControlClusterClientMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDehumidControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDehumidControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Dehumidification Control Cluster Client Tick
@@ -7412,7 +7508,7 @@ EmberAfStatus emberAfDehumidControlClusterClientPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDehumidControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfDehumidControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Dehumidification Control Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -7420,7 +7516,7 @@ void emberAfDehumidControlClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDehumidControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDehumidControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Dehumidification Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -7430,14 +7526,15 @@ void emberAfDehumidControlClusterServerAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDehumidControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDehumidControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Dehumidification Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDehumidControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfDehumidControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Dehumidification Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -7447,8 +7544,8 @@ void emberAfDehumidControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDehumidControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfDehumidControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Dehumidification Control Cluster Server Message Sent
  *
@@ -7475,7 +7572,8 @@ void emberAfDehumidControlClusterServerMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDehumidControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDehumidControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Dehumidification Control Cluster Server Tick
@@ -7484,7 +7582,7 @@ EmberAfStatus emberAfDehumidControlClusterServerPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDehumidControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfDehumidControlClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Dehumidification Control Cluster Callbacks */
 
@@ -7498,7 +7596,7 @@ void emberAfDehumidControlClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfThermostatUiConfigClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfThermostatUiConfigClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Thermostat User Interface Configuration Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -7508,14 +7606,15 @@ void emberAfThermostatUiConfigClusterClientAttributeChangedCallback(uint8_t endp
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfThermostatUiConfigClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfThermostatUiConfigClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                   EmberAfStatus status);
 /** @brief Thermostat User Interface Configuration Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfThermostatUiConfigClusterClientInitCallback(uint8_t endpoint);
+void emberAfThermostatUiConfigClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Thermostat User Interface Configuration Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -7526,7 +7625,7 @@ void emberAfThermostatUiConfigClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfThermostatUiConfigClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                        EmberAfAttributeId attributeId,
+                                                                                        chip::AttributeId attributeId,
                                                                                         uint16_t manufacturerCode);
 /** @brief Thermostat User Interface Configuration Cluster Client Message Sent
  *
@@ -7553,7 +7652,8 @@ void emberAfThermostatUiConfigClusterClientMessageSentCallback(EmberOutgoingMess
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfThermostatUiConfigClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfThermostatUiConfigClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 EmberAfAttributeType attributeType, uint8_t size,
                                                                                 uint8_t * value);
 /** @brief Thermostat User Interface Configuration Cluster Client Tick
@@ -7562,7 +7662,7 @@ EmberAfStatus emberAfThermostatUiConfigClusterClientPreAttributeChangedCallback(
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfThermostatUiConfigClusterClientTickCallback(uint8_t endpoint);
+void emberAfThermostatUiConfigClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Thermostat User Interface Configuration Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -7570,7 +7670,7 @@ void emberAfThermostatUiConfigClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfThermostatUiConfigClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfThermostatUiConfigClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Thermostat User Interface Configuration Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -7580,14 +7680,15 @@ void emberAfThermostatUiConfigClusterServerAttributeChangedCallback(uint8_t endp
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfThermostatUiConfigClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfThermostatUiConfigClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                   EmberAfStatus status);
 /** @brief Thermostat User Interface Configuration Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfThermostatUiConfigClusterServerInitCallback(uint8_t endpoint);
+void emberAfThermostatUiConfigClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Thermostat User Interface Configuration Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -7598,7 +7699,7 @@ void emberAfThermostatUiConfigClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfThermostatUiConfigClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                        EmberAfAttributeId attributeId,
+                                                                                        chip::AttributeId attributeId,
                                                                                         uint16_t manufacturerCode);
 /** @brief Thermostat User Interface Configuration Cluster Server Message Sent
  *
@@ -7625,7 +7726,8 @@ void emberAfThermostatUiConfigClusterServerMessageSentCallback(EmberOutgoingMess
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfThermostatUiConfigClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfThermostatUiConfigClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 EmberAfAttributeType attributeType, uint8_t size,
                                                                                 uint8_t * value);
 /** @brief Thermostat User Interface Configuration Cluster Server Tick
@@ -7634,7 +7736,7 @@ EmberAfStatus emberAfThermostatUiConfigClusterServerPreAttributeChangedCallback(
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfThermostatUiConfigClusterServerTickCallback(uint8_t endpoint);
+void emberAfThermostatUiConfigClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Thermostat User Interface Configuration Cluster Callbacks */
 
@@ -7648,7 +7750,7 @@ void emberAfThermostatUiConfigClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfColorControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfColorControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Color Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -7658,14 +7760,15 @@ void emberAfColorControlClusterClientAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfColorControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfColorControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief Color Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfColorControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfColorControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Color Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -7675,7 +7778,8 @@ void emberAfColorControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfColorControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfColorControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief Color Control Cluster Client Message Sent
  *
@@ -7702,7 +7806,7 @@ void emberAfColorControlClusterClientMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfColorControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfColorControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief Color Control Cluster Client Tick
@@ -7711,7 +7815,7 @@ EmberAfStatus emberAfColorControlClusterClientPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfColorControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfColorControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Color Control Cluster Color Loop Set
  *
  *
@@ -7869,7 +7973,7 @@ bool emberAfColorControlClusterMoveToSaturationCallback(uint8_t saturation, uint
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfColorControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfColorControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Color Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -7879,14 +7983,15 @@ void emberAfColorControlClusterServerAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfColorControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfColorControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief Color Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfColorControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfColorControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Color Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -7896,7 +8001,8 @@ void emberAfColorControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfColorControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfColorControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief Color Control Cluster Server Message Sent
  *
@@ -7923,7 +8029,7 @@ void emberAfColorControlClusterServerMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfColorControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfColorControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief Color Control Cluster Server Tick
@@ -7932,7 +8038,7 @@ EmberAfStatus emberAfColorControlClusterServerPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfColorControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfColorControlClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Color Control Cluster Step Color
  *
  *
@@ -8005,7 +8111,7 @@ bool emberAfColorControlClusterStopMoveStepCallback(uint8_t optionsMask, uint8_t
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBallastConfigurationClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBallastConfigurationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Ballast Configuration Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8015,14 +8121,15 @@ void emberAfBallastConfigurationClusterClientAttributeChangedCallback(uint8_t en
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBallastConfigurationClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBallastConfigurationClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                     EmberAfStatus status);
 /** @brief Ballast Configuration Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBallastConfigurationClusterClientInitCallback(uint8_t endpoint);
+void emberAfBallastConfigurationClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Ballast Configuration Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8033,7 +8140,7 @@ void emberAfBallastConfigurationClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfBallastConfigurationClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId,
+                                                                                          chip::AttributeId attributeId,
                                                                                           uint16_t manufacturerCode);
 /** @brief Ballast Configuration Cluster Client Message Sent
  *
@@ -8060,7 +8167,8 @@ void emberAfBallastConfigurationClusterClientMessageSentCallback(EmberOutgoingMe
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBallastConfigurationClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBallastConfigurationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   EmberAfAttributeType attributeType, uint8_t size,
                                                                                   uint8_t * value);
 /** @brief Ballast Configuration Cluster Client Tick
@@ -8069,7 +8177,7 @@ EmberAfStatus emberAfBallastConfigurationClusterClientPreAttributeChangedCallbac
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBallastConfigurationClusterClientTickCallback(uint8_t endpoint);
+void emberAfBallastConfigurationClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Ballast Configuration Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8077,7 +8185,7 @@ void emberAfBallastConfigurationClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBallastConfigurationClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBallastConfigurationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Ballast Configuration Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8087,14 +8195,15 @@ void emberAfBallastConfigurationClusterServerAttributeChangedCallback(uint8_t en
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBallastConfigurationClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBallastConfigurationClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                     EmberAfStatus status);
 /** @brief Ballast Configuration Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBallastConfigurationClusterServerInitCallback(uint8_t endpoint);
+void emberAfBallastConfigurationClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Ballast Configuration Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -8105,7 +8214,7 @@ void emberAfBallastConfigurationClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfBallastConfigurationClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId,
+                                                                                          chip::AttributeId attributeId,
                                                                                           uint16_t manufacturerCode);
 /** @brief Ballast Configuration Cluster Server Message Sent
  *
@@ -8132,7 +8241,8 @@ void emberAfBallastConfigurationClusterServerMessageSentCallback(EmberOutgoingMe
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBallastConfigurationClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBallastConfigurationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   EmberAfAttributeType attributeType, uint8_t size,
                                                                                   uint8_t * value);
 /** @brief Ballast Configuration Cluster Server Tick
@@ -8141,7 +8251,7 @@ EmberAfStatus emberAfBallastConfigurationClusterServerPreAttributeChangedCallbac
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBallastConfigurationClusterServerTickCallback(uint8_t endpoint);
+void emberAfBallastConfigurationClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Ballast Configuration Cluster Callbacks */
 
@@ -8155,7 +8265,7 @@ void emberAfBallastConfigurationClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIllumMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIllumMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Illuminance Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8165,14 +8275,15 @@ void emberAfIllumMeasurementClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIllumMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIllumMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Illuminance Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIllumMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfIllumMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Illuminance Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8182,8 +8293,8 @@ void emberAfIllumMeasurementClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIllumMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfIllumMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Illuminance Measurement Cluster Client Message Sent
  *
@@ -8210,7 +8321,8 @@ void emberAfIllumMeasurementClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIllumMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIllumMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Illuminance Measurement Cluster Client Tick
@@ -8219,7 +8331,7 @@ EmberAfStatus emberAfIllumMeasurementClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIllumMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfIllumMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Illuminance Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8227,7 +8339,7 @@ void emberAfIllumMeasurementClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIllumMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIllumMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Illuminance Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8237,14 +8349,15 @@ void emberAfIllumMeasurementClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIllumMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIllumMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Illuminance Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIllumMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfIllumMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Illuminance Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -8254,8 +8367,8 @@ void emberAfIllumMeasurementClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIllumMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfIllumMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Illuminance Measurement Cluster Server Message Sent
  *
@@ -8282,7 +8395,8 @@ void emberAfIllumMeasurementClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIllumMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIllumMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Illuminance Measurement Cluster Server Tick
@@ -8291,7 +8405,7 @@ EmberAfStatus emberAfIllumMeasurementClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIllumMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfIllumMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Illuminance Measurement Cluster Callbacks */
 
@@ -8305,7 +8419,7 @@ void emberAfIllumMeasurementClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIllumLevelSensingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIllumLevelSensingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Illuminance Level Sensing Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8315,14 +8429,15 @@ void emberAfIllumLevelSensingClusterClientAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIllumLevelSensingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIllumLevelSensingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief Illuminance Level Sensing Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIllumLevelSensingClusterClientInitCallback(uint8_t endpoint);
+void emberAfIllumLevelSensingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Illuminance Level Sensing Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8333,7 +8448,7 @@ void emberAfIllumLevelSensingClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfIllumLevelSensingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief Illuminance Level Sensing Cluster Client Message Sent
  *
@@ -8360,7 +8475,8 @@ void emberAfIllumLevelSensingClusterClientMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIllumLevelSensingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIllumLevelSensingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief Illuminance Level Sensing Cluster Client Tick
@@ -8369,7 +8485,7 @@ EmberAfStatus emberAfIllumLevelSensingClusterClientPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIllumLevelSensingClusterClientTickCallback(uint8_t endpoint);
+void emberAfIllumLevelSensingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Illuminance Level Sensing Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8377,7 +8493,7 @@ void emberAfIllumLevelSensingClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIllumLevelSensingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIllumLevelSensingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Illuminance Level Sensing Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8387,14 +8503,15 @@ void emberAfIllumLevelSensingClusterServerAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIllumLevelSensingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIllumLevelSensingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief Illuminance Level Sensing Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIllumLevelSensingClusterServerInitCallback(uint8_t endpoint);
+void emberAfIllumLevelSensingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Illuminance Level Sensing Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -8405,7 +8522,7 @@ void emberAfIllumLevelSensingClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfIllumLevelSensingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief Illuminance Level Sensing Cluster Server Message Sent
  *
@@ -8432,7 +8549,8 @@ void emberAfIllumLevelSensingClusterServerMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIllumLevelSensingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIllumLevelSensingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief Illuminance Level Sensing Cluster Server Tick
@@ -8441,7 +8559,7 @@ EmberAfStatus emberAfIllumLevelSensingClusterServerPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIllumLevelSensingClusterServerTickCallback(uint8_t endpoint);
+void emberAfIllumLevelSensingClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Illuminance Level Sensing Cluster Callbacks */
 
@@ -8455,7 +8573,7 @@ void emberAfIllumLevelSensingClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTempMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfTempMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Temperature Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8465,14 +8583,15 @@ void emberAfTempMeasurementClusterClientAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTempMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfTempMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Temperature Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTempMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfTempMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Temperature Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8482,8 +8601,8 @@ void emberAfTempMeasurementClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfTempMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfTempMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Temperature Measurement Cluster Client Message Sent
  *
@@ -8510,7 +8629,8 @@ void emberAfTempMeasurementClusterClientMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfTempMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfTempMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Temperature Measurement Cluster Client Tick
@@ -8519,7 +8639,7 @@ EmberAfStatus emberAfTempMeasurementClusterClientPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTempMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfTempMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Temperature Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8527,7 +8647,7 @@ void emberAfTempMeasurementClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTempMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfTempMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Temperature Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8537,14 +8657,15 @@ void emberAfTempMeasurementClusterServerAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTempMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfTempMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Temperature Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTempMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfTempMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Temperature Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -8554,8 +8675,8 @@ void emberAfTempMeasurementClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfTempMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfTempMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Temperature Measurement Cluster Server Message Sent
  *
@@ -8582,7 +8703,8 @@ void emberAfTempMeasurementClusterServerMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfTempMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfTempMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Temperature Measurement Cluster Server Tick
@@ -8591,7 +8713,7 @@ EmberAfStatus emberAfTempMeasurementClusterServerPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTempMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfTempMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Temperature Measurement Cluster Callbacks */
 
@@ -8605,7 +8727,7 @@ void emberAfTempMeasurementClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPressureMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPressureMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Pressure Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8615,14 +8737,15 @@ void emberAfPressureMeasurementClusterClientAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPressureMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPressureMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief Pressure Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPressureMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfPressureMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Pressure Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8633,7 +8756,7 @@ void emberAfPressureMeasurementClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfPressureMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief Pressure Measurement Cluster Client Message Sent
  *
@@ -8660,7 +8783,8 @@ void emberAfPressureMeasurementClusterClientMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPressureMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPressureMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief Pressure Measurement Cluster Client Tick
@@ -8669,7 +8793,7 @@ EmberAfStatus emberAfPressureMeasurementClusterClientPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPressureMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfPressureMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Pressure Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8677,7 +8801,7 @@ void emberAfPressureMeasurementClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPressureMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPressureMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Pressure Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8687,14 +8811,15 @@ void emberAfPressureMeasurementClusterServerAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPressureMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPressureMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief Pressure Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPressureMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfPressureMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Pressure Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -8705,7 +8830,7 @@ void emberAfPressureMeasurementClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfPressureMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief Pressure Measurement Cluster Server Message Sent
  *
@@ -8732,7 +8857,8 @@ void emberAfPressureMeasurementClusterServerMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPressureMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPressureMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief Pressure Measurement Cluster Server Tick
@@ -8741,7 +8867,7 @@ EmberAfStatus emberAfPressureMeasurementClusterServerPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPressureMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfPressureMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Pressure Measurement Cluster Callbacks */
 
@@ -8755,7 +8881,7 @@ void emberAfPressureMeasurementClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfFlowMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfFlowMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Flow Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8765,14 +8891,15 @@ void emberAfFlowMeasurementClusterClientAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFlowMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfFlowMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Flow Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFlowMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfFlowMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Flow Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8782,8 +8909,8 @@ void emberAfFlowMeasurementClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfFlowMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfFlowMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Flow Measurement Cluster Client Message Sent
  *
@@ -8810,7 +8937,8 @@ void emberAfFlowMeasurementClusterClientMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfFlowMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfFlowMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Flow Measurement Cluster Client Tick
@@ -8819,7 +8947,7 @@ EmberAfStatus emberAfFlowMeasurementClusterClientPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFlowMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfFlowMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Flow Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8827,7 +8955,7 @@ void emberAfFlowMeasurementClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfFlowMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfFlowMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Flow Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8837,14 +8965,15 @@ void emberAfFlowMeasurementClusterServerAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFlowMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfFlowMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Flow Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFlowMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfFlowMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Flow Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -8854,8 +8983,8 @@ void emberAfFlowMeasurementClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfFlowMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfFlowMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Flow Measurement Cluster Server Message Sent
  *
@@ -8882,7 +9011,8 @@ void emberAfFlowMeasurementClusterServerMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfFlowMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfFlowMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Flow Measurement Cluster Server Tick
@@ -8891,7 +9021,7 @@ EmberAfStatus emberAfFlowMeasurementClusterServerPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFlowMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfFlowMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Flow Measurement Cluster Callbacks */
 
@@ -8905,7 +9035,8 @@ void emberAfFlowMeasurementClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfRelativeHumidityMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId);
 /** @brief Relative Humidity Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8915,7 +9046,7 @@ void emberAfRelativeHumidityMeasurementClusterClientAttributeChangedCallback(uin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfRelativeHumidityMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                             EmberAfStatus status);
 /** @brief Relative Humidity Measurement Cluster Client Init
  *
@@ -8923,7 +9054,7 @@ void emberAfRelativeHumidityMeasurementClusterClientDefaultResponseCallback(uint
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfRelativeHumidityMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Relative Humidity Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8934,7 +9065,7 @@ void emberAfRelativeHumidityMeasurementClusterClientInitCallback(uint8_t endpoin
  * Ver.: always
  */
 void emberAfRelativeHumidityMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                 EmberAfAttributeId attributeId,
+                                                                                                 chip::AttributeId attributeId,
                                                                                                  uint16_t manufacturerCode);
 /** @brief Relative Humidity Measurement Cluster Client Message Sent
  *
@@ -8962,7 +9093,7 @@ void emberAfRelativeHumidityMeasurementClusterClientMessageSentCallback(EmberOut
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfRelativeHumidityMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          EmberAfAttributeType attributeType,
                                                                                          uint8_t size, uint8_t * value);
 /** @brief Relative Humidity Measurement Cluster Client Tick
@@ -8971,7 +9102,7 @@ EmberAfStatus emberAfRelativeHumidityMeasurementClusterClientPreAttributeChanged
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfRelativeHumidityMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Relative Humidity Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8979,7 +9110,8 @@ void emberAfRelativeHumidityMeasurementClusterClientTickCallback(uint8_t endpoin
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfRelativeHumidityMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId);
 /** @brief Relative Humidity Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8989,7 +9121,7 @@ void emberAfRelativeHumidityMeasurementClusterServerAttributeChangedCallback(uin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfRelativeHumidityMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                             EmberAfStatus status);
 /** @brief Relative Humidity Measurement Cluster Server Init
  *
@@ -8997,7 +9129,7 @@ void emberAfRelativeHumidityMeasurementClusterServerDefaultResponseCallback(uint
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfRelativeHumidityMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Relative Humidity Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9008,7 +9140,7 @@ void emberAfRelativeHumidityMeasurementClusterServerInitCallback(uint8_t endpoin
  * Ver.: always
  */
 void emberAfRelativeHumidityMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                 EmberAfAttributeId attributeId,
+                                                                                                 chip::AttributeId attributeId,
                                                                                                  uint16_t manufacturerCode);
 /** @brief Relative Humidity Measurement Cluster Server Message Sent
  *
@@ -9036,7 +9168,7 @@ void emberAfRelativeHumidityMeasurementClusterServerMessageSentCallback(EmberOut
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfRelativeHumidityMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          EmberAfAttributeType attributeType,
                                                                                          uint8_t size, uint8_t * value);
 /** @brief Relative Humidity Measurement Cluster Server Tick
@@ -9045,7 +9177,7 @@ EmberAfStatus emberAfRelativeHumidityMeasurementClusterServerPreAttributeChanged
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfRelativeHumidityMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Relative Humidity Measurement Cluster Callbacks */
 
@@ -9059,7 +9191,7 @@ void emberAfRelativeHumidityMeasurementClusterServerTickCallback(uint8_t endpoin
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOccupancySensingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOccupancySensingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Occupancy Sensing Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9069,14 +9201,15 @@ void emberAfOccupancySensingClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOccupancySensingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOccupancySensingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Occupancy Sensing Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOccupancySensingClusterClientInitCallback(uint8_t endpoint);
+void emberAfOccupancySensingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Occupancy Sensing Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -9086,8 +9219,8 @@ void emberAfOccupancySensingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOccupancySensingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfOccupancySensingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Occupancy Sensing Cluster Client Message Sent
  *
@@ -9114,7 +9247,8 @@ void emberAfOccupancySensingClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOccupancySensingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOccupancySensingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Occupancy Sensing Cluster Client Tick
@@ -9123,7 +9257,7 @@ EmberAfStatus emberAfOccupancySensingClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOccupancySensingClusterClientTickCallback(uint8_t endpoint);
+void emberAfOccupancySensingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Occupancy Sensing Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -9131,7 +9265,7 @@ void emberAfOccupancySensingClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOccupancySensingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOccupancySensingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Occupancy Sensing Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -9141,14 +9275,15 @@ void emberAfOccupancySensingClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOccupancySensingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOccupancySensingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Occupancy Sensing Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOccupancySensingClusterServerInitCallback(uint8_t endpoint);
+void emberAfOccupancySensingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Occupancy Sensing Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9158,8 +9293,8 @@ void emberAfOccupancySensingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOccupancySensingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfOccupancySensingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Occupancy Sensing Cluster Server Message Sent
  *
@@ -9186,7 +9321,8 @@ void emberAfOccupancySensingClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOccupancySensingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOccupancySensingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Occupancy Sensing Cluster Server Tick
@@ -9195,7 +9331,7 @@ EmberAfStatus emberAfOccupancySensingClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOccupancySensingClusterServerTickCallback(uint8_t endpoint);
+void emberAfOccupancySensingClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Occupancy Sensing Cluster Callbacks */
 
@@ -9210,7 +9346,7 @@ void emberAfOccupancySensingClusterServerTickCallback(uint8_t endpoint);
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfCarbonMonoxideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                        EmberAfAttributeId attributeId);
+                                                                                        chip::AttributeId attributeId);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9220,7 +9356,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterClientAttributeChangedC
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfCarbonMonoxideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                        EmberAfStatus status);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Client Init
  *
@@ -9228,7 +9364,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterClientDefaultResponseCa
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfCarbonMonoxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -9239,7 +9375,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterClientInitCallback(uint
  * Ver.: always
  */
 void emberAfCarbonMonoxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -9267,14 +9403,14 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterClientMessageSentCallba
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfCarbonMonoxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfCarbonMonoxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -9283,7 +9419,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterClientTickCallback(uint
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfCarbonMonoxideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                        EmberAfAttributeId attributeId);
+                                                                                        chip::AttributeId attributeId);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -9293,7 +9429,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterServerAttributeChangedC
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfCarbonMonoxideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                        EmberAfStatus status);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Init
  *
@@ -9301,7 +9437,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterServerDefaultResponseCa
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfCarbonMonoxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9312,7 +9448,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterServerInitCallback(uint
  * Ver.: always
  */
 void emberAfCarbonMonoxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -9340,14 +9476,14 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterServerMessageSentCallba
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfCarbonMonoxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfCarbonMonoxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Carbon Monoxide Concentration Measurement Cluster Callbacks */
 
@@ -9362,7 +9498,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterServerTickCallback(uint
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfCarbonDioxideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId);
+                                                                                       chip::AttributeId attributeId);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9372,7 +9508,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterClientAttributeChangedCa
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfCarbonDioxideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                       EmberAfStatus status);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Client Init
  *
@@ -9380,7 +9516,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterClientDefaultResponseCal
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfCarbonDioxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -9391,7 +9527,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterClientInitCallback(uint8
  * Ver.: always
  */
 void emberAfCarbonDioxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -9419,14 +9555,14 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterClientMessageSentCallbac
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfCarbonDioxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfCarbonDioxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -9435,7 +9571,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterClientTickCallback(uint8
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfCarbonDioxideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId);
+                                                                                       chip::AttributeId attributeId);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -9445,7 +9581,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterServerAttributeChangedCa
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfCarbonDioxideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                       EmberAfStatus status);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Init
  *
@@ -9453,7 +9589,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterServerDefaultResponseCal
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfCarbonDioxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9464,7 +9600,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterServerInitCallback(uint8
  * Ver.: always
  */
 void emberAfCarbonDioxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -9492,14 +9628,14 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterServerMessageSentCallbac
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfCarbonDioxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfCarbonDioxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Carbon Dioxide Concentration Measurement Cluster Callbacks */
 
@@ -9513,7 +9649,8 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterServerTickCallback(uint8
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfEthyleneConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Ethylene Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9523,7 +9660,7 @@ void emberAfEthyleneConcentrationMeasurementClusterClientAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfEthyleneConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Ethylene Concentration Measurement Cluster Client Init
  *
@@ -9531,7 +9668,7 @@ void emberAfEthyleneConcentrationMeasurementClusterClientDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfEthyleneConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Ethylene Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -9541,8 +9678,9 @@ void emberAfEthyleneConcentrationMeasurementClusterClientInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfEthyleneConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Ethylene Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -9570,7 +9708,7 @@ void emberAfEthyleneConcentrationMeasurementClusterClientMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfEthyleneConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Ethylene Concentration Measurement Cluster Client Tick
@@ -9579,7 +9717,7 @@ EmberAfStatus emberAfEthyleneConcentrationMeasurementClusterClientPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfEthyleneConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Ethylene Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -9587,7 +9725,8 @@ void emberAfEthyleneConcentrationMeasurementClusterClientTickCallback(uint8_t en
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfEthyleneConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Ethylene Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -9597,7 +9736,7 @@ void emberAfEthyleneConcentrationMeasurementClusterServerAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfEthyleneConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Ethylene Concentration Measurement Cluster Server Init
  *
@@ -9605,7 +9744,7 @@ void emberAfEthyleneConcentrationMeasurementClusterServerDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfEthyleneConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Ethylene Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9615,8 +9754,9 @@ void emberAfEthyleneConcentrationMeasurementClusterServerInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfEthyleneConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Ethylene Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -9644,7 +9784,7 @@ void emberAfEthyleneConcentrationMeasurementClusterServerMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfEthyleneConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Ethylene Concentration Measurement Cluster Server Tick
@@ -9653,7 +9793,7 @@ EmberAfStatus emberAfEthyleneConcentrationMeasurementClusterServerPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfEthyleneConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Ethylene Concentration Measurement Cluster Callbacks */
 
@@ -9668,7 +9808,7 @@ void emberAfEthyleneConcentrationMeasurementClusterServerTickCallback(uint8_t en
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfEthyleneOxideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId);
+                                                                                       chip::AttributeId attributeId);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9678,7 +9818,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterClientAttributeChangedCa
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfEthyleneOxideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                       EmberAfStatus status);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Client Init
  *
@@ -9686,7 +9826,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterClientDefaultResponseCal
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfEthyleneOxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -9697,7 +9837,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterClientInitCallback(uint8
  * Ver.: always
  */
 void emberAfEthyleneOxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -9725,14 +9865,14 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterClientMessageSentCallbac
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfEthyleneOxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfEthyleneOxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -9741,7 +9881,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterClientTickCallback(uint8
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfEthyleneOxideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId);
+                                                                                       chip::AttributeId attributeId);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -9751,7 +9891,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterServerAttributeChangedCa
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfEthyleneOxideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                       EmberAfStatus status);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Init
  *
@@ -9759,7 +9899,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterServerDefaultResponseCal
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfEthyleneOxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9770,7 +9910,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterServerInitCallback(uint8
  * Ver.: always
  */
 void emberAfEthyleneOxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -9798,14 +9938,14 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterServerMessageSentCallbac
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfEthyleneOxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfEthyleneOxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Ethylene Oxide Concentration Measurement Cluster Callbacks */
 
@@ -9819,7 +9959,8 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterServerTickCallback(uint8
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfHydrogenConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Hydrogen Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9829,7 +9970,7 @@ void emberAfHydrogenConcentrationMeasurementClusterClientAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfHydrogenConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Hydrogen Concentration Measurement Cluster Client Init
  *
@@ -9837,7 +9978,7 @@ void emberAfHydrogenConcentrationMeasurementClusterClientDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfHydrogenConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Hydrogen Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -9847,8 +9988,9 @@ void emberAfHydrogenConcentrationMeasurementClusterClientInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfHydrogenConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Hydrogen Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -9876,7 +10018,7 @@ void emberAfHydrogenConcentrationMeasurementClusterClientMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfHydrogenConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Hydrogen Concentration Measurement Cluster Client Tick
@@ -9885,7 +10027,7 @@ EmberAfStatus emberAfHydrogenConcentrationMeasurementClusterClientPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfHydrogenConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Hydrogen Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -9893,7 +10035,8 @@ void emberAfHydrogenConcentrationMeasurementClusterClientTickCallback(uint8_t en
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfHydrogenConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Hydrogen Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -9903,7 +10046,7 @@ void emberAfHydrogenConcentrationMeasurementClusterServerAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfHydrogenConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Hydrogen Concentration Measurement Cluster Server Init
  *
@@ -9911,7 +10054,7 @@ void emberAfHydrogenConcentrationMeasurementClusterServerDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfHydrogenConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Hydrogen Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9921,8 +10064,9 @@ void emberAfHydrogenConcentrationMeasurementClusterServerInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfHydrogenConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Hydrogen Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -9950,7 +10094,7 @@ void emberAfHydrogenConcentrationMeasurementClusterServerMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfHydrogenConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Hydrogen Concentration Measurement Cluster Server Tick
@@ -9959,7 +10103,7 @@ EmberAfStatus emberAfHydrogenConcentrationMeasurementClusterServerPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfHydrogenConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Hydrogen Concentration Measurement Cluster Callbacks */
 
@@ -9974,7 +10118,7 @@ void emberAfHydrogenConcentrationMeasurementClusterServerTickCallback(uint8_t en
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfHydrogenSulphideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId);
+                                                                                          chip::AttributeId attributeId);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9984,15 +10128,15 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterClientAttributeChange
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                         EmberAfStatus status);
+void emberAfHydrogenSulphideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                         uint8_t commandId, EmberAfStatus status);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfHydrogenSulphideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10003,7 +10147,7 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterClientInitCallback(ui
  * Ver.: always
  */
 void emberAfHydrogenSulphideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -10031,14 +10175,14 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterClientMessageSentCall
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfHydrogenSulphideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfHydrogenSulphideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10047,7 +10191,7 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterClientTickCallback(ui
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfHydrogenSulphideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId);
+                                                                                          chip::AttributeId attributeId);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10057,15 +10201,15 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterServerAttributeChange
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                         EmberAfStatus status);
+void emberAfHydrogenSulphideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                         uint8_t commandId, EmberAfStatus status);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfHydrogenSulphideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10076,7 +10220,7 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterServerInitCallback(ui
  * Ver.: always
  */
 void emberAfHydrogenSulphideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -10104,14 +10248,14 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterServerMessageSentCall
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfHydrogenSulphideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfHydrogenSulphideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Hydrogen Sulphide Concentration Measurement Cluster Callbacks */
 
@@ -10125,8 +10269,8 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterServerTickCallback(ui
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId);
+void emberAfNitricOxideConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId);
 /** @brief Nitric Oxide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -10136,7 +10280,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterClientAttributeChangedCall
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfNitricOxideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                     EmberAfStatus status);
 /** @brief Nitric Oxide Concentration Measurement Cluster Client Init
  *
@@ -10144,7 +10288,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterClientDefaultResponseCallb
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfNitricOxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Nitric Oxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10155,7 +10299,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterClientInitCallback(uint8_t
  * Ver.: always
  */
 void emberAfNitricOxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Nitric Oxide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -10183,7 +10327,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterClientMessageSentCallback(
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfNitricOxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                                 EmberAfAttributeId attributeId,
+                                                                                                 chip::AttributeId attributeId,
                                                                                                  EmberAfAttributeType attributeType,
                                                                                                  uint8_t size, uint8_t * value);
 /** @brief Nitric Oxide Concentration Measurement Cluster Client Tick
@@ -10192,7 +10336,7 @@ EmberAfStatus emberAfNitricOxideConcentrationMeasurementClusterClientPreAttribut
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfNitricOxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10200,8 +10344,8 @@ void emberAfNitricOxideConcentrationMeasurementClusterClientTickCallback(uint8_t
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId);
+void emberAfNitricOxideConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId);
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10211,7 +10355,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterServerAttributeChangedCall
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfNitricOxideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                     EmberAfStatus status);
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Init
  *
@@ -10219,7 +10363,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterServerDefaultResponseCallb
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfNitricOxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10230,7 +10374,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterServerInitCallback(uint8_t
  * Ver.: always
  */
 void emberAfNitricOxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -10258,7 +10402,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterServerMessageSentCallback(
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfNitricOxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                                 EmberAfAttributeId attributeId,
+                                                                                                 chip::AttributeId attributeId,
                                                                                                  EmberAfAttributeType attributeType,
                                                                                                  uint8_t size, uint8_t * value);
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Tick
@@ -10267,7 +10411,7 @@ EmberAfStatus emberAfNitricOxideConcentrationMeasurementClusterServerPreAttribut
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfNitricOxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Nitric Oxide Concentration Measurement Cluster Callbacks */
 
@@ -10282,7 +10426,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterServerTickCallback(uint8_t
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfNitrogenDioxideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId);
+                                                                                         chip::AttributeId attributeId);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -10292,15 +10436,15 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterClientAttributeChanged
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                        EmberAfStatus status);
+void emberAfNitrogenDioxideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                        uint8_t commandId, EmberAfStatus status);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfNitrogenDioxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10311,7 +10455,7 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterClientInitCallback(uin
  * Ver.: always
  */
 void emberAfNitrogenDioxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -10339,14 +10483,14 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterClientMessageSentCallb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfNitrogenDioxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfNitrogenDioxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10355,7 +10499,7 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterClientTickCallback(uin
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfNitrogenDioxideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId);
+                                                                                         chip::AttributeId attributeId);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10365,15 +10509,15 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterServerAttributeChanged
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                        EmberAfStatus status);
+void emberAfNitrogenDioxideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                        uint8_t commandId, EmberAfStatus status);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfNitrogenDioxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10384,7 +10528,7 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterServerInitCallback(uin
  * Ver.: always
  */
 void emberAfNitrogenDioxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -10412,14 +10556,14 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterServerMessageSentCallb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfNitrogenDioxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfNitrogenDioxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Nitrogen Dioxide Concentration Measurement Cluster Callbacks */
 
@@ -10433,7 +10577,8 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterServerTickCallback(uin
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOxygenConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId);
 /** @brief Oxygen Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -10443,7 +10588,7 @@ void emberAfOxygenConcentrationMeasurementClusterClientAttributeChangedCallback(
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfOxygenConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                EmberAfStatus status);
 /** @brief Oxygen Concentration Measurement Cluster Client Init
  *
@@ -10451,7 +10596,7 @@ void emberAfOxygenConcentrationMeasurementClusterClientDefaultResponseCallback(u
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfOxygenConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Oxygen Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10462,7 +10607,7 @@ void emberAfOxygenConcentrationMeasurementClusterClientInitCallback(uint8_t endp
  * Ver.: always
  */
 void emberAfOxygenConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                    EmberAfAttributeId attributeId,
+                                                                                                    chip::AttributeId attributeId,
                                                                                                     uint16_t manufacturerCode);
 /** @brief Oxygen Concentration Measurement Cluster Client Message Sent
  *
@@ -10490,7 +10635,7 @@ void emberAfOxygenConcentrationMeasurementClusterClientMessageSentCallback(Ember
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfOxygenConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                            EmberAfAttributeId attributeId,
+                                                                                            chip::AttributeId attributeId,
                                                                                             EmberAfAttributeType attributeType,
                                                                                             uint8_t size, uint8_t * value);
 /** @brief Oxygen Concentration Measurement Cluster Client Tick
@@ -10499,7 +10644,7 @@ EmberAfStatus emberAfOxygenConcentrationMeasurementClusterClientPreAttributeChan
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfOxygenConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Oxygen Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10507,7 +10652,8 @@ void emberAfOxygenConcentrationMeasurementClusterClientTickCallback(uint8_t endp
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOxygenConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId);
 /** @brief Oxygen Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10517,7 +10663,7 @@ void emberAfOxygenConcentrationMeasurementClusterServerAttributeChangedCallback(
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfOxygenConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                EmberAfStatus status);
 /** @brief Oxygen Concentration Measurement Cluster Server Init
  *
@@ -10525,7 +10671,7 @@ void emberAfOxygenConcentrationMeasurementClusterServerDefaultResponseCallback(u
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfOxygenConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Oxygen Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10536,7 +10682,7 @@ void emberAfOxygenConcentrationMeasurementClusterServerInitCallback(uint8_t endp
  * Ver.: always
  */
 void emberAfOxygenConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                    EmberAfAttributeId attributeId,
+                                                                                                    chip::AttributeId attributeId,
                                                                                                     uint16_t manufacturerCode);
 /** @brief Oxygen Concentration Measurement Cluster Server Message Sent
  *
@@ -10564,7 +10710,7 @@ void emberAfOxygenConcentrationMeasurementClusterServerMessageSentCallback(Ember
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfOxygenConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                            EmberAfAttributeId attributeId,
+                                                                                            chip::AttributeId attributeId,
                                                                                             EmberAfAttributeType attributeType,
                                                                                             uint8_t size, uint8_t * value);
 /** @brief Oxygen Concentration Measurement Cluster Server Tick
@@ -10573,7 +10719,7 @@ EmberAfStatus emberAfOxygenConcentrationMeasurementClusterServerPreAttributeChan
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfOxygenConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Oxygen Concentration Measurement Cluster Callbacks */
 
@@ -10587,7 +10733,8 @@ void emberAfOxygenConcentrationMeasurementClusterServerTickCallback(uint8_t endp
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOzoneConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId);
 /** @brief Ozone Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -10597,7 +10744,7 @@ void emberAfOzoneConcentrationMeasurementClusterClientAttributeChangedCallback(u
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfOzoneConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                               EmberAfStatus status);
 /** @brief Ozone Concentration Measurement Cluster Client Init
  *
@@ -10605,7 +10752,7 @@ void emberAfOzoneConcentrationMeasurementClusterClientDefaultResponseCallback(ui
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfOzoneConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Ozone Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10616,7 +10763,7 @@ void emberAfOzoneConcentrationMeasurementClusterClientInitCallback(uint8_t endpo
  * Ver.: always
  */
 void emberAfOzoneConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                   EmberAfAttributeId attributeId,
+                                                                                                   chip::AttributeId attributeId,
                                                                                                    uint16_t manufacturerCode);
 /** @brief Ozone Concentration Measurement Cluster Client Message Sent
  *
@@ -10644,7 +10791,7 @@ void emberAfOzoneConcentrationMeasurementClusterClientMessageSentCallback(EmberO
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfOzoneConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                           EmberAfAttributeId attributeId,
+                                                                                           chip::AttributeId attributeId,
                                                                                            EmberAfAttributeType attributeType,
                                                                                            uint8_t size, uint8_t * value);
 /** @brief Ozone Concentration Measurement Cluster Client Tick
@@ -10653,7 +10800,7 @@ EmberAfStatus emberAfOzoneConcentrationMeasurementClusterClientPreAttributeChang
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfOzoneConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Ozone Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10661,7 +10808,8 @@ void emberAfOzoneConcentrationMeasurementClusterClientTickCallback(uint8_t endpo
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOzoneConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId);
 /** @brief Ozone Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10671,7 +10819,7 @@ void emberAfOzoneConcentrationMeasurementClusterServerAttributeChangedCallback(u
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfOzoneConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                               EmberAfStatus status);
 /** @brief Ozone Concentration Measurement Cluster Server Init
  *
@@ -10679,7 +10827,7 @@ void emberAfOzoneConcentrationMeasurementClusterServerDefaultResponseCallback(ui
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfOzoneConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Ozone Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10690,7 +10838,7 @@ void emberAfOzoneConcentrationMeasurementClusterServerInitCallback(uint8_t endpo
  * Ver.: always
  */
 void emberAfOzoneConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                   EmberAfAttributeId attributeId,
+                                                                                                   chip::AttributeId attributeId,
                                                                                                    uint16_t manufacturerCode);
 /** @brief Ozone Concentration Measurement Cluster Server Message Sent
  *
@@ -10718,7 +10866,7 @@ void emberAfOzoneConcentrationMeasurementClusterServerMessageSentCallback(EmberO
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfOzoneConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                           EmberAfAttributeId attributeId,
+                                                                                           chip::AttributeId attributeId,
                                                                                            EmberAfAttributeType attributeType,
                                                                                            uint8_t size, uint8_t * value);
 /** @brief Ozone Concentration Measurement Cluster Server Tick
@@ -10727,7 +10875,7 @@ EmberAfStatus emberAfOzoneConcentrationMeasurementClusterServerPreAttributeChang
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfOzoneConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Ozone Concentration Measurement Cluster Callbacks */
 
@@ -10742,7 +10890,7 @@ void emberAfOzoneConcentrationMeasurementClusterServerTickCallback(uint8_t endpo
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfSulfurDioxideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId);
+                                                                                       chip::AttributeId attributeId);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -10752,7 +10900,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterClientAttributeChangedCa
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfSulfurDioxideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                       EmberAfStatus status);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Client Init
  *
@@ -10760,7 +10908,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterClientDefaultResponseCal
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfSulfurDioxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10771,7 +10919,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterClientInitCallback(uint8
  * Ver.: always
  */
 void emberAfSulfurDioxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -10799,14 +10947,14 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterClientMessageSentCallbac
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfSulfurDioxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfSulfurDioxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10815,7 +10963,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterClientTickCallback(uint8
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfSulfurDioxideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId);
+                                                                                       chip::AttributeId attributeId);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10825,7 +10973,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterServerAttributeChangedCa
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfSulfurDioxideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                       EmberAfStatus status);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Init
  *
@@ -10833,7 +10981,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterServerDefaultResponseCal
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfSulfurDioxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10844,7 +10992,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterServerInitCallback(uint8
  * Ver.: always
  */
 void emberAfSulfurDioxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -10872,14 +11020,14 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterServerMessageSentCallbac
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfSulfurDioxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfSulfurDioxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Sulfur Dioxide Concentration Measurement Cluster Callbacks */
 
@@ -10894,7 +11042,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterServerTickCallback(uint8
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfDissolvedOxygenConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId);
+                                                                                         chip::AttributeId attributeId);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -10904,15 +11052,15 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterClientAttributeChanged
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                        EmberAfStatus status);
+void emberAfDissolvedOxygenConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                        uint8_t commandId, EmberAfStatus status);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfDissolvedOxygenConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10923,7 +11071,7 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterClientInitCallback(uin
  * Ver.: always
  */
 void emberAfDissolvedOxygenConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -10951,14 +11099,14 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterClientMessageSentCallb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfDissolvedOxygenConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfDissolvedOxygenConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10967,7 +11115,7 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterClientTickCallback(uin
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfDissolvedOxygenConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId);
+                                                                                         chip::AttributeId attributeId);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10977,15 +11125,15 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterServerAttributeChanged
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                        EmberAfStatus status);
+void emberAfDissolvedOxygenConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                        uint8_t commandId, EmberAfStatus status);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfDissolvedOxygenConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10996,7 +11144,7 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterServerInitCallback(uin
  * Ver.: always
  */
 void emberAfDissolvedOxygenConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -11024,14 +11172,14 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterServerMessageSentCallb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfDissolvedOxygenConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfDissolvedOxygenConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Dissolved Oxygen Concentration Measurement Cluster Callbacks */
 
@@ -11045,7 +11193,8 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterServerTickCallback(uin
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBromateConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId);
 /** @brief Bromate Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11055,7 +11204,7 @@ void emberAfBromateConcentrationMeasurementClusterClientAttributeChangedCallback
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfBromateConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                 EmberAfStatus status);
 /** @brief Bromate Concentration Measurement Cluster Client Init
  *
@@ -11063,7 +11212,7 @@ void emberAfBromateConcentrationMeasurementClusterClientDefaultResponseCallback(
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfBromateConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Bromate Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11074,7 +11223,7 @@ void emberAfBromateConcentrationMeasurementClusterClientInitCallback(uint8_t end
  * Ver.: always
  */
 void emberAfBromateConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                     EmberAfAttributeId attributeId,
+                                                                                                     chip::AttributeId attributeId,
                                                                                                      uint16_t manufacturerCode);
 /** @brief Bromate Concentration Measurement Cluster Client Message Sent
  *
@@ -11102,7 +11251,7 @@ void emberAfBromateConcentrationMeasurementClusterClientMessageSentCallback(Embe
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfBromateConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              EmberAfAttributeType attributeType,
                                                                                              uint8_t size, uint8_t * value);
 /** @brief Bromate Concentration Measurement Cluster Client Tick
@@ -11111,7 +11260,7 @@ EmberAfStatus emberAfBromateConcentrationMeasurementClusterClientPreAttributeCha
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfBromateConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Bromate Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -11119,7 +11268,8 @@ void emberAfBromateConcentrationMeasurementClusterClientTickCallback(uint8_t end
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBromateConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId);
 /** @brief Bromate Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -11129,7 +11279,7 @@ void emberAfBromateConcentrationMeasurementClusterServerAttributeChangedCallback
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfBromateConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                 EmberAfStatus status);
 /** @brief Bromate Concentration Measurement Cluster Server Init
  *
@@ -11137,7 +11287,7 @@ void emberAfBromateConcentrationMeasurementClusterServerDefaultResponseCallback(
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfBromateConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Bromate Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -11148,7 +11298,7 @@ void emberAfBromateConcentrationMeasurementClusterServerInitCallback(uint8_t end
  * Ver.: always
  */
 void emberAfBromateConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                     EmberAfAttributeId attributeId,
+                                                                                                     chip::AttributeId attributeId,
                                                                                                      uint16_t manufacturerCode);
 /** @brief Bromate Concentration Measurement Cluster Server Message Sent
  *
@@ -11176,7 +11326,7 @@ void emberAfBromateConcentrationMeasurementClusterServerMessageSentCallback(Embe
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfBromateConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              EmberAfAttributeType attributeType,
                                                                                              uint8_t size, uint8_t * value);
 /** @brief Bromate Concentration Measurement Cluster Server Tick
@@ -11185,7 +11335,7 @@ EmberAfStatus emberAfBromateConcentrationMeasurementClusterServerPreAttributeCha
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfBromateConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Bromate Concentration Measurement Cluster Callbacks */
 
@@ -11199,8 +11349,8 @@ void emberAfBromateConcentrationMeasurementClusterServerTickCallback(uint8_t end
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId);
+void emberAfChloraminesConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId);
 /** @brief Chloramines Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11210,7 +11360,7 @@ void emberAfChloraminesConcentrationMeasurementClusterClientAttributeChangedCall
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChloraminesConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                     EmberAfStatus status);
 /** @brief Chloramines Concentration Measurement Cluster Client Init
  *
@@ -11218,7 +11368,7 @@ void emberAfChloraminesConcentrationMeasurementClusterClientDefaultResponseCallb
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfChloraminesConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Chloramines Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11229,7 +11379,7 @@ void emberAfChloraminesConcentrationMeasurementClusterClientInitCallback(uint8_t
  * Ver.: always
  */
 void emberAfChloraminesConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Chloramines Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -11257,7 +11407,7 @@ void emberAfChloraminesConcentrationMeasurementClusterClientMessageSentCallback(
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChloraminesConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                                 EmberAfAttributeId attributeId,
+                                                                                                 chip::AttributeId attributeId,
                                                                                                  EmberAfAttributeType attributeType,
                                                                                                  uint8_t size, uint8_t * value);
 /** @brief Chloramines Concentration Measurement Cluster Client Tick
@@ -11266,7 +11416,7 @@ EmberAfStatus emberAfChloraminesConcentrationMeasurementClusterClientPreAttribut
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfChloraminesConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Chloramines Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -11274,8 +11424,8 @@ void emberAfChloraminesConcentrationMeasurementClusterClientTickCallback(uint8_t
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId);
+void emberAfChloraminesConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId);
 /** @brief Chloramines Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -11285,7 +11435,7 @@ void emberAfChloraminesConcentrationMeasurementClusterServerAttributeChangedCall
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChloraminesConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                     EmberAfStatus status);
 /** @brief Chloramines Concentration Measurement Cluster Server Init
  *
@@ -11293,7 +11443,7 @@ void emberAfChloraminesConcentrationMeasurementClusterServerDefaultResponseCallb
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfChloraminesConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Chloramines Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -11304,7 +11454,7 @@ void emberAfChloraminesConcentrationMeasurementClusterServerInitCallback(uint8_t
  * Ver.: always
  */
 void emberAfChloraminesConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Chloramines Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -11332,7 +11482,7 @@ void emberAfChloraminesConcentrationMeasurementClusterServerMessageSentCallback(
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChloraminesConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                                 EmberAfAttributeId attributeId,
+                                                                                                 chip::AttributeId attributeId,
                                                                                                  EmberAfAttributeType attributeType,
                                                                                                  uint8_t size, uint8_t * value);
 /** @brief Chloramines Concentration Measurement Cluster Server Tick
@@ -11341,7 +11491,7 @@ EmberAfStatus emberAfChloraminesConcentrationMeasurementClusterServerPreAttribut
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfChloraminesConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Chloramines Concentration Measurement Cluster Callbacks */
 
@@ -11355,7 +11505,8 @@ void emberAfChloraminesConcentrationMeasurementClusterServerTickCallback(uint8_t
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfChlorineConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Chlorine Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11365,7 +11516,7 @@ void emberAfChlorineConcentrationMeasurementClusterClientAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChlorineConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Chlorine Concentration Measurement Cluster Client Init
  *
@@ -11373,7 +11524,7 @@ void emberAfChlorineConcentrationMeasurementClusterClientDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfChlorineConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Chlorine Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11383,8 +11534,9 @@ void emberAfChlorineConcentrationMeasurementClusterClientInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfChlorineConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Chlorine Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -11412,7 +11564,7 @@ void emberAfChlorineConcentrationMeasurementClusterClientMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChlorineConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Chlorine Concentration Measurement Cluster Client Tick
@@ -11421,7 +11573,7 @@ EmberAfStatus emberAfChlorineConcentrationMeasurementClusterClientPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfChlorineConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Chlorine Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -11429,7 +11581,8 @@ void emberAfChlorineConcentrationMeasurementClusterClientTickCallback(uint8_t en
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfChlorineConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Chlorine Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -11439,7 +11592,7 @@ void emberAfChlorineConcentrationMeasurementClusterServerAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChlorineConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Chlorine Concentration Measurement Cluster Server Init
  *
@@ -11447,7 +11600,7 @@ void emberAfChlorineConcentrationMeasurementClusterServerDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfChlorineConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Chlorine Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -11457,8 +11610,9 @@ void emberAfChlorineConcentrationMeasurementClusterServerInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfChlorineConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Chlorine Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -11486,7 +11640,7 @@ void emberAfChlorineConcentrationMeasurementClusterServerMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChlorineConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Chlorine Concentration Measurement Cluster Server Tick
@@ -11495,7 +11649,7 @@ EmberAfStatus emberAfChlorineConcentrationMeasurementClusterServerPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfChlorineConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Chlorine Concentration Measurement Cluster Callbacks */
 
@@ -11510,7 +11664,7 @@ void emberAfChlorineConcentrationMeasurementClusterServerTickCallback(uint8_t en
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId);
+                                                                                               chip::AttributeId attributeId);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11520,7 +11674,8 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientAttributeC
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                              uint8_t commandId,
                                                                                               EmberAfStatus status);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Client Init
  *
@@ -11528,7 +11683,7 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientDefaultRes
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11539,7 +11694,7 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientInitCallba
  * Ver.: always
  */
 void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -11567,14 +11722,14 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientMessageSen
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -11583,7 +11738,7 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientTickCallba
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId);
+                                                                                               chip::AttributeId attributeId);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -11593,7 +11748,8 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerAttributeC
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                              uint8_t commandId,
                                                                                               EmberAfStatus status);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Init
  *
@@ -11601,7 +11757,7 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerDefaultRes
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -11612,7 +11768,7 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerInitCallba
  * Ver.: always
  */
 void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -11640,14 +11796,14 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerMessageSen
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Fecal coliform and E. Coli Concentration Measurement Cluster Callbacks */
 
@@ -11661,7 +11817,8 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerTickCallba
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfFluorideConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Fluoride Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11671,7 +11828,7 @@ void emberAfFluorideConcentrationMeasurementClusterClientAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfFluorideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Fluoride Concentration Measurement Cluster Client Init
  *
@@ -11679,7 +11836,7 @@ void emberAfFluorideConcentrationMeasurementClusterClientDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfFluorideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Fluoride Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11689,8 +11846,9 @@ void emberAfFluorideConcentrationMeasurementClusterClientInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfFluorideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Fluoride Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -11718,7 +11876,7 @@ void emberAfFluorideConcentrationMeasurementClusterClientMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfFluorideConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Fluoride Concentration Measurement Cluster Client Tick
@@ -11727,7 +11885,7 @@ EmberAfStatus emberAfFluorideConcentrationMeasurementClusterClientPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfFluorideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Fluoride Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -11735,7 +11893,8 @@ void emberAfFluorideConcentrationMeasurementClusterClientTickCallback(uint8_t en
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfFluorideConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Fluoride Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -11745,7 +11904,7 @@ void emberAfFluorideConcentrationMeasurementClusterServerAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfFluorideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Fluoride Concentration Measurement Cluster Server Init
  *
@@ -11753,7 +11912,7 @@ void emberAfFluorideConcentrationMeasurementClusterServerDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfFluorideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Fluoride Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -11763,8 +11922,9 @@ void emberAfFluorideConcentrationMeasurementClusterServerInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfFluorideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Fluoride Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -11792,7 +11952,7 @@ void emberAfFluorideConcentrationMeasurementClusterServerMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfFluorideConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Fluoride Concentration Measurement Cluster Server Tick
@@ -11801,7 +11961,7 @@ EmberAfStatus emberAfFluorideConcentrationMeasurementClusterServerPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfFluorideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Fluoride Concentration Measurement Cluster Callbacks */
 
@@ -11816,7 +11976,7 @@ void emberAfFluorideConcentrationMeasurementClusterServerTickCallback(uint8_t en
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId);
+                                                                                         chip::AttributeId attributeId);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11826,15 +11986,15 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientAttributeChanged
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                        EmberAfStatus status);
+void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                        uint8_t commandId, EmberAfStatus status);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11845,7 +12005,7 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientInitCallback(uin
  * Ver.: always
  */
 void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -11873,14 +12033,14 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientMessageSentCallb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfHaloaceticAcidsConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -11889,7 +12049,7 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientTickCallback(uin
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId);
+                                                                                         chip::AttributeId attributeId);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -11899,15 +12059,15 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerAttributeChanged
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                        EmberAfStatus status);
+void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                        uint8_t commandId, EmberAfStatus status);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -11918,7 +12078,7 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerInitCallback(uin
  * Ver.: always
  */
 void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -11946,14 +12106,14 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerMessageSentCallb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfHaloaceticAcidsConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Haloacetic Acids Concentration Measurement Cluster Callbacks */
 
@@ -11968,7 +12128,7 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerTickCallback(uin
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId);
+                                                                                              chip::AttributeId attributeId);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11978,7 +12138,8 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientAttributeCh
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                             uint8_t commandId,
                                                                                              EmberAfStatus status);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Client Init
  *
@@ -11986,7 +12147,7 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientDefaultResp
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11997,7 +12158,7 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientInitCallbac
  * Ver.: always
  */
 void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -12025,14 +12186,14 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientMessageSent
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12041,7 +12202,7 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientTickCallbac
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId);
+                                                                                              chip::AttributeId attributeId);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12051,7 +12212,8 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerAttributeCh
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                             uint8_t commandId,
                                                                                              EmberAfStatus status);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Init
  *
@@ -12059,7 +12221,7 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerDefaultResp
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12070,7 +12232,7 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerInitCallbac
  * Ver.: always
  */
 void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -12098,14 +12260,14 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerMessageSent
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Total Trihalomethanes Concentration Measurement Cluster Callbacks */
 
@@ -12120,7 +12282,7 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerTickCallbac
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId);
+                                                                                               chip::AttributeId attributeId);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -12130,7 +12292,8 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientAttributeC
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                              uint8_t commandId,
                                                                                               EmberAfStatus status);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Client Init
  *
@@ -12138,7 +12301,7 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientDefaultRes
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -12149,7 +12312,7 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientInitCallba
  * Ver.: always
  */
 void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -12177,14 +12340,14 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientMessageSen
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12193,7 +12356,7 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientTickCallba
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId);
+                                                                                               chip::AttributeId attributeId);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12203,7 +12366,8 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerAttributeC
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                              uint8_t commandId,
                                                                                               EmberAfStatus status);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Init
  *
@@ -12211,7 +12375,7 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerDefaultRes
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12222,7 +12386,7 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerInitCallba
  * Ver.: always
  */
 void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -12250,14 +12414,14 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerMessageSen
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Total Coliform Bacteria Concentration Measurement Cluster Callbacks */
 
@@ -12271,8 +12435,8 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerTickCallba
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                   EmberAfAttributeId attributeId);
+void emberAfTurbidityConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId);
 /** @brief Turbidity Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -12282,7 +12446,7 @@ void emberAfTurbidityConcentrationMeasurementClusterClientAttributeChangedCallba
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfTurbidityConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                   EmberAfStatus status);
 /** @brief Turbidity Concentration Measurement Cluster Client Init
  *
@@ -12290,7 +12454,7 @@ void emberAfTurbidityConcentrationMeasurementClusterClientDefaultResponseCallbac
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfTurbidityConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Turbidity Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -12301,7 +12465,7 @@ void emberAfTurbidityConcentrationMeasurementClusterClientInitCallback(uint8_t e
  * Ver.: always
  */
 void emberAfTurbidityConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Turbidity Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -12329,7 +12493,7 @@ void emberAfTurbidityConcentrationMeasurementClusterClientMessageSentCallback(Em
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfTurbidityConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                EmberAfAttributeType attributeType,
                                                                                                uint8_t size, uint8_t * value);
 /** @brief Turbidity Concentration Measurement Cluster Client Tick
@@ -12338,7 +12502,7 @@ EmberAfStatus emberAfTurbidityConcentrationMeasurementClusterClientPreAttributeC
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfTurbidityConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Turbidity Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12346,8 +12510,8 @@ void emberAfTurbidityConcentrationMeasurementClusterClientTickCallback(uint8_t e
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                   EmberAfAttributeId attributeId);
+void emberAfTurbidityConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId);
 /** @brief Turbidity Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12357,7 +12521,7 @@ void emberAfTurbidityConcentrationMeasurementClusterServerAttributeChangedCallba
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfTurbidityConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                   EmberAfStatus status);
 /** @brief Turbidity Concentration Measurement Cluster Server Init
  *
@@ -12365,7 +12529,7 @@ void emberAfTurbidityConcentrationMeasurementClusterServerDefaultResponseCallbac
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfTurbidityConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Turbidity Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12376,7 +12540,7 @@ void emberAfTurbidityConcentrationMeasurementClusterServerInitCallback(uint8_t e
  * Ver.: always
  */
 void emberAfTurbidityConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Turbidity Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -12404,7 +12568,7 @@ void emberAfTurbidityConcentrationMeasurementClusterServerMessageSentCallback(Em
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfTurbidityConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                EmberAfAttributeType attributeType,
                                                                                                uint8_t size, uint8_t * value);
 /** @brief Turbidity Concentration Measurement Cluster Server Tick
@@ -12413,7 +12577,7 @@ EmberAfStatus emberAfTurbidityConcentrationMeasurementClusterServerPreAttributeC
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfTurbidityConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Turbidity Concentration Measurement Cluster Callbacks */
 
@@ -12427,7 +12591,8 @@ void emberAfTurbidityConcentrationMeasurementClusterServerTickCallback(uint8_t e
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfCopperConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId);
 /** @brief Copper Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -12437,7 +12602,7 @@ void emberAfCopperConcentrationMeasurementClusterClientAttributeChangedCallback(
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfCopperConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                EmberAfStatus status);
 /** @brief Copper Concentration Measurement Cluster Client Init
  *
@@ -12445,7 +12610,7 @@ void emberAfCopperConcentrationMeasurementClusterClientDefaultResponseCallback(u
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfCopperConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Copper Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -12456,7 +12621,7 @@ void emberAfCopperConcentrationMeasurementClusterClientInitCallback(uint8_t endp
  * Ver.: always
  */
 void emberAfCopperConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                    EmberAfAttributeId attributeId,
+                                                                                                    chip::AttributeId attributeId,
                                                                                                     uint16_t manufacturerCode);
 /** @brief Copper Concentration Measurement Cluster Client Message Sent
  *
@@ -12484,7 +12649,7 @@ void emberAfCopperConcentrationMeasurementClusterClientMessageSentCallback(Ember
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfCopperConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                            EmberAfAttributeId attributeId,
+                                                                                            chip::AttributeId attributeId,
                                                                                             EmberAfAttributeType attributeType,
                                                                                             uint8_t size, uint8_t * value);
 /** @brief Copper Concentration Measurement Cluster Client Tick
@@ -12493,7 +12658,7 @@ EmberAfStatus emberAfCopperConcentrationMeasurementClusterClientPreAttributeChan
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfCopperConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Copper Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12501,7 +12666,8 @@ void emberAfCopperConcentrationMeasurementClusterClientTickCallback(uint8_t endp
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfCopperConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId);
 /** @brief Copper Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12511,7 +12677,7 @@ void emberAfCopperConcentrationMeasurementClusterServerAttributeChangedCallback(
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfCopperConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                EmberAfStatus status);
 /** @brief Copper Concentration Measurement Cluster Server Init
  *
@@ -12519,7 +12685,7 @@ void emberAfCopperConcentrationMeasurementClusterServerDefaultResponseCallback(u
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfCopperConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Copper Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12530,7 +12696,7 @@ void emberAfCopperConcentrationMeasurementClusterServerInitCallback(uint8_t endp
  * Ver.: always
  */
 void emberAfCopperConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                    EmberAfAttributeId attributeId,
+                                                                                                    chip::AttributeId attributeId,
                                                                                                     uint16_t manufacturerCode);
 /** @brief Copper Concentration Measurement Cluster Server Message Sent
  *
@@ -12558,7 +12724,7 @@ void emberAfCopperConcentrationMeasurementClusterServerMessageSentCallback(Ember
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfCopperConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                            EmberAfAttributeId attributeId,
+                                                                                            chip::AttributeId attributeId,
                                                                                             EmberAfAttributeType attributeType,
                                                                                             uint8_t size, uint8_t * value);
 /** @brief Copper Concentration Measurement Cluster Server Tick
@@ -12567,7 +12733,7 @@ EmberAfStatus emberAfCopperConcentrationMeasurementClusterServerPreAttributeChan
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfCopperConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Copper Concentration Measurement Cluster Callbacks */
 
@@ -12581,7 +12747,8 @@ void emberAfCopperConcentrationMeasurementClusterServerTickCallback(uint8_t endp
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfLeadConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId);
 /** @brief Lead Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -12591,7 +12758,7 @@ void emberAfLeadConcentrationMeasurementClusterClientAttributeChangedCallback(ui
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfLeadConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                              EmberAfStatus status);
 /** @brief Lead Concentration Measurement Cluster Client Init
  *
@@ -12599,7 +12766,7 @@ void emberAfLeadConcentrationMeasurementClusterClientDefaultResponseCallback(uin
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfLeadConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Lead Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -12610,7 +12777,7 @@ void emberAfLeadConcentrationMeasurementClusterClientInitCallback(uint8_t endpoi
  * Ver.: always
  */
 void emberAfLeadConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                  EmberAfAttributeId attributeId,
+                                                                                                  chip::AttributeId attributeId,
                                                                                                   uint16_t manufacturerCode);
 /** @brief Lead Concentration Measurement Cluster Client Message Sent
  *
@@ -12638,7 +12805,7 @@ void emberAfLeadConcentrationMeasurementClusterClientMessageSentCallback(EmberOu
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfLeadConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId,
+                                                                                          chip::AttributeId attributeId,
                                                                                           EmberAfAttributeType attributeType,
                                                                                           uint8_t size, uint8_t * value);
 /** @brief Lead Concentration Measurement Cluster Client Tick
@@ -12647,7 +12814,7 @@ EmberAfStatus emberAfLeadConcentrationMeasurementClusterClientPreAttributeChange
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfLeadConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Lead Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12655,7 +12822,8 @@ void emberAfLeadConcentrationMeasurementClusterClientTickCallback(uint8_t endpoi
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfLeadConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId);
 /** @brief Lead Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12665,7 +12833,7 @@ void emberAfLeadConcentrationMeasurementClusterServerAttributeChangedCallback(ui
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfLeadConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                              EmberAfStatus status);
 /** @brief Lead Concentration Measurement Cluster Server Init
  *
@@ -12673,7 +12841,7 @@ void emberAfLeadConcentrationMeasurementClusterServerDefaultResponseCallback(uin
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfLeadConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Lead Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12684,7 +12852,7 @@ void emberAfLeadConcentrationMeasurementClusterServerInitCallback(uint8_t endpoi
  * Ver.: always
  */
 void emberAfLeadConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                  EmberAfAttributeId attributeId,
+                                                                                                  chip::AttributeId attributeId,
                                                                                                   uint16_t manufacturerCode);
 /** @brief Lead Concentration Measurement Cluster Server Message Sent
  *
@@ -12712,7 +12880,7 @@ void emberAfLeadConcentrationMeasurementClusterServerMessageSentCallback(EmberOu
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfLeadConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId,
+                                                                                          chip::AttributeId attributeId,
                                                                                           EmberAfAttributeType attributeType,
                                                                                           uint8_t size, uint8_t * value);
 /** @brief Lead Concentration Measurement Cluster Server Tick
@@ -12721,7 +12889,7 @@ EmberAfStatus emberAfLeadConcentrationMeasurementClusterServerPreAttributeChange
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfLeadConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Lead Concentration Measurement Cluster Callbacks */
 
@@ -12735,8 +12903,8 @@ void emberAfLeadConcentrationMeasurementClusterServerTickCallback(uint8_t endpoi
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                   EmberAfAttributeId attributeId);
+void emberAfManganeseConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId);
 /** @brief Manganese Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -12746,7 +12914,7 @@ void emberAfManganeseConcentrationMeasurementClusterClientAttributeChangedCallba
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfManganeseConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                   EmberAfStatus status);
 /** @brief Manganese Concentration Measurement Cluster Client Init
  *
@@ -12754,7 +12922,7 @@ void emberAfManganeseConcentrationMeasurementClusterClientDefaultResponseCallbac
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfManganeseConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Manganese Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -12765,7 +12933,7 @@ void emberAfManganeseConcentrationMeasurementClusterClientInitCallback(uint8_t e
  * Ver.: always
  */
 void emberAfManganeseConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Manganese Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -12793,7 +12961,7 @@ void emberAfManganeseConcentrationMeasurementClusterClientMessageSentCallback(Em
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfManganeseConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                EmberAfAttributeType attributeType,
                                                                                                uint8_t size, uint8_t * value);
 /** @brief Manganese Concentration Measurement Cluster Client Tick
@@ -12802,7 +12970,7 @@ EmberAfStatus emberAfManganeseConcentrationMeasurementClusterClientPreAttributeC
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfManganeseConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Manganese Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12810,8 +12978,8 @@ void emberAfManganeseConcentrationMeasurementClusterClientTickCallback(uint8_t e
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                   EmberAfAttributeId attributeId);
+void emberAfManganeseConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId);
 /** @brief Manganese Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12821,7 +12989,7 @@ void emberAfManganeseConcentrationMeasurementClusterServerAttributeChangedCallba
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfManganeseConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                   EmberAfStatus status);
 /** @brief Manganese Concentration Measurement Cluster Server Init
  *
@@ -12829,7 +12997,7 @@ void emberAfManganeseConcentrationMeasurementClusterServerDefaultResponseCallbac
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfManganeseConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Manganese Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12840,7 +13008,7 @@ void emberAfManganeseConcentrationMeasurementClusterServerInitCallback(uint8_t e
  * Ver.: always
  */
 void emberAfManganeseConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Manganese Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -12868,7 +13036,7 @@ void emberAfManganeseConcentrationMeasurementClusterServerMessageSentCallback(Em
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfManganeseConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                EmberAfAttributeType attributeType,
                                                                                                uint8_t size, uint8_t * value);
 /** @brief Manganese Concentration Measurement Cluster Server Tick
@@ -12877,7 +13045,7 @@ EmberAfStatus emberAfManganeseConcentrationMeasurementClusterServerPreAttributeC
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfManganeseConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Manganese Concentration Measurement Cluster Callbacks */
 
@@ -12891,7 +13059,8 @@ void emberAfManganeseConcentrationMeasurementClusterServerTickCallback(uint8_t e
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSulfateConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId);
 /** @brief Sulfate Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -12901,7 +13070,7 @@ void emberAfSulfateConcentrationMeasurementClusterClientAttributeChangedCallback
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfSulfateConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                 EmberAfStatus status);
 /** @brief Sulfate Concentration Measurement Cluster Client Init
  *
@@ -12909,7 +13078,7 @@ void emberAfSulfateConcentrationMeasurementClusterClientDefaultResponseCallback(
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfSulfateConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Sulfate Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -12920,7 +13089,7 @@ void emberAfSulfateConcentrationMeasurementClusterClientInitCallback(uint8_t end
  * Ver.: always
  */
 void emberAfSulfateConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                     EmberAfAttributeId attributeId,
+                                                                                                     chip::AttributeId attributeId,
                                                                                                      uint16_t manufacturerCode);
 /** @brief Sulfate Concentration Measurement Cluster Client Message Sent
  *
@@ -12948,7 +13117,7 @@ void emberAfSulfateConcentrationMeasurementClusterClientMessageSentCallback(Embe
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfSulfateConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              EmberAfAttributeType attributeType,
                                                                                              uint8_t size, uint8_t * value);
 /** @brief Sulfate Concentration Measurement Cluster Client Tick
@@ -12957,7 +13126,7 @@ EmberAfStatus emberAfSulfateConcentrationMeasurementClusterClientPreAttributeCha
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfSulfateConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Sulfate Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12965,7 +13134,8 @@ void emberAfSulfateConcentrationMeasurementClusterClientTickCallback(uint8_t end
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSulfateConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId);
 /** @brief Sulfate Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12975,7 +13145,7 @@ void emberAfSulfateConcentrationMeasurementClusterServerAttributeChangedCallback
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfSulfateConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                 EmberAfStatus status);
 /** @brief Sulfate Concentration Measurement Cluster Server Init
  *
@@ -12983,7 +13153,7 @@ void emberAfSulfateConcentrationMeasurementClusterServerDefaultResponseCallback(
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfSulfateConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Sulfate Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12994,7 +13164,7 @@ void emberAfSulfateConcentrationMeasurementClusterServerInitCallback(uint8_t end
  * Ver.: always
  */
 void emberAfSulfateConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                     EmberAfAttributeId attributeId,
+                                                                                                     chip::AttributeId attributeId,
                                                                                                      uint16_t manufacturerCode);
 /** @brief Sulfate Concentration Measurement Cluster Server Message Sent
  *
@@ -13022,7 +13192,7 @@ void emberAfSulfateConcentrationMeasurementClusterServerMessageSentCallback(Embe
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfSulfateConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              EmberAfAttributeType attributeType,
                                                                                              uint8_t size, uint8_t * value);
 /** @brief Sulfate Concentration Measurement Cluster Server Tick
@@ -13031,7 +13201,7 @@ EmberAfStatus emberAfSulfateConcentrationMeasurementClusterServerPreAttributeCha
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfSulfateConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Sulfate Concentration Measurement Cluster Callbacks */
 
@@ -13046,7 +13216,7 @@ void emberAfSulfateConcentrationMeasurementClusterServerTickCallback(uint8_t end
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfBromodichloromethaneConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId);
+                                                                                              chip::AttributeId attributeId);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -13056,7 +13226,8 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterClientAttributeCh
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfBromodichloromethaneConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                             uint8_t commandId,
                                                                                              EmberAfStatus status);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Client Init
  *
@@ -13064,7 +13235,7 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterClientDefaultResp
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfBromodichloromethaneConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -13075,7 +13246,7 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterClientInitCallbac
  * Ver.: always
  */
 void emberAfBromodichloromethaneConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -13103,14 +13274,14 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterClientMessageSent
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfBromodichloromethaneConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfBromodichloromethaneConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -13119,7 +13290,7 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterClientTickCallbac
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfBromodichloromethaneConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId);
+                                                                                              chip::AttributeId attributeId);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -13129,7 +13300,8 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterServerAttributeCh
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfBromodichloromethaneConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                             uint8_t commandId,
                                                                                              EmberAfStatus status);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Init
  *
@@ -13137,7 +13309,7 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterServerDefaultResp
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfBromodichloromethaneConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -13148,7 +13320,7 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterServerInitCallbac
  * Ver.: always
  */
 void emberAfBromodichloromethaneConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -13176,14 +13348,14 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterServerMessageSent
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfBromodichloromethaneConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfBromodichloromethaneConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Bromodichloromethane Concentration Measurement Cluster Callbacks */
 
@@ -13197,8 +13369,8 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterServerTickCallbac
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                   EmberAfAttributeId attributeId);
+void emberAfBromoformConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId);
 /** @brief Bromoform Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -13208,7 +13380,7 @@ void emberAfBromoformConcentrationMeasurementClusterClientAttributeChangedCallba
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfBromoformConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                   EmberAfStatus status);
 /** @brief Bromoform Concentration Measurement Cluster Client Init
  *
@@ -13216,7 +13388,7 @@ void emberAfBromoformConcentrationMeasurementClusterClientDefaultResponseCallbac
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfBromoformConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Bromoform Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -13227,7 +13399,7 @@ void emberAfBromoformConcentrationMeasurementClusterClientInitCallback(uint8_t e
  * Ver.: always
  */
 void emberAfBromoformConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Bromoform Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -13255,7 +13427,7 @@ void emberAfBromoformConcentrationMeasurementClusterClientMessageSentCallback(Em
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfBromoformConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                EmberAfAttributeType attributeType,
                                                                                                uint8_t size, uint8_t * value);
 /** @brief Bromoform Concentration Measurement Cluster Client Tick
@@ -13264,7 +13436,7 @@ EmberAfStatus emberAfBromoformConcentrationMeasurementClusterClientPreAttributeC
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfBromoformConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Bromoform Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -13272,8 +13444,8 @@ void emberAfBromoformConcentrationMeasurementClusterClientTickCallback(uint8_t e
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                   EmberAfAttributeId attributeId);
+void emberAfBromoformConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId);
 /** @brief Bromoform Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -13283,7 +13455,7 @@ void emberAfBromoformConcentrationMeasurementClusterServerAttributeChangedCallba
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfBromoformConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                   EmberAfStatus status);
 /** @brief Bromoform Concentration Measurement Cluster Server Init
  *
@@ -13291,7 +13463,7 @@ void emberAfBromoformConcentrationMeasurementClusterServerDefaultResponseCallbac
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfBromoformConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Bromoform Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -13302,7 +13474,7 @@ void emberAfBromoformConcentrationMeasurementClusterServerInitCallback(uint8_t e
  * Ver.: always
  */
 void emberAfBromoformConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Bromoform Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -13330,7 +13502,7 @@ void emberAfBromoformConcentrationMeasurementClusterServerMessageSentCallback(Em
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfBromoformConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                EmberAfAttributeType attributeType,
                                                                                                uint8_t size, uint8_t * value);
 /** @brief Bromoform Concentration Measurement Cluster Server Tick
@@ -13339,7 +13511,7 @@ EmberAfStatus emberAfBromoformConcentrationMeasurementClusterServerPreAttributeC
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfBromoformConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Bromoform Concentration Measurement Cluster Callbacks */
 
@@ -13354,7 +13526,7 @@ void emberAfBromoformConcentrationMeasurementClusterServerTickCallback(uint8_t e
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId);
+                                                                                              chip::AttributeId attributeId);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -13364,7 +13536,8 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientAttributeCh
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                             uint8_t commandId,
                                                                                              EmberAfStatus status);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Client Init
  *
@@ -13372,7 +13545,7 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientDefaultResp
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -13383,7 +13556,7 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientInitCallbac
  * Ver.: always
  */
 void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -13411,14 +13584,14 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientMessageSent
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChlorodibromomethaneConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -13427,7 +13600,7 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientTickCallbac
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId);
+                                                                                              chip::AttributeId attributeId);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -13437,7 +13610,8 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerAttributeCh
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                             uint8_t commandId,
                                                                                              EmberAfStatus status);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Init
  *
@@ -13445,7 +13619,7 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerDefaultResp
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -13456,7 +13630,7 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerInitCallbac
  * Ver.: always
  */
 void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -13484,14 +13658,14 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerMessageSent
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChlorodibromomethaneConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Chlorodibromomethane Concentration Measurement Cluster Callbacks */
 
@@ -13505,8 +13679,8 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerTickCallbac
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId);
+void emberAfChloroformConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId);
 /** @brief Chloroform Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -13516,7 +13690,7 @@ void emberAfChloroformConcentrationMeasurementClusterClientAttributeChangedCallb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChloroformConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                    EmberAfStatus status);
 /** @brief Chloroform Concentration Measurement Cluster Client Init
  *
@@ -13524,7 +13698,7 @@ void emberAfChloroformConcentrationMeasurementClusterClientDefaultResponseCallba
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfChloroformConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Chloroform Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -13535,7 +13709,7 @@ void emberAfChloroformConcentrationMeasurementClusterClientInitCallback(uint8_t 
  * Ver.: always
  */
 void emberAfChloroformConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Chloroform Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -13563,7 +13737,7 @@ void emberAfChloroformConcentrationMeasurementClusterClientMessageSentCallback(E
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChloroformConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                                EmberAfAttributeId attributeId,
+                                                                                                chip::AttributeId attributeId,
                                                                                                 EmberAfAttributeType attributeType,
                                                                                                 uint8_t size, uint8_t * value);
 /** @brief Chloroform Concentration Measurement Cluster Client Tick
@@ -13572,7 +13746,7 @@ EmberAfStatus emberAfChloroformConcentrationMeasurementClusterClientPreAttribute
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfChloroformConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Chloroform Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -13580,8 +13754,8 @@ void emberAfChloroformConcentrationMeasurementClusterClientTickCallback(uint8_t 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId);
+void emberAfChloroformConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId);
 /** @brief Chloroform Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -13591,7 +13765,7 @@ void emberAfChloroformConcentrationMeasurementClusterServerAttributeChangedCallb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChloroformConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                    EmberAfStatus status);
 /** @brief Chloroform Concentration Measurement Cluster Server Init
  *
@@ -13599,7 +13773,7 @@ void emberAfChloroformConcentrationMeasurementClusterServerDefaultResponseCallba
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfChloroformConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Chloroform Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -13610,7 +13784,7 @@ void emberAfChloroformConcentrationMeasurementClusterServerInitCallback(uint8_t 
  * Ver.: always
  */
 void emberAfChloroformConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Chloroform Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -13638,7 +13812,7 @@ void emberAfChloroformConcentrationMeasurementClusterServerMessageSentCallback(E
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChloroformConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                                EmberAfAttributeId attributeId,
+                                                                                                chip::AttributeId attributeId,
                                                                                                 EmberAfAttributeType attributeType,
                                                                                                 uint8_t size, uint8_t * value);
 /** @brief Chloroform Concentration Measurement Cluster Server Tick
@@ -13647,7 +13821,7 @@ EmberAfStatus emberAfChloroformConcentrationMeasurementClusterServerPreAttribute
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfChloroformConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Chloroform Concentration Measurement Cluster Callbacks */
 
@@ -13661,7 +13835,8 @@ void emberAfChloroformConcentrationMeasurementClusterServerTickCallback(uint8_t 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSodiumConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId);
 /** @brief Sodium Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -13671,7 +13846,7 @@ void emberAfSodiumConcentrationMeasurementClusterClientAttributeChangedCallback(
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfSodiumConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                EmberAfStatus status);
 /** @brief Sodium Concentration Measurement Cluster Client Init
  *
@@ -13679,7 +13854,7 @@ void emberAfSodiumConcentrationMeasurementClusterClientDefaultResponseCallback(u
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfSodiumConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Sodium Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -13690,7 +13865,7 @@ void emberAfSodiumConcentrationMeasurementClusterClientInitCallback(uint8_t endp
  * Ver.: always
  */
 void emberAfSodiumConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                    EmberAfAttributeId attributeId,
+                                                                                                    chip::AttributeId attributeId,
                                                                                                     uint16_t manufacturerCode);
 /** @brief Sodium Concentration Measurement Cluster Client Message Sent
  *
@@ -13718,7 +13893,7 @@ void emberAfSodiumConcentrationMeasurementClusterClientMessageSentCallback(Ember
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfSodiumConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                            EmberAfAttributeId attributeId,
+                                                                                            chip::AttributeId attributeId,
                                                                                             EmberAfAttributeType attributeType,
                                                                                             uint8_t size, uint8_t * value);
 /** @brief Sodium Concentration Measurement Cluster Client Tick
@@ -13727,7 +13902,7 @@ EmberAfStatus emberAfSodiumConcentrationMeasurementClusterClientPreAttributeChan
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfSodiumConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Sodium Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -13735,7 +13910,8 @@ void emberAfSodiumConcentrationMeasurementClusterClientTickCallback(uint8_t endp
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSodiumConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId);
 /** @brief Sodium Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -13745,7 +13921,7 @@ void emberAfSodiumConcentrationMeasurementClusterServerAttributeChangedCallback(
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfSodiumConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                EmberAfStatus status);
 /** @brief Sodium Concentration Measurement Cluster Server Init
  *
@@ -13753,7 +13929,7 @@ void emberAfSodiumConcentrationMeasurementClusterServerDefaultResponseCallback(u
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfSodiumConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Sodium Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -13764,7 +13940,7 @@ void emberAfSodiumConcentrationMeasurementClusterServerInitCallback(uint8_t endp
  * Ver.: always
  */
 void emberAfSodiumConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                    EmberAfAttributeId attributeId,
+                                                                                                    chip::AttributeId attributeId,
                                                                                                     uint16_t manufacturerCode);
 /** @brief Sodium Concentration Measurement Cluster Server Message Sent
  *
@@ -13792,7 +13968,7 @@ void emberAfSodiumConcentrationMeasurementClusterServerMessageSentCallback(Ember
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfSodiumConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                            EmberAfAttributeId attributeId,
+                                                                                            chip::AttributeId attributeId,
                                                                                             EmberAfAttributeType attributeType,
                                                                                             uint8_t size, uint8_t * value);
 /** @brief Sodium Concentration Measurement Cluster Server Tick
@@ -13801,7 +13977,7 @@ EmberAfStatus emberAfSodiumConcentrationMeasurementClusterServerPreAttributeChan
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfSodiumConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Sodium Concentration Measurement Cluster Callbacks */
 
@@ -13815,7 +13991,7 @@ void emberAfSodiumConcentrationMeasurementClusterServerTickCallback(uint8_t endp
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIasZoneClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIasZoneClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief IAS Zone Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -13825,14 +14001,14 @@ void emberAfIasZoneClusterClientAttributeChangedCallback(uint8_t endpoint, Ember
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIasZoneClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIasZoneClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief IAS Zone Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIasZoneClusterClientInitCallback(uint8_t endpoint);
+void emberAfIasZoneClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief IAS Zone Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -13842,7 +14018,8 @@ void emberAfIasZoneClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIasZoneClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIasZoneClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              uint16_t manufacturerCode);
 /** @brief IAS Zone Cluster Client Message Sent
  *
@@ -13869,7 +14046,7 @@ void emberAfIasZoneClusterClientMessageSentCallback(EmberOutgoingMessageType typ
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIasZoneClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIasZoneClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                      EmberAfAttributeType attributeType, uint8_t size,
                                                                      uint8_t * value);
 /** @brief IAS Zone Cluster Client Tick
@@ -13878,7 +14055,7 @@ EmberAfStatus emberAfIasZoneClusterClientPreAttributeChangedCallback(uint8_t end
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIasZoneClusterClientTickCallback(uint8_t endpoint);
+void emberAfIasZoneClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief IAS Zone Cluster Initiate Normal Operation Mode
  *
  *
@@ -13912,7 +14089,7 @@ bool emberAfIasZoneClusterInitiateTestModeResponseCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIasZoneClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIasZoneClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief IAS Zone Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -13922,14 +14099,14 @@ void emberAfIasZoneClusterServerAttributeChangedCallback(uint8_t endpoint, Ember
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIasZoneClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIasZoneClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief IAS Zone Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIasZoneClusterServerInitCallback(uint8_t endpoint);
+void emberAfIasZoneClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief IAS Zone Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -13939,7 +14116,8 @@ void emberAfIasZoneClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIasZoneClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIasZoneClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              uint16_t manufacturerCode);
 /** @brief IAS Zone Cluster Server Message Sent
  *
@@ -13966,7 +14144,7 @@ void emberAfIasZoneClusterServerMessageSentCallback(EmberOutgoingMessageType typ
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIasZoneClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIasZoneClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                      EmberAfAttributeType attributeType, uint8_t size,
                                                                      uint8_t * value);
 /** @brief IAS Zone Cluster Server Tick
@@ -13975,7 +14153,7 @@ EmberAfStatus emberAfIasZoneClusterServerPreAttributeChangedCallback(uint8_t end
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIasZoneClusterServerTickCallback(uint8_t endpoint);
+void emberAfIasZoneClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief IAS Zone Cluster Zone Enroll Request
  *
  *
@@ -14049,7 +14227,7 @@ bool emberAfIasAceClusterBypassResponseCallback(uint8_t numberOfZones, uint8_t *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIasAceClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIasAceClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief IAS ACE Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -14059,14 +14237,14 @@ void emberAfIasAceClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIasAceClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIasAceClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief IAS ACE Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIasAceClusterClientInitCallback(uint8_t endpoint);
+void emberAfIasAceClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief IAS ACE Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -14076,7 +14254,8 @@ void emberAfIasAceClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIasAceClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIasAceClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief IAS ACE Cluster Client Message Sent
  *
@@ -14103,7 +14282,7 @@ void emberAfIasAceClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIasAceClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIasAceClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief IAS ACE Cluster Client Tick
@@ -14112,7 +14291,7 @@ EmberAfStatus emberAfIasAceClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIasAceClusterClientTickCallback(uint8_t endpoint);
+void emberAfIasAceClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief IAS ACE Cluster Emergency
  *
  *
@@ -14243,7 +14422,7 @@ bool emberAfIasAceClusterPanicCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIasAceClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIasAceClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief IAS ACE Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -14253,14 +14432,14 @@ void emberAfIasAceClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIasAceClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIasAceClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief IAS ACE Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIasAceClusterServerInitCallback(uint8_t endpoint);
+void emberAfIasAceClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief IAS ACE Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -14270,7 +14449,8 @@ void emberAfIasAceClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIasAceClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIasAceClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief IAS ACE Cluster Server Message Sent
  *
@@ -14297,7 +14477,7 @@ void emberAfIasAceClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIasAceClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIasAceClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief IAS ACE Cluster Server Tick
@@ -14306,7 +14486,7 @@ EmberAfStatus emberAfIasAceClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIasAceClusterServerTickCallback(uint8_t endpoint);
+void emberAfIasAceClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief IAS ACE Cluster Set Bypassed Zone List
  *
  *
@@ -14339,7 +14519,7 @@ bool emberAfIasAceClusterZoneStatusChangedCallback(uint8_t zoneId, uint16_t zone
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIasWdClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIasWdClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief IAS WD Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -14349,14 +14529,14 @@ void emberAfIasWdClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIasWdClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIasWdClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief IAS WD Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIasWdClusterClientInitCallback(uint8_t endpoint);
+void emberAfIasWdClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief IAS WD Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -14366,7 +14546,7 @@ void emberAfIasWdClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIasWdClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIasWdClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief IAS WD Cluster Client Message Sent
  *
@@ -14392,7 +14572,7 @@ void emberAfIasWdClusterClientMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIasWdClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIasWdClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief IAS WD Cluster Client Tick
@@ -14401,7 +14581,7 @@ EmberAfStatus emberAfIasWdClusterClientPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIasWdClusterClientTickCallback(uint8_t endpoint);
+void emberAfIasWdClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief IAS WD Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -14409,7 +14589,7 @@ void emberAfIasWdClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIasWdClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIasWdClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief IAS WD Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -14419,14 +14599,14 @@ void emberAfIasWdClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIasWdClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIasWdClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief IAS WD Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIasWdClusterServerInitCallback(uint8_t endpoint);
+void emberAfIasWdClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief IAS WD Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -14436,7 +14616,7 @@ void emberAfIasWdClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIasWdClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIasWdClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief IAS WD Cluster Server Message Sent
  *
@@ -14462,7 +14642,7 @@ void emberAfIasWdClusterServerMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIasWdClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIasWdClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief IAS WD Cluster Server Tick
@@ -14471,7 +14651,7 @@ EmberAfStatus emberAfIasWdClusterServerPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIasWdClusterServerTickCallback(uint8_t endpoint);
+void emberAfIasWdClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief IAS WD Cluster Squawk
  *
  *
@@ -14510,7 +14690,7 @@ bool emberAfGenericTunnelClusterAdvertiseProtocolAddressCallback(uint8_t * proto
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGenericTunnelClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGenericTunnelClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Generic Tunnel Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -14520,14 +14700,15 @@ void emberAfGenericTunnelClusterClientAttributeChangedCallback(uint8_t endpoint,
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGenericTunnelClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGenericTunnelClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                              EmberAfStatus status);
 /** @brief Generic Tunnel Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGenericTunnelClusterClientInitCallback(uint8_t endpoint);
+void emberAfGenericTunnelClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Generic Tunnel Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -14537,7 +14718,8 @@ void emberAfGenericTunnelClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGenericTunnelClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGenericTunnelClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    uint16_t manufacturerCode);
 /** @brief Generic Tunnel Cluster Client Message Sent
  *
@@ -14564,7 +14746,7 @@ void emberAfGenericTunnelClusterClientMessageSentCallback(EmberOutgoingMessageTy
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGenericTunnelClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGenericTunnelClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            EmberAfAttributeType attributeType, uint8_t size,
                                                                            uint8_t * value);
 /** @brief Generic Tunnel Cluster Client Tick
@@ -14573,7 +14755,7 @@ EmberAfStatus emberAfGenericTunnelClusterClientPreAttributeChangedCallback(uint8
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGenericTunnelClusterClientTickCallback(uint8_t endpoint);
+void emberAfGenericTunnelClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Generic Tunnel Cluster Match Protocol Address
  *
  *
@@ -14596,7 +14778,7 @@ bool emberAfGenericTunnelClusterMatchProtocolAddressResponseCallback(uint8_t * d
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGenericTunnelClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGenericTunnelClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Generic Tunnel Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -14606,14 +14788,15 @@ void emberAfGenericTunnelClusterServerAttributeChangedCallback(uint8_t endpoint,
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGenericTunnelClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGenericTunnelClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                              EmberAfStatus status);
 /** @brief Generic Tunnel Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGenericTunnelClusterServerInitCallback(uint8_t endpoint);
+void emberAfGenericTunnelClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Generic Tunnel Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -14623,7 +14806,8 @@ void emberAfGenericTunnelClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGenericTunnelClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGenericTunnelClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    uint16_t manufacturerCode);
 /** @brief Generic Tunnel Cluster Server Message Sent
  *
@@ -14650,7 +14834,7 @@ void emberAfGenericTunnelClusterServerMessageSentCallback(EmberOutgoingMessageTy
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGenericTunnelClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGenericTunnelClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            EmberAfAttributeType attributeType, uint8_t size,
                                                                            uint8_t * value);
 /** @brief Generic Tunnel Cluster Server Tick
@@ -14659,7 +14843,7 @@ EmberAfStatus emberAfGenericTunnelClusterServerPreAttributeChangedCallback(uint8
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGenericTunnelClusterServerTickCallback(uint8_t endpoint);
+void emberAfGenericTunnelClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Generic Tunnel Cluster Callbacks */
 
@@ -14673,7 +14857,7 @@ void emberAfGenericTunnelClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBacnetProtocolTunnelClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief BACnet Protocol Tunnel Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -14683,14 +14867,15 @@ void emberAfBacnetProtocolTunnelClusterClientAttributeChangedCallback(uint8_t en
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBacnetProtocolTunnelClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                     EmberAfStatus status);
 /** @brief BACnet Protocol Tunnel Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterClientInitCallback(uint8_t endpoint);
+void emberAfBacnetProtocolTunnelClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief BACnet Protocol Tunnel Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -14701,7 +14886,7 @@ void emberAfBacnetProtocolTunnelClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfBacnetProtocolTunnelClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId,
+                                                                                          chip::AttributeId attributeId,
                                                                                           uint16_t manufacturerCode);
 /** @brief BACnet Protocol Tunnel Cluster Client Message Sent
  *
@@ -14728,7 +14913,8 @@ void emberAfBacnetProtocolTunnelClusterClientMessageSentCallback(EmberOutgoingMe
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBacnetProtocolTunnelClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBacnetProtocolTunnelClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   EmberAfAttributeType attributeType, uint8_t size,
                                                                                   uint8_t * value);
 /** @brief BACnet Protocol Tunnel Cluster Client Tick
@@ -14737,7 +14923,7 @@ EmberAfStatus emberAfBacnetProtocolTunnelClusterClientPreAttributeChangedCallbac
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterClientTickCallback(uint8_t endpoint);
+void emberAfBacnetProtocolTunnelClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief BACnet Protocol Tunnel Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -14745,7 +14931,7 @@ void emberAfBacnetProtocolTunnelClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBacnetProtocolTunnelClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief BACnet Protocol Tunnel Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -14755,14 +14941,15 @@ void emberAfBacnetProtocolTunnelClusterServerAttributeChangedCallback(uint8_t en
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBacnetProtocolTunnelClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                     EmberAfStatus status);
 /** @brief BACnet Protocol Tunnel Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterServerInitCallback(uint8_t endpoint);
+void emberAfBacnetProtocolTunnelClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief BACnet Protocol Tunnel Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -14773,7 +14960,7 @@ void emberAfBacnetProtocolTunnelClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfBacnetProtocolTunnelClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId,
+                                                                                          chip::AttributeId attributeId,
                                                                                           uint16_t manufacturerCode);
 /** @brief BACnet Protocol Tunnel Cluster Server Message Sent
  *
@@ -14800,7 +14987,8 @@ void emberAfBacnetProtocolTunnelClusterServerMessageSentCallback(EmberOutgoingMe
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBacnetProtocolTunnelClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBacnetProtocolTunnelClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   EmberAfAttributeType attributeType, uint8_t size,
                                                                                   uint8_t * value);
 /** @brief BACnet Protocol Tunnel Cluster Server Tick
@@ -14809,7 +14997,7 @@ EmberAfStatus emberAfBacnetProtocolTunnelClusterServerPreAttributeChangedCallbac
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterServerTickCallback(uint8_t endpoint);
+void emberAfBacnetProtocolTunnelClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief BACnet Protocol Tunnel Cluster Transfer Npdu
  *
  *
@@ -14830,7 +15018,7 @@ bool emberAfBacnetProtocolTunnelClusterTransferNpduCallback(uint8_t * npdu);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAf11073ProtocolTunnelClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief 11073 Protocol Tunnel Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -14840,14 +15028,15 @@ void emberAf11073ProtocolTunnelClusterClientAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAf11073ProtocolTunnelClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief 11073 Protocol Tunnel Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterClientInitCallback(uint8_t endpoint);
+void emberAf11073ProtocolTunnelClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief 11073 Protocol Tunnel Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -14858,7 +15047,7 @@ void emberAf11073ProtocolTunnelClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAf11073ProtocolTunnelClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief 11073 Protocol Tunnel Cluster Client Message Sent
  *
@@ -14885,7 +15074,8 @@ void emberAf11073ProtocolTunnelClusterClientMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAf11073ProtocolTunnelClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAf11073ProtocolTunnelClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief 11073 Protocol Tunnel Cluster Client Tick
@@ -14894,7 +15084,7 @@ EmberAfStatus emberAf11073ProtocolTunnelClusterClientPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterClientTickCallback(uint8_t endpoint);
+void emberAf11073ProtocolTunnelClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief 11073 Protocol Tunnel Cluster Connect Request
  *
  *
@@ -14927,7 +15117,7 @@ bool emberAf11073ProtocolTunnelClusterDisconnectRequestCallback(uint8_t * manage
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAf11073ProtocolTunnelClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief 11073 Protocol Tunnel Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -14937,14 +15127,15 @@ void emberAf11073ProtocolTunnelClusterServerAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAf11073ProtocolTunnelClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief 11073 Protocol Tunnel Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterServerInitCallback(uint8_t endpoint);
+void emberAf11073ProtocolTunnelClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief 11073 Protocol Tunnel Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -14955,7 +15146,7 @@ void emberAf11073ProtocolTunnelClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAf11073ProtocolTunnelClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief 11073 Protocol Tunnel Cluster Server Message Sent
  *
@@ -14982,7 +15173,8 @@ void emberAf11073ProtocolTunnelClusterServerMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAf11073ProtocolTunnelClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAf11073ProtocolTunnelClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief 11073 Protocol Tunnel Cluster Server Tick
@@ -14991,7 +15183,7 @@ EmberAfStatus emberAf11073ProtocolTunnelClusterServerPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterServerTickCallback(uint8_t endpoint);
+void emberAf11073ProtocolTunnelClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief 11073 Protocol Tunnel Cluster Transfer A P D U
  *
  *
@@ -15012,7 +15204,7 @@ bool emberAf11073ProtocolTunnelClusterTransferAPDUCallback(uint8_t * apdu);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIso7816ProtocolTunnelClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief ISO 7816 Protocol Tunnel Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -15022,14 +15214,15 @@ void emberAfIso7816ProtocolTunnelClusterClientAttributeChangedCallback(uint8_t e
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIso7816ProtocolTunnelClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                      EmberAfStatus status);
 /** @brief ISO 7816 Protocol Tunnel Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterClientInitCallback(uint8_t endpoint);
+void emberAfIso7816ProtocolTunnelClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief ISO 7816 Protocol Tunnel Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -15040,7 +15233,7 @@ void emberAfIso7816ProtocolTunnelClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfIso7816ProtocolTunnelClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                           EmberAfAttributeId attributeId,
+                                                                                           chip::AttributeId attributeId,
                                                                                            uint16_t manufacturerCode);
 /** @brief ISO 7816 Protocol Tunnel Cluster Client Message Sent
  *
@@ -15067,7 +15260,8 @@ void emberAfIso7816ProtocolTunnelClusterClientMessageSentCallback(EmberOutgoingM
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIso7816ProtocolTunnelClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIso7816ProtocolTunnelClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                                    uint8_t * value);
 /** @brief ISO 7816 Protocol Tunnel Cluster Client Tick
@@ -15076,7 +15270,7 @@ EmberAfStatus emberAfIso7816ProtocolTunnelClusterClientPreAttributeChangedCallba
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterClientTickCallback(uint8_t endpoint);
+void emberAfIso7816ProtocolTunnelClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief ISO 7816 Protocol Tunnel Cluster Extract Smart Card
  *
  *
@@ -15096,7 +15290,7 @@ bool emberAfIso7816ProtocolTunnelClusterInsertSmartCardCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIso7816ProtocolTunnelClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief ISO 7816 Protocol Tunnel Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -15106,14 +15300,15 @@ void emberAfIso7816ProtocolTunnelClusterServerAttributeChangedCallback(uint8_t e
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIso7816ProtocolTunnelClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                      EmberAfStatus status);
 /** @brief ISO 7816 Protocol Tunnel Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterServerInitCallback(uint8_t endpoint);
+void emberAfIso7816ProtocolTunnelClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief ISO 7816 Protocol Tunnel Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -15124,7 +15319,7 @@ void emberAfIso7816ProtocolTunnelClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfIso7816ProtocolTunnelClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                           EmberAfAttributeId attributeId,
+                                                                                           chip::AttributeId attributeId,
                                                                                            uint16_t manufacturerCode);
 /** @brief ISO 7816 Protocol Tunnel Cluster Server Message Sent
  *
@@ -15151,7 +15346,8 @@ void emberAfIso7816ProtocolTunnelClusterServerMessageSentCallback(EmberOutgoingM
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIso7816ProtocolTunnelClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIso7816ProtocolTunnelClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                                    uint8_t * value);
 /** @brief ISO 7816 Protocol Tunnel Cluster Server Tick
@@ -15160,7 +15356,7 @@ EmberAfStatus emberAfIso7816ProtocolTunnelClusterServerPreAttributeChangedCallba
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterServerTickCallback(uint8_t endpoint);
+void emberAfIso7816ProtocolTunnelClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief ISO 7816 Protocol Tunnel Cluster Transfer Apdu
  *
  *
@@ -15190,7 +15386,7 @@ bool emberAfPriceClusterCancelTariffCallback(uint32_t providerId, uint32_t issue
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPriceClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPriceClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Price Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -15200,14 +15396,14 @@ void emberAfPriceClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPriceClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPriceClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Price Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPriceClusterClientInitCallback(uint8_t endpoint);
+void emberAfPriceClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Price Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -15217,7 +15413,7 @@ void emberAfPriceClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPriceClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPriceClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief Price Cluster Client Message Sent
  *
@@ -15243,7 +15439,7 @@ void emberAfPriceClusterClientMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPriceClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPriceClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief Price Cluster Client Tick
@@ -15252,7 +15448,7 @@ EmberAfStatus emberAfPriceClusterClientPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPriceClusterClientTickCallback(uint8_t endpoint);
+void emberAfPriceClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Price Cluster Cpp Event Response
  *
  *
@@ -15652,7 +15848,7 @@ bool emberAfPriceClusterPublishTierLabelsCallback(uint32_t providerId, uint32_t 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPriceClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPriceClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Price Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -15662,14 +15858,14 @@ void emberAfPriceClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPriceClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPriceClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Price Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPriceClusterServerInitCallback(uint8_t endpoint);
+void emberAfPriceClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Price Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -15679,7 +15875,7 @@ void emberAfPriceClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPriceClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPriceClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief Price Cluster Server Message Sent
  *
@@ -15705,7 +15901,7 @@ void emberAfPriceClusterServerMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPriceClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPriceClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief Price Cluster Server Tick
@@ -15714,7 +15910,7 @@ EmberAfStatus emberAfPriceClusterServerPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPriceClusterServerTickCallback(uint8_t endpoint);
+void emberAfPriceClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Price Cluster Callbacks */
 
@@ -15748,7 +15944,8 @@ bool emberAfDemandResponseLoadControlClusterCancelLoadControlEventCallback(uint3
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDemandResponseLoadControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                           chip::AttributeId attributeId);
 /** @brief Demand Response and Load Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -15758,7 +15955,7 @@ void emberAfDemandResponseLoadControlClusterClientAttributeChangedCallback(uint8
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfDemandResponseLoadControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                           EmberAfStatus status);
 /** @brief Demand Response and Load Control Cluster Client Init
  *
@@ -15766,7 +15963,7 @@ void emberAfDemandResponseLoadControlClusterClientDefaultResponseCallback(uint8_
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfDemandResponseLoadControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Demand Response and Load Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -15777,7 +15974,7 @@ void emberAfDemandResponseLoadControlClusterClientInitCallback(uint8_t endpoint)
  * Ver.: always
  */
 void emberAfDemandResponseLoadControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                uint16_t manufacturerCode);
 /** @brief Demand Response and Load Control Cluster Client Message Sent
  *
@@ -15805,7 +16002,7 @@ void emberAfDemandResponseLoadControlClusterClientMessageSentCallback(EmberOutgo
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfDemandResponseLoadControlClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        EmberAfAttributeType attributeType,
                                                                                        uint8_t size, uint8_t * value);
 /** @brief Demand Response and Load Control Cluster Client Tick
@@ -15814,7 +16011,7 @@ EmberAfStatus emberAfDemandResponseLoadControlClusterClientPreAttributeChangedCa
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfDemandResponseLoadControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Demand Response and Load Control Cluster Get Scheduled Events
  *
  *
@@ -15878,7 +16075,8 @@ bool emberAfDemandResponseLoadControlClusterReportEventStatusCallback(uint32_t i
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDemandResponseLoadControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                           chip::AttributeId attributeId);
 /** @brief Demand Response and Load Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -15888,7 +16086,7 @@ void emberAfDemandResponseLoadControlClusterServerAttributeChangedCallback(uint8
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfDemandResponseLoadControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                           EmberAfStatus status);
 /** @brief Demand Response and Load Control Cluster Server Init
  *
@@ -15896,7 +16094,7 @@ void emberAfDemandResponseLoadControlClusterServerDefaultResponseCallback(uint8_
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfDemandResponseLoadControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Demand Response and Load Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -15907,7 +16105,7 @@ void emberAfDemandResponseLoadControlClusterServerInitCallback(uint8_t endpoint)
  * Ver.: always
  */
 void emberAfDemandResponseLoadControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                uint16_t manufacturerCode);
 /** @brief Demand Response and Load Control Cluster Server Message Sent
  *
@@ -15935,7 +16133,7 @@ void emberAfDemandResponseLoadControlClusterServerMessageSentCallback(EmberOutgo
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfDemandResponseLoadControlClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        EmberAfAttributeType attributeType,
                                                                                        uint8_t size, uint8_t * value);
 /** @brief Demand Response and Load Control Cluster Server Tick
@@ -15944,7 +16142,7 @@ EmberAfStatus emberAfDemandResponseLoadControlClusterServerPreAttributeChangedCa
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfDemandResponseLoadControlClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Demand Response and Load Control Cluster Callbacks */
 
@@ -15972,7 +16170,7 @@ bool emberAfSimpleMeteringClusterChangeSupplyCallback(uint32_t providerId, uint3
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSimpleMeteringClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSimpleMeteringClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Simple Metering Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -15982,14 +16180,15 @@ void emberAfSimpleMeteringClusterClientAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSimpleMeteringClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSimpleMeteringClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Simple Metering Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSimpleMeteringClusterClientInitCallback(uint8_t endpoint);
+void emberAfSimpleMeteringClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Simple Metering Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -15999,8 +16198,8 @@ void emberAfSimpleMeteringClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfSimpleMeteringClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfSimpleMeteringClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Simple Metering Cluster Client Message Sent
  *
@@ -16027,7 +16226,8 @@ void emberAfSimpleMeteringClusterClientMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSimpleMeteringClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSimpleMeteringClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Simple Metering Cluster Client Tick
@@ -16036,7 +16236,7 @@ EmberAfStatus emberAfSimpleMeteringClusterClientPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSimpleMeteringClusterClientTickCallback(uint8_t endpoint);
+void emberAfSimpleMeteringClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Simple Metering Cluster Configure Mirror
  *
  *
@@ -16063,7 +16263,7 @@ bool emberAfSimpleMeteringClusterConfigureMirrorCallback(uint32_t issuerEventId,
 bool emberAfSimpleMeteringClusterConfigureNotificationFlagsCallback(uint32_t issuerEventId, uint8_t notificationScheme,
                                                                     uint16_t notificationFlagAttributeId, uint16_t clusterId,
                                                                     uint16_t manufacturerCode, uint8_t numberOfCommands,
-                                                                    uint8_t * commandIds);
+                                                                    chip::CommandId * commandIds);
 /** @brief Simple Metering Cluster Configure Notification Scheme
  *
  *
@@ -16248,7 +16448,7 @@ bool emberAfSimpleMeteringClusterScheduleSnapshotResponseCallback(uint32_t issue
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSimpleMeteringClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSimpleMeteringClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Simple Metering Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -16258,14 +16458,15 @@ void emberAfSimpleMeteringClusterServerAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSimpleMeteringClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSimpleMeteringClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Simple Metering Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSimpleMeteringClusterServerInitCallback(uint8_t endpoint);
+void emberAfSimpleMeteringClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Simple Metering Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -16275,8 +16476,8 @@ void emberAfSimpleMeteringClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfSimpleMeteringClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfSimpleMeteringClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Simple Metering Cluster Server Message Sent
  *
@@ -16303,7 +16504,8 @@ void emberAfSimpleMeteringClusterServerMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSimpleMeteringClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSimpleMeteringClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Simple Metering Cluster Server Tick
@@ -16312,7 +16514,7 @@ EmberAfStatus emberAfSimpleMeteringClusterServerPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSimpleMeteringClusterServerTickCallback(uint8_t endpoint);
+void emberAfSimpleMeteringClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Simple Metering Cluster Set Supply Status
  *
  *
@@ -16416,7 +16618,7 @@ bool emberAfMessagingClusterCancelMessageCallback(uint32_t messageId, uint8_t me
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMessagingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMessagingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Messaging Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -16426,14 +16628,15 @@ void emberAfMessagingClusterClientAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMessagingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMessagingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Messaging Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMessagingClusterClientInitCallback(uint8_t endpoint);
+void emberAfMessagingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Messaging Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -16443,7 +16646,8 @@ void emberAfMessagingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfMessagingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfMessagingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Messaging Cluster Client Message Sent
  *
@@ -16470,7 +16674,7 @@ void emberAfMessagingClusterClientMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMessagingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMessagingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Messaging Cluster Client Tick
@@ -16479,7 +16683,7 @@ EmberAfStatus emberAfMessagingClusterClientPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMessagingClusterClientTickCallback(uint8_t endpoint);
+void emberAfMessagingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Messaging Cluster Display Message
  *
  *
@@ -16539,7 +16743,7 @@ bool emberAfMessagingClusterMessageConfirmationCallback(uint32_t messageId, uint
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMessagingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMessagingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Messaging Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -16549,14 +16753,15 @@ void emberAfMessagingClusterServerAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMessagingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMessagingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Messaging Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMessagingClusterServerInitCallback(uint8_t endpoint);
+void emberAfMessagingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Messaging Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -16566,7 +16771,8 @@ void emberAfMessagingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfMessagingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfMessagingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Messaging Cluster Server Message Sent
  *
@@ -16593,7 +16799,7 @@ void emberAfMessagingClusterServerMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMessagingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMessagingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Messaging Cluster Server Tick
@@ -16602,7 +16808,7 @@ EmberAfStatus emberAfMessagingClusterServerPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMessagingClusterServerTickCallback(uint8_t endpoint);
+void emberAfMessagingClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Messaging Cluster Callbacks */
 
@@ -16632,7 +16838,7 @@ bool emberAfTunnelingClusterAckTransferDataServerToClientCallback(uint16_t tunne
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTunnelingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfTunnelingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Tunneling Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -16642,14 +16848,15 @@ void emberAfTunnelingClusterClientAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTunnelingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfTunnelingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Tunneling Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTunnelingClusterClientInitCallback(uint8_t endpoint);
+void emberAfTunnelingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Tunneling Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -16659,7 +16866,8 @@ void emberAfTunnelingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfTunnelingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfTunnelingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Tunneling Cluster Client Message Sent
  *
@@ -16686,7 +16894,7 @@ void emberAfTunnelingClusterClientMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfTunnelingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfTunnelingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Tunneling Cluster Client Tick
@@ -16695,7 +16903,7 @@ EmberAfStatus emberAfTunnelingClusterClientPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTunnelingClusterClientTickCallback(uint8_t endpoint);
+void emberAfTunnelingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Tunneling Cluster Close Tunnel
  *
  *
@@ -16754,7 +16962,7 @@ bool emberAfTunnelingClusterRequestTunnelResponseCallback(uint16_t tunnelId, uin
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTunnelingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfTunnelingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Tunneling Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -16764,14 +16972,15 @@ void emberAfTunnelingClusterServerAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTunnelingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfTunnelingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Tunneling Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTunnelingClusterServerInitCallback(uint8_t endpoint);
+void emberAfTunnelingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Tunneling Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -16781,7 +16990,8 @@ void emberAfTunnelingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfTunnelingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfTunnelingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Tunneling Cluster Server Message Sent
  *
@@ -16808,7 +17018,7 @@ void emberAfTunnelingClusterServerMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfTunnelingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfTunnelingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Tunneling Cluster Server Tick
@@ -16817,7 +17027,7 @@ EmberAfStatus emberAfTunnelingClusterServerPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTunnelingClusterServerTickCallback(uint8_t endpoint);
+void emberAfTunnelingClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Tunneling Cluster Supported Tunnel Protocols Response
  *
  *
@@ -16922,7 +17132,7 @@ bool emberAfPrepaymentClusterChangePaymentModeResponseCallback(uint8_t friendlyC
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPrepaymentClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPrepaymentClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Prepayment Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -16932,14 +17142,15 @@ void emberAfPrepaymentClusterClientAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPrepaymentClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPrepaymentClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Prepayment Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPrepaymentClusterClientInitCallback(uint8_t endpoint);
+void emberAfPrepaymentClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Prepayment Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -16949,7 +17160,8 @@ void emberAfPrepaymentClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPrepaymentClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPrepaymentClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Prepayment Cluster Client Message Sent
  *
@@ -16976,7 +17188,7 @@ void emberAfPrepaymentClusterClientMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPrepaymentClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPrepaymentClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Prepayment Cluster Client Tick
@@ -16985,7 +17197,7 @@ EmberAfStatus emberAfPrepaymentClusterClientPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPrepaymentClusterClientTickCallback(uint8_t endpoint);
+void emberAfPrepaymentClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Prepayment Cluster Consumer Top Up
  *
  *
@@ -17105,7 +17317,7 @@ bool emberAfPrepaymentClusterSelectAvailableEmergencyCreditCallback(uint32_t com
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPrepaymentClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPrepaymentClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Prepayment Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -17115,14 +17327,15 @@ void emberAfPrepaymentClusterServerAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPrepaymentClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPrepaymentClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Prepayment Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPrepaymentClusterServerInitCallback(uint8_t endpoint);
+void emberAfPrepaymentClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Prepayment Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -17132,7 +17345,8 @@ void emberAfPrepaymentClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPrepaymentClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPrepaymentClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Prepayment Cluster Server Message Sent
  *
@@ -17159,7 +17373,7 @@ void emberAfPrepaymentClusterServerMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPrepaymentClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPrepaymentClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Prepayment Cluster Server Tick
@@ -17168,7 +17382,7 @@ EmberAfStatus emberAfPrepaymentClusterServerPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPrepaymentClusterServerTickCallback(uint8_t endpoint);
+void emberAfPrepaymentClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Prepayment Cluster Set Low Credit Warning Level
  *
  *
@@ -17213,7 +17427,7 @@ bool emberAfPrepaymentClusterSetOverallDebtCapCallback(uint32_t providerId, uint
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfEnergyManagementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfEnergyManagementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Energy Management Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -17223,14 +17437,15 @@ void emberAfEnergyManagementClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEnergyManagementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfEnergyManagementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Energy Management Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEnergyManagementClusterClientInitCallback(uint8_t endpoint);
+void emberAfEnergyManagementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Energy Management Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -17240,8 +17455,8 @@ void emberAfEnergyManagementClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfEnergyManagementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfEnergyManagementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Energy Management Cluster Client Message Sent
  *
@@ -17268,7 +17483,8 @@ void emberAfEnergyManagementClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfEnergyManagementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfEnergyManagementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Energy Management Cluster Client Tick
@@ -17277,7 +17493,7 @@ EmberAfStatus emberAfEnergyManagementClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEnergyManagementClusterClientTickCallback(uint8_t endpoint);
+void emberAfEnergyManagementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Energy Management Cluster Manage Event
  *
  *
@@ -17316,7 +17532,7 @@ bool emberAfEnergyManagementClusterReportEventStatusCallback(uint32_t issuerEven
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfEnergyManagementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfEnergyManagementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Energy Management Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -17326,14 +17542,15 @@ void emberAfEnergyManagementClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEnergyManagementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfEnergyManagementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Energy Management Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEnergyManagementClusterServerInitCallback(uint8_t endpoint);
+void emberAfEnergyManagementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Energy Management Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -17343,8 +17560,8 @@ void emberAfEnergyManagementClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfEnergyManagementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfEnergyManagementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Energy Management Cluster Server Message Sent
  *
@@ -17371,7 +17588,8 @@ void emberAfEnergyManagementClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfEnergyManagementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfEnergyManagementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Energy Management Cluster Server Tick
@@ -17380,7 +17598,7 @@ EmberAfStatus emberAfEnergyManagementClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEnergyManagementClusterServerTickCallback(uint8_t endpoint);
+void emberAfEnergyManagementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Energy Management Cluster Callbacks */
 
@@ -17403,7 +17621,7 @@ bool emberAfCalendarClusterCancelCalendarCallback(uint32_t providerId, uint32_t 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfCalendarClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfCalendarClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Calendar Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -17413,14 +17631,15 @@ void emberAfCalendarClusterClientAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCalendarClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfCalendarClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Calendar Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCalendarClusterClientInitCallback(uint8_t endpoint);
+void emberAfCalendarClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Calendar Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -17430,7 +17649,8 @@ void emberAfCalendarClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfCalendarClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfCalendarClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Calendar Cluster Client Message Sent
  *
@@ -17457,7 +17677,7 @@ void emberAfCalendarClusterClientMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfCalendarClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfCalendarClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Calendar Cluster Client Tick
@@ -17466,7 +17686,7 @@ EmberAfStatus emberAfCalendarClusterClientPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCalendarClusterClientTickCallback(uint8_t endpoint);
+void emberAfCalendarClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Calendar Cluster Get Calendar
  *
  *
@@ -17622,7 +17842,7 @@ bool emberAfCalendarClusterPublishWeekProfileCallback(uint32_t providerId, uint3
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfCalendarClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfCalendarClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Calendar Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -17632,14 +17852,15 @@ void emberAfCalendarClusterServerAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCalendarClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfCalendarClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Calendar Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCalendarClusterServerInitCallback(uint8_t endpoint);
+void emberAfCalendarClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Calendar Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -17649,7 +17870,8 @@ void emberAfCalendarClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfCalendarClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfCalendarClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Calendar Cluster Server Message Sent
  *
@@ -17676,7 +17898,7 @@ void emberAfCalendarClusterServerMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfCalendarClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfCalendarClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Calendar Cluster Server Tick
@@ -17685,7 +17907,7 @@ EmberAfStatus emberAfCalendarClusterServerPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCalendarClusterServerTickCallback(uint8_t endpoint);
+void emberAfCalendarClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Calendar Cluster Callbacks */
 
@@ -17699,7 +17921,7 @@ void emberAfCalendarClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDeviceManagementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDeviceManagementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Device Management Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -17709,14 +17931,15 @@ void emberAfDeviceManagementClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDeviceManagementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDeviceManagementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Device Management Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDeviceManagementClusterClientInitCallback(uint8_t endpoint);
+void emberAfDeviceManagementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Device Management Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -17726,8 +17949,8 @@ void emberAfDeviceManagementClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDeviceManagementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfDeviceManagementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Device Management Cluster Client Message Sent
  *
@@ -17754,7 +17977,8 @@ void emberAfDeviceManagementClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDeviceManagementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDeviceManagementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Device Management Cluster Client Tick
@@ -17763,7 +17987,7 @@ EmberAfStatus emberAfDeviceManagementClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDeviceManagementClusterClientTickCallback(uint8_t endpoint);
+void emberAfDeviceManagementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Device Management Cluster Get C I N
  *
  *
@@ -17863,7 +18087,7 @@ bool emberAfDeviceManagementClusterRequestNewPasswordResponseCallback(uint32_t i
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDeviceManagementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDeviceManagementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Device Management Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -17873,14 +18097,15 @@ void emberAfDeviceManagementClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDeviceManagementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDeviceManagementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Device Management Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDeviceManagementClusterServerInitCallback(uint8_t endpoint);
+void emberAfDeviceManagementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Device Management Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -17890,8 +18115,8 @@ void emberAfDeviceManagementClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDeviceManagementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfDeviceManagementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Device Management Cluster Server Message Sent
  *
@@ -17918,7 +18143,8 @@ void emberAfDeviceManagementClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDeviceManagementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDeviceManagementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Device Management Cluster Server Tick
@@ -17927,7 +18153,7 @@ EmberAfStatus emberAfDeviceManagementClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDeviceManagementClusterServerTickCallback(uint8_t endpoint);
+void emberAfDeviceManagementClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Device Management Cluster Set Event Configuration
  *
  *
@@ -17990,7 +18216,7 @@ bool emberAfEventsClusterClearEventLogResponseCallback(uint8_t clearedEventsLogs
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfEventsClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfEventsClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Events Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -18000,14 +18226,14 @@ void emberAfEventsClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEventsClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfEventsClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Events Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEventsClusterClientInitCallback(uint8_t endpoint);
+void emberAfEventsClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Events Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -18017,7 +18243,8 @@ void emberAfEventsClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfEventsClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfEventsClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Events Cluster Client Message Sent
  *
@@ -18044,7 +18271,7 @@ void emberAfEventsClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfEventsClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfEventsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Events Cluster Client Tick
@@ -18053,7 +18280,7 @@ EmberAfStatus emberAfEventsClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEventsClusterClientTickCallback(uint8_t endpoint);
+void emberAfEventsClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Events Cluster Get Event Log
  *
  *
@@ -18098,7 +18325,7 @@ bool emberAfEventsClusterPublishEventLogCallback(uint16_t totalNumberOfEvents, u
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfEventsClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfEventsClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Events Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -18108,14 +18335,14 @@ void emberAfEventsClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEventsClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfEventsClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Events Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEventsClusterServerInitCallback(uint8_t endpoint);
+void emberAfEventsClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Events Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -18125,7 +18352,8 @@ void emberAfEventsClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfEventsClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfEventsClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Events Cluster Server Message Sent
  *
@@ -18152,7 +18380,7 @@ void emberAfEventsClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfEventsClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfEventsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Events Cluster Server Tick
@@ -18161,7 +18389,7 @@ EmberAfStatus emberAfEventsClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEventsClusterServerTickCallback(uint8_t endpoint);
+void emberAfEventsClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Events Cluster Callbacks */
 
@@ -18175,7 +18403,7 @@ void emberAfEventsClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMduPairingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMduPairingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief MDU Pairing Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -18185,14 +18413,15 @@ void emberAfMduPairingClusterClientAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMduPairingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMduPairingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief MDU Pairing Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMduPairingClusterClientInitCallback(uint8_t endpoint);
+void emberAfMduPairingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief MDU Pairing Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -18202,7 +18431,8 @@ void emberAfMduPairingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfMduPairingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfMduPairingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief MDU Pairing Cluster Client Message Sent
  *
@@ -18229,7 +18459,7 @@ void emberAfMduPairingClusterClientMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMduPairingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMduPairingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief MDU Pairing Cluster Client Tick
@@ -18238,7 +18468,7 @@ EmberAfStatus emberAfMduPairingClusterClientPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMduPairingClusterClientTickCallback(uint8_t endpoint);
+void emberAfMduPairingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief MDU Pairing Cluster Pairing Request
  *
  *
@@ -18266,7 +18496,7 @@ bool emberAfMduPairingClusterPairingResponseCallback(uint32_t pairingInformation
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMduPairingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMduPairingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief MDU Pairing Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -18276,14 +18506,15 @@ void emberAfMduPairingClusterServerAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMduPairingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMduPairingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief MDU Pairing Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMduPairingClusterServerInitCallback(uint8_t endpoint);
+void emberAfMduPairingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief MDU Pairing Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -18293,7 +18524,8 @@ void emberAfMduPairingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfMduPairingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfMduPairingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief MDU Pairing Cluster Server Message Sent
  *
@@ -18320,7 +18552,7 @@ void emberAfMduPairingClusterServerMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMduPairingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMduPairingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief MDU Pairing Cluster Server Tick
@@ -18329,7 +18561,7 @@ EmberAfStatus emberAfMduPairingClusterServerPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMduPairingClusterServerTickCallback(uint8_t endpoint);
+void emberAfMduPairingClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END MDU Pairing Cluster Callbacks */
 
@@ -18343,7 +18575,7 @@ void emberAfMduPairingClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSubGhzClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSubGhzClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Sub-GHz Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -18353,14 +18585,14 @@ void emberAfSubGhzClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSubGhzClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSubGhzClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Sub-GHz Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSubGhzClusterClientInitCallback(uint8_t endpoint);
+void emberAfSubGhzClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Sub-GHz Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -18370,7 +18602,8 @@ void emberAfSubGhzClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfSubGhzClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfSubGhzClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Sub-GHz Cluster Client Message Sent
  *
@@ -18397,7 +18630,7 @@ void emberAfSubGhzClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSubGhzClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSubGhzClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Sub-GHz Cluster Client Tick
@@ -18406,7 +18639,7 @@ EmberAfStatus emberAfSubGhzClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSubGhzClusterClientTickCallback(uint8_t endpoint);
+void emberAfSubGhzClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Sub-GHz Cluster Get Suspend Zcl Messages Status
  *
  *
@@ -18420,7 +18653,7 @@ bool emberAfSubGhzClusterGetSuspendZclMessagesStatusCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSubGhzClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSubGhzClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Sub-GHz Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -18430,14 +18663,14 @@ void emberAfSubGhzClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSubGhzClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSubGhzClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Sub-GHz Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSubGhzClusterServerInitCallback(uint8_t endpoint);
+void emberAfSubGhzClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Sub-GHz Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -18447,7 +18680,8 @@ void emberAfSubGhzClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfSubGhzClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfSubGhzClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Sub-GHz Cluster Server Message Sent
  *
@@ -18474,7 +18708,7 @@ void emberAfSubGhzClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSubGhzClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSubGhzClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Sub-GHz Cluster Server Tick
@@ -18483,7 +18717,7 @@ EmberAfStatus emberAfSubGhzClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSubGhzClusterServerTickCallback(uint8_t endpoint);
+void emberAfSubGhzClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Sub-GHz Cluster Suspend Zcl Messages
  *
  *
@@ -18515,7 +18749,7 @@ bool emberAfKeyEstablishmentClusterClientCommandReceivedCallback(EmberAfClusterC
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfKeyEstablishmentClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfKeyEstablishmentClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Key Establishment Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -18525,14 +18759,15 @@ void emberAfKeyEstablishmentClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfKeyEstablishmentClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfKeyEstablishmentClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Key Establishment Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfKeyEstablishmentClusterClientInitCallback(uint8_t endpoint);
+void emberAfKeyEstablishmentClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Key Establishment Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -18542,8 +18777,8 @@ void emberAfKeyEstablishmentClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfKeyEstablishmentClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfKeyEstablishmentClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Key Establishment Cluster Client Message Sent
  *
@@ -18570,7 +18805,8 @@ void emberAfKeyEstablishmentClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfKeyEstablishmentClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfKeyEstablishmentClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Key Establishment Cluster Client Tick
@@ -18579,7 +18815,7 @@ EmberAfStatus emberAfKeyEstablishmentClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfKeyEstablishmentClusterClientTickCallback(uint8_t endpoint);
+void emberAfKeyEstablishmentClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Key Establishment Cluster Confirm Key Data Request
  *
  *
@@ -18639,7 +18875,7 @@ bool emberAfKeyEstablishmentClusterInitiateKeyEstablishmentResponseCallback(uint
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfKeyEstablishmentClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfKeyEstablishmentClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Key Establishment Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -18649,14 +18885,15 @@ void emberAfKeyEstablishmentClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfKeyEstablishmentClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfKeyEstablishmentClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Key Establishment Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfKeyEstablishmentClusterServerInitCallback(uint8_t endpoint);
+void emberAfKeyEstablishmentClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Key Establishment Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -18666,8 +18903,8 @@ void emberAfKeyEstablishmentClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfKeyEstablishmentClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfKeyEstablishmentClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Key Establishment Cluster Server Message Sent
  *
@@ -18694,7 +18931,8 @@ void emberAfKeyEstablishmentClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfKeyEstablishmentClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfKeyEstablishmentClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Key Establishment Cluster Server Tick
@@ -18703,7 +18941,7 @@ EmberAfStatus emberAfKeyEstablishmentClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfKeyEstablishmentClusterServerTickCallback(uint8_t endpoint);
+void emberAfKeyEstablishmentClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Key Establishment Cluster Terminate Key Establishment
  *
  *
@@ -18738,7 +18976,7 @@ bool emberAfKeyEstablishmentClusterServerCommandReceivedCallback(EmberAfClusterC
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfInformationClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfInformationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Information Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -18748,14 +18986,15 @@ void emberAfInformationClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfInformationClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfInformationClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Information Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfInformationClusterClientInitCallback(uint8_t endpoint);
+void emberAfInformationClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Information Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -18765,7 +19004,8 @@ void emberAfInformationClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfInformationClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfInformationClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Information Cluster Client Message Sent
  *
@@ -18792,7 +19032,7 @@ void emberAfInformationClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfInformationClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfInformationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Information Cluster Client Tick
@@ -18801,7 +19041,7 @@ EmberAfStatus emberAfInformationClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfInformationClusterClientTickCallback(uint8_t endpoint);
+void emberAfInformationClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Information Cluster Configure Delivery Enable
  *
  *
@@ -18916,7 +19156,7 @@ bool emberAfInformationClusterSendPreferenceResponseCallback(uint8_t * statusFee
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfInformationClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfInformationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Information Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -18926,14 +19166,15 @@ void emberAfInformationClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfInformationClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfInformationClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Information Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfInformationClusterServerInitCallback(uint8_t endpoint);
+void emberAfInformationClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Information Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -18943,7 +19184,8 @@ void emberAfInformationClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfInformationClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfInformationClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Information Cluster Server Message Sent
  *
@@ -18970,7 +19212,7 @@ void emberAfInformationClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfInformationClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfInformationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Information Cluster Server Request Preference
@@ -18985,7 +19227,7 @@ bool emberAfInformationClusterServerRequestPreferenceCallback(void);
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfInformationClusterServerTickCallback(uint8_t endpoint);
+void emberAfInformationClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Information Cluster Update
  *
  *
@@ -19015,7 +19257,7 @@ bool emberAfInformationClusterUpdateResponseCallback(uint8_t * notificationList)
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDataSharingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDataSharingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Data Sharing Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -19025,14 +19267,15 @@ void emberAfDataSharingClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDataSharingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDataSharingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Data Sharing Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDataSharingClusterClientInitCallback(uint8_t endpoint);
+void emberAfDataSharingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Data Sharing Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -19042,7 +19285,8 @@ void emberAfDataSharingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDataSharingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDataSharingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Data Sharing Cluster Client Message Sent
  *
@@ -19069,7 +19313,7 @@ void emberAfDataSharingClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDataSharingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDataSharingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Data Sharing Cluster Client Tick
@@ -19078,7 +19322,7 @@ EmberAfStatus emberAfDataSharingClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDataSharingClusterClientTickCallback(uint8_t endpoint);
+void emberAfDataSharingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Data Sharing Cluster File Transmission
  *
  *
@@ -19136,7 +19380,7 @@ bool emberAfDataSharingClusterRecordTransmissionCallback(uint8_t transmitOptions
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDataSharingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDataSharingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Data Sharing Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -19146,14 +19390,15 @@ void emberAfDataSharingClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDataSharingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDataSharingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Data Sharing Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDataSharingClusterServerInitCallback(uint8_t endpoint);
+void emberAfDataSharingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Data Sharing Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -19163,7 +19408,8 @@ void emberAfDataSharingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDataSharingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDataSharingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Data Sharing Cluster Server Message Sent
  *
@@ -19190,7 +19436,7 @@ void emberAfDataSharingClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDataSharingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDataSharingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Data Sharing Cluster Server Tick
@@ -19199,7 +19445,7 @@ EmberAfStatus emberAfDataSharingClusterServerPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDataSharingClusterServerTickCallback(uint8_t endpoint);
+void emberAfDataSharingClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Data Sharing Cluster Write File Request
  *
  *
@@ -19236,7 +19482,7 @@ bool emberAfGamingClusterActionControlCallback(uint32_t actions);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGamingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGamingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Gaming Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -19246,14 +19492,14 @@ void emberAfGamingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGamingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGamingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Gaming Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGamingClusterClientInitCallback(uint8_t endpoint);
+void emberAfGamingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Gaming Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -19263,7 +19509,8 @@ void emberAfGamingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGamingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGamingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Gaming Cluster Client Message Sent
  *
@@ -19290,7 +19537,7 @@ void emberAfGamingClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGamingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGamingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Gaming Cluster Client Tick
@@ -19299,7 +19546,7 @@ EmberAfStatus emberAfGamingClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGamingClusterClientTickCallback(uint8_t endpoint);
+void emberAfGamingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Gaming Cluster Download Game
  *
  *
@@ -19329,7 +19576,7 @@ bool emberAfGamingClusterGameAnnouncementCallback(uint16_t gameId, uint8_t gameM
  * @param status   Ver.: always
  * @param message   Ver.: always
  */
-bool emberAfGamingClusterGeneralResponseCallback(uint8_t commandId, uint8_t status, uint8_t * message);
+bool emberAfGamingClusterGeneralResponseCallback(chip::CommandId commandId, uint8_t status, uint8_t * message);
 /** @brief Gaming Cluster Join Game
  *
  *
@@ -19372,7 +19619,7 @@ bool emberAfGamingClusterSearchGameCallback(uint8_t specificGame, uint16_t gameI
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGamingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGamingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Gaming Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -19382,14 +19629,14 @@ void emberAfGamingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGamingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGamingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Gaming Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGamingClusterServerInitCallback(uint8_t endpoint);
+void emberAfGamingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Gaming Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -19399,7 +19646,8 @@ void emberAfGamingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGamingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGamingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Gaming Cluster Server Message Sent
  *
@@ -19426,7 +19674,7 @@ void emberAfGamingClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGamingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGamingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Gaming Cluster Server Tick
@@ -19435,7 +19683,7 @@ EmberAfStatus emberAfGamingClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGamingClusterServerTickCallback(uint8_t endpoint);
+void emberAfGamingClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Gaming Cluster Start Game
  *
  *
@@ -19461,7 +19709,7 @@ bool emberAfGamingClusterStartOverCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDataRateControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDataRateControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Data Rate Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -19471,14 +19719,15 @@ void emberAfDataRateControlClusterClientAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDataRateControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDataRateControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Data Rate Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDataRateControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfDataRateControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Data Rate Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -19488,8 +19737,8 @@ void emberAfDataRateControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDataRateControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfDataRateControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Data Rate Control Cluster Client Message Sent
  *
@@ -19516,7 +19765,8 @@ void emberAfDataRateControlClusterClientMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDataRateControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDataRateControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Data Rate Control Cluster Client Tick
@@ -19525,7 +19775,7 @@ EmberAfStatus emberAfDataRateControlClusterClientPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDataRateControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfDataRateControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Data Rate Control Cluster Data Rate Control
  *
  *
@@ -19570,7 +19820,7 @@ bool emberAfDataRateControlClusterPathDeletionCallback(uint16_t originatorAddres
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDataRateControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDataRateControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Data Rate Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -19580,14 +19830,15 @@ void emberAfDataRateControlClusterServerAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDataRateControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDataRateControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Data Rate Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDataRateControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfDataRateControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Data Rate Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -19597,8 +19848,8 @@ void emberAfDataRateControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDataRateControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfDataRateControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Data Rate Control Cluster Server Message Sent
  *
@@ -19625,7 +19876,8 @@ void emberAfDataRateControlClusterServerMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDataRateControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDataRateControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Data Rate Control Cluster Server Tick
@@ -19634,7 +19886,7 @@ EmberAfStatus emberAfDataRateControlClusterServerPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDataRateControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfDataRateControlClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Data Rate Control Cluster Callbacks */
 
@@ -19648,7 +19900,7 @@ void emberAfDataRateControlClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfVoiceOverZigbeeClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Voice over ZigBee Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -19658,14 +19910,15 @@ void emberAfVoiceOverZigbeeClusterClientAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfVoiceOverZigbeeClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Voice over ZigBee Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterClientInitCallback(uint8_t endpoint);
+void emberAfVoiceOverZigbeeClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Voice over ZigBee Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -19675,8 +19928,8 @@ void emberAfVoiceOverZigbeeClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfVoiceOverZigbeeClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Voice over ZigBee Cluster Client Message Sent
  *
@@ -19703,7 +19956,8 @@ void emberAfVoiceOverZigbeeClusterClientMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfVoiceOverZigbeeClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfVoiceOverZigbeeClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Voice over ZigBee Cluster Client Tick
@@ -19712,7 +19966,7 @@ EmberAfStatus emberAfVoiceOverZigbeeClusterClientPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterClientTickCallback(uint8_t endpoint);
+void emberAfVoiceOverZigbeeClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Voice over ZigBee Cluster Control
  *
  *
@@ -19755,7 +20009,7 @@ bool emberAfVoiceOverZigbeeClusterEstablishmentResponseCallback(uint8_t ackNack,
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfVoiceOverZigbeeClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Voice over ZigBee Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -19765,14 +20019,15 @@ void emberAfVoiceOverZigbeeClusterServerAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfVoiceOverZigbeeClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Voice over ZigBee Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterServerInitCallback(uint8_t endpoint);
+void emberAfVoiceOverZigbeeClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Voice over ZigBee Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -19782,8 +20037,8 @@ void emberAfVoiceOverZigbeeClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfVoiceOverZigbeeClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Voice over ZigBee Cluster Server Message Sent
  *
@@ -19810,7 +20065,8 @@ void emberAfVoiceOverZigbeeClusterServerMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfVoiceOverZigbeeClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfVoiceOverZigbeeClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Voice over ZigBee Cluster Server Tick
@@ -19819,7 +20075,7 @@ EmberAfStatus emberAfVoiceOverZigbeeClusterServerPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterServerTickCallback(uint8_t endpoint);
+void emberAfVoiceOverZigbeeClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Voice over ZigBee Cluster Voice Transmission
  *
  *
@@ -19866,7 +20122,7 @@ bool emberAfChattingClusterChatMessageCallback(uint16_t destinationUid, uint16_t
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChattingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfChattingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Chatting Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -19876,14 +20132,15 @@ void emberAfChattingClusterClientAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChattingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfChattingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Chatting Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChattingClusterClientInitCallback(uint8_t endpoint);
+void emberAfChattingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Chatting Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -19893,7 +20150,8 @@ void emberAfChattingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfChattingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfChattingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Chatting Cluster Client Message Sent
  *
@@ -19920,7 +20178,7 @@ void emberAfChattingClusterClientMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfChattingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfChattingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Chatting Cluster Client Tick
@@ -19929,7 +20187,7 @@ EmberAfStatus emberAfChattingClusterClientPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChattingClusterClientTickCallback(uint8_t endpoint);
+void emberAfChattingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Chatting Cluster Get Node Information Request
  *
  *
@@ -19996,7 +20254,7 @@ bool emberAfChattingClusterSearchChatResponseCallback(uint8_t options, uint8_t *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChattingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfChattingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Chatting Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -20006,14 +20264,15 @@ void emberAfChattingClusterServerAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChattingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfChattingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Chatting Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChattingClusterServerInitCallback(uint8_t endpoint);
+void emberAfChattingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Chatting Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -20023,7 +20282,8 @@ void emberAfChattingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfChattingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfChattingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Chatting Cluster Server Message Sent
  *
@@ -20050,7 +20310,7 @@ void emberAfChattingClusterServerMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfChattingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfChattingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Chatting Cluster Server Tick
@@ -20059,7 +20319,7 @@ EmberAfStatus emberAfChattingClusterServerPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChattingClusterServerTickCallback(uint8_t endpoint);
+void emberAfChattingClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Chatting Cluster Start Chat Request
  *
  *
@@ -20094,7 +20354,8 @@ bool emberAfChattingClusterSwitchChairmanConfirmCallback(uint16_t cid, uint8_t *
  * @param address   Ver.: always
  * @param endpoint   Ver.: always
  */
-bool emberAfChattingClusterSwitchChairmanNotificationCallback(uint16_t cid, uint16_t uid, uint16_t address, uint8_t endpoint);
+bool emberAfChattingClusterSwitchChairmanNotificationCallback(uint16_t cid, uint16_t uid, uint16_t address,
+                                                              chip::EndpointId endpoint);
 /** @brief Chatting Cluster Switch Chairman Request
  *
  *
@@ -20175,7 +20436,7 @@ bool emberAfPaymentClusterBuyRequestCallback(uint8_t * userId, uint16_t userType
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPaymentClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPaymentClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Payment Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -20185,14 +20446,14 @@ void emberAfPaymentClusterClientAttributeChangedCallback(uint8_t endpoint, Ember
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPaymentClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPaymentClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Payment Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPaymentClusterClientInitCallback(uint8_t endpoint);
+void emberAfPaymentClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Payment Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -20202,7 +20463,8 @@ void emberAfPaymentClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPaymentClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPaymentClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              uint16_t manufacturerCode);
 /** @brief Payment Cluster Client Message Sent
  *
@@ -20229,7 +20491,7 @@ void emberAfPaymentClusterClientMessageSentCallback(EmberOutgoingMessageType typ
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPaymentClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPaymentClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                      EmberAfAttributeType attributeType, uint8_t size,
                                                                      uint8_t * value);
 /** @brief Payment Cluster Client Tick
@@ -20238,7 +20500,7 @@ EmberAfStatus emberAfPaymentClusterClientPreAttributeChangedCallback(uint8_t end
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPaymentClusterClientTickCallback(uint8_t endpoint);
+void emberAfPaymentClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Payment Cluster Payment Confirm
  *
  *
@@ -20267,7 +20529,7 @@ bool emberAfPaymentClusterReceiptDeliveryCallback(uint8_t * serialNumber, uint32
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPaymentClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPaymentClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Payment Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -20277,14 +20539,14 @@ void emberAfPaymentClusterServerAttributeChangedCallback(uint8_t endpoint, Ember
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPaymentClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPaymentClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Payment Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPaymentClusterServerInitCallback(uint8_t endpoint);
+void emberAfPaymentClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Payment Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -20294,7 +20556,8 @@ void emberAfPaymentClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPaymentClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPaymentClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              uint16_t manufacturerCode);
 /** @brief Payment Cluster Server Message Sent
  *
@@ -20321,7 +20584,7 @@ void emberAfPaymentClusterServerMessageSentCallback(EmberOutgoingMessageType typ
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPaymentClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPaymentClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                      EmberAfAttributeType attributeType, uint8_t size,
                                                                      uint8_t * value);
 /** @brief Payment Cluster Server Tick
@@ -20330,7 +20593,7 @@ EmberAfStatus emberAfPaymentClusterServerPreAttributeChangedCallback(uint8_t end
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPaymentClusterServerTickCallback(uint8_t endpoint);
+void emberAfPaymentClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Payment Cluster Transaction End
  *
  *
@@ -20369,7 +20632,7 @@ bool emberAfBillingClusterCheckBillStatusCallback(uint8_t * userId, uint16_t ser
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBillingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBillingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Billing Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -20379,14 +20642,14 @@ void emberAfBillingClusterClientAttributeChangedCallback(uint8_t endpoint, Ember
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBillingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBillingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Billing Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBillingClusterClientInitCallback(uint8_t endpoint);
+void emberAfBillingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Billing Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -20396,7 +20659,8 @@ void emberAfBillingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBillingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfBillingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              uint16_t manufacturerCode);
 /** @brief Billing Cluster Client Message Sent
  *
@@ -20423,7 +20687,7 @@ void emberAfBillingClusterClientMessageSentCallback(EmberOutgoingMessageType typ
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBillingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBillingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                      EmberAfAttributeType attributeType, uint8_t size,
                                                                      uint8_t * value);
 /** @brief Billing Cluster Client Tick
@@ -20432,7 +20696,7 @@ EmberAfStatus emberAfBillingClusterClientPreAttributeChangedCallback(uint8_t end
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBillingClusterClientTickCallback(uint8_t endpoint);
+void emberAfBillingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Billing Cluster Send Bill Record
  *
  *
@@ -20452,7 +20716,7 @@ bool emberAfBillingClusterSendBillRecordCallback(uint8_t * userId, uint16_t serv
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBillingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBillingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Billing Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -20462,14 +20726,14 @@ void emberAfBillingClusterServerAttributeChangedCallback(uint8_t endpoint, Ember
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBillingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBillingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Billing Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBillingClusterServerInitCallback(uint8_t endpoint);
+void emberAfBillingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Billing Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -20479,7 +20743,8 @@ void emberAfBillingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBillingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfBillingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              uint16_t manufacturerCode);
 /** @brief Billing Cluster Server Message Sent
  *
@@ -20506,7 +20771,7 @@ void emberAfBillingClusterServerMessageSentCallback(EmberOutgoingMessageType typ
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBillingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBillingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                      EmberAfAttributeType attributeType, uint8_t size,
                                                                      uint8_t * value);
 /** @brief Billing Cluster Server Tick
@@ -20515,7 +20780,7 @@ EmberAfStatus emberAfBillingClusterServerPreAttributeChangedCallback(uint8_t end
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBillingClusterServerTickCallback(uint8_t endpoint);
+void emberAfBillingClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Billing Cluster Session Keep Alive
  *
  *
@@ -20574,7 +20839,7 @@ bool emberAfBillingClusterUnsubscribeCallback(uint8_t * userId, uint16_t service
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceIdentificationClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceIdentificationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Identification Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -20584,14 +20849,15 @@ void emberAfApplianceIdentificationClusterClientAttributeChangedCallback(uint8_t
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceIdentificationClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceIdentificationClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                        EmberAfStatus status);
 /** @brief Appliance Identification Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceIdentificationClusterClientInitCallback(uint8_t endpoint);
+void emberAfApplianceIdentificationClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Identification Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -20602,7 +20868,7 @@ void emberAfApplianceIdentificationClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfApplianceIdentificationClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              uint16_t manufacturerCode);
 /** @brief Appliance Identification Cluster Client Message Sent
  *
@@ -20629,8 +20895,8 @@ void emberAfApplianceIdentificationClusterClientMessageSentCallback(EmberOutgoin
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceIdentificationClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceIdentificationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      EmberAfAttributeType attributeType,
                                                                                      uint8_t size, uint8_t * value);
 /** @brief Appliance Identification Cluster Client Tick
@@ -20639,7 +20905,7 @@ EmberAfStatus emberAfApplianceIdentificationClusterClientPreAttributeChangedCall
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceIdentificationClusterClientTickCallback(uint8_t endpoint);
+void emberAfApplianceIdentificationClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Appliance Identification Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -20647,7 +20913,7 @@ void emberAfApplianceIdentificationClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceIdentificationClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceIdentificationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Identification Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -20657,14 +20923,15 @@ void emberAfApplianceIdentificationClusterServerAttributeChangedCallback(uint8_t
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceIdentificationClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceIdentificationClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                        EmberAfStatus status);
 /** @brief Appliance Identification Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceIdentificationClusterServerInitCallback(uint8_t endpoint);
+void emberAfApplianceIdentificationClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Identification Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -20675,7 +20942,7 @@ void emberAfApplianceIdentificationClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfApplianceIdentificationClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              uint16_t manufacturerCode);
 /** @brief Appliance Identification Cluster Server Message Sent
  *
@@ -20702,8 +20969,8 @@ void emberAfApplianceIdentificationClusterServerMessageSentCallback(EmberOutgoin
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceIdentificationClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceIdentificationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      EmberAfAttributeType attributeType,
                                                                                      uint8_t size, uint8_t * value);
 /** @brief Appliance Identification Cluster Server Tick
@@ -20712,7 +20979,7 @@ EmberAfStatus emberAfApplianceIdentificationClusterServerPreAttributeChangedCall
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceIdentificationClusterServerTickCallback(uint8_t endpoint);
+void emberAfApplianceIdentificationClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Appliance Identification Cluster Callbacks */
 
@@ -20726,7 +20993,7 @@ void emberAfApplianceIdentificationClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMeterIdentificationClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMeterIdentificationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Meter Identification Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -20736,14 +21003,15 @@ void emberAfMeterIdentificationClusterClientAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMeterIdentificationClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMeterIdentificationClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief Meter Identification Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMeterIdentificationClusterClientInitCallback(uint8_t endpoint);
+void emberAfMeterIdentificationClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Meter Identification Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -20754,7 +21022,7 @@ void emberAfMeterIdentificationClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfMeterIdentificationClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief Meter Identification Cluster Client Message Sent
  *
@@ -20781,7 +21049,8 @@ void emberAfMeterIdentificationClusterClientMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMeterIdentificationClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMeterIdentificationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief Meter Identification Cluster Client Tick
@@ -20790,7 +21059,7 @@ EmberAfStatus emberAfMeterIdentificationClusterClientPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMeterIdentificationClusterClientTickCallback(uint8_t endpoint);
+void emberAfMeterIdentificationClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Meter Identification Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -20798,7 +21067,7 @@ void emberAfMeterIdentificationClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMeterIdentificationClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMeterIdentificationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Meter Identification Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -20808,14 +21077,15 @@ void emberAfMeterIdentificationClusterServerAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMeterIdentificationClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMeterIdentificationClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief Meter Identification Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMeterIdentificationClusterServerInitCallback(uint8_t endpoint);
+void emberAfMeterIdentificationClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Meter Identification Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -20826,7 +21096,7 @@ void emberAfMeterIdentificationClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfMeterIdentificationClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief Meter Identification Cluster Server Message Sent
  *
@@ -20853,7 +21123,8 @@ void emberAfMeterIdentificationClusterServerMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMeterIdentificationClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMeterIdentificationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief Meter Identification Cluster Server Tick
@@ -20862,7 +21133,7 @@ EmberAfStatus emberAfMeterIdentificationClusterServerPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMeterIdentificationClusterServerTickCallback(uint8_t endpoint);
+void emberAfMeterIdentificationClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Meter Identification Cluster Callbacks */
 
@@ -20884,7 +21155,7 @@ bool emberAfApplianceEventsAndAlertClusterAlertsNotificationCallback(uint8_t ale
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceEventsAndAlertClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Events and Alert Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -20894,14 +21165,15 @@ void emberAfApplianceEventsAndAlertClusterClientAttributeChangedCallback(uint8_t
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceEventsAndAlertClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                        EmberAfStatus status);
 /** @brief Appliance Events and Alert Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterClientInitCallback(uint8_t endpoint);
+void emberAfApplianceEventsAndAlertClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Events and Alert Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -20912,7 +21184,7 @@ void emberAfApplianceEventsAndAlertClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfApplianceEventsAndAlertClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              uint16_t manufacturerCode);
 /** @brief Appliance Events and Alert Cluster Client Message Sent
  *
@@ -20939,8 +21211,8 @@ void emberAfApplianceEventsAndAlertClusterClientMessageSentCallback(EmberOutgoin
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceEventsAndAlertClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceEventsAndAlertClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      EmberAfAttributeType attributeType,
                                                                                      uint8_t size, uint8_t * value);
 /** @brief Appliance Events and Alert Cluster Client Tick
@@ -20949,7 +21221,7 @@ EmberAfStatus emberAfApplianceEventsAndAlertClusterClientPreAttributeChangedCall
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterClientTickCallback(uint8_t endpoint);
+void emberAfApplianceEventsAndAlertClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Appliance Events and Alert Cluster Events Notification
  *
  *
@@ -20979,7 +21251,7 @@ bool emberAfApplianceEventsAndAlertClusterGetAlertsResponseCallback(uint8_t aler
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceEventsAndAlertClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Events and Alert Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -20989,14 +21261,15 @@ void emberAfApplianceEventsAndAlertClusterServerAttributeChangedCallback(uint8_t
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceEventsAndAlertClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                        EmberAfStatus status);
 /** @brief Appliance Events and Alert Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterServerInitCallback(uint8_t endpoint);
+void emberAfApplianceEventsAndAlertClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Events and Alert Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -21007,7 +21280,7 @@ void emberAfApplianceEventsAndAlertClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfApplianceEventsAndAlertClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              uint16_t manufacturerCode);
 /** @brief Appliance Events and Alert Cluster Server Message Sent
  *
@@ -21034,8 +21307,8 @@ void emberAfApplianceEventsAndAlertClusterServerMessageSentCallback(EmberOutgoin
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceEventsAndAlertClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceEventsAndAlertClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      EmberAfAttributeType attributeType,
                                                                                      uint8_t size, uint8_t * value);
 /** @brief Appliance Events and Alert Cluster Server Tick
@@ -21044,7 +21317,7 @@ EmberAfStatus emberAfApplianceEventsAndAlertClusterServerPreAttributeChangedCall
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterServerTickCallback(uint8_t endpoint);
+void emberAfApplianceEventsAndAlertClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Appliance Events and Alert Cluster Callbacks */
 
@@ -21058,7 +21331,7 @@ void emberAfApplianceEventsAndAlertClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceStatisticsClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceStatisticsClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Statistics Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -21068,14 +21341,15 @@ void emberAfApplianceStatisticsClusterClientAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceStatisticsClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceStatisticsClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief Appliance Statistics Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceStatisticsClusterClientInitCallback(uint8_t endpoint);
+void emberAfApplianceStatisticsClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Statistics Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -21086,7 +21360,7 @@ void emberAfApplianceStatisticsClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfApplianceStatisticsClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief Appliance Statistics Cluster Client Message Sent
  *
@@ -21113,7 +21387,8 @@ void emberAfApplianceStatisticsClusterClientMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceStatisticsClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceStatisticsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief Appliance Statistics Cluster Client Tick
@@ -21122,7 +21397,7 @@ EmberAfStatus emberAfApplianceStatisticsClusterClientPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceStatisticsClusterClientTickCallback(uint8_t endpoint);
+void emberAfApplianceStatisticsClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Appliance Statistics Cluster Log Notification
  *
  *
@@ -21173,7 +21448,7 @@ bool emberAfApplianceStatisticsClusterLogResponseCallback(uint32_t timeStamp, ui
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceStatisticsClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceStatisticsClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Statistics Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -21183,14 +21458,15 @@ void emberAfApplianceStatisticsClusterServerAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceStatisticsClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceStatisticsClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief Appliance Statistics Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceStatisticsClusterServerInitCallback(uint8_t endpoint);
+void emberAfApplianceStatisticsClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Statistics Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -21201,7 +21477,7 @@ void emberAfApplianceStatisticsClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfApplianceStatisticsClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief Appliance Statistics Cluster Server Message Sent
  *
@@ -21228,7 +21504,8 @@ void emberAfApplianceStatisticsClusterServerMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceStatisticsClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceStatisticsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief Appliance Statistics Cluster Server Tick
@@ -21237,7 +21514,7 @@ EmberAfStatus emberAfApplianceStatisticsClusterServerPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceStatisticsClusterServerTickCallback(uint8_t endpoint);
+void emberAfApplianceStatisticsClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Appliance Statistics Cluster Statistics Available
  *
  *
@@ -21259,7 +21536,7 @@ bool emberAfApplianceStatisticsClusterStatisticsAvailableCallback(uint8_t logQue
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfElectricalMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfElectricalMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Electrical Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -21269,14 +21546,15 @@ void emberAfElectricalMeasurementClusterClientAttributeChangedCallback(uint8_t e
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfElectricalMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfElectricalMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                      EmberAfStatus status);
 /** @brief Electrical Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfElectricalMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfElectricalMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Electrical Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -21287,7 +21565,7 @@ void emberAfElectricalMeasurementClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfElectricalMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                           EmberAfAttributeId attributeId,
+                                                                                           chip::AttributeId attributeId,
                                                                                            uint16_t manufacturerCode);
 /** @brief Electrical Measurement Cluster Client Message Sent
  *
@@ -21314,7 +21592,8 @@ void emberAfElectricalMeasurementClusterClientMessageSentCallback(EmberOutgoingM
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfElectricalMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfElectricalMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                                    uint8_t * value);
 /** @brief Electrical Measurement Cluster Client Tick
@@ -21323,7 +21602,7 @@ EmberAfStatus emberAfElectricalMeasurementClusterClientPreAttributeChangedCallba
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfElectricalMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfElectricalMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Electrical Measurement Cluster Get Measurement Profile Command
  *
  *
@@ -21332,7 +21611,7 @@ void emberAfElectricalMeasurementClusterClientTickCallback(uint8_t endpoint);
  * @param startTime   Ver.: always
  * @param numberOfIntervals   Ver.: always
  */
-bool emberAfElectricalMeasurementClusterGetMeasurementProfileCommandCallback(uint16_t attributeId, uint32_t startTime,
+bool emberAfElectricalMeasurementClusterGetMeasurementProfileCommandCallback(chip::AttributeId attributeId, uint32_t startTime,
                                                                              uint8_t numberOfIntervals);
 /** @brief Electrical Measurement Cluster Get Measurement Profile Response Command
  *
@@ -21348,7 +21627,8 @@ bool emberAfElectricalMeasurementClusterGetMeasurementProfileCommandCallback(uin
 bool emberAfElectricalMeasurementClusterGetMeasurementProfileResponseCommandCallback(uint32_t startTime, uint8_t status,
                                                                                      uint8_t profileIntervalPeriod,
                                                                                      uint8_t numberOfIntervalsDelivered,
-                                                                                     uint16_t attributeId, uint8_t * intervals);
+                                                                                     chip::AttributeId attributeId,
+                                                                                     uint8_t * intervals);
 /** @brief Electrical Measurement Cluster Get Profile Info Command
  *
  *
@@ -21374,7 +21654,7 @@ bool emberAfElectricalMeasurementClusterGetProfileInfoResponseCommandCallback(ui
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfElectricalMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfElectricalMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Electrical Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -21384,14 +21664,15 @@ void emberAfElectricalMeasurementClusterServerAttributeChangedCallback(uint8_t e
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfElectricalMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfElectricalMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                      EmberAfStatus status);
 /** @brief Electrical Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfElectricalMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfElectricalMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Electrical Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -21402,7 +21683,7 @@ void emberAfElectricalMeasurementClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfElectricalMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                           EmberAfAttributeId attributeId,
+                                                                                           chip::AttributeId attributeId,
                                                                                            uint16_t manufacturerCode);
 /** @brief Electrical Measurement Cluster Server Message Sent
  *
@@ -21429,7 +21710,8 @@ void emberAfElectricalMeasurementClusterServerMessageSentCallback(EmberOutgoingM
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfElectricalMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfElectricalMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                                    uint8_t * value);
 /** @brief Electrical Measurement Cluster Server Tick
@@ -21438,7 +21720,7 @@ EmberAfStatus emberAfElectricalMeasurementClusterServerPreAttributeChangedCallba
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfElectricalMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfElectricalMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Electrical Measurement Cluster Callbacks */
 
@@ -21452,7 +21734,7 @@ void emberAfElectricalMeasurementClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDiagnosticsClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDiagnosticsClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Diagnostics Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -21462,14 +21744,15 @@ void emberAfDiagnosticsClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDiagnosticsClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDiagnosticsClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Diagnostics Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDiagnosticsClusterClientInitCallback(uint8_t endpoint);
+void emberAfDiagnosticsClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Diagnostics Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -21479,7 +21762,8 @@ void emberAfDiagnosticsClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDiagnosticsClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDiagnosticsClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Diagnostics Cluster Client Message Sent
  *
@@ -21506,7 +21790,7 @@ void emberAfDiagnosticsClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDiagnosticsClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDiagnosticsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Diagnostics Cluster Client Tick
@@ -21515,7 +21799,7 @@ EmberAfStatus emberAfDiagnosticsClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDiagnosticsClusterClientTickCallback(uint8_t endpoint);
+void emberAfDiagnosticsClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Diagnostics Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -21523,7 +21807,7 @@ void emberAfDiagnosticsClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDiagnosticsClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDiagnosticsClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Diagnostics Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -21533,14 +21817,15 @@ void emberAfDiagnosticsClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDiagnosticsClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDiagnosticsClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Diagnostics Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDiagnosticsClusterServerInitCallback(uint8_t endpoint);
+void emberAfDiagnosticsClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Diagnostics Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -21550,7 +21835,8 @@ void emberAfDiagnosticsClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDiagnosticsClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDiagnosticsClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Diagnostics Cluster Server Message Sent
  *
@@ -21577,7 +21863,7 @@ void emberAfDiagnosticsClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDiagnosticsClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDiagnosticsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Diagnostics Cluster Server Tick
@@ -21586,7 +21872,7 @@ EmberAfStatus emberAfDiagnosticsClusterServerPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDiagnosticsClusterServerTickCallback(uint8_t endpoint);
+void emberAfDiagnosticsClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Diagnostics Cluster Callbacks */
 
@@ -21600,7 +21886,7 @@ void emberAfDiagnosticsClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfZllCommissioningClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfZllCommissioningClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief ZLL Commissioning Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -21610,14 +21896,15 @@ void emberAfZllCommissioningClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfZllCommissioningClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfZllCommissioningClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief ZLL Commissioning Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfZllCommissioningClusterClientInitCallback(uint8_t endpoint);
+void emberAfZllCommissioningClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief ZLL Commissioning Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -21627,8 +21914,8 @@ void emberAfZllCommissioningClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfZllCommissioningClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfZllCommissioningClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief ZLL Commissioning Cluster Client Message Sent
  *
@@ -21655,7 +21942,8 @@ void emberAfZllCommissioningClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfZllCommissioningClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfZllCommissioningClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief ZLL Commissioning Cluster Client Tick
@@ -21664,7 +21952,7 @@ EmberAfStatus emberAfZllCommissioningClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfZllCommissioningClusterClientTickCallback(uint8_t endpoint);
+void emberAfZllCommissioningClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief ZLL Commissioning Cluster Device Information Request
  *
  *
@@ -21902,7 +22190,7 @@ bool emberAfZllCommissioningClusterScanResponseCallback(uint32_t transaction, ui
                                                         uint8_t zllInformation, uint16_t keyBitmask, uint32_t responseId,
                                                         uint8_t * extendedPanId, uint8_t networkUpdateId, uint8_t logicalChannel,
                                                         uint16_t panId, uint16_t networkAddress, uint8_t numberOfSubDevices,
-                                                        uint8_t totalGroupIds, uint8_t endpointId, uint16_t profileId,
+                                                        uint8_t totalGroupIds, chip::EndpointId endpointId, uint16_t profileId,
                                                         uint16_t deviceId, uint8_t version, uint8_t groupIdCount);
 /** @brief ZLL Commissioning Cluster Server Attribute Changed
  *
@@ -21911,7 +22199,7 @@ bool emberAfZllCommissioningClusterScanResponseCallback(uint32_t transaction, ui
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfZllCommissioningClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfZllCommissioningClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief ZLL Commissioning Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -21921,14 +22209,15 @@ void emberAfZllCommissioningClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfZllCommissioningClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfZllCommissioningClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief ZLL Commissioning Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfZllCommissioningClusterServerInitCallback(uint8_t endpoint);
+void emberAfZllCommissioningClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief ZLL Commissioning Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -21938,8 +22227,8 @@ void emberAfZllCommissioningClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfZllCommissioningClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfZllCommissioningClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief ZLL Commissioning Cluster Server Message Sent
  *
@@ -21966,7 +22255,8 @@ void emberAfZllCommissioningClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfZllCommissioningClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfZllCommissioningClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief ZLL Commissioning Cluster Server Tick
@@ -21975,7 +22265,7 @@ EmberAfStatus emberAfZllCommissioningClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfZllCommissioningClusterServerTickCallback(uint8_t endpoint);
+void emberAfZllCommissioningClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END ZLL Commissioning Cluster Callbacks */
 
@@ -21989,7 +22279,7 @@ void emberAfZllCommissioningClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSampleMfgSpecificClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Sample Mfg Specific Cluster Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -21999,14 +22289,15 @@ void emberAfSampleMfgSpecificClusterClientAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSampleMfgSpecificClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief Sample Mfg Specific Cluster Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterClientInitCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Sample Mfg Specific Cluster Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -22017,7 +22308,7 @@ void emberAfSampleMfgSpecificClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfSampleMfgSpecificClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief Sample Mfg Specific Cluster Cluster Client Message Sent
  *
@@ -22044,7 +22335,8 @@ void emberAfSampleMfgSpecificClusterClientMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSampleMfgSpecificClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSampleMfgSpecificClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief Sample Mfg Specific Cluster Cluster Client Tick
@@ -22053,7 +22345,7 @@ EmberAfStatus emberAfSampleMfgSpecificClusterClientPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterClientTickCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Sample Mfg Specific Cluster Cluster Command One
  *
  *
@@ -22068,7 +22360,7 @@ bool emberAfSampleMfgSpecificClusterCommandOneCallback(uint8_t argOne);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSampleMfgSpecificClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Sample Mfg Specific Cluster Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -22078,14 +22370,15 @@ void emberAfSampleMfgSpecificClusterServerAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSampleMfgSpecificClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief Sample Mfg Specific Cluster Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterServerInitCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Sample Mfg Specific Cluster Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -22096,7 +22389,7 @@ void emberAfSampleMfgSpecificClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfSampleMfgSpecificClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief Sample Mfg Specific Cluster Cluster Server Message Sent
  *
@@ -22123,7 +22416,8 @@ void emberAfSampleMfgSpecificClusterServerMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSampleMfgSpecificClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSampleMfgSpecificClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief Sample Mfg Specific Cluster Cluster Server Tick
@@ -22132,7 +22426,7 @@ EmberAfStatus emberAfSampleMfgSpecificClusterServerPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterServerTickCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Sample Mfg Specific Cluster Cluster Callbacks */
 
@@ -22146,7 +22440,7 @@ void emberAfSampleMfgSpecificClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSampleMfgSpecificCluster2ClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -22156,14 +22450,15 @@ void emberAfSampleMfgSpecificCluster2ClientAttributeChangedCallback(uint8_t endp
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSampleMfgSpecificCluster2ClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                   EmberAfStatus status);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ClientInitCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificCluster2ClientInitCallback(chip::EndpointId endpoint);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -22174,7 +22469,7 @@ void emberAfSampleMfgSpecificCluster2ClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfSampleMfgSpecificCluster2ClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                        EmberAfAttributeId attributeId,
+                                                                                        chip::AttributeId attributeId,
                                                                                         uint16_t manufacturerCode);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Client Message Sent
  *
@@ -22201,7 +22496,8 @@ void emberAfSampleMfgSpecificCluster2ClientMessageSentCallback(EmberOutgoingMess
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSampleMfgSpecificCluster2ClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSampleMfgSpecificCluster2ClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 EmberAfAttributeType attributeType, uint8_t size,
                                                                                 uint8_t * value);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Client Tick
@@ -22210,7 +22506,7 @@ EmberAfStatus emberAfSampleMfgSpecificCluster2ClientPreAttributeChangedCallback(
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ClientTickCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificCluster2ClientTickCallback(chip::EndpointId endpoint);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Command Two
  *
  *
@@ -22225,7 +22521,7 @@ bool emberAfSampleMfgSpecificCluster2CommandTwoCallback(uint8_t argOne);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSampleMfgSpecificCluster2ServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -22235,14 +22531,15 @@ void emberAfSampleMfgSpecificCluster2ServerAttributeChangedCallback(uint8_t endp
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSampleMfgSpecificCluster2ServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                   EmberAfStatus status);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ServerInitCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificCluster2ServerInitCallback(chip::EndpointId endpoint);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -22253,7 +22550,7 @@ void emberAfSampleMfgSpecificCluster2ServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfSampleMfgSpecificCluster2ServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                        EmberAfAttributeId attributeId,
+                                                                                        chip::AttributeId attributeId,
                                                                                         uint16_t manufacturerCode);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Server Message Sent
  *
@@ -22280,7 +22577,8 @@ void emberAfSampleMfgSpecificCluster2ServerMessageSentCallback(EmberOutgoingMess
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSampleMfgSpecificCluster2ServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSampleMfgSpecificCluster2ServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 EmberAfAttributeType attributeType, uint8_t size,
                                                                                 uint8_t * value);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Server Tick
@@ -22289,7 +22587,7 @@ EmberAfStatus emberAfSampleMfgSpecificCluster2ServerPreAttributeChangedCallback(
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ServerTickCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificCluster2ServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Sample Mfg Specific Cluster 2 Cluster Callbacks */
 
@@ -22303,7 +22601,7 @@ void emberAfSampleMfgSpecificCluster2ServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOtaConfigurationClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOtaConfigurationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Configuration Cluster Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -22313,14 +22611,15 @@ void emberAfOtaConfigurationClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOtaConfigurationClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOtaConfigurationClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Configuration Cluster Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOtaConfigurationClusterClientInitCallback(uint8_t endpoint);
+void emberAfOtaConfigurationClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Configuration Cluster Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -22330,8 +22629,8 @@ void emberAfOtaConfigurationClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOtaConfigurationClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfOtaConfigurationClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Configuration Cluster Cluster Client Message Sent
  *
@@ -22358,7 +22657,8 @@ void emberAfOtaConfigurationClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOtaConfigurationClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOtaConfigurationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Configuration Cluster Cluster Client Tick
@@ -22367,7 +22667,7 @@ EmberAfStatus emberAfOtaConfigurationClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOtaConfigurationClusterClientTickCallback(uint8_t endpoint);
+void emberAfOtaConfigurationClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Configuration Cluster Cluster Lock Tokens
  *
  *
@@ -22396,7 +22696,7 @@ bool emberAfOtaConfigurationClusterReturnTokenCallback(uint16_t token, uint8_t *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOtaConfigurationClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOtaConfigurationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Configuration Cluster Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -22406,14 +22706,15 @@ void emberAfOtaConfigurationClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOtaConfigurationClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOtaConfigurationClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Configuration Cluster Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOtaConfigurationClusterServerInitCallback(uint8_t endpoint);
+void emberAfOtaConfigurationClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Configuration Cluster Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -22423,8 +22724,8 @@ void emberAfOtaConfigurationClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOtaConfigurationClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfOtaConfigurationClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Configuration Cluster Cluster Server Message Sent
  *
@@ -22451,7 +22752,8 @@ void emberAfOtaConfigurationClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOtaConfigurationClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOtaConfigurationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Configuration Cluster Cluster Server Tick
@@ -22460,7 +22762,7 @@ EmberAfStatus emberAfOtaConfigurationClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOtaConfigurationClusterServerTickCallback(uint8_t endpoint);
+void emberAfOtaConfigurationClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Configuration Cluster Cluster Set Token
  *
  *
@@ -22489,7 +22791,7 @@ bool emberAfOtaConfigurationClusterUnlockTokensCallback(uint8_t * data);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMfglibClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMfglibClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief MFGLIB Cluster Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -22499,14 +22801,14 @@ void emberAfMfglibClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMfglibClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMfglibClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief MFGLIB Cluster Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMfglibClusterClientInitCallback(uint8_t endpoint);
+void emberAfMfglibClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief MFGLIB Cluster Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -22516,7 +22818,8 @@ void emberAfMfglibClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfMfglibClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfMfglibClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief MFGLIB Cluster Cluster Client Message Sent
  *
@@ -22543,7 +22846,7 @@ void emberAfMfglibClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMfglibClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMfglibClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief MFGLIB Cluster Cluster Client Tick
@@ -22552,7 +22855,7 @@ EmberAfStatus emberAfMfglibClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMfglibClusterClientTickCallback(uint8_t endpoint);
+void emberAfMfglibClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief MFGLIB Cluster Cluster Rx Mode
  *
  *
@@ -22569,7 +22872,7 @@ bool emberAfMfglibClusterRxModeCallback(uint8_t channel, int8_t power, uint16_t 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMfglibClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMfglibClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief MFGLIB Cluster Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -22579,14 +22882,14 @@ void emberAfMfglibClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMfglibClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMfglibClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief MFGLIB Cluster Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMfglibClusterServerInitCallback(uint8_t endpoint);
+void emberAfMfglibClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief MFGLIB Cluster Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -22596,7 +22899,8 @@ void emberAfMfglibClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfMfglibClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfMfglibClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief MFGLIB Cluster Cluster Server Message Sent
  *
@@ -22623,7 +22927,7 @@ void emberAfMfglibClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMfglibClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMfglibClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief MFGLIB Cluster Cluster Server Tick
@@ -22632,7 +22936,7 @@ EmberAfStatus emberAfMfglibClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMfglibClusterServerTickCallback(uint8_t endpoint);
+void emberAfMfglibClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief MFGLIB Cluster Cluster Stream
  *
  *
@@ -22677,7 +22981,7 @@ bool emberAfSlWwahClusterApsAckRequirementQueryCallback(void);
  *
  * @param clusterId   Ver.: always
  */
-bool emberAfSlWwahClusterApsLinkKeyAuthorizationQueryCallback(uint16_t clusterId);
+bool emberAfSlWwahClusterApsLinkKeyAuthorizationQueryCallback(chip::ClusterId clusterId);
 /** @brief SL Works With All Hubs Cluster Aps Link Key Authorization Query Response
  *
  *
@@ -22685,7 +22989,7 @@ bool emberAfSlWwahClusterApsLinkKeyAuthorizationQueryCallback(uint16_t clusterId
  * @param clusterId   Ver.: always
  * @param apsLinkKeyAuthStatus   Ver.: always
  */
-bool emberAfSlWwahClusterApsLinkKeyAuthorizationQueryResponseCallback(uint16_t clusterId, uint8_t apsLinkKeyAuthStatus);
+bool emberAfSlWwahClusterApsLinkKeyAuthorizationQueryResponseCallback(chip::ClusterId clusterId, uint8_t apsLinkKeyAuthStatus);
 /** @brief SL Works With All Hubs Cluster Clear Binding Table
  *
  *
@@ -22699,7 +23003,7 @@ bool emberAfSlWwahClusterClearBindingTableCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSlWwahClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSlWwahClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief SL Works With All Hubs Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -22709,14 +23013,14 @@ void emberAfSlWwahClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSlWwahClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSlWwahClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief SL Works With All Hubs Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSlWwahClusterClientInitCallback(uint8_t endpoint);
+void emberAfSlWwahClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief SL Works With All Hubs Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -22726,7 +23030,8 @@ void emberAfSlWwahClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfSlWwahClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfSlWwahClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief SL Works With All Hubs Cluster Client Message Sent
  *
@@ -22753,7 +23058,7 @@ void emberAfSlWwahClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSlWwahClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSlWwahClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief SL Works With All Hubs Cluster Client Tick
@@ -22762,7 +23067,7 @@ EmberAfStatus emberAfSlWwahClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSlWwahClusterClientTickCallback(uint8_t endpoint);
+void emberAfSlWwahClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief SL Works With All Hubs Cluster Debug Report Query
  *
  *
@@ -22978,7 +23283,7 @@ bool emberAfSlWwahClusterRequireApsAcksOnUnicastsCallback(uint8_t numberExemptCl
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSlWwahClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSlWwahClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief SL Works With All Hubs Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -22988,14 +23293,14 @@ void emberAfSlWwahClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSlWwahClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSlWwahClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief SL Works With All Hubs Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSlWwahClusterServerInitCallback(uint8_t endpoint);
+void emberAfSlWwahClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief SL Works With All Hubs Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -23005,7 +23310,8 @@ void emberAfSlWwahClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfSlWwahClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfSlWwahClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief SL Works With All Hubs Cluster Server Message Sent
  *
@@ -23032,7 +23338,7 @@ void emberAfSlWwahClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSlWwahClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSlWwahClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief SL Works With All Hubs Cluster Server Tick
@@ -23041,7 +23347,7 @@ EmberAfStatus emberAfSlWwahClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSlWwahClusterServerTickCallback(uint8_t endpoint);
+void emberAfSlWwahClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief SL Works With All Hubs Cluster Set Ias Zone Enrollment Method
  *
  *

--- a/examples/lock-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lock-app/nrfconnect/main/ZclCallbacks.cpp
@@ -28,7 +28,7 @@
 
 using namespace ::chip;
 
-void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,
+void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
 {
     if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
@@ -54,7 +54,7 @@ void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clust
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint)
+void emberAfPluginOnOffClusterServerPostInitCallback(EndpointId endpoint)
 {
     GetAppTask().UpdateClusterState();
 }

--- a/examples/temperature-measurement-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/temperature-measurement-app/esp32/main/CHIPDeviceManager.cpp
@@ -93,7 +93,7 @@ exit:
     return err;
 }
 
-void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,
+void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
 {
     CHIPDeviceManagerCallbacks * cb = CHIPDeviceManager::GetInstance().GetCHIPDeviceManagerCallbacks();

--- a/examples/temperature-measurement-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/temperature-measurement-app/esp32/main/DeviceCallbacks.cpp
@@ -52,9 +52,8 @@ void DeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_
     ESP_LOGI(TAG, "Current free heap: %d\n", heap_caps_get_free_size(MALLOC_CAP_8BIT));
 }
 
-void DeviceCallbacks::PostAttributeChangeCallback(uint8_t endpointId, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
-                                                  uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size,
-                                                  uint8_t * value)
+void DeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
+                                                  uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
 {
     ESP_LOGI(TAG, "PostAttributeChangeCallback - Cluster ID: '0x%04x', EndPoint ID: '0x%02x', Attribute ID: '0x%04x'", clusterId,
              endpointId, attributeId);

--- a/examples/temperature-measurement-app/esp32/main/gen/af-structs.h
+++ b/examples/temperature-measurement-app/esp32/main/gen/af-structs.h
@@ -20,6 +20,8 @@
 #ifndef SILABS_EMBER_AF_STRUCTS
 #define SILABS_EMBER_AF_STRUCTS
 
+#include "basic-types.h"
+
 // Generated structs from the metadata
 // Struct for IasAceZoneStatusResult
 typedef struct _IasAceZoneStatusResult
@@ -31,7 +33,7 @@ typedef struct _IasAceZoneStatusResult
 // Struct for ReadAttributeStatusRecord
 typedef struct _ReadAttributeStatusRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t status;
     uint8_t attributeType;
     uint8_t * attributeLocation;
@@ -40,7 +42,7 @@ typedef struct _ReadAttributeStatusRecord
 // Struct for WriteAttributeRecord
 typedef struct _WriteAttributeRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t attributeType;
     uint8_t * attributeLocation;
 } WriteAttributeRecord;
@@ -49,14 +51,14 @@ typedef struct _WriteAttributeRecord
 typedef struct _WriteAttributeStatusRecord
 {
     uint8_t status;
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
 } WriteAttributeStatusRecord;
 
 // Struct for ConfigureReportingRecord
 typedef struct _ConfigureReportingRecord
 {
     uint8_t direction;
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t attributeType;
     uint16_t minimumReportingInterval;
     uint16_t maximumReportingInterval;
@@ -69,7 +71,7 @@ typedef struct _ConfigureReportingStatusRecord
 {
     uint8_t status;
     uint8_t direction;
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
 } ConfigureReportingStatusRecord;
 
 // Struct for ReadReportingConfigurationRecord
@@ -77,7 +79,7 @@ typedef struct _ReadReportingConfigurationRecord
 {
     uint8_t status;
     uint8_t direction;
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t attributeType;
     uint16_t minimumReportingInterval;
     uint16_t maximumReportingInterval;
@@ -89,13 +91,13 @@ typedef struct _ReadReportingConfigurationRecord
 typedef struct _ReadReportingConfigurationAttributeRecord
 {
     uint8_t direction;
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
 } ReadReportingConfigurationAttributeRecord;
 
 // Struct for ReportAttributeRecord
 typedef struct _ReportAttributeRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t attributeType;
     uint8_t * attributeLocation;
 } ReportAttributeRecord;
@@ -103,14 +105,14 @@ typedef struct _ReportAttributeRecord
 // Struct for DiscoverAttributesInfoRecord
 typedef struct _DiscoverAttributesInfoRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t attributeType;
 } DiscoverAttributesInfoRecord;
 
 // Struct for ExtendedDiscoverAttributesInfoRecord
 typedef struct _ExtendedDiscoverAttributesInfoRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t attributeType;
     uint8_t attributeAccessControl;
 } ExtendedDiscoverAttributesInfoRecord;
@@ -118,7 +120,7 @@ typedef struct _ExtendedDiscoverAttributesInfoRecord
 // Struct for ReadStructuredAttributeRecord
 typedef struct _ReadStructuredAttributeRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t indicator;
     uint16_t indicies;
 } ReadStructuredAttributeRecord;
@@ -126,7 +128,7 @@ typedef struct _ReadStructuredAttributeRecord
 // Struct for WriteStructuredAttributeRecord
 typedef struct _WriteStructuredAttributeRecord
 {
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t indicator;
     uint16_t indicies;
     uint8_t attributeType;
@@ -137,7 +139,7 @@ typedef struct _WriteStructuredAttributeRecord
 typedef struct _WriteStructuredAttributeStatusRecord
 {
     uint8_t status;
-    uint16_t attributeId;
+    chip::AttributeId attributeId;
     uint8_t indicator;
     uint16_t indicies;
 } WriteStructuredAttributeStatusRecord;
@@ -387,7 +389,7 @@ typedef struct _DeviceInformationRecord
 // Struct for GroupInformationRecord
 typedef struct _GroupInformationRecord
 {
-    uint16_t groupId;
+    chip::GroupId groupId;
     uint8_t groupType;
 } GroupInformationRecord;
 

--- a/examples/temperature-measurement-app/esp32/main/gen/call-command-handler.cpp
+++ b/examples/temperature-measurement-app/esp32/main/gen/call-command-handler.cpp
@@ -40,6 +40,8 @@
 #include "command-id.h"
 #include "util.h"
 
+using namespace chip;
+
 static EmberAfStatus status(bool wasHandled, bool clusterExists, bool mfgSpecific)
 {
     if (wasHandled)

--- a/examples/temperature-measurement-app/esp32/main/gen/callback-stub.cpp
+++ b/examples/temperature-measurement-app/esp32/main/gen/callback-stub.cpp
@@ -25,6 +25,8 @@
 #include <assert.h>
 //#include "hal/hal.h"
 
+using namespace chip;
+
 /** @brief Add To Current App Tasks
  *
  * This function is only useful to sleepy end devices.  This function will note
@@ -71,8 +73,8 @@ void emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
  * @param value   Ver.: always
  * @param type   Ver.: always
  */
-EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(uint8_t endpoint, EmberAfClusterId clusterId,
-                                                                          EmberAfAttributeId attributeId, uint8_t mask,
+EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId clusterId,
+                                                                          AttributeId attributeId, uint8_t mask,
                                                                           uint16_t manufacturerCode, uint8_t * value, uint8_t type)
 {
     return EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_NORMAL; // Default
@@ -88,8 +90,8 @@ EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(uint8_
  * @param manufacturerCode   Ver.: always
  * @param attributeId   Ver.: always
  */
-bool emberAfAttributeReadAccessCallback(uint8_t endpoint, EmberAfClusterId clusterId, uint16_t manufacturerCode,
-                                        uint16_t attributeId)
+bool emberAfAttributeReadAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode,
+                                        AttributeId attributeId)
 {
     return true;
 }
@@ -104,8 +106,8 @@ bool emberAfAttributeReadAccessCallback(uint8_t endpoint, EmberAfClusterId clust
  * @param manufacturerCode   Ver.: always
  * @param attributeId   Ver.: always
  */
-bool emberAfAttributeWriteAccessCallback(uint8_t endpoint, EmberAfClusterId clusterId, uint16_t manufacturerCode,
-                                         uint16_t attributeId)
+bool emberAfAttributeWriteAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode,
+                                         AttributeId attributeId)
 {
     return true;
 }
@@ -117,7 +119,7 @@ bool emberAfAttributeWriteAccessCallback(uint8_t endpoint, EmberAfClusterId clus
  *
  * @param endpoint The endpoint.  Ver.: always
  */
-void emberAfGroupsClusterClearGroupTableCallback(uint8_t endpoint) {}
+void emberAfGroupsClusterClearGroupTableCallback(EndpointId endpoint) {}
 
 /** @brief Key Establishment Cluster Client Command Received
  *
@@ -143,7 +145,7 @@ bool emberAfKeyEstablishmentClusterClientCommandReceivedCallback(EmberAfClusterC
  * @param endpoint   Ver.: always
  * @param clusterId   Ver.: always
  */
-void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId) {}
+void emberAfClusterInitCallback(EndpointId endpoint, ClusterId clusterId) {}
 
 /** @brief Default Response
  *
@@ -157,7 +159,7 @@ void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId) {}
  * @param status Specifies either SUCCESS or the nature of the error that was
  * detected in the received command.  Ver.: always
  */
-bool emberAfDefaultResponseCallback(EmberAfClusterId clusterId, uint8_t commandId, EmberAfStatus status)
+bool emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, EmberAfStatus status)
 {
     return false;
 }
@@ -182,8 +184,8 @@ bool emberAfDefaultResponseCallback(EmberAfClusterId clusterId, uint8_t commandI
  * @param extended Indicates whether the response is in the extended format or
  * not.  Ver.: always
  */
-bool emberAfDiscoverAttributesResponseCallback(EmberAfClusterId clusterId, bool discoveryComplete, uint8_t * buffer,
-                                               uint16_t bufLen, bool extended)
+bool emberAfDiscoverAttributesResponseCallback(ClusterId clusterId, bool discoveryComplete, uint8_t * buffer, uint16_t bufLen,
+                                               bool extended)
 {
     return false;
 }
@@ -202,8 +204,8 @@ bool emberAfDiscoverAttributesResponseCallback(EmberAfClusterId clusterId, bool 
  * @param commandIdCount The length of bytes of the list, whish is the same as
  * the number of identifiers.  Ver.: always
  */
-bool emberAfDiscoverCommandsGeneratedResponseCallback(EmberAfClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
-                                                      uint8_t * commandIds, uint16_t commandIdCount)
+bool emberAfDiscoverCommandsGeneratedResponseCallback(ClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
+                                                      CommandId * commandIds, uint16_t commandIdCount)
 {
     return false;
 }
@@ -222,8 +224,8 @@ bool emberAfDiscoverCommandsGeneratedResponseCallback(EmberAfClusterId clusterId
  * @param commandIdCount The length of bytes of the list, whish is the same as
  * the number of identifiers.  Ver.: always
  */
-bool emberAfDiscoverCommandsReceivedResponseCallback(EmberAfClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
-                                                     uint8_t * commandIds, uint16_t commandIdCount)
+bool emberAfDiscoverCommandsReceivedResponseCallback(ClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
+                                                     CommandId * commandIds, uint16_t commandIdCount)
 {
     return false;
 }
@@ -299,7 +301,7 @@ void emberAfEnergyScanResultCallback(uint8_t channel, int8_t rssi) {}
  * @param buffer   Ver.: always
  * @param maxReadLength   Ver.: always
  */
-EmberAfStatus emberAfExternalAttributeReadCallback(uint8_t endpoint, EmberAfClusterId clusterId,
+EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
                                                    EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
                                                    uint8_t * buffer, uint16_t maxReadLength)
 {
@@ -352,7 +354,7 @@ EmberAfStatus emberAfExternalAttributeReadCallback(uint8_t endpoint, EmberAfClus
  * @param manufacturerCode   Ver.: always
  * @param buffer   Ver.: always
  */
-EmberAfStatus emberAfExternalAttributeWriteCallback(uint8_t endpoint, EmberAfClusterId clusterId,
+EmberAfStatus emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId,
                                                     EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
                                                     uint8_t * buffer)
 {
@@ -512,7 +514,7 @@ bool emberAfGetEndpointByIndexCallback(uint8_t index, uint8_t * endpointReturn)
  * information is written if the callback is providing the information.  Ver.:
  * always
  */
-bool emberAfGetEndpointDescriptionCallback(uint8_t endpoint, EmberEndpointDescription * result)
+bool emberAfGetEndpointDescriptionCallback(EndpointId endpoint, EmberEndpointDescription * result)
 {
     return false;
 }
@@ -534,7 +536,8 @@ bool emberAfGetEndpointDescriptionCallback(uint8_t endpoint, EmberEndpointDescri
  * @param returnEndpointInfo A pointer to a data struct that will be written
  * with information about the endpoint.  Ver.: always
  */
-bool emberAfGetEndpointInfoCallback(uint8_t endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo)
+bool emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex,
+                                    EmberAfEndpointInfoStruct * returnEndpointInfo)
 {
     return false;
 }
@@ -723,7 +726,7 @@ EmberStatus emberAfInitiateInterPanKeyEstablishmentCallback(EmberPanId panId, co
  * @param nodeId The node id of the remote device.  Ver.: always
  * @param endpoint The endpoint on the remote device.  Ver.: always
  */
-EmberStatus emberAfInitiateKeyEstablishmentCallback(EmberNodeId nodeId, uint8_t endpoint)
+EmberStatus emberAfInitiateKeyEstablishmentCallback(EmberNodeId nodeId, EndpointId endpoint)
 {
     return EMBER_LIBRARY_NOT_PRESENT;
 }
@@ -1047,7 +1050,7 @@ void emberAfPluginTemperatureMeasurementServerOverTemperatureCallback(uint8_t pr
  * @param size   Ver.: always
  * @param value   Ver.: always
  */
-void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,
+void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
 {}
 #endif
@@ -1079,9 +1082,8 @@ void emberAfPostEm4ResetCallback(void)
  * @param size   Ver.: always
  * @param value   Ver.: always
  */
-EmberAfStatus emberAfPreAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
-                                                uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size,
-                                                uint8_t * value)
+EmberAfStatus emberAfPreAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
+                                                uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
 {
     return EMBER_ZCL_STATUS_SUCCESS;
 }
@@ -1214,7 +1216,7 @@ bool emberAfPreZDOMessageReceivedCallback(EmberNodeId emberNodeId, EmberApsFrame
  * Ver.: always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
     return false;
 }
@@ -1303,7 +1305,7 @@ void emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
  * always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfReportAttributesCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+bool emberAfReportAttributesCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
     return false;
 }
@@ -1541,7 +1543,7 @@ void emberAfUnusedPanIdFoundCallback(EmberPanId panId, uint8_t channel) {}
  * Ver.: always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfWriteAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+bool emberAfWriteAttributesResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
     return false;
 }

--- a/examples/temperature-measurement-app/esp32/main/gen/callback.h
+++ b/examples/temperature-measurement-app/esp32/main/gen/callback.h
@@ -82,8 +82,8 @@ void emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks);
  * @param value   Ver.: always
  * @param type   Ver.: always
  */
-EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(uint8_t endpoint, EmberAfClusterId clusterId,
-                                                                          EmberAfAttributeId attributeId, uint8_t mask,
+EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
+                                                                          chip::AttributeId attributeId, uint8_t mask,
                                                                           uint16_t manufacturerCode, uint8_t * value, uint8_t type);
 /** @brief Attribute Read Access
  *
@@ -95,8 +95,8 @@ EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(uint8_
  * @param manufacturerCode   Ver.: always
  * @param attributeId   Ver.: always
  */
-bool emberAfAttributeReadAccessCallback(uint8_t endpoint, EmberAfClusterId clusterId, uint16_t manufacturerCode,
-                                        uint16_t attributeId);
+bool emberAfAttributeReadAccessCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode,
+                                        chip::AttributeId attributeId);
 /** @brief Attribute Write Access
  *
  * This function is called whenever the Application Framework needs to check
@@ -107,8 +107,8 @@ bool emberAfAttributeReadAccessCallback(uint8_t endpoint, EmberAfClusterId clust
  * @param manufacturerCode   Ver.: always
  * @param attributeId   Ver.: always
  */
-bool emberAfAttributeWriteAccessCallback(uint8_t endpoint, EmberAfClusterId clusterId, uint16_t manufacturerCode,
-                                         uint16_t attributeId);
+bool emberAfAttributeWriteAccessCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode,
+                                         chip::AttributeId attributeId);
 /** @brief Clear Report Table
  *
  * This function is called by the framework when the application should clear
@@ -125,7 +125,7 @@ EmberStatus emberAfClearReportTableCallback(void);
  * @param endpoint   Ver.: always
  * @param clusterId   Ver.: always
  */
-void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId);
+void emberAfClusterInitCallback(chip::EndpointId endpoint, chip::ClusterId clusterId);
 /** @brief Default Response
  *
  * This function is called by the application framework when a Default Response
@@ -138,7 +138,7 @@ void emberAfClusterInitCallback(uint8_t endpoint, EmberAfClusterId clusterId);
  * @param status Specifies either SUCCESS or the nature of the error that was
  * detected in the received command.  Ver.: always
  */
-bool emberAfDefaultResponseCallback(EmberAfClusterId clusterId, uint8_t commandId, EmberAfStatus status);
+bool emberAfDefaultResponseCallback(chip::ClusterId clusterId, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Discover Attributes Response
  *
  * This function is called by the application framework when a Discover
@@ -159,8 +159,8 @@ bool emberAfDefaultResponseCallback(EmberAfClusterId clusterId, uint8_t commandI
  * @param extended Indicates whether the response is in the extended format or
  * not.  Ver.: always
  */
-bool emberAfDiscoverAttributesResponseCallback(EmberAfClusterId clusterId, bool discoveryComplete, uint8_t * buffer,
-                                               uint16_t bufLen, bool extended);
+bool emberAfDiscoverAttributesResponseCallback(chip::ClusterId clusterId, bool discoveryComplete, uint8_t * buffer, uint16_t bufLen,
+                                               bool extended);
 /** @brief Discover Commands Generated Response
  *
  * This function is called by the framework when Discover Commands Generated
@@ -175,8 +175,8 @@ bool emberAfDiscoverAttributesResponseCallback(EmberAfClusterId clusterId, bool 
  * @param commandIdCount The length of bytes of the list, whish is the same as
  * the number of identifiers.  Ver.: always
  */
-bool emberAfDiscoverCommandsGeneratedResponseCallback(EmberAfClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
-                                                      uint8_t * commandIds, uint16_t commandIdCount);
+bool emberAfDiscoverCommandsGeneratedResponseCallback(chip::ClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
+                                                      chip::CommandId * commandIds, uint16_t commandIdCount);
 /** @brief Discover Commands Received Response
  *
  * This function is called by the framework when Discover Commands Received
@@ -191,8 +191,8 @@ bool emberAfDiscoverCommandsGeneratedResponseCallback(EmberAfClusterId clusterId
  * @param commandIdCount The length of bytes of the list, whish is the same as
  * the number of identifiers.  Ver.: always
  */
-bool emberAfDiscoverCommandsReceivedResponseCallback(EmberAfClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
-                                                     uint8_t * commandIds, uint16_t commandIdCount);
+bool emberAfDiscoverCommandsReceivedResponseCallback(chip::ClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
+                                                     chip::CommandId * commandIds, uint16_t commandIdCount);
 /** @brief Eeprom Init
  *
  * Tells the system to initialize the EEPROM if it is not already initialized.
@@ -260,7 +260,7 @@ void emberAfEnergyScanResultCallback(uint8_t channel, int8_t rssi);
  * @param buffer   Ver.: always
  * @param maxReadLength   Ver.: always
  */
-EmberAfStatus emberAfExternalAttributeReadCallback(uint8_t endpoint, EmberAfClusterId clusterId,
+EmberAfStatus emberAfExternalAttributeReadCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
                                                    EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
                                                    uint8_t * buffer, uint16_t maxReadLength);
 /** @brief External Attribute Write
@@ -309,7 +309,7 @@ EmberAfStatus emberAfExternalAttributeReadCallback(uint8_t endpoint, EmberAfClus
  * @param manufacturerCode   Ver.: always
  * @param buffer   Ver.: always
  */
-EmberAfStatus emberAfExternalAttributeWriteCallback(uint8_t endpoint, EmberAfClusterId clusterId,
+EmberAfStatus emberAfExternalAttributeWriteCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
                                                     EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
                                                     uint8_t * buffer);
 /** @brief Find Unused Pan Id And Form
@@ -425,7 +425,7 @@ bool emberAfGetEndpointByIndexCallback(uint8_t index, uint8_t * endpointReturn);
  * information is written if the callback is providing the information.  Ver.:
  * always
  */
-bool emberAfGetEndpointDescriptionCallback(uint8_t endpoint, EmberEndpointDescription * result);
+bool emberAfGetEndpointDescriptionCallback(chip::EndpointId endpoint, EmberEndpointDescription * result);
 /** @brief Get Endpoint Info
  *
  * This function is a callback to an application implemented endpoint that
@@ -443,7 +443,8 @@ bool emberAfGetEndpointDescriptionCallback(uint8_t endpoint, EmberEndpointDescri
  * @param returnEndpointInfo A pointer to a data struct that will be written
  * with information about the endpoint.  Ver.: always
  */
-bool emberAfGetEndpointInfoCallback(uint8_t endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo);
+bool emberAfGetEndpointInfoCallback(chip::EndpointId endpoint, uint8_t * returnNetworkIndex,
+                                    EmberAfEndpointInfoStruct * returnEndpointInfo);
 /** @brief Get Form And Join Extended Pan Id
  *
  * This callback is called by the framework to get the extended PAN ID used by
@@ -586,7 +587,7 @@ EmberStatus emberAfInitiateInterPanKeyEstablishmentCallback(EmberPanId panId, co
  * @param nodeId The node id of the remote device.  Ver.: always
  * @param endpoint The endpoint on the remote device.  Ver.: always
  */
-EmberStatus emberAfInitiateKeyEstablishmentCallback(EmberNodeId nodeId, uint8_t endpoint);
+EmberStatus emberAfInitiateKeyEstablishmentCallback(EmberNodeId nodeId, chip::EndpointId endpoint);
 /** @brief Initiate Partner Link Key Exchange
  *
  * This function is called by the framework to initiate a partner link key
@@ -834,8 +835,8 @@ bool emberAfPerformingKeyEstablishmentCallback(void);
  * @param size   Ver.: always
  * @param value   Ver.: always
  */
-void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value);
+void emberAfPostAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
+                                        uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value);
 /** @brief Post Em4 Reset
  *
  * A callback called by application framework, and implemented by em4 plugin
@@ -859,7 +860,7 @@ void emberAfPostEm4ResetCallback(void);
  * @param size   Ver.: always
  * @param value   Ver.: always
  */
-EmberAfStatus emberAfPreAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPreAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
                                                 uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size,
                                                 uint8_t * value);
 /** @brief Pre Cli Send
@@ -969,7 +970,7 @@ bool emberAfPreZDOMessageReceivedCallback(EmberNodeId emberNodeId, EmberApsFrame
  * Ver.: always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+bool emberAfReadAttributesResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration
@@ -1039,7 +1040,7 @@ void emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks);
  * always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfReportAttributesCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+bool emberAfReportAttributesCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 /** @brief Scan Complete
  *
  * This is called by the low-level stack code when an 802.15.4 active scan
@@ -1244,7 +1245,7 @@ void emberAfUnusedPanIdFoundCallback(EmberPanId panId, uint8_t channel);
  * Ver.: always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfWriteAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+bool emberAfWriteAttributesResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 /** @brief Zigbee Key Establishment
  *
  * A callback to the application to notify it of the status of the request for a
@@ -1267,7 +1268,7 @@ void emberAfZigbeeKeyEstablishmentCallback(EmberEUI64 partner, EmberKeyStatus st
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBasicClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBasicClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Basic Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -1277,14 +1278,14 @@ void emberAfBasicClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBasicClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBasicClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Basic Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBasicClusterClientInitCallback(uint8_t endpoint);
+void emberAfBasicClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Basic Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -1294,7 +1295,7 @@ void emberAfBasicClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBasicClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfBasicClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief Basic Cluster Client Message Sent
  *
@@ -1320,7 +1321,7 @@ void emberAfBasicClusterClientMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBasicClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBasicClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief Basic Cluster Client Tick
@@ -1329,7 +1330,7 @@ EmberAfStatus emberAfBasicClusterClientPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBasicClusterClientTickCallback(uint8_t endpoint);
+void emberAfBasicClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Basic Cluster Get Locales Supported
  *
  *
@@ -1359,7 +1360,7 @@ bool emberAfBasicClusterResetToFactoryDefaultsCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBasicClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBasicClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Basic Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -1369,14 +1370,14 @@ void emberAfBasicClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBasicClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBasicClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Basic Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBasicClusterServerInitCallback(uint8_t endpoint);
+void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Basic Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -1386,7 +1387,7 @@ void emberAfBasicClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBasicClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfBasicClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief Basic Cluster Server Message Sent
  *
@@ -1412,7 +1413,7 @@ void emberAfBasicClusterServerMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBasicClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBasicClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief Basic Cluster Server Tick
@@ -1421,7 +1422,7 @@ EmberAfStatus emberAfBasicClusterServerPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBasicClusterServerTickCallback(uint8_t endpoint);
+void emberAfBasicClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Basic Cluster Callbacks */
 
@@ -1435,7 +1436,7 @@ void emberAfBasicClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPowerConfigClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPowerConfigClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Power Configuration Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -1445,14 +1446,15 @@ void emberAfPowerConfigClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPowerConfigClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPowerConfigClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Power Configuration Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPowerConfigClusterClientInitCallback(uint8_t endpoint);
+void emberAfPowerConfigClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Power Configuration Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -1462,7 +1464,8 @@ void emberAfPowerConfigClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPowerConfigClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPowerConfigClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Power Configuration Cluster Client Message Sent
  *
@@ -1489,7 +1492,7 @@ void emberAfPowerConfigClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPowerConfigClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPowerConfigClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Power Configuration Cluster Client Tick
@@ -1498,7 +1501,7 @@ EmberAfStatus emberAfPowerConfigClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPowerConfigClusterClientTickCallback(uint8_t endpoint);
+void emberAfPowerConfigClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Power Configuration Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -1506,7 +1509,7 @@ void emberAfPowerConfigClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPowerConfigClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPowerConfigClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Power Configuration Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -1516,14 +1519,15 @@ void emberAfPowerConfigClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPowerConfigClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPowerConfigClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Power Configuration Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPowerConfigClusterServerInitCallback(uint8_t endpoint);
+void emberAfPowerConfigClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Power Configuration Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -1533,7 +1537,8 @@ void emberAfPowerConfigClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPowerConfigClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPowerConfigClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Power Configuration Cluster Server Message Sent
  *
@@ -1560,7 +1565,7 @@ void emberAfPowerConfigClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPowerConfigClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPowerConfigClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Power Configuration Cluster Server Tick
@@ -1569,7 +1574,7 @@ EmberAfStatus emberAfPowerConfigClusterServerPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPowerConfigClusterServerTickCallback(uint8_t endpoint);
+void emberAfPowerConfigClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Power Configuration Cluster Callbacks */
 
@@ -1583,7 +1588,7 @@ void emberAfPowerConfigClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDeviceTempClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDeviceTempClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Device Temperature Configuration Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -1593,14 +1598,15 @@ void emberAfDeviceTempClusterClientAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDeviceTempClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDeviceTempClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Device Temperature Configuration Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDeviceTempClusterClientInitCallback(uint8_t endpoint);
+void emberAfDeviceTempClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Device Temperature Configuration Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -1610,7 +1616,8 @@ void emberAfDeviceTempClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDeviceTempClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDeviceTempClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Device Temperature Configuration Cluster Client Message Sent
  *
@@ -1637,7 +1644,7 @@ void emberAfDeviceTempClusterClientMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDeviceTempClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDeviceTempClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Device Temperature Configuration Cluster Client Tick
@@ -1646,7 +1653,7 @@ EmberAfStatus emberAfDeviceTempClusterClientPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDeviceTempClusterClientTickCallback(uint8_t endpoint);
+void emberAfDeviceTempClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Device Temperature Configuration Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -1654,7 +1661,7 @@ void emberAfDeviceTempClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDeviceTempClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDeviceTempClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Device Temperature Configuration Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -1664,14 +1671,15 @@ void emberAfDeviceTempClusterServerAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDeviceTempClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDeviceTempClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Device Temperature Configuration Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDeviceTempClusterServerInitCallback(uint8_t endpoint);
+void emberAfDeviceTempClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Device Temperature Configuration Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -1681,7 +1689,8 @@ void emberAfDeviceTempClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDeviceTempClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDeviceTempClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Device Temperature Configuration Cluster Server Message Sent
  *
@@ -1708,7 +1717,7 @@ void emberAfDeviceTempClusterServerMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDeviceTempClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDeviceTempClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Device Temperature Configuration Cluster Server Tick
@@ -1717,7 +1726,7 @@ EmberAfStatus emberAfDeviceTempClusterServerPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDeviceTempClusterServerTickCallback(uint8_t endpoint);
+void emberAfDeviceTempClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Device Temperature Configuration Cluster Callbacks */
 
@@ -1731,7 +1740,7 @@ void emberAfDeviceTempClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIdentifyClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIdentifyClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Identify Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -1741,14 +1750,15 @@ void emberAfIdentifyClusterClientAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIdentifyClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIdentifyClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Identify Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIdentifyClusterClientInitCallback(uint8_t endpoint);
+void emberAfIdentifyClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Identify Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -1758,7 +1768,8 @@ void emberAfIdentifyClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIdentifyClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIdentifyClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Identify Cluster Client Message Sent
  *
@@ -1785,7 +1796,7 @@ void emberAfIdentifyClusterClientMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIdentifyClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIdentifyClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Identify Cluster Client Tick
@@ -1794,7 +1805,7 @@ EmberAfStatus emberAfIdentifyClusterClientPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIdentifyClusterClientTickCallback(uint8_t endpoint);
+void emberAfIdentifyClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Identify Cluster E Z Mode Invoke
  *
  *
@@ -1829,7 +1840,7 @@ bool emberAfIdentifyClusterIdentifyQueryResponseCallback(uint16_t timeout);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIdentifyClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIdentifyClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Identify Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -1839,14 +1850,15 @@ void emberAfIdentifyClusterServerAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIdentifyClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIdentifyClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Identify Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIdentifyClusterServerInitCallback(uint8_t endpoint);
+void emberAfIdentifyClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Identify Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -1856,7 +1868,8 @@ void emberAfIdentifyClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIdentifyClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIdentifyClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Identify Cluster Server Message Sent
  *
@@ -1883,7 +1896,7 @@ void emberAfIdentifyClusterServerMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIdentifyClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIdentifyClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Identify Cluster Server Tick
@@ -1892,7 +1905,7 @@ EmberAfStatus emberAfIdentifyClusterServerPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIdentifyClusterServerTickCallback(uint8_t endpoint);
+void emberAfIdentifyClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Identify Cluster Trigger Effect
  *
  *
@@ -1922,7 +1935,7 @@ bool emberAfIdentifyClusterUpdateCommissionStateCallback(uint8_t action, uint8_t
  *
  * @param endpoint The endpoint.  Ver.: always
  */
-void emberAfGroupsClusterClearGroupTableCallback(uint8_t endpoint);
+void emberAfGroupsClusterClearGroupTableCallback(chip::EndpointId endpoint);
 /** @brief Groups Cluster Add Group
  *
  *
@@ -1930,7 +1943,7 @@ void emberAfGroupsClusterClearGroupTableCallback(uint8_t endpoint);
  * @param groupId   Ver.: always
  * @param groupName   Ver.: always
  */
-bool emberAfGroupsClusterAddGroupCallback(uint16_t groupId, uint8_t * groupName);
+bool emberAfGroupsClusterAddGroupCallback(chip::GroupId groupId, uint8_t * groupName);
 /** @brief Groups Cluster Add Group If Identifying
  *
  *
@@ -1938,7 +1951,7 @@ bool emberAfGroupsClusterAddGroupCallback(uint16_t groupId, uint8_t * groupName)
  * @param groupId   Ver.: always
  * @param groupName   Ver.: always
  */
-bool emberAfGroupsClusterAddGroupIfIdentifyingCallback(uint16_t groupId, uint8_t * groupName);
+bool emberAfGroupsClusterAddGroupIfIdentifyingCallback(chip::GroupId groupId, uint8_t * groupName);
 /** @brief Groups Cluster Add Group Response
  *
  *
@@ -1946,7 +1959,7 @@ bool emberAfGroupsClusterAddGroupIfIdentifyingCallback(uint16_t groupId, uint8_t
  * @param status   Ver.: always
  * @param groupId   Ver.: always
  */
-bool emberAfGroupsClusterAddGroupResponseCallback(uint8_t status, uint16_t groupId);
+bool emberAfGroupsClusterAddGroupResponseCallback(uint8_t status, chip::GroupId groupId);
 /** @brief Groups Cluster Client Attribute Changed
  *
  * Client Attribute Changed
@@ -1954,7 +1967,7 @@ bool emberAfGroupsClusterAddGroupResponseCallback(uint8_t status, uint16_t group
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGroupsClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGroupsClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Groups Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -1964,14 +1977,14 @@ void emberAfGroupsClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGroupsClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGroupsClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Groups Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGroupsClusterClientInitCallback(uint8_t endpoint);
+void emberAfGroupsClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Groups Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -1981,7 +1994,8 @@ void emberAfGroupsClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGroupsClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGroupsClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Groups Cluster Client Message Sent
  *
@@ -2008,7 +2022,7 @@ void emberAfGroupsClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGroupsClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGroupsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Groups Cluster Client Tick
@@ -2017,7 +2031,7 @@ EmberAfStatus emberAfGroupsClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGroupsClusterClientTickCallback(uint8_t endpoint);
+void emberAfGroupsClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Groups Cluster Get Group Membership
  *
  *
@@ -2047,7 +2061,7 @@ bool emberAfGroupsClusterRemoveAllGroupsCallback(void);
  *
  * @param groupId   Ver.: always
  */
-bool emberAfGroupsClusterRemoveGroupCallback(uint16_t groupId);
+bool emberAfGroupsClusterRemoveGroupCallback(chip::GroupId groupId);
 /** @brief Groups Cluster Remove Group Response
  *
  *
@@ -2055,7 +2069,7 @@ bool emberAfGroupsClusterRemoveGroupCallback(uint16_t groupId);
  * @param status   Ver.: always
  * @param groupId   Ver.: always
  */
-bool emberAfGroupsClusterRemoveGroupResponseCallback(uint8_t status, uint16_t groupId);
+bool emberAfGroupsClusterRemoveGroupResponseCallback(uint8_t status, chip::GroupId groupId);
 /** @brief Groups Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -2063,7 +2077,7 @@ bool emberAfGroupsClusterRemoveGroupResponseCallback(uint8_t status, uint16_t gr
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGroupsClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGroupsClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Groups Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -2073,14 +2087,14 @@ void emberAfGroupsClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGroupsClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGroupsClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Groups Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGroupsClusterServerInitCallback(uint8_t endpoint);
+void emberAfGroupsClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Groups Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -2090,7 +2104,8 @@ void emberAfGroupsClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGroupsClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGroupsClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Groups Cluster Server Message Sent
  *
@@ -2117,7 +2132,7 @@ void emberAfGroupsClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGroupsClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGroupsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Groups Cluster Server Tick
@@ -2126,14 +2141,14 @@ EmberAfStatus emberAfGroupsClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGroupsClusterServerTickCallback(uint8_t endpoint);
+void emberAfGroupsClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Groups Cluster View Group
  *
  *
  *
  * @param groupId   Ver.: always
  */
-bool emberAfGroupsClusterViewGroupCallback(uint16_t groupId);
+bool emberAfGroupsClusterViewGroupCallback(chip::GroupId groupId);
 /** @brief Groups Cluster View Group Response
  *
  *
@@ -2142,7 +2157,7 @@ bool emberAfGroupsClusterViewGroupCallback(uint16_t groupId);
  * @param groupId   Ver.: always
  * @param groupName   Ver.: always
  */
-bool emberAfGroupsClusterViewGroupResponseCallback(uint8_t status, uint16_t groupId, uint8_t * groupName);
+bool emberAfGroupsClusterViewGroupResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t * groupName);
 
 /** @} END Groups Cluster Callbacks */
 
@@ -2156,7 +2171,7 @@ bool emberAfGroupsClusterViewGroupResponseCallback(uint8_t status, uint16_t grou
  *
  * @param endpoint The endpoint.  Ver.: always
  */
-void emberAfScenesClusterClearSceneTableCallback(uint8_t endpoint);
+void emberAfScenesClusterClearSceneTableCallback(chip::EndpointId endpoint);
 /** @brief Scenes Cluster Add Scene
  *
  *
@@ -2167,7 +2182,7 @@ void emberAfScenesClusterClearSceneTableCallback(uint8_t endpoint);
  * @param sceneName   Ver.: always
  * @param extensionFieldSets   Ver.: always
  */
-bool emberAfScenesClusterAddSceneCallback(uint16_t groupId, uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
+bool emberAfScenesClusterAddSceneCallback(chip::GroupId groupId, uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
                                           uint8_t * extensionFieldSets);
 /** @brief Scenes Cluster Add Scene Response
  *
@@ -2177,7 +2192,7 @@ bool emberAfScenesClusterAddSceneCallback(uint16_t groupId, uint8_t sceneId, uin
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterAddSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterAddSceneResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster Client Attribute Changed
  *
  * Client Attribute Changed
@@ -2185,7 +2200,7 @@ bool emberAfScenesClusterAddSceneResponseCallback(uint8_t status, uint16_t group
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfScenesClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfScenesClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Scenes Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -2195,14 +2210,14 @@ void emberAfScenesClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfScenesClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfScenesClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Scenes Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfScenesClusterClientInitCallback(uint8_t endpoint);
+void emberAfScenesClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Scenes Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -2212,7 +2227,8 @@ void emberAfScenesClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfScenesClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfScenesClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Scenes Cluster Client Message Sent
  *
@@ -2239,7 +2255,7 @@ void emberAfScenesClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfScenesClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfScenesClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Scenes Cluster Client Tick
@@ -2248,7 +2264,7 @@ EmberAfStatus emberAfScenesClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfScenesClusterClientTickCallback(uint8_t endpoint);
+void emberAfScenesClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Scenes Cluster Copy Scene
  *
  *
@@ -2280,8 +2296,8 @@ bool emberAfScenesClusterCopySceneResponseCallback(uint8_t status, uint16_t grou
  * @param sceneName   Ver.: always
  * @param extensionFieldSets   Ver.: always
  */
-bool emberAfScenesClusterEnhancedAddSceneCallback(uint16_t groupId, uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
-                                                  uint8_t * extensionFieldSets);
+bool emberAfScenesClusterEnhancedAddSceneCallback(chip::GroupId groupId, uint8_t sceneId, uint16_t transitionTime,
+                                                  uint8_t * sceneName, uint8_t * extensionFieldSets);
 /** @brief Scenes Cluster Enhanced Add Scene Response
  *
  *
@@ -2290,7 +2306,7 @@ bool emberAfScenesClusterEnhancedAddSceneCallback(uint16_t groupId, uint8_t scen
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterEnhancedAddSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterEnhancedAddSceneResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster Enhanced View Scene
  *
  *
@@ -2298,7 +2314,7 @@ bool emberAfScenesClusterEnhancedAddSceneResponseCallback(uint8_t status, uint16
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterEnhancedViewSceneCallback(uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterEnhancedViewSceneCallback(chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster Enhanced View Scene Response
  *
  *
@@ -2310,7 +2326,7 @@ bool emberAfScenesClusterEnhancedViewSceneCallback(uint16_t groupId, uint8_t sce
  * @param sceneName   Ver.: always
  * @param extensionFieldSets   Ver.: always
  */
-bool emberAfScenesClusterEnhancedViewSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId,
+bool emberAfScenesClusterEnhancedViewSceneResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t sceneId,
                                                            uint16_t transitionTime, uint8_t * sceneName,
                                                            uint8_t * extensionFieldSets);
 /** @brief Scenes Cluster Get Scene Membership
@@ -2319,7 +2335,7 @@ bool emberAfScenesClusterEnhancedViewSceneResponseCallback(uint8_t status, uint1
  *
  * @param groupId   Ver.: always
  */
-bool emberAfScenesClusterGetSceneMembershipCallback(uint16_t groupId);
+bool emberAfScenesClusterGetSceneMembershipCallback(chip::GroupId groupId);
 /** @brief Scenes Cluster Get Scene Membership Response
  *
  *
@@ -2330,8 +2346,8 @@ bool emberAfScenesClusterGetSceneMembershipCallback(uint16_t groupId);
  * @param sceneCount   Ver.: always
  * @param sceneList   Ver.: always
  */
-bool emberAfScenesClusterGetSceneMembershipResponseCallback(uint8_t status, uint8_t capacity, uint16_t groupId, uint8_t sceneCount,
-                                                            uint8_t * sceneList);
+bool emberAfScenesClusterGetSceneMembershipResponseCallback(uint8_t status, uint8_t capacity, chip::GroupId groupId,
+                                                            uint8_t sceneCount, uint8_t * sceneList);
 /** @brief Scenes Cluster Recall Scene
  *
  *
@@ -2340,14 +2356,14 @@ bool emberAfScenesClusterGetSceneMembershipResponseCallback(uint8_t status, uint
  * @param sceneId   Ver.: always
  * @param transitionTime   Ver.: since zcl-7.0-07-5123-07
  */
-bool emberAfScenesClusterRecallSceneCallback(uint16_t groupId, uint8_t sceneId, uint16_t transitionTime);
+bool emberAfScenesClusterRecallSceneCallback(chip::GroupId groupId, uint8_t sceneId, uint16_t transitionTime);
 /** @brief Scenes Cluster Remove All Scenes
  *
  *
  *
  * @param groupId   Ver.: always
  */
-bool emberAfScenesClusterRemoveAllScenesCallback(uint16_t groupId);
+bool emberAfScenesClusterRemoveAllScenesCallback(chip::GroupId groupId);
 /** @brief Scenes Cluster Remove All Scenes Response
  *
  *
@@ -2355,7 +2371,7 @@ bool emberAfScenesClusterRemoveAllScenesCallback(uint16_t groupId);
  * @param status   Ver.: always
  * @param groupId   Ver.: always
  */
-bool emberAfScenesClusterRemoveAllScenesResponseCallback(uint8_t status, uint16_t groupId);
+bool emberAfScenesClusterRemoveAllScenesResponseCallback(uint8_t status, chip::GroupId groupId);
 /** @brief Scenes Cluster Remove Scene
  *
  *
@@ -2363,7 +2379,7 @@ bool emberAfScenesClusterRemoveAllScenesResponseCallback(uint8_t status, uint16_
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterRemoveSceneCallback(uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterRemoveSceneCallback(chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster Remove Scene Response
  *
  *
@@ -2372,7 +2388,7 @@ bool emberAfScenesClusterRemoveSceneCallback(uint16_t groupId, uint8_t sceneId);
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterRemoveSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterRemoveSceneResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -2380,7 +2396,7 @@ bool emberAfScenesClusterRemoveSceneResponseCallback(uint8_t status, uint16_t gr
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfScenesClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfScenesClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Scenes Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -2390,14 +2406,14 @@ void emberAfScenesClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfScenesClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfScenesClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Scenes Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfScenesClusterServerInitCallback(uint8_t endpoint);
+void emberAfScenesClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Scenes Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -2407,7 +2423,8 @@ void emberAfScenesClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfScenesClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfScenesClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Scenes Cluster Server Message Sent
  *
@@ -2434,7 +2451,7 @@ void emberAfScenesClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfScenesClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfScenesClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Scenes Cluster Server Tick
@@ -2443,7 +2460,7 @@ EmberAfStatus emberAfScenesClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfScenesClusterServerTickCallback(uint8_t endpoint);
+void emberAfScenesClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Scenes Cluster Store Scene
  *
  *
@@ -2451,7 +2468,7 @@ void emberAfScenesClusterServerTickCallback(uint8_t endpoint);
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterStoreSceneCallback(uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterStoreSceneCallback(chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster Store Scene Response
  *
  *
@@ -2460,7 +2477,7 @@ bool emberAfScenesClusterStoreSceneCallback(uint16_t groupId, uint8_t sceneId);
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterStoreSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterStoreSceneResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster View Scene
  *
  *
@@ -2468,7 +2485,7 @@ bool emberAfScenesClusterStoreSceneResponseCallback(uint8_t status, uint16_t gro
  * @param groupId   Ver.: always
  * @param sceneId   Ver.: always
  */
-bool emberAfScenesClusterViewSceneCallback(uint16_t groupId, uint8_t sceneId);
+bool emberAfScenesClusterViewSceneCallback(chip::GroupId groupId, uint8_t sceneId);
 /** @brief Scenes Cluster View Scene Response
  *
  *
@@ -2480,7 +2497,7 @@ bool emberAfScenesClusterViewSceneCallback(uint16_t groupId, uint8_t sceneId);
  * @param sceneName   Ver.: always
  * @param extensionFieldSets   Ver.: always
  */
-bool emberAfScenesClusterViewSceneResponseCallback(uint8_t status, uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
+bool emberAfScenesClusterViewSceneResponseCallback(uint8_t status, chip::GroupId groupId, uint8_t sceneId, uint16_t transitionTime,
                                                    uint8_t * sceneName, uint8_t * extensionFieldSets);
 /** @} END Scenes Cluster Callbacks */
 
@@ -2494,7 +2511,7 @@ bool emberAfScenesClusterViewSceneResponseCallback(uint8_t status, uint16_t grou
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOnOffClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOnOffClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief On/off Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -2504,14 +2521,14 @@ void emberAfOnOffClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOnOffClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOnOffClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief On/off Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOnOffClusterClientInitCallback(uint8_t endpoint);
+void emberAfOnOffClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief On/off Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -2521,7 +2538,7 @@ void emberAfOnOffClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOnOffClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfOnOffClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief On/off Cluster Client Message Sent
  *
@@ -2547,7 +2564,7 @@ void emberAfOnOffClusterClientMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOnOffClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOnOffClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief On/off Cluster Client Tick
@@ -2556,7 +2573,7 @@ EmberAfStatus emberAfOnOffClusterClientPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOnOffClusterClientTickCallback(uint8_t endpoint);
+void emberAfOnOffClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief On/off Cluster Off
  *
  *
@@ -2629,7 +2646,7 @@ bool emberAfOnOffClusterSampleMfgSpecificToggleWithTransitionCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOnOffClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOnOffClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief On/off Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -2639,14 +2656,14 @@ void emberAfOnOffClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOnOffClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOnOffClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief On/off Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOnOffClusterServerInitCallback(uint8_t endpoint);
+void emberAfOnOffClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief On/off Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -2656,7 +2673,7 @@ void emberAfOnOffClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOnOffClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfOnOffClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief On/off Cluster Server Message Sent
  *
@@ -2682,7 +2699,7 @@ void emberAfOnOffClusterServerMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOnOffClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOnOffClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief On/off Cluster Server Tick
@@ -2691,7 +2708,7 @@ EmberAfStatus emberAfOnOffClusterServerPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOnOffClusterServerTickCallback(uint8_t endpoint);
+void emberAfOnOffClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief On/off Cluster Toggle
  *
  *
@@ -2711,7 +2728,7 @@ bool emberAfOnOffClusterToggleCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOnOffSwitchConfigClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief On/off Switch Configuration Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -2721,14 +2738,15 @@ void emberAfOnOffSwitchConfigClusterClientAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOnOffSwitchConfigClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief On/off Switch Configuration Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterClientInitCallback(uint8_t endpoint);
+void emberAfOnOffSwitchConfigClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief On/off Switch Configuration Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -2739,7 +2757,7 @@ void emberAfOnOffSwitchConfigClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfOnOffSwitchConfigClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief On/off Switch Configuration Cluster Client Message Sent
  *
@@ -2766,7 +2784,8 @@ void emberAfOnOffSwitchConfigClusterClientMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOnOffSwitchConfigClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOnOffSwitchConfigClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief On/off Switch Configuration Cluster Client Tick
@@ -2775,7 +2794,7 @@ EmberAfStatus emberAfOnOffSwitchConfigClusterClientPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterClientTickCallback(uint8_t endpoint);
+void emberAfOnOffSwitchConfigClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief On/off Switch Configuration Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -2783,7 +2802,7 @@ void emberAfOnOffSwitchConfigClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOnOffSwitchConfigClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief On/off Switch Configuration Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -2793,14 +2812,15 @@ void emberAfOnOffSwitchConfigClusterServerAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOnOffSwitchConfigClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief On/off Switch Configuration Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterServerInitCallback(uint8_t endpoint);
+void emberAfOnOffSwitchConfigClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief On/off Switch Configuration Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -2811,7 +2831,7 @@ void emberAfOnOffSwitchConfigClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfOnOffSwitchConfigClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief On/off Switch Configuration Cluster Server Message Sent
  *
@@ -2838,7 +2858,8 @@ void emberAfOnOffSwitchConfigClusterServerMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOnOffSwitchConfigClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOnOffSwitchConfigClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief On/off Switch Configuration Cluster Server Tick
@@ -2847,7 +2868,7 @@ EmberAfStatus emberAfOnOffSwitchConfigClusterServerPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOnOffSwitchConfigClusterServerTickCallback(uint8_t endpoint);
+void emberAfOnOffSwitchConfigClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END On/off Switch Configuration Cluster Callbacks */
 
@@ -2861,7 +2882,7 @@ void emberAfOnOffSwitchConfigClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfLevelControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfLevelControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Level Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -2871,14 +2892,15 @@ void emberAfLevelControlClusterClientAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfLevelControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfLevelControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief Level Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfLevelControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfLevelControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Level Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -2888,7 +2910,8 @@ void emberAfLevelControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfLevelControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfLevelControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief Level Control Cluster Client Message Sent
  *
@@ -2915,7 +2938,7 @@ void emberAfLevelControlClusterClientMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfLevelControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfLevelControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief Level Control Cluster Client Tick
@@ -2924,7 +2947,7 @@ EmberAfStatus emberAfLevelControlClusterClientPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfLevelControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfLevelControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Level Control Cluster Move
  *
  *
@@ -2969,7 +2992,7 @@ bool emberAfLevelControlClusterMoveWithOnOffCallback(uint8_t moveMode, uint8_t r
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfLevelControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfLevelControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Level Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -2979,14 +3002,15 @@ void emberAfLevelControlClusterServerAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfLevelControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfLevelControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief Level Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfLevelControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfLevelControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Level Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -2996,7 +3020,8 @@ void emberAfLevelControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfLevelControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfLevelControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief Level Control Cluster Server Message Sent
  *
@@ -3023,7 +3048,7 @@ void emberAfLevelControlClusterServerMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfLevelControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfLevelControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief Level Control Cluster Server Tick
@@ -3032,7 +3057,7 @@ EmberAfStatus emberAfLevelControlClusterServerPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfLevelControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfLevelControlClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Level Control Cluster Step
  *
  *
@@ -3081,7 +3106,7 @@ bool emberAfLevelControlClusterStopWithOnOffCallback(void);
  * @param alarmCode   Ver.: always
  * @param clusterId   Ver.: always
  */
-bool emberAfAlarmClusterAlarmCallback(uint8_t alarmCode, uint16_t clusterId);
+bool emberAfAlarmClusterAlarmCallback(uint8_t alarmCode, chip::ClusterId clusterId);
 /** @brief Alarms Cluster Client Attribute Changed
  *
  * Client Attribute Changed
@@ -3089,7 +3114,7 @@ bool emberAfAlarmClusterAlarmCallback(uint8_t alarmCode, uint16_t clusterId);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfAlarmClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfAlarmClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Alarms Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -3099,14 +3124,14 @@ void emberAfAlarmClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfAlarmClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfAlarmClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Alarms Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfAlarmClusterClientInitCallback(uint8_t endpoint);
+void emberAfAlarmClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Alarms Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -3116,7 +3141,7 @@ void emberAfAlarmClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfAlarmClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfAlarmClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief Alarms Cluster Client Message Sent
  *
@@ -3142,7 +3167,7 @@ void emberAfAlarmClusterClientMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfAlarmClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfAlarmClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief Alarms Cluster Client Tick
@@ -3151,7 +3176,7 @@ EmberAfStatus emberAfAlarmClusterClientPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfAlarmClusterClientTickCallback(uint8_t endpoint);
+void emberAfAlarmClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Alarms Cluster Get Alarm
  *
  *
@@ -3167,7 +3192,7 @@ bool emberAfAlarmClusterGetAlarmCallback(void);
  * @param clusterId   Ver.: always
  * @param timeStamp   Ver.: always
  */
-bool emberAfAlarmClusterGetAlarmResponseCallback(uint8_t status, uint8_t alarmCode, uint16_t clusterId, uint32_t timeStamp);
+bool emberAfAlarmClusterGetAlarmResponseCallback(uint8_t status, uint8_t alarmCode, chip::ClusterId clusterId, uint32_t timeStamp);
 /** @brief Alarms Cluster Reset Alarm
  *
  *
@@ -3175,7 +3200,7 @@ bool emberAfAlarmClusterGetAlarmResponseCallback(uint8_t status, uint8_t alarmCo
  * @param alarmCode   Ver.: always
  * @param clusterId   Ver.: always
  */
-bool emberAfAlarmClusterResetAlarmCallback(uint8_t alarmCode, uint16_t clusterId);
+bool emberAfAlarmClusterResetAlarmCallback(uint8_t alarmCode, chip::ClusterId clusterId);
 /** @brief Alarms Cluster Reset Alarm Log
  *
  *
@@ -3195,7 +3220,7 @@ bool emberAfAlarmClusterResetAllAlarmsCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfAlarmClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfAlarmClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Alarms Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -3205,14 +3230,14 @@ void emberAfAlarmClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfAlarmClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfAlarmClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Alarms Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfAlarmClusterServerInitCallback(uint8_t endpoint);
+void emberAfAlarmClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Alarms Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -3222,7 +3247,7 @@ void emberAfAlarmClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfAlarmClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfAlarmClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief Alarms Cluster Server Message Sent
  *
@@ -3248,7 +3273,7 @@ void emberAfAlarmClusterServerMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfAlarmClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfAlarmClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief Alarms Cluster Server Tick
@@ -3257,7 +3282,7 @@ EmberAfStatus emberAfAlarmClusterServerPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfAlarmClusterServerTickCallback(uint8_t endpoint);
+void emberAfAlarmClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Alarms Cluster Callbacks */
 
@@ -3271,7 +3296,7 @@ void emberAfAlarmClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTimeClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfTimeClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Time Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -3281,14 +3306,14 @@ void emberAfTimeClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTimeClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfTimeClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Time Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTimeClusterClientInitCallback(uint8_t endpoint);
+void emberAfTimeClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Time Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -3298,7 +3323,7 @@ void emberAfTimeClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfTimeClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfTimeClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           uint16_t manufacturerCode);
 /** @brief Time Cluster Client Message Sent
  *
@@ -3324,7 +3349,7 @@ void emberAfTimeClusterClientMessageSentCallback(EmberOutgoingMessageType type, 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfTimeClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfTimeClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                   EmberAfAttributeType attributeType, uint8_t size,
                                                                   uint8_t * value);
 /** @brief Time Cluster Client Tick
@@ -3333,7 +3358,7 @@ EmberAfStatus emberAfTimeClusterClientPreAttributeChangedCallback(uint8_t endpoi
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTimeClusterClientTickCallback(uint8_t endpoint);
+void emberAfTimeClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Time Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -3341,7 +3366,7 @@ void emberAfTimeClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTimeClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfTimeClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Time Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -3351,14 +3376,14 @@ void emberAfTimeClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTimeClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfTimeClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Time Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTimeClusterServerInitCallback(uint8_t endpoint);
+void emberAfTimeClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Time Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -3368,7 +3393,7 @@ void emberAfTimeClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfTimeClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfTimeClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           uint16_t manufacturerCode);
 /** @brief Time Cluster Server Message Sent
  *
@@ -3394,7 +3419,7 @@ void emberAfTimeClusterServerMessageSentCallback(EmberOutgoingMessageType type, 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfTimeClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfTimeClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                   EmberAfAttributeType attributeType, uint8_t size,
                                                                   uint8_t * value);
 /** @brief Time Cluster Server Tick
@@ -3403,7 +3428,7 @@ EmberAfStatus emberAfTimeClusterServerPreAttributeChangedCallback(uint8_t endpoi
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTimeClusterServerTickCallback(uint8_t endpoint);
+void emberAfTimeClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Time Cluster Callbacks */
 
@@ -3428,7 +3453,7 @@ bool emberAfRssiLocationClusterAnchorNodeAnnounceCallback(uint8_t * anchorNodeIe
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfRssiLocationClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfRssiLocationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief RSSI Location Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -3438,14 +3463,15 @@ void emberAfRssiLocationClusterClientAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfRssiLocationClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfRssiLocationClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief RSSI Location Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfRssiLocationClusterClientInitCallback(uint8_t endpoint);
+void emberAfRssiLocationClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief RSSI Location Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -3455,7 +3481,8 @@ void emberAfRssiLocationClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfRssiLocationClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfRssiLocationClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief RSSI Location Cluster Client Message Sent
  *
@@ -3482,7 +3509,7 @@ void emberAfRssiLocationClusterClientMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfRssiLocationClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfRssiLocationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief RSSI Location Cluster Client Tick
@@ -3491,7 +3518,7 @@ EmberAfStatus emberAfRssiLocationClusterClientPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfRssiLocationClusterClientTickCallback(uint8_t endpoint);
+void emberAfRssiLocationClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief RSSI Location Cluster Compact Location Data Notification
  *
  *
@@ -3633,7 +3660,7 @@ bool emberAfRssiLocationClusterSendPingsCallback(uint8_t * targetAddress, uint8_
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfRssiLocationClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfRssiLocationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief RSSI Location Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -3643,14 +3670,15 @@ void emberAfRssiLocationClusterServerAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfRssiLocationClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfRssiLocationClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief RSSI Location Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfRssiLocationClusterServerInitCallback(uint8_t endpoint);
+void emberAfRssiLocationClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief RSSI Location Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -3660,7 +3688,8 @@ void emberAfRssiLocationClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfRssiLocationClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfRssiLocationClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief RSSI Location Cluster Server Message Sent
  *
@@ -3687,7 +3716,7 @@ void emberAfRssiLocationClusterServerMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfRssiLocationClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfRssiLocationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief RSSI Location Cluster Server Tick
@@ -3696,7 +3725,7 @@ EmberAfStatus emberAfRssiLocationClusterServerPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfRssiLocationClusterServerTickCallback(uint8_t endpoint);
+void emberAfRssiLocationClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief RSSI Location Cluster Set Absolute Location
  *
  *
@@ -3734,7 +3763,7 @@ bool emberAfRssiLocationClusterSetDeviceConfigurationCallback(int16_t power, uin
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBinaryInputBasicClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBinaryInputBasicClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Binary Input (Basic) Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -3744,14 +3773,15 @@ void emberAfBinaryInputBasicClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBinaryInputBasicClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBinaryInputBasicClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Binary Input (Basic) Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBinaryInputBasicClusterClientInitCallback(uint8_t endpoint);
+void emberAfBinaryInputBasicClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Binary Input (Basic) Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -3761,8 +3791,8 @@ void emberAfBinaryInputBasicClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBinaryInputBasicClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfBinaryInputBasicClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Binary Input (Basic) Cluster Client Message Sent
  *
@@ -3789,7 +3819,8 @@ void emberAfBinaryInputBasicClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBinaryInputBasicClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBinaryInputBasicClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Binary Input (Basic) Cluster Client Tick
@@ -3798,7 +3829,7 @@ EmberAfStatus emberAfBinaryInputBasicClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBinaryInputBasicClusterClientTickCallback(uint8_t endpoint);
+void emberAfBinaryInputBasicClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Binary Input (Basic) Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -3806,7 +3837,7 @@ void emberAfBinaryInputBasicClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBinaryInputBasicClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBinaryInputBasicClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Binary Input (Basic) Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -3816,14 +3847,15 @@ void emberAfBinaryInputBasicClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBinaryInputBasicClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBinaryInputBasicClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Binary Input (Basic) Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBinaryInputBasicClusterServerInitCallback(uint8_t endpoint);
+void emberAfBinaryInputBasicClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Binary Input (Basic) Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -3833,8 +3865,8 @@ void emberAfBinaryInputBasicClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBinaryInputBasicClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfBinaryInputBasicClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Binary Input (Basic) Cluster Server Message Sent
  *
@@ -3861,7 +3893,8 @@ void emberAfBinaryInputBasicClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBinaryInputBasicClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBinaryInputBasicClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Binary Input (Basic) Cluster Server Tick
@@ -3870,7 +3903,7 @@ EmberAfStatus emberAfBinaryInputBasicClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBinaryInputBasicClusterServerTickCallback(uint8_t endpoint);
+void emberAfBinaryInputBasicClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Binary Input (Basic) Cluster Callbacks */
 
@@ -3884,7 +3917,7 @@ void emberAfBinaryInputBasicClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfCommissioningClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfCommissioningClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Commissioning Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -3894,14 +3927,15 @@ void emberAfCommissioningClusterClientAttributeChangedCallback(uint8_t endpoint,
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCommissioningClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfCommissioningClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                              EmberAfStatus status);
 /** @brief Commissioning Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCommissioningClusterClientInitCallback(uint8_t endpoint);
+void emberAfCommissioningClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Commissioning Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -3911,7 +3945,8 @@ void emberAfCommissioningClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfCommissioningClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfCommissioningClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    uint16_t manufacturerCode);
 /** @brief Commissioning Cluster Client Message Sent
  *
@@ -3938,7 +3973,7 @@ void emberAfCommissioningClusterClientMessageSentCallback(EmberOutgoingMessageTy
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfCommissioningClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfCommissioningClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            EmberAfAttributeType attributeType, uint8_t size,
                                                                            uint8_t * value);
 /** @brief Commissioning Cluster Client Tick
@@ -3947,7 +3982,7 @@ EmberAfStatus emberAfCommissioningClusterClientPreAttributeChangedCallback(uint8
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCommissioningClusterClientTickCallback(uint8_t endpoint);
+void emberAfCommissioningClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Commissioning Cluster Reset Startup Parameters
  *
  *
@@ -4016,7 +4051,7 @@ bool emberAfCommissioningClusterSaveStartupParametersResponseCallback(uint8_t st
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfCommissioningClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfCommissioningClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Commissioning Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -4026,14 +4061,15 @@ void emberAfCommissioningClusterServerAttributeChangedCallback(uint8_t endpoint,
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCommissioningClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfCommissioningClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                              EmberAfStatus status);
 /** @brief Commissioning Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCommissioningClusterServerInitCallback(uint8_t endpoint);
+void emberAfCommissioningClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Commissioning Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -4043,7 +4079,8 @@ void emberAfCommissioningClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfCommissioningClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfCommissioningClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    uint16_t manufacturerCode);
 /** @brief Commissioning Cluster Server Message Sent
  *
@@ -4070,7 +4107,7 @@ void emberAfCommissioningClusterServerMessageSentCallback(EmberOutgoingMessageTy
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfCommissioningClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfCommissioningClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            EmberAfAttributeType attributeType, uint8_t size,
                                                                            uint8_t * value);
 /** @brief Commissioning Cluster Server Tick
@@ -4079,7 +4116,7 @@ EmberAfStatus emberAfCommissioningClusterServerPreAttributeChangedCallback(uint8
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCommissioningClusterServerTickCallback(uint8_t endpoint);
+void emberAfCommissioningClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Commissioning Cluster Callbacks */
 
@@ -4093,7 +4130,7 @@ void emberAfCommissioningClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPartitionClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPartitionClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Partition Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -4103,14 +4140,15 @@ void emberAfPartitionClusterClientAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPartitionClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPartitionClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Partition Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPartitionClusterClientInitCallback(uint8_t endpoint);
+void emberAfPartitionClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Partition Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -4120,7 +4158,8 @@ void emberAfPartitionClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPartitionClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPartitionClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Partition Cluster Client Message Sent
  *
@@ -4147,7 +4186,7 @@ void emberAfPartitionClusterClientMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPartitionClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPartitionClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Partition Cluster Client Tick
@@ -4156,7 +4195,7 @@ EmberAfStatus emberAfPartitionClusterClientPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPartitionClusterClientTickCallback(uint8_t endpoint);
+void emberAfPartitionClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Partition Cluster Multiple Ack
  *
  *
@@ -4188,7 +4227,7 @@ bool emberAfPartitionClusterReadHandshakeParamResponseCallback(uint16_t partitio
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPartitionClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPartitionClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Partition Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -4198,14 +4237,15 @@ void emberAfPartitionClusterServerAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPartitionClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPartitionClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Partition Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPartitionClusterServerInitCallback(uint8_t endpoint);
+void emberAfPartitionClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Partition Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -4215,7 +4255,8 @@ void emberAfPartitionClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPartitionClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPartitionClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Partition Cluster Server Message Sent
  *
@@ -4242,7 +4283,7 @@ void emberAfPartitionClusterServerMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPartitionClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPartitionClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Partition Cluster Server Tick
@@ -4251,7 +4292,7 @@ EmberAfStatus emberAfPartitionClusterServerPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPartitionClusterServerTickCallback(uint8_t endpoint);
+void emberAfPartitionClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Partition Cluster Transfer Partitioned Frame
  *
  *
@@ -4281,7 +4322,7 @@ bool emberAfPartitionClusterWriteHandshakeParamCallback(uint16_t partitionedClus
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOtaBootloadClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOtaBootloadClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Over the Air Bootloading Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -4291,14 +4332,15 @@ void emberAfOtaBootloadClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOtaBootloadClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOtaBootloadClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Over the Air Bootloading Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOtaBootloadClusterClientInitCallback(uint8_t endpoint);
+void emberAfOtaBootloadClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Over the Air Bootloading Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -4308,7 +4350,8 @@ void emberAfOtaBootloadClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOtaBootloadClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfOtaBootloadClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Over the Air Bootloading Cluster Client Message Sent
  *
@@ -4335,7 +4378,7 @@ void emberAfOtaBootloadClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOtaBootloadClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOtaBootloadClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Over the Air Bootloading Cluster Client Tick
@@ -4344,7 +4387,7 @@ EmberAfStatus emberAfOtaBootloadClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOtaBootloadClusterClientTickCallback(uint8_t endpoint);
+void emberAfOtaBootloadClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Over the Air Bootloading Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -4352,7 +4395,7 @@ void emberAfOtaBootloadClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOtaBootloadClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOtaBootloadClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Over the Air Bootloading Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -4362,14 +4405,15 @@ void emberAfOtaBootloadClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOtaBootloadClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOtaBootloadClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Over the Air Bootloading Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOtaBootloadClusterServerInitCallback(uint8_t endpoint);
+void emberAfOtaBootloadClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Over the Air Bootloading Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -4379,7 +4423,8 @@ void emberAfOtaBootloadClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOtaBootloadClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfOtaBootloadClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Over the Air Bootloading Cluster Server Message Sent
  *
@@ -4406,7 +4451,7 @@ void emberAfOtaBootloadClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOtaBootloadClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOtaBootloadClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Over the Air Bootloading Cluster Server Tick
@@ -4415,7 +4460,7 @@ EmberAfStatus emberAfOtaBootloadClusterServerPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOtaBootloadClusterServerTickCallback(uint8_t endpoint);
+void emberAfOtaBootloadClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Over the Air Bootloading Cluster Callbacks */
 
@@ -4429,7 +4474,7 @@ void emberAfOtaBootloadClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPowerProfileClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPowerProfileClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Power Profile Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -4439,14 +4484,15 @@ void emberAfPowerProfileClusterClientAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPowerProfileClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPowerProfileClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief Power Profile Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPowerProfileClusterClientInitCallback(uint8_t endpoint);
+void emberAfPowerProfileClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Power Profile Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -4456,7 +4502,8 @@ void emberAfPowerProfileClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPowerProfileClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPowerProfileClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief Power Profile Cluster Client Message Sent
  *
@@ -4483,7 +4530,7 @@ void emberAfPowerProfileClusterClientMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPowerProfileClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPowerProfileClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief Power Profile Cluster Client Tick
@@ -4492,7 +4539,7 @@ EmberAfStatus emberAfPowerProfileClusterClientPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPowerProfileClusterClientTickCallback(uint8_t endpoint);
+void emberAfPowerProfileClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Power Profile Cluster Energy Phases Schedule Notification
  *
  *
@@ -4687,7 +4734,7 @@ bool emberAfPowerProfileClusterPowerProfilesStateNotificationCallback(uint8_t po
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPowerProfileClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPowerProfileClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Power Profile Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -4697,14 +4744,15 @@ void emberAfPowerProfileClusterServerAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPowerProfileClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPowerProfileClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief Power Profile Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPowerProfileClusterServerInitCallback(uint8_t endpoint);
+void emberAfPowerProfileClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Power Profile Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -4714,7 +4762,8 @@ void emberAfPowerProfileClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPowerProfileClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPowerProfileClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief Power Profile Cluster Server Message Sent
  *
@@ -4741,7 +4790,7 @@ void emberAfPowerProfileClusterServerMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPowerProfileClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPowerProfileClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief Power Profile Cluster Server Tick
@@ -4750,7 +4799,7 @@ EmberAfStatus emberAfPowerProfileClusterServerPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPowerProfileClusterServerTickCallback(uint8_t endpoint);
+void emberAfPowerProfileClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Power Profile Cluster Callbacks */
 
@@ -4764,7 +4813,7 @@ void emberAfPowerProfileClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -4774,14 +4823,15 @@ void emberAfApplianceControlClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Appliance Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfApplianceControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -4791,8 +4841,8 @@ void emberAfApplianceControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfApplianceControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfApplianceControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Appliance Control Cluster Client Message Sent
  *
@@ -4819,7 +4869,8 @@ void emberAfApplianceControlClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Appliance Control Cluster Client Tick
@@ -4828,14 +4879,14 @@ EmberAfStatus emberAfApplianceControlClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfApplianceControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Appliance Control Cluster Execution Of A Command
  *
  *
  *
  * @param commandId   Ver.: always
  */
-bool emberAfApplianceControlClusterExecutionOfACommandCallback(uint8_t commandId);
+bool emberAfApplianceControlClusterExecutionOfACommandCallback(chip::CommandId commandId);
 /** @brief Appliance Control Cluster Overload Pause
  *
  *
@@ -4862,7 +4913,7 @@ bool emberAfApplianceControlClusterOverloadWarningCallback(uint8_t warningEvent)
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -4872,14 +4923,15 @@ void emberAfApplianceControlClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Appliance Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfApplianceControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -4889,8 +4941,8 @@ void emberAfApplianceControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfApplianceControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfApplianceControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Appliance Control Cluster Server Message Sent
  *
@@ -4917,7 +4969,8 @@ void emberAfApplianceControlClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Appliance Control Cluster Server Tick
@@ -4926,7 +4979,7 @@ EmberAfStatus emberAfApplianceControlClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfApplianceControlClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Appliance Control Cluster Signal State
  *
  *
@@ -4990,7 +5043,7 @@ bool emberAfPollControlClusterCheckInResponseCallback(uint8_t startFastPolling, 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPollControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPollControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Poll Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -5000,14 +5053,15 @@ void emberAfPollControlClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPollControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPollControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Poll Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPollControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfPollControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Poll Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -5017,7 +5071,8 @@ void emberAfPollControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPollControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPollControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Poll Control Cluster Client Message Sent
  *
@@ -5044,7 +5099,7 @@ void emberAfPollControlClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPollControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPollControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Poll Control Cluster Client Tick
@@ -5053,7 +5108,7 @@ EmberAfStatus emberAfPollControlClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPollControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfPollControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Poll Control Cluster Fast Poll Stop
  *
  *
@@ -5067,7 +5122,7 @@ bool emberAfPollControlClusterFastPollStopCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPollControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPollControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Poll Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -5077,14 +5132,15 @@ void emberAfPollControlClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPollControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPollControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Poll Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPollControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfPollControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Poll Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -5094,7 +5150,8 @@ void emberAfPollControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPollControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPollControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Poll Control Cluster Server Message Sent
  *
@@ -5121,7 +5178,7 @@ void emberAfPollControlClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPollControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPollControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Poll Control Cluster Server Tick
@@ -5130,7 +5187,7 @@ EmberAfStatus emberAfPollControlClusterServerPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPollControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfPollControlClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Poll Control Cluster Set Long Poll Interval
  *
  *
@@ -5158,7 +5215,7 @@ bool emberAfPollControlClusterSetShortPollIntervalCallback(uint16_t newShortPoll
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGreenPowerClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGreenPowerClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Green Power Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -5168,14 +5225,15 @@ void emberAfGreenPowerClusterClientAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGreenPowerClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGreenPowerClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Green Power Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGreenPowerClusterClientInitCallback(uint8_t endpoint);
+void emberAfGreenPowerClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Green Power Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -5185,7 +5243,8 @@ void emberAfGreenPowerClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGreenPowerClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGreenPowerClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Green Power Cluster Client Message Sent
  *
@@ -5212,7 +5271,7 @@ void emberAfGreenPowerClusterClientMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGreenPowerClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGreenPowerClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Green Power Cluster Client Tick
@@ -5221,7 +5280,7 @@ EmberAfStatus emberAfGreenPowerClusterClientPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGreenPowerClusterClientTickCallback(uint8_t endpoint);
+void emberAfGreenPowerClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Green Power Cluster Gp Commissioning Notification
  *
  *
@@ -5238,7 +5297,7 @@ void emberAfGreenPowerClusterClientTickCallback(uint8_t endpoint);
  * @param mic   Ver.: since gp-1.0-09-5499-24
  */
 bool emberAfGreenPowerClusterGpCommissioningNotificationCallback(uint16_t options, uint32_t gpdSrcId, uint8_t * gpdIeee,
-                                                                 uint8_t endpoint, uint32_t gpdSecurityFrameCounter,
+                                                                 chip::EndpointId endpoint, uint32_t gpdSecurityFrameCounter,
                                                                  uint8_t gpdCommandId, uint8_t * gpdCommandPayload,
                                                                  uint16_t gppShortAddress, uint8_t gppLink, uint32_t mic);
 /** @brief Green Power Cluster Gp Notification
@@ -5326,7 +5385,7 @@ bool emberAfGreenPowerClusterGpPairingCallback(uint32_t options, uint32_t gpdSrc
  * @param reportDescriptor   Ver.: always
  */
 bool emberAfGreenPowerClusterGpPairingConfigurationCallback(
-    uint8_t actions, uint16_t options, uint32_t gpdSrcId, uint8_t * gpdIeee, uint8_t endpoint, uint8_t deviceId,
+    uint8_t actions, uint16_t options, uint32_t gpdSrcId, uint8_t * gpdIeee, chip::EndpointId endpoint, uint8_t deviceId,
     uint8_t groupListCount, uint8_t * groupList, uint16_t gpdAssignedAlias, uint8_t groupcastRadius, uint8_t securityOptions,
     uint32_t gpdSecurityFrameCounter, uint8_t * gpdSecurityKey, uint8_t numberOfPairedEndpoints, uint8_t * pairedEndpoints,
     uint8_t applicationInformation, uint16_t manufacturerId, uint16_t modeId, uint8_t numberOfGpdCommands,
@@ -5342,7 +5401,8 @@ bool emberAfGreenPowerClusterGpPairingConfigurationCallback(
  * @param gpdIeee   Ver.: since gp-1.0-09-5499-24
  * @param endpoint   Ver.: always
  */
-bool emberAfGreenPowerClusterGpPairingSearchCallback(uint16_t options, uint32_t gpdSrcId, uint8_t * gpdIeee, uint8_t endpoint);
+bool emberAfGreenPowerClusterGpPairingSearchCallback(uint16_t options, uint32_t gpdSrcId, uint8_t * gpdIeee,
+                                                     chip::EndpointId endpoint);
 /** @brief Green Power Cluster Gp Proxy Commissioning Mode
  *
  *
@@ -5390,8 +5450,8 @@ bool emberAfGreenPowerClusterGpProxyTableResponseCallback(uint8_t status, uint8_
  * @param gpdCommandPayload   Ver.: always
  */
 bool emberAfGreenPowerClusterGpResponseCallback(uint8_t options, uint16_t tempMasterShortAddress, uint8_t tempMasterTxChannel,
-                                                uint32_t gpdSrcId, uint8_t * gpdIeee, uint8_t endpoint, uint8_t gpdCommandId,
-                                                uint8_t * gpdCommandPayload);
+                                                uint32_t gpdSrcId, uint8_t * gpdIeee, chip::EndpointId endpoint,
+                                                uint8_t gpdCommandId, uint8_t * gpdCommandPayload);
 /** @brief Green Power Cluster Gp Sink Commissioning Mode
  *
  *
@@ -5460,7 +5520,7 @@ bool emberAfGreenPowerClusterGpTranslationTableResponseCallback(uint8_t status, 
  * @param translations   Ver.: since gp-1.0-09-5499-24
  */
 bool emberAfGreenPowerClusterGpTranslationTableUpdateCallback(uint16_t options, uint32_t gpdSrcId, uint8_t * gpdIeee,
-                                                              uint8_t endpoint, uint8_t * translations);
+                                                              chip::EndpointId endpoint, uint8_t * translations);
 /** @brief Green Power Cluster Gp Tunneling Stop
  *
  *
@@ -5483,7 +5543,7 @@ bool emberAfGreenPowerClusterGpTunnelingStopCallback(uint8_t options, uint32_t g
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGreenPowerClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGreenPowerClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Green Power Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -5493,14 +5553,15 @@ void emberAfGreenPowerClusterServerAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGreenPowerClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGreenPowerClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Green Power Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGreenPowerClusterServerInitCallback(uint8_t endpoint);
+void emberAfGreenPowerClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Green Power Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -5510,7 +5571,8 @@ void emberAfGreenPowerClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGreenPowerClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGreenPowerClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Green Power Cluster Server Message Sent
  *
@@ -5537,7 +5599,7 @@ void emberAfGreenPowerClusterServerMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGreenPowerClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGreenPowerClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Green Power Cluster Server Tick
@@ -5546,7 +5608,7 @@ EmberAfStatus emberAfGreenPowerClusterServerPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGreenPowerClusterServerTickCallback(uint8_t endpoint);
+void emberAfGreenPowerClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Green Power Cluster Callbacks */
 
@@ -5560,7 +5622,7 @@ void emberAfGreenPowerClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfKeepaliveClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfKeepaliveClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Keep-Alive Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -5570,14 +5632,15 @@ void emberAfKeepaliveClusterClientAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfKeepaliveClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfKeepaliveClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Keep-Alive Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfKeepaliveClusterClientInitCallback(uint8_t endpoint);
+void emberAfKeepaliveClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Keep-Alive Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -5587,7 +5650,8 @@ void emberAfKeepaliveClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfKeepaliveClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfKeepaliveClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Keep-Alive Cluster Client Message Sent
  *
@@ -5614,7 +5678,7 @@ void emberAfKeepaliveClusterClientMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfKeepaliveClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfKeepaliveClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Keep-Alive Cluster Client Tick
@@ -5623,7 +5687,7 @@ EmberAfStatus emberAfKeepaliveClusterClientPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfKeepaliveClusterClientTickCallback(uint8_t endpoint);
+void emberAfKeepaliveClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Keep-Alive Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -5631,7 +5695,7 @@ void emberAfKeepaliveClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfKeepaliveClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfKeepaliveClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Keep-Alive Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -5641,14 +5705,15 @@ void emberAfKeepaliveClusterServerAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfKeepaliveClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfKeepaliveClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Keep-Alive Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfKeepaliveClusterServerInitCallback(uint8_t endpoint);
+void emberAfKeepaliveClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Keep-Alive Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -5658,7 +5723,8 @@ void emberAfKeepaliveClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfKeepaliveClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfKeepaliveClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Keep-Alive Cluster Server Message Sent
  *
@@ -5685,7 +5751,7 @@ void emberAfKeepaliveClusterServerMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfKeepaliveClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfKeepaliveClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Keep-Alive Cluster Server Tick
@@ -5694,7 +5760,7 @@ EmberAfStatus emberAfKeepaliveClusterServerPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfKeepaliveClusterServerTickCallback(uint8_t endpoint);
+void emberAfKeepaliveClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Keep-Alive Cluster Callbacks */
 
@@ -5708,7 +5774,7 @@ void emberAfKeepaliveClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfShadeConfigClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfShadeConfigClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Shade Configuration Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -5718,14 +5784,15 @@ void emberAfShadeConfigClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfShadeConfigClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfShadeConfigClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Shade Configuration Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfShadeConfigClusterClientInitCallback(uint8_t endpoint);
+void emberAfShadeConfigClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Shade Configuration Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -5735,7 +5802,8 @@ void emberAfShadeConfigClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfShadeConfigClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfShadeConfigClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Shade Configuration Cluster Client Message Sent
  *
@@ -5762,7 +5830,7 @@ void emberAfShadeConfigClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfShadeConfigClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfShadeConfigClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Shade Configuration Cluster Client Tick
@@ -5771,7 +5839,7 @@ EmberAfStatus emberAfShadeConfigClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfShadeConfigClusterClientTickCallback(uint8_t endpoint);
+void emberAfShadeConfigClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Shade Configuration Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -5779,7 +5847,7 @@ void emberAfShadeConfigClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfShadeConfigClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfShadeConfigClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Shade Configuration Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -5789,14 +5857,15 @@ void emberAfShadeConfigClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfShadeConfigClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfShadeConfigClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Shade Configuration Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfShadeConfigClusterServerInitCallback(uint8_t endpoint);
+void emberAfShadeConfigClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Shade Configuration Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -5806,7 +5875,8 @@ void emberAfShadeConfigClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfShadeConfigClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfShadeConfigClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Shade Configuration Cluster Server Message Sent
  *
@@ -5833,7 +5903,7 @@ void emberAfShadeConfigClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfShadeConfigClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfShadeConfigClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Shade Configuration Cluster Server Tick
@@ -5842,7 +5912,7 @@ EmberAfStatus emberAfShadeConfigClusterServerPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfShadeConfigClusterServerTickCallback(uint8_t endpoint);
+void emberAfShadeConfigClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Shade Configuration Cluster Callbacks */
 
@@ -5954,7 +6024,7 @@ bool emberAfDoorLockClusterClearYeardayScheduleResponseCallback(uint8_t status);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDoorLockClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDoorLockClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Door Lock Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -5964,14 +6034,15 @@ void emberAfDoorLockClusterClientAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDoorLockClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDoorLockClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Door Lock Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDoorLockClusterClientInitCallback(uint8_t endpoint);
+void emberAfDoorLockClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Door Lock Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -5981,7 +6052,8 @@ void emberAfDoorLockClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDoorLockClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDoorLockClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Door Lock Cluster Client Message Sent
  *
@@ -6008,7 +6080,7 @@ void emberAfDoorLockClusterClientMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDoorLockClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDoorLockClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Door Lock Cluster Client Tick
@@ -6017,7 +6089,7 @@ EmberAfStatus emberAfDoorLockClusterClientPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDoorLockClusterClientTickCallback(uint8_t endpoint);
+void emberAfDoorLockClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Door Lock Cluster Get Holiday Schedule
  *
  *
@@ -6216,7 +6288,7 @@ bool emberAfDoorLockClusterProgrammingEventNotificationCallback(uint8_t source, 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDoorLockClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDoorLockClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Door Lock Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -6226,14 +6298,15 @@ void emberAfDoorLockClusterServerAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDoorLockClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDoorLockClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Door Lock Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDoorLockClusterServerInitCallback(uint8_t endpoint);
+void emberAfDoorLockClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Door Lock Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -6243,7 +6316,8 @@ void emberAfDoorLockClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDoorLockClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDoorLockClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Door Lock Cluster Server Message Sent
  *
@@ -6270,7 +6344,7 @@ void emberAfDoorLockClusterServerMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDoorLockClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDoorLockClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Door Lock Cluster Server Tick
@@ -6279,7 +6353,7 @@ EmberAfStatus emberAfDoorLockClusterServerPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDoorLockClusterServerTickCallback(uint8_t endpoint);
+void emberAfDoorLockClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Door Lock Cluster Set Holiday Schedule
  *
  *
@@ -6457,7 +6531,7 @@ bool emberAfDoorLockClusterUnlockWithTimeoutResponseCallback(uint8_t status);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfWindowCoveringClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfWindowCoveringClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Window Covering Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -6467,14 +6541,15 @@ void emberAfWindowCoveringClusterClientAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfWindowCoveringClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfWindowCoveringClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Window Covering Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfWindowCoveringClusterClientInitCallback(uint8_t endpoint);
+void emberAfWindowCoveringClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Window Covering Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -6484,8 +6559,8 @@ void emberAfWindowCoveringClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfWindowCoveringClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfWindowCoveringClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Window Covering Cluster Client Message Sent
  *
@@ -6512,7 +6587,8 @@ void emberAfWindowCoveringClusterClientMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfWindowCoveringClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfWindowCoveringClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Window Covering Cluster Client Tick
@@ -6521,7 +6597,7 @@ EmberAfStatus emberAfWindowCoveringClusterClientPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfWindowCoveringClusterClientTickCallback(uint8_t endpoint);
+void emberAfWindowCoveringClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Window Covering Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -6529,7 +6605,7 @@ void emberAfWindowCoveringClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfWindowCoveringClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfWindowCoveringClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Window Covering Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -6539,14 +6615,15 @@ void emberAfWindowCoveringClusterServerAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfWindowCoveringClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfWindowCoveringClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Window Covering Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfWindowCoveringClusterServerInitCallback(uint8_t endpoint);
+void emberAfWindowCoveringClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Window Covering Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -6556,8 +6633,8 @@ void emberAfWindowCoveringClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfWindowCoveringClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfWindowCoveringClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Window Covering Cluster Server Message Sent
  *
@@ -6584,7 +6661,8 @@ void emberAfWindowCoveringClusterServerMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfWindowCoveringClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfWindowCoveringClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Window Covering Cluster Server Tick
@@ -6593,7 +6671,7 @@ EmberAfStatus emberAfWindowCoveringClusterServerPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfWindowCoveringClusterServerTickCallback(uint8_t endpoint);
+void emberAfWindowCoveringClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Window Covering Cluster Window Covering Down Close
  *
  *
@@ -6666,7 +6744,7 @@ bool emberAfBarrierControlClusterBarrierControlStopCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBarrierControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBarrierControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Barrier Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -6676,14 +6754,15 @@ void emberAfBarrierControlClusterClientAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBarrierControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBarrierControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Barrier Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBarrierControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfBarrierControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Barrier Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -6693,8 +6772,8 @@ void emberAfBarrierControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBarrierControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfBarrierControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Barrier Control Cluster Client Message Sent
  *
@@ -6721,7 +6800,8 @@ void emberAfBarrierControlClusterClientMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBarrierControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBarrierControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Barrier Control Cluster Client Tick
@@ -6730,7 +6810,7 @@ EmberAfStatus emberAfBarrierControlClusterClientPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBarrierControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfBarrierControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Barrier Control Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -6738,7 +6818,7 @@ void emberAfBarrierControlClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBarrierControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBarrierControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Barrier Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -6748,14 +6828,15 @@ void emberAfBarrierControlClusterServerAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBarrierControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBarrierControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Barrier Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBarrierControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfBarrierControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Barrier Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -6765,8 +6846,8 @@ void emberAfBarrierControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBarrierControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfBarrierControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Barrier Control Cluster Server Message Sent
  *
@@ -6793,7 +6874,8 @@ void emberAfBarrierControlClusterServerMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBarrierControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBarrierControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Barrier Control Cluster Server Tick
@@ -6802,7 +6884,7 @@ EmberAfStatus emberAfBarrierControlClusterServerPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBarrierControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfBarrierControlClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Barrier Control Cluster Callbacks */
 
@@ -6816,7 +6898,7 @@ void emberAfBarrierControlClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPumpConfigControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPumpConfigControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Pump Configuration and Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -6826,14 +6908,15 @@ void emberAfPumpConfigControlClusterClientAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPumpConfigControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPumpConfigControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief Pump Configuration and Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPumpConfigControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfPumpConfigControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Pump Configuration and Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -6844,7 +6927,7 @@ void emberAfPumpConfigControlClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfPumpConfigControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief Pump Configuration and Control Cluster Client Message Sent
  *
@@ -6871,7 +6954,8 @@ void emberAfPumpConfigControlClusterClientMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPumpConfigControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPumpConfigControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief Pump Configuration and Control Cluster Client Tick
@@ -6880,7 +6964,7 @@ EmberAfStatus emberAfPumpConfigControlClusterClientPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPumpConfigControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfPumpConfigControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Pump Configuration and Control Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -6888,7 +6972,7 @@ void emberAfPumpConfigControlClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPumpConfigControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPumpConfigControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Pump Configuration and Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -6898,14 +6982,15 @@ void emberAfPumpConfigControlClusterServerAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPumpConfigControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPumpConfigControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief Pump Configuration and Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPumpConfigControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfPumpConfigControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Pump Configuration and Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -6916,7 +7001,7 @@ void emberAfPumpConfigControlClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfPumpConfigControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief Pump Configuration and Control Cluster Server Message Sent
  *
@@ -6943,7 +7028,8 @@ void emberAfPumpConfigControlClusterServerMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPumpConfigControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPumpConfigControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief Pump Configuration and Control Cluster Server Tick
@@ -6952,7 +7038,7 @@ EmberAfStatus emberAfPumpConfigControlClusterServerPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPumpConfigControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfPumpConfigControlClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Pump Configuration and Control Cluster Callbacks */
 
@@ -6972,7 +7058,7 @@ bool emberAfThermostatClusterClearWeeklyScheduleCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfThermostatClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfThermostatClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Thermostat Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -6982,14 +7068,15 @@ void emberAfThermostatClusterClientAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfThermostatClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfThermostatClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Thermostat Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfThermostatClusterClientInitCallback(uint8_t endpoint);
+void emberAfThermostatClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Thermostat Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -6999,7 +7086,8 @@ void emberAfThermostatClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfThermostatClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfThermostatClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Thermostat Cluster Client Message Sent
  *
@@ -7026,7 +7114,7 @@ void emberAfThermostatClusterClientMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfThermostatClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfThermostatClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Thermostat Cluster Client Tick
@@ -7035,7 +7123,7 @@ EmberAfStatus emberAfThermostatClusterClientPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfThermostatClusterClientTickCallback(uint8_t endpoint);
+void emberAfThermostatClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Thermostat Cluster Current Weekly Schedule
  *
  *
@@ -7081,7 +7169,7 @@ bool emberAfThermostatClusterRelayStatusLogCallback(uint16_t timeOfDay, uint16_t
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfThermostatClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfThermostatClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Thermostat Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -7091,14 +7179,15 @@ void emberAfThermostatClusterServerAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfThermostatClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfThermostatClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Thermostat Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfThermostatClusterServerInitCallback(uint8_t endpoint);
+void emberAfThermostatClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Thermostat Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -7108,7 +7197,8 @@ void emberAfThermostatClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfThermostatClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfThermostatClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Thermostat Cluster Server Message Sent
  *
@@ -7135,7 +7225,7 @@ void emberAfThermostatClusterServerMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Thermostat Cluster Server Tick
@@ -7144,7 +7234,7 @@ EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfThermostatClusterServerTickCallback(uint8_t endpoint);
+void emberAfThermostatClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Thermostat Cluster Set Weekly Schedule
  *
  *
@@ -7177,7 +7267,7 @@ bool emberAfThermostatClusterSetpointRaiseLowerCallback(uint8_t mode, int8_t amo
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfFanControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfFanControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Fan Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -7187,14 +7277,15 @@ void emberAfFanControlClusterClientAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFanControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfFanControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Fan Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFanControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfFanControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Fan Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -7204,7 +7295,8 @@ void emberAfFanControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfFanControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfFanControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Fan Control Cluster Client Message Sent
  *
@@ -7231,7 +7323,7 @@ void emberAfFanControlClusterClientMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfFanControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfFanControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Fan Control Cluster Client Tick
@@ -7240,7 +7332,7 @@ EmberAfStatus emberAfFanControlClusterClientPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFanControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfFanControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Fan Control Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -7248,7 +7340,7 @@ void emberAfFanControlClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfFanControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfFanControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Fan Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -7258,14 +7350,15 @@ void emberAfFanControlClusterServerAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFanControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfFanControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Fan Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFanControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfFanControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Fan Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -7275,7 +7368,8 @@ void emberAfFanControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfFanControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfFanControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Fan Control Cluster Server Message Sent
  *
@@ -7302,7 +7396,7 @@ void emberAfFanControlClusterServerMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfFanControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfFanControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Fan Control Cluster Server Tick
@@ -7311,7 +7405,7 @@ EmberAfStatus emberAfFanControlClusterServerPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFanControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfFanControlClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Fan Control Cluster Callbacks */
 
@@ -7325,7 +7419,7 @@ void emberAfFanControlClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDehumidControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDehumidControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Dehumidification Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -7335,14 +7429,15 @@ void emberAfDehumidControlClusterClientAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDehumidControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDehumidControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Dehumidification Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDehumidControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfDehumidControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Dehumidification Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -7352,8 +7447,8 @@ void emberAfDehumidControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDehumidControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfDehumidControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Dehumidification Control Cluster Client Message Sent
  *
@@ -7380,7 +7475,8 @@ void emberAfDehumidControlClusterClientMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDehumidControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDehumidControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Dehumidification Control Cluster Client Tick
@@ -7389,7 +7485,7 @@ EmberAfStatus emberAfDehumidControlClusterClientPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDehumidControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfDehumidControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Dehumidification Control Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -7397,7 +7493,7 @@ void emberAfDehumidControlClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDehumidControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDehumidControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Dehumidification Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -7407,14 +7503,15 @@ void emberAfDehumidControlClusterServerAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDehumidControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDehumidControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Dehumidification Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDehumidControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfDehumidControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Dehumidification Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -7424,8 +7521,8 @@ void emberAfDehumidControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDehumidControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfDehumidControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Dehumidification Control Cluster Server Message Sent
  *
@@ -7452,7 +7549,8 @@ void emberAfDehumidControlClusterServerMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDehumidControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDehumidControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Dehumidification Control Cluster Server Tick
@@ -7461,7 +7559,7 @@ EmberAfStatus emberAfDehumidControlClusterServerPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDehumidControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfDehumidControlClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Dehumidification Control Cluster Callbacks */
 
@@ -7475,7 +7573,7 @@ void emberAfDehumidControlClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfThermostatUiConfigClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfThermostatUiConfigClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Thermostat User Interface Configuration Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -7485,14 +7583,15 @@ void emberAfThermostatUiConfigClusterClientAttributeChangedCallback(uint8_t endp
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfThermostatUiConfigClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfThermostatUiConfigClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                   EmberAfStatus status);
 /** @brief Thermostat User Interface Configuration Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfThermostatUiConfigClusterClientInitCallback(uint8_t endpoint);
+void emberAfThermostatUiConfigClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Thermostat User Interface Configuration Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -7503,7 +7602,7 @@ void emberAfThermostatUiConfigClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfThermostatUiConfigClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                        EmberAfAttributeId attributeId,
+                                                                                        chip::AttributeId attributeId,
                                                                                         uint16_t manufacturerCode);
 /** @brief Thermostat User Interface Configuration Cluster Client Message Sent
  *
@@ -7530,7 +7629,8 @@ void emberAfThermostatUiConfigClusterClientMessageSentCallback(EmberOutgoingMess
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfThermostatUiConfigClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfThermostatUiConfigClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 EmberAfAttributeType attributeType, uint8_t size,
                                                                                 uint8_t * value);
 /** @brief Thermostat User Interface Configuration Cluster Client Tick
@@ -7539,7 +7639,7 @@ EmberAfStatus emberAfThermostatUiConfigClusterClientPreAttributeChangedCallback(
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfThermostatUiConfigClusterClientTickCallback(uint8_t endpoint);
+void emberAfThermostatUiConfigClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Thermostat User Interface Configuration Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -7547,7 +7647,7 @@ void emberAfThermostatUiConfigClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfThermostatUiConfigClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfThermostatUiConfigClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Thermostat User Interface Configuration Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -7557,14 +7657,15 @@ void emberAfThermostatUiConfigClusterServerAttributeChangedCallback(uint8_t endp
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfThermostatUiConfigClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfThermostatUiConfigClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                   EmberAfStatus status);
 /** @brief Thermostat User Interface Configuration Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfThermostatUiConfigClusterServerInitCallback(uint8_t endpoint);
+void emberAfThermostatUiConfigClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Thermostat User Interface Configuration Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -7575,7 +7676,7 @@ void emberAfThermostatUiConfigClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfThermostatUiConfigClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                        EmberAfAttributeId attributeId,
+                                                                                        chip::AttributeId attributeId,
                                                                                         uint16_t manufacturerCode);
 /** @brief Thermostat User Interface Configuration Cluster Server Message Sent
  *
@@ -7602,7 +7703,8 @@ void emberAfThermostatUiConfigClusterServerMessageSentCallback(EmberOutgoingMess
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfThermostatUiConfigClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfThermostatUiConfigClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 EmberAfAttributeType attributeType, uint8_t size,
                                                                                 uint8_t * value);
 /** @brief Thermostat User Interface Configuration Cluster Server Tick
@@ -7611,7 +7713,7 @@ EmberAfStatus emberAfThermostatUiConfigClusterServerPreAttributeChangedCallback(
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfThermostatUiConfigClusterServerTickCallback(uint8_t endpoint);
+void emberAfThermostatUiConfigClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Thermostat User Interface Configuration Cluster Callbacks */
 
@@ -7625,7 +7727,7 @@ void emberAfThermostatUiConfigClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfColorControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfColorControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Color Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -7635,14 +7737,15 @@ void emberAfColorControlClusterClientAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfColorControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfColorControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief Color Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfColorControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfColorControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Color Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -7652,7 +7755,8 @@ void emberAfColorControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfColorControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfColorControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief Color Control Cluster Client Message Sent
  *
@@ -7679,7 +7783,7 @@ void emberAfColorControlClusterClientMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfColorControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfColorControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief Color Control Cluster Client Tick
@@ -7688,7 +7792,7 @@ EmberAfStatus emberAfColorControlClusterClientPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfColorControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfColorControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Color Control Cluster Color Loop Set
  *
  *
@@ -7846,7 +7950,7 @@ bool emberAfColorControlClusterMoveToSaturationCallback(uint8_t saturation, uint
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfColorControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfColorControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Color Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -7856,14 +7960,15 @@ void emberAfColorControlClusterServerAttributeChangedCallback(uint8_t endpoint, 
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfColorControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfColorControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                             EmberAfStatus status);
 /** @brief Color Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfColorControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfColorControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Color Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -7873,7 +7978,8 @@ void emberAfColorControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfColorControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfColorControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   uint16_t manufacturerCode);
 /** @brief Color Control Cluster Server Message Sent
  *
@@ -7900,7 +8006,7 @@ void emberAfColorControlClusterServerMessageSentCallback(EmberOutgoingMessageTyp
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfColorControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfColorControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                           EmberAfAttributeType attributeType, uint8_t size,
                                                                           uint8_t * value);
 /** @brief Color Control Cluster Server Tick
@@ -7909,7 +8015,7 @@ EmberAfStatus emberAfColorControlClusterServerPreAttributeChangedCallback(uint8_
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfColorControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfColorControlClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Color Control Cluster Step Color
  *
  *
@@ -7982,7 +8088,7 @@ bool emberAfColorControlClusterStopMoveStepCallback(uint8_t optionsMask, uint8_t
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBallastConfigurationClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBallastConfigurationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Ballast Configuration Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -7992,14 +8098,15 @@ void emberAfBallastConfigurationClusterClientAttributeChangedCallback(uint8_t en
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBallastConfigurationClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBallastConfigurationClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                     EmberAfStatus status);
 /** @brief Ballast Configuration Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBallastConfigurationClusterClientInitCallback(uint8_t endpoint);
+void emberAfBallastConfigurationClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Ballast Configuration Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8010,7 +8117,7 @@ void emberAfBallastConfigurationClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfBallastConfigurationClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId,
+                                                                                          chip::AttributeId attributeId,
                                                                                           uint16_t manufacturerCode);
 /** @brief Ballast Configuration Cluster Client Message Sent
  *
@@ -8037,7 +8144,8 @@ void emberAfBallastConfigurationClusterClientMessageSentCallback(EmberOutgoingMe
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBallastConfigurationClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBallastConfigurationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   EmberAfAttributeType attributeType, uint8_t size,
                                                                                   uint8_t * value);
 /** @brief Ballast Configuration Cluster Client Tick
@@ -8046,7 +8154,7 @@ EmberAfStatus emberAfBallastConfigurationClusterClientPreAttributeChangedCallbac
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBallastConfigurationClusterClientTickCallback(uint8_t endpoint);
+void emberAfBallastConfigurationClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Ballast Configuration Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8054,7 +8162,7 @@ void emberAfBallastConfigurationClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBallastConfigurationClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBallastConfigurationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Ballast Configuration Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8064,14 +8172,15 @@ void emberAfBallastConfigurationClusterServerAttributeChangedCallback(uint8_t en
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBallastConfigurationClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBallastConfigurationClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                     EmberAfStatus status);
 /** @brief Ballast Configuration Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBallastConfigurationClusterServerInitCallback(uint8_t endpoint);
+void emberAfBallastConfigurationClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Ballast Configuration Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -8082,7 +8191,7 @@ void emberAfBallastConfigurationClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfBallastConfigurationClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId,
+                                                                                          chip::AttributeId attributeId,
                                                                                           uint16_t manufacturerCode);
 /** @brief Ballast Configuration Cluster Server Message Sent
  *
@@ -8109,7 +8218,8 @@ void emberAfBallastConfigurationClusterServerMessageSentCallback(EmberOutgoingMe
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBallastConfigurationClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBallastConfigurationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   EmberAfAttributeType attributeType, uint8_t size,
                                                                                   uint8_t * value);
 /** @brief Ballast Configuration Cluster Server Tick
@@ -8118,7 +8228,7 @@ EmberAfStatus emberAfBallastConfigurationClusterServerPreAttributeChangedCallbac
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBallastConfigurationClusterServerTickCallback(uint8_t endpoint);
+void emberAfBallastConfigurationClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Ballast Configuration Cluster Callbacks */
 
@@ -8132,7 +8242,7 @@ void emberAfBallastConfigurationClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIllumMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIllumMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Illuminance Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8142,14 +8252,15 @@ void emberAfIllumMeasurementClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIllumMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIllumMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Illuminance Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIllumMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfIllumMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Illuminance Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8159,8 +8270,8 @@ void emberAfIllumMeasurementClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIllumMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfIllumMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Illuminance Measurement Cluster Client Message Sent
  *
@@ -8187,7 +8298,8 @@ void emberAfIllumMeasurementClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIllumMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIllumMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Illuminance Measurement Cluster Client Tick
@@ -8196,7 +8308,7 @@ EmberAfStatus emberAfIllumMeasurementClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIllumMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfIllumMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Illuminance Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8204,7 +8316,7 @@ void emberAfIllumMeasurementClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIllumMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIllumMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Illuminance Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8214,14 +8326,15 @@ void emberAfIllumMeasurementClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIllumMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIllumMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Illuminance Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIllumMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfIllumMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Illuminance Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -8231,8 +8344,8 @@ void emberAfIllumMeasurementClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIllumMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfIllumMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Illuminance Measurement Cluster Server Message Sent
  *
@@ -8259,7 +8372,8 @@ void emberAfIllumMeasurementClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIllumMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIllumMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Illuminance Measurement Cluster Server Tick
@@ -8268,7 +8382,7 @@ EmberAfStatus emberAfIllumMeasurementClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIllumMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfIllumMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Illuminance Measurement Cluster Callbacks */
 
@@ -8282,7 +8396,7 @@ void emberAfIllumMeasurementClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIllumLevelSensingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIllumLevelSensingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Illuminance Level Sensing Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8292,14 +8406,15 @@ void emberAfIllumLevelSensingClusterClientAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIllumLevelSensingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIllumLevelSensingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief Illuminance Level Sensing Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIllumLevelSensingClusterClientInitCallback(uint8_t endpoint);
+void emberAfIllumLevelSensingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Illuminance Level Sensing Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8310,7 +8425,7 @@ void emberAfIllumLevelSensingClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfIllumLevelSensingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief Illuminance Level Sensing Cluster Client Message Sent
  *
@@ -8337,7 +8452,8 @@ void emberAfIllumLevelSensingClusterClientMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIllumLevelSensingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIllumLevelSensingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief Illuminance Level Sensing Cluster Client Tick
@@ -8346,7 +8462,7 @@ EmberAfStatus emberAfIllumLevelSensingClusterClientPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIllumLevelSensingClusterClientTickCallback(uint8_t endpoint);
+void emberAfIllumLevelSensingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Illuminance Level Sensing Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8354,7 +8470,7 @@ void emberAfIllumLevelSensingClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIllumLevelSensingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIllumLevelSensingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Illuminance Level Sensing Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8364,14 +8480,15 @@ void emberAfIllumLevelSensingClusterServerAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIllumLevelSensingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIllumLevelSensingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief Illuminance Level Sensing Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIllumLevelSensingClusterServerInitCallback(uint8_t endpoint);
+void emberAfIllumLevelSensingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Illuminance Level Sensing Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -8382,7 +8499,7 @@ void emberAfIllumLevelSensingClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfIllumLevelSensingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief Illuminance Level Sensing Cluster Server Message Sent
  *
@@ -8409,7 +8526,8 @@ void emberAfIllumLevelSensingClusterServerMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIllumLevelSensingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIllumLevelSensingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief Illuminance Level Sensing Cluster Server Tick
@@ -8418,7 +8536,7 @@ EmberAfStatus emberAfIllumLevelSensingClusterServerPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIllumLevelSensingClusterServerTickCallback(uint8_t endpoint);
+void emberAfIllumLevelSensingClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Illuminance Level Sensing Cluster Callbacks */
 
@@ -8432,7 +8550,7 @@ void emberAfIllumLevelSensingClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTempMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfTempMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Temperature Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8442,14 +8560,15 @@ void emberAfTempMeasurementClusterClientAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTempMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfTempMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Temperature Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTempMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfTempMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Temperature Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8459,8 +8578,8 @@ void emberAfTempMeasurementClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfTempMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfTempMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Temperature Measurement Cluster Client Message Sent
  *
@@ -8487,7 +8606,8 @@ void emberAfTempMeasurementClusterClientMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfTempMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfTempMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Temperature Measurement Cluster Client Tick
@@ -8496,7 +8616,7 @@ EmberAfStatus emberAfTempMeasurementClusterClientPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTempMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfTempMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Temperature Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8504,7 +8624,7 @@ void emberAfTempMeasurementClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTempMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfTempMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Temperature Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8514,14 +8634,15 @@ void emberAfTempMeasurementClusterServerAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTempMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfTempMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Temperature Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTempMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfTempMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Temperature Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -8531,8 +8652,8 @@ void emberAfTempMeasurementClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfTempMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfTempMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Temperature Measurement Cluster Server Message Sent
  *
@@ -8559,7 +8680,8 @@ void emberAfTempMeasurementClusterServerMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfTempMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfTempMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Temperature Measurement Cluster Server Tick
@@ -8568,7 +8690,7 @@ EmberAfStatus emberAfTempMeasurementClusterServerPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTempMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfTempMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Temperature Measurement Cluster Callbacks */
 
@@ -8582,7 +8704,7 @@ void emberAfTempMeasurementClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPressureMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPressureMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Pressure Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8592,14 +8714,15 @@ void emberAfPressureMeasurementClusterClientAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPressureMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPressureMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief Pressure Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPressureMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfPressureMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Pressure Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8610,7 +8733,7 @@ void emberAfPressureMeasurementClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfPressureMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief Pressure Measurement Cluster Client Message Sent
  *
@@ -8637,7 +8760,8 @@ void emberAfPressureMeasurementClusterClientMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPressureMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPressureMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief Pressure Measurement Cluster Client Tick
@@ -8646,7 +8770,7 @@ EmberAfStatus emberAfPressureMeasurementClusterClientPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPressureMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfPressureMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Pressure Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8654,7 +8778,7 @@ void emberAfPressureMeasurementClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPressureMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPressureMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Pressure Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8664,14 +8788,15 @@ void emberAfPressureMeasurementClusterServerAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPressureMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPressureMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief Pressure Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPressureMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfPressureMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Pressure Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -8682,7 +8807,7 @@ void emberAfPressureMeasurementClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfPressureMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief Pressure Measurement Cluster Server Message Sent
  *
@@ -8709,7 +8834,8 @@ void emberAfPressureMeasurementClusterServerMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPressureMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPressureMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief Pressure Measurement Cluster Server Tick
@@ -8718,7 +8844,7 @@ EmberAfStatus emberAfPressureMeasurementClusterServerPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPressureMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfPressureMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Pressure Measurement Cluster Callbacks */
 
@@ -8732,7 +8858,7 @@ void emberAfPressureMeasurementClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfFlowMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfFlowMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Flow Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8742,14 +8868,15 @@ void emberAfFlowMeasurementClusterClientAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFlowMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfFlowMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Flow Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFlowMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfFlowMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Flow Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8759,8 +8886,8 @@ void emberAfFlowMeasurementClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfFlowMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfFlowMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Flow Measurement Cluster Client Message Sent
  *
@@ -8787,7 +8914,8 @@ void emberAfFlowMeasurementClusterClientMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfFlowMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfFlowMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Flow Measurement Cluster Client Tick
@@ -8796,7 +8924,7 @@ EmberAfStatus emberAfFlowMeasurementClusterClientPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFlowMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfFlowMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Flow Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8804,7 +8932,7 @@ void emberAfFlowMeasurementClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfFlowMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfFlowMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Flow Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8814,14 +8942,15 @@ void emberAfFlowMeasurementClusterServerAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFlowMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfFlowMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Flow Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFlowMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfFlowMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Flow Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -8831,8 +8960,8 @@ void emberAfFlowMeasurementClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfFlowMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfFlowMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Flow Measurement Cluster Server Message Sent
  *
@@ -8859,7 +8988,8 @@ void emberAfFlowMeasurementClusterServerMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfFlowMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfFlowMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Flow Measurement Cluster Server Tick
@@ -8868,7 +8998,7 @@ EmberAfStatus emberAfFlowMeasurementClusterServerPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFlowMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfFlowMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Flow Measurement Cluster Callbacks */
 
@@ -8882,7 +9012,8 @@ void emberAfFlowMeasurementClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfRelativeHumidityMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId);
 /** @brief Relative Humidity Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -8892,7 +9023,7 @@ void emberAfRelativeHumidityMeasurementClusterClientAttributeChangedCallback(uin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfRelativeHumidityMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                             EmberAfStatus status);
 /** @brief Relative Humidity Measurement Cluster Client Init
  *
@@ -8900,7 +9031,7 @@ void emberAfRelativeHumidityMeasurementClusterClientDefaultResponseCallback(uint
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfRelativeHumidityMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Relative Humidity Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -8911,7 +9042,7 @@ void emberAfRelativeHumidityMeasurementClusterClientInitCallback(uint8_t endpoin
  * Ver.: always
  */
 void emberAfRelativeHumidityMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                 EmberAfAttributeId attributeId,
+                                                                                                 chip::AttributeId attributeId,
                                                                                                  uint16_t manufacturerCode);
 /** @brief Relative Humidity Measurement Cluster Client Message Sent
  *
@@ -8939,7 +9070,7 @@ void emberAfRelativeHumidityMeasurementClusterClientMessageSentCallback(EmberOut
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfRelativeHumidityMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          EmberAfAttributeType attributeType,
                                                                                          uint8_t size, uint8_t * value);
 /** @brief Relative Humidity Measurement Cluster Client Tick
@@ -8948,7 +9079,7 @@ EmberAfStatus emberAfRelativeHumidityMeasurementClusterClientPreAttributeChanged
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfRelativeHumidityMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Relative Humidity Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -8956,7 +9087,8 @@ void emberAfRelativeHumidityMeasurementClusterClientTickCallback(uint8_t endpoin
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfRelativeHumidityMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId);
 /** @brief Relative Humidity Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -8966,7 +9098,7 @@ void emberAfRelativeHumidityMeasurementClusterServerAttributeChangedCallback(uin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfRelativeHumidityMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                             EmberAfStatus status);
 /** @brief Relative Humidity Measurement Cluster Server Init
  *
@@ -8974,7 +9106,7 @@ void emberAfRelativeHumidityMeasurementClusterServerDefaultResponseCallback(uint
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfRelativeHumidityMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Relative Humidity Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -8985,7 +9117,7 @@ void emberAfRelativeHumidityMeasurementClusterServerInitCallback(uint8_t endpoin
  * Ver.: always
  */
 void emberAfRelativeHumidityMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                 EmberAfAttributeId attributeId,
+                                                                                                 chip::AttributeId attributeId,
                                                                                                  uint16_t manufacturerCode);
 /** @brief Relative Humidity Measurement Cluster Server Message Sent
  *
@@ -9013,7 +9145,7 @@ void emberAfRelativeHumidityMeasurementClusterServerMessageSentCallback(EmberOut
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfRelativeHumidityMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          EmberAfAttributeType attributeType,
                                                                                          uint8_t size, uint8_t * value);
 /** @brief Relative Humidity Measurement Cluster Server Tick
@@ -9022,7 +9154,7 @@ EmberAfStatus emberAfRelativeHumidityMeasurementClusterServerPreAttributeChanged
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfRelativeHumidityMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfRelativeHumidityMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Relative Humidity Measurement Cluster Callbacks */
 
@@ -9036,7 +9168,7 @@ void emberAfRelativeHumidityMeasurementClusterServerTickCallback(uint8_t endpoin
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOccupancySensingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOccupancySensingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Occupancy Sensing Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9046,14 +9178,15 @@ void emberAfOccupancySensingClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOccupancySensingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOccupancySensingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Occupancy Sensing Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOccupancySensingClusterClientInitCallback(uint8_t endpoint);
+void emberAfOccupancySensingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Occupancy Sensing Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -9063,8 +9196,8 @@ void emberAfOccupancySensingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOccupancySensingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfOccupancySensingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Occupancy Sensing Cluster Client Message Sent
  *
@@ -9091,7 +9224,8 @@ void emberAfOccupancySensingClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOccupancySensingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOccupancySensingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Occupancy Sensing Cluster Client Tick
@@ -9100,7 +9234,7 @@ EmberAfStatus emberAfOccupancySensingClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOccupancySensingClusterClientTickCallback(uint8_t endpoint);
+void emberAfOccupancySensingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Occupancy Sensing Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -9108,7 +9242,7 @@ void emberAfOccupancySensingClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOccupancySensingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOccupancySensingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Occupancy Sensing Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -9118,14 +9252,15 @@ void emberAfOccupancySensingClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOccupancySensingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOccupancySensingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Occupancy Sensing Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOccupancySensingClusterServerInitCallback(uint8_t endpoint);
+void emberAfOccupancySensingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Occupancy Sensing Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9135,8 +9270,8 @@ void emberAfOccupancySensingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOccupancySensingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfOccupancySensingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Occupancy Sensing Cluster Server Message Sent
  *
@@ -9163,7 +9298,8 @@ void emberAfOccupancySensingClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOccupancySensingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOccupancySensingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Occupancy Sensing Cluster Server Tick
@@ -9172,7 +9308,7 @@ EmberAfStatus emberAfOccupancySensingClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOccupancySensingClusterServerTickCallback(uint8_t endpoint);
+void emberAfOccupancySensingClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Occupancy Sensing Cluster Callbacks */
 
@@ -9187,7 +9323,7 @@ void emberAfOccupancySensingClusterServerTickCallback(uint8_t endpoint);
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfCarbonMonoxideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                        EmberAfAttributeId attributeId);
+                                                                                        chip::AttributeId attributeId);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9197,7 +9333,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterClientAttributeChangedC
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfCarbonMonoxideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                        EmberAfStatus status);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Client Init
  *
@@ -9205,7 +9341,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterClientDefaultResponseCa
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfCarbonMonoxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -9216,7 +9352,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterClientInitCallback(uint
  * Ver.: always
  */
 void emberAfCarbonMonoxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -9244,14 +9380,14 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterClientMessageSentCallba
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfCarbonMonoxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfCarbonMonoxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -9260,7 +9396,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterClientTickCallback(uint
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfCarbonMonoxideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                        EmberAfAttributeId attributeId);
+                                                                                        chip::AttributeId attributeId);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -9270,7 +9406,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterServerAttributeChangedC
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfCarbonMonoxideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                        EmberAfStatus status);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Init
  *
@@ -9278,7 +9414,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterServerDefaultResponseCa
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfCarbonMonoxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9289,7 +9425,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterServerInitCallback(uint
  * Ver.: always
  */
 void emberAfCarbonMonoxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -9317,14 +9453,14 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterServerMessageSentCallba
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfCarbonMonoxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfCarbonMonoxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Carbon Monoxide Concentration Measurement Cluster Callbacks */
 
@@ -9339,7 +9475,7 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterServerTickCallback(uint
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfCarbonDioxideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId);
+                                                                                       chip::AttributeId attributeId);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9349,7 +9485,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterClientAttributeChangedCa
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfCarbonDioxideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                       EmberAfStatus status);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Client Init
  *
@@ -9357,7 +9493,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterClientDefaultResponseCal
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfCarbonDioxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -9368,7 +9504,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterClientInitCallback(uint8
  * Ver.: always
  */
 void emberAfCarbonDioxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -9396,14 +9532,14 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterClientMessageSentCallbac
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfCarbonDioxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfCarbonDioxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -9412,7 +9548,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterClientTickCallback(uint8
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfCarbonDioxideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId);
+                                                                                       chip::AttributeId attributeId);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -9422,7 +9558,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterServerAttributeChangedCa
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfCarbonDioxideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                       EmberAfStatus status);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Init
  *
@@ -9430,7 +9566,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterServerDefaultResponseCal
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfCarbonDioxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9441,7 +9577,7 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterServerInitCallback(uint8
  * Ver.: always
  */
 void emberAfCarbonDioxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -9469,14 +9605,14 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterServerMessageSentCallbac
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfCarbonDioxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfCarbonDioxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Carbon Dioxide Concentration Measurement Cluster Callbacks */
 
@@ -9490,7 +9626,8 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterServerTickCallback(uint8
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfEthyleneConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Ethylene Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9500,7 +9637,7 @@ void emberAfEthyleneConcentrationMeasurementClusterClientAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfEthyleneConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Ethylene Concentration Measurement Cluster Client Init
  *
@@ -9508,7 +9645,7 @@ void emberAfEthyleneConcentrationMeasurementClusterClientDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfEthyleneConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Ethylene Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -9518,8 +9655,9 @@ void emberAfEthyleneConcentrationMeasurementClusterClientInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfEthyleneConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Ethylene Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -9547,7 +9685,7 @@ void emberAfEthyleneConcentrationMeasurementClusterClientMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfEthyleneConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Ethylene Concentration Measurement Cluster Client Tick
@@ -9556,7 +9694,7 @@ EmberAfStatus emberAfEthyleneConcentrationMeasurementClusterClientPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfEthyleneConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Ethylene Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -9564,7 +9702,8 @@ void emberAfEthyleneConcentrationMeasurementClusterClientTickCallback(uint8_t en
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfEthyleneConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Ethylene Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -9574,7 +9713,7 @@ void emberAfEthyleneConcentrationMeasurementClusterServerAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfEthyleneConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Ethylene Concentration Measurement Cluster Server Init
  *
@@ -9582,7 +9721,7 @@ void emberAfEthyleneConcentrationMeasurementClusterServerDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfEthyleneConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Ethylene Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9592,8 +9731,9 @@ void emberAfEthyleneConcentrationMeasurementClusterServerInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfEthyleneConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Ethylene Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -9621,7 +9761,7 @@ void emberAfEthyleneConcentrationMeasurementClusterServerMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfEthyleneConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Ethylene Concentration Measurement Cluster Server Tick
@@ -9630,7 +9770,7 @@ EmberAfStatus emberAfEthyleneConcentrationMeasurementClusterServerPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEthyleneConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfEthyleneConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Ethylene Concentration Measurement Cluster Callbacks */
 
@@ -9645,7 +9785,7 @@ void emberAfEthyleneConcentrationMeasurementClusterServerTickCallback(uint8_t en
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfEthyleneOxideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId);
+                                                                                       chip::AttributeId attributeId);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9655,7 +9795,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterClientAttributeChangedCa
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfEthyleneOxideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                       EmberAfStatus status);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Client Init
  *
@@ -9663,7 +9803,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterClientDefaultResponseCal
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfEthyleneOxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -9674,7 +9814,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterClientInitCallback(uint8
  * Ver.: always
  */
 void emberAfEthyleneOxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -9702,14 +9842,14 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterClientMessageSentCallbac
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfEthyleneOxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfEthyleneOxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -9718,7 +9858,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterClientTickCallback(uint8
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfEthyleneOxideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId);
+                                                                                       chip::AttributeId attributeId);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -9728,7 +9868,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterServerAttributeChangedCa
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfEthyleneOxideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                       EmberAfStatus status);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Init
  *
@@ -9736,7 +9876,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterServerDefaultResponseCal
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfEthyleneOxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9747,7 +9887,7 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterServerInitCallback(uint8
  * Ver.: always
  */
 void emberAfEthyleneOxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -9775,14 +9915,14 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterServerMessageSentCallbac
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfEthyleneOxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfEthyleneOxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Ethylene Oxide Concentration Measurement Cluster Callbacks */
 
@@ -9796,7 +9936,8 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterServerTickCallback(uint8
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfHydrogenConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Hydrogen Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9806,7 +9947,7 @@ void emberAfHydrogenConcentrationMeasurementClusterClientAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfHydrogenConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Hydrogen Concentration Measurement Cluster Client Init
  *
@@ -9814,7 +9955,7 @@ void emberAfHydrogenConcentrationMeasurementClusterClientDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfHydrogenConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Hydrogen Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -9824,8 +9965,9 @@ void emberAfHydrogenConcentrationMeasurementClusterClientInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfHydrogenConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Hydrogen Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -9853,7 +9995,7 @@ void emberAfHydrogenConcentrationMeasurementClusterClientMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfHydrogenConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Hydrogen Concentration Measurement Cluster Client Tick
@@ -9862,7 +10004,7 @@ EmberAfStatus emberAfHydrogenConcentrationMeasurementClusterClientPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfHydrogenConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Hydrogen Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -9870,7 +10012,8 @@ void emberAfHydrogenConcentrationMeasurementClusterClientTickCallback(uint8_t en
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfHydrogenConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Hydrogen Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -9880,7 +10023,7 @@ void emberAfHydrogenConcentrationMeasurementClusterServerAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfHydrogenConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Hydrogen Concentration Measurement Cluster Server Init
  *
@@ -9888,7 +10031,7 @@ void emberAfHydrogenConcentrationMeasurementClusterServerDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfHydrogenConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Hydrogen Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -9898,8 +10041,9 @@ void emberAfHydrogenConcentrationMeasurementClusterServerInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfHydrogenConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Hydrogen Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -9927,7 +10071,7 @@ void emberAfHydrogenConcentrationMeasurementClusterServerMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfHydrogenConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Hydrogen Concentration Measurement Cluster Server Tick
@@ -9936,7 +10080,7 @@ EmberAfStatus emberAfHydrogenConcentrationMeasurementClusterServerPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfHydrogenConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfHydrogenConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Hydrogen Concentration Measurement Cluster Callbacks */
 
@@ -9951,7 +10095,7 @@ void emberAfHydrogenConcentrationMeasurementClusterServerTickCallback(uint8_t en
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfHydrogenSulphideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId);
+                                                                                          chip::AttributeId attributeId);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -9961,15 +10105,15 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterClientAttributeChange
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                         EmberAfStatus status);
+void emberAfHydrogenSulphideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                         uint8_t commandId, EmberAfStatus status);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfHydrogenSulphideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -9980,7 +10124,7 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterClientInitCallback(ui
  * Ver.: always
  */
 void emberAfHydrogenSulphideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -10008,14 +10152,14 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterClientMessageSentCall
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfHydrogenSulphideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfHydrogenSulphideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10024,7 +10168,7 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterClientTickCallback(ui
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfHydrogenSulphideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId);
+                                                                                          chip::AttributeId attributeId);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10034,15 +10178,15 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterServerAttributeChange
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                         EmberAfStatus status);
+void emberAfHydrogenSulphideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                         uint8_t commandId, EmberAfStatus status);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfHydrogenSulphideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10053,7 +10197,7 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterServerInitCallback(ui
  * Ver.: always
  */
 void emberAfHydrogenSulphideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -10081,14 +10225,14 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterServerMessageSentCall
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfHydrogenSulphideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfHydrogenSulphideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Hydrogen Sulphide Concentration Measurement Cluster Callbacks */
 
@@ -10102,8 +10246,8 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterServerTickCallback(ui
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId);
+void emberAfNitricOxideConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId);
 /** @brief Nitric Oxide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -10113,7 +10257,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterClientAttributeChangedCall
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfNitricOxideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                     EmberAfStatus status);
 /** @brief Nitric Oxide Concentration Measurement Cluster Client Init
  *
@@ -10121,7 +10265,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterClientDefaultResponseCallb
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfNitricOxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Nitric Oxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10132,7 +10276,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterClientInitCallback(uint8_t
  * Ver.: always
  */
 void emberAfNitricOxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Nitric Oxide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -10160,7 +10304,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterClientMessageSentCallback(
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfNitricOxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                                 EmberAfAttributeId attributeId,
+                                                                                                 chip::AttributeId attributeId,
                                                                                                  EmberAfAttributeType attributeType,
                                                                                                  uint8_t size, uint8_t * value);
 /** @brief Nitric Oxide Concentration Measurement Cluster Client Tick
@@ -10169,7 +10313,7 @@ EmberAfStatus emberAfNitricOxideConcentrationMeasurementClusterClientPreAttribut
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfNitricOxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10177,8 +10321,8 @@ void emberAfNitricOxideConcentrationMeasurementClusterClientTickCallback(uint8_t
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId);
+void emberAfNitricOxideConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId);
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10188,7 +10332,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterServerAttributeChangedCall
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfNitricOxideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                     EmberAfStatus status);
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Init
  *
@@ -10196,7 +10340,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterServerDefaultResponseCallb
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfNitricOxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10207,7 +10351,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterServerInitCallback(uint8_t
  * Ver.: always
  */
 void emberAfNitricOxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -10235,7 +10379,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterServerMessageSentCallback(
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfNitricOxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                                 EmberAfAttributeId attributeId,
+                                                                                                 chip::AttributeId attributeId,
                                                                                                  EmberAfAttributeType attributeType,
                                                                                                  uint8_t size, uint8_t * value);
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Tick
@@ -10244,7 +10388,7 @@ EmberAfStatus emberAfNitricOxideConcentrationMeasurementClusterServerPreAttribut
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfNitricOxideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfNitricOxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Nitric Oxide Concentration Measurement Cluster Callbacks */
 
@@ -10259,7 +10403,7 @@ void emberAfNitricOxideConcentrationMeasurementClusterServerTickCallback(uint8_t
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfNitrogenDioxideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId);
+                                                                                         chip::AttributeId attributeId);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -10269,15 +10413,15 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterClientAttributeChanged
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                        EmberAfStatus status);
+void emberAfNitrogenDioxideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                        uint8_t commandId, EmberAfStatus status);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfNitrogenDioxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10288,7 +10432,7 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterClientInitCallback(uin
  * Ver.: always
  */
 void emberAfNitrogenDioxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -10316,14 +10460,14 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterClientMessageSentCallb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfNitrogenDioxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfNitrogenDioxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10332,7 +10476,7 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterClientTickCallback(uin
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfNitrogenDioxideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId);
+                                                                                         chip::AttributeId attributeId);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10342,15 +10486,15 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterServerAttributeChanged
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                        EmberAfStatus status);
+void emberAfNitrogenDioxideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                        uint8_t commandId, EmberAfStatus status);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfNitrogenDioxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10361,7 +10505,7 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterServerInitCallback(uin
  * Ver.: always
  */
 void emberAfNitrogenDioxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -10389,14 +10533,14 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterServerMessageSentCallb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfNitrogenDioxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfNitrogenDioxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Nitrogen Dioxide Concentration Measurement Cluster Callbacks */
 
@@ -10410,7 +10554,8 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterServerTickCallback(uin
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOxygenConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId);
 /** @brief Oxygen Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -10420,7 +10565,7 @@ void emberAfOxygenConcentrationMeasurementClusterClientAttributeChangedCallback(
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfOxygenConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                EmberAfStatus status);
 /** @brief Oxygen Concentration Measurement Cluster Client Init
  *
@@ -10428,7 +10573,7 @@ void emberAfOxygenConcentrationMeasurementClusterClientDefaultResponseCallback(u
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfOxygenConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Oxygen Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10439,7 +10584,7 @@ void emberAfOxygenConcentrationMeasurementClusterClientInitCallback(uint8_t endp
  * Ver.: always
  */
 void emberAfOxygenConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                    EmberAfAttributeId attributeId,
+                                                                                                    chip::AttributeId attributeId,
                                                                                                     uint16_t manufacturerCode);
 /** @brief Oxygen Concentration Measurement Cluster Client Message Sent
  *
@@ -10467,7 +10612,7 @@ void emberAfOxygenConcentrationMeasurementClusterClientMessageSentCallback(Ember
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfOxygenConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                            EmberAfAttributeId attributeId,
+                                                                                            chip::AttributeId attributeId,
                                                                                             EmberAfAttributeType attributeType,
                                                                                             uint8_t size, uint8_t * value);
 /** @brief Oxygen Concentration Measurement Cluster Client Tick
@@ -10476,7 +10621,7 @@ EmberAfStatus emberAfOxygenConcentrationMeasurementClusterClientPreAttributeChan
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfOxygenConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Oxygen Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10484,7 +10629,8 @@ void emberAfOxygenConcentrationMeasurementClusterClientTickCallback(uint8_t endp
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOxygenConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId);
 /** @brief Oxygen Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10494,7 +10640,7 @@ void emberAfOxygenConcentrationMeasurementClusterServerAttributeChangedCallback(
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfOxygenConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                EmberAfStatus status);
 /** @brief Oxygen Concentration Measurement Cluster Server Init
  *
@@ -10502,7 +10648,7 @@ void emberAfOxygenConcentrationMeasurementClusterServerDefaultResponseCallback(u
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfOxygenConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Oxygen Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10513,7 +10659,7 @@ void emberAfOxygenConcentrationMeasurementClusterServerInitCallback(uint8_t endp
  * Ver.: always
  */
 void emberAfOxygenConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                    EmberAfAttributeId attributeId,
+                                                                                                    chip::AttributeId attributeId,
                                                                                                     uint16_t manufacturerCode);
 /** @brief Oxygen Concentration Measurement Cluster Server Message Sent
  *
@@ -10541,7 +10687,7 @@ void emberAfOxygenConcentrationMeasurementClusterServerMessageSentCallback(Ember
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfOxygenConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                            EmberAfAttributeId attributeId,
+                                                                                            chip::AttributeId attributeId,
                                                                                             EmberAfAttributeType attributeType,
                                                                                             uint8_t size, uint8_t * value);
 /** @brief Oxygen Concentration Measurement Cluster Server Tick
@@ -10550,7 +10696,7 @@ EmberAfStatus emberAfOxygenConcentrationMeasurementClusterServerPreAttributeChan
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOxygenConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfOxygenConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Oxygen Concentration Measurement Cluster Callbacks */
 
@@ -10564,7 +10710,8 @@ void emberAfOxygenConcentrationMeasurementClusterServerTickCallback(uint8_t endp
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOzoneConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId);
 /** @brief Ozone Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -10574,7 +10721,7 @@ void emberAfOzoneConcentrationMeasurementClusterClientAttributeChangedCallback(u
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfOzoneConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                               EmberAfStatus status);
 /** @brief Ozone Concentration Measurement Cluster Client Init
  *
@@ -10582,7 +10729,7 @@ void emberAfOzoneConcentrationMeasurementClusterClientDefaultResponseCallback(ui
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfOzoneConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Ozone Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10593,7 +10740,7 @@ void emberAfOzoneConcentrationMeasurementClusterClientInitCallback(uint8_t endpo
  * Ver.: always
  */
 void emberAfOzoneConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                   EmberAfAttributeId attributeId,
+                                                                                                   chip::AttributeId attributeId,
                                                                                                    uint16_t manufacturerCode);
 /** @brief Ozone Concentration Measurement Cluster Client Message Sent
  *
@@ -10621,7 +10768,7 @@ void emberAfOzoneConcentrationMeasurementClusterClientMessageSentCallback(EmberO
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfOzoneConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                           EmberAfAttributeId attributeId,
+                                                                                           chip::AttributeId attributeId,
                                                                                            EmberAfAttributeType attributeType,
                                                                                            uint8_t size, uint8_t * value);
 /** @brief Ozone Concentration Measurement Cluster Client Tick
@@ -10630,7 +10777,7 @@ EmberAfStatus emberAfOzoneConcentrationMeasurementClusterClientPreAttributeChang
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfOzoneConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Ozone Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10638,7 +10785,8 @@ void emberAfOzoneConcentrationMeasurementClusterClientTickCallback(uint8_t endpo
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOzoneConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId);
 /** @brief Ozone Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10648,7 +10796,7 @@ void emberAfOzoneConcentrationMeasurementClusterServerAttributeChangedCallback(u
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfOzoneConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                               EmberAfStatus status);
 /** @brief Ozone Concentration Measurement Cluster Server Init
  *
@@ -10656,7 +10804,7 @@ void emberAfOzoneConcentrationMeasurementClusterServerDefaultResponseCallback(ui
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfOzoneConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Ozone Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10667,7 +10815,7 @@ void emberAfOzoneConcentrationMeasurementClusterServerInitCallback(uint8_t endpo
  * Ver.: always
  */
 void emberAfOzoneConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                   EmberAfAttributeId attributeId,
+                                                                                                   chip::AttributeId attributeId,
                                                                                                    uint16_t manufacturerCode);
 /** @brief Ozone Concentration Measurement Cluster Server Message Sent
  *
@@ -10695,7 +10843,7 @@ void emberAfOzoneConcentrationMeasurementClusterServerMessageSentCallback(EmberO
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfOzoneConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                           EmberAfAttributeId attributeId,
+                                                                                           chip::AttributeId attributeId,
                                                                                            EmberAfAttributeType attributeType,
                                                                                            uint8_t size, uint8_t * value);
 /** @brief Ozone Concentration Measurement Cluster Server Tick
@@ -10704,7 +10852,7 @@ EmberAfStatus emberAfOzoneConcentrationMeasurementClusterServerPreAttributeChang
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOzoneConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfOzoneConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Ozone Concentration Measurement Cluster Callbacks */
 
@@ -10719,7 +10867,7 @@ void emberAfOzoneConcentrationMeasurementClusterServerTickCallback(uint8_t endpo
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfSulfurDioxideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId);
+                                                                                       chip::AttributeId attributeId);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -10729,7 +10877,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterClientAttributeChangedCa
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfSulfurDioxideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                       EmberAfStatus status);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Client Init
  *
@@ -10737,7 +10885,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterClientDefaultResponseCal
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfSulfurDioxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10748,7 +10896,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterClientInitCallback(uint8
  * Ver.: always
  */
 void emberAfSulfurDioxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -10776,14 +10924,14 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterClientMessageSentCallbac
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfSulfurDioxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfSulfurDioxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10792,7 +10940,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterClientTickCallback(uint8
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfSulfurDioxideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId);
+                                                                                       chip::AttributeId attributeId);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10802,7 +10950,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterServerAttributeChangedCa
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfSulfurDioxideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                       EmberAfStatus status);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Init
  *
@@ -10810,7 +10958,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterServerDefaultResponseCal
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfSulfurDioxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10821,7 +10969,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterServerInitCallback(uint8
  * Ver.: always
  */
 void emberAfSulfurDioxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -10849,14 +10997,14 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterServerMessageSentCallbac
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfSulfurDioxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfSulfurDioxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Sulfur Dioxide Concentration Measurement Cluster Callbacks */
 
@@ -10871,7 +11019,7 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterServerTickCallback(uint8
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfDissolvedOxygenConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId);
+                                                                                         chip::AttributeId attributeId);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -10881,15 +11029,15 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterClientAttributeChanged
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                        EmberAfStatus status);
+void emberAfDissolvedOxygenConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                        uint8_t commandId, EmberAfStatus status);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfDissolvedOxygenConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -10900,7 +11048,7 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterClientInitCallback(uin
  * Ver.: always
  */
 void emberAfDissolvedOxygenConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -10928,14 +11076,14 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterClientMessageSentCallb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfDissolvedOxygenConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfDissolvedOxygenConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -10944,7 +11092,7 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterClientTickCallback(uin
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfDissolvedOxygenConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId);
+                                                                                         chip::AttributeId attributeId);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -10954,15 +11102,15 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterServerAttributeChanged
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                        EmberAfStatus status);
+void emberAfDissolvedOxygenConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                        uint8_t commandId, EmberAfStatus status);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfDissolvedOxygenConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -10973,7 +11121,7 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterServerInitCallback(uin
  * Ver.: always
  */
 void emberAfDissolvedOxygenConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -11001,14 +11149,14 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterServerMessageSentCallb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfDissolvedOxygenConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfDissolvedOxygenConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Dissolved Oxygen Concentration Measurement Cluster Callbacks */
 
@@ -11022,7 +11170,8 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterServerTickCallback(uin
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBromateConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId);
 /** @brief Bromate Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11032,7 +11181,7 @@ void emberAfBromateConcentrationMeasurementClusterClientAttributeChangedCallback
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfBromateConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                 EmberAfStatus status);
 /** @brief Bromate Concentration Measurement Cluster Client Init
  *
@@ -11040,7 +11189,7 @@ void emberAfBromateConcentrationMeasurementClusterClientDefaultResponseCallback(
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfBromateConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Bromate Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11051,7 +11200,7 @@ void emberAfBromateConcentrationMeasurementClusterClientInitCallback(uint8_t end
  * Ver.: always
  */
 void emberAfBromateConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                     EmberAfAttributeId attributeId,
+                                                                                                     chip::AttributeId attributeId,
                                                                                                      uint16_t manufacturerCode);
 /** @brief Bromate Concentration Measurement Cluster Client Message Sent
  *
@@ -11079,7 +11228,7 @@ void emberAfBromateConcentrationMeasurementClusterClientMessageSentCallback(Embe
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfBromateConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              EmberAfAttributeType attributeType,
                                                                                              uint8_t size, uint8_t * value);
 /** @brief Bromate Concentration Measurement Cluster Client Tick
@@ -11088,7 +11237,7 @@ EmberAfStatus emberAfBromateConcentrationMeasurementClusterClientPreAttributeCha
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfBromateConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Bromate Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -11096,7 +11245,8 @@ void emberAfBromateConcentrationMeasurementClusterClientTickCallback(uint8_t end
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBromateConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId);
 /** @brief Bromate Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -11106,7 +11256,7 @@ void emberAfBromateConcentrationMeasurementClusterServerAttributeChangedCallback
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfBromateConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                 EmberAfStatus status);
 /** @brief Bromate Concentration Measurement Cluster Server Init
  *
@@ -11114,7 +11264,7 @@ void emberAfBromateConcentrationMeasurementClusterServerDefaultResponseCallback(
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfBromateConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Bromate Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -11125,7 +11275,7 @@ void emberAfBromateConcentrationMeasurementClusterServerInitCallback(uint8_t end
  * Ver.: always
  */
 void emberAfBromateConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                     EmberAfAttributeId attributeId,
+                                                                                                     chip::AttributeId attributeId,
                                                                                                      uint16_t manufacturerCode);
 /** @brief Bromate Concentration Measurement Cluster Server Message Sent
  *
@@ -11153,7 +11303,7 @@ void emberAfBromateConcentrationMeasurementClusterServerMessageSentCallback(Embe
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfBromateConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              EmberAfAttributeType attributeType,
                                                                                              uint8_t size, uint8_t * value);
 /** @brief Bromate Concentration Measurement Cluster Server Tick
@@ -11162,7 +11312,7 @@ EmberAfStatus emberAfBromateConcentrationMeasurementClusterServerPreAttributeCha
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBromateConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfBromateConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Bromate Concentration Measurement Cluster Callbacks */
 
@@ -11176,8 +11326,8 @@ void emberAfBromateConcentrationMeasurementClusterServerTickCallback(uint8_t end
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId);
+void emberAfChloraminesConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId);
 /** @brief Chloramines Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11187,7 +11337,7 @@ void emberAfChloraminesConcentrationMeasurementClusterClientAttributeChangedCall
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChloraminesConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                     EmberAfStatus status);
 /** @brief Chloramines Concentration Measurement Cluster Client Init
  *
@@ -11195,7 +11345,7 @@ void emberAfChloraminesConcentrationMeasurementClusterClientDefaultResponseCallb
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfChloraminesConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Chloramines Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11206,7 +11356,7 @@ void emberAfChloraminesConcentrationMeasurementClusterClientInitCallback(uint8_t
  * Ver.: always
  */
 void emberAfChloraminesConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Chloramines Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -11234,7 +11384,7 @@ void emberAfChloraminesConcentrationMeasurementClusterClientMessageSentCallback(
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChloraminesConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                                 EmberAfAttributeId attributeId,
+                                                                                                 chip::AttributeId attributeId,
                                                                                                  EmberAfAttributeType attributeType,
                                                                                                  uint8_t size, uint8_t * value);
 /** @brief Chloramines Concentration Measurement Cluster Client Tick
@@ -11243,7 +11393,7 @@ EmberAfStatus emberAfChloraminesConcentrationMeasurementClusterClientPreAttribut
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfChloraminesConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Chloramines Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -11251,8 +11401,8 @@ void emberAfChloraminesConcentrationMeasurementClusterClientTickCallback(uint8_t
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId);
+void emberAfChloraminesConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId);
 /** @brief Chloramines Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -11262,7 +11412,7 @@ void emberAfChloraminesConcentrationMeasurementClusterServerAttributeChangedCall
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChloraminesConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                     EmberAfStatus status);
 /** @brief Chloramines Concentration Measurement Cluster Server Init
  *
@@ -11270,7 +11420,7 @@ void emberAfChloraminesConcentrationMeasurementClusterServerDefaultResponseCallb
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfChloraminesConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Chloramines Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -11281,7 +11431,7 @@ void emberAfChloraminesConcentrationMeasurementClusterServerInitCallback(uint8_t
  * Ver.: always
  */
 void emberAfChloraminesConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Chloramines Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -11309,7 +11459,7 @@ void emberAfChloraminesConcentrationMeasurementClusterServerMessageSentCallback(
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChloraminesConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                                 EmberAfAttributeId attributeId,
+                                                                                                 chip::AttributeId attributeId,
                                                                                                  EmberAfAttributeType attributeType,
                                                                                                  uint8_t size, uint8_t * value);
 /** @brief Chloramines Concentration Measurement Cluster Server Tick
@@ -11318,7 +11468,7 @@ EmberAfStatus emberAfChloraminesConcentrationMeasurementClusterServerPreAttribut
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChloraminesConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfChloraminesConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Chloramines Concentration Measurement Cluster Callbacks */
 
@@ -11332,7 +11482,8 @@ void emberAfChloraminesConcentrationMeasurementClusterServerTickCallback(uint8_t
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfChlorineConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Chlorine Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11342,7 +11493,7 @@ void emberAfChlorineConcentrationMeasurementClusterClientAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChlorineConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Chlorine Concentration Measurement Cluster Client Init
  *
@@ -11350,7 +11501,7 @@ void emberAfChlorineConcentrationMeasurementClusterClientDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfChlorineConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Chlorine Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11360,8 +11511,9 @@ void emberAfChlorineConcentrationMeasurementClusterClientInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfChlorineConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Chlorine Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -11389,7 +11541,7 @@ void emberAfChlorineConcentrationMeasurementClusterClientMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChlorineConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Chlorine Concentration Measurement Cluster Client Tick
@@ -11398,7 +11550,7 @@ EmberAfStatus emberAfChlorineConcentrationMeasurementClusterClientPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfChlorineConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Chlorine Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -11406,7 +11558,8 @@ void emberAfChlorineConcentrationMeasurementClusterClientTickCallback(uint8_t en
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfChlorineConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Chlorine Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -11416,7 +11569,7 @@ void emberAfChlorineConcentrationMeasurementClusterServerAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChlorineConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Chlorine Concentration Measurement Cluster Server Init
  *
@@ -11424,7 +11577,7 @@ void emberAfChlorineConcentrationMeasurementClusterServerDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfChlorineConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Chlorine Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -11434,8 +11587,9 @@ void emberAfChlorineConcentrationMeasurementClusterServerInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfChlorineConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Chlorine Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -11463,7 +11617,7 @@ void emberAfChlorineConcentrationMeasurementClusterServerMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChlorineConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Chlorine Concentration Measurement Cluster Server Tick
@@ -11472,7 +11626,7 @@ EmberAfStatus emberAfChlorineConcentrationMeasurementClusterServerPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChlorineConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfChlorineConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Chlorine Concentration Measurement Cluster Callbacks */
 
@@ -11487,7 +11641,7 @@ void emberAfChlorineConcentrationMeasurementClusterServerTickCallback(uint8_t en
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId);
+                                                                                               chip::AttributeId attributeId);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11497,7 +11651,8 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientAttributeC
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                              uint8_t commandId,
                                                                                               EmberAfStatus status);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Client Init
  *
@@ -11505,7 +11660,7 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientDefaultRes
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11516,7 +11671,7 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientInitCallba
  * Ver.: always
  */
 void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -11544,14 +11699,14 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientMessageSen
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -11560,7 +11715,7 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientTickCallba
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId);
+                                                                                               chip::AttributeId attributeId);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -11570,7 +11725,8 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerAttributeC
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                              uint8_t commandId,
                                                                                               EmberAfStatus status);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Init
  *
@@ -11578,7 +11734,7 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerDefaultRes
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -11589,7 +11745,7 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerInitCallba
  * Ver.: always
  */
 void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -11617,14 +11773,14 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerMessageSen
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Fecal coliform and E. Coli Concentration Measurement Cluster Callbacks */
 
@@ -11638,7 +11794,8 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerTickCallba
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfFluorideConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Fluoride Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11648,7 +11805,7 @@ void emberAfFluorideConcentrationMeasurementClusterClientAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfFluorideConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Fluoride Concentration Measurement Cluster Client Init
  *
@@ -11656,7 +11813,7 @@ void emberAfFluorideConcentrationMeasurementClusterClientDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfFluorideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Fluoride Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11666,8 +11823,9 @@ void emberAfFluorideConcentrationMeasurementClusterClientInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfFluorideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Fluoride Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -11695,7 +11853,7 @@ void emberAfFluorideConcentrationMeasurementClusterClientMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfFluorideConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Fluoride Concentration Measurement Cluster Client Tick
@@ -11704,7 +11862,7 @@ EmberAfStatus emberAfFluorideConcentrationMeasurementClusterClientPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfFluorideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Fluoride Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -11712,7 +11870,8 @@ void emberAfFluorideConcentrationMeasurementClusterClientTickCallback(uint8_t en
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfFluorideConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId);
 /** @brief Fluoride Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -11722,7 +11881,7 @@ void emberAfFluorideConcentrationMeasurementClusterServerAttributeChangedCallbac
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfFluorideConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                  EmberAfStatus status);
 /** @brief Fluoride Concentration Measurement Cluster Server Init
  *
@@ -11730,7 +11889,7 @@ void emberAfFluorideConcentrationMeasurementClusterServerDefaultResponseCallback
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfFluorideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Fluoride Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -11740,8 +11899,9 @@ void emberAfFluorideConcentrationMeasurementClusterServerInitCallback(uint8_t en
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+void emberAfFluorideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                                      chip::AttributeId attributeId,
+                                                                                                      uint16_t manufacturerCode);
 /** @brief Fluoride Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -11769,7 +11929,7 @@ void emberAfFluorideConcentrationMeasurementClusterServerMessageSentCallback(Emb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfFluorideConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId,
+                                                                                              chip::AttributeId attributeId,
                                                                                               EmberAfAttributeType attributeType,
                                                                                               uint8_t size, uint8_t * value);
 /** @brief Fluoride Concentration Measurement Cluster Server Tick
@@ -11778,7 +11938,7 @@ EmberAfStatus emberAfFluorideConcentrationMeasurementClusterServerPreAttributeCh
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfFluorideConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfFluorideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Fluoride Concentration Measurement Cluster Callbacks */
 
@@ -11793,7 +11953,7 @@ void emberAfFluorideConcentrationMeasurementClusterServerTickCallback(uint8_t en
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId);
+                                                                                         chip::AttributeId attributeId);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11803,15 +11963,15 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientAttributeChanged
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                        EmberAfStatus status);
+void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                        uint8_t commandId, EmberAfStatus status);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11822,7 +11982,7 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientInitCallback(uin
  * Ver.: always
  */
 void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -11850,14 +12010,14 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientMessageSentCallb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfHaloaceticAcidsConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -11866,7 +12026,7 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientTickCallback(uin
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId);
+                                                                                         chip::AttributeId attributeId);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -11876,15 +12036,15 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerAttributeChanged
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
-                                                                                        EmberAfStatus status);
+void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                        uint8_t commandId, EmberAfStatus status);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -11895,7 +12055,7 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerInitCallback(uin
  * Ver.: always
  */
 void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -11923,14 +12083,14 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerMessageSentCallb
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfHaloaceticAcidsConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Haloacetic Acids Concentration Measurement Cluster Callbacks */
 
@@ -11945,7 +12105,7 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerTickCallback(uin
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId);
+                                                                                              chip::AttributeId attributeId);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -11955,7 +12115,8 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientAttributeCh
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                             uint8_t commandId,
                                                                                              EmberAfStatus status);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Client Init
  *
@@ -11963,7 +12124,7 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientDefaultResp
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -11974,7 +12135,7 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientInitCallbac
  * Ver.: always
  */
 void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -12002,14 +12163,14 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientMessageSent
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12018,7 +12179,7 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientTickCallbac
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId);
+                                                                                              chip::AttributeId attributeId);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12028,7 +12189,8 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerAttributeCh
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                             uint8_t commandId,
                                                                                              EmberAfStatus status);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Init
  *
@@ -12036,7 +12198,7 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerDefaultResp
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12047,7 +12209,7 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerInitCallbac
  * Ver.: always
  */
 void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -12075,14 +12237,14 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerMessageSent
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Total Trihalomethanes Concentration Measurement Cluster Callbacks */
 
@@ -12097,7 +12259,7 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerTickCallbac
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId);
+                                                                                               chip::AttributeId attributeId);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -12107,7 +12269,8 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientAttributeC
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                              uint8_t commandId,
                                                                                               EmberAfStatus status);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Client Init
  *
@@ -12115,7 +12278,7 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientDefaultRes
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -12126,7 +12289,7 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientInitCallba
  * Ver.: always
  */
 void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -12154,14 +12317,14 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientMessageSen
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12170,7 +12333,7 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientTickCallba
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId);
+                                                                                               chip::AttributeId attributeId);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12180,7 +12343,8 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerAttributeC
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                              uint8_t commandId,
                                                                                               EmberAfStatus status);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Init
  *
@@ -12188,7 +12352,7 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerDefaultRes
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12199,7 +12363,7 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerInitCallba
  * Ver.: always
  */
 void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -12227,14 +12391,14 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerMessageSen
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Total Coliform Bacteria Concentration Measurement Cluster Callbacks */
 
@@ -12248,8 +12412,8 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerTickCallba
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                   EmberAfAttributeId attributeId);
+void emberAfTurbidityConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId);
 /** @brief Turbidity Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -12259,7 +12423,7 @@ void emberAfTurbidityConcentrationMeasurementClusterClientAttributeChangedCallba
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfTurbidityConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                   EmberAfStatus status);
 /** @brief Turbidity Concentration Measurement Cluster Client Init
  *
@@ -12267,7 +12431,7 @@ void emberAfTurbidityConcentrationMeasurementClusterClientDefaultResponseCallbac
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfTurbidityConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Turbidity Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -12278,7 +12442,7 @@ void emberAfTurbidityConcentrationMeasurementClusterClientInitCallback(uint8_t e
  * Ver.: always
  */
 void emberAfTurbidityConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Turbidity Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -12306,7 +12470,7 @@ void emberAfTurbidityConcentrationMeasurementClusterClientMessageSentCallback(Em
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfTurbidityConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                EmberAfAttributeType attributeType,
                                                                                                uint8_t size, uint8_t * value);
 /** @brief Turbidity Concentration Measurement Cluster Client Tick
@@ -12315,7 +12479,7 @@ EmberAfStatus emberAfTurbidityConcentrationMeasurementClusterClientPreAttributeC
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfTurbidityConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Turbidity Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12323,8 +12487,8 @@ void emberAfTurbidityConcentrationMeasurementClusterClientTickCallback(uint8_t e
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                   EmberAfAttributeId attributeId);
+void emberAfTurbidityConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId);
 /** @brief Turbidity Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12334,7 +12498,7 @@ void emberAfTurbidityConcentrationMeasurementClusterServerAttributeChangedCallba
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfTurbidityConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                   EmberAfStatus status);
 /** @brief Turbidity Concentration Measurement Cluster Server Init
  *
@@ -12342,7 +12506,7 @@ void emberAfTurbidityConcentrationMeasurementClusterServerDefaultResponseCallbac
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfTurbidityConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Turbidity Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12353,7 +12517,7 @@ void emberAfTurbidityConcentrationMeasurementClusterServerInitCallback(uint8_t e
  * Ver.: always
  */
 void emberAfTurbidityConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Turbidity Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -12381,7 +12545,7 @@ void emberAfTurbidityConcentrationMeasurementClusterServerMessageSentCallback(Em
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfTurbidityConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                EmberAfAttributeType attributeType,
                                                                                                uint8_t size, uint8_t * value);
 /** @brief Turbidity Concentration Measurement Cluster Server Tick
@@ -12390,7 +12554,7 @@ EmberAfStatus emberAfTurbidityConcentrationMeasurementClusterServerPreAttributeC
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTurbidityConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfTurbidityConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Turbidity Concentration Measurement Cluster Callbacks */
 
@@ -12404,7 +12568,8 @@ void emberAfTurbidityConcentrationMeasurementClusterServerTickCallback(uint8_t e
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfCopperConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId);
 /** @brief Copper Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -12414,7 +12579,7 @@ void emberAfCopperConcentrationMeasurementClusterClientAttributeChangedCallback(
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfCopperConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                EmberAfStatus status);
 /** @brief Copper Concentration Measurement Cluster Client Init
  *
@@ -12422,7 +12587,7 @@ void emberAfCopperConcentrationMeasurementClusterClientDefaultResponseCallback(u
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfCopperConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Copper Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -12433,7 +12598,7 @@ void emberAfCopperConcentrationMeasurementClusterClientInitCallback(uint8_t endp
  * Ver.: always
  */
 void emberAfCopperConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                    EmberAfAttributeId attributeId,
+                                                                                                    chip::AttributeId attributeId,
                                                                                                     uint16_t manufacturerCode);
 /** @brief Copper Concentration Measurement Cluster Client Message Sent
  *
@@ -12461,7 +12626,7 @@ void emberAfCopperConcentrationMeasurementClusterClientMessageSentCallback(Ember
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfCopperConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                            EmberAfAttributeId attributeId,
+                                                                                            chip::AttributeId attributeId,
                                                                                             EmberAfAttributeType attributeType,
                                                                                             uint8_t size, uint8_t * value);
 /** @brief Copper Concentration Measurement Cluster Client Tick
@@ -12470,7 +12635,7 @@ EmberAfStatus emberAfCopperConcentrationMeasurementClusterClientPreAttributeChan
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfCopperConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Copper Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12478,7 +12643,8 @@ void emberAfCopperConcentrationMeasurementClusterClientTickCallback(uint8_t endp
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfCopperConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId);
 /** @brief Copper Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12488,7 +12654,7 @@ void emberAfCopperConcentrationMeasurementClusterServerAttributeChangedCallback(
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfCopperConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                EmberAfStatus status);
 /** @brief Copper Concentration Measurement Cluster Server Init
  *
@@ -12496,7 +12662,7 @@ void emberAfCopperConcentrationMeasurementClusterServerDefaultResponseCallback(u
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfCopperConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Copper Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12507,7 +12673,7 @@ void emberAfCopperConcentrationMeasurementClusterServerInitCallback(uint8_t endp
  * Ver.: always
  */
 void emberAfCopperConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                    EmberAfAttributeId attributeId,
+                                                                                                    chip::AttributeId attributeId,
                                                                                                     uint16_t manufacturerCode);
 /** @brief Copper Concentration Measurement Cluster Server Message Sent
  *
@@ -12535,7 +12701,7 @@ void emberAfCopperConcentrationMeasurementClusterServerMessageSentCallback(Ember
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfCopperConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                            EmberAfAttributeId attributeId,
+                                                                                            chip::AttributeId attributeId,
                                                                                             EmberAfAttributeType attributeType,
                                                                                             uint8_t size, uint8_t * value);
 /** @brief Copper Concentration Measurement Cluster Server Tick
@@ -12544,7 +12710,7 @@ EmberAfStatus emberAfCopperConcentrationMeasurementClusterServerPreAttributeChan
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCopperConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfCopperConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Copper Concentration Measurement Cluster Callbacks */
 
@@ -12558,7 +12724,8 @@ void emberAfCopperConcentrationMeasurementClusterServerTickCallback(uint8_t endp
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfLeadConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId);
 /** @brief Lead Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -12568,7 +12735,7 @@ void emberAfLeadConcentrationMeasurementClusterClientAttributeChangedCallback(ui
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfLeadConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                              EmberAfStatus status);
 /** @brief Lead Concentration Measurement Cluster Client Init
  *
@@ -12576,7 +12743,7 @@ void emberAfLeadConcentrationMeasurementClusterClientDefaultResponseCallback(uin
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfLeadConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Lead Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -12587,7 +12754,7 @@ void emberAfLeadConcentrationMeasurementClusterClientInitCallback(uint8_t endpoi
  * Ver.: always
  */
 void emberAfLeadConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                  EmberAfAttributeId attributeId,
+                                                                                                  chip::AttributeId attributeId,
                                                                                                   uint16_t manufacturerCode);
 /** @brief Lead Concentration Measurement Cluster Client Message Sent
  *
@@ -12615,7 +12782,7 @@ void emberAfLeadConcentrationMeasurementClusterClientMessageSentCallback(EmberOu
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfLeadConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId,
+                                                                                          chip::AttributeId attributeId,
                                                                                           EmberAfAttributeType attributeType,
                                                                                           uint8_t size, uint8_t * value);
 /** @brief Lead Concentration Measurement Cluster Client Tick
@@ -12624,7 +12791,7 @@ EmberAfStatus emberAfLeadConcentrationMeasurementClusterClientPreAttributeChange
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfLeadConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Lead Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12632,7 +12799,8 @@ void emberAfLeadConcentrationMeasurementClusterClientTickCallback(uint8_t endpoi
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfLeadConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId);
 /** @brief Lead Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12642,7 +12810,7 @@ void emberAfLeadConcentrationMeasurementClusterServerAttributeChangedCallback(ui
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfLeadConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                              EmberAfStatus status);
 /** @brief Lead Concentration Measurement Cluster Server Init
  *
@@ -12650,7 +12818,7 @@ void emberAfLeadConcentrationMeasurementClusterServerDefaultResponseCallback(uin
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfLeadConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Lead Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12661,7 +12829,7 @@ void emberAfLeadConcentrationMeasurementClusterServerInitCallback(uint8_t endpoi
  * Ver.: always
  */
 void emberAfLeadConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                  EmberAfAttributeId attributeId,
+                                                                                                  chip::AttributeId attributeId,
                                                                                                   uint16_t manufacturerCode);
 /** @brief Lead Concentration Measurement Cluster Server Message Sent
  *
@@ -12689,7 +12857,7 @@ void emberAfLeadConcentrationMeasurementClusterServerMessageSentCallback(EmberOu
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfLeadConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId,
+                                                                                          chip::AttributeId attributeId,
                                                                                           EmberAfAttributeType attributeType,
                                                                                           uint8_t size, uint8_t * value);
 /** @brief Lead Concentration Measurement Cluster Server Tick
@@ -12698,7 +12866,7 @@ EmberAfStatus emberAfLeadConcentrationMeasurementClusterServerPreAttributeChange
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfLeadConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfLeadConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Lead Concentration Measurement Cluster Callbacks */
 
@@ -12712,8 +12880,8 @@ void emberAfLeadConcentrationMeasurementClusterServerTickCallback(uint8_t endpoi
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                   EmberAfAttributeId attributeId);
+void emberAfManganeseConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId);
 /** @brief Manganese Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -12723,7 +12891,7 @@ void emberAfManganeseConcentrationMeasurementClusterClientAttributeChangedCallba
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfManganeseConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                   EmberAfStatus status);
 /** @brief Manganese Concentration Measurement Cluster Client Init
  *
@@ -12731,7 +12899,7 @@ void emberAfManganeseConcentrationMeasurementClusterClientDefaultResponseCallbac
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfManganeseConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Manganese Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -12742,7 +12910,7 @@ void emberAfManganeseConcentrationMeasurementClusterClientInitCallback(uint8_t e
  * Ver.: always
  */
 void emberAfManganeseConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Manganese Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -12770,7 +12938,7 @@ void emberAfManganeseConcentrationMeasurementClusterClientMessageSentCallback(Em
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfManganeseConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                EmberAfAttributeType attributeType,
                                                                                                uint8_t size, uint8_t * value);
 /** @brief Manganese Concentration Measurement Cluster Client Tick
@@ -12779,7 +12947,7 @@ EmberAfStatus emberAfManganeseConcentrationMeasurementClusterClientPreAttributeC
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfManganeseConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Manganese Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12787,8 +12955,8 @@ void emberAfManganeseConcentrationMeasurementClusterClientTickCallback(uint8_t e
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                   EmberAfAttributeId attributeId);
+void emberAfManganeseConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId);
 /** @brief Manganese Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12798,7 +12966,7 @@ void emberAfManganeseConcentrationMeasurementClusterServerAttributeChangedCallba
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfManganeseConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                   EmberAfStatus status);
 /** @brief Manganese Concentration Measurement Cluster Server Init
  *
@@ -12806,7 +12974,7 @@ void emberAfManganeseConcentrationMeasurementClusterServerDefaultResponseCallbac
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfManganeseConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Manganese Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12817,7 +12985,7 @@ void emberAfManganeseConcentrationMeasurementClusterServerInitCallback(uint8_t e
  * Ver.: always
  */
 void emberAfManganeseConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Manganese Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -12845,7 +13013,7 @@ void emberAfManganeseConcentrationMeasurementClusterServerMessageSentCallback(Em
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfManganeseConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                EmberAfAttributeType attributeType,
                                                                                                uint8_t size, uint8_t * value);
 /** @brief Manganese Concentration Measurement Cluster Server Tick
@@ -12854,7 +13022,7 @@ EmberAfStatus emberAfManganeseConcentrationMeasurementClusterServerPreAttributeC
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfManganeseConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfManganeseConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Manganese Concentration Measurement Cluster Callbacks */
 
@@ -12868,7 +13036,8 @@ void emberAfManganeseConcentrationMeasurementClusterServerTickCallback(uint8_t e
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSulfateConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId);
 /** @brief Sulfate Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -12878,7 +13047,7 @@ void emberAfSulfateConcentrationMeasurementClusterClientAttributeChangedCallback
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfSulfateConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                 EmberAfStatus status);
 /** @brief Sulfate Concentration Measurement Cluster Client Init
  *
@@ -12886,7 +13055,7 @@ void emberAfSulfateConcentrationMeasurementClusterClientDefaultResponseCallback(
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfSulfateConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Sulfate Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -12897,7 +13066,7 @@ void emberAfSulfateConcentrationMeasurementClusterClientInitCallback(uint8_t end
  * Ver.: always
  */
 void emberAfSulfateConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                     EmberAfAttributeId attributeId,
+                                                                                                     chip::AttributeId attributeId,
                                                                                                      uint16_t manufacturerCode);
 /** @brief Sulfate Concentration Measurement Cluster Client Message Sent
  *
@@ -12925,7 +13094,7 @@ void emberAfSulfateConcentrationMeasurementClusterClientMessageSentCallback(Embe
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfSulfateConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              EmberAfAttributeType attributeType,
                                                                                              uint8_t size, uint8_t * value);
 /** @brief Sulfate Concentration Measurement Cluster Client Tick
@@ -12934,7 +13103,7 @@ EmberAfStatus emberAfSulfateConcentrationMeasurementClusterClientPreAttributeCha
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfSulfateConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Sulfate Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -12942,7 +13111,8 @@ void emberAfSulfateConcentrationMeasurementClusterClientTickCallback(uint8_t end
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSulfateConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId);
 /** @brief Sulfate Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -12952,7 +13122,7 @@ void emberAfSulfateConcentrationMeasurementClusterServerAttributeChangedCallback
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfSulfateConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                 EmberAfStatus status);
 /** @brief Sulfate Concentration Measurement Cluster Server Init
  *
@@ -12960,7 +13130,7 @@ void emberAfSulfateConcentrationMeasurementClusterServerDefaultResponseCallback(
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfSulfateConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Sulfate Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -12971,7 +13141,7 @@ void emberAfSulfateConcentrationMeasurementClusterServerInitCallback(uint8_t end
  * Ver.: always
  */
 void emberAfSulfateConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                     EmberAfAttributeId attributeId,
+                                                                                                     chip::AttributeId attributeId,
                                                                                                      uint16_t manufacturerCode);
 /** @brief Sulfate Concentration Measurement Cluster Server Message Sent
  *
@@ -12999,7 +13169,7 @@ void emberAfSulfateConcentrationMeasurementClusterServerMessageSentCallback(Embe
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfSulfateConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              EmberAfAttributeType attributeType,
                                                                                              uint8_t size, uint8_t * value);
 /** @brief Sulfate Concentration Measurement Cluster Server Tick
@@ -13008,7 +13178,7 @@ EmberAfStatus emberAfSulfateConcentrationMeasurementClusterServerPreAttributeCha
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSulfateConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfSulfateConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Sulfate Concentration Measurement Cluster Callbacks */
 
@@ -13023,7 +13193,7 @@ void emberAfSulfateConcentrationMeasurementClusterServerTickCallback(uint8_t end
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfBromodichloromethaneConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId);
+                                                                                              chip::AttributeId attributeId);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -13033,7 +13203,8 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterClientAttributeCh
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfBromodichloromethaneConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                             uint8_t commandId,
                                                                                              EmberAfStatus status);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Client Init
  *
@@ -13041,7 +13212,7 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterClientDefaultResp
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfBromodichloromethaneConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -13052,7 +13223,7 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterClientInitCallbac
  * Ver.: always
  */
 void emberAfBromodichloromethaneConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -13080,14 +13251,14 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterClientMessageSent
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfBromodichloromethaneConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfBromodichloromethaneConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -13096,7 +13267,7 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterClientTickCallbac
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfBromodichloromethaneConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId);
+                                                                                              chip::AttributeId attributeId);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -13106,7 +13277,8 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterServerAttributeCh
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfBromodichloromethaneConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                             uint8_t commandId,
                                                                                              EmberAfStatus status);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Init
  *
@@ -13114,7 +13286,7 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterServerDefaultResp
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfBromodichloromethaneConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -13125,7 +13297,7 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterServerInitCallbac
  * Ver.: always
  */
 void emberAfBromodichloromethaneConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -13153,14 +13325,14 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterServerMessageSent
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfBromodichloromethaneConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfBromodichloromethaneConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Bromodichloromethane Concentration Measurement Cluster Callbacks */
 
@@ -13174,8 +13346,8 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterServerTickCallbac
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                   EmberAfAttributeId attributeId);
+void emberAfBromoformConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId);
 /** @brief Bromoform Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -13185,7 +13357,7 @@ void emberAfBromoformConcentrationMeasurementClusterClientAttributeChangedCallba
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfBromoformConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                   EmberAfStatus status);
 /** @brief Bromoform Concentration Measurement Cluster Client Init
  *
@@ -13193,7 +13365,7 @@ void emberAfBromoformConcentrationMeasurementClusterClientDefaultResponseCallbac
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfBromoformConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Bromoform Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -13204,7 +13376,7 @@ void emberAfBromoformConcentrationMeasurementClusterClientInitCallback(uint8_t e
  * Ver.: always
  */
 void emberAfBromoformConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Bromoform Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -13232,7 +13404,7 @@ void emberAfBromoformConcentrationMeasurementClusterClientMessageSentCallback(Em
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfBromoformConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                EmberAfAttributeType attributeType,
                                                                                                uint8_t size, uint8_t * value);
 /** @brief Bromoform Concentration Measurement Cluster Client Tick
@@ -13241,7 +13413,7 @@ EmberAfStatus emberAfBromoformConcentrationMeasurementClusterClientPreAttributeC
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfBromoformConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Bromoform Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -13249,8 +13421,8 @@ void emberAfBromoformConcentrationMeasurementClusterClientTickCallback(uint8_t e
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                   EmberAfAttributeId attributeId);
+void emberAfBromoformConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId);
 /** @brief Bromoform Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -13260,7 +13432,7 @@ void emberAfBromoformConcentrationMeasurementClusterServerAttributeChangedCallba
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfBromoformConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                   EmberAfStatus status);
 /** @brief Bromoform Concentration Measurement Cluster Server Init
  *
@@ -13268,7 +13440,7 @@ void emberAfBromoformConcentrationMeasurementClusterServerDefaultResponseCallbac
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfBromoformConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Bromoform Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -13279,7 +13451,7 @@ void emberAfBromoformConcentrationMeasurementClusterServerInitCallback(uint8_t e
  * Ver.: always
  */
 void emberAfBromoformConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Bromoform Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -13307,7 +13479,7 @@ void emberAfBromoformConcentrationMeasurementClusterServerMessageSentCallback(Em
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfBromoformConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                EmberAfAttributeType attributeType,
                                                                                                uint8_t size, uint8_t * value);
 /** @brief Bromoform Concentration Measurement Cluster Server Tick
@@ -13316,7 +13488,7 @@ EmberAfStatus emberAfBromoformConcentrationMeasurementClusterServerPreAttributeC
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBromoformConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfBromoformConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Bromoform Concentration Measurement Cluster Callbacks */
 
@@ -13331,7 +13503,7 @@ void emberAfBromoformConcentrationMeasurementClusterServerTickCallback(uint8_t e
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId);
+                                                                                              chip::AttributeId attributeId);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -13341,7 +13513,8 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientAttributeCh
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                             uint8_t commandId,
                                                                                              EmberAfStatus status);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Client Init
  *
@@ -13349,7 +13522,7 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientDefaultResp
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -13360,7 +13533,7 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientInitCallbac
  * Ver.: always
  */
 void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -13388,14 +13561,14 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientMessageSent
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChlorodibromomethaneConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Client Tick
  *
  * Client Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -13404,7 +13577,7 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientTickCallbac
  * @param attributeId Attribute that changed  Ver.: always
  */
 void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                              EmberAfAttributeId attributeId);
+                                                                                              chip::AttributeId attributeId);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -13414,7 +13587,8 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerAttributeCh
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint,
+                                                                                             uint8_t commandId,
                                                                                              EmberAfStatus status);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Init
  *
@@ -13422,7 +13596,7 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerDefaultResp
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -13433,7 +13607,7 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerInitCallbac
  * Ver.: always
  */
 void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -13461,14 +13635,14 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerMessageSent
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChlorodibromomethaneConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Tick
  *
  * Server Tick
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Chlorodibromomethane Concentration Measurement Cluster Callbacks */
 
@@ -13482,8 +13656,8 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerTickCallbac
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId);
+void emberAfChloroformConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId);
 /** @brief Chloroform Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -13493,7 +13667,7 @@ void emberAfChloroformConcentrationMeasurementClusterClientAttributeChangedCallb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChloroformConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                    EmberAfStatus status);
 /** @brief Chloroform Concentration Measurement Cluster Client Init
  *
@@ -13501,7 +13675,7 @@ void emberAfChloroformConcentrationMeasurementClusterClientDefaultResponseCallba
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfChloroformConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Chloroform Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -13512,7 +13686,7 @@ void emberAfChloroformConcentrationMeasurementClusterClientInitCallback(uint8_t 
  * Ver.: always
  */
 void emberAfChloroformConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Chloroform Concentration Measurement Cluster Client Message Sent
  *
  * Client Message Sent
@@ -13540,7 +13714,7 @@ void emberAfChloroformConcentrationMeasurementClusterClientMessageSentCallback(E
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChloroformConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                                EmberAfAttributeId attributeId,
+                                                                                                chip::AttributeId attributeId,
                                                                                                 EmberAfAttributeType attributeType,
                                                                                                 uint8_t size, uint8_t * value);
 /** @brief Chloroform Concentration Measurement Cluster Client Tick
@@ -13549,7 +13723,7 @@ EmberAfStatus emberAfChloroformConcentrationMeasurementClusterClientPreAttribute
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfChloroformConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Chloroform Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -13557,8 +13731,8 @@ void emberAfChloroformConcentrationMeasurementClusterClientTickCallback(uint8_t 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId);
+void emberAfChloroformConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId);
 /** @brief Chloroform Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -13568,7 +13742,7 @@ void emberAfChloroformConcentrationMeasurementClusterServerAttributeChangedCallb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfChloroformConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                    EmberAfStatus status);
 /** @brief Chloroform Concentration Measurement Cluster Server Init
  *
@@ -13576,7 +13750,7 @@ void emberAfChloroformConcentrationMeasurementClusterServerDefaultResponseCallba
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfChloroformConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Chloroform Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -13587,7 +13761,7 @@ void emberAfChloroformConcentrationMeasurementClusterServerInitCallback(uint8_t 
  * Ver.: always
  */
 void emberAfChloroformConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    uint8_t endpoint, EmberAfAttributeId attributeId, uint16_t manufacturerCode);
+    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 /** @brief Chloroform Concentration Measurement Cluster Server Message Sent
  *
  * Server Message Sent
@@ -13615,7 +13789,7 @@ void emberAfChloroformConcentrationMeasurementClusterServerMessageSentCallback(E
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfChloroformConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                                EmberAfAttributeId attributeId,
+                                                                                                chip::AttributeId attributeId,
                                                                                                 EmberAfAttributeType attributeType,
                                                                                                 uint8_t size, uint8_t * value);
 /** @brief Chloroform Concentration Measurement Cluster Server Tick
@@ -13624,7 +13798,7 @@ EmberAfStatus emberAfChloroformConcentrationMeasurementClusterServerPreAttribute
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChloroformConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfChloroformConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Chloroform Concentration Measurement Cluster Callbacks */
 
@@ -13638,7 +13812,8 @@ void emberAfChloroformConcentrationMeasurementClusterServerTickCallback(uint8_t 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSodiumConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId);
 /** @brief Sodium Concentration Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -13648,7 +13823,7 @@ void emberAfSodiumConcentrationMeasurementClusterClientAttributeChangedCallback(
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfSodiumConcentrationMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                EmberAfStatus status);
 /** @brief Sodium Concentration Measurement Cluster Client Init
  *
@@ -13656,7 +13831,7 @@ void emberAfSodiumConcentrationMeasurementClusterClientDefaultResponseCallback(u
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfSodiumConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Sodium Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -13667,7 +13842,7 @@ void emberAfSodiumConcentrationMeasurementClusterClientInitCallback(uint8_t endp
  * Ver.: always
  */
 void emberAfSodiumConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                    EmberAfAttributeId attributeId,
+                                                                                                    chip::AttributeId attributeId,
                                                                                                     uint16_t manufacturerCode);
 /** @brief Sodium Concentration Measurement Cluster Client Message Sent
  *
@@ -13695,7 +13870,7 @@ void emberAfSodiumConcentrationMeasurementClusterClientMessageSentCallback(Ember
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfSodiumConcentrationMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                            EmberAfAttributeId attributeId,
+                                                                                            chip::AttributeId attributeId,
                                                                                             EmberAfAttributeType attributeType,
                                                                                             uint8_t size, uint8_t * value);
 /** @brief Sodium Concentration Measurement Cluster Client Tick
@@ -13704,7 +13879,7 @@ EmberAfStatus emberAfSodiumConcentrationMeasurementClusterClientPreAttributeChan
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfSodiumConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Sodium Concentration Measurement Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -13712,7 +13887,8 @@ void emberAfSodiumConcentrationMeasurementClusterClientTickCallback(uint8_t endp
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSodiumConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId);
 /** @brief Sodium Concentration Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -13722,7 +13898,7 @@ void emberAfSodiumConcentrationMeasurementClusterServerAttributeChangedCallback(
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfSodiumConcentrationMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                                EmberAfStatus status);
 /** @brief Sodium Concentration Measurement Cluster Server Init
  *
@@ -13730,7 +13906,7 @@ void emberAfSodiumConcentrationMeasurementClusterServerDefaultResponseCallback(u
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfSodiumConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Sodium Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -13741,7 +13917,7 @@ void emberAfSodiumConcentrationMeasurementClusterServerInitCallback(uint8_t endp
  * Ver.: always
  */
 void emberAfSodiumConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                                    EmberAfAttributeId attributeId,
+                                                                                                    chip::AttributeId attributeId,
                                                                                                     uint16_t manufacturerCode);
 /** @brief Sodium Concentration Measurement Cluster Server Message Sent
  *
@@ -13769,7 +13945,7 @@ void emberAfSodiumConcentrationMeasurementClusterServerMessageSentCallback(Ember
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfSodiumConcentrationMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                            EmberAfAttributeId attributeId,
+                                                                                            chip::AttributeId attributeId,
                                                                                             EmberAfAttributeType attributeType,
                                                                                             uint8_t size, uint8_t * value);
 /** @brief Sodium Concentration Measurement Cluster Server Tick
@@ -13778,7 +13954,7 @@ EmberAfStatus emberAfSodiumConcentrationMeasurementClusterServerPreAttributeChan
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSodiumConcentrationMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfSodiumConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Sodium Concentration Measurement Cluster Callbacks */
 
@@ -13792,7 +13968,7 @@ void emberAfSodiumConcentrationMeasurementClusterServerTickCallback(uint8_t endp
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIasZoneClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIasZoneClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief IAS Zone Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -13802,14 +13978,14 @@ void emberAfIasZoneClusterClientAttributeChangedCallback(uint8_t endpoint, Ember
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIasZoneClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIasZoneClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief IAS Zone Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIasZoneClusterClientInitCallback(uint8_t endpoint);
+void emberAfIasZoneClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief IAS Zone Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -13819,7 +13995,8 @@ void emberAfIasZoneClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIasZoneClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIasZoneClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              uint16_t manufacturerCode);
 /** @brief IAS Zone Cluster Client Message Sent
  *
@@ -13846,7 +14023,7 @@ void emberAfIasZoneClusterClientMessageSentCallback(EmberOutgoingMessageType typ
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIasZoneClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIasZoneClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                      EmberAfAttributeType attributeType, uint8_t size,
                                                                      uint8_t * value);
 /** @brief IAS Zone Cluster Client Tick
@@ -13855,7 +14032,7 @@ EmberAfStatus emberAfIasZoneClusterClientPreAttributeChangedCallback(uint8_t end
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIasZoneClusterClientTickCallback(uint8_t endpoint);
+void emberAfIasZoneClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief IAS Zone Cluster Initiate Normal Operation Mode
  *
  *
@@ -13889,7 +14066,7 @@ bool emberAfIasZoneClusterInitiateTestModeResponseCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIasZoneClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIasZoneClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief IAS Zone Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -13899,14 +14076,14 @@ void emberAfIasZoneClusterServerAttributeChangedCallback(uint8_t endpoint, Ember
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIasZoneClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIasZoneClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief IAS Zone Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIasZoneClusterServerInitCallback(uint8_t endpoint);
+void emberAfIasZoneClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief IAS Zone Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -13916,7 +14093,8 @@ void emberAfIasZoneClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIasZoneClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIasZoneClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              uint16_t manufacturerCode);
 /** @brief IAS Zone Cluster Server Message Sent
  *
@@ -13943,7 +14121,7 @@ void emberAfIasZoneClusterServerMessageSentCallback(EmberOutgoingMessageType typ
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIasZoneClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIasZoneClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                      EmberAfAttributeType attributeType, uint8_t size,
                                                                      uint8_t * value);
 /** @brief IAS Zone Cluster Server Tick
@@ -13952,7 +14130,7 @@ EmberAfStatus emberAfIasZoneClusterServerPreAttributeChangedCallback(uint8_t end
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIasZoneClusterServerTickCallback(uint8_t endpoint);
+void emberAfIasZoneClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief IAS Zone Cluster Zone Enroll Request
  *
  *
@@ -14026,7 +14204,7 @@ bool emberAfIasAceClusterBypassResponseCallback(uint8_t numberOfZones, uint8_t *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIasAceClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIasAceClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief IAS ACE Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -14036,14 +14214,14 @@ void emberAfIasAceClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIasAceClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIasAceClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief IAS ACE Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIasAceClusterClientInitCallback(uint8_t endpoint);
+void emberAfIasAceClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief IAS ACE Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -14053,7 +14231,8 @@ void emberAfIasAceClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIasAceClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIasAceClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief IAS ACE Cluster Client Message Sent
  *
@@ -14080,7 +14259,7 @@ void emberAfIasAceClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIasAceClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIasAceClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief IAS ACE Cluster Client Tick
@@ -14089,7 +14268,7 @@ EmberAfStatus emberAfIasAceClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIasAceClusterClientTickCallback(uint8_t endpoint);
+void emberAfIasAceClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief IAS ACE Cluster Emergency
  *
  *
@@ -14220,7 +14399,7 @@ bool emberAfIasAceClusterPanicCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIasAceClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIasAceClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief IAS ACE Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -14230,14 +14409,14 @@ void emberAfIasAceClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIasAceClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIasAceClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief IAS ACE Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIasAceClusterServerInitCallback(uint8_t endpoint);
+void emberAfIasAceClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief IAS ACE Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -14247,7 +14426,8 @@ void emberAfIasAceClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIasAceClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIasAceClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief IAS ACE Cluster Server Message Sent
  *
@@ -14274,7 +14454,7 @@ void emberAfIasAceClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIasAceClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIasAceClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief IAS ACE Cluster Server Tick
@@ -14283,7 +14463,7 @@ EmberAfStatus emberAfIasAceClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIasAceClusterServerTickCallback(uint8_t endpoint);
+void emberAfIasAceClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief IAS ACE Cluster Set Bypassed Zone List
  *
  *
@@ -14316,7 +14496,7 @@ bool emberAfIasAceClusterZoneStatusChangedCallback(uint8_t zoneId, uint16_t zone
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIasWdClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIasWdClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief IAS WD Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -14326,14 +14506,14 @@ void emberAfIasWdClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIasWdClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIasWdClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief IAS WD Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIasWdClusterClientInitCallback(uint8_t endpoint);
+void emberAfIasWdClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief IAS WD Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -14343,7 +14523,7 @@ void emberAfIasWdClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIasWdClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIasWdClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief IAS WD Cluster Client Message Sent
  *
@@ -14369,7 +14549,7 @@ void emberAfIasWdClusterClientMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIasWdClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIasWdClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief IAS WD Cluster Client Tick
@@ -14378,7 +14558,7 @@ EmberAfStatus emberAfIasWdClusterClientPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIasWdClusterClientTickCallback(uint8_t endpoint);
+void emberAfIasWdClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief IAS WD Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -14386,7 +14566,7 @@ void emberAfIasWdClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIasWdClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIasWdClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief IAS WD Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -14396,14 +14576,14 @@ void emberAfIasWdClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIasWdClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIasWdClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief IAS WD Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIasWdClusterServerInitCallback(uint8_t endpoint);
+void emberAfIasWdClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief IAS WD Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -14413,7 +14593,7 @@ void emberAfIasWdClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfIasWdClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfIasWdClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief IAS WD Cluster Server Message Sent
  *
@@ -14439,7 +14619,7 @@ void emberAfIasWdClusterServerMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIasWdClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIasWdClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief IAS WD Cluster Server Tick
@@ -14448,7 +14628,7 @@ EmberAfStatus emberAfIasWdClusterServerPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIasWdClusterServerTickCallback(uint8_t endpoint);
+void emberAfIasWdClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief IAS WD Cluster Squawk
  *
  *
@@ -14487,7 +14667,7 @@ bool emberAfGenericTunnelClusterAdvertiseProtocolAddressCallback(uint8_t * proto
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGenericTunnelClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGenericTunnelClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Generic Tunnel Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -14497,14 +14677,15 @@ void emberAfGenericTunnelClusterClientAttributeChangedCallback(uint8_t endpoint,
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGenericTunnelClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGenericTunnelClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                              EmberAfStatus status);
 /** @brief Generic Tunnel Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGenericTunnelClusterClientInitCallback(uint8_t endpoint);
+void emberAfGenericTunnelClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Generic Tunnel Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -14514,7 +14695,8 @@ void emberAfGenericTunnelClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGenericTunnelClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGenericTunnelClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    uint16_t manufacturerCode);
 /** @brief Generic Tunnel Cluster Client Message Sent
  *
@@ -14541,7 +14723,7 @@ void emberAfGenericTunnelClusterClientMessageSentCallback(EmberOutgoingMessageTy
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGenericTunnelClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGenericTunnelClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            EmberAfAttributeType attributeType, uint8_t size,
                                                                            uint8_t * value);
 /** @brief Generic Tunnel Cluster Client Tick
@@ -14550,7 +14732,7 @@ EmberAfStatus emberAfGenericTunnelClusterClientPreAttributeChangedCallback(uint8
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGenericTunnelClusterClientTickCallback(uint8_t endpoint);
+void emberAfGenericTunnelClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Generic Tunnel Cluster Match Protocol Address
  *
  *
@@ -14573,7 +14755,7 @@ bool emberAfGenericTunnelClusterMatchProtocolAddressResponseCallback(uint8_t * d
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGenericTunnelClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGenericTunnelClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Generic Tunnel Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -14583,14 +14765,15 @@ void emberAfGenericTunnelClusterServerAttributeChangedCallback(uint8_t endpoint,
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGenericTunnelClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGenericTunnelClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                              EmberAfStatus status);
 /** @brief Generic Tunnel Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGenericTunnelClusterServerInitCallback(uint8_t endpoint);
+void emberAfGenericTunnelClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Generic Tunnel Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -14600,7 +14783,8 @@ void emberAfGenericTunnelClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGenericTunnelClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGenericTunnelClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    uint16_t manufacturerCode);
 /** @brief Generic Tunnel Cluster Server Message Sent
  *
@@ -14627,7 +14811,7 @@ void emberAfGenericTunnelClusterServerMessageSentCallback(EmberOutgoingMessageTy
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGenericTunnelClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGenericTunnelClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            EmberAfAttributeType attributeType, uint8_t size,
                                                                            uint8_t * value);
 /** @brief Generic Tunnel Cluster Server Tick
@@ -14636,7 +14820,7 @@ EmberAfStatus emberAfGenericTunnelClusterServerPreAttributeChangedCallback(uint8
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGenericTunnelClusterServerTickCallback(uint8_t endpoint);
+void emberAfGenericTunnelClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Generic Tunnel Cluster Callbacks */
 
@@ -14650,7 +14834,7 @@ void emberAfGenericTunnelClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBacnetProtocolTunnelClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief BACnet Protocol Tunnel Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -14660,14 +14844,15 @@ void emberAfBacnetProtocolTunnelClusterClientAttributeChangedCallback(uint8_t en
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBacnetProtocolTunnelClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                     EmberAfStatus status);
 /** @brief BACnet Protocol Tunnel Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterClientInitCallback(uint8_t endpoint);
+void emberAfBacnetProtocolTunnelClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief BACnet Protocol Tunnel Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -14678,7 +14863,7 @@ void emberAfBacnetProtocolTunnelClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfBacnetProtocolTunnelClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId,
+                                                                                          chip::AttributeId attributeId,
                                                                                           uint16_t manufacturerCode);
 /** @brief BACnet Protocol Tunnel Cluster Client Message Sent
  *
@@ -14705,7 +14890,8 @@ void emberAfBacnetProtocolTunnelClusterClientMessageSentCallback(EmberOutgoingMe
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBacnetProtocolTunnelClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBacnetProtocolTunnelClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   EmberAfAttributeType attributeType, uint8_t size,
                                                                                   uint8_t * value);
 /** @brief BACnet Protocol Tunnel Cluster Client Tick
@@ -14714,7 +14900,7 @@ EmberAfStatus emberAfBacnetProtocolTunnelClusterClientPreAttributeChangedCallbac
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterClientTickCallback(uint8_t endpoint);
+void emberAfBacnetProtocolTunnelClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief BACnet Protocol Tunnel Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -14722,7 +14908,7 @@ void emberAfBacnetProtocolTunnelClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBacnetProtocolTunnelClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief BACnet Protocol Tunnel Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -14732,14 +14918,15 @@ void emberAfBacnetProtocolTunnelClusterServerAttributeChangedCallback(uint8_t en
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBacnetProtocolTunnelClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                     EmberAfStatus status);
 /** @brief BACnet Protocol Tunnel Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterServerInitCallback(uint8_t endpoint);
+void emberAfBacnetProtocolTunnelClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief BACnet Protocol Tunnel Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -14750,7 +14937,7 @@ void emberAfBacnetProtocolTunnelClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfBacnetProtocolTunnelClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                          EmberAfAttributeId attributeId,
+                                                                                          chip::AttributeId attributeId,
                                                                                           uint16_t manufacturerCode);
 /** @brief BACnet Protocol Tunnel Cluster Server Message Sent
  *
@@ -14777,7 +14964,8 @@ void emberAfBacnetProtocolTunnelClusterServerMessageSentCallback(EmberOutgoingMe
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBacnetProtocolTunnelClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBacnetProtocolTunnelClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                  chip::AttributeId attributeId,
                                                                                   EmberAfAttributeType attributeType, uint8_t size,
                                                                                   uint8_t * value);
 /** @brief BACnet Protocol Tunnel Cluster Server Tick
@@ -14786,7 +14974,7 @@ EmberAfStatus emberAfBacnetProtocolTunnelClusterServerPreAttributeChangedCallbac
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBacnetProtocolTunnelClusterServerTickCallback(uint8_t endpoint);
+void emberAfBacnetProtocolTunnelClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief BACnet Protocol Tunnel Cluster Transfer Npdu
  *
  *
@@ -14807,7 +14995,7 @@ bool emberAfBacnetProtocolTunnelClusterTransferNpduCallback(uint8_t * npdu);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAf11073ProtocolTunnelClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief 11073 Protocol Tunnel Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -14817,14 +15005,15 @@ void emberAf11073ProtocolTunnelClusterClientAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAf11073ProtocolTunnelClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief 11073 Protocol Tunnel Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterClientInitCallback(uint8_t endpoint);
+void emberAf11073ProtocolTunnelClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief 11073 Protocol Tunnel Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -14835,7 +15024,7 @@ void emberAf11073ProtocolTunnelClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAf11073ProtocolTunnelClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief 11073 Protocol Tunnel Cluster Client Message Sent
  *
@@ -14862,7 +15051,8 @@ void emberAf11073ProtocolTunnelClusterClientMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAf11073ProtocolTunnelClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAf11073ProtocolTunnelClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief 11073 Protocol Tunnel Cluster Client Tick
@@ -14871,7 +15061,7 @@ EmberAfStatus emberAf11073ProtocolTunnelClusterClientPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterClientTickCallback(uint8_t endpoint);
+void emberAf11073ProtocolTunnelClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief 11073 Protocol Tunnel Cluster Connect Request
  *
  *
@@ -14904,7 +15094,7 @@ bool emberAf11073ProtocolTunnelClusterDisconnectRequestCallback(uint8_t * manage
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAf11073ProtocolTunnelClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief 11073 Protocol Tunnel Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -14914,14 +15104,15 @@ void emberAf11073ProtocolTunnelClusterServerAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAf11073ProtocolTunnelClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief 11073 Protocol Tunnel Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterServerInitCallback(uint8_t endpoint);
+void emberAf11073ProtocolTunnelClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief 11073 Protocol Tunnel Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -14932,7 +15123,7 @@ void emberAf11073ProtocolTunnelClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAf11073ProtocolTunnelClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief 11073 Protocol Tunnel Cluster Server Message Sent
  *
@@ -14959,7 +15150,8 @@ void emberAf11073ProtocolTunnelClusterServerMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAf11073ProtocolTunnelClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAf11073ProtocolTunnelClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief 11073 Protocol Tunnel Cluster Server Tick
@@ -14968,7 +15160,7 @@ EmberAfStatus emberAf11073ProtocolTunnelClusterServerPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAf11073ProtocolTunnelClusterServerTickCallback(uint8_t endpoint);
+void emberAf11073ProtocolTunnelClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief 11073 Protocol Tunnel Cluster Transfer A P D U
  *
  *
@@ -14989,7 +15181,7 @@ bool emberAf11073ProtocolTunnelClusterTransferAPDUCallback(uint8_t * apdu);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIso7816ProtocolTunnelClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief ISO 7816 Protocol Tunnel Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -14999,14 +15191,15 @@ void emberAfIso7816ProtocolTunnelClusterClientAttributeChangedCallback(uint8_t e
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIso7816ProtocolTunnelClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                      EmberAfStatus status);
 /** @brief ISO 7816 Protocol Tunnel Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterClientInitCallback(uint8_t endpoint);
+void emberAfIso7816ProtocolTunnelClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief ISO 7816 Protocol Tunnel Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -15017,7 +15210,7 @@ void emberAfIso7816ProtocolTunnelClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfIso7816ProtocolTunnelClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                           EmberAfAttributeId attributeId,
+                                                                                           chip::AttributeId attributeId,
                                                                                            uint16_t manufacturerCode);
 /** @brief ISO 7816 Protocol Tunnel Cluster Client Message Sent
  *
@@ -15044,7 +15237,8 @@ void emberAfIso7816ProtocolTunnelClusterClientMessageSentCallback(EmberOutgoingM
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIso7816ProtocolTunnelClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIso7816ProtocolTunnelClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                                    uint8_t * value);
 /** @brief ISO 7816 Protocol Tunnel Cluster Client Tick
@@ -15053,7 +15247,7 @@ EmberAfStatus emberAfIso7816ProtocolTunnelClusterClientPreAttributeChangedCallba
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterClientTickCallback(uint8_t endpoint);
+void emberAfIso7816ProtocolTunnelClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief ISO 7816 Protocol Tunnel Cluster Extract Smart Card
  *
  *
@@ -15073,7 +15267,7 @@ bool emberAfIso7816ProtocolTunnelClusterInsertSmartCardCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfIso7816ProtocolTunnelClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief ISO 7816 Protocol Tunnel Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -15083,14 +15277,15 @@ void emberAfIso7816ProtocolTunnelClusterServerAttributeChangedCallback(uint8_t e
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfIso7816ProtocolTunnelClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                      EmberAfStatus status);
 /** @brief ISO 7816 Protocol Tunnel Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterServerInitCallback(uint8_t endpoint);
+void emberAfIso7816ProtocolTunnelClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief ISO 7816 Protocol Tunnel Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -15101,7 +15296,7 @@ void emberAfIso7816ProtocolTunnelClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfIso7816ProtocolTunnelClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                           EmberAfAttributeId attributeId,
+                                                                                           chip::AttributeId attributeId,
                                                                                            uint16_t manufacturerCode);
 /** @brief ISO 7816 Protocol Tunnel Cluster Server Message Sent
  *
@@ -15128,7 +15323,8 @@ void emberAfIso7816ProtocolTunnelClusterServerMessageSentCallback(EmberOutgoingM
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfIso7816ProtocolTunnelClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIso7816ProtocolTunnelClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                                    uint8_t * value);
 /** @brief ISO 7816 Protocol Tunnel Cluster Server Tick
@@ -15137,7 +15333,7 @@ EmberAfStatus emberAfIso7816ProtocolTunnelClusterServerPreAttributeChangedCallba
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfIso7816ProtocolTunnelClusterServerTickCallback(uint8_t endpoint);
+void emberAfIso7816ProtocolTunnelClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief ISO 7816 Protocol Tunnel Cluster Transfer Apdu
  *
  *
@@ -15167,7 +15363,7 @@ bool emberAfPriceClusterCancelTariffCallback(uint32_t providerId, uint32_t issue
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPriceClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPriceClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Price Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -15177,14 +15373,14 @@ void emberAfPriceClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPriceClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPriceClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Price Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPriceClusterClientInitCallback(uint8_t endpoint);
+void emberAfPriceClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Price Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -15194,7 +15390,7 @@ void emberAfPriceClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPriceClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPriceClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief Price Cluster Client Message Sent
  *
@@ -15220,7 +15416,7 @@ void emberAfPriceClusterClientMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPriceClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPriceClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief Price Cluster Client Tick
@@ -15229,7 +15425,7 @@ EmberAfStatus emberAfPriceClusterClientPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPriceClusterClientTickCallback(uint8_t endpoint);
+void emberAfPriceClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Price Cluster Cpp Event Response
  *
  *
@@ -15629,7 +15825,7 @@ bool emberAfPriceClusterPublishTierLabelsCallback(uint32_t providerId, uint32_t 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPriceClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPriceClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Price Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -15639,14 +15835,14 @@ void emberAfPriceClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAf
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPriceClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPriceClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Price Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPriceClusterServerInitCallback(uint8_t endpoint);
+void emberAfPriceClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Price Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -15656,7 +15852,7 @@ void emberAfPriceClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPriceClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPriceClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 /** @brief Price Cluster Server Message Sent
  *
@@ -15682,7 +15878,7 @@ void emberAfPriceClusterServerMessageSentCallback(EmberOutgoingMessageType type,
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPriceClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPriceClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 /** @brief Price Cluster Server Tick
@@ -15691,7 +15887,7 @@ EmberAfStatus emberAfPriceClusterServerPreAttributeChangedCallback(uint8_t endpo
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPriceClusterServerTickCallback(uint8_t endpoint);
+void emberAfPriceClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Price Cluster Callbacks */
 
@@ -15725,7 +15921,8 @@ bool emberAfDemandResponseLoadControlClusterCancelLoadControlEventCallback(uint3
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDemandResponseLoadControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                           chip::AttributeId attributeId);
 /** @brief Demand Response and Load Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -15735,7 +15932,7 @@ void emberAfDemandResponseLoadControlClusterClientAttributeChangedCallback(uint8
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfDemandResponseLoadControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                           EmberAfStatus status);
 /** @brief Demand Response and Load Control Cluster Client Init
  *
@@ -15743,7 +15940,7 @@ void emberAfDemandResponseLoadControlClusterClientDefaultResponseCallback(uint8_
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfDemandResponseLoadControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Demand Response and Load Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -15754,7 +15951,7 @@ void emberAfDemandResponseLoadControlClusterClientInitCallback(uint8_t endpoint)
  * Ver.: always
  */
 void emberAfDemandResponseLoadControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                uint16_t manufacturerCode);
 /** @brief Demand Response and Load Control Cluster Client Message Sent
  *
@@ -15782,7 +15979,7 @@ void emberAfDemandResponseLoadControlClusterClientMessageSentCallback(EmberOutgo
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfDemandResponseLoadControlClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        EmberAfAttributeType attributeType,
                                                                                        uint8_t size, uint8_t * value);
 /** @brief Demand Response and Load Control Cluster Client Tick
@@ -15791,7 +15988,7 @@ EmberAfStatus emberAfDemandResponseLoadControlClusterClientPreAttributeChangedCa
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfDemandResponseLoadControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Demand Response and Load Control Cluster Get Scheduled Events
  *
  *
@@ -15855,7 +16052,8 @@ bool emberAfDemandResponseLoadControlClusterReportEventStatusCallback(uint32_t i
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDemandResponseLoadControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                           chip::AttributeId attributeId);
 /** @brief Demand Response and Load Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -15865,7 +16063,7 @@ void emberAfDemandResponseLoadControlClusterServerAttributeChangedCallback(uint8
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId,
+void emberAfDemandResponseLoadControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, uint8_t commandId,
                                                                           EmberAfStatus status);
 /** @brief Demand Response and Load Control Cluster Server Init
  *
@@ -15873,7 +16071,7 @@ void emberAfDemandResponseLoadControlClusterServerDefaultResponseCallback(uint8_
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfDemandResponseLoadControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Demand Response and Load Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -15884,7 +16082,7 @@ void emberAfDemandResponseLoadControlClusterServerInitCallback(uint8_t endpoint)
  * Ver.: always
  */
 void emberAfDemandResponseLoadControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                               EmberAfAttributeId attributeId,
+                                                                                               chip::AttributeId attributeId,
                                                                                                uint16_t manufacturerCode);
 /** @brief Demand Response and Load Control Cluster Server Message Sent
  *
@@ -15912,7 +16110,7 @@ void emberAfDemandResponseLoadControlClusterServerMessageSentCallback(EmberOutgo
  * @param value Attribute value  Ver.: always
  */
 EmberAfStatus emberAfDemandResponseLoadControlClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        EmberAfAttributeType attributeType,
                                                                                        uint8_t size, uint8_t * value);
 /** @brief Demand Response and Load Control Cluster Server Tick
@@ -15921,7 +16119,7 @@ EmberAfStatus emberAfDemandResponseLoadControlClusterServerPreAttributeChangedCa
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDemandResponseLoadControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfDemandResponseLoadControlClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Demand Response and Load Control Cluster Callbacks */
 
@@ -15949,7 +16147,7 @@ bool emberAfSimpleMeteringClusterChangeSupplyCallback(uint32_t providerId, uint3
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSimpleMeteringClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSimpleMeteringClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Simple Metering Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -15959,14 +16157,15 @@ void emberAfSimpleMeteringClusterClientAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSimpleMeteringClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSimpleMeteringClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Simple Metering Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSimpleMeteringClusterClientInitCallback(uint8_t endpoint);
+void emberAfSimpleMeteringClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Simple Metering Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -15976,8 +16175,8 @@ void emberAfSimpleMeteringClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfSimpleMeteringClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfSimpleMeteringClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Simple Metering Cluster Client Message Sent
  *
@@ -16004,7 +16203,8 @@ void emberAfSimpleMeteringClusterClientMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSimpleMeteringClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSimpleMeteringClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Simple Metering Cluster Client Tick
@@ -16013,7 +16213,7 @@ EmberAfStatus emberAfSimpleMeteringClusterClientPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSimpleMeteringClusterClientTickCallback(uint8_t endpoint);
+void emberAfSimpleMeteringClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Simple Metering Cluster Configure Mirror
  *
  *
@@ -16040,7 +16240,7 @@ bool emberAfSimpleMeteringClusterConfigureMirrorCallback(uint32_t issuerEventId,
 bool emberAfSimpleMeteringClusterConfigureNotificationFlagsCallback(uint32_t issuerEventId, uint8_t notificationScheme,
                                                                     uint16_t notificationFlagAttributeId, uint16_t clusterId,
                                                                     uint16_t manufacturerCode, uint8_t numberOfCommands,
-                                                                    uint8_t * commandIds);
+                                                                    chip::CommandId * commandIds);
 /** @brief Simple Metering Cluster Configure Notification Scheme
  *
  *
@@ -16225,7 +16425,7 @@ bool emberAfSimpleMeteringClusterScheduleSnapshotResponseCallback(uint32_t issue
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSimpleMeteringClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSimpleMeteringClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Simple Metering Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -16235,14 +16435,15 @@ void emberAfSimpleMeteringClusterServerAttributeChangedCallback(uint8_t endpoint
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSimpleMeteringClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSimpleMeteringClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                               EmberAfStatus status);
 /** @brief Simple Metering Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSimpleMeteringClusterServerInitCallback(uint8_t endpoint);
+void emberAfSimpleMeteringClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Simple Metering Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -16252,8 +16453,8 @@ void emberAfSimpleMeteringClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfSimpleMeteringClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                    EmberAfAttributeId attributeId,
+void emberAfSimpleMeteringClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                    chip::AttributeId attributeId,
                                                                                     uint16_t manufacturerCode);
 /** @brief Simple Metering Cluster Server Message Sent
  *
@@ -16280,7 +16481,8 @@ void emberAfSimpleMeteringClusterServerMessageSentCallback(EmberOutgoingMessageT
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSimpleMeteringClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSimpleMeteringClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             EmberAfAttributeType attributeType, uint8_t size,
                                                                             uint8_t * value);
 /** @brief Simple Metering Cluster Server Tick
@@ -16289,7 +16491,7 @@ EmberAfStatus emberAfSimpleMeteringClusterServerPreAttributeChangedCallback(uint
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSimpleMeteringClusterServerTickCallback(uint8_t endpoint);
+void emberAfSimpleMeteringClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Simple Metering Cluster Set Supply Status
  *
  *
@@ -16393,7 +16595,7 @@ bool emberAfMessagingClusterCancelMessageCallback(uint32_t messageId, uint8_t me
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMessagingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMessagingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Messaging Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -16403,14 +16605,15 @@ void emberAfMessagingClusterClientAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMessagingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMessagingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Messaging Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMessagingClusterClientInitCallback(uint8_t endpoint);
+void emberAfMessagingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Messaging Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -16420,7 +16623,8 @@ void emberAfMessagingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfMessagingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfMessagingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Messaging Cluster Client Message Sent
  *
@@ -16447,7 +16651,7 @@ void emberAfMessagingClusterClientMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMessagingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMessagingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Messaging Cluster Client Tick
@@ -16456,7 +16660,7 @@ EmberAfStatus emberAfMessagingClusterClientPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMessagingClusterClientTickCallback(uint8_t endpoint);
+void emberAfMessagingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Messaging Cluster Display Message
  *
  *
@@ -16516,7 +16720,7 @@ bool emberAfMessagingClusterMessageConfirmationCallback(uint32_t messageId, uint
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMessagingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMessagingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Messaging Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -16526,14 +16730,15 @@ void emberAfMessagingClusterServerAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMessagingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMessagingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Messaging Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMessagingClusterServerInitCallback(uint8_t endpoint);
+void emberAfMessagingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Messaging Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -16543,7 +16748,8 @@ void emberAfMessagingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfMessagingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfMessagingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Messaging Cluster Server Message Sent
  *
@@ -16570,7 +16776,7 @@ void emberAfMessagingClusterServerMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMessagingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMessagingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Messaging Cluster Server Tick
@@ -16579,7 +16785,7 @@ EmberAfStatus emberAfMessagingClusterServerPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMessagingClusterServerTickCallback(uint8_t endpoint);
+void emberAfMessagingClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Messaging Cluster Callbacks */
 
@@ -16609,7 +16815,7 @@ bool emberAfTunnelingClusterAckTransferDataServerToClientCallback(uint16_t tunne
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTunnelingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfTunnelingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Tunneling Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -16619,14 +16825,15 @@ void emberAfTunnelingClusterClientAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTunnelingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfTunnelingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Tunneling Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTunnelingClusterClientInitCallback(uint8_t endpoint);
+void emberAfTunnelingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Tunneling Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -16636,7 +16843,8 @@ void emberAfTunnelingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfTunnelingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfTunnelingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Tunneling Cluster Client Message Sent
  *
@@ -16663,7 +16871,7 @@ void emberAfTunnelingClusterClientMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfTunnelingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfTunnelingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Tunneling Cluster Client Tick
@@ -16672,7 +16880,7 @@ EmberAfStatus emberAfTunnelingClusterClientPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTunnelingClusterClientTickCallback(uint8_t endpoint);
+void emberAfTunnelingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Tunneling Cluster Close Tunnel
  *
  *
@@ -16731,7 +16939,7 @@ bool emberAfTunnelingClusterRequestTunnelResponseCallback(uint16_t tunnelId, uin
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfTunnelingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfTunnelingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Tunneling Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -16741,14 +16949,15 @@ void emberAfTunnelingClusterServerAttributeChangedCallback(uint8_t endpoint, Emb
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfTunnelingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfTunnelingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                          EmberAfStatus status);
 /** @brief Tunneling Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfTunnelingClusterServerInitCallback(uint8_t endpoint);
+void emberAfTunnelingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Tunneling Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -16758,7 +16967,8 @@ void emberAfTunnelingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfTunnelingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfTunnelingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                uint16_t manufacturerCode);
 /** @brief Tunneling Cluster Server Message Sent
  *
@@ -16785,7 +16995,7 @@ void emberAfTunnelingClusterServerMessageSentCallback(EmberOutgoingMessageType t
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfTunnelingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfTunnelingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                        EmberAfAttributeType attributeType, uint8_t size,
                                                                        uint8_t * value);
 /** @brief Tunneling Cluster Server Tick
@@ -16794,7 +17004,7 @@ EmberAfStatus emberAfTunnelingClusterServerPreAttributeChangedCallback(uint8_t e
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfTunnelingClusterServerTickCallback(uint8_t endpoint);
+void emberAfTunnelingClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Tunneling Cluster Supported Tunnel Protocols Response
  *
  *
@@ -16899,7 +17109,7 @@ bool emberAfPrepaymentClusterChangePaymentModeResponseCallback(uint8_t friendlyC
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPrepaymentClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPrepaymentClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Prepayment Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -16909,14 +17119,15 @@ void emberAfPrepaymentClusterClientAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPrepaymentClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPrepaymentClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Prepayment Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPrepaymentClusterClientInitCallback(uint8_t endpoint);
+void emberAfPrepaymentClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Prepayment Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -16926,7 +17137,8 @@ void emberAfPrepaymentClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPrepaymentClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPrepaymentClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Prepayment Cluster Client Message Sent
  *
@@ -16953,7 +17165,7 @@ void emberAfPrepaymentClusterClientMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPrepaymentClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPrepaymentClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Prepayment Cluster Client Tick
@@ -16962,7 +17174,7 @@ EmberAfStatus emberAfPrepaymentClusterClientPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPrepaymentClusterClientTickCallback(uint8_t endpoint);
+void emberAfPrepaymentClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Prepayment Cluster Consumer Top Up
  *
  *
@@ -17082,7 +17294,7 @@ bool emberAfPrepaymentClusterSelectAvailableEmergencyCreditCallback(uint32_t com
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPrepaymentClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPrepaymentClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Prepayment Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -17092,14 +17304,15 @@ void emberAfPrepaymentClusterServerAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPrepaymentClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPrepaymentClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief Prepayment Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPrepaymentClusterServerInitCallback(uint8_t endpoint);
+void emberAfPrepaymentClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Prepayment Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -17109,7 +17322,8 @@ void emberAfPrepaymentClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPrepaymentClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPrepaymentClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief Prepayment Cluster Server Message Sent
  *
@@ -17136,7 +17350,7 @@ void emberAfPrepaymentClusterServerMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPrepaymentClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPrepaymentClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief Prepayment Cluster Server Tick
@@ -17145,7 +17359,7 @@ EmberAfStatus emberAfPrepaymentClusterServerPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPrepaymentClusterServerTickCallback(uint8_t endpoint);
+void emberAfPrepaymentClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Prepayment Cluster Set Low Credit Warning Level
  *
  *
@@ -17190,7 +17404,7 @@ bool emberAfPrepaymentClusterSetOverallDebtCapCallback(uint32_t providerId, uint
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfEnergyManagementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfEnergyManagementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Energy Management Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -17200,14 +17414,15 @@ void emberAfEnergyManagementClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEnergyManagementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfEnergyManagementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Energy Management Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEnergyManagementClusterClientInitCallback(uint8_t endpoint);
+void emberAfEnergyManagementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Energy Management Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -17217,8 +17432,8 @@ void emberAfEnergyManagementClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfEnergyManagementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfEnergyManagementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Energy Management Cluster Client Message Sent
  *
@@ -17245,7 +17460,8 @@ void emberAfEnergyManagementClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfEnergyManagementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfEnergyManagementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Energy Management Cluster Client Tick
@@ -17254,7 +17470,7 @@ EmberAfStatus emberAfEnergyManagementClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEnergyManagementClusterClientTickCallback(uint8_t endpoint);
+void emberAfEnergyManagementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Energy Management Cluster Manage Event
  *
  *
@@ -17293,7 +17509,7 @@ bool emberAfEnergyManagementClusterReportEventStatusCallback(uint32_t issuerEven
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfEnergyManagementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfEnergyManagementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Energy Management Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -17303,14 +17519,15 @@ void emberAfEnergyManagementClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEnergyManagementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfEnergyManagementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Energy Management Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEnergyManagementClusterServerInitCallback(uint8_t endpoint);
+void emberAfEnergyManagementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Energy Management Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -17320,8 +17537,8 @@ void emberAfEnergyManagementClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfEnergyManagementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfEnergyManagementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Energy Management Cluster Server Message Sent
  *
@@ -17348,7 +17565,8 @@ void emberAfEnergyManagementClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfEnergyManagementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfEnergyManagementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Energy Management Cluster Server Tick
@@ -17357,7 +17575,7 @@ EmberAfStatus emberAfEnergyManagementClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEnergyManagementClusterServerTickCallback(uint8_t endpoint);
+void emberAfEnergyManagementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Energy Management Cluster Callbacks */
 
@@ -17380,7 +17598,7 @@ bool emberAfCalendarClusterCancelCalendarCallback(uint32_t providerId, uint32_t 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfCalendarClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfCalendarClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Calendar Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -17390,14 +17608,15 @@ void emberAfCalendarClusterClientAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCalendarClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfCalendarClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Calendar Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCalendarClusterClientInitCallback(uint8_t endpoint);
+void emberAfCalendarClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Calendar Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -17407,7 +17626,8 @@ void emberAfCalendarClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfCalendarClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfCalendarClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Calendar Cluster Client Message Sent
  *
@@ -17434,7 +17654,7 @@ void emberAfCalendarClusterClientMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfCalendarClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfCalendarClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Calendar Cluster Client Tick
@@ -17443,7 +17663,7 @@ EmberAfStatus emberAfCalendarClusterClientPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCalendarClusterClientTickCallback(uint8_t endpoint);
+void emberAfCalendarClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Calendar Cluster Get Calendar
  *
  *
@@ -17599,7 +17819,7 @@ bool emberAfCalendarClusterPublishWeekProfileCallback(uint32_t providerId, uint3
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfCalendarClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfCalendarClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Calendar Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -17609,14 +17829,15 @@ void emberAfCalendarClusterServerAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfCalendarClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfCalendarClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Calendar Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfCalendarClusterServerInitCallback(uint8_t endpoint);
+void emberAfCalendarClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Calendar Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -17626,7 +17847,8 @@ void emberAfCalendarClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfCalendarClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfCalendarClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Calendar Cluster Server Message Sent
  *
@@ -17653,7 +17875,7 @@ void emberAfCalendarClusterServerMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfCalendarClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfCalendarClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Calendar Cluster Server Tick
@@ -17662,7 +17884,7 @@ EmberAfStatus emberAfCalendarClusterServerPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfCalendarClusterServerTickCallback(uint8_t endpoint);
+void emberAfCalendarClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Calendar Cluster Callbacks */
 
@@ -17676,7 +17898,7 @@ void emberAfCalendarClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDeviceManagementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDeviceManagementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Device Management Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -17686,14 +17908,15 @@ void emberAfDeviceManagementClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDeviceManagementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDeviceManagementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Device Management Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDeviceManagementClusterClientInitCallback(uint8_t endpoint);
+void emberAfDeviceManagementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Device Management Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -17703,8 +17926,8 @@ void emberAfDeviceManagementClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDeviceManagementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfDeviceManagementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Device Management Cluster Client Message Sent
  *
@@ -17731,7 +17954,8 @@ void emberAfDeviceManagementClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDeviceManagementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDeviceManagementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Device Management Cluster Client Tick
@@ -17740,7 +17964,7 @@ EmberAfStatus emberAfDeviceManagementClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDeviceManagementClusterClientTickCallback(uint8_t endpoint);
+void emberAfDeviceManagementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Device Management Cluster Get C I N
  *
  *
@@ -17840,7 +18064,7 @@ bool emberAfDeviceManagementClusterRequestNewPasswordResponseCallback(uint32_t i
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDeviceManagementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDeviceManagementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Device Management Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -17850,14 +18074,15 @@ void emberAfDeviceManagementClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDeviceManagementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDeviceManagementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Device Management Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDeviceManagementClusterServerInitCallback(uint8_t endpoint);
+void emberAfDeviceManagementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Device Management Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -17867,8 +18092,8 @@ void emberAfDeviceManagementClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDeviceManagementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfDeviceManagementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Device Management Cluster Server Message Sent
  *
@@ -17895,7 +18120,8 @@ void emberAfDeviceManagementClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDeviceManagementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDeviceManagementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Device Management Cluster Server Tick
@@ -17904,7 +18130,7 @@ EmberAfStatus emberAfDeviceManagementClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDeviceManagementClusterServerTickCallback(uint8_t endpoint);
+void emberAfDeviceManagementClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Device Management Cluster Set Event Configuration
  *
  *
@@ -17967,7 +18193,7 @@ bool emberAfEventsClusterClearEventLogResponseCallback(uint8_t clearedEventsLogs
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfEventsClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfEventsClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Events Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -17977,14 +18203,14 @@ void emberAfEventsClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEventsClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfEventsClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Events Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEventsClusterClientInitCallback(uint8_t endpoint);
+void emberAfEventsClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Events Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -17994,7 +18220,8 @@ void emberAfEventsClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfEventsClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfEventsClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Events Cluster Client Message Sent
  *
@@ -18021,7 +18248,7 @@ void emberAfEventsClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfEventsClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfEventsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Events Cluster Client Tick
@@ -18030,7 +18257,7 @@ EmberAfStatus emberAfEventsClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEventsClusterClientTickCallback(uint8_t endpoint);
+void emberAfEventsClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Events Cluster Get Event Log
  *
  *
@@ -18075,7 +18302,7 @@ bool emberAfEventsClusterPublishEventLogCallback(uint16_t totalNumberOfEvents, u
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfEventsClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfEventsClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Events Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -18085,14 +18312,14 @@ void emberAfEventsClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfEventsClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfEventsClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Events Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfEventsClusterServerInitCallback(uint8_t endpoint);
+void emberAfEventsClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Events Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -18102,7 +18329,8 @@ void emberAfEventsClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfEventsClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfEventsClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Events Cluster Server Message Sent
  *
@@ -18129,7 +18357,7 @@ void emberAfEventsClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfEventsClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfEventsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Events Cluster Server Tick
@@ -18138,7 +18366,7 @@ EmberAfStatus emberAfEventsClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfEventsClusterServerTickCallback(uint8_t endpoint);
+void emberAfEventsClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Events Cluster Callbacks */
 
@@ -18152,7 +18380,7 @@ void emberAfEventsClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMduPairingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMduPairingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief MDU Pairing Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -18162,14 +18390,15 @@ void emberAfMduPairingClusterClientAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMduPairingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMduPairingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief MDU Pairing Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMduPairingClusterClientInitCallback(uint8_t endpoint);
+void emberAfMduPairingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief MDU Pairing Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -18179,7 +18408,8 @@ void emberAfMduPairingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfMduPairingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfMduPairingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief MDU Pairing Cluster Client Message Sent
  *
@@ -18206,7 +18436,7 @@ void emberAfMduPairingClusterClientMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMduPairingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMduPairingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief MDU Pairing Cluster Client Tick
@@ -18215,7 +18445,7 @@ EmberAfStatus emberAfMduPairingClusterClientPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMduPairingClusterClientTickCallback(uint8_t endpoint);
+void emberAfMduPairingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief MDU Pairing Cluster Pairing Request
  *
  *
@@ -18243,7 +18473,7 @@ bool emberAfMduPairingClusterPairingResponseCallback(uint32_t pairingInformation
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMduPairingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMduPairingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief MDU Pairing Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -18253,14 +18483,15 @@ void emberAfMduPairingClusterServerAttributeChangedCallback(uint8_t endpoint, Em
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMduPairingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMduPairingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                           EmberAfStatus status);
 /** @brief MDU Pairing Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMduPairingClusterServerInitCallback(uint8_t endpoint);
+void emberAfMduPairingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief MDU Pairing Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -18270,7 +18501,8 @@ void emberAfMduPairingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfMduPairingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfMduPairingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 uint16_t manufacturerCode);
 /** @brief MDU Pairing Cluster Server Message Sent
  *
@@ -18297,7 +18529,7 @@ void emberAfMduPairingClusterServerMessageSentCallback(EmberOutgoingMessageType 
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMduPairingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMduPairingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                         EmberAfAttributeType attributeType, uint8_t size,
                                                                         uint8_t * value);
 /** @brief MDU Pairing Cluster Server Tick
@@ -18306,7 +18538,7 @@ EmberAfStatus emberAfMduPairingClusterServerPreAttributeChangedCallback(uint8_t 
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMduPairingClusterServerTickCallback(uint8_t endpoint);
+void emberAfMduPairingClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END MDU Pairing Cluster Callbacks */
 
@@ -18320,7 +18552,7 @@ void emberAfMduPairingClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSubGhzClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSubGhzClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Sub-GHz Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -18330,14 +18562,14 @@ void emberAfSubGhzClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSubGhzClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSubGhzClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Sub-GHz Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSubGhzClusterClientInitCallback(uint8_t endpoint);
+void emberAfSubGhzClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Sub-GHz Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -18347,7 +18579,8 @@ void emberAfSubGhzClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfSubGhzClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfSubGhzClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Sub-GHz Cluster Client Message Sent
  *
@@ -18374,7 +18607,7 @@ void emberAfSubGhzClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSubGhzClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSubGhzClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Sub-GHz Cluster Client Tick
@@ -18383,7 +18616,7 @@ EmberAfStatus emberAfSubGhzClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSubGhzClusterClientTickCallback(uint8_t endpoint);
+void emberAfSubGhzClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Sub-GHz Cluster Get Suspend Zcl Messages Status
  *
  *
@@ -18397,7 +18630,7 @@ bool emberAfSubGhzClusterGetSuspendZclMessagesStatusCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSubGhzClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSubGhzClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Sub-GHz Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -18407,14 +18640,14 @@ void emberAfSubGhzClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSubGhzClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSubGhzClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Sub-GHz Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSubGhzClusterServerInitCallback(uint8_t endpoint);
+void emberAfSubGhzClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Sub-GHz Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -18424,7 +18657,8 @@ void emberAfSubGhzClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfSubGhzClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfSubGhzClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Sub-GHz Cluster Server Message Sent
  *
@@ -18451,7 +18685,7 @@ void emberAfSubGhzClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSubGhzClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSubGhzClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Sub-GHz Cluster Server Tick
@@ -18460,7 +18694,7 @@ EmberAfStatus emberAfSubGhzClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSubGhzClusterServerTickCallback(uint8_t endpoint);
+void emberAfSubGhzClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Sub-GHz Cluster Suspend Zcl Messages
  *
  *
@@ -18492,7 +18726,7 @@ bool emberAfKeyEstablishmentClusterClientCommandReceivedCallback(EmberAfClusterC
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfKeyEstablishmentClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfKeyEstablishmentClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Key Establishment Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -18502,14 +18736,15 @@ void emberAfKeyEstablishmentClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfKeyEstablishmentClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfKeyEstablishmentClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Key Establishment Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfKeyEstablishmentClusterClientInitCallback(uint8_t endpoint);
+void emberAfKeyEstablishmentClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Key Establishment Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -18519,8 +18754,8 @@ void emberAfKeyEstablishmentClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfKeyEstablishmentClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfKeyEstablishmentClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Key Establishment Cluster Client Message Sent
  *
@@ -18547,7 +18782,8 @@ void emberAfKeyEstablishmentClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfKeyEstablishmentClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfKeyEstablishmentClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Key Establishment Cluster Client Tick
@@ -18556,7 +18792,7 @@ EmberAfStatus emberAfKeyEstablishmentClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfKeyEstablishmentClusterClientTickCallback(uint8_t endpoint);
+void emberAfKeyEstablishmentClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Key Establishment Cluster Confirm Key Data Request
  *
  *
@@ -18616,7 +18852,7 @@ bool emberAfKeyEstablishmentClusterInitiateKeyEstablishmentResponseCallback(uint
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfKeyEstablishmentClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfKeyEstablishmentClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Key Establishment Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -18626,14 +18862,15 @@ void emberAfKeyEstablishmentClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfKeyEstablishmentClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfKeyEstablishmentClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Key Establishment Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfKeyEstablishmentClusterServerInitCallback(uint8_t endpoint);
+void emberAfKeyEstablishmentClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Key Establishment Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -18643,8 +18880,8 @@ void emberAfKeyEstablishmentClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfKeyEstablishmentClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfKeyEstablishmentClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Key Establishment Cluster Server Message Sent
  *
@@ -18671,7 +18908,8 @@ void emberAfKeyEstablishmentClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfKeyEstablishmentClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfKeyEstablishmentClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Key Establishment Cluster Server Tick
@@ -18680,7 +18918,7 @@ EmberAfStatus emberAfKeyEstablishmentClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfKeyEstablishmentClusterServerTickCallback(uint8_t endpoint);
+void emberAfKeyEstablishmentClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Key Establishment Cluster Terminate Key Establishment
  *
  *
@@ -18715,7 +18953,7 @@ bool emberAfKeyEstablishmentClusterServerCommandReceivedCallback(EmberAfClusterC
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfInformationClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfInformationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Information Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -18725,14 +18963,15 @@ void emberAfInformationClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfInformationClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfInformationClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Information Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfInformationClusterClientInitCallback(uint8_t endpoint);
+void emberAfInformationClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Information Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -18742,7 +18981,8 @@ void emberAfInformationClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfInformationClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfInformationClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Information Cluster Client Message Sent
  *
@@ -18769,7 +19009,7 @@ void emberAfInformationClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfInformationClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfInformationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Information Cluster Client Tick
@@ -18778,7 +19018,7 @@ EmberAfStatus emberAfInformationClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfInformationClusterClientTickCallback(uint8_t endpoint);
+void emberAfInformationClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Information Cluster Configure Delivery Enable
  *
  *
@@ -18893,7 +19133,7 @@ bool emberAfInformationClusterSendPreferenceResponseCallback(uint8_t * statusFee
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfInformationClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfInformationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Information Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -18903,14 +19143,15 @@ void emberAfInformationClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfInformationClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfInformationClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Information Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfInformationClusterServerInitCallback(uint8_t endpoint);
+void emberAfInformationClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Information Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -18920,7 +19161,8 @@ void emberAfInformationClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfInformationClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfInformationClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Information Cluster Server Message Sent
  *
@@ -18947,7 +19189,7 @@ void emberAfInformationClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfInformationClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfInformationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Information Cluster Server Request Preference
@@ -18962,7 +19204,7 @@ bool emberAfInformationClusterServerRequestPreferenceCallback(void);
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfInformationClusterServerTickCallback(uint8_t endpoint);
+void emberAfInformationClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Information Cluster Update
  *
  *
@@ -18992,7 +19234,7 @@ bool emberAfInformationClusterUpdateResponseCallback(uint8_t * notificationList)
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDataSharingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDataSharingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Data Sharing Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -19002,14 +19244,15 @@ void emberAfDataSharingClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDataSharingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDataSharingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Data Sharing Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDataSharingClusterClientInitCallback(uint8_t endpoint);
+void emberAfDataSharingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Data Sharing Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -19019,7 +19262,8 @@ void emberAfDataSharingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDataSharingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDataSharingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Data Sharing Cluster Client Message Sent
  *
@@ -19046,7 +19290,7 @@ void emberAfDataSharingClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDataSharingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDataSharingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Data Sharing Cluster Client Tick
@@ -19055,7 +19299,7 @@ EmberAfStatus emberAfDataSharingClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDataSharingClusterClientTickCallback(uint8_t endpoint);
+void emberAfDataSharingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Data Sharing Cluster File Transmission
  *
  *
@@ -19113,7 +19357,7 @@ bool emberAfDataSharingClusterRecordTransmissionCallback(uint8_t transmitOptions
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDataSharingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDataSharingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Data Sharing Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -19123,14 +19367,15 @@ void emberAfDataSharingClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDataSharingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDataSharingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Data Sharing Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDataSharingClusterServerInitCallback(uint8_t endpoint);
+void emberAfDataSharingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Data Sharing Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -19140,7 +19385,8 @@ void emberAfDataSharingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDataSharingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDataSharingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Data Sharing Cluster Server Message Sent
  *
@@ -19167,7 +19413,7 @@ void emberAfDataSharingClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDataSharingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDataSharingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Data Sharing Cluster Server Tick
@@ -19176,7 +19422,7 @@ EmberAfStatus emberAfDataSharingClusterServerPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDataSharingClusterServerTickCallback(uint8_t endpoint);
+void emberAfDataSharingClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Data Sharing Cluster Write File Request
  *
  *
@@ -19213,7 +19459,7 @@ bool emberAfGamingClusterActionControlCallback(uint32_t actions);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGamingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGamingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Gaming Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -19223,14 +19469,14 @@ void emberAfGamingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGamingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGamingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Gaming Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGamingClusterClientInitCallback(uint8_t endpoint);
+void emberAfGamingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Gaming Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -19240,7 +19486,8 @@ void emberAfGamingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGamingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGamingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Gaming Cluster Client Message Sent
  *
@@ -19267,7 +19514,7 @@ void emberAfGamingClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGamingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGamingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Gaming Cluster Client Tick
@@ -19276,7 +19523,7 @@ EmberAfStatus emberAfGamingClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGamingClusterClientTickCallback(uint8_t endpoint);
+void emberAfGamingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Gaming Cluster Download Game
  *
  *
@@ -19306,7 +19553,7 @@ bool emberAfGamingClusterGameAnnouncementCallback(uint16_t gameId, uint8_t gameM
  * @param status   Ver.: always
  * @param message   Ver.: always
  */
-bool emberAfGamingClusterGeneralResponseCallback(uint8_t commandId, uint8_t status, uint8_t * message);
+bool emberAfGamingClusterGeneralResponseCallback(chip::CommandId commandId, uint8_t status, uint8_t * message);
 /** @brief Gaming Cluster Join Game
  *
  *
@@ -19349,7 +19596,7 @@ bool emberAfGamingClusterSearchGameCallback(uint8_t specificGame, uint16_t gameI
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfGamingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfGamingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Gaming Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -19359,14 +19606,14 @@ void emberAfGamingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfGamingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfGamingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Gaming Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfGamingClusterServerInitCallback(uint8_t endpoint);
+void emberAfGamingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Gaming Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -19376,7 +19623,8 @@ void emberAfGamingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfGamingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfGamingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief Gaming Cluster Server Message Sent
  *
@@ -19403,7 +19651,7 @@ void emberAfGamingClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfGamingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfGamingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief Gaming Cluster Server Tick
@@ -19412,7 +19660,7 @@ EmberAfStatus emberAfGamingClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfGamingClusterServerTickCallback(uint8_t endpoint);
+void emberAfGamingClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Gaming Cluster Start Game
  *
  *
@@ -19438,7 +19686,7 @@ bool emberAfGamingClusterStartOverCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDataRateControlClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDataRateControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Data Rate Control Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -19448,14 +19696,15 @@ void emberAfDataRateControlClusterClientAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDataRateControlClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDataRateControlClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Data Rate Control Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDataRateControlClusterClientInitCallback(uint8_t endpoint);
+void emberAfDataRateControlClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Data Rate Control Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -19465,8 +19714,8 @@ void emberAfDataRateControlClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDataRateControlClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfDataRateControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Data Rate Control Cluster Client Message Sent
  *
@@ -19493,7 +19742,8 @@ void emberAfDataRateControlClusterClientMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDataRateControlClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDataRateControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Data Rate Control Cluster Client Tick
@@ -19502,7 +19752,7 @@ EmberAfStatus emberAfDataRateControlClusterClientPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDataRateControlClusterClientTickCallback(uint8_t endpoint);
+void emberAfDataRateControlClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Data Rate Control Cluster Data Rate Control
  *
  *
@@ -19547,7 +19797,7 @@ bool emberAfDataRateControlClusterPathDeletionCallback(uint16_t originatorAddres
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDataRateControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDataRateControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Data Rate Control Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -19557,14 +19807,15 @@ void emberAfDataRateControlClusterServerAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDataRateControlClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDataRateControlClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Data Rate Control Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDataRateControlClusterServerInitCallback(uint8_t endpoint);
+void emberAfDataRateControlClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Data Rate Control Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -19574,8 +19825,8 @@ void emberAfDataRateControlClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDataRateControlClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfDataRateControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Data Rate Control Cluster Server Message Sent
  *
@@ -19602,7 +19853,8 @@ void emberAfDataRateControlClusterServerMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDataRateControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDataRateControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Data Rate Control Cluster Server Tick
@@ -19611,7 +19863,7 @@ EmberAfStatus emberAfDataRateControlClusterServerPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDataRateControlClusterServerTickCallback(uint8_t endpoint);
+void emberAfDataRateControlClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Data Rate Control Cluster Callbacks */
 
@@ -19625,7 +19877,7 @@ void emberAfDataRateControlClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfVoiceOverZigbeeClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Voice over ZigBee Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -19635,14 +19887,15 @@ void emberAfVoiceOverZigbeeClusterClientAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfVoiceOverZigbeeClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Voice over ZigBee Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterClientInitCallback(uint8_t endpoint);
+void emberAfVoiceOverZigbeeClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Voice over ZigBee Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -19652,8 +19905,8 @@ void emberAfVoiceOverZigbeeClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfVoiceOverZigbeeClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Voice over ZigBee Cluster Client Message Sent
  *
@@ -19680,7 +19933,8 @@ void emberAfVoiceOverZigbeeClusterClientMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfVoiceOverZigbeeClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfVoiceOverZigbeeClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Voice over ZigBee Cluster Client Tick
@@ -19689,7 +19943,7 @@ EmberAfStatus emberAfVoiceOverZigbeeClusterClientPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterClientTickCallback(uint8_t endpoint);
+void emberAfVoiceOverZigbeeClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Voice over ZigBee Cluster Control
  *
  *
@@ -19732,7 +19986,7 @@ bool emberAfVoiceOverZigbeeClusterEstablishmentResponseCallback(uint8_t ackNack,
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfVoiceOverZigbeeClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Voice over ZigBee Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -19742,14 +19996,15 @@ void emberAfVoiceOverZigbeeClusterServerAttributeChangedCallback(uint8_t endpoin
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfVoiceOverZigbeeClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                EmberAfStatus status);
 /** @brief Voice over ZigBee Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterServerInitCallback(uint8_t endpoint);
+void emberAfVoiceOverZigbeeClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Voice over ZigBee Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -19759,8 +20014,8 @@ void emberAfVoiceOverZigbeeClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+void emberAfVoiceOverZigbeeClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      uint16_t manufacturerCode);
 /** @brief Voice over ZigBee Cluster Server Message Sent
  *
@@ -19787,7 +20042,8 @@ void emberAfVoiceOverZigbeeClusterServerMessageSentCallback(EmberOutgoingMessage
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfVoiceOverZigbeeClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfVoiceOverZigbeeClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              EmberAfAttributeType attributeType, uint8_t size,
                                                                              uint8_t * value);
 /** @brief Voice over ZigBee Cluster Server Tick
@@ -19796,7 +20052,7 @@ EmberAfStatus emberAfVoiceOverZigbeeClusterServerPreAttributeChangedCallback(uin
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfVoiceOverZigbeeClusterServerTickCallback(uint8_t endpoint);
+void emberAfVoiceOverZigbeeClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Voice over ZigBee Cluster Voice Transmission
  *
  *
@@ -19843,7 +20099,7 @@ bool emberAfChattingClusterChatMessageCallback(uint16_t destinationUid, uint16_t
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChattingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfChattingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Chatting Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -19853,14 +20109,15 @@ void emberAfChattingClusterClientAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChattingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfChattingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Chatting Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChattingClusterClientInitCallback(uint8_t endpoint);
+void emberAfChattingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Chatting Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -19870,7 +20127,8 @@ void emberAfChattingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfChattingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfChattingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Chatting Cluster Client Message Sent
  *
@@ -19897,7 +20155,7 @@ void emberAfChattingClusterClientMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfChattingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfChattingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Chatting Cluster Client Tick
@@ -19906,7 +20164,7 @@ EmberAfStatus emberAfChattingClusterClientPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChattingClusterClientTickCallback(uint8_t endpoint);
+void emberAfChattingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Chatting Cluster Get Node Information Request
  *
  *
@@ -19973,7 +20231,7 @@ bool emberAfChattingClusterSearchChatResponseCallback(uint8_t options, uint8_t *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfChattingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfChattingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Chatting Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -19983,14 +20241,15 @@ void emberAfChattingClusterServerAttributeChangedCallback(uint8_t endpoint, Embe
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfChattingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfChattingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                         EmberAfStatus status);
 /** @brief Chatting Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfChattingClusterServerInitCallback(uint8_t endpoint);
+void emberAfChattingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Chatting Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -20000,7 +20259,8 @@ void emberAfChattingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfChattingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfChattingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               uint16_t manufacturerCode);
 /** @brief Chatting Cluster Server Message Sent
  *
@@ -20027,7 +20287,7 @@ void emberAfChattingClusterServerMessageSentCallback(EmberOutgoingMessageType ty
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfChattingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfChattingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                       EmberAfAttributeType attributeType, uint8_t size,
                                                                       uint8_t * value);
 /** @brief Chatting Cluster Server Tick
@@ -20036,7 +20296,7 @@ EmberAfStatus emberAfChattingClusterServerPreAttributeChangedCallback(uint8_t en
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfChattingClusterServerTickCallback(uint8_t endpoint);
+void emberAfChattingClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Chatting Cluster Start Chat Request
  *
  *
@@ -20071,7 +20331,8 @@ bool emberAfChattingClusterSwitchChairmanConfirmCallback(uint16_t cid, uint8_t *
  * @param address   Ver.: always
  * @param endpoint   Ver.: always
  */
-bool emberAfChattingClusterSwitchChairmanNotificationCallback(uint16_t cid, uint16_t uid, uint16_t address, uint8_t endpoint);
+bool emberAfChattingClusterSwitchChairmanNotificationCallback(uint16_t cid, uint16_t uid, uint16_t address,
+                                                              chip::EndpointId endpoint);
 /** @brief Chatting Cluster Switch Chairman Request
  *
  *
@@ -20152,7 +20413,7 @@ bool emberAfPaymentClusterBuyRequestCallback(uint8_t * userId, uint16_t userType
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPaymentClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPaymentClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Payment Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -20162,14 +20423,14 @@ void emberAfPaymentClusterClientAttributeChangedCallback(uint8_t endpoint, Ember
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPaymentClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPaymentClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Payment Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPaymentClusterClientInitCallback(uint8_t endpoint);
+void emberAfPaymentClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Payment Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -20179,7 +20440,8 @@ void emberAfPaymentClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPaymentClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPaymentClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              uint16_t manufacturerCode);
 /** @brief Payment Cluster Client Message Sent
  *
@@ -20206,7 +20468,7 @@ void emberAfPaymentClusterClientMessageSentCallback(EmberOutgoingMessageType typ
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPaymentClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPaymentClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                      EmberAfAttributeType attributeType, uint8_t size,
                                                                      uint8_t * value);
 /** @brief Payment Cluster Client Tick
@@ -20215,7 +20477,7 @@ EmberAfStatus emberAfPaymentClusterClientPreAttributeChangedCallback(uint8_t end
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPaymentClusterClientTickCallback(uint8_t endpoint);
+void emberAfPaymentClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Payment Cluster Payment Confirm
  *
  *
@@ -20244,7 +20506,7 @@ bool emberAfPaymentClusterReceiptDeliveryCallback(uint8_t * serialNumber, uint32
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfPaymentClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfPaymentClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Payment Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -20254,14 +20516,14 @@ void emberAfPaymentClusterServerAttributeChangedCallback(uint8_t endpoint, Ember
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfPaymentClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfPaymentClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Payment Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPaymentClusterServerInitCallback(uint8_t endpoint);
+void emberAfPaymentClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Payment Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -20271,7 +20533,8 @@ void emberAfPaymentClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfPaymentClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfPaymentClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              uint16_t manufacturerCode);
 /** @brief Payment Cluster Server Message Sent
  *
@@ -20298,7 +20561,7 @@ void emberAfPaymentClusterServerMessageSentCallback(EmberOutgoingMessageType typ
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfPaymentClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPaymentClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                      EmberAfAttributeType attributeType, uint8_t size,
                                                                      uint8_t * value);
 /** @brief Payment Cluster Server Tick
@@ -20307,7 +20570,7 @@ EmberAfStatus emberAfPaymentClusterServerPreAttributeChangedCallback(uint8_t end
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfPaymentClusterServerTickCallback(uint8_t endpoint);
+void emberAfPaymentClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Payment Cluster Transaction End
  *
  *
@@ -20346,7 +20609,7 @@ bool emberAfBillingClusterCheckBillStatusCallback(uint8_t * userId, uint16_t ser
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBillingClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBillingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Billing Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -20356,14 +20619,14 @@ void emberAfBillingClusterClientAttributeChangedCallback(uint8_t endpoint, Ember
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBillingClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBillingClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Billing Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBillingClusterClientInitCallback(uint8_t endpoint);
+void emberAfBillingClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Billing Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -20373,7 +20636,8 @@ void emberAfBillingClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBillingClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfBillingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              uint16_t manufacturerCode);
 /** @brief Billing Cluster Client Message Sent
  *
@@ -20400,7 +20664,7 @@ void emberAfBillingClusterClientMessageSentCallback(EmberOutgoingMessageType typ
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBillingClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBillingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                      EmberAfAttributeType attributeType, uint8_t size,
                                                                      uint8_t * value);
 /** @brief Billing Cluster Client Tick
@@ -20409,7 +20673,7 @@ EmberAfStatus emberAfBillingClusterClientPreAttributeChangedCallback(uint8_t end
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBillingClusterClientTickCallback(uint8_t endpoint);
+void emberAfBillingClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Billing Cluster Send Bill Record
  *
  *
@@ -20429,7 +20693,7 @@ bool emberAfBillingClusterSendBillRecordCallback(uint8_t * userId, uint16_t serv
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfBillingClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfBillingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Billing Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -20439,14 +20703,14 @@ void emberAfBillingClusterServerAttributeChangedCallback(uint8_t endpoint, Ember
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfBillingClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfBillingClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief Billing Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfBillingClusterServerInitCallback(uint8_t endpoint);
+void emberAfBillingClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Billing Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -20456,7 +20720,8 @@ void emberAfBillingClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfBillingClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfBillingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                             chip::AttributeId attributeId,
                                                                              uint16_t manufacturerCode);
 /** @brief Billing Cluster Server Message Sent
  *
@@ -20483,7 +20748,7 @@ void emberAfBillingClusterServerMessageSentCallback(EmberOutgoingMessageType typ
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfBillingClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfBillingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                      EmberAfAttributeType attributeType, uint8_t size,
                                                                      uint8_t * value);
 /** @brief Billing Cluster Server Tick
@@ -20492,7 +20757,7 @@ EmberAfStatus emberAfBillingClusterServerPreAttributeChangedCallback(uint8_t end
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfBillingClusterServerTickCallback(uint8_t endpoint);
+void emberAfBillingClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Billing Cluster Session Keep Alive
  *
  *
@@ -20551,7 +20816,7 @@ bool emberAfBillingClusterUnsubscribeCallback(uint8_t * userId, uint16_t service
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceIdentificationClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceIdentificationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Identification Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -20561,14 +20826,15 @@ void emberAfApplianceIdentificationClusterClientAttributeChangedCallback(uint8_t
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceIdentificationClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceIdentificationClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                        EmberAfStatus status);
 /** @brief Appliance Identification Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceIdentificationClusterClientInitCallback(uint8_t endpoint);
+void emberAfApplianceIdentificationClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Identification Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -20579,7 +20845,7 @@ void emberAfApplianceIdentificationClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfApplianceIdentificationClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              uint16_t manufacturerCode);
 /** @brief Appliance Identification Cluster Client Message Sent
  *
@@ -20606,8 +20872,8 @@ void emberAfApplianceIdentificationClusterClientMessageSentCallback(EmberOutgoin
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceIdentificationClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceIdentificationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      EmberAfAttributeType attributeType,
                                                                                      uint8_t size, uint8_t * value);
 /** @brief Appliance Identification Cluster Client Tick
@@ -20616,7 +20882,7 @@ EmberAfStatus emberAfApplianceIdentificationClusterClientPreAttributeChangedCall
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceIdentificationClusterClientTickCallback(uint8_t endpoint);
+void emberAfApplianceIdentificationClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Appliance Identification Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -20624,7 +20890,7 @@ void emberAfApplianceIdentificationClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceIdentificationClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceIdentificationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Identification Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -20634,14 +20900,15 @@ void emberAfApplianceIdentificationClusterServerAttributeChangedCallback(uint8_t
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceIdentificationClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceIdentificationClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                        EmberAfStatus status);
 /** @brief Appliance Identification Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceIdentificationClusterServerInitCallback(uint8_t endpoint);
+void emberAfApplianceIdentificationClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Identification Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -20652,7 +20919,7 @@ void emberAfApplianceIdentificationClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfApplianceIdentificationClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              uint16_t manufacturerCode);
 /** @brief Appliance Identification Cluster Server Message Sent
  *
@@ -20679,8 +20946,8 @@ void emberAfApplianceIdentificationClusterServerMessageSentCallback(EmberOutgoin
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceIdentificationClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceIdentificationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      EmberAfAttributeType attributeType,
                                                                                      uint8_t size, uint8_t * value);
 /** @brief Appliance Identification Cluster Server Tick
@@ -20689,7 +20956,7 @@ EmberAfStatus emberAfApplianceIdentificationClusterServerPreAttributeChangedCall
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceIdentificationClusterServerTickCallback(uint8_t endpoint);
+void emberAfApplianceIdentificationClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Appliance Identification Cluster Callbacks */
 
@@ -20703,7 +20970,7 @@ void emberAfApplianceIdentificationClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMeterIdentificationClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMeterIdentificationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Meter Identification Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -20713,14 +20980,15 @@ void emberAfMeterIdentificationClusterClientAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMeterIdentificationClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMeterIdentificationClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief Meter Identification Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMeterIdentificationClusterClientInitCallback(uint8_t endpoint);
+void emberAfMeterIdentificationClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Meter Identification Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -20731,7 +20999,7 @@ void emberAfMeterIdentificationClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfMeterIdentificationClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief Meter Identification Cluster Client Message Sent
  *
@@ -20758,7 +21026,8 @@ void emberAfMeterIdentificationClusterClientMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMeterIdentificationClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMeterIdentificationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief Meter Identification Cluster Client Tick
@@ -20767,7 +21036,7 @@ EmberAfStatus emberAfMeterIdentificationClusterClientPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMeterIdentificationClusterClientTickCallback(uint8_t endpoint);
+void emberAfMeterIdentificationClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Meter Identification Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -20775,7 +21044,7 @@ void emberAfMeterIdentificationClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMeterIdentificationClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMeterIdentificationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Meter Identification Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -20785,14 +21054,15 @@ void emberAfMeterIdentificationClusterServerAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMeterIdentificationClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMeterIdentificationClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief Meter Identification Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMeterIdentificationClusterServerInitCallback(uint8_t endpoint);
+void emberAfMeterIdentificationClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Meter Identification Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -20803,7 +21073,7 @@ void emberAfMeterIdentificationClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfMeterIdentificationClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief Meter Identification Cluster Server Message Sent
  *
@@ -20830,7 +21100,8 @@ void emberAfMeterIdentificationClusterServerMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMeterIdentificationClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMeterIdentificationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief Meter Identification Cluster Server Tick
@@ -20839,7 +21110,7 @@ EmberAfStatus emberAfMeterIdentificationClusterServerPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMeterIdentificationClusterServerTickCallback(uint8_t endpoint);
+void emberAfMeterIdentificationClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Meter Identification Cluster Callbacks */
 
@@ -20861,7 +21132,7 @@ bool emberAfApplianceEventsAndAlertClusterAlertsNotificationCallback(uint8_t ale
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceEventsAndAlertClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Events and Alert Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -20871,14 +21142,15 @@ void emberAfApplianceEventsAndAlertClusterClientAttributeChangedCallback(uint8_t
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceEventsAndAlertClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                        EmberAfStatus status);
 /** @brief Appliance Events and Alert Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterClientInitCallback(uint8_t endpoint);
+void emberAfApplianceEventsAndAlertClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Events and Alert Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -20889,7 +21161,7 @@ void emberAfApplianceEventsAndAlertClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfApplianceEventsAndAlertClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              uint16_t manufacturerCode);
 /** @brief Appliance Events and Alert Cluster Client Message Sent
  *
@@ -20916,8 +21188,8 @@ void emberAfApplianceEventsAndAlertClusterClientMessageSentCallback(EmberOutgoin
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceEventsAndAlertClusterClientPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceEventsAndAlertClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      EmberAfAttributeType attributeType,
                                                                                      uint8_t size, uint8_t * value);
 /** @brief Appliance Events and Alert Cluster Client Tick
@@ -20926,7 +21198,7 @@ EmberAfStatus emberAfApplianceEventsAndAlertClusterClientPreAttributeChangedCall
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterClientTickCallback(uint8_t endpoint);
+void emberAfApplianceEventsAndAlertClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Appliance Events and Alert Cluster Events Notification
  *
  *
@@ -20956,7 +21228,7 @@ bool emberAfApplianceEventsAndAlertClusterGetAlertsResponseCallback(uint8_t aler
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceEventsAndAlertClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Events and Alert Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -20966,14 +21238,15 @@ void emberAfApplianceEventsAndAlertClusterServerAttributeChangedCallback(uint8_t
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceEventsAndAlertClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                        EmberAfStatus status);
 /** @brief Appliance Events and Alert Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterServerInitCallback(uint8_t endpoint);
+void emberAfApplianceEventsAndAlertClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Events and Alert Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -20984,7 +21257,7 @@ void emberAfApplianceEventsAndAlertClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfApplianceEventsAndAlertClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                             EmberAfAttributeId attributeId,
+                                                                                             chip::AttributeId attributeId,
                                                                                              uint16_t manufacturerCode);
 /** @brief Appliance Events and Alert Cluster Server Message Sent
  *
@@ -21011,8 +21284,8 @@ void emberAfApplianceEventsAndAlertClusterServerMessageSentCallback(EmberOutgoin
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceEventsAndAlertClusterServerPreAttributeChangedCallback(uint8_t endpoint,
-                                                                                     EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceEventsAndAlertClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                     chip::AttributeId attributeId,
                                                                                      EmberAfAttributeType attributeType,
                                                                                      uint8_t size, uint8_t * value);
 /** @brief Appliance Events and Alert Cluster Server Tick
@@ -21021,7 +21294,7 @@ EmberAfStatus emberAfApplianceEventsAndAlertClusterServerPreAttributeChangedCall
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceEventsAndAlertClusterServerTickCallback(uint8_t endpoint);
+void emberAfApplianceEventsAndAlertClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Appliance Events and Alert Cluster Callbacks */
 
@@ -21035,7 +21308,7 @@ void emberAfApplianceEventsAndAlertClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceStatisticsClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceStatisticsClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Statistics Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -21045,14 +21318,15 @@ void emberAfApplianceStatisticsClusterClientAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceStatisticsClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceStatisticsClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief Appliance Statistics Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceStatisticsClusterClientInitCallback(uint8_t endpoint);
+void emberAfApplianceStatisticsClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Statistics Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -21063,7 +21337,7 @@ void emberAfApplianceStatisticsClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfApplianceStatisticsClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief Appliance Statistics Cluster Client Message Sent
  *
@@ -21090,7 +21364,8 @@ void emberAfApplianceStatisticsClusterClientMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceStatisticsClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceStatisticsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief Appliance Statistics Cluster Client Tick
@@ -21099,7 +21374,7 @@ EmberAfStatus emberAfApplianceStatisticsClusterClientPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceStatisticsClusterClientTickCallback(uint8_t endpoint);
+void emberAfApplianceStatisticsClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Appliance Statistics Cluster Log Notification
  *
  *
@@ -21150,7 +21425,7 @@ bool emberAfApplianceStatisticsClusterLogResponseCallback(uint32_t timeStamp, ui
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfApplianceStatisticsClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfApplianceStatisticsClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Appliance Statistics Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -21160,14 +21435,15 @@ void emberAfApplianceStatisticsClusterServerAttributeChangedCallback(uint8_t end
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfApplianceStatisticsClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfApplianceStatisticsClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                    EmberAfStatus status);
 /** @brief Appliance Statistics Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfApplianceStatisticsClusterServerInitCallback(uint8_t endpoint);
+void emberAfApplianceStatisticsClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Appliance Statistics Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -21178,7 +21454,7 @@ void emberAfApplianceStatisticsClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfApplianceStatisticsClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                         EmberAfAttributeId attributeId,
+                                                                                         chip::AttributeId attributeId,
                                                                                          uint16_t manufacturerCode);
 /** @brief Appliance Statistics Cluster Server Message Sent
  *
@@ -21205,7 +21481,8 @@ void emberAfApplianceStatisticsClusterServerMessageSentCallback(EmberOutgoingMes
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfApplianceStatisticsClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfApplianceStatisticsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  EmberAfAttributeType attributeType, uint8_t size,
                                                                                  uint8_t * value);
 /** @brief Appliance Statistics Cluster Server Tick
@@ -21214,7 +21491,7 @@ EmberAfStatus emberAfApplianceStatisticsClusterServerPreAttributeChangedCallback
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfApplianceStatisticsClusterServerTickCallback(uint8_t endpoint);
+void emberAfApplianceStatisticsClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Appliance Statistics Cluster Statistics Available
  *
  *
@@ -21236,7 +21513,7 @@ bool emberAfApplianceStatisticsClusterStatisticsAvailableCallback(uint8_t logQue
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfElectricalMeasurementClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfElectricalMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Electrical Measurement Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -21246,14 +21523,15 @@ void emberAfElectricalMeasurementClusterClientAttributeChangedCallback(uint8_t e
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfElectricalMeasurementClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfElectricalMeasurementClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                      EmberAfStatus status);
 /** @brief Electrical Measurement Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfElectricalMeasurementClusterClientInitCallback(uint8_t endpoint);
+void emberAfElectricalMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Electrical Measurement Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -21264,7 +21542,7 @@ void emberAfElectricalMeasurementClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfElectricalMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                           EmberAfAttributeId attributeId,
+                                                                                           chip::AttributeId attributeId,
                                                                                            uint16_t manufacturerCode);
 /** @brief Electrical Measurement Cluster Client Message Sent
  *
@@ -21291,7 +21569,8 @@ void emberAfElectricalMeasurementClusterClientMessageSentCallback(EmberOutgoingM
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfElectricalMeasurementClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfElectricalMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                                    uint8_t * value);
 /** @brief Electrical Measurement Cluster Client Tick
@@ -21300,7 +21579,7 @@ EmberAfStatus emberAfElectricalMeasurementClusterClientPreAttributeChangedCallba
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfElectricalMeasurementClusterClientTickCallback(uint8_t endpoint);
+void emberAfElectricalMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Electrical Measurement Cluster Get Measurement Profile Command
  *
  *
@@ -21309,7 +21588,7 @@ void emberAfElectricalMeasurementClusterClientTickCallback(uint8_t endpoint);
  * @param startTime   Ver.: always
  * @param numberOfIntervals   Ver.: always
  */
-bool emberAfElectricalMeasurementClusterGetMeasurementProfileCommandCallback(uint16_t attributeId, uint32_t startTime,
+bool emberAfElectricalMeasurementClusterGetMeasurementProfileCommandCallback(chip::AttributeId attributeId, uint32_t startTime,
                                                                              uint8_t numberOfIntervals);
 /** @brief Electrical Measurement Cluster Get Measurement Profile Response Command
  *
@@ -21325,7 +21604,8 @@ bool emberAfElectricalMeasurementClusterGetMeasurementProfileCommandCallback(uin
 bool emberAfElectricalMeasurementClusterGetMeasurementProfileResponseCommandCallback(uint32_t startTime, uint8_t status,
                                                                                      uint8_t profileIntervalPeriod,
                                                                                      uint8_t numberOfIntervalsDelivered,
-                                                                                     uint16_t attributeId, uint8_t * intervals);
+                                                                                     chip::AttributeId attributeId,
+                                                                                     uint8_t * intervals);
 /** @brief Electrical Measurement Cluster Get Profile Info Command
  *
  *
@@ -21351,7 +21631,7 @@ bool emberAfElectricalMeasurementClusterGetProfileInfoResponseCommandCallback(ui
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfElectricalMeasurementClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfElectricalMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Electrical Measurement Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -21361,14 +21641,15 @@ void emberAfElectricalMeasurementClusterServerAttributeChangedCallback(uint8_t e
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfElectricalMeasurementClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfElectricalMeasurementClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                      EmberAfStatus status);
 /** @brief Electrical Measurement Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfElectricalMeasurementClusterServerInitCallback(uint8_t endpoint);
+void emberAfElectricalMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Electrical Measurement Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -21379,7 +21660,7 @@ void emberAfElectricalMeasurementClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfElectricalMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                           EmberAfAttributeId attributeId,
+                                                                                           chip::AttributeId attributeId,
                                                                                            uint16_t manufacturerCode);
 /** @brief Electrical Measurement Cluster Server Message Sent
  *
@@ -21406,7 +21687,8 @@ void emberAfElectricalMeasurementClusterServerMessageSentCallback(EmberOutgoingM
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfElectricalMeasurementClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfElectricalMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                   chip::AttributeId attributeId,
                                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                                    uint8_t * value);
 /** @brief Electrical Measurement Cluster Server Tick
@@ -21415,7 +21697,7 @@ EmberAfStatus emberAfElectricalMeasurementClusterServerPreAttributeChangedCallba
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfElectricalMeasurementClusterServerTickCallback(uint8_t endpoint);
+void emberAfElectricalMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Electrical Measurement Cluster Callbacks */
 
@@ -21429,7 +21711,7 @@ void emberAfElectricalMeasurementClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDiagnosticsClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDiagnosticsClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Diagnostics Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -21439,14 +21721,15 @@ void emberAfDiagnosticsClusterClientAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDiagnosticsClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDiagnosticsClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Diagnostics Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDiagnosticsClusterClientInitCallback(uint8_t endpoint);
+void emberAfDiagnosticsClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Diagnostics Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -21456,7 +21739,8 @@ void emberAfDiagnosticsClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDiagnosticsClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDiagnosticsClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Diagnostics Cluster Client Message Sent
  *
@@ -21483,7 +21767,7 @@ void emberAfDiagnosticsClusterClientMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDiagnosticsClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDiagnosticsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Diagnostics Cluster Client Tick
@@ -21492,7 +21776,7 @@ EmberAfStatus emberAfDiagnosticsClusterClientPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDiagnosticsClusterClientTickCallback(uint8_t endpoint);
+void emberAfDiagnosticsClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Diagnostics Cluster Server Attribute Changed
  *
  * Server Attribute Changed
@@ -21500,7 +21784,7 @@ void emberAfDiagnosticsClusterClientTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfDiagnosticsClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfDiagnosticsClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Diagnostics Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -21510,14 +21794,15 @@ void emberAfDiagnosticsClusterServerAttributeChangedCallback(uint8_t endpoint, E
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfDiagnosticsClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfDiagnosticsClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                            EmberAfStatus status);
 /** @brief Diagnostics Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfDiagnosticsClusterServerInitCallback(uint8_t endpoint);
+void emberAfDiagnosticsClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Diagnostics Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -21527,7 +21812,8 @@ void emberAfDiagnosticsClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfDiagnosticsClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfDiagnosticsClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                 chip::AttributeId attributeId,
                                                                                  uint16_t manufacturerCode);
 /** @brief Diagnostics Cluster Server Message Sent
  *
@@ -21554,7 +21840,7 @@ void emberAfDiagnosticsClusterServerMessageSentCallback(EmberOutgoingMessageType
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfDiagnosticsClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfDiagnosticsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value);
 /** @brief Diagnostics Cluster Server Tick
@@ -21563,7 +21849,7 @@ EmberAfStatus emberAfDiagnosticsClusterServerPreAttributeChangedCallback(uint8_t
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfDiagnosticsClusterServerTickCallback(uint8_t endpoint);
+void emberAfDiagnosticsClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Diagnostics Cluster Callbacks */
 
@@ -21577,7 +21863,7 @@ void emberAfDiagnosticsClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfZllCommissioningClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfZllCommissioningClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief ZLL Commissioning Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -21587,14 +21873,15 @@ void emberAfZllCommissioningClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfZllCommissioningClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfZllCommissioningClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief ZLL Commissioning Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfZllCommissioningClusterClientInitCallback(uint8_t endpoint);
+void emberAfZllCommissioningClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief ZLL Commissioning Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -21604,8 +21891,8 @@ void emberAfZllCommissioningClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfZllCommissioningClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfZllCommissioningClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief ZLL Commissioning Cluster Client Message Sent
  *
@@ -21632,7 +21919,8 @@ void emberAfZllCommissioningClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfZllCommissioningClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfZllCommissioningClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief ZLL Commissioning Cluster Client Tick
@@ -21641,7 +21929,7 @@ EmberAfStatus emberAfZllCommissioningClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfZllCommissioningClusterClientTickCallback(uint8_t endpoint);
+void emberAfZllCommissioningClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief ZLL Commissioning Cluster Device Information Request
  *
  *
@@ -21879,7 +22167,7 @@ bool emberAfZllCommissioningClusterScanResponseCallback(uint32_t transaction, ui
                                                         uint8_t zllInformation, uint16_t keyBitmask, uint32_t responseId,
                                                         uint8_t * extendedPanId, uint8_t networkUpdateId, uint8_t logicalChannel,
                                                         uint16_t panId, uint16_t networkAddress, uint8_t numberOfSubDevices,
-                                                        uint8_t totalGroupIds, uint8_t endpointId, uint16_t profileId,
+                                                        uint8_t totalGroupIds, chip::EndpointId endpointId, uint16_t profileId,
                                                         uint16_t deviceId, uint8_t version, uint8_t groupIdCount);
 /** @brief ZLL Commissioning Cluster Server Attribute Changed
  *
@@ -21888,7 +22176,7 @@ bool emberAfZllCommissioningClusterScanResponseCallback(uint32_t transaction, ui
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfZllCommissioningClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfZllCommissioningClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief ZLL Commissioning Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -21898,14 +22186,15 @@ void emberAfZllCommissioningClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfZllCommissioningClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfZllCommissioningClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief ZLL Commissioning Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfZllCommissioningClusterServerInitCallback(uint8_t endpoint);
+void emberAfZllCommissioningClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief ZLL Commissioning Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -21915,8 +22204,8 @@ void emberAfZllCommissioningClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfZllCommissioningClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfZllCommissioningClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief ZLL Commissioning Cluster Server Message Sent
  *
@@ -21943,7 +22232,8 @@ void emberAfZllCommissioningClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfZllCommissioningClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfZllCommissioningClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief ZLL Commissioning Cluster Server Tick
@@ -21952,7 +22242,7 @@ EmberAfStatus emberAfZllCommissioningClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfZllCommissioningClusterServerTickCallback(uint8_t endpoint);
+void emberAfZllCommissioningClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END ZLL Commissioning Cluster Callbacks */
 
@@ -21966,7 +22256,7 @@ void emberAfZllCommissioningClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSampleMfgSpecificClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Sample Mfg Specific Cluster Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -21976,14 +22266,15 @@ void emberAfSampleMfgSpecificClusterClientAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSampleMfgSpecificClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief Sample Mfg Specific Cluster Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterClientInitCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Sample Mfg Specific Cluster Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -21994,7 +22285,7 @@ void emberAfSampleMfgSpecificClusterClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfSampleMfgSpecificClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief Sample Mfg Specific Cluster Cluster Client Message Sent
  *
@@ -22021,7 +22312,8 @@ void emberAfSampleMfgSpecificClusterClientMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSampleMfgSpecificClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSampleMfgSpecificClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief Sample Mfg Specific Cluster Cluster Client Tick
@@ -22030,7 +22322,7 @@ EmberAfStatus emberAfSampleMfgSpecificClusterClientPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterClientTickCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Sample Mfg Specific Cluster Cluster Command One
  *
  *
@@ -22045,7 +22337,7 @@ bool emberAfSampleMfgSpecificClusterCommandOneCallback(uint8_t argOne);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSampleMfgSpecificClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Sample Mfg Specific Cluster Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -22055,14 +22347,15 @@ void emberAfSampleMfgSpecificClusterServerAttributeChangedCallback(uint8_t endpo
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSampleMfgSpecificClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                  EmberAfStatus status);
 /** @brief Sample Mfg Specific Cluster Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterServerInitCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Sample Mfg Specific Cluster Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -22073,7 +22366,7 @@ void emberAfSampleMfgSpecificClusterServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfSampleMfgSpecificClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                       EmberAfAttributeId attributeId,
+                                                                                       chip::AttributeId attributeId,
                                                                                        uint16_t manufacturerCode);
 /** @brief Sample Mfg Specific Cluster Cluster Server Message Sent
  *
@@ -22100,7 +22393,8 @@ void emberAfSampleMfgSpecificClusterServerMessageSentCallback(EmberOutgoingMessa
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSampleMfgSpecificClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSampleMfgSpecificClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                               chip::AttributeId attributeId,
                                                                                EmberAfAttributeType attributeType, uint8_t size,
                                                                                uint8_t * value);
 /** @brief Sample Mfg Specific Cluster Cluster Server Tick
@@ -22109,7 +22403,7 @@ EmberAfStatus emberAfSampleMfgSpecificClusterServerPreAttributeChangedCallback(u
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSampleMfgSpecificClusterServerTickCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificClusterServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Sample Mfg Specific Cluster Cluster Callbacks */
 
@@ -22123,7 +22417,7 @@ void emberAfSampleMfgSpecificClusterServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSampleMfgSpecificCluster2ClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -22133,14 +22427,15 @@ void emberAfSampleMfgSpecificCluster2ClientAttributeChangedCallback(uint8_t endp
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSampleMfgSpecificCluster2ClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                   EmberAfStatus status);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ClientInitCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificCluster2ClientInitCallback(chip::EndpointId endpoint);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -22151,7 +22446,7 @@ void emberAfSampleMfgSpecificCluster2ClientInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfSampleMfgSpecificCluster2ClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                        EmberAfAttributeId attributeId,
+                                                                                        chip::AttributeId attributeId,
                                                                                         uint16_t manufacturerCode);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Client Message Sent
  *
@@ -22178,7 +22473,8 @@ void emberAfSampleMfgSpecificCluster2ClientMessageSentCallback(EmberOutgoingMess
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSampleMfgSpecificCluster2ClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSampleMfgSpecificCluster2ClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 EmberAfAttributeType attributeType, uint8_t size,
                                                                                 uint8_t * value);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Client Tick
@@ -22187,7 +22483,7 @@ EmberAfStatus emberAfSampleMfgSpecificCluster2ClientPreAttributeChangedCallback(
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ClientTickCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificCluster2ClientTickCallback(chip::EndpointId endpoint);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Command Two
  *
  *
@@ -22202,7 +22498,7 @@ bool emberAfSampleMfgSpecificCluster2CommandTwoCallback(uint8_t argOne);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSampleMfgSpecificCluster2ServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -22212,14 +22508,15 @@ void emberAfSampleMfgSpecificCluster2ServerAttributeChangedCallback(uint8_t endp
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSampleMfgSpecificCluster2ServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                   EmberAfStatus status);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ServerInitCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificCluster2ServerInitCallback(chip::EndpointId endpoint);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -22230,7 +22527,7 @@ void emberAfSampleMfgSpecificCluster2ServerInitCallback(uint8_t endpoint);
  * Ver.: always
  */
 void emberAfSampleMfgSpecificCluster2ServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                        EmberAfAttributeId attributeId,
+                                                                                        chip::AttributeId attributeId,
                                                                                         uint16_t manufacturerCode);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Server Message Sent
  *
@@ -22257,7 +22554,8 @@ void emberAfSampleMfgSpecificCluster2ServerMessageSentCallback(EmberOutgoingMess
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSampleMfgSpecificCluster2ServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSampleMfgSpecificCluster2ServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                chip::AttributeId attributeId,
                                                                                 EmberAfAttributeType attributeType, uint8_t size,
                                                                                 uint8_t * value);
 /** @brief Sample Mfg Specific Cluster 2 Cluster Server Tick
@@ -22266,7 +22564,7 @@ EmberAfStatus emberAfSampleMfgSpecificCluster2ServerPreAttributeChangedCallback(
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSampleMfgSpecificCluster2ServerTickCallback(uint8_t endpoint);
+void emberAfSampleMfgSpecificCluster2ServerTickCallback(chip::EndpointId endpoint);
 
 /** @} END Sample Mfg Specific Cluster 2 Cluster Callbacks */
 
@@ -22280,7 +22578,7 @@ void emberAfSampleMfgSpecificCluster2ServerTickCallback(uint8_t endpoint);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOtaConfigurationClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOtaConfigurationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Configuration Cluster Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -22290,14 +22588,15 @@ void emberAfOtaConfigurationClusterClientAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOtaConfigurationClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOtaConfigurationClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Configuration Cluster Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOtaConfigurationClusterClientInitCallback(uint8_t endpoint);
+void emberAfOtaConfigurationClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief Configuration Cluster Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -22307,8 +22606,8 @@ void emberAfOtaConfigurationClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOtaConfigurationClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfOtaConfigurationClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Configuration Cluster Cluster Client Message Sent
  *
@@ -22335,7 +22634,8 @@ void emberAfOtaConfigurationClusterClientMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOtaConfigurationClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOtaConfigurationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Configuration Cluster Cluster Client Tick
@@ -22344,7 +22644,7 @@ EmberAfStatus emberAfOtaConfigurationClusterClientPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOtaConfigurationClusterClientTickCallback(uint8_t endpoint);
+void emberAfOtaConfigurationClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief Configuration Cluster Cluster Lock Tokens
  *
  *
@@ -22373,7 +22673,7 @@ bool emberAfOtaConfigurationClusterReturnTokenCallback(uint16_t token, uint8_t *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfOtaConfigurationClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfOtaConfigurationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief Configuration Cluster Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -22383,14 +22683,15 @@ void emberAfOtaConfigurationClusterServerAttributeChangedCallback(uint8_t endpoi
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfOtaConfigurationClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfOtaConfigurationClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId,
+                                                                 EmberAfStatus status);
 /** @brief Configuration Cluster Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfOtaConfigurationClusterServerInitCallback(uint8_t endpoint);
+void emberAfOtaConfigurationClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief Configuration Cluster Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -22400,8 +22701,8 @@ void emberAfOtaConfigurationClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfOtaConfigurationClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint,
-                                                                                      EmberAfAttributeId attributeId,
+void emberAfOtaConfigurationClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                                      chip::AttributeId attributeId,
                                                                                       uint16_t manufacturerCode);
 /** @brief Configuration Cluster Cluster Server Message Sent
  *
@@ -22428,7 +22729,8 @@ void emberAfOtaConfigurationClusterServerMessageSentCallback(EmberOutgoingMessag
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfOtaConfigurationClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfOtaConfigurationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                              chip::AttributeId attributeId,
                                                                               EmberAfAttributeType attributeType, uint8_t size,
                                                                               uint8_t * value);
 /** @brief Configuration Cluster Cluster Server Tick
@@ -22437,7 +22739,7 @@ EmberAfStatus emberAfOtaConfigurationClusterServerPreAttributeChangedCallback(ui
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfOtaConfigurationClusterServerTickCallback(uint8_t endpoint);
+void emberAfOtaConfigurationClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief Configuration Cluster Cluster Set Token
  *
  *
@@ -22466,7 +22768,7 @@ bool emberAfOtaConfigurationClusterUnlockTokensCallback(uint8_t * data);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMfglibClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMfglibClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief MFGLIB Cluster Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -22476,14 +22778,14 @@ void emberAfMfglibClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMfglibClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMfglibClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief MFGLIB Cluster Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMfglibClusterClientInitCallback(uint8_t endpoint);
+void emberAfMfglibClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief MFGLIB Cluster Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -22493,7 +22795,8 @@ void emberAfMfglibClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfMfglibClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfMfglibClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief MFGLIB Cluster Cluster Client Message Sent
  *
@@ -22520,7 +22823,7 @@ void emberAfMfglibClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMfglibClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMfglibClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief MFGLIB Cluster Cluster Client Tick
@@ -22529,7 +22832,7 @@ EmberAfStatus emberAfMfglibClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMfglibClusterClientTickCallback(uint8_t endpoint);
+void emberAfMfglibClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief MFGLIB Cluster Cluster Rx Mode
  *
  *
@@ -22546,7 +22849,7 @@ bool emberAfMfglibClusterRxModeCallback(uint8_t channel, int8_t power, uint16_t 
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfMfglibClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfMfglibClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief MFGLIB Cluster Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -22556,14 +22859,14 @@ void emberAfMfglibClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfMfglibClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfMfglibClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief MFGLIB Cluster Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfMfglibClusterServerInitCallback(uint8_t endpoint);
+void emberAfMfglibClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief MFGLIB Cluster Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -22573,7 +22876,8 @@ void emberAfMfglibClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfMfglibClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfMfglibClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief MFGLIB Cluster Cluster Server Message Sent
  *
@@ -22600,7 +22904,7 @@ void emberAfMfglibClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfMfglibClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfMfglibClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief MFGLIB Cluster Cluster Server Tick
@@ -22609,7 +22913,7 @@ EmberAfStatus emberAfMfglibClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfMfglibClusterServerTickCallback(uint8_t endpoint);
+void emberAfMfglibClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief MFGLIB Cluster Cluster Stream
  *
  *
@@ -22654,7 +22958,7 @@ bool emberAfSlWwahClusterApsAckRequirementQueryCallback(void);
  *
  * @param clusterId   Ver.: always
  */
-bool emberAfSlWwahClusterApsLinkKeyAuthorizationQueryCallback(uint16_t clusterId);
+bool emberAfSlWwahClusterApsLinkKeyAuthorizationQueryCallback(chip::ClusterId clusterId);
 /** @brief SL Works With All Hubs Cluster Aps Link Key Authorization Query Response
  *
  *
@@ -22662,7 +22966,7 @@ bool emberAfSlWwahClusterApsLinkKeyAuthorizationQueryCallback(uint16_t clusterId
  * @param clusterId   Ver.: always
  * @param apsLinkKeyAuthStatus   Ver.: always
  */
-bool emberAfSlWwahClusterApsLinkKeyAuthorizationQueryResponseCallback(uint16_t clusterId, uint8_t apsLinkKeyAuthStatus);
+bool emberAfSlWwahClusterApsLinkKeyAuthorizationQueryResponseCallback(chip::ClusterId clusterId, uint8_t apsLinkKeyAuthStatus);
 /** @brief SL Works With All Hubs Cluster Clear Binding Table
  *
  *
@@ -22676,7 +22980,7 @@ bool emberAfSlWwahClusterClearBindingTableCallback(void);
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSlWwahClusterClientAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSlWwahClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief SL Works With All Hubs Cluster Client Default Response
  *
  * This function is called when the client receives the default response from
@@ -22686,14 +22990,14 @@ void emberAfSlWwahClusterClientAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSlWwahClusterClientDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSlWwahClusterClientDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief SL Works With All Hubs Cluster Client Init
  *
  * Client Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSlWwahClusterClientInitCallback(uint8_t endpoint);
+void emberAfSlWwahClusterClientInitCallback(chip::EndpointId endpoint);
 /** @brief SL Works With All Hubs Cluster Client Manufacturer Specific Attribute Changed
  *
  * Client Manufacturer Specific Attribute Changed
@@ -22703,7 +23007,8 @@ void emberAfSlWwahClusterClientInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfSlWwahClusterClientManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfSlWwahClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief SL Works With All Hubs Cluster Client Message Sent
  *
@@ -22730,7 +23035,7 @@ void emberAfSlWwahClusterClientMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSlWwahClusterClientPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSlWwahClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief SL Works With All Hubs Cluster Client Tick
@@ -22739,7 +23044,7 @@ EmberAfStatus emberAfSlWwahClusterClientPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSlWwahClusterClientTickCallback(uint8_t endpoint);
+void emberAfSlWwahClusterClientTickCallback(chip::EndpointId endpoint);
 /** @brief SL Works With All Hubs Cluster Debug Report Query
  *
  *
@@ -22955,7 +23260,7 @@ bool emberAfSlWwahClusterRequireApsAcksOnUnicastsCallback(uint8_t numberExemptCl
  * @param endpoint Endpoint that is being initialized  Ver.: always
  * @param attributeId Attribute that changed  Ver.: always
  */
-void emberAfSlWwahClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId);
+void emberAfSlWwahClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 /** @brief SL Works With All Hubs Cluster Server Default Response
  *
  * This function is called when the server receives the default response from
@@ -22965,14 +23270,14 @@ void emberAfSlWwahClusterServerAttributeChangedCallback(uint8_t endpoint, EmberA
  * @param commandId Command id  Ver.: always
  * @param status Status in default response  Ver.: always
  */
-void emberAfSlWwahClusterServerDefaultResponseCallback(uint8_t endpoint, uint8_t commandId, EmberAfStatus status);
+void emberAfSlWwahClusterServerDefaultResponseCallback(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 /** @brief SL Works With All Hubs Cluster Server Init
  *
  * Server Init
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfSlWwahClusterServerInitCallback(uint8_t endpoint);
+void emberAfSlWwahClusterServerInitCallback(chip::EndpointId endpoint);
 /** @brief SL Works With All Hubs Cluster Server Manufacturer Specific Attribute Changed
  *
  * Server Manufacturer Specific Attribute Changed
@@ -22982,7 +23287,8 @@ void emberAfSlWwahClusterServerInitCallback(uint8_t endpoint);
  * @param manufacturerCode Manufacturer Code of the attribute that changed
  * Ver.: always
  */
-void emberAfSlWwahClusterServerManufacturerSpecificAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+void emberAfSlWwahClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
+                                                                            chip::AttributeId attributeId,
                                                                             uint16_t manufacturerCode);
 /** @brief SL Works With All Hubs Cluster Server Message Sent
  *
@@ -23009,7 +23315,7 @@ void emberAfSlWwahClusterServerMessageSentCallback(EmberOutgoingMessageType type
  * @param size Attribute size  Ver.: always
  * @param value Attribute value  Ver.: always
  */
-EmberAfStatus emberAfSlWwahClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfSlWwahClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                     EmberAfAttributeType attributeType, uint8_t size,
                                                                     uint8_t * value);
 /** @brief SL Works With All Hubs Cluster Server Tick
@@ -23018,7 +23324,7 @@ EmberAfStatus emberAfSlWwahClusterServerPreAttributeChangedCallback(uint8_t endp
  *
  * @param endpoint Endpoint that is being served  Ver.: always
  */
-void emberAfSlWwahClusterServerTickCallback(uint8_t endpoint);
+void emberAfSlWwahClusterServerTickCallback(chip::EndpointId endpoint);
 /** @brief SL Works With All Hubs Cluster Set Ias Zone Enrollment Method
  *
  *

--- a/examples/temperature-measurement-app/esp32/main/gen/clusters-callback-stubs.cpp
+++ b/examples/temperature-measurement-app/esp32/main/gen/clusters-callback-stubs.cpp
@@ -22,6 +22,8 @@
 
 #include "af.h"
 
+using namespace chip;
+
 /** @brief Identify Cluster Identify Query Response
  *
  *
@@ -352,15 +354,15 @@ bool emberAfIasZoneClusterZoneStatusChangeNotificationCallback(uint16_t zoneStat
 
 // endpoint_config.h callbacks, grep'd from SDK, comment these out as clusters come in
 
-void emberAfDoorLockClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId) {}
-void emberAfIasZoneClusterClientInitCallback(uint8_t endpoint) {}
-void emberAfIasZoneClusterServerInitCallback(uint8_t endpoint) {}
+void emberAfDoorLockClusterServerAttributeChangedCallback(EndpointId endpoint, AttributeId attributeId) {}
+void emberAfIasZoneClusterClientInitCallback(EndpointId endpoint) {}
+void emberAfIasZoneClusterServerInitCallback(EndpointId endpoint) {}
 void emberAfIasZoneClusterServerMessageSentCallback(EmberOutgoingMessageType type, uint16_t indexOrDestination,
                                                     EmberApsFrame * apsFrame, uint16_t msgLen, uint8_t * message,
                                                     EmberStatus status)
 {}
 
-EmberAfStatus emberAfIasZoneClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfIasZoneClusterServerPreAttributeChangedCallback(EndpointId endpoint, AttributeId attributeId,
                                                                      EmberAfAttributeType attributeType, uint8_t size,
                                                                      uint8_t * value)
 {
@@ -368,10 +370,10 @@ EmberAfStatus emberAfIasZoneClusterServerPreAttributeChangedCallback(uint8_t end
 }
 
 void emberAfPluginDoorLockServerInitCallback(void) {}
-void emberAfPollControlClusterServerAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId) {}
-void emberAfPollControlClusterServerInitCallback(uint8_t endpoint) {}
+void emberAfPollControlClusterServerAttributeChangedCallback(EndpointId endpoint, AttributeId attributeId) {}
+void emberAfPollControlClusterServerInitCallback(EndpointId endpoint) {}
 void emberAfPluginPollControlServerStackStatusCallback(EmberStatus status) {}
-EmberAfStatus emberAfPollControlClusterServerPreAttributeChangedCallback(uint8_t endpoint, EmberAfAttributeId attributeId,
+EmberAfStatus emberAfPollControlClusterServerPreAttributeChangedCallback(EndpointId endpoint, AttributeId attributeId,
                                                                          EmberAfAttributeType attributeType, uint8_t size,
                                                                          uint8_t * value)
 {

--- a/examples/temperature-measurement-app/esp32/main/include/CHIPDeviceManager.h
+++ b/examples/temperature-measurement-app/esp32/main/include/CHIPDeviceManager.h
@@ -73,7 +73,7 @@ public:
      * @param size               size of the attribute
      * @param value              pointer to the new value
      */
-    virtual void PostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
+    virtual void PostAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
                                              uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
     {}
     virtual ~CHIPDeviceManagerCallbacks() {}

--- a/examples/temperature-measurement-app/esp32/main/include/DeviceCallbacks.h
+++ b/examples/temperature-measurement-app/esp32/main/include/DeviceCallbacks.h
@@ -34,14 +34,14 @@ class DeviceCallbacks : public chip::DeviceManager::CHIPDeviceManagerCallbacks
 {
 public:
     virtual void DeviceEventCallback(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
-    virtual void PostAttributeChangeCallback(uint8_t endpointId, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
+    virtual void PostAttributeChangeCallback(chip::EndpointId endpointId, chip::ClusterId clusterId, chip::AttributeId attributeId,
                                              uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value);
 
 private:
     void OnInternetConnectivityChange(const chip::DeviceLayer::ChipDeviceEvent * event);
     void OnSessionEstablished(const chip::DeviceLayer::ChipDeviceEvent * event);
-    void OnOnOffPostAttributeChangeCallback(uint8_t endpointId, uint16_t attributeId, uint8_t * value);
-    void OnIdentifyPostAttributeChangeCallback(uint8_t endpointId, uint16_t attributeId, uint8_t * value);
+    void OnOnOffPostAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);
+    void OnIdentifyPostAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);
 };
 
 #endif // DEVICE_CALLBACKS_H

--- a/src/app/chip-zcl-zpro-codec-api.h
+++ b/src/app/chip-zcl-zpro-codec-api.h
@@ -923,15 +923,16 @@ uint16_t encodeDoorLockClusterReadActuatorEnabledAttribute(uint8_t * buffer, uin
  * @brief
  *    Encode an add-group command for Groups server into buffer including the APS frame
  */
-uint16_t encodeGroupsClusterAddGroupCommand(uint8_t * buffer, uint16_t buf_length, CHIPEndpointId destination_endpoint,
-                                            CHIPGroupId groupId, char * groupName);
+uint16_t encodeGroupsClusterAddGroupCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
+                                            chip::GroupId groupId, char * groupName);
 
 /**
  * @brief
  *    Encode an add-group-if-identifying command for Groups server into buffer including the APS frame
  */
-uint16_t encodeGroupsClusterAddGroupIfIdentifyingCommand(uint8_t * buffer, uint16_t buf_length, CHIPEndpointId destination_endpoint,
-                                                         CHIPGroupId groupId, char * groupName);
+uint16_t encodeGroupsClusterAddGroupIfIdentifyingCommand(uint8_t * buffer, uint16_t buf_length,
+                                                         chip::EndpointId destination_endpoint, chip::GroupId groupId,
+                                                         char * groupName);
 
 /**
  * @brief
@@ -950,15 +951,15 @@ uint16_t encodeGroupsClusterRemoveAllGroupsCommand(uint8_t * buffer, uint16_t bu
  * @brief
  *    Encode an remove-group command for Groups server into buffer including the APS frame
  */
-uint16_t encodeGroupsClusterRemoveGroupCommand(uint8_t * buffer, uint16_t buf_length, CHIPEndpointId destination_endpoint,
-                                               CHIPGroupId groupId);
+uint16_t encodeGroupsClusterRemoveGroupCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
+                                               chip::GroupId groupId);
 
 /**
  * @brief
  *    Encode an view-group command for Groups server into buffer including the APS frame
  */
-uint16_t encodeGroupsClusterViewGroupCommand(uint8_t * buffer, uint16_t buf_length, CHIPEndpointId destination_endpoint,
-                                             CHIPGroupId groupId);
+uint16_t encodeGroupsClusterViewGroupCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
+                                             chip::GroupId groupId);
 
 /**
  * @brief
@@ -1267,51 +1268,51 @@ uint16_t encodeOnOffClusterReportOnOffAttribute(uint8_t * buffer, uint16_t buf_l
  * @brief
  *    Encode an add-scene command for Scenes server into buffer including the APS frame
  */
-uint16_t encodeScenesClusterAddSceneCommand(uint8_t * buffer, uint16_t buf_length, CHIPEndpointId destination_endpoint,
-                                            CHIPGroupId groupID, uint8_t sceneID, uint16_t transitionTime, char * sceneName,
-                                            uint16_t clusterId, char * extensionFieldSet);
+uint16_t encodeScenesClusterAddSceneCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
+                                            chip::GroupId groupID, uint8_t sceneID, uint16_t transitionTime, char * sceneName,
+                                            chip::ClusterId clusterId, char * extensionFieldSet);
 
 /**
  * @brief
  *    Encode an get-scene-membership command for Scenes server into buffer including the APS frame
  */
-uint16_t encodeScenesClusterGetSceneMembershipCommand(uint8_t * buffer, uint16_t buf_length, CHIPEndpointId destination_endpoint,
-                                                      CHIPGroupId groupID);
+uint16_t encodeScenesClusterGetSceneMembershipCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
+                                                      chip::GroupId groupID);
 
 /**
  * @brief
  *    Encode an recall-scene command for Scenes server into buffer including the APS frame
  */
-uint16_t encodeScenesClusterRecallSceneCommand(uint8_t * buffer, uint16_t buf_length, CHIPEndpointId destination_endpoint,
-                                               CHIPGroupId groupID, uint8_t sceneID, uint16_t transitionTime);
+uint16_t encodeScenesClusterRecallSceneCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
+                                               chip::GroupId groupID, uint8_t sceneID, uint16_t transitionTime);
 
 /**
  * @brief
  *    Encode an remove-all-scenes command for Scenes server into buffer including the APS frame
  */
-uint16_t encodeScenesClusterRemoveAllScenesCommand(uint8_t * buffer, uint16_t buf_length, CHIPEndpointId destination_endpoint,
-                                                   CHIPGroupId groupID);
+uint16_t encodeScenesClusterRemoveAllScenesCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
+                                                   chip::GroupId groupID);
 
 /**
  * @brief
  *    Encode an remove-scene command for Scenes server into buffer including the APS frame
  */
-uint16_t encodeScenesClusterRemoveSceneCommand(uint8_t * buffer, uint16_t buf_length, CHIPEndpointId destination_endpoint,
-                                               CHIPGroupId groupID, uint8_t sceneID);
+uint16_t encodeScenesClusterRemoveSceneCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
+                                               chip::GroupId groupID, uint8_t sceneID);
 
 /**
  * @brief
  *    Encode an store-scene command for Scenes server into buffer including the APS frame
  */
-uint16_t encodeScenesClusterStoreSceneCommand(uint8_t * buffer, uint16_t buf_length, CHIPEndpointId destination_endpoint,
-                                              CHIPGroupId groupID, uint8_t sceneID);
+uint16_t encodeScenesClusterStoreSceneCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
+                                              chip::GroupId groupID, uint8_t sceneID);
 
 /**
  * @brief
  *    Encode an view-scene command for Scenes server into buffer including the APS frame
  */
-uint16_t encodeScenesClusterViewSceneCommand(uint8_t * buffer, uint16_t buf_length, CHIPEndpointId destination_endpoint,
-                                             CHIPGroupId groupID, uint8_t sceneID);
+uint16_t encodeScenesClusterViewSceneCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
+                                             chip::GroupId groupID, uint8_t sceneID);
 
 /**
  * @brief

--- a/src/app/chip-zcl-zpro-codec.h
+++ b/src/app/chip-zcl-zpro-codec.h
@@ -31,15 +31,15 @@ typedef struct
     /** The application profile ID that describes the format of the message. */
     uint16_t profileId;
     /** The cluster ID for this message. */
-    CHIPClusterId clusterId;
+    chip::ClusterId clusterId;
     /** The source endpoint. */
-    CHIPEndpointId sourceEndpoint;
+    chip::EndpointId sourceEndpoint;
     /** The destination endpoint. */
-    CHIPEndpointId destinationEndpoint;
+    chip::EndpointId destinationEndpoint;
     /** A bitmask of options from the enumeration above. */
     EmberApsOption options;
     /** The group ID for this message, if it is multicast mode. */
-    CHIPGroupId groupId;
+    chip::GroupId groupId;
     /** The sequence number. */
     uint8_t sequence;
     uint8_t radius;

--- a/src/app/clusters/barrier-control-server/barrier-control-server.cpp
+++ b/src/app/clusters/barrier-control-server/barrier-control-server.cpp
@@ -104,8 +104,8 @@ bool emAfPluginBarrierControlServerIsPartialBarrierSupported(EndpointId endpoint
 
 static uint16_t getOpenOrClosePeriod(EndpointId endpoint, bool open)
 {
-    uint16_t period                = 0;
-    EmberAfAttributeId attributeId = 0xFFFF;
+    uint16_t period         = 0;
+    AttributeId attributeId = 0xFFFF;
 #if defined(ZCL_USING_BARRIER_CONTROL_CLUSTER_BARRIER_OPEN_PERIOD_ATTRIBUTE)
     if (open)
     {
@@ -169,12 +169,12 @@ void emAfPluginBarrierControlServerIncrementEvents(EndpointId endpoint, bool ope
 #endif
     );
 
-    EmberAfAttributeId baseEventAttributeId = ZCL_BARRIER_OPEN_EVENTS_ATTRIBUTE_ID;
+    AttributeId baseEventAttributeId = ZCL_BARRIER_OPEN_EVENTS_ATTRIBUTE_ID;
     for (size_t bit = 0; bit < 4; bit++)
     {
         if (READBIT(mask, bit))
         {
-            EmberAfAttributeId attributeId = static_cast<EmberAfAttributeId>(baseEventAttributeId + bit);
+            AttributeId attributeId = static_cast<AttributeId>(baseEventAttributeId + bit);
             uint16_t events;
             EmberAfStatus status = emberAfReadServerAttribute(endpoint, ZCL_BARRIER_CONTROL_CLUSTER_ID, attributeId,
                                                               (uint8_t *) &events, sizeof(events));

--- a/src/app/clusters/barrier-control-server/barrier-control-server.h
+++ b/src/app/clusters/barrier-control-server/barrier-control-server.h
@@ -50,23 +50,23 @@
 
 // This will always either return the current BarrierPosition attribute value
 // or assert.
-uint8_t emAfPluginBarrierControlServerGetBarrierPosition(CHIPEndpointId endpoint);
+uint8_t emAfPluginBarrierControlServerGetBarrierPosition(chip::EndpointId endpoint);
 
 // This will always either set the current BarrierPosition attribute value or
 // assert.
-void emAfPluginBarrierControlServerSetBarrierPosition(CHIPEndpointId endpoint, uint8_t barrierPosition);
+void emAfPluginBarrierControlServerSetBarrierPosition(chip::EndpointId endpoint, uint8_t barrierPosition);
 
 // This will either return whether or not the PartialBarrier bit is set in the
 // Capabilities attribute value, or it will assert.
-bool emAfPluginBarrierControlServerIsPartialBarrierSupported(CHIPEndpointId endpoint);
+bool emAfPluginBarrierControlServerIsPartialBarrierSupported(chip::EndpointId endpoint);
 
 // This will increment the OpenEvents, CloseEvents, CommandOpenEvents, and
 // CommandCloseEvents attribute values depending on which combination of the
 // open and command arguments are passed, or assert.
-void emAfPluginBarrierControlServerIncrementEvents(CHIPEndpointId endpoint, bool open, bool command);
+void emAfPluginBarrierControlServerIncrementEvents(chip::EndpointId endpoint, bool open, bool command);
 
 // This will read the SafetyStatus attribute and return the value, or assert.
-uint16_t emAfPluginBarrierControlServerGetSafetyStatus(CHIPEndpointId endpoint);
+uint16_t emAfPluginBarrierControlServerGetSafetyStatus(chip::EndpointId endpoint);
 
 // We use a minimum delay so that our barrier changes position in a realistic
 // amount of time.

--- a/src/app/clusters/basic/basic.h
+++ b/src/app/clusters/basic/basic.h
@@ -29,4 +29,4 @@
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPluginBasicResetToFactoryDefaultsCallback(CHIPEndpointId endpoint);
+void emberAfPluginBasicResetToFactoryDefaultsCallback(chip::EndpointId endpoint);

--- a/src/app/clusters/color-control-server/color-control-server.h
+++ b/src/app/clusters/color-control-server/color-control-server.h
@@ -26,7 +26,7 @@
  *
  * @param endpoint The identifying endpoint Ver.: always
  */
-void emberAfPluginColorControlServerComputePwmFromHsvCallback(CHIPEndpointId endpoint);
+void emberAfPluginColorControlServerComputePwmFromHsvCallback(chip::EndpointId endpoint);
 
 /** @brief Compute Pwm from HSV
  *
@@ -35,7 +35,7 @@ void emberAfPluginColorControlServerComputePwmFromHsvCallback(CHIPEndpointId end
  *
  * @param endpoint The identifying endpoint Ver.: always
  */
-void emberAfPluginColorControlServerComputePwmFromTempCallback(CHIPEndpointId endpoint);
+void emberAfPluginColorControlServerComputePwmFromTempCallback(chip::EndpointId endpoint);
 
 /** @brief Compute Pwm from HSV
  *
@@ -44,4 +44,4 @@ void emberAfPluginColorControlServerComputePwmFromTempCallback(CHIPEndpointId en
  *
  * @param endpoint The identifying endpoint Ver.: always
  */
-void emberAfPluginColorControlServerComputePwmFromXyCallback(CHIPEndpointId endpoint);
+void emberAfPluginColorControlServerComputePwmFromXyCallback(chip::EndpointId endpoint);

--- a/src/app/clusters/door-lock-server/door-lock-server-core.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server-core.cpp
@@ -117,7 +117,7 @@ EmberAfStatus emAfPluginDoorLockServerNoteDoorStateChanged(EmberAfDoorState stat
     defined(ZCL_USING_DOOR_LOCK_CLUSTER_DOOR_CLOSED_EVENTS_ATTRIBUTE)
     if (state == EMBER_ZCL_DOOR_STATE_OPEN || state == EMBER_ZCL_DOOR_STATE_CLOSED)
     {
-        EmberAfAttributeId attributeId =
+        AttributeId attributeId =
             (state == EMBER_ZCL_DOOR_STATE_OPEN ? ZCL_DOOR_OPEN_EVENTS_ATTRIBUTE_ID : ZCL_DOOR_CLOSED_EVENTS_ATTRIBUTE_ID);
         uint32_t events;
         status = emberAfReadServerAttribute(DOOR_LOCK_SERVER_ENDPOINT, ZCL_DOOR_LOCK_CLUSTER_ID, attributeId, (uint8_t *) &events,

--- a/src/app/clusters/door-lock-server/door-lock-server-user.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server-user.cpp
@@ -724,7 +724,7 @@ void emberAfPluginDoorLockServerRelockEventHandler(void)
     emberAfDoorLockClusterPrintln("Door automatically relocked: 0x%X", status);
 }
 
-void emberAfDoorLockClusterServerAttributeChangedCallback(EndpointId endpoint, EmberAfAttributeId attributeId)
+void emberAfDoorLockClusterServerAttributeChangedCallback(EndpointId endpoint, AttributeId attributeId)
 {
     if (endpoint == DOOR_LOCK_SERVER_ENDPOINT && attributeId == ZCL_LOCK_STATE_ATTRIBUTE_ID)
     {

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -48,7 +48,7 @@
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 typedef struct
 {
-    EmberAfAttributeId id;
+    chip::AttributeId id;
     uint16_t value;
 } EmAfPluginDoorLockServerAttributeData;
 

--- a/src/app/clusters/groups-server/groups-server.h
+++ b/src/app/clusters/groups-server/groups-server.h
@@ -28,7 +28,7 @@
  * @param groupId Group ID Ver.: always
  * @param groupName Group Name Ver.: always
  */
-void emberAfPluginGroupsServerGetGroupNameCallback(CHIPEndpointId endpoint, CHIPGroupId groupId, uint8_t * groupName);
+void emberAfPluginGroupsServerGetGroupNameCallback(chip::EndpointId endpoint, chip::GroupId groupId, uint8_t * groupName);
 
 /** @brief Set Group Name
  *
@@ -38,7 +38,7 @@ void emberAfPluginGroupsServerGetGroupNameCallback(CHIPEndpointId endpoint, CHIP
  * @param groupId Group ID Ver.: always
  * @param groupName Group Name Ver.: always
  */
-void emberAfPluginGroupsServerSetGroupNameCallback(CHIPEndpointId endpoint, CHIPGroupId groupId, uint8_t * groupName);
+void emberAfPluginGroupsServerSetGroupNameCallback(chip::EndpointId endpoint, chip::GroupId groupId, uint8_t * groupName);
 
 /** @brief Group Names Supported
  *
@@ -46,7 +46,7 @@ void emberAfPluginGroupsServerSetGroupNameCallback(CHIPEndpointId endpoint, CHIP
  *
  * @param endpoint Endpoint Ver.: always
  */
-bool emberAfPluginGroupsServerGroupNamesSupportedCallback(CHIPEndpointId endpoint);
+bool emberAfPluginGroupsServerGroupNamesSupportedCallback(chip::EndpointId endpoint);
 
 /** @brief Groups Cluster Endpoint In Group
  *
@@ -57,4 +57,4 @@ bool emberAfPluginGroupsServerGroupNamesSupportedCallback(CHIPEndpointId endpoin
  * @param endpoint The endpoint.  Ver.: always
  * @param groupId The group identifier.  Ver.: always
  */
-bool emberAfGroupsClusterEndpointInGroupCallback(CHIPEndpointId endpoint, CHIPGroupId groupId);
+bool emberAfGroupsClusterEndpointInGroupCallback(chip::EndpointId endpoint, chip::GroupId groupId);

--- a/src/app/clusters/ias-zone-client/ias-zone-client.cpp
+++ b/src/app/clusters/ias-zone-client/ias-zone-client.cpp
@@ -111,7 +111,7 @@ static void iasClientLoadCommand(void);
 //-----------------------------------------------------------------------------
 // Functions
 
-void emberAfIasZoneClusterClientInitCallback(uint8_t endpoint)
+void emberAfIasZoneClusterClientInitCallback(EndpointId endpoint)
 {
     emAfClearServers();
     myEndpoint = endpoint;
@@ -163,7 +163,7 @@ static void setServerZoneState(uint8_t serverIndex, uint8_t zoneState)
     iasClientSaveCommand();
 }
 
-static void setServerEndpoint(uint8_t serverIndex, uint8_t endpoint)
+static void setServerEndpoint(uint8_t serverIndex, EndpointId endpoint)
 {
     emberAfIasZoneClientKnownServers[serverIndex].endpoint = endpoint;
     iasClientSaveCommand();
@@ -517,7 +517,7 @@ void readIasZoneServerCieAddress(EmberNodeId nodeId)
     }
 }
 
-void emberAfPluginIasZoneClientWriteAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+void emberAfPluginIasZoneClientWriteAttributesResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
     if (clusterId == ZCL_IAS_ZONE_CLUSTER_ID && iasZoneClientState == IAS_ZONE_CLIENT_STATE_SET_CIE_ADDRESS &&
         buffer[0] == EMBER_ZCL_STATUS_SUCCESS)
@@ -528,7 +528,7 @@ void emberAfPluginIasZoneClientWriteAttributesResponseCallback(EmberAfClusterId 
     return;
 }
 
-void emberAfPluginIasZoneClientReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+void emberAfPluginIasZoneClientReadAttributesResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
     uint8_t zoneStatus, zoneType, zoneState;
     if (clusterId == ZCL_IAS_ZONE_CLUSTER_ID &&
@@ -539,8 +539,8 @@ void emberAfPluginIasZoneClientReadAttributesResponseCallback(EmberAfClusterId c
         while ((i + 3) <= bufLen)
         { // 3 to insure we can read at least the attribute ID
           // and the status
-            uint16_t attributeId = buffer[i] + (buffer[i + 1] << 8);
-            uint8_t status       = buffer[i + 2];
+            AttributeId attributeId = buffer[i] + (buffer[i + 1] << 8);
+            uint8_t status          = buffer[i + 2];
             i += 3;
             // emberAfIasZoneClusterPrintln("Parsing Attribute 0x%2X, Status: 0x%X", attributeId, status);
             if (status == EMBER_ZCL_STATUS_SUCCESS)
@@ -612,6 +612,6 @@ void emberAfPluginIasZoneClientReadAttributesResponseCallback(EmberAfClusterId c
 
 void emberAfPluginIasZoneClientZdoCallback(EmberNodeId emberNodeId, EmberApsFrame * apsFrame, uint8_t * message, uint16_t length) {}
 
-void emberAfPluginIasZoneClientWriteAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen) {}
+void emberAfPluginIasZoneClientWriteAttributesResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen) {}
 
-void emberAfPluginIasZoneClientReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen) {}
+void emberAfPluginIasZoneClientReadAttributesResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen) {}

--- a/src/app/clusters/ias-zone-client/ias-zone-client.h
+++ b/src/app/clusters/ias-zone-client/ias-zone-client.h
@@ -62,6 +62,6 @@ void emAfClearServers(void);
 
 void emberAfPluginIasZoneClientZdoCallback(EmberNodeId emberNodeId, EmberApsFrame * apsFrame, uint8_t * message, uint16_t length);
 
-void emberAfPluginIasZoneClientWriteAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+void emberAfPluginIasZoneClientWriteAttributesResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 
-void emberAfPluginIasZoneClientReadAttributesResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+void emberAfPluginIasZoneClientReadAttributesResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);

--- a/src/app/clusters/ias-zone-server/ias-zone-server.cpp
+++ b/src/app/clusters/ias-zone-server/ias-zone-server.cpp
@@ -760,7 +760,7 @@ void emberAfIasZoneClusterServerMessageSentCallback(EmberOutgoingMessageType typ
 {
 #if defined(EMBER_AF_PLUGIN_IAS_ZONE_SERVER_ENABLE_QUEUE)
     uint8_t frameControl;
-    uint8_t commandId;
+    CommandId commandId;
 
     IasZoneStatusQueueEntry dummyEntry;
 

--- a/src/app/clusters/ias-zone-server/ias-zone-server.h
+++ b/src/app/clusters/ias-zone-server/ias-zone-server.h
@@ -83,7 +83,7 @@ typedef struct
  * @return EMBER_SUCCESS if the attribute update and notify succeeded, error
  * code otherwise.
  */
-EmberStatus emberAfPluginIasZoneServerUpdateZoneStatus(CHIPEndpointId endpoint, uint16_t newStatus,
+EmberStatus emberAfPluginIasZoneServerUpdateZoneStatus(chip::EndpointId endpoint, uint16_t newStatus,
                                                        uint16_t timeSinceStatusOccurredQs);
 
 /** @brief Gets the CIE assigned zone id of a given endpoint.
@@ -95,7 +95,7 @@ EmberStatus emberAfPluginIasZoneServerUpdateZoneStatus(CHIPEndpointId endpoint, 
  *
  * @return The zone ID assigned by the CIE at time of enrollment.
  */
-uint8_t emberAfPluginIasZoneServerGetZoneId(CHIPEndpointId endpoint);
+uint8_t emberAfPluginIasZoneServerGetZoneId(chip::EndpointId endpoint);
 
 /** @brief Determines the enrollment status of a given endpoint.
  *
@@ -106,7 +106,7 @@ uint8_t emberAfPluginIasZoneServerGetZoneId(CHIPEndpointId endpoint);
  *
  * @return True if enrolled, false otherwise.
  */
-bool emberAfIasZoneClusterAmIEnrolled(CHIPEndpointId endpoint);
+bool emberAfIasZoneClusterAmIEnrolled(chip::EndpointId endpoint);
 
 /** @brief Set the enrollment status.
  *
@@ -117,7 +117,7 @@ bool emberAfIasZoneClusterAmIEnrolled(CHIPEndpointId endpoint);
  *
  * @return An ::EmberAfStatus value indicating the status of the set action.
  */
-EmberAfStatus emberAfPluginIasZoneClusterSetEnrollmentMethod(CHIPEndpointId endpoint, EmberAfIasZoneEnrollmentMode method);
+EmberAfStatus emberAfPluginIasZoneClusterSetEnrollmentMethod(chip::EndpointId endpoint, EmberAfIasZoneEnrollmentMode method);
 
 /** @brief Configure the retry parameters of the status queue.
  *

--- a/src/app/clusters/identify/identify.cpp
+++ b/src/app/clusters/identify/identify.cpp
@@ -90,7 +90,7 @@ void emberAfIdentifyClusterServerTickCallback(EndpointId endpoint)
     }
 }
 
-void emberAfIdentifyClusterServerAttributeChangedCallback(EndpointId endpoint, EmberAfAttributeId attributeId)
+void emberAfIdentifyClusterServerAttributeChangedCallback(EndpointId endpoint, AttributeId attributeId)
 {
     if (attributeId == ZCL_IDENTIFY_TIME_ATTRIBUTE_ID)
     {

--- a/src/app/clusters/identify/identify.h
+++ b/src/app/clusters/identify/identify.h
@@ -32,7 +32,7 @@
  * @param endpoint The endpoint.  Ver.: always
  * @param identityTime  Ver.: always
  */
-bool emberAfPluginIdentifyStartFeedbackCallback(CHIPEndpointId endpoint, uint16_t identifyTime);
+bool emberAfPluginIdentifyStartFeedbackCallback(chip::EndpointId endpoint, uint16_t identifyTime);
 
 /** @brief Stop Feedback.
  *
@@ -42,4 +42,4 @@ bool emberAfPluginIdentifyStartFeedbackCallback(CHIPEndpointId endpoint, uint16_
  *
  * @param endpoint The endpoint.  Ver.: always
  */
-bool emberAfPluginIdentifyStopFeedbackCallback(CHIPEndpointId endpoint);
+bool emberAfPluginIdentifyStopFeedbackCallback(chip::EndpointId endpoint);

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -89,7 +89,7 @@ static bool areStartUpLevelControlServerAttributesTokenized(EndpointId endpoint)
 
 typedef struct
 {
-    uint8_t commandId;
+    CommandId commandId;
     uint8_t moveToLevel;
     bool increasing;
     bool useOnLevel;
@@ -104,16 +104,16 @@ static EmberAfLevelControlState stateTable[EMBER_AF_LEVEL_CONTROL_CLUSTER_SERVER
 
 static EmberAfLevelControlState * getState(EndpointId endpoint);
 
-static void moveToLevelHandler(uint8_t commandId, uint8_t level, uint16_t transitionTimeDs, uint8_t optionMask,
+static void moveToLevelHandler(CommandId commandId, uint8_t level, uint16_t transitionTimeDs, uint8_t optionMask,
                                uint8_t optionOverride, uint16_t storedLevel);
-static void moveHandler(uint8_t commandId, uint8_t moveMode, uint8_t rate, uint8_t optionMask, uint8_t optionOverride);
-static void stepHandler(uint8_t commandId, uint8_t stepMode, uint8_t stepSize, uint16_t transitionTimeDs, uint8_t optionMask,
+static void moveHandler(CommandId commandId, uint8_t moveMode, uint8_t rate, uint8_t optionMask, uint8_t optionOverride);
+static void stepHandler(CommandId commandId, uint8_t stepMode, uint8_t stepSize, uint16_t transitionTimeDs, uint8_t optionMask,
                         uint8_t optionOverride);
-static void stopHandler(uint8_t commandId, uint8_t optionMask, uint8_t optionOverride);
+static void stopHandler(CommandId commandId, uint8_t optionMask, uint8_t optionOverride);
 
 static void setOnOffValue(EndpointId endpoint, bool onOff);
 static void writeRemainingTime(EndpointId endpoint, uint16_t remainingTimeMs);
-static bool shouldExecuteIfOff(EndpointId endpoint, uint8_t commandId, uint8_t optionMask, uint8_t optionOverride);
+static bool shouldExecuteIfOff(EndpointId endpoint, CommandId commandId, uint8_t optionMask, uint8_t optionOverride);
 
 #if defined(ZCL_USING_LEVEL_CONTROL_CLUSTER_OPTIONS_ATTRIBUTE) && defined(EMBER_AF_PLUGIN_COLOR_CONTROL_SERVER_TEMP)
 static void reallyUpdateCoupledColorTemp(EndpointId endpoint);
@@ -315,7 +315,7 @@ static void setOnOffValue(EndpointId endpoint, bool onOff)
 #endif // EMBER_AF_PLUGIN_ON_OFF
 }
 
-static bool shouldExecuteIfOff(EndpointId endpoint, uint8_t commandId, uint8_t optionMask, uint8_t optionOverride)
+static bool shouldExecuteIfOff(EndpointId endpoint, CommandId commandId, uint8_t optionMask, uint8_t optionOverride)
 {
 #ifdef ZCL_USING_LEVEL_CONTROL_CLUSTER_OPTIONS_ATTRIBUTE
     // From 3.10.2.2.8.1 of ZCL7 document 14-0127-20j-zcl-ch-3-general.docx:
@@ -461,7 +461,7 @@ bool emberAfLevelControlClusterStopWithOnOffCallback(void)
     return true;
 }
 
-static void moveToLevelHandler(uint8_t commandId, uint8_t level, uint16_t transitionTimeDs, uint8_t optionMask,
+static void moveToLevelHandler(CommandId commandId, uint8_t level, uint16_t transitionTimeDs, uint8_t optionMask,
                                uint8_t optionOverride, uint16_t storedLevel)
 {
     EndpointId endpoint              = emberAfCurrentEndpoint();
@@ -595,7 +595,7 @@ send_default_response:
     }
 }
 
-static void moveHandler(uint8_t commandId, uint8_t moveMode, uint8_t rate, uint8_t optionMask, uint8_t optionOverride)
+static void moveHandler(CommandId commandId, uint8_t moveMode, uint8_t rate, uint8_t optionMask, uint8_t optionOverride)
 {
     EndpointId endpoint              = emberAfCurrentEndpoint();
     EmberAfLevelControlState * state = getState(endpoint);
@@ -706,7 +706,7 @@ send_default_response:
     emberAfSendImmediateDefaultResponse(status);
 }
 
-static void stepHandler(uint8_t commandId, uint8_t stepMode, uint8_t stepSize, uint16_t transitionTimeDs, uint8_t optionMask,
+static void stepHandler(CommandId commandId, uint8_t stepMode, uint8_t stepSize, uint16_t transitionTimeDs, uint8_t optionMask,
                         uint8_t optionOverride)
 {
     EndpointId endpoint              = emberAfCurrentEndpoint();
@@ -826,7 +826,7 @@ send_default_response:
     emberAfSendImmediateDefaultResponse(status);
 }
 
-static void stopHandler(uint8_t commandId, uint8_t optionMask, uint8_t optionOverride)
+static void stopHandler(CommandId commandId, uint8_t optionMask, uint8_t optionOverride)
 {
     EndpointId endpoint              = emberAfCurrentEndpoint();
     EmberAfLevelControlState * state = getState(endpoint);

--- a/src/app/clusters/level-control/level-control.h
+++ b/src/app/clusters/level-control/level-control.h
@@ -58,4 +58,4 @@
  *
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
-void emberAfPluginLevelControlClusterServerPostInitCallback(CHIPEndpointId endpoint);
+void emberAfPluginLevelControlClusterServerPostInitCallback(chip::EndpointId endpoint);

--- a/src/app/clusters/messaging-client/messaging-client.cpp
+++ b/src/app/clusters/messaging-client/messaging-client.cpp
@@ -62,14 +62,14 @@ static void esiDeletionCallback(uint8_t esiIndex)
     }
 }
 
-void emberAfMessagingClusterClientInitCallback(uint8_t endpoint)
+void emberAfMessagingClusterClientInitCallback(EndpointId endpoint)
 {
     emAfPluginMessagingClientClearMessage(endpoint);
     // Subscribing for ESI Management plugin deletion announcements.
     emberAfPluginEsiManagementSubscribeToDeletionAnnouncements(esiDeletionCallback);
 }
 
-void emAfPluginMessagingClientClearMessage(uint8_t endpoint)
+void emAfPluginMessagingClientClearMessage(EndpointId endpoint)
 {
     uint8_t ep = emberAfFindClusterClientEndpointIndex(endpoint, ZCL_MESSAGING_CLUSTER_ID);
     if (ep != 0xFF)
@@ -86,7 +86,7 @@ void emAfPluginMessagingClientClearMessage(uint8_t endpoint)
     }
 }
 
-void emberAfMessagingClusterClientTickCallback(uint8_t endpoint)
+void emberAfMessagingClusterClientTickCallback(EndpointId endpoint)
 {
     uint8_t ep = emberAfFindClusterClientEndpointIndex(endpoint, ZCL_MESSAGING_CLUSTER_ID);
 
@@ -124,10 +124,10 @@ bool emberAfMessagingClusterDisplayMessageCallback(uint32_t messageId, uint8_t m
                                                    uint16_t durationInMinutes, uint8_t * msg,
                                                    uint8_t optionalExtendedMessageControl)
 {
-    uint8_t endpoint = emberAfCurrentEndpoint();
-    uint8_t ep       = emberAfFindClusterClientEndpointIndex(endpoint, ZCL_MESSAGING_CLUSTER_ID);
-    uint32_t now     = emberAfGetCurrentTime();
-    uint8_t esiIndex = emberAfPluginEsiManagementUpdateEsiAndGetIndex(emberAfCurrentCommand());
+    EndpointId endpoint = emberAfCurrentEndpoint();
+    uint8_t ep          = emberAfFindClusterClientEndpointIndex(endpoint, ZCL_MESSAGING_CLUSTER_ID);
+    uint32_t now        = emberAfGetCurrentTime();
+    uint8_t esiIndex    = emberAfPluginEsiManagementUpdateEsiAndGetIndex(emberAfCurrentCommand());
 
     emberAfMessagingClusterPrint("RX: DisplayMessage"
                                  " 0x%4x, 0x%x, 0x%4x, 0x%2x, \"",
@@ -242,8 +242,8 @@ kickout:
 
 bool emberAfMessagingClusterCancelMessageCallback(uint32_t messageId, uint8_t messageControl)
 {
-    uint8_t endpoint = emberAfCurrentEndpoint();
-    uint8_t ep       = emberAfFindClusterClientEndpointIndex(endpoint, ZCL_MESSAGING_CLUSTER_ID);
+    EndpointId endpoint = emberAfCurrentEndpoint();
+    uint8_t ep          = emberAfFindClusterClientEndpointIndex(endpoint, ZCL_MESSAGING_CLUSTER_ID);
     EmberAfStatus status;
 
     if (ep == 0xFF)
@@ -270,7 +270,7 @@ bool emberAfMessagingClusterCancelMessageCallback(uint32_t messageId, uint8_t me
     return true;
 }
 
-void emAfPluginMessagingClientPrintInfo(uint8_t endpoint)
+void emAfPluginMessagingClientPrintInfo(EndpointId endpoint)
 {
     uint8_t ep = emberAfFindClusterClientEndpointIndex(endpoint, ZCL_MESSAGING_CLUSTER_ID);
 
@@ -297,7 +297,7 @@ void emAfPluginMessagingClientPrintInfo(uint8_t endpoint)
     emberAfMessagingClusterFlush();
 }
 
-EmberAfStatus emberAfPluginMessagingClientConfirmMessage(uint8_t endpoint)
+EmberAfStatus emberAfPluginMessagingClientConfirmMessage(EndpointId endpoint)
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_NOT_FOUND;
     uint8_t ep           = emberAfFindClusterClientEndpointIndex(endpoint, ZCL_MESSAGING_CLUSTER_ID);

--- a/src/app/clusters/messaging-client/messaging-client.h
+++ b/src/app/clusters/messaging-client/messaging-client.h
@@ -60,7 +60,7 @@
  * @param endpoint The relevant endpoint.
  *
  **/
-void emAfPluginMessagingClientClearMessage(uint8_t endpoint);
+void emAfPluginMessagingClientClearMessage(chip::EndpointId endpoint);
 
 /**
  * @brief Prints information about the message.
@@ -68,7 +68,7 @@ void emAfPluginMessagingClientClearMessage(uint8_t endpoint);
  * @param endpoint The relevant endpoint.
  *
  **/
-void emAfPluginMessagingClientPrintInfo(uint8_t endpoint);
+void emAfPluginMessagingClientPrintInfo(chip::EndpointId endpoint);
 
 /**
  * @brief Confirms a message.
@@ -81,4 +81,4 @@ void emAfPluginMessagingClientPrintInfo(uint8_t endpoint);
  * ::EMBER_ZCL_STATUS_FAILURE if an error occurred, or
  * ::EMBER_ZCL_STATUS_NOT_FOUND if the message does not exist.
  */
-EmberAfStatus emberAfPluginMessagingClientConfirmMessage(uint8_t endpoint);
+EmberAfStatus emberAfPluginMessagingClientConfirmMessage(chip::EndpointId endpoint);

--- a/src/app/clusters/messaging-server/messaging-server.h
+++ b/src/app/clusters/messaging-server/messaging-server.h
@@ -95,7 +95,7 @@ typedef struct
  * @return True if the message is valid or false is the message does not exist
  * or is expired.
  */
-bool emberAfPluginMessagingServerGetMessage(CHIPEndpointId endpoint, EmberAfPluginMessagingServerMessage * message);
+bool emberAfPluginMessagingServerGetMessage(chip::EndpointId endpoint, EmberAfPluginMessagingServerMessage * message);
 
 /**
  * @brief Sets the message used by the Messaging server plugin.
@@ -110,8 +110,8 @@ bool emberAfPluginMessagingServerGetMessage(CHIPEndpointId endpoint, EmberAfPlug
  * @param message The ::EmberAfPluginMessagingServerMessage structure
  * describing the message.  If NULL, the message is removed from the server.
  */
-void emberAfPluginMessagingServerSetMessage(CHIPEndpointId endpoint, const EmberAfPluginMessagingServerMessage * message);
+void emberAfPluginMessagingServerSetMessage(chip::EndpointId endpoint, const EmberAfPluginMessagingServerMessage * message);
 
-void emAfPluginMessagingServerPrintInfo(CHIPEndpointId endpoint);
+void emAfPluginMessagingServerPrintInfo(chip::EndpointId endpoint);
 void emberAfPluginMessagingServerDisplayMessage(EmberNodeId nodeId, uint8_t srcEndpoint, uint8_t dstEndpoint);
 void emberAfPluginMessagingServerCancelMessage(EmberNodeId nodeId, uint8_t srcEndpoint, uint8_t dstEndpoint);

--- a/src/app/clusters/on-off-server/on-off.h
+++ b/src/app/clusters/on-off-server/on-off.h
@@ -29,7 +29,7 @@
  * @param command   Ver.: always
  * @param initiatedByLevelChange   Ver.: always
  */
-EmberAfStatus emberAfOnOffClusterSetValueCallback(CHIPEndpointId endpoint, uint8_t command, bool initiatedByLevelChange);
+EmberAfStatus emberAfOnOffClusterSetValueCallback(chip::EndpointId endpoint, uint8_t command, bool initiatedByLevelChange);
 
 /** @brief On/off Cluster Level Control Effect
  *
@@ -40,4 +40,4 @@ EmberAfStatus emberAfOnOffClusterSetValueCallback(CHIPEndpointId endpoint, uint8
  * @param endpoint   Ver.: always
  * @param newValue   Ver.: always
  */
-void emberAfOnOffClusterLevelControlEffectCallback(CHIPEndpointId endpoint, bool newValue);
+void emberAfOnOffClusterLevelControlEffectCallback(chip::EndpointId endpoint, bool newValue);

--- a/src/app/clusters/scenes-client/scenes-client.cpp
+++ b/src/app/clusters/scenes-client/scenes-client.cpp
@@ -133,7 +133,7 @@ bool emberAfPluginScenesClientParseViewSceneResponse(const EmberAfClusterCommand
         // one-byte length.
         while (extensionFieldSetsIndex + 3 <= extensionFieldSetsLen)
         {
-            EmberAfClusterId clusterId;
+            ClusterId clusterId;
             uint8_t length;
             clusterId               = emberAfGetInt16u(extensionFieldSets, extensionFieldSetsIndex, extensionFieldSetsLen);
             extensionFieldSetsIndex = static_cast<uint16_t>(extensionFieldSetsIndex + 2);

--- a/src/app/clusters/scenes-client/scenes-client.h
+++ b/src/app/clusters/scenes-client/scenes-client.h
@@ -44,9 +44,9 @@
 
 #include "af-types.h"
 
-bool emberAfPluginScenesClientParseAddSceneResponse(const EmberAfClusterCommand * cmd, uint8_t status, CHIPGroupId groupId,
+bool emberAfPluginScenesClientParseAddSceneResponse(const EmberAfClusterCommand * cmd, uint8_t status, chip::GroupId groupId,
                                                     uint8_t sceneId);
 
-bool emberAfPluginScenesClientParseViewSceneResponse(const EmberAfClusterCommand * cmd, uint8_t status, CHIPGroupId groupId,
+bool emberAfPluginScenesClientParseViewSceneResponse(const EmberAfClusterCommand * cmd, uint8_t status, chip::GroupId groupId,
                                                      uint8_t sceneId, uint16_t transitionTime, const uint8_t * sceneName,
                                                      const uint8_t * extensionFieldSets);

--- a/src/app/clusters/scenes/scenes.cpp
+++ b/src/app/clusters/scenes/scenes.cpp
@@ -57,7 +57,7 @@ uint8_t emberAfPluginScenesServerEntriesInUse = 0;
 EmberAfSceneTableEntry emberAfPluginScenesServerSceneTable[EMBER_AF_PLUGIN_SCENES_TABLE_SIZE];
 #endif
 
-static bool readServerAttribute(EndpointId endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, const char * name,
+static bool readServerAttribute(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, const char * name,
                                 uint8_t * data, uint8_t size)
 {
     bool success = false;
@@ -76,8 +76,8 @@ static bool readServerAttribute(EndpointId endpoint, EmberAfClusterId clusterId,
     return success;
 }
 
-static EmberAfStatus writeServerAttribute(EndpointId endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
-                                          const char * name, uint8_t * data, EmberAfAttributeType type)
+static EmberAfStatus writeServerAttribute(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, const char * name,
+                                          uint8_t * data, EmberAfAttributeType type)
 {
     EmberAfStatus status = emberAfWriteServerAttribute(endpoint, clusterId, attributeId, data, type);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
@@ -758,7 +758,7 @@ bool emberAfPluginScenesServerParseAddScene(const EmberAfClusterCommand * cmd, G
 
     while (extensionFieldSetsIndex < extensionFieldSetsLen)
     {
-        EmberAfClusterId clusterId;
+        ClusterId clusterId;
         uint8_t length;
 
         // Each extension field set must contain a two-byte cluster id and a one-

--- a/src/app/clusters/scenes/scenes.h
+++ b/src/app/clusters/scenes/scenes.h
@@ -42,8 +42,8 @@
 #include <app/util/af-types.h>
 #include <stdint.h>
 
-EmberAfStatus emberAfScenesSetSceneCountAttribute(CHIPEndpointId endpoint, uint8_t newCount);
-EmberAfStatus emberAfScenesMakeValid(CHIPEndpointId endpoint, uint8_t sceneId, CHIPGroupId groupId);
+EmberAfStatus emberAfScenesSetSceneCountAttribute(chip::EndpointId endpoint, uint8_t newCount);
+EmberAfStatus emberAfScenesMakeValid(chip::EndpointId endpoint, uint8_t sceneId, chip::GroupId groupId);
 
 // DEPRECATED.
 #define emberAfScenesMakeInvalid emberAfScenesClusterMakeInvalidCallback
@@ -79,9 +79,9 @@ extern EmberAfSceneTableEntry emberAfPluginScenesServerSceneTable[];
 #define emberAfPluginScenesServerDecrNumSceneEntriesInUse() (--emberAfPluginScenesServerEntriesInUse)
 #endif // Use tokens
 
-bool emberAfPluginScenesServerParseAddScene(const EmberAfClusterCommand * cmd, CHIPGroupId groupId, uint8_t sceneId,
+bool emberAfPluginScenesServerParseAddScene(const EmberAfClusterCommand * cmd, chip::GroupId groupId, uint8_t sceneId,
                                             uint16_t transitionTime, uint8_t * sceneName, uint8_t * extensionFieldSets);
-bool emberAfPluginScenesServerParseViewScene(const EmberAfClusterCommand * cmd, CHIPGroupId groupId, uint8_t sceneId);
+bool emberAfPluginScenesServerParseViewScene(const EmberAfClusterCommand * cmd, chip::GroupId groupId, uint8_t sceneId);
 
 /** @brief Scenes Cluster Recall Saved Scene
  *
@@ -92,7 +92,7 @@ bool emberAfPluginScenesServerParseViewScene(const EmberAfClusterCommand * cmd, 
  * @param groupId The group identifier.  Ver.: always
  * @param sceneId The scene identifier.  Ver.: always
  */
-EmberAfStatus emberAfScenesClusterRecallSavedSceneCallback(CHIPEndpointId endpoint, CHIPGroupId groupId, uint8_t sceneId);
+EmberAfStatus emberAfScenesClusterRecallSavedSceneCallback(chip::EndpointId endpoint, chip::GroupId groupId, uint8_t sceneId);
 
 /** @brief Scenes Cluster Store Current Scene
  *
@@ -106,7 +106,7 @@ EmberAfStatus emberAfScenesClusterRecallSavedSceneCallback(CHIPEndpointId endpoi
  * @param groupId The group identifier.  Ver.: always
  * @param sceneId The scene identifier.  Ver.: always
  */
-EmberAfStatus emberAfScenesClusterStoreCurrentSceneCallback(CHIPEndpointId endpoint, CHIPGroupId groupId, uint8_t sceneId);
+EmberAfStatus emberAfScenesClusterStoreCurrentSceneCallback(chip::EndpointId endpoint, chip::GroupId groupId, uint8_t sceneId);
 
 /** @brief Scenes Cluster Remove Scenes In Group
  *
@@ -115,7 +115,7 @@ EmberAfStatus emberAfScenesClusterStoreCurrentSceneCallback(CHIPEndpointId endpo
  * @param endpoint Endpoint  Ver.: always
  * @param groupId Group ID  Ver.: always
  */
-void emberAfScenesClusterRemoveScenesInGroupCallback(CHIPEndpointId endpoint, CHIPGroupId groupId);
+void emberAfScenesClusterRemoveScenesInGroupCallback(chip::EndpointId endpoint, chip::GroupId groupId);
 
 /** @brief Scenes Cluster Make Invalid
  *
@@ -124,4 +124,4 @@ void emberAfScenesClusterRemoveScenesInGroupCallback(CHIPEndpointId endpoint, CH
  *
  * @param endpoint   Ver.: always
  */
-EmberAfStatus emberAfScenesClusterMakeInvalidCallback(CHIPEndpointId endpoint);
+EmberAfStatus emberAfScenesClusterMakeInvalidCallback(chip::EndpointId endpoint);

--- a/src/app/reporting/reporting.cpp
+++ b/src/app/reporting/reporting.cpp
@@ -57,11 +57,11 @@ using namespace chip;
 
 #define NULL_INDEX 0xFF
 
-static void conditionallySendReport(EndpointId endpoint, EmberAfClusterId clusterId);
+static void conditionallySendReport(EndpointId endpoint, ClusterId clusterId);
 static void scheduleTick(void);
 static void removeConfiguration(uint8_t index);
 static void removeConfigurationAndScheduleTick(uint8_t index);
-static EmberAfStatus configureReceivedAttribute(const EmberAfClusterCommand * cmd, EmberAfAttributeId attributeId, uint8_t mask,
+static EmberAfStatus configureReceivedAttribute(const EmberAfClusterCommand * cmd, AttributeId attributeId, uint8_t mask,
                                                 uint16_t timeout);
 static void putReportableChangeInResp(const EmberAfPluginReportingEntry * entry, EmberAfAttributeType dataType);
 static void retrySendReport(EmberOutgoingMessageType type, uint64_t indexOrDestination, EmberApsFrame * apsFrame, uint16_t msgLen,
@@ -344,7 +344,7 @@ void emberAfPluginReportingTickEventHandler(void)
     scheduleTick();
 }
 
-static void conditionallySendReport(EndpointId endpoint, EmberAfClusterId clusterId)
+static void conditionallySendReport(EndpointId endpoint, ClusterId clusterId)
 {
     EmberStatus status;
     if (emberAfIsDeviceEnabled(endpoint) || clusterId == ZCL_IDENTIFY_CLUSTER_ID)
@@ -402,13 +402,13 @@ bool emberAfConfigureReportingCommandCallback(const EmberAfClusterCommand * cmd)
     // of the direction field.
     while (bufIndex + 3 < cmd->bufLen)
     {
-        EmberAfAttributeId attributeId;
+        AttributeId attributeId;
         EmberAfReportingDirection direction;
         EmberAfStatus status;
 
         direction = (EmberAfReportingDirection) emberAfGetInt8u(cmd->buffer, bufIndex, cmd->bufLen);
         bufIndex++;
-        attributeId = (EmberAfAttributeId) emberAfGetInt16u(cmd->buffer, bufIndex, cmd->bufLen);
+        attributeId = (AttributeId) emberAfGetInt16u(cmd->buffer, bufIndex, cmd->bufLen);
         bufIndex    = static_cast<uint16_t>(bufIndex + 2);
 
         emberAfReportingPrintln(" - direction:%x, attr:%2x", direction, attributeId);
@@ -551,7 +551,7 @@ bool emberAfReadReportingConfigurationCommandCallback(const EmberAfClusterComman
     // attribute id.
     while (bufIndex + 3 <= cmd->bufLen)
     {
-        EmberAfAttributeId attributeId;
+        AttributeId attributeId;
         EmberAfAttributeMetadata * metadata = NULL;
         EmberAfPluginReportingEntry entry;
         EmberAfReportingDirection direction;
@@ -560,7 +560,7 @@ bool emberAfReadReportingConfigurationCommandCallback(const EmberAfClusterComman
 
         direction = (EmberAfReportingDirection) emberAfGetInt8u(cmd->buffer, bufIndex, cmd->bufLen);
         bufIndex++;
-        attributeId = (EmberAfAttributeId) emberAfGetInt16u(cmd->buffer, bufIndex, cmd->bufLen);
+        attributeId = (AttributeId) emberAfGetInt16u(cmd->buffer, bufIndex, cmd->bufLen);
         bufIndex    = static_cast<uint16_t>(bufIndex + 2);
 
         switch (direction)
@@ -944,7 +944,7 @@ EmberAfStatus emberAfPluginReportingConfigureReportedAttribute(const EmberAfPlug
     return status;
 }
 
-static EmberAfStatus configureReceivedAttribute(const EmberAfClusterCommand * cmd, EmberAfAttributeId attributeId, uint8_t mask,
+static EmberAfStatus configureReceivedAttribute(const EmberAfClusterCommand * cmd, AttributeId attributeId, uint8_t mask,
                                                 uint16_t timeout)
 {
     EmberAfPluginReportingEntry entry;
@@ -1070,12 +1070,12 @@ uint8_t emAfPluginReportingConditionallyAddReportingEntry(EmberAfPluginReporting
     return 0;
 }
 
-bool emberAfConfigureReportingResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+bool emberAfConfigureReportingResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
     return false;
 }
 
-bool emberAfReadReportingConfigurationResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+bool emberAfReadReportingConfigurationResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
     return false;
 }

--- a/src/app/reporting/reporting.h
+++ b/src/app/reporting/reporting.h
@@ -123,7 +123,7 @@ EmberStatus emberAfClearReportTableCallback(void);
  * always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfConfigureReportingResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+bool emberAfConfigureReportingResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 
 /** @brief Read Reporting Configuration Response
  *
@@ -137,7 +137,7 @@ bool emberAfConfigureReportingResponseCallback(EmberAfClusterId clusterId, uint8
  * records.  Ver.: always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfReadReportingConfigurationResponseCallback(EmberAfClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+bool emberAfReadReportingConfigurationResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 
 /** @brief Reporting Attribute Change
  *
@@ -154,5 +154,5 @@ bool emberAfReadReportingConfigurationResponseCallback(EmberAfClusterId clusterI
  * @param type   Ver.: always
  * @param data   Ver.: always
  */
-void emberAfReportingAttributeChangeCallback(CHIPEndpointId endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
+void emberAfReportingAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
                                              uint8_t mask, uint16_t manufacturerCode, EmberAfAttributeType type, uint8_t * data);

--- a/src/app/util/af-event.cpp
+++ b/src/app/util/af-event.cpp
@@ -126,7 +126,7 @@ const char * emberAfGetEventString(uint8_t index)
     return (index == 0XFF ? emAfStackEventString : emAfEventStrings[index]);
 }
 
-static EmberAfEventContext * findEventContext(EndpointId endpoint, EmberAfClusterId clusterId, bool isClient)
+static EmberAfEventContext * findEventContext(EndpointId endpoint, ClusterId clusterId, bool isClient)
 {
 #if defined(EMBER_AF_GENERATED_EVENT_CONTEXT)
     uint16_t i;
@@ -204,7 +204,7 @@ EmberStatus emberAfEventControlSetDelayMinutes(EmberEventControl * control, uint
     }
 }
 
-EmberStatus emberAfScheduleTickExtended(EndpointId endpoint, EmberAfClusterId clusterId, bool isClient, uint32_t delayMs,
+EmberStatus emberAfScheduleTickExtended(EndpointId endpoint, ClusterId clusterId, bool isClient, uint32_t delayMs,
                                         EmberAfEventPollControl pollControl, EmberAfEventSleepControl sleepControl)
 {
     EmberAfEventContext * context = findEventContext(endpoint, clusterId, isClient);
@@ -223,7 +223,7 @@ EmberStatus emberAfScheduleTickExtended(EndpointId endpoint, EmberAfClusterId cl
     return EMBER_BAD_ARGUMENT;
 }
 
-EmberStatus emberAfScheduleClusterTick(EndpointId endpoint, EmberAfClusterId clusterId, bool isClient, uint32_t delayMs,
+EmberStatus emberAfScheduleClusterTick(EndpointId endpoint, ClusterId clusterId, bool isClient, uint32_t delayMs,
                                        EmberAfEventSleepControl sleepControl)
 {
     return emberAfScheduleTickExtended(endpoint, clusterId, isClient, delayMs,
@@ -231,29 +231,29 @@ EmberStatus emberAfScheduleClusterTick(EndpointId endpoint, EmberAfClusterId clu
                                        (sleepControl == EMBER_AF_STAY_AWAKE ? EMBER_AF_STAY_AWAKE : EMBER_AF_OK_TO_SLEEP));
 }
 
-EmberStatus emberAfScheduleClientTickExtended(EndpointId endpoint, EmberAfClusterId clusterId, uint32_t delayMs,
+EmberStatus emberAfScheduleClientTickExtended(EndpointId endpoint, ClusterId clusterId, uint32_t delayMs,
                                               EmberAfEventPollControl pollControl, EmberAfEventSleepControl sleepControl)
 {
     return emberAfScheduleTickExtended(endpoint, clusterId, EMBER_AF_CLIENT_CLUSTER_TICK, delayMs, pollControl, sleepControl);
 }
 
-EmberStatus emberAfScheduleClientTick(EndpointId endpoint, EmberAfClusterId clusterId, uint32_t delayMs)
+EmberStatus emberAfScheduleClientTick(EndpointId endpoint, ClusterId clusterId, uint32_t delayMs)
 {
     return emberAfScheduleClientTickExtended(endpoint, clusterId, delayMs, EMBER_AF_LONG_POLL, EMBER_AF_OK_TO_SLEEP);
 }
 
-EmberStatus emberAfScheduleServerTickExtended(EndpointId endpoint, EmberAfClusterId clusterId, uint32_t delayMs,
+EmberStatus emberAfScheduleServerTickExtended(EndpointId endpoint, ClusterId clusterId, uint32_t delayMs,
                                               EmberAfEventPollControl pollControl, EmberAfEventSleepControl sleepControl)
 {
     return emberAfScheduleTickExtended(endpoint, clusterId, EMBER_AF_SERVER_CLUSTER_TICK, delayMs, pollControl, sleepControl);
 }
 
-EmberStatus emberAfScheduleServerTick(EndpointId endpoint, EmberAfClusterId clusterId, uint32_t delayMs)
+EmberStatus emberAfScheduleServerTick(EndpointId endpoint, ClusterId clusterId, uint32_t delayMs)
 {
     return emberAfScheduleServerTickExtended(endpoint, clusterId, delayMs, EMBER_AF_LONG_POLL, EMBER_AF_OK_TO_SLEEP);
 }
 
-EmberStatus emberAfDeactivateClusterTick(EndpointId endpoint, EmberAfClusterId clusterId, bool isClient)
+EmberStatus emberAfDeactivateClusterTick(EndpointId endpoint, ClusterId clusterId, bool isClient)
 {
     EmberAfEventContext * context = findEventContext(endpoint, clusterId, isClient);
     if (context != NULL)
@@ -264,12 +264,12 @@ EmberStatus emberAfDeactivateClusterTick(EndpointId endpoint, EmberAfClusterId c
     return EMBER_BAD_ARGUMENT;
 }
 
-EmberStatus emberAfDeactivateClientTick(EndpointId endpoint, EmberAfClusterId clusterId)
+EmberStatus emberAfDeactivateClientTick(EndpointId endpoint, ClusterId clusterId)
 {
     return emberAfDeactivateClusterTick(endpoint, clusterId, EMBER_AF_CLIENT_CLUSTER_TICK);
 }
 
-EmberStatus emberAfDeactivateServerTick(EndpointId endpoint, EmberAfClusterId clusterId)
+EmberStatus emberAfDeactivateServerTick(EndpointId endpoint, ClusterId clusterId)
 {
     return emberAfDeactivateClusterTick(endpoint, clusterId, EMBER_AF_SERVER_CLUSTER_TICK);
 }

--- a/src/app/util/af-main-common.cpp
+++ b/src/app/util/af-main-common.cpp
@@ -338,9 +338,9 @@ static EmberStatus send(EmberOutgoingMessageType type, uint64_t indexOrDestinati
     return status;
 }
 
-EmberStatus emberAfSendMulticastWithAliasWithCallback(EmberMulticastId multicastId, EmberApsFrame * apsFrame,
-                                                      uint16_t messageLength, uint8_t * message, EmberNodeId alias,
-                                                      uint8_t sequence, EmberAfMessageSentFunction callback)
+EmberStatus emberAfSendMulticastWithAliasWithCallback(GroupId multicastId, EmberApsFrame * apsFrame, uint16_t messageLength,
+                                                      uint8_t * message, EmberNodeId alias, uint8_t sequence,
+                                                      EmberAfMessageSentFunction callback)
 {
     apsFrame->groupId = multicastId;
     return send(EMBER_OUTGOING_MULTICAST_WITH_ALIAS, multicastId, apsFrame, messageLength, message,
@@ -348,7 +348,7 @@ EmberStatus emberAfSendMulticastWithAliasWithCallback(EmberMulticastId multicast
                 alias, sequence, callback);
 }
 
-EmberStatus emberAfSendMulticastWithCallback(EmberMulticastId multicastId, EmberApsFrame * apsFrame, uint16_t messageLength,
+EmberStatus emberAfSendMulticastWithCallback(GroupId multicastId, EmberApsFrame * apsFrame, uint16_t messageLength,
                                              uint8_t * message, EmberAfMessageSentFunction callback)
 {
     apsFrame->groupId = multicastId;
@@ -359,7 +359,7 @@ EmberStatus emberAfSendMulticastWithCallback(EmberMulticastId multicastId, Ember
                 callback);
 }
 
-EmberStatus emberAfSendMulticast(EmberMulticastId multicastId, EmberApsFrame * apsFrame, uint16_t messageLength, uint8_t * message)
+EmberStatus emberAfSendMulticast(GroupId multicastId, EmberApsFrame * apsFrame, uint16_t messageLength, uint8_t * message)
 {
     return emberAfSendMulticastWithCallback(multicastId, apsFrame, messageLength, message, NULL);
 }
@@ -502,8 +502,8 @@ EmberStatus emberAfSendUnicastToBindings(EmberApsFrame * apsFrame, uint16_t mess
 }
 
 EmberStatus emberAfSendInterPan(EmberPanId panId, const EmberEUI64 destinationLongId, EmberNodeId destinationShortId,
-                                EmberMulticastId multicastId, EmberAfClusterId clusterId, EmberAfProfileId profileId,
-                                uint16_t messageLength, uint8_t * messageBytes)
+                                GroupId multicastId, ClusterId clusterId, EmberAfProfileId profileId, uint16_t messageLength,
+                                uint8_t * messageBytes)
 {
     EmberAfInterpanHeader header;
     memset(&header, 0, sizeof(EmberAfInterpanHeader));

--- a/src/app/util/af-main.h
+++ b/src/app/util/af-main.h
@@ -148,7 +148,7 @@ void emberAfFormatMfgString(uint8_t * mfgString);
 extern bool emberAfPrintReceivedMessages;
 
 void emAfParseAndPrintVersion(EmberVersion versionStruct);
-void emAfPrintEzspEndpointFlags(CHIPEndpointId endpoint);
+void emAfPrintEzspEndpointFlags(chip::EndpointId endpoint);
 
 // Old names
 #define emberAfMoveInProgress() emberAfMoveInProgressCallback()

--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -169,7 +169,7 @@ typedef struct
     /**
      * Attribute ID, according to ZCL specs.
      */
-    EmberAfAttributeId attributeId;
+    chip::AttributeId attributeId;
     /**
      * Attribute type, according to ZCL specs.
      */
@@ -199,7 +199,7 @@ typedef struct
     /**
      *  ID of cluster according to ZCL spec
      */
-    EmberAfClusterId clusterId;
+    chip::ClusterId clusterId;
     /**
      * Pointer to attribute metadata array for this cluster.
      */
@@ -236,7 +236,7 @@ typedef struct
     /**
      * Endpoint that the attribute is located on
      */
-    CHIPEndpointId endpoint;
+    chip::EndpointId endpoint;
 
     /**
      * Cluster that the attribute is located on. If the cluster
@@ -244,7 +244,7 @@ typedef struct
      * The manufacturer code should also be set to the code associated
      * with the manufacturer specific cluster.
      */
-    EmberAfClusterId clusterId;
+    chip::ClusterId clusterId;
 
     /**
      * Cluster mask for the cluster, used to determine if it is
@@ -258,7 +258,7 @@ typedef struct
      * inside the manufacturer specific range 0xfc00 - 0xffff, or the manufacturer
      * code is NOT 0, the attribute is assumed to be manufacturer specific.
      */
-    EmberAfAttributeId attributeId;
+    chip::AttributeId attributeId;
 
     /**
      * Manufacturer Code associated with the cluster and or attribute.
@@ -388,12 +388,12 @@ typedef struct
      * APS data
      */
     EmberAfProfileId profileId;
-    EmberAfClusterId clusterId;
+    chip::ClusterId clusterId;
     /**
      * The groupId is only used for
      * EMBER_AF_INTERPAN_MULTICAST
      */
-    EmberMulticastId groupId;
+    chip::GroupId groupId;
     EmberAfInterpanOptions options;
 } EmberAfInterpanHeader;
 
@@ -418,8 +418,8 @@ typedef uint8_t EmberAfAllowedInterpanOptions;
 typedef struct
 {
     EmberAfProfileId profileId;
-    EmberAfClusterId clusterId;
-    uint8_t commandId;
+    chip::ClusterId clusterId;
+    chip::CommandId commandId;
     EmberAfAllowedInterpanOptions options;
 } EmberAfAllowedInterPanMessage;
 
@@ -445,7 +445,7 @@ typedef struct
     bool mfgSpecific;
     uint16_t mfgCode;
     uint8_t seqNum;
-    CHIPCommandId commandId;
+    chip::CommandId commandId;
     uint8_t payloadStartIndex;
     uint8_t direction;
     EmberAfInterpanHeader * interPanHeader;
@@ -506,7 +506,7 @@ typedef struct
     /**
      * Actual zigbee endpoint number.
      */
-    CHIPEndpointId endpoint;
+    chip::EndpointId endpoint;
     /**
      * Profile ID of the device on this endpoint.
      */
@@ -560,14 +560,14 @@ typedef struct
     uint32_t eventId;
 #ifdef EMBER_AF_PLUGIN_DRLC_SERVER
     EmberEUI64 source;
-    CHIPEndpointId sourceEndpoint;
+    chip::EndpointId sourceEndpoint;
 #endif // EMBER_AF_PLUGIN_DRLC_SERVER
 
 #ifdef EMBER_AF_PLUGIN_DRLC
     EmberAfPluginEsiManagementBitmask esiBitmask;
 #endif // EMBER_AF_PLUGIN_DRLC
 
-    CHIPEndpointId destinationEndpoint;
+    chip::EndpointId destinationEndpoint;
     uint16_t deviceClass;
     uint8_t utilityEnrollmentGroup;
     /**
@@ -662,7 +662,7 @@ typedef struct
 typedef struct
 {
     uint8_t count;
-    const CHIPEndpointId * list;
+    const chip::EndpointId * list;
 } EmberAfEndpointList;
 
 /**
@@ -672,12 +672,12 @@ typedef struct
 typedef struct
 {
     uint8_t inClusterCount;
-    const CHIPClusterId * inClusterList;
+    const chip::ClusterId * inClusterList;
     uint8_t outClusterCount;
-    const CHIPClusterId * outClusterList;
+    const chip::ClusterId * outClusterList;
     EmberAfProfileId profileId;
     uint16_t deviceId;
-    CHIPEndpointId endpoint;
+    chip::EndpointId endpoint;
 } EmberAfClusterList;
 
 /**
@@ -799,11 +799,11 @@ typedef struct
     /**
      * The endpoint of the associated cluster event.
      */
-    CHIPEndpointId endpoint;
+    chip::EndpointId endpoint;
     /**
      * The cluster id of the associated cluster event.
      */
-    EmberAfClusterId clusterId;
+    chip::ClusterId clusterId;
     /**
      * The server/client identity of the associated cluster event.
      */
@@ -833,7 +833,7 @@ typedef void (*EmberAfNetworkEventHandler)(void);
 /**
  * @brief Type for referring to the handler for endpoint events.
  */
-typedef void (*EmberAfEndpointEventHandler)(CHIPEndpointId endpoint);
+typedef void (*EmberAfEndpointEventHandler)(chip::EndpointId endpoint);
 
 #ifdef EMBER_AF_PLUGIN_GROUPS_SERVER
 /**
@@ -856,8 +856,8 @@ typedef void (*EmberAfEndpointEventHandler)(CHIPEndpointId endpoint);
  */
 typedef struct
 {
-    CHIPEndpointId endpoint; // 0x00 when not in use
-    CHIPGroupId groupId;
+    chip::EndpointId endpoint; // 0x00 when not in use
+    chip::GroupId groupId;
     uint8_t bindingIndex;
 #ifdef EMBER_AF_PLUGIN_GROUPS_SERVER_NAME_SUPPORT
     uint8_t name[ZCL_GROUPS_CLUSTER_MAXIMUM_NAME_LENGTH + 1];
@@ -893,8 +893,8 @@ typedef struct
  */
 typedef struct
 {
-    CHIPEndpointId endpoint; // 0x00 when this record is not in use
-    CHIPGroupId groupId;     // 0x0000 if not associated with a group
+    chip::EndpointId endpoint; // 0x00 when this record is not in use
+    chip::GroupId groupId;     // 0x0000 if not associated with a group
     uint8_t sceneId;
 #ifdef EMBER_AF_PLUGIN_SCENES_NAME_SUPPORT
     uint8_t name[ZCL_SCENES_CLUSTER_MAXIMUM_NAME_LENGTH + 1];
@@ -959,7 +959,7 @@ typedef struct
     bool valid;
     bool active;
     EmberAfPluginEsiManagementBitmask esiBitmask;
-    CHIPEndpointId clientEndpoint;
+    chip::EndpointId clientEndpoint;
     uint32_t messageId;
     uint8_t messageControl;
     uint32_t startTime;
@@ -973,7 +973,7 @@ typedef struct
 {
     bool valid;
     bool active;
-    CHIPEndpointId clientEndpoint;
+    chip::EndpointId clientEndpoint;
     uint32_t providerId;
     uint8_t rateLabel[ZCL_PRICE_CLUSTER_MAXIMUM_RATE_LABEL_LENGTH + 1];
     uint32_t issuerEventId;
@@ -1034,11 +1034,11 @@ typedef struct
      * report is received.  If ::EMBER_AF_PLUGIN_REPORTING_UNUSED_ENDPOINT_ID,
      * the entry is unused.
      */
-    CHIPEndpointId endpoint;
+    chip::EndpointId endpoint;
     /** The cluster where the attribute is located. */
-    EmberAfClusterId clusterId;
+    chip::ClusterId clusterId;
     /** The id of the attribute being reported or received. */
-    EmberAfAttributeId attributeId;
+    chip::AttributeId attributeId;
     /** CLUSTER_MASK_SERVER for server-side attributes or CLUSTER_MASK_CLIENT for
      *  client-side attributes.
      */
@@ -1068,7 +1068,7 @@ typedef struct
             /** The node id of the source of the received reports. */
             ChipNodeId source;
             /** The remote endpoint from which the attribute is reported. */
-            CHIPEndpointId endpoint;
+            chip::EndpointId endpoint;
             /** The maximum expected time between reports, measured in seconds. */
             uint16_t timeout;
         } received;
@@ -1121,7 +1121,7 @@ enum
  */
 typedef struct
 {
-    EmberMulticastId groupId;
+    chip::GroupId groupId;
     uint8_t groupType;
 } EmberAfPluginZllCommissioningGroupInformationRecord;
 
@@ -1132,7 +1132,7 @@ typedef struct
 typedef struct
 {
     EmberNodeId networkAddress;
-    CHIPEndpointId endpointId;
+    chip::EndpointId endpointId;
     uint16_t profileId;
     uint16_t deviceId;
     uint8_t version;
@@ -1210,7 +1210,7 @@ typedef enum
  * the cluster. The rate of tick is determined by the metadata of the
  * cluster.
  */
-typedef void (*EmberAfTickFunction)(CHIPEndpointId endpoint);
+typedef void (*EmberAfTickFunction)(chip::EndpointId endpoint);
 
 /**
  * @brief Type for referring to the init callback for cluster.
@@ -1218,14 +1218,14 @@ typedef void (*EmberAfTickFunction)(CHIPEndpointId endpoint);
  * Init function is called when the application starts up, once for
  * each cluster/endpoint combination.
  */
-typedef void (*EmberAfInitFunction)(CHIPEndpointId endpoint);
+typedef void (*EmberAfInitFunction)(chip::EndpointId endpoint);
 
 /**
  * @brief Type for referring to the attribute changed callback function.
  *
  * This function is called just after an attribute changes.
  */
-typedef void (*EmberAfClusterAttributeChangedCallback)(CHIPEndpointId endpoint, EmberAfAttributeId attributeId);
+typedef void (*EmberAfClusterAttributeChangedCallback)(chip::EndpointId endpoint, chip::AttributeId attributeId);
 
 /**
  * @brief Type for referring to the manufacturer specific
@@ -1233,7 +1233,7 @@ typedef void (*EmberAfClusterAttributeChangedCallback)(CHIPEndpointId endpoint, 
  *
  * This function is called just after a manufacturer specific attribute changes.
  */
-typedef void (*EmberAfManufacturerSpecificClusterAttributeChangedCallback)(CHIPEndpointId endpoint, EmberAfAttributeId attributeId,
+typedef void (*EmberAfManufacturerSpecificClusterAttributeChangedCallback)(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                            uint16_t manufacturerCode);
 
 /**
@@ -1241,7 +1241,7 @@ typedef void (*EmberAfManufacturerSpecificClusterAttributeChangedCallback)(CHIPE
  *
  * This function is called before an attribute changes.
  */
-typedef EmberAfStatus (*EmberAfClusterPreAttributeChangedCallback)(CHIPEndpointId endpoint, EmberAfAttributeId attributeId,
+typedef EmberAfStatus (*EmberAfClusterPreAttributeChangedCallback)(chip::EndpointId endpoint, chip::AttributeId attributeId,
                                                                    EmberAfAttributeType attributeType, uint8_t size,
                                                                    uint8_t * value);
 
@@ -1251,7 +1251,7 @@ typedef EmberAfStatus (*EmberAfClusterPreAttributeChangedCallback)(CHIPEndpointI
  * This function is called when default response is received, before
  * the global callback. Global callback is called immediately afterwards.
  */
-typedef void (*EmberAfDefaultResponseFunction)(CHIPEndpointId endpoint, uint8_t commandId, EmberAfStatus status);
+typedef void (*EmberAfDefaultResponseFunction)(chip::EndpointId endpoint, chip::CommandId commandId, EmberAfStatus status);
 
 /**
  * @brief Type for referring to the message sent callback function.
@@ -1338,7 +1338,7 @@ typedef struct
 typedef struct
 {
     uint16_t clusterId;
-    uint8_t commandId;
+    chip::CommandId commandId;
     uint8_t mask;
 } EmberAfCommandMetadata;
 
@@ -1633,10 +1633,10 @@ typedef uint16_t EmberAfRemoteClusterType;
  */
 typedef struct
 {
-    EmberAfClusterId clusterId;
+    chip::ClusterId clusterId;
     EmberAfProfileId profileId;
     uint16_t deviceId;
-    CHIPEndpointId endpoint;
+    chip::EndpointId endpoint;
     EmberAfRemoteClusterType type;
 } EmberAfRemoteClusterStruct;
 
@@ -1646,16 +1646,16 @@ typedef struct
 typedef struct
 {
     EmberEUI64 targetEUI64;
-    CHIPEndpointId sourceEndpoint;
-    CHIPEndpointId destEndpoint;
-    CHIPClusterId clusterId;
+    chip::EndpointId sourceEndpoint;
+    chip::EndpointId destEndpoint;
+    chip::ClusterId clusterId;
     EmberEUI64 destEUI64;
     EmberEUI64 sourceEUI64;
 } EmberAfRemoteBindingStruct;
 
 typedef struct
 {
-    EmberAfClusterId clusterId;
+    chip::ClusterId clusterId;
     bool server;
 } EmberAfClusterInfo;
 
@@ -1671,7 +1671,7 @@ typedef struct
     EmberAfClusterInfo clusters[EMBER_AF_MAX_CLUSTERS_PER_ENDPOINT];
     EmberAfProfileId profileId;
     uint16_t deviceId;
-    CHIPEndpointId endpoint;
+    chip::EndpointId endpoint;
     uint8_t clusterCount;
 } EmberAfEndpointInfoStruct;
 

--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -117,12 +117,12 @@
  *
  * @return Returns pointer to the attribute metadata location.
  */
-EmberAfAttributeMetadata * emberAfLocateAttributeMetadata(CHIPEndpointId endpoint, EmberAfClusterId clusterId,
-                                                          EmberAfAttributeId attributeId, uint8_t mask, uint16_t manufacturerCode);
+EmberAfAttributeMetadata * emberAfLocateAttributeMetadata(chip::EndpointId endpoint, chip::ClusterId clusterId,
+                                                          chip::AttributeId attributeId, uint8_t mask, uint16_t manufacturerCode);
 
 #ifdef DOXYGEN_SHOULD_SKIP_THIS
 /** @brief Returns true if the attribute exists. */
-bool emberAfContainsAttribute(CHIPEndpointId endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,
+bool emberAfContainsAttribute(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t mask,
                               uint16_t manufacturerCode);
 #else
 #define emberAfContainsAttribute(endpoint, clusterId, attributeId, mask, manufacturerCode)                                         \
@@ -137,7 +137,7 @@ bool emberAfContainsAttribute(CHIPEndpointId endpoint, EmberAfClusterId clusterI
  * For standard libraries (when ClusterId < FC00),
  * the manufacturerCode is ignored.
  */
-bool emberAfContainsClusterWithMfgCode(CHIPEndpointId endpoint, EmberAfClusterId clusterId, uint16_t manufacturerCode);
+bool emberAfContainsClusterWithMfgCode(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode);
 
 /**
  * @brief Returns true if endpoint contains the ZCL cluster with specified id.
@@ -150,7 +150,7 @@ bool emberAfContainsClusterWithMfgCode(CHIPEndpointId endpoint, EmberAfClusterId
  * then this will return the first cluster that it finds in the Cluster table.
  * and will not return any other clusters that share that id.
  */
-bool emberAfContainsCluster(CHIPEndpointId endpoint, EmberAfClusterId clusterId);
+bool emberAfContainsCluster(chip::EndpointId endpoint, chip::ClusterId clusterId);
 
 /**
  * @brief Returns true if endpoint has cluster server, checking for mfg code.
@@ -159,7 +159,7 @@ bool emberAfContainsCluster(CHIPEndpointId endpoint, EmberAfClusterId clusterId)
  * the endpoint contains server of a given cluster.
  * For standard librarys (when ClusterId < FC00), the manufacturerCode is ignored.
  */
-bool emberAfContainsServerWithMfgCode(CHIPEndpointId endpoint, EmberAfClusterId clusterId, uint16_t manufacturerCode);
+bool emberAfContainsServerWithMfgCode(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode);
 
 /**
  * @brief Returns true if endpoint contains the ZCL server with specified id.
@@ -172,7 +172,7 @@ bool emberAfContainsServerWithMfgCode(CHIPEndpointId endpoint, EmberAfClusterId 
  * then this will return the first cluster that it finds in the Cluster table.
  * and will not return any other clusters that share that id.
  */
-bool emberAfContainsServer(CHIPEndpointId endpoint, EmberAfClusterId clusterId);
+bool emberAfContainsServer(chip::EndpointId endpoint, chip::ClusterId clusterId);
 
 /**
  * @brief Returns true if endpoint contains cluster client.
@@ -182,7 +182,7 @@ bool emberAfContainsServer(CHIPEndpointId endpoint, EmberAfClusterId clusterId);
  * For standard library clusters (when ClusterId < FC00),
  * the manufacturerCode is ignored.
  */
-bool emberAfContainsClientWithMfgCode(CHIPEndpointId endpoint, EmberAfClusterId clusterId, uint16_t manufacturerCode);
+bool emberAfContainsClientWithMfgCode(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode);
 
 /**
  * @brief Returns true if endpoint contains the ZCL client with specified id.
@@ -195,7 +195,7 @@ bool emberAfContainsClientWithMfgCode(CHIPEndpointId endpoint, EmberAfClusterId 
  * then this will return the first cluster that it finds in the Cluster table.
  * and will not return any other clusters that share that id.
  */
-bool emberAfContainsClient(CHIPEndpointId endpoint, EmberAfClusterId clusterId);
+bool emberAfContainsClient(chip::EndpointId endpoint, chip::ClusterId clusterId);
 
 /**
  * @brief write an attribute, performing all the checks.
@@ -216,7 +216,7 @@ bool emberAfContainsClient(CHIPEndpointId endpoint, EmberAfClusterId clusterId);
  *      emberAfWriteManufacturerSpecificClientAttribute,
  *      emberAfWriteManufacturerSpecificServerAttribute
  */
-EmberAfStatus emberAfWriteAttribute(CHIPEndpointId endpoint, EmberAfClusterId cluster, EmberAfAttributeId attributeID, uint8_t mask,
+EmberAfStatus emberAfWriteAttribute(chip::EndpointId endpoint, chip::ClusterId cluster, chip::AttributeId attributeID, uint8_t mask,
                                     uint8_t * dataPtr, EmberAfAttributeType dataType);
 
 /**
@@ -231,7 +231,7 @@ EmberAfStatus emberAfWriteAttribute(CHIPEndpointId endpoint, EmberAfClusterId cl
  *      emberAfWriteManufacturerSpecificClientAttribute,
  *      emberAfWriteManufacturerSpecificServerAttribute
  */
-EmberAfStatus emberAfWriteServerAttribute(CHIPEndpointId endpoint, EmberAfClusterId cluster, EmberAfAttributeId attributeID,
+EmberAfStatus emberAfWriteServerAttribute(chip::EndpointId endpoint, chip::ClusterId cluster, chip::AttributeId attributeID,
                                           uint8_t * dataPtr, EmberAfAttributeType dataType);
 
 /**
@@ -246,7 +246,7 @@ EmberAfStatus emberAfWriteServerAttribute(CHIPEndpointId endpoint, EmberAfCluste
  *      emberAfWriteManufacturerSpecificClientAttribute,
  *      emberAfWriteManufacturerSpecificServerAttribute
  */
-EmberAfStatus emberAfWriteClientAttribute(CHIPEndpointId endpoint, EmberAfClusterId cluster, EmberAfAttributeId attributeID,
+EmberAfStatus emberAfWriteClientAttribute(chip::EndpointId endpoint, chip::ClusterId cluster, chip::AttributeId attributeID,
                                           uint8_t * dataPtr, EmberAfAttributeType dataType);
 
 /**
@@ -261,8 +261,8 @@ EmberAfStatus emberAfWriteClientAttribute(CHIPEndpointId endpoint, EmberAfCluste
  * @see emberAfWriteClientAttribute, emberAfWriteServerAttribute,
  *      emberAfWriteManufacturerSpecificClientAttribute
  */
-EmberAfStatus emberAfWriteManufacturerSpecificServerAttribute(CHIPEndpointId endpoint, EmberAfClusterId cluster,
-                                                              EmberAfAttributeId attributeID, uint16_t manufacturerCode,
+EmberAfStatus emberAfWriteManufacturerSpecificServerAttribute(chip::EndpointId endpoint, chip::ClusterId cluster,
+                                                              chip::AttributeId attributeID, uint16_t manufacturerCode,
                                                               uint8_t * dataPtr, EmberAfAttributeType dataType);
 
 /**
@@ -277,8 +277,8 @@ EmberAfStatus emberAfWriteManufacturerSpecificServerAttribute(CHIPEndpointId end
  * @see emberAfWriteClientAttribute, emberAfWriteServerAttribute,
  *      emberAfWriteManufacturerSpecificServerAttribute
  */
-EmberAfStatus emberAfWriteManufacturerSpecificClientAttribute(CHIPEndpointId endpoint, EmberAfClusterId cluster,
-                                                              EmberAfAttributeId attributeID, uint16_t manufacturerCode,
+EmberAfStatus emberAfWriteManufacturerSpecificClientAttribute(chip::EndpointId endpoint, chip::ClusterId cluster,
+                                                              chip::AttributeId attributeID, uint16_t manufacturerCode,
                                                               uint8_t * dataPtr, EmberAfAttributeType dataType);
 
 /**
@@ -295,7 +295,7 @@ EmberAfStatus emberAfWriteManufacturerSpecificClientAttribute(CHIPEndpointId end
  * @param buffer Location where attribute will be written from.
  * @param dataType ZCL attribute type.
  */
-EmberAfStatus emberAfVerifyAttributeWrite(CHIPEndpointId endpoint, EmberAfClusterId cluster, EmberAfAttributeId attributeID,
+EmberAfStatus emberAfVerifyAttributeWrite(chip::EndpointId endpoint, chip::ClusterId cluster, chip::AttributeId attributeID,
                                           uint8_t mask, uint16_t manufacturerCode, uint8_t * dataPtr,
                                           EmberAfAttributeType dataType);
 
@@ -311,7 +311,7 @@ EmberAfStatus emberAfVerifyAttributeWrite(CHIPEndpointId endpoint, EmberAfCluste
  *      emberAfReadManufacturerSpecificClientAttribute,
  *      emberAfReadManufacturerSpecificServerAttribute
  */
-EmberAfStatus emberAfReadAttribute(CHIPEndpointId endpoint, EmberAfClusterId cluster, EmberAfAttributeId attributeID, uint8_t mask,
+EmberAfStatus emberAfReadAttribute(chip::EndpointId endpoint, chip::ClusterId cluster, chip::AttributeId attributeID, uint8_t mask,
                                    uint8_t * dataPtr, uint8_t readLength, EmberAfAttributeType * dataType);
 
 /**
@@ -326,7 +326,7 @@ EmberAfStatus emberAfReadAttribute(CHIPEndpointId endpoint, EmberAfClusterId clu
  *      emberAfReadManufacturerSpecificClientAttribute,
  *      emberAfReadManufacturerSpecificServerAttribute
  */
-EmberAfStatus emberAfReadServerAttribute(CHIPEndpointId endpoint, EmberAfClusterId cluster, EmberAfAttributeId attributeID,
+EmberAfStatus emberAfReadServerAttribute(chip::EndpointId endpoint, chip::ClusterId cluster, chip::AttributeId attributeID,
                                          uint8_t * dataPtr, uint8_t readLength);
 
 /**
@@ -341,7 +341,7 @@ EmberAfStatus emberAfReadServerAttribute(CHIPEndpointId endpoint, EmberAfCluster
  *      emberAfReadManufacturerSpecificClientAttribute,
  *      emberAfReadManufacturerSpecificServerAttribute
  */
-EmberAfStatus emberAfReadClientAttribute(CHIPEndpointId endpoint, EmberAfClusterId cluster, EmberAfAttributeId attributeID,
+EmberAfStatus emberAfReadClientAttribute(chip::EndpointId endpoint, chip::ClusterId cluster, chip::AttributeId attributeID,
                                          uint8_t * dataPtr, uint8_t readLength);
 
 /**
@@ -355,8 +355,8 @@ EmberAfStatus emberAfReadClientAttribute(CHIPEndpointId endpoint, EmberAfCluster
  * @see emberAfReadClientAttribute, emberAfReadServerAttribute,
  *      emberAfReadManufacturerSpecificClientAttribute
  */
-EmberAfStatus emberAfReadManufacturerSpecificServerAttribute(CHIPEndpointId endpoint, EmberAfClusterId cluster,
-                                                             EmberAfAttributeId attributeID, uint16_t manufacturerCode,
+EmberAfStatus emberAfReadManufacturerSpecificServerAttribute(chip::EndpointId endpoint, chip::ClusterId cluster,
+                                                             chip::AttributeId attributeID, uint16_t manufacturerCode,
                                                              uint8_t * dataPtr, uint8_t readLength);
 
 /**
@@ -370,8 +370,8 @@ EmberAfStatus emberAfReadManufacturerSpecificServerAttribute(CHIPEndpointId endp
  * @see emberAfReadClientAttribute, emberAfReadServerAttribute,
  *      emberAfReadManufacturerSpecificServerAttribute
  */
-EmberAfStatus emberAfReadManufacturerSpecificClientAttribute(CHIPEndpointId endpoint, EmberAfClusterId cluster,
-                                                             EmberAfAttributeId attributeID, uint16_t manufacturerCode,
+EmberAfStatus emberAfReadManufacturerSpecificClientAttribute(chip::EndpointId endpoint, chip::ClusterId cluster,
+                                                             chip::AttributeId attributeID, uint16_t manufacturerCode,
                                                              uint8_t * dataPtr, uint8_t readLength);
 
 /**
@@ -446,29 +446,29 @@ extern EmberAfDefinedEndpoint emAfEndpoints[];
 /**
  * @brief Macro that takes index of endpoint, and returns Zigbee endpoint
  */
-CHIPEndpointId emberAfEndpointFromIndex(uint8_t index);
+chip::EndpointId emberAfEndpointFromIndex(uint8_t index);
 
 /**
  * Returns the index of a given endpoint
  */
-uint8_t emberAfIndexFromEndpoint(CHIPEndpointId endpoint);
+uint8_t emberAfIndexFromEndpoint(chip::EndpointId endpoint);
 
 /**
  * Returns the index of a given endpoint; Does not ignore disabled endpoints
  */
-uint8_t emberAfIndexFromEndpointIncludingDisabledEndpoints(CHIPEndpointId endpoint);
+uint8_t emberAfIndexFromEndpointIncludingDisabledEndpoints(chip::EndpointId endpoint);
 
 /**
  * Returns the endpoint index within a given cluster (Client-side),
  * looking only for standard clusters.
  */
-uint8_t emberAfFindClusterClientEndpointIndex(CHIPEndpointId endpoint, EmberAfClusterId clusterId);
+uint8_t emberAfFindClusterClientEndpointIndex(chip::EndpointId endpoint, chip::ClusterId clusterId);
 
 /**
  * Returns the endpoint index within a given cluster (Server-side),
  * looking only for standard clusters.
  */
-uint8_t emberAfFindClusterServerEndpointIndex(CHIPEndpointId endpoint, EmberAfClusterId clusterId);
+uint8_t emberAfFindClusterServerEndpointIndex(chip::EndpointId endpoint, chip::ClusterId clusterId);
 
 /**
  * @brief Macro that takes index of endpoint, and returns profile Id for it
@@ -627,7 +627,7 @@ uint16_t emberAfAttributeValueSize(EmberAfAttributeType dataType, const uint8_t 
  *
  * @param endpoint Zigbee endpoint number
  */
-bool emberAfIsDeviceEnabled(CHIPEndpointId endpoint);
+bool emberAfIsDeviceEnabled(chip::EndpointId endpoint);
 
 /**
  * @brief Function that checks if endpoint is identifying
@@ -637,7 +637,7 @@ bool emberAfIsDeviceEnabled(CHIPEndpointId endpoint);
  *
  * @param endpoint Zigbee endpoint number
  */
-bool emberAfIsDeviceIdentifying(CHIPEndpointId endpoint);
+bool emberAfIsDeviceIdentifying(chip::EndpointId endpoint);
 
 /**
  * @brief Function that enables or disables an endpoint.
@@ -647,7 +647,7 @@ bool emberAfIsDeviceIdentifying(CHIPEndpointId endpoint);
  *
  * @param endpoint Zigbee endpoint number
  */
-void emberAfSetDeviceEnabled(CHIPEndpointId endpoint, bool enabled);
+void emberAfSetDeviceEnabled(chip::EndpointId endpoint, bool enabled);
 
 /** @} END Device Control */
 
@@ -657,7 +657,7 @@ void emberAfSetDeviceEnabled(CHIPEndpointId endpoint, bool enabled);
 /**
  * @brief Enable/disable endpoints
  */
-bool emberAfEndpointEnableDisable(CHIPEndpointId endpoint, bool enable);
+bool emberAfEndpointEnableDisable(chip::EndpointId endpoint, bool enable);
 
 /**
  * @brief Determine if an endpoint at the specified index is enabled or disabled
@@ -901,7 +901,7 @@ void emberAfRunEvents(void);
  *
  * @return EMBER_SUCCESS if the event was scheduled or an error otherwise.
  */
-EmberStatus emberAfScheduleTickExtended(CHIPEndpointId endpoint, EmberAfClusterId clusterId, bool isClient, uint32_t delayMs,
+EmberStatus emberAfScheduleTickExtended(chip::EndpointId endpoint, chip::ClusterId clusterId, bool isClient, uint32_t delayMs,
                                         EmberAfEventPollControl pollControl, EmberAfEventSleepControl sleepControl);
 
 /**
@@ -923,7 +923,7 @@ EmberStatus emberAfScheduleTickExtended(CHIPEndpointId endpoint, EmberAfClusterI
  *
  * @return EMBER_SUCCESS if the event was scheduled or an error otherwise.
  */
-EmberStatus emberAfScheduleClusterTick(CHIPEndpointId endpoint, EmberAfClusterId clusterId, bool isClient, uint32_t delayMs,
+EmberStatus emberAfScheduleClusterTick(chip::EndpointId endpoint, chip::ClusterId clusterId, bool isClient, uint32_t delayMs,
                                        EmberAfEventSleepControl sleepControl);
 
 /**
@@ -940,7 +940,7 @@ EmberStatus emberAfScheduleClusterTick(CHIPEndpointId endpoint, EmberAfClusterId
  *
  * @return EMBER_SUCCESS if the event was scheduled or an error otherwise.
  */
-EmberStatus emberAfScheduleClientTickExtended(CHIPEndpointId endpoint, EmberAfClusterId clusterId, uint32_t delayMs,
+EmberStatus emberAfScheduleClientTickExtended(chip::EndpointId endpoint, chip::ClusterId clusterId, uint32_t delayMs,
                                               EmberAfEventPollControl pollControl, EmberAfEventSleepControl sleepControl);
 
 /**
@@ -954,7 +954,7 @@ EmberStatus emberAfScheduleClientTickExtended(CHIPEndpointId endpoint, EmberAfCl
  *
  * @return EMBER_SUCCESS if the event was scheduled or an error otherwise.
  */
-EmberStatus emberAfScheduleClientTick(CHIPEndpointId endpoint, EmberAfClusterId clusterId, uint32_t delayMs);
+EmberStatus emberAfScheduleClientTick(chip::EndpointId endpoint, chip::ClusterId clusterId, uint32_t delayMs);
 
 /**
  * @brief A function used to schedule a cluster server event.  This function
@@ -970,7 +970,7 @@ EmberStatus emberAfScheduleClientTick(CHIPEndpointId endpoint, EmberAfClusterId 
  *
  * @return EMBER_SUCCESS if the event was scheduled or an error otherwise.
  */
-EmberStatus emberAfScheduleServerTickExtended(CHIPEndpointId endpoint, EmberAfClusterId clusterId, uint32_t delayMs,
+EmberStatus emberAfScheduleServerTickExtended(chip::EndpointId endpoint, chip::ClusterId clusterId, uint32_t delayMs,
                                               EmberAfEventPollControl pollControl, EmberAfEventSleepControl sleepControl);
 
 /**
@@ -984,7 +984,7 @@ EmberStatus emberAfScheduleServerTickExtended(CHIPEndpointId endpoint, EmberAfCl
  *
  * @return EMBER_SUCCESS if the event was scheduled or an error otherwise.
  */
-EmberStatus emberAfScheduleServerTick(CHIPEndpointId endpoint, EmberAfClusterId clusterId, uint32_t delayMs);
+EmberStatus emberAfScheduleServerTick(chip::EndpointId endpoint, chip::ClusterId clusterId, uint32_t delayMs);
 
 /**
  * @brief A function used to deactivate a cluster-related event.  This function
@@ -1000,7 +1000,7 @@ EmberStatus emberAfScheduleServerTick(CHIPEndpointId endpoint, EmberAfClusterId 
  *
  * @return EMBER_SUCCESS if the event was deactivated or an error otherwise.
  */
-EmberStatus emberAfDeactivateClusterTick(CHIPEndpointId endpoint, EmberAfClusterId clusterId, bool isClient);
+EmberStatus emberAfDeactivateClusterTick(chip::EndpointId endpoint, chip::ClusterId clusterId, bool isClient);
 
 /**
  * @brief A function used to deactivate a cluster client event.  This function
@@ -1011,7 +1011,7 @@ EmberStatus emberAfDeactivateClusterTick(CHIPEndpointId endpoint, EmberAfCluster
  *
  * @return EMBER_SUCCESS if the event was deactivated or an error otherwise.
  */
-EmberStatus emberAfDeactivateClientTick(CHIPEndpointId endpoint, EmberAfClusterId clusterId);
+EmberStatus emberAfDeactivateClientTick(chip::EndpointId endpoint, chip::ClusterId clusterId);
 
 /**
  * @brief A function used to deactivate a cluster server event.  This function
@@ -1022,7 +1022,7 @@ EmberStatus emberAfDeactivateClientTick(CHIPEndpointId endpoint, EmberAfClusterI
  *
  * @return EMBER_SUCCESS if the event was deactivated or an error otherwise.
  */
-EmberStatus emberAfDeactivateServerTick(CHIPEndpointId endpoint, EmberAfClusterId clusterId);
+EmberStatus emberAfDeactivateServerTick(chip::EndpointId endpoint, chip::ClusterId clusterId);
 
 /**
  * @brief Sets the ::EmberEventControl to run "delayMs" milliseconds in the
@@ -1120,28 +1120,28 @@ EmberStatus emberAfNetworkEventControlSetDelayMinutes(EmberEventControl * contro
  * @brief Sets the ::EmberEventControl for the specified endpoint as inactive.
  * See ::emberEventControlSetInactive.
  */
-EmberStatus emberAfEndpointEventControlSetInactive(EmberEventControl * controls, CHIPEndpointId endpoint);
+EmberStatus emberAfEndpointEventControlSetInactive(EmberEventControl * controls, chip::EndpointId endpoint);
 /**
  * @brief Returns true if the event for the current number is active.  See
  * ::emberEventControlGetActive.
  */
-bool emberAfEndpointEventControlGetActive(EmberEventControl * controls, CHIPEndpointId endpoint);
+bool emberAfEndpointEventControlGetActive(EmberEventControl * controls, chip::EndpointId endpoint);
 /**
  * @brief Sets the ::EmberEventControl for the specified endpoint to run at the
  * next available opportunity.  See ::emberEventControlSetActive.
  */
-EmberStatus emberAfEndpointEventControlSetActive(EmberEventControl * controls, CHIPEndpointId endpoint);
+EmberStatus emberAfEndpointEventControlSetActive(EmberEventControl * controls, chip::EndpointId endpoint);
 /**
  * @brief Sets the ::EmberEventControl for the specified endpoint to run
  * "delayMs" milliseconds in the future.  See ::emberEventControlSetDelayMS.
  */
-EmberStatus emberAfEndpointEventControlSetDelayMS(EmberEventControl * controls, CHIPEndpointId endpoint, uint32_t delayMs);
+EmberStatus emberAfEndpointEventControlSetDelayMS(EmberEventControl * controls, chip::EndpointId endpoint, uint32_t delayMs);
 #ifdef DOXYGEN_SHOULD_SKIP_THIS
 /**
  * @brief Sets the ::EmberEventControl for the specified endpoint to run
  * "delayMs" milliseconds in the future.  See ::emberEventControlSetDelayMS.
  */
-EmberStatus emberAfEndpointEventControlSetDelay(EmberEventControl * controls, CHIPEndpointId endpoint, uint32_t delayMs);
+EmberStatus emberAfEndpointEventControlSetDelay(EmberEventControl * controls, chip::EndpointId endpoint, uint32_t delayMs);
 #else
 #define emberAfEndpointEventControlSetDelay(controls, endpoint, delayMs)                                                           \
     emberAfEndpointEventControlSetDelayMS(controls, endpoint, delayMs);
@@ -1151,12 +1151,12 @@ EmberStatus emberAfEndpointEventControlSetDelay(EmberEventControl * controls, CH
  * "delayQs" quarter seconds in the future.  See
  * ::emberAfEventControlSetDelayQS.
  */
-EmberStatus emberAfEndpointEventControlSetDelayQS(EmberEventControl * controls, CHIPEndpointId endpoint, uint32_t delayQs);
+EmberStatus emberAfEndpointEventControlSetDelayQS(EmberEventControl * controls, chip::EndpointId endpoint, uint32_t delayQs);
 /**
  * @brief Sets the ::EmberEventControl for the specified endpoint to run
  * "delayM" minutes in the future.  See ::emberAfEventControlSetDelayMinutes.
  */
-EmberStatus emberAfEndpointEventControlSetDelayMinutes(EmberEventControl * controls, CHIPEndpointId endpoint, uint16_t delayM);
+EmberStatus emberAfEndpointEventControlSetDelayMinutes(EmberEventControl * controls, chip::EndpointId endpoint, uint16_t delayM);
 
 /**
  * @brief A function used to retrieve the number of milliseconds until
@@ -1252,7 +1252,7 @@ EmberStatus emberAfSendResponseWithCallback(EmberAfMessageSentFunction callback)
 /**
  * @brief Sends multicast.
  */
-EmberStatus emberAfSendMulticast(EmberMulticastId multicastId, EmberApsFrame * apsFrame, uint16_t messageLength, uint8_t * message);
+EmberStatus emberAfSendMulticast(chip::GroupId multicastId, EmberApsFrame * apsFrame, uint16_t messageLength, uint8_t * message);
 
 /**
  * @brief Multicasts the message to the group in the binding table that
@@ -1266,14 +1266,14 @@ EmberStatus emberAfSendMulticastToBindings(EmberApsFrame * apsFrame, uint16_t me
 /**
  * @brief Sends Multicast with alias with attached message sent callback
  */
-EmberStatus emberAfSendMulticastWithAliasWithCallback(EmberMulticastId multicastId, EmberApsFrame * apsFrame,
-                                                      uint16_t messageLength, uint8_t * message, EmberNodeId alias,
-                                                      uint8_t sequence, EmberAfMessageSentFunction callback);
+EmberStatus emberAfSendMulticastWithAliasWithCallback(chip::GroupId multicastId, EmberApsFrame * apsFrame, uint16_t messageLength,
+                                                      uint8_t * message, EmberNodeId alias, uint8_t sequence,
+                                                      EmberAfMessageSentFunction callback);
 
 /**
  * @brief Sends multicast with attached message sent callback.
  */
-EmberStatus emberAfSendMulticastWithCallback(EmberMulticastId multicastId, EmberApsFrame * apsFrame, uint16_t messageLength,
+EmberStatus emberAfSendMulticastWithCallback(chip::GroupId multicastId, EmberApsFrame * apsFrame, uint16_t messageLength,
                                              uint8_t * message, EmberAfMessageSentFunction callback);
 
 /**
@@ -1324,13 +1324,13 @@ EmberStatus emberAfSendUnicastToBindingsWithCallback(EmberApsFrame * apsFrame, u
  * @brief Sends interpan message.
  */
 EmberStatus emberAfSendInterPan(EmberPanId panId, const EmberEUI64 destinationLongId, EmberNodeId destinationShortId,
-                                EmberMulticastId multicastId, EmberAfClusterId clusterId, EmberAfProfileId profileId,
+                                chip::GroupId multicastId, chip::ClusterId clusterId, EmberAfProfileId profileId,
                                 uint16_t messageLength, uint8_t * messageBytes);
 
 /**
  * @brief Sends end device binding request.
  */
-EmberStatus emberAfSendEndDeviceBind(CHIPEndpointId endpoint);
+EmberStatus emberAfSendEndDeviceBind(chip::EndpointId endpoint);
 
 /**
  * @brief Sends the command prepared with emberAfFill.... macro.
@@ -1356,7 +1356,7 @@ EmberStatus emberAfSendCommandUnicastToBindingsWithCallback(EmberAfMessageSentFu
  * using the emberAfFill... macros from the client command API. It
  * will be sent as multicast.
  */
-EmberStatus emberAfSendCommandMulticast(EmberMulticastId multicastId);
+EmberStatus emberAfSendCommandMulticast(chip::GroupId multicastId);
 
 /**
  * @brief Sends the command prepared with emberAfFill.... macro.
@@ -1365,12 +1365,12 @@ EmberStatus emberAfSendCommandMulticast(EmberMulticastId multicastId);
  * using the emberAfFill... macros from the client command API. It
  * will be sent as multicast.
  */
-EmberStatus emberAfSendCommandMulticastWithAlias(EmberMulticastId multicastId, EmberNodeId alias, uint8_t sequence);
+EmberStatus emberAfSendCommandMulticastWithAlias(chip::GroupId multicastId, EmberNodeId alias, uint8_t sequence);
 
 /**
  * @brief emberAfSendCommandMulticast with attached message sent callback.
  */
-EmberStatus emberAfSendCommandMulticastWithCallback(EmberMulticastId multicastId, EmberAfMessageSentFunction callback);
+EmberStatus emberAfSendCommandMulticastWithCallback(chip::GroupId multicastId, EmberAfMessageSentFunction callback);
 
 /**
  * @brief Sends the command prepared with emberAfFill.... macro.
@@ -1435,7 +1435,7 @@ EmberStatus emberAfSendCommandBroadcastWithAlias(EmberNodeId destination, EmberN
  * multicastId is not zero, the message will be sent using multicast mode.
  */
 EmberStatus emberAfSendCommandInterPan(EmberPanId panId, const EmberEUI64 destinationLongId, EmberNodeId destinationShortId,
-                                       EmberMulticastId multicastId, EmberAfProfileId profileId);
+                                       chip::GroupId multicastId, EmberAfProfileId profileId);
 
 /**
  * @brief Sends a default response to a cluster command.
@@ -1500,7 +1500,7 @@ EmberApsFrame * emberAfGetCommandApsFrame(void);
 /**
  * @brief Set the source and destination endpoints in the client API APS frame.
  */
-void emberAfSetCommandEndpoints(CHIPEndpointId sourceEndpoint, CHIPEndpointId destinationEndpoint);
+void emberAfSetCommandEndpoints(chip::EndpointId sourceEndpoint, chip::EndpointId destinationEndpoint);
 
 /**
  * @brief Friendly define for use in discovering client clusters with
@@ -1539,7 +1539,7 @@ void emberAfSetCommandEndpoints(CHIPEndpointId sourceEndpoint, CHIPEndpointId de
  *  a match is discovered.  (For broadcast discoveries, this is called once per
  *  matching node, even if a node has multiple matching endpoints.)
  */
-EmberStatus emberAfFindDevicesByProfileAndCluster(EmberNodeId target, EmberAfProfileId profileId, EmberAfClusterId clusterId,
+EmberStatus emberAfFindDevicesByProfileAndCluster(EmberNodeId target, EmberAfProfileId profileId, chip::ClusterId clusterId,
                                                   bool serverCluster, EmberAfServiceDiscoveryCallback * callback);
 
 /**
@@ -1663,7 +1663,7 @@ extern EmberAfClusterCommand * emAfCurrentCommand;
  * @param endpoint The endpoint on the remote device.
  * @return ::EMBER_SUCCESS if key establishment was initiated successfully
  */
-EmberStatus emberAfInitiateKeyEstablishment(EmberNodeId nodeId, CHIPEndpointId endpoint);
+EmberStatus emberAfInitiateKeyEstablishment(EmberNodeId nodeId, chip::EndpointId endpoint);
 
 /** @brief Use this function to initiate key establishment with a remote node on
  * a different PAN.  ::emberAfInterPanKeyEstablishmentCallback will be called
@@ -1692,7 +1692,7 @@ bool emberAfPerformingKeyEstablishment(void);
  * @return ::EMBER_SUCCESS if the partner link key exchange was initiated
  * successfully.
  */
-EmberStatus emberAfInitiatePartnerLinkKeyExchange(EmberNodeId target, CHIPEndpointId endpoint,
+EmberStatus emberAfInitiatePartnerLinkKeyExchange(EmberNodeId target, chip::EndpointId endpoint,
                                                   EmberAfPartnerLinkKeyExchangeCallback * callback);
 #else
 #define emberAfInitiateKeyEstablishment(nodeId, endpoint) emberAfInitiateKeyEstablishmentCallback(nodeId, endpoint)
@@ -1796,7 +1796,7 @@ EmberStatus emberAfPushCallbackNetworkIndex(void);
  * API must be paired with a subsequent call to ::emberAfPopNetworkIndex.
  */
 
-EmberStatus emberAfPushEndpointNetworkIndex(CHIPEndpointId endpoint);
+EmberStatus emberAfPushEndpointNetworkIndex(chip::EndpointId endpoint);
 /** @brief Removes the topmost network from the stack of networks maintained by
  * the framework and sets the current network to the new topmost network.
  * Every call to this API must be paired with a prior call to

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -111,7 +111,7 @@ const uint16_t attributeManufacturerCodeCount                   = GENERATED_ATTR
 // Forward declarations
 
 // Returns endpoint index within a given cluster
-static uint8_t findClusterEndpointIndex(EndpointId endpoint, EmberAfClusterId clusterId, uint8_t mask, uint16_t manufacturerCode);
+static uint8_t findClusterEndpointIndex(EndpointId endpoint, ClusterId clusterId, uint8_t mask, uint16_t manufacturerCode);
 
 //------------------------------------------------------------------------------
 
@@ -181,7 +181,7 @@ bool emberAfIsLongStringAttributeType(EmberAfAttributeType attributeType)
 }
 
 // This function is used to call the per-cluster default response callback
-void emberAfClusterDefaultResponseWithMfgCodeCallback(EndpointId endpoint, EmberAfClusterId clusterId, uint8_t commandId,
+void emberAfClusterDefaultResponseWithMfgCodeCallback(EndpointId endpoint, ClusterId clusterId, uint8_t commandId,
                                                       EmberAfStatus status, uint8_t clientServerMask, uint16_t manufacturerCode)
 {
     EmberAfCluster * cluster = emberAfFindClusterWithMfgCode(endpoint, clusterId, clientServerMask, manufacturerCode);
@@ -200,7 +200,7 @@ void emberAfClusterDefaultResponseWithMfgCodeCallback(EndpointId endpoint, Ember
 // This function is used to call the per-cluster default response callback, and
 // wraps the emberAfClusterDefaultResponseWithMfgCodeCallback with a
 // EMBER_AF_NULL_MANUFACTURER_CODE.
-void emberAfClusterDefaultResponseCallback(EndpointId endpoint, EmberAfClusterId clusterId, uint8_t commandId, EmberAfStatus status,
+void emberAfClusterDefaultResponseCallback(EndpointId endpoint, ClusterId clusterId, CommandId commandId, EmberAfStatus status,
                                            uint8_t clientServerMask)
 {
     emberAfClusterDefaultResponseWithMfgCodeCallback(endpoint, clusterId, commandId, status, clientServerMask,
@@ -243,7 +243,7 @@ void emberAfClusterMessageSentCallback(EmberOutgoingMessageType type, uint16_t i
 }
 
 // This function is used to call the per-cluster attribute changed callback
-void emAfClusterAttributeChangedCallback(EndpointId endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
+void emAfClusterAttributeChangedCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId,
                                          uint8_t clientServerMask, uint16_t manufacturerCode)
 {
     EmberAfCluster * cluster = emberAfFindClusterWithMfgCode(endpoint, clusterId, clientServerMask, manufacturerCode);
@@ -274,10 +274,9 @@ void emAfClusterAttributeChangedCallback(EndpointId endpoint, EmberAfClusterId c
 }
 
 // This function is used to call the per-cluster pre-attribute changed callback
-EmberAfStatus emAfClusterPreAttributeChangedCallback(EndpointId endpoint, EmberAfClusterId clusterId,
-                                                     EmberAfAttributeId attributeId, uint8_t clientServerMask,
-                                                     uint16_t manufacturerCode, EmberAfAttributeType attributeType, uint8_t size,
-                                                     uint8_t * value)
+EmberAfStatus emAfClusterPreAttributeChangedCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId,
+                                                     uint8_t clientServerMask, uint16_t manufacturerCode,
+                                                     EmberAfAttributeType attributeType, uint8_t size, uint8_t * value)
 {
     EmberAfCluster * cluster = emberAfFindClusterWithMfgCode(endpoint, clusterId, clientServerMask, manufacturerCode);
     if (cluster == NULL)
@@ -334,8 +333,8 @@ void emAfCallInits(void)
 }
 
 // Returns the pointer to metadata, or null if it is not found
-EmberAfAttributeMetadata * emberAfLocateAttributeMetadata(EndpointId endpoint, EmberAfClusterId clusterId,
-                                                          EmberAfAttributeId attributeId, uint8_t mask, uint16_t manufacturerCode)
+EmberAfAttributeMetadata * emberAfLocateAttributeMetadata(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId,
+                                                          uint8_t mask, uint16_t manufacturerCode)
 {
     EmberAfAttributeMetadata * metadata = NULL;
     EmberAfAttributeSearchRecord record;
@@ -598,7 +597,7 @@ EmberAfStatus emAfReadOrWriteAttribute(EmberAfAttributeSearchRecord * attRecord,
 // mask = 0 -> find either client or server
 // mask = CLUSTER_MASK_CLIENT -> find client
 // mask = CLUSTER_MASK_SERVER -> find server
-EmberAfCluster * emberAfFindClusterInTypeWithMfgCode(EmberAfEndpointType * endpointType, EmberAfClusterId clusterId,
+EmberAfCluster * emberAfFindClusterInTypeWithMfgCode(EmberAfEndpointType * endpointType, ClusterId clusterId,
                                                      EmberAfClusterMask mask, uint16_t manufacturerCode)
 {
     uint8_t i;
@@ -622,14 +621,14 @@ EmberAfCluster * emberAfFindClusterInTypeWithMfgCode(EmberAfEndpointType * endpo
 
 // This functions wraps emberAfFindClusterInTypeWithMfgCode with
 // a manufacturerCode of EMBER_AF_NULL_MANUFACTURER_CODE.
-EmberAfCluster * emberAfFindClusterInType(EmberAfEndpointType * endpointType, EmberAfClusterId clusterId, EmberAfClusterMask mask)
+EmberAfCluster * emberAfFindClusterInType(EmberAfEndpointType * endpointType, ClusterId clusterId, EmberAfClusterMask mask)
 {
     return emberAfFindClusterInTypeWithMfgCode(endpointType, clusterId, mask, EMBER_AF_NULL_MANUFACTURER_CODE);
 }
 
 // This code is used during unit tests for clusters that do not involve manufacturer code.
 // Should this code be used in other locations, manufacturerCode should be added.
-uint8_t emberAfClusterIndex(EndpointId endpoint, EmberAfClusterId clusterId, EmberAfClusterMask mask)
+uint8_t emberAfClusterIndex(EndpointId endpoint, ClusterId clusterId, EmberAfClusterMask mask)
 {
     uint8_t ep;
     uint8_t index = 0xFF;
@@ -649,46 +648,46 @@ uint8_t emberAfClusterIndex(EndpointId endpoint, EmberAfClusterId clusterId, Emb
 }
 
 // Returns true uf endpoint contains passed cluster
-bool emberAfContainsClusterWithMfgCode(EndpointId endpoint, EmberAfClusterId clusterId, uint16_t manufacturerCode)
+bool emberAfContainsClusterWithMfgCode(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode)
 {
     return (emberAfFindClusterWithMfgCode(endpoint, clusterId, 0, manufacturerCode) != NULL);
 }
 
 // Returns true if endpoint contains passed cluster as a server
-bool emberAfContainsServerWithMfgCode(EndpointId endpoint, EmberAfClusterId clusterId, uint16_t manufacturerCode)
+bool emberAfContainsServerWithMfgCode(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode)
 {
     return (emberAfFindClusterWithMfgCode(endpoint, clusterId, CLUSTER_MASK_SERVER, manufacturerCode) != NULL);
 }
 
 // Returns true if endpoint contains passed cluster as a client
-bool emberAfContainsClientWithMfgCode(EndpointId endpoint, EmberAfClusterId clusterId, uint16_t manufacturerCode)
+bool emberAfContainsClientWithMfgCode(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode)
 {
     return (emberAfFindClusterWithMfgCode(endpoint, clusterId, CLUSTER_MASK_CLIENT, manufacturerCode) != NULL);
 }
 
 // Wraps emberAfContainsClusterWithMfgCode with EMBER_AF_NULL_MANUFACTURER_CODE
 // This will find the first cluster that has the clusterId given, regardless of mfgCode.
-bool emberAfContainsCluster(EndpointId endpoint, EmberAfClusterId clusterId)
+bool emberAfContainsCluster(EndpointId endpoint, ClusterId clusterId)
 {
     return (emberAfFindClusterWithMfgCode(endpoint, clusterId, 0, EMBER_AF_NULL_MANUFACTURER_CODE) != NULL);
 }
 
 // Wraps emberAfContainsServerWithMfgCode with EMBER_AF_NULL_MANUFACTURER_CODE
 // This will find the first server that has the clusterId given, regardless of mfgCode.
-bool emberAfContainsServer(EndpointId endpoint, EmberAfClusterId clusterId)
+bool emberAfContainsServer(EndpointId endpoint, ClusterId clusterId)
 {
     return (emberAfFindClusterWithMfgCode(endpoint, clusterId, CLUSTER_MASK_SERVER, EMBER_AF_NULL_MANUFACTURER_CODE) != NULL);
 }
 
 // Wraps emberAfContainsClientWithMfgCode with EMBER_AF_NULL_MANUFACTURER_CODE
 // This will find the first client that has the clusterId given, regardless of mfgCode.
-bool emberAfContainsClient(EndpointId endpoint, EmberAfClusterId clusterId)
+bool emberAfContainsClient(EndpointId endpoint, ClusterId clusterId)
 {
     return (emberAfFindClusterWithMfgCode(endpoint, clusterId, CLUSTER_MASK_CLIENT, EMBER_AF_NULL_MANUFACTURER_CODE) != NULL);
 }
 
 // Finds the cluster that matches endpoint, clusterId, direction, and manufacturerCode.
-EmberAfCluster * emberAfFindClusterWithMfgCode(EndpointId endpoint, EmberAfClusterId clusterId, EmberAfClusterMask mask,
+EmberAfCluster * emberAfFindClusterWithMfgCode(EndpointId endpoint, ClusterId clusterId, EmberAfClusterMask mask,
                                                uint16_t manufacturerCode)
 {
     uint8_t ep = emberAfIndexFromEndpoint(endpoint);
@@ -705,13 +704,13 @@ EmberAfCluster * emberAfFindClusterWithMfgCode(EndpointId endpoint, EmberAfClust
 // This function wraps emberAfFindClusterWithMfgCode with EMBER_AF_NULL_MANUFACTURER_CODE
 // and will ignore the manufacturerCode when trying to find clusters.
 // This will return the first cluster in the cluster table that matches the parameters given.
-EmberAfCluster * emberAfFindCluster(EndpointId endpoint, EmberAfClusterId clusterId, EmberAfClusterMask mask)
+EmberAfCluster * emberAfFindCluster(EndpointId endpoint, ClusterId clusterId, EmberAfClusterMask mask)
 {
     return emberAfFindClusterWithMfgCode(endpoint, clusterId, mask, EMBER_AF_NULL_MANUFACTURER_CODE);
 }
 
 // Returns cluster within the endpoint; Does not ignore disabled endpoints
-EmberAfCluster * emberAfFindClusterIncludingDisabledEndpointsWithMfgCode(EndpointId endpoint, EmberAfClusterId clusterId,
+EmberAfCluster * emberAfFindClusterIncludingDisabledEndpointsWithMfgCode(EndpointId endpoint, ClusterId clusterId,
                                                                          EmberAfClusterMask mask, uint16_t manufacturerCode)
 {
     uint8_t ep = emberAfIndexFromEndpointIncludingDisabledEndpoints(endpoint);
@@ -724,41 +723,39 @@ EmberAfCluster * emberAfFindClusterIncludingDisabledEndpointsWithMfgCode(Endpoin
 
 // Returns cluster within the endpoint; Does not ignore disabled endpoints
 // This will ignore manufacturerCode.
-EmberAfCluster * emberAfFindClusterIncludingDisabledEndpoints(EndpointId endpoint, EmberAfClusterId clusterId,
-                                                              EmberAfClusterMask mask)
+EmberAfCluster * emberAfFindClusterIncludingDisabledEndpoints(EndpointId endpoint, ClusterId clusterId, EmberAfClusterMask mask)
 {
     return emberAfFindClusterIncludingDisabledEndpointsWithMfgCode(endpoint, clusterId, mask, EMBER_AF_NULL_MANUFACTURER_CODE);
 }
 
 // Server wrapper for findClusterEndpointIndex.
-static uint8_t emberAfFindClusterServerEndpointIndexWithMfgCode(EndpointId endpoint, EmberAfClusterId clusterId,
-                                                                uint16_t manufacturerCode)
+static uint8_t emberAfFindClusterServerEndpointIndexWithMfgCode(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode)
 {
     return findClusterEndpointIndex(endpoint, clusterId, CLUSTER_MASK_SERVER, manufacturerCode);
 }
 
 // Client wrapper for findClusterEndpointIndex.
-uint8_t emberAfFindClusterClientEndpointIndexWithMfgCode(EndpointId endpoint, EmberAfClusterId clusterId, uint16_t manufacturerCode)
+uint8_t emberAfFindClusterClientEndpointIndexWithMfgCode(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode)
 {
     return findClusterEndpointIndex(endpoint, clusterId, CLUSTER_MASK_CLIENT, manufacturerCode);
 }
 
 // Server wrapper for findClusterEndpointIndex
 // This will ignore manufacturerCode, and return the index for the first server that matches on clusterId
-uint8_t emberAfFindClusterServerEndpointIndex(EndpointId endpoint, EmberAfClusterId clusterId)
+uint8_t emberAfFindClusterServerEndpointIndex(EndpointId endpoint, ClusterId clusterId)
 {
     return emberAfFindClusterServerEndpointIndexWithMfgCode(endpoint, clusterId, EMBER_AF_NULL_MANUFACTURER_CODE);
 }
 
 // Client wrapper for findClusterEndpointIndex
 // This will ignore manufacturerCode, and return the index for the first client that matches on clusterId
-uint8_t emberAfFindClusterClientEndpointIndex(EndpointId endpoint, EmberAfClusterId clusterId)
+uint8_t emberAfFindClusterClientEndpointIndex(EndpointId endpoint, ClusterId clusterId)
 {
     return emberAfFindClusterClientEndpointIndexWithMfgCode(endpoint, clusterId, EMBER_AF_NULL_MANUFACTURER_CODE);
 }
 
 // Returns the endpoint index within a given cluster
-static uint8_t findClusterEndpointIndex(EndpointId endpoint, EmberAfClusterId clusterId, uint8_t mask, uint16_t manufacturerCode)
+static uint8_t findClusterEndpointIndex(EndpointId endpoint, ClusterId clusterId, uint8_t mask, uint16_t manufacturerCode)
 {
     uint8_t i, epi = 0;
 
@@ -1009,7 +1006,7 @@ EmberAfCluster * emberAfGetNthCluster(EndpointId endpoint, uint8_t n, bool serve
 
 // Returns number of clusters put into the passed cluster list
 // for the given endpoint and client/server polarity
-uint8_t emberAfGetClustersFromEndpoint(EndpointId endpoint, EmberAfClusterId * clusterList, uint8_t listLen, bool server)
+uint8_t emberAfGetClustersFromEndpoint(EndpointId endpoint, ClusterId * clusterList, uint8_t listLen, bool server)
 {
     uint8_t clusterCount = emberAfClusterCount(endpoint, server);
     uint8_t i;
@@ -1155,7 +1152,7 @@ void emAfLoadAttributesFromTokens(EndpointId endpoint)
 // 'data' argument may be null, since we changed the ptrToDefaultValue
 // to be null instead of pointing to all zeroes.
 // This function has to be able to deal with that.
-void emAfSaveAttributeToToken(uint8_t * data, EndpointId endpoint, EmberAfClusterId clusterId, EmberAfAttributeMetadata * metadata)
+void emAfSaveAttributeToToken(uint8_t * data, EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * metadata)
 {
     // Get out of here if this attribute doesn't have a token.
     if (!emberAfAttributeIsTokenized(metadata))
@@ -1295,7 +1292,7 @@ bool emberAfExtractCommandIds(bool outgoing, EmberAfClusterCommand * cmd, Cluste
 }
 #else
 // We just need an empty stub if we don't support it
-bool emberAfExtractCommandIds(bool outgoing, EmberAfClusterCommand * cmd, uint16_t clusterId, uint8_t * buffer,
+bool emberAfExtractCommandIds(bool outgoing, EmberAfClusterCommand * cmd, ClusterId clusterId, uint8_t * buffer,
                               uint16_t bufferLength, uint16_t * bufferIndex, uint8_t startId, uint8_t maxIdCount)
 {
     return true;

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -90,7 +90,7 @@ void emAfCallInits(void);
 
 // Initial configuration
 void emberAfEndpointConfigure(void);
-bool emberAfExtractCommandIds(bool outgoing, EmberAfClusterCommand * cmd, CHIPClusterId clusterId, uint8_t * buffer,
+bool emberAfExtractCommandIds(bool outgoing, EmberAfClusterCommand * cmd, chip::ClusterId clusterId, uint8_t * buffer,
                               uint16_t bufferLength, uint16_t * bufferIndex, uint8_t startId, uint8_t maxIdCount);
 
 EmberAfStatus emAfReadOrWriteAttribute(EmberAfAttributeSearchRecord * attRecord, EmberAfAttributeMetadata ** metadata,
@@ -99,10 +99,10 @@ EmberAfStatus emAfReadOrWriteAttribute(EmberAfAttributeSearchRecord * attRecord,
 bool emAfMatchCluster(EmberAfCluster * cluster, EmberAfAttributeSearchRecord * attRecord);
 bool emAfMatchAttribute(EmberAfCluster * cluster, EmberAfAttributeMetadata * am, EmberAfAttributeSearchRecord * attRecord);
 
-EmberAfCluster * emberAfFindClusterInTypeWithMfgCode(EmberAfEndpointType * endpointType, EmberAfClusterId clusterId,
+EmberAfCluster * emberAfFindClusterInTypeWithMfgCode(EmberAfEndpointType * endpointType, chip::ClusterId clusterId,
                                                      EmberAfClusterMask mask, uint16_t manufacturerCode);
 
-EmberAfCluster * emberAfFindClusterInType(EmberAfEndpointType * endpointType, EmberAfClusterId clusterId, EmberAfClusterMask mask);
+EmberAfCluster * emberAfFindClusterInType(EmberAfEndpointType * endpointType, chip::ClusterId clusterId, EmberAfClusterMask mask);
 
 // This function returns the index of cluster for the particular endpoint.
 // Mask is either CLUSTER_MASK_CLIENT or CLUSTER_MASK_SERVER
@@ -114,35 +114,35 @@ EmberAfCluster * emberAfFindClusterInType(EmberAfEndpointType * endpointType, Em
 //    clusterIndex(Y,10,CLUSTER_MASK_SERVER) returns 0
 //    clusterIndex(Y,11,CLUSTER_MASK_SERVER) returns 0xFF
 //    clusterIndex(Y,12,CLUSTER_MASK_SERVER) returns 0xFF
-uint8_t emberAfClusterIndex(CHIPEndpointId endpoint, EmberAfClusterId clusterId, EmberAfClusterMask mask);
+uint8_t emberAfClusterIndex(chip::EndpointId endpoint, chip::ClusterId clusterId, EmberAfClusterMask mask);
 
 // If server == true, returns the number of server clusters,
 // otherwise number of client clusters on this endpoint
-uint8_t emberAfClusterCount(CHIPEndpointId endpoint, bool server);
+uint8_t emberAfClusterCount(chip::EndpointId endpoint, bool server);
 
 // Returns the clusterId of Nth server or client cluster,
 // depending on server toggle.
-EmberAfCluster * emberAfGetNthCluster(CHIPEndpointId endpoint, uint8_t n, bool server);
+EmberAfCluster * emberAfGetNthCluster(chip::EndpointId endpoint, uint8_t n, bool server);
 
 // Returns number of clusters put into the passed cluster list
 // for the given endpoint and client/server polarity
-uint8_t emberAfGetClustersFromEndpoint(CHIPEndpointId endpoint, EmberAfClusterId * clusterList, uint8_t listLen, bool server);
+uint8_t emberAfGetClustersFromEndpoint(chip::EndpointId endpoint, chip::ClusterId * clusterList, uint8_t listLen, bool server);
 
 // Returns cluster within the endpoint, or NULL if it isn't there
-EmberAfCluster * emberAfFindClusterWithMfgCode(CHIPEndpointId endpoint, EmberAfClusterId clusterId, EmberAfClusterMask mask,
+EmberAfCluster * emberAfFindClusterWithMfgCode(chip::EndpointId endpoint, chip::ClusterId clusterId, EmberAfClusterMask mask,
                                                uint16_t manufacturerCode);
 
 // Returns cluster within the endpoint, or NULL if it isn't there
 // This wraps emberAfFindClusterWithMfgCode with EMBER_AF_NULL_MANUFACTURER_CODE
-EmberAfCluster * emberAfFindCluster(CHIPEndpointId endpoint, EmberAfClusterId clusterId, EmberAfClusterMask mask);
+EmberAfCluster * emberAfFindCluster(chip::EndpointId endpoint, chip::ClusterId clusterId, EmberAfClusterMask mask);
 
 // Returns cluster within the endpoint; Does not ignore disabled endpoints
-EmberAfCluster * emberAfFindClusterIncludingDisabledEndpointsWithMfgCode(CHIPEndpointId endpoint, EmberAfClusterId clusterId,
+EmberAfCluster * emberAfFindClusterIncludingDisabledEndpointsWithMfgCode(chip::EndpointId endpoint, chip::ClusterId clusterId,
                                                                          EmberAfClusterMask mask, uint16_t manufacturerCode);
 
 // Returns cluster within the endpoint; Does not ignore disabled endpoints
 // This wraps emberAfFindClusterIncludingDisabledEndpointsWithMfgCode with EMBER_AF_NULL_MANUFACTURER_CODE
-EmberAfCluster * emberAfFindClusterIncludingDisabledEndpoints(CHIPEndpointId endpoint, EmberAfClusterId clusterId,
+EmberAfCluster * emberAfFindClusterIncludingDisabledEndpoints(chip::EndpointId endpoint, chip::ClusterId clusterId,
                                                               EmberAfClusterMask mask);
 
 // Function mask must contain one of the CLUSTER_MASK function macros,
@@ -152,40 +152,40 @@ EmberAfCluster * emberAfFindClusterIncludingDisabledEndpoints(CHIPEndpointId end
 EmberAfGenericClusterFunction emberAfFindClusterFunction(EmberAfCluster * cluster, EmberAfClusterMask functionMask);
 
 // Public APIs for loading attributes
-void emberAfInitializeAttributes(CHIPEndpointId endpoint);
-void emberAfResetAttributes(CHIPEndpointId endpoint);
+void emberAfInitializeAttributes(chip::EndpointId endpoint);
+void emberAfResetAttributes(chip::EndpointId endpoint);
 
 // Loads the attributes from built-in default and / or tokens
-void emAfLoadAttributeDefaults(CHIPEndpointId endpoint, bool writeTokens);
+void emAfLoadAttributeDefaults(chip::EndpointId endpoint, bool writeTokens);
 
 // This function loads from tokens all the attributes that
 // are defined to be stored in tokens.
-void emAfLoadAttributesFromTokens(CHIPEndpointId endpoint);
+void emAfLoadAttributesFromTokens(chip::EndpointId endpoint);
 
 // After the RAM value has changed, code should call this
 // function. If this attribute has been
 // tagged as stored-to-token, then code will store
 // the attribute to token.
-void emAfSaveAttributeToToken(uint8_t * data, CHIPEndpointId endpoint, EmberAfClusterId clusterId,
+void emAfSaveAttributeToToken(uint8_t * data, chip::EndpointId endpoint, chip::ClusterId clusterId,
                               EmberAfAttributeMetadata * metadata);
 
 // Calls the attribute changed callback
-void emAfClusterAttributeChangedCallback(CHIPEndpointId endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
+void emAfClusterAttributeChangedCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
                                          uint8_t clientServerMask, uint16_t manufacturerCode);
 
 // Calls the attribute changed callback for a specific cluster.
-EmberAfStatus emAfClusterPreAttributeChangedCallback(CHIPEndpointId endpoint, EmberAfClusterId clusterId,
-                                                     EmberAfAttributeId attributeId, uint8_t clientServerMask,
+EmberAfStatus emAfClusterPreAttributeChangedCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
+                                                     chip::AttributeId attributeId, uint8_t clientServerMask,
                                                      uint16_t manufacturerCode, EmberAfAttributeType attributeType, uint8_t size,
                                                      uint8_t * value);
 
 // Calls the default response callback for a specific cluster, and wraps emberAfClusterDefaultResponseWithMfgCodeCallback
 // with the EMBER_NULL_MANUFACTURER_CODE
-void emberAfClusterDefaultResponseCallback(CHIPEndpointId endpoint, EmberAfClusterId clusterId, uint8_t commandId,
+void emberAfClusterDefaultResponseCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, uint8_t commandId,
                                            EmberAfStatus status, uint8_t clientServerMask);
 
 // Calls the default response callback for a specific cluster.
-void emberAfClusterDefaultResponseWithMfgCodeCallback(CHIPEndpointId endpoint, EmberAfClusterId clusterId, uint8_t commandId,
+void emberAfClusterDefaultResponseWithMfgCodeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, uint8_t commandId,
                                                       EmberAfStatus status, uint8_t clientServerMask, uint16_t manufacturerCode);
 
 // Calls the message sent callback for a specific cluster, and wraps emberAfClusterMessageSentWithMfgCodeCallback
@@ -205,7 +205,7 @@ uint16_t emAfGetManufacturerCodeForAttribute(EmberAfCluster * cluster, EmberAfAt
 // returns true if the mask matches a passed interval
 bool emberAfCheckTick(EmberAfClusterMask mask, uint8_t passedMask);
 
-bool emberAfEndpointIsEnabled(CHIPEndpointId endpoint);
+bool emberAfEndpointIsEnabled(chip::EndpointId endpoint);
 
 // Note the difference in implementation from emberAfGetNthCluster().
 // emberAfGetClusterByIndex() retrieves the cluster by index regardless of server/client
@@ -216,8 +216,8 @@ bool emberAfEndpointIsEnabled(CHIPEndpointId endpoint);
 //  - Use emberAfGetClusterCountForEndpoint() with emberAfGetClusterByIndex()
 //
 // Don't mix them.
-uint8_t emberAfGetClusterCountForEndpoint(CHIPEndpointId endpoint);
-EmberAfCluster * emberAfGetClusterByIndex(CHIPEndpointId endpoint, uint8_t clusterIndex);
+uint8_t emberAfGetClusterCountForEndpoint(chip::EndpointId endpoint);
+EmberAfCluster * emberAfGetClusterByIndex(chip::EndpointId endpoint, uint8_t clusterIndex);
 
-EmberAfProfileId emberAfGetProfileIdForEndpoint(CHIPEndpointId endpoint);
-uint16_t emberAfGetDeviceIdForEndpoint(CHIPEndpointId endpoint);
+EmberAfProfileId emberAfGetProfileIdForEndpoint(chip::EndpointId endpoint);
+uint16_t emberAfGetDeviceIdForEndpoint(chip::EndpointId endpoint);

--- a/src/app/util/attribute-table.cpp
+++ b/src/app/util/attribute-table.cpp
@@ -68,9 +68,8 @@ using namespace chip;
 //------------------------------------------------------------------------------
 // Globals
 
-EmberAfStatus emberAfWriteAttributeExternal(EndpointId endpoint, EmberAfClusterId cluster, EmberAfAttributeId attributeID,
-                                            uint8_t mask, uint16_t manufacturerCode, uint8_t * dataPtr,
-                                            EmberAfAttributeType dataType)
+EmberAfStatus emberAfWriteAttributeExternal(EndpointId endpoint, ClusterId cluster, AttributeId attributeID, uint8_t mask,
+                                            uint16_t manufacturerCode, uint8_t * dataPtr, EmberAfAttributeType dataType)
 {
     EmberAfAttributeWritePermission extWritePermission =
         emberAfAllowNetworkWriteAttributeCallback(endpoint, cluster, attributeID, mask, manufacturerCode, dataPtr, dataType);
@@ -88,7 +87,7 @@ EmberAfStatus emberAfWriteAttributeExternal(EndpointId endpoint, EmberAfClusterI
 }
 
 //@deprecated use emberAfWriteServerAttribute or emberAfWriteClientAttribute
-EmberAfStatus emberAfWriteAttribute(EndpointId endpoint, EmberAfClusterId cluster, EmberAfAttributeId attributeID, uint8_t mask,
+EmberAfStatus emberAfWriteAttribute(EndpointId endpoint, ClusterId cluster, AttributeId attributeID, uint8_t mask,
                                     uint8_t * dataPtr, EmberAfAttributeType dataType)
 {
     return emAfWriteAttribute(endpoint, cluster, attributeID, mask, EMBER_AF_NULL_MANUFACTURER_CODE, dataPtr, dataType,
@@ -96,8 +95,8 @@ EmberAfStatus emberAfWriteAttribute(EndpointId endpoint, EmberAfClusterId cluste
                               false); // just test?
 }
 
-EmberAfStatus emberAfWriteClientAttribute(EndpointId endpoint, EmberAfClusterId cluster, EmberAfAttributeId attributeID,
-                                          uint8_t * dataPtr, EmberAfAttributeType dataType)
+EmberAfStatus emberAfWriteClientAttribute(EndpointId endpoint, ClusterId cluster, AttributeId attributeID, uint8_t * dataPtr,
+                                          EmberAfAttributeType dataType)
 {
     return emAfWriteAttribute(endpoint, cluster, attributeID, CLUSTER_MASK_CLIENT, EMBER_AF_NULL_MANUFACTURER_CODE, dataPtr,
                               dataType,
@@ -105,8 +104,8 @@ EmberAfStatus emberAfWriteClientAttribute(EndpointId endpoint, EmberAfClusterId 
                               false); // just test?
 }
 
-EmberAfStatus emberAfWriteServerAttribute(EndpointId endpoint, EmberAfClusterId cluster, EmberAfAttributeId attributeID,
-                                          uint8_t * dataPtr, EmberAfAttributeType dataType)
+EmberAfStatus emberAfWriteServerAttribute(EndpointId endpoint, ClusterId cluster, AttributeId attributeID, uint8_t * dataPtr,
+                                          EmberAfAttributeType dataType)
 {
     return emAfWriteAttribute(endpoint, cluster, attributeID, CLUSTER_MASK_SERVER, EMBER_AF_NULL_MANUFACTURER_CODE, dataPtr,
                               dataType,
@@ -114,69 +113,67 @@ EmberAfStatus emberAfWriteServerAttribute(EndpointId endpoint, EmberAfClusterId 
                               false); // just test?
 }
 
-EmberAfStatus emberAfWriteManufacturerSpecificClientAttribute(EndpointId endpoint, EmberAfClusterId cluster,
-                                                              EmberAfAttributeId attributeID, uint16_t manufacturerCode,
-                                                              uint8_t * dataPtr, EmberAfAttributeType dataType)
+EmberAfStatus emberAfWriteManufacturerSpecificClientAttribute(EndpointId endpoint, ClusterId cluster, AttributeId attributeID,
+                                                              uint16_t manufacturerCode, uint8_t * dataPtr,
+                                                              EmberAfAttributeType dataType)
 {
     return emAfWriteAttribute(endpoint, cluster, attributeID, CLUSTER_MASK_CLIENT, manufacturerCode, dataPtr, dataType,
                               true,   // override read-only?
                               false); // just test?
 }
 
-EmberAfStatus emberAfWriteManufacturerSpecificServerAttribute(EndpointId endpoint, EmberAfClusterId cluster,
-                                                              EmberAfAttributeId attributeID, uint16_t manufacturerCode,
-                                                              uint8_t * dataPtr, EmberAfAttributeType dataType)
+EmberAfStatus emberAfWriteManufacturerSpecificServerAttribute(EndpointId endpoint, ClusterId cluster, AttributeId attributeID,
+                                                              uint16_t manufacturerCode, uint8_t * dataPtr,
+                                                              EmberAfAttributeType dataType)
 {
     return emAfWriteAttribute(endpoint, cluster, attributeID, CLUSTER_MASK_SERVER, manufacturerCode, dataPtr, dataType,
                               true,   // override read-only?
                               false); // just test?
 }
 
-EmberAfStatus emberAfVerifyAttributeWrite(EndpointId endpoint, EmberAfClusterId cluster, EmberAfAttributeId attributeID,
-                                          uint8_t mask, uint16_t manufacturerCode, uint8_t * dataPtr, EmberAfAttributeType dataType)
+EmberAfStatus emberAfVerifyAttributeWrite(EndpointId endpoint, ClusterId cluster, AttributeId attributeID, uint8_t mask,
+                                          uint16_t manufacturerCode, uint8_t * dataPtr, EmberAfAttributeType dataType)
 {
     return emAfWriteAttribute(endpoint, cluster, attributeID, mask, manufacturerCode, dataPtr, dataType,
                               false, // override read-only?
                               true); // just test?
 }
 
-EmberAfStatus emberAfReadAttribute(EndpointId endpoint, EmberAfClusterId cluster, EmberAfAttributeId attributeID, uint8_t mask,
-                                   uint8_t * dataPtr, uint8_t readLength, EmberAfAttributeType * dataType)
+EmberAfStatus emberAfReadAttribute(EndpointId endpoint, ClusterId cluster, AttributeId attributeID, uint8_t mask, uint8_t * dataPtr,
+                                   uint8_t readLength, EmberAfAttributeType * dataType)
 {
     return emAfReadAttribute(endpoint, cluster, attributeID, mask, EMBER_AF_NULL_MANUFACTURER_CODE, dataPtr, readLength, dataType);
 }
 
-EmberAfStatus emberAfReadServerAttribute(EndpointId endpoint, EmberAfClusterId cluster, EmberAfAttributeId attributeID,
-                                         uint8_t * dataPtr, uint8_t readLength)
+EmberAfStatus emberAfReadServerAttribute(EndpointId endpoint, ClusterId cluster, AttributeId attributeID, uint8_t * dataPtr,
+                                         uint8_t readLength)
 {
     return emAfReadAttribute(endpoint, cluster, attributeID, CLUSTER_MASK_SERVER, EMBER_AF_NULL_MANUFACTURER_CODE, dataPtr,
                              readLength, NULL);
 }
 
-EmberAfStatus emberAfReadClientAttribute(EndpointId endpoint, EmberAfClusterId cluster, EmberAfAttributeId attributeID,
-                                         uint8_t * dataPtr, uint8_t readLength)
+EmberAfStatus emberAfReadClientAttribute(EndpointId endpoint, ClusterId cluster, AttributeId attributeID, uint8_t * dataPtr,
+                                         uint8_t readLength)
 {
     return emAfReadAttribute(endpoint, cluster, attributeID, CLUSTER_MASK_CLIENT, EMBER_AF_NULL_MANUFACTURER_CODE, dataPtr,
                              readLength, NULL);
 }
 
-EmberAfStatus emberAfReadManufacturerSpecificServerAttribute(EndpointId endpoint, EmberAfClusterId cluster,
-                                                             EmberAfAttributeId attributeID, uint16_t manufacturerCode,
-                                                             uint8_t * dataPtr, uint8_t readLength)
+EmberAfStatus emberAfReadManufacturerSpecificServerAttribute(EndpointId endpoint, ClusterId cluster, AttributeId attributeID,
+                                                             uint16_t manufacturerCode, uint8_t * dataPtr, uint8_t readLength)
 {
     return emAfReadAttribute(endpoint, cluster, attributeID, CLUSTER_MASK_SERVER, manufacturerCode, dataPtr, readLength, NULL);
 }
 
-EmberAfStatus emberAfReadManufacturerSpecificClientAttribute(EndpointId endpoint, EmberAfClusterId cluster,
-                                                             EmberAfAttributeId attributeID, uint16_t manufacturerCode,
-                                                             uint8_t * dataPtr, uint8_t readLength)
+EmberAfStatus emberAfReadManufacturerSpecificClientAttribute(EndpointId endpoint, ClusterId cluster, AttributeId attributeID,
+                                                             uint16_t manufacturerCode, uint8_t * dataPtr, uint8_t readLength)
 {
     return emAfReadAttribute(endpoint, cluster, attributeID, CLUSTER_MASK_CLIENT, manufacturerCode, dataPtr, readLength, NULL);
 }
 
-bool emberAfReadSequentialAttributesAddToResponse(EndpointId endpoint, EmberAfClusterId clusterId,
-                                                  EmberAfAttributeId startAttributeId, uint8_t mask, uint16_t manufacturerCode,
-                                                  uint8_t maxAttributeIds, bool includeAccessControl)
+bool emberAfReadSequentialAttributesAddToResponse(EndpointId endpoint, ClusterId clusterId, AttributeId startAttributeId,
+                                                  uint8_t mask, uint16_t manufacturerCode, uint8_t maxAttributeIds,
+                                                  bool includeAccessControl)
 {
     uint16_t i;
     uint16_t discovered = 0;
@@ -248,7 +245,7 @@ bool emberAfReadSequentialAttributesAddToResponse(EndpointId endpoint, EmberAfCl
     return (discovered + skipped == total);
 }
 
-static void emberAfAttributeDecodeAndPrintCluster(EmberAfClusterId cluster, uint16_t mfgCode)
+static void emberAfAttributeDecodeAndPrintCluster(ClusterId cluster, uint16_t mfgCode)
 {
 #if defined(EMBER_AF_PRINT_ENABLE) && defined(EMBER_AF_PRINT_ATTRIBUTES)
     uint16_t index = emberAfFindClusterNameIndexWithMfgCode(cluster, mfgCode);
@@ -342,8 +339,8 @@ void emberAfPrintAttributeTable(void)
 // 1) unsupported: [attrId:2] [status:1]
 // 2) supported:   [attrId:2] [status:1] [type:1] [data:n]
 //
-void emberAfRetrieveAttributeAndCraftResponse(EndpointId endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attrId,
-                                              uint8_t mask, uint16_t manufacturerCode, uint16_t readLength)
+void emberAfRetrieveAttributeAndCraftResponse(EndpointId endpoint, ClusterId clusterId, AttributeId attrId, uint8_t mask,
+                                              uint16_t manufacturerCode, uint16_t readLength)
 {
     EmberAfStatus status;
     uint8_t data[ATTRIBUTE_LARGEST];
@@ -419,8 +416,8 @@ void emberAfRetrieveAttributeAndCraftResponse(EndpointId endpoint, EmberAfCluste
 // insufficient space in the buffer or an error occurs, buffer and bufIndex will
 // remain unchanged.  Otherwise, bufIndex will be incremented appropriately and
 // the fields will be written to the buffer.
-EmberAfStatus emberAfAppendAttributeReportFields(EndpointId endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId,
-                                                 uint8_t mask, uint8_t * buffer, uint8_t bufLen, uint8_t * bufIndex)
+EmberAfStatus emberAfAppendAttributeReportFields(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
+                                                 uint8_t * buffer, uint8_t bufLen, uint8_t * bufIndex)
 {
     EmberAfStatus status;
     EmberAfAttributeType type;
@@ -489,7 +486,7 @@ kickout:
 // the table or the data is too large, returns true and writes to dataPtr
 // if the attribute is supported and the readLength specified is less than
 // the length of the data.
-EmberAfStatus emAfWriteAttribute(EndpointId endpoint, EmberAfClusterId cluster, EmberAfAttributeId attributeID, uint8_t mask,
+EmberAfStatus emAfWriteAttribute(EndpointId endpoint, ClusterId cluster, AttributeId attributeID, uint8_t mask,
                                  uint16_t manufacturerCode, uint8_t * data, EmberAfAttributeType dataType,
                                  bool overrideReadOnlyAndDataType, bool justTest)
 {
@@ -634,7 +631,7 @@ EmberAfStatus emAfWriteAttribute(EndpointId endpoint, EmberAfClusterId cluster, 
 // If dataPtr is NULL, no data is copied to the caller.
 // readLength should be 0 in that case.
 
-EmberAfStatus emAfReadAttribute(EndpointId endpoint, EmberAfClusterId cluster, EmberAfAttributeId attributeID, uint8_t mask,
+EmberAfStatus emAfReadAttribute(EndpointId endpoint, ClusterId cluster, AttributeId attributeID, uint8_t mask,
                                 uint16_t manufacturerCode, uint8_t * dataPtr, uint16_t readLength, EmberAfAttributeType * dataType)
 {
     EmberAfAttributeMetadata * metadata = NULL;

--- a/src/app/util/attribute-table.h
+++ b/src/app/util/attribute-table.h
@@ -46,24 +46,24 @@
 #define ZCL_NULL_ATTRIBUTE_TABLE_INDEX 0xFFFF
 
 // Remote devices writing attributes of local device
-EmberAfStatus emberAfWriteAttributeExternal(CHIPEndpointId endpoint, EmberAfClusterId cluster, EmberAfAttributeId attributeID,
+EmberAfStatus emberAfWriteAttributeExternal(chip::EndpointId endpoint, chip::ClusterId cluster, chip::AttributeId attributeID,
                                             uint8_t mask, uint16_t manufacturerCode, uint8_t * dataPtr,
                                             EmberAfAttributeType dataType);
 
-void emberAfRetrieveAttributeAndCraftResponse(CHIPEndpointId endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attrId,
+void emberAfRetrieveAttributeAndCraftResponse(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attrId,
                                               uint8_t mask, uint16_t manufacturerCode, uint16_t readLength);
-EmberAfStatus emberAfAppendAttributeReportFields(CHIPEndpointId endpoint, EmberAfClusterId clusterId,
-                                                 EmberAfAttributeId attributeId, uint8_t mask, uint8_t * buffer, uint8_t bufLen,
+EmberAfStatus emberAfAppendAttributeReportFields(chip::EndpointId endpoint, chip::ClusterId clusterId,
+                                                 chip::AttributeId attributeId, uint8_t mask, uint8_t * buffer, uint8_t bufLen,
                                                  uint8_t * bufIndex);
 void emberAfPrintAttributeTable(void);
 
-bool emberAfReadSequentialAttributesAddToResponse(CHIPEndpointId endpoint, EmberAfClusterId clusterId,
-                                                  EmberAfAttributeId startAttributeId, uint8_t mask, uint16_t manufacturerCode,
+bool emberAfReadSequentialAttributesAddToResponse(chip::EndpointId endpoint, chip::ClusterId clusterId,
+                                                  chip::AttributeId startAttributeId, uint8_t mask, uint16_t manufacturerCode,
                                                   uint8_t maxAttributeIds, bool includeAccessControl);
 
-EmberAfStatus emAfWriteAttribute(CHIPEndpointId endpoint, EmberAfClusterId cluster, EmberAfAttributeId attributeID, uint8_t mask,
+EmberAfStatus emAfWriteAttribute(chip::EndpointId endpoint, chip::ClusterId cluster, chip::AttributeId attributeID, uint8_t mask,
                                  uint16_t manufacturerCode, uint8_t * data, EmberAfAttributeType dataType,
                                  bool overrideReadOnlyAndDataType, bool justTest);
 
-EmberAfStatus emAfReadAttribute(CHIPEndpointId endpoint, EmberAfClusterId cluster, EmberAfAttributeId attributeID, uint8_t mask,
+EmberAfStatus emAfReadAttribute(chip::EndpointId endpoint, chip::ClusterId cluster, chip::AttributeId attributeID, uint8_t mask,
                                 uint16_t manufacturerCode, uint8_t * dataPtr, uint16_t readLength, EmberAfAttributeType * dataType);

--- a/src/app/util/basic-types.h
+++ b/src/app/util/basic-types.h
@@ -25,22 +25,16 @@
 
 #include <stdint.h>
 
-/**
- * Types for use by CHIP C code, until we switch to C++.
- */
-typedef uint8_t CHIPEndpointId;
-typedef uint16_t CHIPClusterId;
-typedef uint16_t CHIPAttributeId;
-typedef uint16_t CHIPGroupId;
-typedef uint8_t CHIPCommandId;
+// Pull in NodeId
+#include <transport/raw/MessageHeader.h>
 
-/**
- * Types for use by generated Silicon Labs code until we convert the generator
- * to using CHIP types.
- */
-typedef CHIPClusterId EmberAfClusterId;
-typedef CHIPAttributeId EmberAfAttributeId;
-typedef CHIPGroupId EmberMulticastId;
+namespace chip {
+typedef uint8_t EndpointId;
+typedef uint16_t ClusterId;
+typedef uint16_t AttributeId;
+typedef uint16_t GroupId;
+typedef uint8_t CommandId;
+} // namespace chip
 
 /**
  * @brief Type for referring to zigbee application profile id
@@ -48,16 +42,3 @@ typedef CHIPGroupId EmberMulticastId;
  *        https://github.com/project-chip/connectedhomeip/issues/3444
  */
 typedef uint16_t EmberAfProfileId;
-
-#ifdef __cplusplus
-// Pull in NodeId
-#include <transport/raw/MessageHeader.h>
-
-namespace chip {
-typedef CHIPEndpointId EndpointId;
-typedef CHIPClusterId ClusterId;
-typedef CHIPAttributeId AttributeId;
-typedef CHIPGroupId GroupId;
-typedef CHIPCommandId CommandId;
-} // namespace chip
-#endif // __cplusplus

--- a/src/app/util/client-api.cpp
+++ b/src/app/util/client-api.cpp
@@ -60,7 +60,7 @@ EmberApsFrame * emAfCommandApsFrame = NULL;
 // It returns number of bytes filled
 // and 0 on error.
 static uint16_t vFillBuffer(uint8_t * buffer, uint16_t bufferLen, uint8_t frameControl, uint16_t manufacturerCode,
-                            uint8_t commandId, const char * format, va_list argPointer)
+                            CommandId commandId, const char * format, va_list argPointer)
 {
     uint32_t value;
     uint8_t valueLen;
@@ -236,8 +236,8 @@ void emberAfSetExternalBuffer(uint8_t * buffer, uint16_t bufferLen, uint16_t * l
     emAfCommandApsFrame   = apsFrame;
 }
 
-uint16_t emberAfFillExternalManufacturerSpecificBuffer(uint8_t frameControl, EmberAfClusterId clusterId, uint16_t manufacturerCode,
-                                                       uint8_t commandId, const char * format, ...)
+uint16_t emberAfFillExternalManufacturerSpecificBuffer(uint8_t frameControl, ClusterId clusterId, uint16_t manufacturerCode,
+                                                       CommandId commandId, const char * format, ...)
 {
     uint16_t returnValue;
     va_list argPointer;
@@ -251,7 +251,7 @@ uint16_t emberAfFillExternalManufacturerSpecificBuffer(uint8_t frameControl, Emb
     return returnValue;
 }
 
-uint16_t emberAfFillExternalBuffer(uint8_t frameControl, EmberAfClusterId clusterId, uint8_t commandId, const char * format, ...)
+uint16_t emberAfFillExternalBuffer(uint8_t frameControl, ClusterId clusterId, CommandId commandId, const char * format, ...)
 {
     uint16_t returnValue;
     va_list argPointer;
@@ -266,7 +266,8 @@ uint16_t emberAfFillExternalBuffer(uint8_t frameControl, EmberAfClusterId cluste
     return returnValue;
 }
 
-uint16_t emberAfFillBuffer(uint8_t * buffer, uint16_t bufferLen, uint8_t frameControl, uint8_t commandId, const char * format, ...)
+uint16_t emberAfFillBuffer(uint8_t * buffer, uint16_t bufferLen, uint8_t frameControl, CommandId commandId, const char * format,
+                           ...)
 {
     uint16_t returnValue;
     va_list argPointer;
@@ -286,12 +287,12 @@ EmberStatus emberAfSendCommandUnicastToBindings(void)
     return emberAfSendCommandUnicastToBindingsWithCallback(NULL);
 }
 
-// EmberStatus emberAfSendCommandMulticastWithCallback(EmberMulticastId multicastId, EmberAfMessageSentFunction callback)
+// EmberStatus emberAfSendCommandMulticastWithCallback(GroupId multicastId, EmberAfMessageSentFunction callback)
 // {
 //     return emberAfSendMulticastWithCallback(multicastId, emAfCommandApsFrame, *emAfResponseLengthPtr, emAfZclBuffer, callback);
 // }
 
-// EmberStatus emberAfSendCommandMulticastWithAliasWithCallback(EmberMulticastId multicastId, EmberNodeId alias, uint8_t sequence,
+// EmberStatus emberAfSendCommandMulticastWithAliasWithCallback(GroupId multicastId, EmberNodeId alias, uint8_t sequence,
 //                                                              EmberAfMessageSentFunction callback)
 // {
 //     return emberAfSendMulticastWithAliasWithCallback(multicastId, emAfCommandApsFrame, *emAfResponseLengthPtr, emAfZclBuffer,
@@ -299,12 +300,12 @@ EmberStatus emberAfSendCommandUnicastToBindings(void)
 //                                                      sequence, callback);
 // }
 
-// EmberStatus emberAfSendCommandMulticast(EmberMulticastId multicastId)
+// EmberStatus emberAfSendCommandMulticast(GroupId multicastId)
 // {
 //     return emberAfSendCommandMulticastWithCallback(multicastId, NULL);
 // }
 
-// EmberStatus emberAfSendCommandMulticastWithAlias(EmberMulticastId multicastId, EmberNodeId alias, uint8_t sequence)
+// EmberStatus emberAfSendCommandMulticastWithAlias(GroupId multicastId, EmberNodeId alias, uint8_t sequence)
 // {
 //     return emberAfSendCommandMulticastWithAliasWithCallback(multicastId, alias, sequence, NULL);
 // }
@@ -350,7 +351,7 @@ EmberStatus emberAfSendCommandMulticastToBindings(void)
 // }
 
 // EmberStatus emberAfSendCommandInterPan(EmberPanId panId, const EmberEUI64 destinationLongId, EmberNodeId destinationShortId,
-//                                        EmberMulticastId multicastId, EmberAfProfileId profileId)
+//                                        GroupId multicastId, EmberAfProfileId profileId)
 // {
 //     return emberAfSendInterPan(panId, destinationLongId, destinationShortId, multicastId, emAfCommandApsFrame->clusterId,
 //     profileId,

--- a/src/app/util/client-api.h
+++ b/src/app/util/client-api.h
@@ -91,7 +91,8 @@
  *            copied as is to the destination buffer. The length is not
  *            included.
  */
-uint16_t emberAfFillExternalBuffer(uint8_t frameControl, EmberAfClusterId clusterId, uint8_t commandId, const char * format, ...);
+uint16_t emberAfFillExternalBuffer(uint8_t frameControl, chip::ClusterId clusterId, chip::CommandId commandId, const char * format,
+                                   ...);
 
 /**
  * @brief Function that fills in the buffer with manufacturer-specific command.
@@ -135,8 +136,8 @@ uint16_t emberAfFillExternalBuffer(uint8_t frameControl, EmberAfClusterId cluste
  *            copied as is to the destination buffer. The length is not
  *            included.
  */
-uint16_t emberAfFillExternalManufacturerSpecificBuffer(uint8_t frameControl, EmberAfClusterId clusterId, uint16_t manufacturerCode,
-                                                       uint8_t commandId, const char * format, ...);
+uint16_t emberAfFillExternalManufacturerSpecificBuffer(uint8_t frameControl, chip::ClusterId clusterId, uint16_t manufacturerCode,
+                                                       chip::CommandId commandId, const char * format, ...);
 
 /**
  * @brief Function that registers the buffer to use with the fill function.
@@ -156,7 +157,8 @@ void emberAfSetExternalBuffer(uint8_t * buffer, uint16_t bufferLen, uint16_t * r
  * Used internally by emberAfFillExternalBuffer, but can be used
  * for generic buffer filling.
  */
-uint16_t emberAfFillBuffer(uint8_t * buffer, uint16_t bufferLen, uint8_t frameControl, uint8_t commandId, const char * format, ...);
+uint16_t emberAfFillBuffer(uint8_t * buffer, uint16_t bufferLen, uint8_t frameControl, chip::CommandId commandId,
+                           const char * format, ...);
 
 #if !defined(DOXYGEN_SHOULD_SKIP_THIS)
 // The buffer used for filling ZCL Messages.

--- a/src/app/util/esi-management.cpp
+++ b/src/app/util/esi-management.cpp
@@ -96,7 +96,8 @@ EmberAfPluginEsiManagementEsiEntry * emberAfPluginEsiManagementGetFreeEntry(void
     return entry;
 }
 
-EmberAfPluginEsiManagementEsiEntry * emberAfPluginEsiManagementEsiLookUpByShortIdAndEndpoint(EmberNodeId shortId, uint8_t endpoint)
+EmberAfPluginEsiManagementEsiEntry * emberAfPluginEsiManagementEsiLookUpByShortIdAndEndpoint(EmberNodeId shortId,
+                                                                                             EndpointId endpoint)
 {
     uint8_t index = emberAfPluginEsiManagementIndexLookUpByShortIdAndEndpoint(shortId, endpoint);
     if (index < EMBER_AF_PLUGIN_ESI_MANAGEMENT_ESI_TABLE_SIZE)
@@ -122,7 +123,7 @@ EmberAfPluginEsiManagementEsiEntry * emberAfPluginEsiManagementEsiLookUpByLongId
     }
 }
 
-uint8_t emberAfPluginEsiManagementIndexLookUpByShortIdAndEndpoint(EmberNodeId shortId, uint8_t endpoint)
+uint8_t emberAfPluginEsiManagementIndexLookUpByShortIdAndEndpoint(EmberNodeId shortId, EndpointId endpoint)
 {
     uint8_t networkIndex = 0; /*emberGetCurrentNetwork(); #2552*/
     uint8_t i;

--- a/src/app/util/esi-management.h
+++ b/src/app/util/esi-management.h
@@ -60,7 +60,7 @@ typedef struct
     EmberEUI64 eui64;
     ChipNodeId nodeId;
     uint8_t networkIndex;
-    CHIPEndpointId endpoint;
+    chip::EndpointId endpoint;
     uint8_t age; // The number of discovery cycles the ESI has not been discovered.
 } EmberAfPluginEsiManagementEsiEntry;
 
@@ -72,7 +72,8 @@ typedef void (*EmberAfEsiManagementDeletionCallback)(uint8_t);
  * Returns a pointer to the entry if a matching entry was found, otherwise it
  * returns NULL.
  */
-EmberAfPluginEsiManagementEsiEntry * emberAfPluginEsiManagementEsiLookUpByShortIdAndEndpoint(EmberNodeId shortId, uint8_t endpoint);
+EmberAfPluginEsiManagementEsiEntry * emberAfPluginEsiManagementEsiLookUpByShortIdAndEndpoint(EmberNodeId shortId,
+                                                                                             chip::EndpointId endpoint);
 
 /**
  * Searches in the ESI table by the pair node (long ID, endopoint).
@@ -81,7 +82,7 @@ EmberAfPluginEsiManagementEsiEntry * emberAfPluginEsiManagementEsiLookUpByShortI
  * returns NULL.
  */
 EmberAfPluginEsiManagementEsiEntry * emberAfPluginEsiManagementEsiLookUpByLongIdAndEndpoint(EmberEUI64 longId,
-                                                                                            CHIPEndpointId endpoint);
+                                                                                            chip::EndpointId endpoint);
 
 /**
  * Allows retrieving the index of an entry that matches the passed short ID
@@ -90,7 +91,7 @@ EmberAfPluginEsiManagementEsiEntry * emberAfPluginEsiManagementEsiLookUpByLongId
  * It returns the index of the matching entry if a matching entry was found,
  * otherwise it returns 0xFF.
  */
-uint8_t emberAfPluginEsiManagementIndexLookUpByShortIdAndEndpoint(EmberNodeId shortId, uint8_t endpoint);
+uint8_t emberAfPluginEsiManagementIndexLookUpByShortIdAndEndpoint(EmberNodeId shortId, chip::EndpointId endpoint);
 
 /**
  * Allows retrieving the index of an entry that matches the passed long ID
@@ -99,7 +100,7 @@ uint8_t emberAfPluginEsiManagementIndexLookUpByShortIdAndEndpoint(EmberNodeId sh
  * It returns the index of the matching entry if a matching entry was found,
  * otherwise it returns 0xFF.
  */
-uint8_t emberAfPluginEsiManagementIndexLookUpByLongIdAndEndpoint(EmberEUI64 longId, CHIPEndpointId endpoint);
+uint8_t emberAfPluginEsiManagementIndexLookUpByLongIdAndEndpoint(EmberEUI64 longId, chip::EndpointId endpoint);
 
 /**
  * Searches in the ESI table by the table index.

--- a/src/app/util/process-global-message.cpp
+++ b/src/app/util/process-global-message.cpp
@@ -104,16 +104,16 @@ static void printDiscoverCommandsResponse(bool generated, ClusterId clusterId, b
 
 bool emAfProcessGlobalCommand(EmberAfClusterCommand * cmd)
 {
-    uint16_t attrId;
+    AttributeId attrId;
     uint8_t frameControl;
     // This is a little clumsy but easier to read and port
     // from earlier implementation.
-    EmberAfClusterId clusterId = cmd->apsFrame->clusterId;
-    CommandId zclCmd           = cmd->commandId;
-    uint8_t * message          = cmd->buffer;
-    uint16_t msgLen            = cmd->bufLen;
-    uint16_t msgIndex          = cmd->payloadStartIndex;
-    uint8_t clientServerMask   = (cmd->direction == ZCL_DIRECTION_CLIENT_TO_SERVER ? CLUSTER_MASK_SERVER : CLUSTER_MASK_CLIENT);
+    ClusterId clusterId      = cmd->apsFrame->clusterId;
+    CommandId zclCmd         = cmd->commandId;
+    uint8_t * message        = cmd->buffer;
+    uint16_t msgLen          = cmd->bufLen;
+    uint16_t msgIndex        = cmd->payloadStartIndex;
+    uint8_t clientServerMask = (cmd->direction == ZCL_DIRECTION_CLIENT_TO_SERVER ? CLUSTER_MASK_SERVER : CLUSTER_MASK_CLIENT);
 
     // If we are disabled then we can only respond to read or write commands
     // or identify cluster (see device enabled attr of basic cluster)
@@ -185,8 +185,8 @@ bool emAfProcessGlobalCommand(EmberAfClusterCommand * cmd)
             {
                 static const struct
                 {
-                    EmberAfClusterId clusterId;
-                    uint16_t attrId;
+                    ClusterId clusterId;
+                    AttributeId attrId;
                 } noDefaultResponseSet[] = {
                     { ZCL_PRICE_CLUSTER_ID, ZCL_THRESHOLD_MULTIPLIER_ATTRIBUTE_ID },
                     { ZCL_PRICE_CLUSTER_ID, ZCL_THRESHOLD_DIVISOR_ATTRIBUTE_ID },
@@ -433,7 +433,7 @@ bool emAfProcessGlobalCommand(EmberAfClusterCommand * cmd)
     // the format of the response is: [done:1] ([attrID:2] [type:1]) * N
     case ZCL_DISCOVER_ATTRIBUTES_COMMAND_ID:
     case ZCL_DISCOVER_ATTRIBUTES_EXTENDED_COMMAND_ID: {
-        EmberAfAttributeId startingAttributeId;
+        AttributeId startingAttributeId;
         uint8_t numberAttributes;
         uint8_t * complete;
 
@@ -611,7 +611,7 @@ bool emAfProcessGlobalCommand(EmberAfClusterCommand * cmd)
     // [command id:1] [status:1]
     case ZCL_DEFAULT_RESPONSE_COMMAND_ID: {
         EmberAfStatus status;
-        uint8_t commandId;
+        CommandId commandId;
         commandId = emberAfGetInt8u(message, msgIndex, msgLen);
         msgIndex++;
         status = (EmberAfStatus) emberAfGetInt8u(message, msgIndex, msgLen);

--- a/src/app/util/types_stub.h
+++ b/src/app/util/types_stub.h
@@ -540,7 +540,7 @@ typedef struct
     /** The type of binding. */
     EmberBindingType type;
     /** The endpoint on the local node. */
-    CHIPEndpointId local;
+    chip::EndpointId local;
     /** A cluster ID that matches one from the local endpoint's simple descriptor.
      * This cluster ID is set by the provisioning application to indicate which
      * part an endpoint's functionality is bound to this particular remote node
@@ -548,9 +548,9 @@ typedef struct
      * that a binding can be used to to send messages with any cluster ID, not
      * just that listed in the binding.
      */
-    CHIPClusterId clusterId;
+    chip::ClusterId clusterId;
     /** The endpoint on the remote node (specified by \c identifier). */
-    CHIPEndpointId remote;
+    chip::EndpointId remote;
     /** A 64-bit destination identifier.  This is either:
      * - The destination ChipNodeId, for unicasts.
      * - A multicast ChipGroupId, for multicasts.
@@ -559,7 +559,7 @@ typedef struct
     union
     {
         ChipNodeId nodeId;
-        CHIPGroupId groupId;
+        chip::GroupId groupId;
     };
     /** The index of the network the binding belongs to. */
     uint8_t networkIndex;

--- a/src/app/util/util.h
+++ b/src/app/util/util.h
@@ -141,12 +141,12 @@ uint16_t emberAfGetMfgCodeFromCurrentCommand(void);
 
 void emberAfInit(void);
 void emberAfTick(void);
-uint16_t emberAfFindClusterNameIndex(CHIPClusterId cluster);
-uint16_t emberAfFindClusterNameIndexWithMfgCode(CHIPClusterId cluster, uint16_t mfgCode);
+uint16_t emberAfFindClusterNameIndex(chip::ClusterId cluster);
+uint16_t emberAfFindClusterNameIndexWithMfgCode(chip::ClusterId cluster, uint16_t mfgCode);
 void emberAfStackDown(void);
 
-void emberAfDecodeAndPrintCluster(CHIPClusterId cluster);
-void emberAfDecodeAndPrintClusterWithMfgCode(CHIPClusterId cluster, uint16_t mfgCode);
+void emberAfDecodeAndPrintCluster(chip::ClusterId cluster);
+void emberAfDecodeAndPrintClusterWithMfgCode(chip::ClusterId cluster, uint16_t mfgCode);
 
 bool emberAfProcessMessage(EmberApsFrame * apsFrame, EmberIncomingMessageType type, uint8_t * message, uint16_t msgLen,
                            ChipNodeId source, InterPanHeader * interPanHeader);

--- a/src/app/zap-templates/af-structs.zapt
+++ b/src/app/zap-templates/af-structs.zapt
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <stdint.h>
+#include "basic-types.h"
 #include "enums.h"
 
 {{#zcl_structs}}
@@ -11,7 +12,22 @@
 // Struct for {{label}}
 typedef struct _{{asType label}} {
 {{#zcl_struct_items}}
+{{#if (isStrEqual label "endpoint")}}
+{{ident}}chip::EndpointId {{asSymbol label}};
+{{else if (isStrEqual label "endpointId")}}
+{{ident}}chip::EndpointId {{asSymbol label}};
+{{else if (isStrEqual type "CLUSTER_ID")}}
+{{ident}}chip::ClusterId {{asSymbol label}};
+{{else if (isStrEqual type "ATTRIBUTE_ID")}}
+{{ident}}chip::AttributeId {{asSymbol label}};
+{{else if (isStrEqual label "groupId")}}
+{{ident}}chip::GroupId {{asSymbol label}};
+{{else if (isStrEqual label "commandId")}}
+{{ident}}chip::CommandId {{asSymbol label}};
+{{else}}
+{{type}} {{label}}
 {{ident}}{{asUnderlyingType type}} {{asSymbol label}};
+{{/if}}
 {{/zcl_struct_items}}
 } {{asUnderlyingType label}};
 {{/zcl_structs}}

--- a/src/app/zap-templates/call-command-handler-src.zapt
+++ b/src/app/zap-templates/call-command-handler-src.zapt
@@ -8,6 +8,8 @@
 #include "command-id.h"
 #include "util.h"
 
+using namespace chip;
+
 {{#all_user_clusters}}
 {{#if (isEnabled enabled)}}
 EmberAfStatus emberAf{{asCamelCased name false}}Cluster{{asCamelCased side false}}CommandParse(EmberAfClusterCommand * cmd);

--- a/src/app/zap-templates/callback-stub-src.zapt
+++ b/src/app/zap-templates/callback-stub-src.zapt
@@ -3,8 +3,10 @@
 #include "callback.h"
 #include "cluster-id.h"
 
+using namespace chip;
+
 // Cluster Init Functions
-void emberAfClusterInitCallback(CHIPEndpointId endpoint, CHIPClusterId clusterId)
+void emberAfClusterInitCallback(chip::EndpointId endpoint, chip::ClusterId clusterId)
 {
     switch (clusterId)
     {
@@ -130,8 +132,8 @@ void emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
  * @param value   Ver.: always
  * @param type   Ver.: always
  */
-EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(CHIPEndpointId endpoint, CHIPClusterId clusterId,
-                                                                          CHIPAttributeId attributeId, uint8_t mask,
+EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
+                                                                          chip::AttributeId attributeId, uint8_t mask,
                                                                           uint16_t manufacturerCode, uint8_t * value, uint8_t type)
 {
     return EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_NORMAL; // Default
@@ -147,8 +149,8 @@ EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(CHIPEn
  * @param manufacturerCode   Ver.: always
  * @param attributeId   Ver.: always
  */
-bool emberAfAttributeReadAccessCallback(CHIPEndpointId endpoint, CHIPClusterId clusterId, uint16_t manufacturerCode,
-                                        CHIPAttributeId attributeId)
+bool emberAfAttributeReadAccessCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode,
+                                        chip::AttributeId attributeId)
 {
     return true;
 }
@@ -163,8 +165,8 @@ bool emberAfAttributeReadAccessCallback(CHIPEndpointId endpoint, CHIPClusterId c
  * @param manufacturerCode   Ver.: always
  * @param attributeId   Ver.: always
  */
-bool emberAfAttributeWriteAccessCallback(CHIPEndpointId endpoint, CHIPClusterId clusterId, uint16_t manufacturerCode,
-                                         CHIPAttributeId attributeId)
+bool emberAfAttributeWriteAccessCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode,
+                                         chip::AttributeId attributeId)
 {
     return true;
 }
@@ -181,7 +183,7 @@ bool emberAfAttributeWriteAccessCallback(CHIPEndpointId endpoint, CHIPClusterId 
  * @param status Specifies either SUCCESS or the nature of the error that was
  * detected in the received command.  Ver.: always
  */
-bool emberAfDefaultResponseCallback(CHIPClusterId clusterId, CHIPCommandId commandId, EmberAfStatus status)
+bool emberAfDefaultResponseCallback(chip::ClusterId clusterId, chip::CommandId commandId, EmberAfStatus status)
 {
     return false;
 }
@@ -206,7 +208,7 @@ bool emberAfDefaultResponseCallback(CHIPClusterId clusterId, CHIPCommandId comma
  * @param extended Indicates whether the response is in the extended format or
  * not.  Ver.: always
  */
-bool emberAfDiscoverAttributesResponseCallback(CHIPClusterId clusterId, bool discoveryComplete, uint8_t * buffer,
+bool emberAfDiscoverAttributesResponseCallback(chip::ClusterId clusterId, bool discoveryComplete, uint8_t * buffer,
                                                uint16_t bufLen, bool extended)
 {
     return false;
@@ -226,8 +228,8 @@ bool emberAfDiscoverAttributesResponseCallback(CHIPClusterId clusterId, bool dis
  * @param commandIdCount The length of bytes of the list, whish is the same as
  * the number of identifiers.  Ver.: always
  */
-bool emberAfDiscoverCommandsGeneratedResponseCallback(CHIPClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
-                                                      CHIPCommandId * commandIds, uint16_t commandIdCount)
+bool emberAfDiscoverCommandsGeneratedResponseCallback(chip::ClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
+                                                      chip::CommandId * commandIds, uint16_t commandIdCount)
 {
     return false;
 }
@@ -246,8 +248,8 @@ bool emberAfDiscoverCommandsGeneratedResponseCallback(CHIPClusterId clusterId, u
  * @param commandIdCount The length of bytes of the list, whish is the same as
  * the number of identifiers.  Ver.: always
  */
-bool emberAfDiscoverCommandsReceivedResponseCallback(CHIPClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
-                                                     CHIPCommandId * commandIds, uint16_t commandIdCount)
+bool emberAfDiscoverCommandsReceivedResponseCallback(chip::ClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
+                                                     chip::CommandId * commandIds, uint16_t commandIdCount)
 {
     return false;
 }
@@ -335,7 +337,7 @@ bool emberAfMessageSentCallback(EmberOutgoingMessageType type, uint16_t indexOrD
  * @param size   Ver.: always
  * @param value   Ver.: always
  */
-EmberAfStatus emberAfPreAttributeChangeCallback(CHIPEndpointId endpoint, CHIPClusterId clusterId, CHIPAttributeId attributeId,
+EmberAfStatus emberAfPreAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
                                                 uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size,
                                                 uint8_t * value)
 {
@@ -357,7 +359,7 @@ EmberAfStatus emberAfPreAttributeChangeCallback(CHIPEndpointId endpoint, CHIPClu
  * @param size   Ver.: always
  * @param value   Ver.: always
  */
-void emberAfPostAttributeChangeCallback(CHIPEndpointId endpoint, CHIPClusterId clusterId, CHIPAttributeId attributeId, uint8_t mask,
+void emberAfPostAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value) {}
 
 /** @brief Read Attributes Response
@@ -371,7 +373,7 @@ void emberAfPostAttributeChangeCallback(CHIPEndpointId endpoint, CHIPClusterId c
  * Ver.: always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfReadAttributesResponseCallback(CHIPClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+bool emberAfReadAttributesResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
     return false;
 }
@@ -412,7 +414,7 @@ bool emberAfReadAttributesResponseCallback(CHIPClusterId clusterId, uint8_t * bu
  * @param buffer   Ver.: always
  * @param maxReadLength   Ver.: always
  */
-EmberAfStatus emberAfExternalAttributeReadCallback(CHIPEndpointId endpoint, CHIPClusterId clusterId,
+EmberAfStatus emberAfExternalAttributeReadCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
                                                    EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
                                                    uint8_t * buffer, uint16_t maxReadLength)
 {
@@ -430,7 +432,7 @@ EmberAfStatus emberAfExternalAttributeReadCallback(CHIPEndpointId endpoint, CHIP
  * Ver.: always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfWriteAttributesResponseCallback(CHIPClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+bool emberAfWriteAttributesResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
     return false;
 }
@@ -481,7 +483,7 @@ bool emberAfWriteAttributesResponseCallback(CHIPClusterId clusterId, uint8_t * b
  * @param manufacturerCode   Ver.: always
  * @param buffer   Ver.: always
  */
-EmberAfStatus emberAfExternalAttributeWriteCallback(CHIPEndpointId endpoint, CHIPClusterId clusterId,
+EmberAfStatus emberAfExternalAttributeWriteCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
                                                     EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
                                                     uint8_t * buffer)
 {
@@ -499,7 +501,7 @@ EmberAfStatus emberAfExternalAttributeWriteCallback(CHIPEndpointId endpoint, CHI
  * always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfReportAttributesCallback(CHIPClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+bool emberAfReportAttributesCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
     return false;
 }
@@ -535,7 +537,7 @@ uint32_t emberAfGetCurrentTimeCallback()
  * @param returnEndpointInfo A pointer to a data struct that will be written
  * with information about the endpoint.  Ver.: always
  */
-bool emberAfGetEndpointInfoCallback(CHIPEndpointId endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo)
+bool emberAfGetEndpointInfoCallback(chip::EndpointId endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo)
 {
     return false;
 }

--- a/src/app/zap-templates/callback.zapt
+++ b/src/app/zap-templates/callback.zapt
@@ -16,7 +16,7 @@
  * @param endpoint   Ver.: always
  * @param clusterId   Ver.: always
  */
-void emberAfClusterInitCallback(CHIPEndpointId endpoint, CHIPClusterId clusterId);
+void emberAfClusterInitCallback(chip::EndpointId endpoint, chip::ClusterId clusterId);
 
 // Cluster Init Functions
 
@@ -32,7 +32,8 @@ void emberAfClusterInitCallback(CHIPEndpointId endpoint, CHIPClusterId clusterId
  *
  * @param endpoint    Endpoint that is being initialized
  */
-void emberAf{{asCamelCased name false}}ClusterInitCallback(CHIPEndpointId endpoint);
+{{#all_user_clusters_names}}
+void emberAf{{asCamelCased name false}}ClusterInitCallback(chip::EndpointId endpoint);
 
 /** @brief {{name}} Cluster {{asCamelCased side false}} Init
  *
@@ -40,7 +41,7 @@ void emberAf{{asCamelCased name false}}ClusterInitCallback(CHIPEndpointId endpoi
  *
  * @param endpoint    Endpoint that is being initialized
  */
-void emberAf{{asCamelCased name false}}Cluster{{asCamelCased side false}}InitCallback(CHIPEndpointId endpoint);
+void emberAf{{asCamelCased name false}}Cluster{{asCamelCased side false}}InitCallback(chip::EndpointId endpoint);
 
 /** @brief {{name}} Cluster {{asCamelCased side false}} Attribute Changed
  *
@@ -49,7 +50,7 @@ void emberAf{{asCamelCased name false}}Cluster{{asCamelCased side false}}InitCal
  * @param endpoint    Endpoint that is being initialized
  * @param attributeId Attribute that changed
  */
-void emberAf{{asCamelCased name false}}Cluster{{asCamelCased side false}}AttributeChangedCallback(CHIPEndpointId endpoint, CHIPAttributeId attributeId);
+void emberAf{{asCamelCased name false}}Cluster{{asCamelCased side false}}AttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
 
 /** @brief {{name}} Cluster {{asCamelCased side false}} Manufacturer Specific Attribute Changed
  *
@@ -59,7 +60,7 @@ void emberAf{{asCamelCased name false}}Cluster{{asCamelCased side false}}Attribu
  * @param attributeId       Attribute that changed
  * @param manufacturerCode  Manufacturer Code of the attribute that changed
  */
-void emberAf{{asCamelCased name false}}Cluster{{asCamelCased side false}}ManufacturerSpecificAttributeChangedCallback(CHIPEndpointId endpoint, CHIPAttributeId attributeId, uint16_t manufacturerCode);
+void emberAf{{asCamelCased name false}}Cluster{{asCamelCased side false}}ManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
 
 /** @brief {{name}} Cluster {{asCamelCased side false}} Message Sent
  *
@@ -84,7 +85,7 @@ void emberAf{{asCamelCased name false}}Cluster{{asCamelCased side false}}Message
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAf{{asCamelCased name false}}Cluster{{asCamelCased side false}}PreAttributeChangedCallback(CHIPEndpointId endpoint, CHIPAttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
+EmberAfStatus emberAf{{asCamelCased name false}}Cluster{{asCamelCased side false}}PreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint8_t size, uint8_t * value);
 
 /** @brief {{name}} Cluster {{asCamelCased side false}} Tick
  *
@@ -92,7 +93,7 @@ EmberAfStatus emberAf{{asCamelCased name false}}Cluster{{asCamelCased side false
  *
  * @param endpoint  Endpoint that is being served
  */
-void emberAf{{asCamelCased name false}}Cluster{{asCamelCased side false}}TickCallback(CHIPEndpointId endpoint);
+void emberAf{{asCamelCased name false}}Cluster{{asCamelCased side false}}TickCallback(chip::EndpointId endpoint);
 {{/all_user_clusters}}
 
 // Cluster Commands Callback
@@ -188,8 +189,8 @@ void emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks);
  * @param value   Ver.: always
  * @param type   Ver.: always
  */
-EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(CHIPEndpointId endpoint, CHIPClusterId clusterId,
-                                                                          CHIPAttributeId attributeId, uint8_t mask,
+EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
+                                                                          chip::AttributeId attributeId, uint8_t mask,
                                                                           uint16_t manufacturerCode, uint8_t * value, uint8_t type);
 
 /** @brief Attribute Read Access
@@ -202,8 +203,8 @@ EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(CHIPEn
  * @param manufacturerCode   Ver.: always
  * @param attributeId   Ver.: always
  */
-bool emberAfAttributeReadAccessCallback(CHIPEndpointId endpoint, CHIPClusterId clusterId, uint16_t manufacturerCode,
-                                        CHIPAttributeId attributeId);
+bool emberAfAttributeReadAccessCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode,
+                                        chip::AttributeId attributeId);
 
 /** @brief Attribute Write Access
  *
@@ -215,8 +216,8 @@ bool emberAfAttributeReadAccessCallback(CHIPEndpointId endpoint, CHIPClusterId c
  * @param manufacturerCode   Ver.: always
  * @param attributeId   Ver.: always
  */
-bool emberAfAttributeWriteAccessCallback(CHIPEndpointId endpoint, CHIPClusterId clusterId, uint16_t manufacturerCode,
-                                         CHIPAttributeId attributeId);
+bool emberAfAttributeWriteAccessCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode,
+                                         chip::AttributeId attributeId);
 
 /** @brief Default Response
  *
@@ -230,7 +231,7 @@ bool emberAfAttributeWriteAccessCallback(CHIPEndpointId endpoint, CHIPClusterId 
  * @param status Specifies either SUCCESS or the nature of the error that was
  * detected in the received command.  Ver.: always
  */
-bool emberAfDefaultResponseCallback(CHIPClusterId clusterId, CHIPCommandId commandId, EmberAfStatus status);
+bool emberAfDefaultResponseCallback(chip::ClusterId clusterId, chip::CommandId commandId, EmberAfStatus status);
 
 /** @brief Discover Attributes Response
  *
@@ -252,7 +253,7 @@ bool emberAfDefaultResponseCallback(CHIPClusterId clusterId, CHIPCommandId comma
  * @param extended Indicates whether the response is in the extended format or
  * not.  Ver.: always
  */
-bool emberAfDiscoverAttributesResponseCallback(CHIPClusterId clusterId, bool discoveryComplete, uint8_t * buffer,
+bool emberAfDiscoverAttributesResponseCallback(chip::ClusterId clusterId, bool discoveryComplete, uint8_t * buffer,
                                                uint16_t bufLen, bool extended);
 
 /** @brief Discover Commands Generated Response
@@ -269,8 +270,8 @@ bool emberAfDiscoverAttributesResponseCallback(CHIPClusterId clusterId, bool dis
  * @param commandIdCount The length of bytes of the list, whish is the same as
  * the number of identifiers.  Ver.: always
  */
-bool emberAfDiscoverCommandsGeneratedResponseCallback(CHIPClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
-                                                      CHIPCommandId * commandIds, uint16_t commandIdCount);
+bool emberAfDiscoverCommandsGeneratedResponseCallback(chip::ClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
+                                                      chip::CommandId * commandIds, uint16_t commandIdCount);
 
 
 /** @brief Discover Commands Received Response
@@ -287,8 +288,8 @@ bool emberAfDiscoverCommandsGeneratedResponseCallback(CHIPClusterId clusterId, u
  * @param commandIdCount The length of bytes of the list, whish is the same as
  * the number of identifiers.  Ver.: always
  */
-bool emberAfDiscoverCommandsReceivedResponseCallback(CHIPClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
-                                                     CHIPCommandId * commandIds, uint16_t commandIdCount);
+bool emberAfDiscoverCommandsReceivedResponseCallback(chip::ClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
+                                                     chip::CommandId * commandIds, uint16_t commandIdCount);
 
 
 /** @brief Pre Command Received
@@ -365,7 +366,7 @@ bool emberAfMessageSentCallback(EmberOutgoingMessageType type, uint16_t indexOrD
  * @param size   Ver.: always
  * @param value   Ver.: always
  */
-EmberAfStatus emberAfPreAttributeChangeCallback(CHIPEndpointId endpoint, CHIPClusterId clusterId, CHIPAttributeId attributeId,
+EmberAfStatus emberAfPreAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
                                                 uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size,
                                                 uint8_t * value);
 
@@ -384,7 +385,7 @@ EmberAfStatus emberAfPreAttributeChangeCallback(CHIPEndpointId endpoint, CHIPClu
  * @param size   Ver.: always
  * @param value   Ver.: always
  */
-void emberAfPostAttributeChangeCallback(CHIPEndpointId endpoint, CHIPClusterId clusterId, CHIPAttributeId attributeId, uint8_t mask,
+void emberAfPostAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value);
 
 /** @brief Read Attributes Response
@@ -398,7 +399,7 @@ void emberAfPostAttributeChangeCallback(CHIPEndpointId endpoint, CHIPClusterId c
  * Ver.: always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfReadAttributesResponseCallback(CHIPClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+bool emberAfReadAttributesResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 
 /** @brief External Attribute Read
  *
@@ -436,7 +437,7 @@ bool emberAfReadAttributesResponseCallback(CHIPClusterId clusterId, uint8_t * bu
  * @param buffer   Ver.: always
  * @param maxReadLength   Ver.: always
  */
-EmberAfStatus emberAfExternalAttributeReadCallback(CHIPEndpointId endpoint, CHIPClusterId clusterId,
+EmberAfStatus emberAfExternalAttributeReadCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
                                                    EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
                                                    uint8_t * buffer, uint16_t maxReadLength);
 
@@ -451,7 +452,7 @@ EmberAfStatus emberAfExternalAttributeReadCallback(CHIPEndpointId endpoint, CHIP
  * Ver.: always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfWriteAttributesResponseCallback(CHIPClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+bool emberAfWriteAttributesResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 
 /** @brief External Attribute Write
  *
@@ -499,7 +500,7 @@ bool emberAfWriteAttributesResponseCallback(CHIPClusterId clusterId, uint8_t * b
  * @param manufacturerCode   Ver.: always
  * @param buffer   Ver.: always
  */
-EmberAfStatus emberAfExternalAttributeWriteCallback(CHIPEndpointId endpoint, CHIPClusterId clusterId,
+EmberAfStatus emberAfExternalAttributeWriteCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
                                                     EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
                                                     uint8_t * buffer);
 
@@ -514,7 +515,7 @@ EmberAfStatus emberAfExternalAttributeWriteCallback(CHIPEndpointId endpoint, CHI
  * always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfReportAttributesCallback(CHIPClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+bool emberAfReportAttributesCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
 
 /** @brief Get Current Time
  *
@@ -544,7 +545,7 @@ uint32_t emberAfGetCurrentTimeCallback();
  * @param returnEndpointInfo A pointer to a data struct that will be written
  * with information about the endpoint.  Ver.: always
  */
-bool emberAfGetEndpointInfoCallback(CHIPEndpointId endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo);
+bool emberAfGetEndpointInfoCallback(chip::EndpointId endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo);
 
 /** @brief Get Source Route Overhead
  *


### PR DESCRIPTION
… types


 #### Problem

The clusters code has different ways of defining some types. For example a `clusterId` can either be:
 * `CHIPClusterId`
 * `chip::ClusterId`
 * `uint16_t clusterId`
 * `EmberAfClusterId`

Similar things happens for `AttributeId`, `CommandId`, `GroupId`, `EndpointId`.

 #### Summary of Changes
 * Use `chip::SomethingId` all over the places
 