### PR TITLE
Add '#define EMBER_AF_PLUGIN_{{clusterName}}' and related to src/app/…

### DIFF
--- a/src/app/zap-templates/gen_config.zapt
+++ b/src/app/zap-templates/gen_config.zapt
@@ -16,3 +16,48 @@
 {{#all_user_clusters}}
 #define EMBER_AF_{{asDelimitedMacro define}}_{{asDelimitedMacro side}}_ENDPOINT_COUNT ({{user_endpoint_count_by_cluster id side}})
 {{/all_user_clusters}}
+
+/**** Cluster Plugins ****/
+{{#all_user_clusters}}
+
+// Use this macro to check if the {{side}} side of the {{name}} cluster is included
+#define ZCL_USING_{{asDelimitedMacro define}}_{{asDelimitedMacro side}}
+#define EMBER_AF_PLUGIN_{{asDelimitedMacro name}}_{{asDelimitedMacro side}}
+{{#if (isServer side)}}
+#define EMBER_AF_PLUGIN_{{asDelimitedMacro name}}
+{{/if}}
+{{#if (isStrEqual name "Color Control")}}
+{{#if (isServer side)}}
+// User options for {{side}} plugin {{name}}
+#define EMBER_AF_PLUGIN_COLOR_CONTROL_SERVER_XY
+#define EMBER_AF_PLUGIN_COLOR_CONTROL_SERVER_TEMP
+#define EMBER_AF_PLUGIN_COLOR_CONTROL_SERVER_HSV
+{{/if}}
+{{else if (isStrEqual name "IAS Zone")}}
+// User options for {{side}} plugin {{name}}
+{{#if (isServer side)}}
+#define EMBER_AF_PLUGIN_IAS_ZONE_SERVER_ZONE_TYPE 541
+{{else}}
+#define EMBER_AF_PLUGIN_IAS_ZONE_CLIENT_MAX_DEVICES 10
+{{/if}}
+{{else if (isStrEqual name "Level Control")}}
+{{#if (isServer side)}}
+// User options for {{side}} plugin {{name}}
+#define EMBER_AF_PLUGIN_LEVEL_CONTROL_MAXIMUM_LEVEL 255
+#define EMBER_AF_PLUGIN_LEVEL_CONTROL_MINIMUM_LEVEL 0
+#define EMBER_AF_PLUGIN_LEVEL_CONTROL_RATE 0
+{{/if}}
+{{else if (isStrEqual name "Scenes")}}
+{{#if (isServer side)}}
+// User options for {{side}} plugin {{name}}
+#define EMBER_AF_PLUGIN_SCENES_TABLE_SIZE 3
+{{/if}}
+{{/if}}
+{{/all_user_clusters}}
+
+// TODO Issue #3871 Reporting should only be enabled if there are reportable attributes
+// Use this macro to check if Reporting plugin is included
+#define EMBER_AF_PLUGIN_REPORTING
+// User options for plugin Reporting
+#define EMBER_AF_PLUGIN_REPORTING_TABLE_SIZE 5
+#define EMBER_AF_PLUGIN_REPORTING_ENABLE_GROUP_BOUND_REPORTS


### PR DESCRIPTION
…zap-templates/gen_config.h


 #### Problem

#3464 get rids of most of the `#define`  from `gen/gen_config.h`. That's a nice cleanup but some of them are still required in order to build properly. Notably the one that are related to `Plugins`.

I have not found a good way to define `EMBER_AF_PLUGIN_REPORTING` conditionaly. I have opened #3871 for it.

 #### Summary of Changes
 * Add `EMBER_AF_PLUGIN_*` macro generations to `src/app/zap-templates/gen_config.zapt`

Fixes #3627