### PR TITLE
Fix mdns build depencency on core.

### DIFF
--- a/src/lib/mdns/BUILD.gn
+++ b/src/lib/mdns/BUILD.gn
@@ -21,6 +21,7 @@ source_set("platform_header") {
 static_library("mdns") {
   public_deps = [
     ":platform_header",
+    "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/platform",
   ]


### PR DESCRIPTION
#### Problem

The `gn_build.sh` script failed with a dependency error,
```
ERROR at //src/lib/mdns/DiscoveryManager.h:20:11: Include not allowed.
#include "core/CHIPError.h"
        ^---------------
It is not in any dependency of
//src/lib/mdns:mdns
The include file is in the target(s):
//src/lib/core:core
which should somehow be reachable.
```

#### Summary of Changes

Add //src/lib/core to mdns dependencies.