### PR TITLE
Remove '-Wno-deprecated-copy' from compiler flags

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -139,7 +139,6 @@ config("disabled_warnings") {
     "-Wno-unknown-warning-option",
     "-Wno-missing-field-initializers",
   ]
-  cflags_cc = [ "-Wno-deprecated-copy" ]
   if (!is_debug) {
     # assert() causes unused variable warnings in release.
     cflags += [ "-Wno-unused" ]


### PR DESCRIPTION
 #### Problem

Seems like `-Wno-deprecated-copy` can be removed from the compiler flags.

 #### Summary of Changes
 * Remove `-Wno-deprecated-copy` from `build/config/compiler/BUILD.gn`
