### PR TITLE
[Build Bustage] 'EmberAfClusterId' has not been declared

### DIFF
--- a/examples/lock-app/qpg6100/src/ZclCallbacks.cpp
+++ b/examples/lock-app/qpg6100/src/ZclCallbacks.cpp
@@ -30,7 +30,7 @@
 
 using namespace ::chip;
 
-void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clusterId, EmberAfAttributeId attributeId, uint8_t mask,
+void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
 {
     if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
@@ -55,15 +55,23 @@ void emberAfPostAttributeChangeCallback(uint8_t endpoint, EmberAfClusterId clust
     }
 }
 
-/** @brief On/off Cluster Server Post Init
+/** @brief Cluster Init
  *
- * Following resolution of the On/Off state at startup for this endpoint,
- * perform any additional initialization needed; e.g., synchronize hardware
- * state.
+ * This function is called when a specific cluster is initialized. It gives the
+ * application an opportunity to take care of cluster initialization procedures.
+ * It is called exactly once for each endpoint where cluster is present.
  *
- * @param endpoint Endpoint that is being initialized  Ver.: always
+ * @param endpoint   Ver.: always
+ * @param clusterId   Ver.: always
+ *
+ * TODO Issue #3841
+ * emberAfClusterInitCallback happens before the stack initialize the cluster
+ * attributes to the default value.
+ * The logic here expects something similar to the deprecated Plugins callback
+ * emberAfPluginOnOffClusterServerPostInitCallback.
+ *
  */
-void emberAfPluginOnOffClusterServerPostInitCallback(uint8_t endpoint)
+void emberAfClusterInitCallback(EndpointId endpoint, ClusterId clusterId)
 {
     GetAppTask().UpdateClusterState();
 }


### PR DESCRIPTION

 #### Problem
 
#3831 was out of luck. `ZclCallbacks.cpp` has been copy-pasted from an old version of it from others examples.

Sadly this version does not compile anymore since #3846 has landed, but the CI for #3831 has runned before it lands I guess.

 #### Summary of Changes
 * Replace the old types by the new `chip::` types