### PR TITLE
Add support in iOS UI for multiple lights

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/UI Helpers/CHIPUIViewUtils.h
+++ b/src/darwin/CHIPTool/CHIPTool/UI Helpers/CHIPUIViewUtils.h
@@ -26,6 +26,9 @@ NS_ASSUME_NONNULL_BEGIN
 + (UIView *)viewWithLabel:(UILabel *)label textField:(UITextField *)textField;
 + (UIView *)viewWithLabel:(UILabel *)label toggle:(UISwitch *)toggle;
 
+
++ (UIStackView *)stackViewWithLabel:(UILabel *)label buttons:(NSArray<UIButton *> *)buttons;
+
 + (UILabel *)addTitle:(NSString *)title toView:(UIView *)view;
 @end
 

--- a/src/darwin/CHIPTool/CHIPTool/UI Helpers/CHIPUIViewUtils.h
+++ b/src/darwin/CHIPTool/CHIPTool/UI Helpers/CHIPUIViewUtils.h
@@ -26,7 +26,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (UIView *)viewWithLabel:(UILabel *)label textField:(UITextField *)textField;
 + (UIView *)viewWithLabel:(UILabel *)label toggle:(UISwitch *)toggle;
 
-
 + (UIStackView *)stackViewWithLabel:(UILabel *)label buttons:(NSArray<UIButton *> *)buttons;
 
 + (UILabel *)addTitle:(NSString *)title toView:(UIView *)view;

--- a/src/darwin/CHIPTool/CHIPTool/UI Helpers/CHIPUIViewUtils.m
+++ b/src/darwin/CHIPTool/CHIPTool/UI Helpers/CHIPUIViewUtils.m
@@ -139,4 +139,35 @@
 
     return containingView;
 }
+
++ (UIStackView *)stackViewWithLabel:(UILabel *)label buttons:(NSArray<UIButton *> *)buttons
+{
+    // Button stack view
+    UIStackView * stackViewButtons = [UIStackView new];
+    stackViewButtons.axis = UILayoutConstraintAxisHorizontal;
+    stackViewButtons.distribution = UIStackViewDistributionEqualSpacing;
+    stackViewButtons.alignment = UIStackViewAlignmentLeading;
+    stackViewButtons.spacing = 10;
+    
+    label.font = [UIFont systemFontOfSize:17];
+    [stackViewButtons addArrangedSubview:label];
+    
+    label.translatesAutoresizingMaskIntoConstraints = false;
+    [label.centerYAnchor constraintEqualToAnchor:stackViewButtons.centerYAnchor].active = YES;
+    
+    stackViewButtons.translatesAutoresizingMaskIntoConstraints = false;
+    for (int i = 0; i < buttons.count; i++) {
+        UIButton * buttonForStack = [buttons objectAtIndex:i];
+        buttonForStack.backgroundColor = UIColor.systemBlueColor;
+        buttonForStack.titleLabel.font = [UIFont systemFontOfSize:17];
+        buttonForStack.titleLabel.textColor = [UIColor whiteColor];
+        buttonForStack.layer.cornerRadius = 5;
+        buttonForStack.clipsToBounds = YES;
+        buttonForStack.translatesAutoresizingMaskIntoConstraints = false;
+        [buttonForStack.widthAnchor constraintGreaterThanOrEqualToConstant:60].active = YES;
+        [stackViewButtons addArrangedSubview:buttonForStack];
+    }
+    
+    return stackViewButtons;
+}
 @end

--- a/src/darwin/CHIPTool/CHIPTool/UI Helpers/CHIPUIViewUtils.m
+++ b/src/darwin/CHIPTool/CHIPTool/UI Helpers/CHIPUIViewUtils.m
@@ -148,13 +148,13 @@
     stackViewButtons.distribution = UIStackViewDistributionEqualSpacing;
     stackViewButtons.alignment = UIStackViewAlignmentLeading;
     stackViewButtons.spacing = 10;
-    
+
     label.font = [UIFont systemFontOfSize:17];
     [stackViewButtons addArrangedSubview:label];
-    
+
     label.translatesAutoresizingMaskIntoConstraints = false;
     [label.centerYAnchor constraintEqualToAnchor:stackViewButtons.centerYAnchor].active = YES;
-    
+
     stackViewButtons.translatesAutoresizingMaskIntoConstraints = false;
     for (int i = 0; i < buttons.count; i++) {
         UIButton * buttonForStack = [buttons objectAtIndex:i];
@@ -167,7 +167,7 @@
         [buttonForStack.widthAnchor constraintGreaterThanOrEqualToConstant:60].active = YES;
         [stackViewButtons addArrangedSubview:buttonForStack];
     }
