### PR TITLE
Use chip::NodeId from transport/raw/MessageHeader.h instead of ChipNo…

### DIFF
--- a/src/app/clusters/ias-zone-server/ias-zone-server.cpp
+++ b/src/app/clusters/ias-zone-server/ias-zone-server.cpp
@@ -210,7 +210,7 @@ EmberAfStatus emberAfIasZoneClusterServerPreAttributeChangedCallback(EndpointId 
     bool zeroAddress;
     EmberBindingTableEntry bindingEntry;
     EmberBindingTableEntry currentBind;
-    ChipNodeId destNodeId;
+    NodeId destNodeId;
     uint8_t ieeeAddress[] = { 0, 0, 0, 0, 0, 0, 0, 0 };
 
     // If this is not a CIE Address write, the CIE address has already been
@@ -220,7 +220,7 @@ EmberAfStatus emberAfIasZoneClusterServerPreAttributeChangedCallback(EndpointId 
         return EMBER_ZCL_STATUS_SUCCESS;
     }
 
-    memcpy(&destNodeId, value, sizeof(ChipNodeId));
+    memcpy(&destNodeId, value, sizeof(NodeId));
 
     // Create the binding table entry
 
@@ -400,7 +400,7 @@ EmberStatus emberAfPluginIasZoneServerUpdateZoneStatus(EndpointId endpoint, uint
     IasZoneStatusQueueEntry newBufferEntry;
     newBufferEntry.endpoint    = endpoint;
     newBufferEntry.status      = newStatus;
-    newBufferEntry.eventTimeMs = chip::System::Layer::GetClock_MonotonicMS();
+    newBufferEntry.eventTimeMs = System::Layer::GetClock_MonotonicMS();
 #endif
     EmberStatus sendStatus;
 
@@ -899,7 +899,7 @@ static int16_t popFromBuffer(IasZoneStatusQueue * ring, IasZoneStatusQueueEntry 
 
 uint16_t computeElapsedTimeQs(IasZoneStatusQueueEntry * entry)
 {
-    uint32_t currentTimeMs = chip::System::Layer::GetClock_MonotonicMS();
+    uint32_t currentTimeMs = System::Layer::GetClock_MonotonicMS();
     int64_t deltaTimeMs    = currentTimeMs - entry->eventTimeMs;
 
     if (deltaTimeMs < 0)

--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -438,7 +438,7 @@ typedef struct
      */
     EmberApsFrame * apsFrame;
     EmberIncomingMessageType type;
-    ChipNodeId source;
+    chip::NodeId source;
     uint8_t * buffer;
     uint16_t bufLen;
     bool clusterSpecific;
@@ -1066,7 +1066,7 @@ typedef struct
         struct
         {
             /** The node id of the source of the received reports. */
-            ChipNodeId source;
+            chip::NodeId source;
             /** The remote endpoint from which the attribute is reported. */
             chip::EndpointId endpoint;
             /** The maximum expected time between reports, measured in seconds. */

--- a/src/app/util/chip-message-send.h
+++ b/src/app/util/chip-message-send.h
@@ -38,4 +38,4 @@
  *                          frame.
  * @param[in] message The message to send after the APS frame.
  */
-EmberStatus chipSendUnicast(ChipNodeId destination, EmberApsFrame * apsFrame, uint16_t messageLength, uint8_t * message);
+EmberStatus chipSendUnicast(chip::NodeId destination, EmberApsFrame * apsFrame, uint16_t messageLength, uint8_t * message);

--- a/src/app/util/common.h
+++ b/src/app/util/common.h
@@ -52,4 +52,4 @@
 extern EmberApsFrame emberAfResponseApsFrame;
 extern uint8_t appResponseData[EMBER_AF_RESPONSE_BUFFER_LEN];
 extern uint16_t appResponseLength;
-extern ChipNodeId emberAfResponseDestination;
+extern chip::NodeId emberAfResponseDestination;

--- a/src/app/util/esi-management.h
+++ b/src/app/util/esi-management.h
@@ -58,7 +58,7 @@
 typedef struct
 {
     EmberEUI64 eui64;
-    ChipNodeId nodeId;
+    chip::NodeId nodeId;
     uint8_t networkIndex;
     chip::EndpointId endpoint;
     uint8_t age; // The number of discovery cycles the ESI has not been discovered.

--- a/src/app/util/message.cpp
+++ b/src/app/util/message.cpp
@@ -43,6 +43,8 @@
 #include "config.h"
 #include "util.h"
 
+using namespace chip;
+
 //------------------------------------------------------------------------------
 
 // these variables are for storing responses that are created by zcl-utils
@@ -53,7 +55,7 @@
 // receives multiple ZCL messages, the stack will queue these and hand
 // these to the application via emberIncomingMsgHandler one at a time.
 EmberApsFrame emberAfResponseApsFrame;
-ChipNodeId emberAfResponseDestination;
+NodeId emberAfResponseDestination;
 uint8_t appResponseData[EMBER_AF_RESPONSE_BUFFER_LEN];
 uint16_t appResponseLength;
 

--- a/src/app/util/types_stub.h
+++ b/src/app/util/types_stub.h
@@ -47,19 +47,8 @@
 
 #include "basic-types.h"
 
-/**
- * Try to use our chip::NodeId definition if we are C++; otherwise define a
- * ChipNodeId that's compatible.
- */
-#ifdef __cplusplus
 #include <transport/raw/MessageHeader.h>
 static_assert(sizeof(chip::NodeId) == sizeof(uint64_t), "Unexpected node if size");
-// Make it easier to have unified function declarations across C and C++ source
-// files.
-typedef chip::NodeId ChipNodeId;
-#else
-typedef uint64_t ChipNodeId;
-#endif // __cplusplus
 
 #include "gen/gen_config.h"
 
@@ -552,13 +541,13 @@ typedef struct
     /** The endpoint on the remote node (specified by \c identifier). */
     chip::EndpointId remote;
     /** A 64-bit destination identifier.  This is either:
-     * - The destination ChipNodeId, for unicasts.
+     * - The destination chip::NodeId, for unicasts.
      * - A multicast ChipGroupId, for multicasts.
      * Which one is being used depends on the type of this binding.
      */
     union
     {
-        ChipNodeId nodeId;
+        chip::NodeId nodeId;
         chip::GroupId groupId;
     };
     /** The index of the network the binding belongs to. */

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -457,7 +457,7 @@ static bool dispatchZclMessage(EmberAfClusterCommand * cmd)
 }
 
 bool emberAfProcessMessageIntoZclCmd(EmberApsFrame * apsFrame, EmberIncomingMessageType type, uint8_t * message,
-                                     uint16_t messageLength, ChipNodeId source, InterPanHeader * interPanHeader,
+                                     uint16_t messageLength, NodeId source, InterPanHeader * interPanHeader,
                                      EmberAfClusterCommand * returnCmd)
 {
     uint8_t minLength =
@@ -503,7 +503,7 @@ bool emberAfProcessMessageIntoZclCmd(EmberApsFrame * apsFrame, EmberIncomingMess
 
 // a single call to process global and cluster-specific messages and callbacks.
 bool emberAfProcessMessage(EmberApsFrame * apsFrame, EmberIncomingMessageType type, uint8_t * message, uint16_t msgLen,
-                           ChipNodeId source, InterPanHeader * interPanHeader)
+                           NodeId source, InterPanHeader * interPanHeader)
 {
     bool msgHandled = false;
     // reset/reinitialize curCmd
@@ -667,7 +667,7 @@ void emAfApplyDisableDefaultResponse(uint8_t * frame_control)
     }
 }
 
-static bool isBroadcastDestination(ChipNodeId responseDestination)
+static bool isBroadcastDestination(NodeId responseDestination)
 {
     // FIXME: Will need to actually figure out how to test for this!
     return false;
@@ -823,8 +823,8 @@ EmberStatus emberAfSendDefaultResponse(const EmberAfClusterCommand * cmd, EmberA
 
 uint8_t emberAfMaximumApsPayloadLength(EmberOutgoingMessageType type, uint64_t indexOrDestination, EmberApsFrame * apsFrame)
 {
-    ChipNodeId destination = EMBER_UNKNOWN_NODE_ID;
-    uint8_t max            = EMBER_AF_MAXIMUM_APS_PAYLOAD_LENGTH;
+    NodeId destination = EMBER_UNKNOWN_NODE_ID;
+    uint8_t max        = EMBER_AF_MAXIMUM_APS_PAYLOAD_LENGTH;
 
     if ((apsFrame->options & EMBER_APS_OPTION_SOURCE_EUI64) != 0U)
     {

--- a/src/app/util/util.h
+++ b/src/app/util/util.h
@@ -149,10 +149,10 @@ void emberAfDecodeAndPrintCluster(chip::ClusterId cluster);
 void emberAfDecodeAndPrintClusterWithMfgCode(chip::ClusterId cluster, uint16_t mfgCode);
 
 bool emberAfProcessMessage(EmberApsFrame * apsFrame, EmberIncomingMessageType type, uint8_t * message, uint16_t msgLen,
-                           ChipNodeId source, InterPanHeader * interPanHeader);
+                           chip::NodeId source, InterPanHeader * interPanHeader);
 
 bool emberAfProcessMessageIntoZclCmd(EmberApsFrame * apsFrame, EmberIncomingMessageType type, uint8_t * message,
-                                     uint16_t messageLength, ChipNodeId source, InterPanHeader * interPanHeader,
+                                     uint16_t messageLength, chip::NodeId source, InterPanHeader * interPanHeader,
                                      EmberAfClusterCommand * returnCmd);
 
 /**


### PR DESCRIPTION
…deId from src/app/util/types_stubs.h

 #### Problem

`ChipNodeId` is defined in `src/app/util/types_stubs.h` as:
```
/**
 * Try to use our chip::NodeId definition if we are C++; otherwise define a
 * ChipNodeId that's compatible.
 */
#ifdef __cplusplus
#include <transport/raw/MessageHeader.h>
static_assert(sizeof(chip::NodeId) == sizeof(uint64_t), "Unexpected node if size");
// Make it easier to have unified function declarations across C and C++ source
// files.
typedef chip::NodeId ChipNodeId;
#else
typedef uint64_t ChipNodeId;
#endif // __cplusplus
```

Now that `src/app` and `gen/` folders have been converted to `.cpp` there is no reason to use `ChipNodeId` instead of `chip::NodeId` anymore.

 

 #### Summary of Changes
 * Replace `ChipNodeId` in order to use `chip::NodeId`
