### PR TITLE
fix wrong max prefix length in nrfconnect logs

### DIFF
--- a/src/platform/nrfconnect/Logging.cpp
+++ b/src/platform/nrfconnect/Logging.cpp
@@ -63,7 +63,8 @@ void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
         char formattedMsg[CHIP_DEVICE_CONFIG_LOG_MESSAGE_MAX_SIZE];
         size_t prefixLen = 0;
 
-        constexpr size_t maxPrefixLen = ChipLoggingModuleNameLen + 3;
+        // Max size for "[TAG] {UINT32}"
+        constexpr size_t maxPrefixLen = ChipLoggingModuleNameLen + 10 + 3;
         static_assert(sizeof(formattedMsg) > maxPrefixLen);
 
         prefixLen += snprintf(formattedMsg, sizeof(formattedMsg), "%u", k_uptime_get_32());


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

https://github.com/project-chip/connectedhomeip/pull/3790
<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes

Fix the wrong length. Resolves https://github.com/project-chip/connectedhomeip/pull/3790.