-    
+
     return stackViewButtons;
 }
 @end

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.m
@@ -102,9 +102,9 @@
 
 - (void)addButtons:(NSInteger)numButtons toStackView:(UIStackView *)stackView
 {
-    for (int i = 1; i <= numButtons; i ++) {
+    for (int i = 1; i <= numButtons; i++) {
         // Create buttons
-        UILabel *labelLight = [UILabel new];
+        UILabel * labelLight = [UILabel new];
         labelLight.text = [NSString stringWithFormat:@"Light %@: ", @(i)];
         UIButton * onButton = [UIButton new];
         onButton.tag = i;
@@ -119,7 +119,8 @@
         [toggleButton setTitle:@"Toggle" forState:UIControlStateNormal];
         [toggleButton addTarget:self action:@selector(toggleButtonTapped:) forControlEvents:UIControlEventTouchUpInside];
 
-        UIStackView * stackViewButtons = [CHIPUIViewUtils stackViewWithLabel:labelLight buttons:@[onButton, offButton, toggleButton]];
+        UIStackView * stackViewButtons = [CHIPUIViewUtils stackViewWithLabel:labelLight
+                                                                     buttons:@[ onButton, offButton, toggleButton ]];
         stackViewButtons.axis = UILayoutConstraintAxisHorizontal;
         stackViewButtons.distribution = UIStackViewDistributionEqualSpacing;
         stackViewButtons.alignment = UIStackViewAlignmentLeading;
@@ -142,10 +143,10 @@
         NSLog(@"Status: On command completed with error %@", [error description]);
     };
 
-    UIButton *button = (UIButton *)sender;
+    UIButton * button = (UIButton *) sender;
     NSInteger lightNumber = button.tag;
     NSLog(@"Light %@ on button pressed.", @(lightNumber));
-    //TODO: Do something based on which light is selected
+    // TODO: Do something based on which light is selected
     [self.onOff on:completionHandler];
 }
 
@@ -155,12 +156,11 @@
         NSLog(@"Status: Off command completed with error %@", [error description]);
     };
 
-    UIButton *button = (UIButton *)sender;
+    UIButton * button = (UIButton *) sender;
     NSInteger lightNumber = button.tag;
     NSLog(@"Light %@ off button pressed.", @(lightNumber));
-    //TODO: Do something based on which light is selected
+    // TODO: Do something based on which light is selected
     [self.onOff off:completionHandler];
-
 }
 
 - (IBAction)toggleButtonTapped:(id)sender
@@ -169,10 +169,10 @@
         NSLog(@"Status: Toggle command completed with error %@", [error description]);
     };
 
-    UIButton *button = (UIButton *)sender;
+    UIButton * button = (UIButton *) sender;
     NSInteger lightNumber = button.tag;
     NSLog(@"Light %@ toggle button pressed.", @(lightNumber));
-    //TODO: Do something based on which light is selected
+    // TODO: Do something based on which light is selected
     [self.onOff toggle:completionHandler];
 }
 

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.m
@@ -118,7 +118,7 @@
         toggleButton.tag = i;
         [toggleButton setTitle:@"Toggle" forState:UIControlStateNormal];
         [toggleButton addTarget:self action:@selector(toggleButtonTapped:) forControlEvents:UIControlEventTouchUpInside];
-        
+
         UIStackView * stackViewButtons = [CHIPUIViewUtils stackViewWithLabel:labelLight buttons:@[onButton, offButton, toggleButton]];
         stackViewButtons.axis = UILayoutConstraintAxisHorizontal;
         stackViewButtons.distribution = UIStackViewDistributionEqualSpacing;
@@ -141,7 +141,7 @@
     CHIPDeviceCallback completionHandler = ^(NSError * error) {
         NSLog(@"Status: On command completed with error %@", [error description]);
     };
-    
+
     UIButton *button = (UIButton *)sender;
     NSInteger lightNumber = button.tag;
     NSLog(@"Light %@ on button pressed.", @(lightNumber));
@@ -154,7 +154,7 @@
     CHIPDeviceCallback completionHandler = ^(NSError * error) {
         NSLog(@"Status: Off command completed with error %@", [error description]);
     };
-    
+
     UIButton *button = (UIButton *)sender;
     NSInteger lightNumber = button.tag;
     NSLog(@"Light %@ off button pressed.", @(lightNumber));
@@ -168,7 +168,7 @@
     CHIPDeviceCallback completionHandler = ^(NSError * error) {
         NSLog(@"Status: Toggle command completed with error %@", [error description]);
     };
-    
+
     UIButton *button = (UIButton *)sender;
     NSInteger lightNumber = button.tag;
     NSLog(@"Light %@ toggle button pressed.", @(lightNumber));

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.m
@@ -83,38 +83,8 @@
     [stackView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor constant:30].active = YES;
     [stackView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-30].active = YES;
 
-    // Button stack view
-    UIStackView * stackViewButtons = [UIStackView new];
-    stackViewButtons.axis = UILayoutConstraintAxisHorizontal;
-    stackViewButtons.distribution = UIStackViewDistributionEqualSpacing;
-    stackViewButtons.alignment = UIStackViewAlignmentLeading;
-    stackViewButtons.spacing = 10;
-    [stackView addArrangedSubview:stackViewButtons];
-
     // Create buttons
