### PR TITLE
Fix some build issues when building examples/lighting-app from ./gn_b…

### DIFF
--- a/examples/lighting-app/lighting-common/gen/endpoint_config.h
+++ b/examples/lighting-app/lighting-common/gen/endpoint_config.h
@@ -157,7 +157,7 @@
 // Generated reporting configuration defaults
 #define EMBER_AF_GENERATED_REPORTING_CONFIG_DEFAULTS                                                                               \
     {                                                                                                                              \
-        { EMBER_ZCL_REPORTING_DIRECTION_REPORTED, 1, 0x0006, 0x0000, CLUSTER_MASK_SERVER, 0x0000, 1, 65534, 0 },                   \
+        { EMBER_ZCL_REPORTING_DIRECTION_REPORTED, 1, 0x0006, 0x0000, CLUSTER_MASK_SERVER, 0x0000, { { 1, 65534, 0 } } },           \
     }
 #define EMBER_AF_GENERATED_REPORTING_CONFIG_DEFAULTS_TABLE_SIZE (1)
 #endif // SILABS_AF_ENDPOINT_CONFIG

--- a/examples/lighting-app/linux/include/LightingManager.h
+++ b/examples/lighting-app/linux/include/LightingManager.h
@@ -51,7 +51,6 @@ public:
 private:
     friend LightingManager & LightingMgr(void);
     State_t mState;
-    uint32_t mGPIONum;
 
     LightingCallback_fn mActionInitiated_CB;
     LightingCallback_fn mActionCompleted_CB;

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -19,8 +19,6 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/PlatformManager.h>
 
-#include <platform/Linux/BLEManagerImpl.h>
-
 #include "af.h"
 #include "gen/attribute-id.h"
 #include "gen/cluster-id.h"


### PR DESCRIPTION
…uild.sh

 #### Problem

While building `examples/lighting-app/linux` there was a few errors using Mac + Clang.
  * `LightingManager.h:54:14: error: private field 'mGPIONum' is not used [-Werror,-Wunused-private-field]`
  * `Linux/BLEManagerImpl.h:83:7: error: redefinition of 'BLEManagerImpl'`
  * `src/app/reporting/reporting-default-configuration.cpp:53:72: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]`

I understand that it is not the main use cases for this particular version of the app. But I found it sometimes useful to build examples locally when working on some particular shared bits before sending it to a device.

 #### Summary of Changes
 * Fix the build warnings/errors