-    UIButton * onButton = [UIButton new];
-    [onButton setTitle:@"On" forState:UIControlStateNormal];
-    [onButton addTarget:self action:@selector(onButtonTapped:) forControlEvents:UIControlEventTouchUpInside];
-    UIButton * offButton = [UIButton new];
-    [offButton setTitle:@"Off" forState:UIControlStateNormal];
-    [offButton addTarget:self action:@selector(offButtonTapped:) forControlEvents:UIControlEventTouchUpInside];
-    UIButton * toggleButton = [UIButton new];
-    [toggleButton setTitle:@"Toggle" forState:UIControlStateNormal];
-    [toggleButton addTarget:self action:@selector(toggleButtonTapped:) forControlEvents:UIControlEventTouchUpInside];
-
-    stackView.translatesAutoresizingMaskIntoConstraints = false;
-    NSArray<UIButton *> * buttons = @[ onButton, offButton, toggleButton ];
-    for (int i = 0; i < buttons.count; i++) {
-        UIButton * buttonForStack = [buttons objectAtIndex:i];
-        buttonForStack.backgroundColor = UIColor.systemBlueColor;
-        buttonForStack.titleLabel.font = [UIFont systemFontOfSize:17];
-        buttonForStack.titleLabel.textColor = [UIColor whiteColor];
-        buttonForStack.layer.cornerRadius = 5;
-        buttonForStack.clipsToBounds = YES;
-        buttonForStack.translatesAutoresizingMaskIntoConstraints = false;
-        [buttonForStack.widthAnchor constraintGreaterThanOrEqualToConstant:60].active = YES;
-        [stackViewButtons addArrangedSubview:buttonForStack];
-    }
+    [self addButtons:3 toStackView:stackView];
 
     // Result message
     _resultLabel = [UILabel new];
@@ -130,6 +100,34 @@
     _resultLabel.adjustsFontSizeToFitWidth = YES;
 }
 
+- (void)addButtons:(NSInteger)numButtons toStackView:(UIStackView *)stackView
+{
+    for (int i = 1; i <= numButtons; i ++) {
+        // Create buttons
+        UILabel *labelLight = [UILabel new];
+        labelLight.text = [NSString stringWithFormat:@"Light %@: ", @(i)];
+        UIButton * onButton = [UIButton new];
+        onButton.tag = i;
+        [onButton setTitle:@"On" forState:UIControlStateNormal];
+        [onButton addTarget:self action:@selector(onButtonTapped:) forControlEvents:UIControlEventTouchUpInside];
+        UIButton * offButton = [UIButton new];
+        offButton.tag = i;
+        [offButton setTitle:@"Off" forState:UIControlStateNormal];
+        [offButton addTarget:self action:@selector(offButtonTapped:) forControlEvents:UIControlEventTouchUpInside];
+        UIButton * toggleButton = [UIButton new];
+        toggleButton.tag = i;
+        [toggleButton setTitle:@"Toggle" forState:UIControlStateNormal];
+        [toggleButton addTarget:self action:@selector(toggleButtonTapped:) forControlEvents:UIControlEventTouchUpInside];
+        
+        UIStackView * stackViewButtons = [CHIPUIViewUtils stackViewWithLabel:labelLight buttons:@[onButton, offButton, toggleButton]];
+        stackViewButtons.axis = UILayoutConstraintAxisHorizontal;
+        stackViewButtons.distribution = UIStackViewDistributionEqualSpacing;
+        stackViewButtons.alignment = UIStackViewAlignmentLeading;
+        stackViewButtons.spacing = 10;
+        [stackView addArrangedSubview:stackViewButtons];
+    }
+}
+
 - (void)updateResult:(NSString *)result
 {
     _resultLabel.hidden = NO;
@@ -143,6 +141,11 @@
     CHIPDeviceCallback completionHandler = ^(NSError * error) {
         NSLog(@"Status: On command completed with error %@", [error description]);
     };
+    
+    UIButton *button = (UIButton *)sender;
+    NSInteger lightNumber = button.tag;
+    NSLog(@"Light %@ on button pressed.", @(lightNumber));
+    //TODO: Do something based on which light is selected
     [self.onOff on:completionHandler];
 }
 
@@ -151,7 +154,13 @@
     CHIPDeviceCallback completionHandler = ^(NSError * error) {
         NSLog(@"Status: Off command completed with error %@", [error description]);
     };
+    
+    UIButton *button = (UIButton *)sender;
+    NSInteger lightNumber = button.tag;
+    NSLog(@"Light %@ off button pressed.", @(lightNumber));
+    //TODO: Do something based on which light is selected
     [self.onOff off:completionHandler];
+
 }
 
 - (IBAction)toggleButtonTapped:(id)sender
@@ -159,6 +168,11 @@
     CHIPDeviceCallback completionHandler = ^(NSError * error) {
         NSLog(@"Status: Toggle command completed with error %@", [error description]);
     };
+    
+    UIButton *button = (UIButton *)sender;
+    NSInteger lightNumber = button.tag;
+    NSLog(@"Light %@ toggle button pressed.", @(lightNumber));
+    //TODO: Do something based on which light is selected
     [self.onOff toggle:completionHandler];
 }
 


### PR DESCRIPTION
 #### Problem
 We need support for controlling multiple lights from the iOS chiptool client app. This just adds UI support and needs follow up CHIP framework support to hook into which endpoints to send the commands to to command the various lights.

 Fixes #1098


