### PR TITLE
Use CHIP prefix for iOS framework handler functions

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
@@ -65,30 +65,30 @@ void CHIPSetNextAvailableDeviceID(uint64_t id)
 @implementation CHIPToolPersistentStorageDelegate
 
 // MARK: CHIPPersistentStorageDelegate
-- (void)GetKeyValue:(NSString *)key handler:(SendKeyValue)completionHandler
+- (void)CHIPGetKeyValue:(NSString *)key handler:(SendKeyValue)completionHandler
 {
     NSString * value = CHIPGetDomainValueForKey(kCHIPToolDefaultsDomain, key);
     NSLog(@"CHIPPersistentStorageDelegate Get Value for Key: %@, value %@", key, value);
     completionHandler(key, value);
 }
 
-- (NSString *)GetKeyValue:(NSString *)key
+- (NSString *)CHIPGetKeyValue:(NSString *)key
 {
     NSString * value = CHIPGetDomainValueForKey(kCHIPToolDefaultsDomain, key);
     NSLog(@"CHIPPersistentStorageDelegate Get Value for Key: %@, value %@", key, value);
     return value;
 }
 
-- (void)SetKeyValue:(NSString *)key value:(NSString *)value handler:(SendStatus)completionHandler
+- (void)CHIPSetKeyValue:(NSString *)key value:(NSString *)value handler:(SendStatus)completionHandler
 {
     CHIPSetDomainValueForKey(kCHIPToolDefaultsDomain, key, value);
-    completionHandler(key, kSet, [CHIPError errorForCHIPErrorCode:0]);
+    completionHandler(key, kCHIPSetKeyValue, [CHIPError errorForCHIPErrorCode:0]);
 }
 
-- (void)DeleteKeyValue:(NSString *)key handler:(SendStatus)completionHandler
+- (void)CHIPDeleteKeyValue:(NSString *)key handler:(SendStatus)completionHandler
 {
     CHIPRemoveDomainValueForKey(kCHIPToolDefaultsDomain, key);
-    completionHandler(key, kDelete, [CHIPError errorForCHIPErrorCode:0]);
+    completionHandler(key, kCHIPDeleteKeyValue, [CHIPError errorForCHIPErrorCode:0]);
 }
 
 @end

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegate.h
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegate.h
@@ -21,9 +21,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSUInteger, Operation) {
-    kGet = 0,
-    kSet,
-    kDelete,
+    kCHIPGetKeyValue = 0,
+    kCHIPSetKeyValue,
+    kCHIPDeleteKeyValue,
 };
 
 typedef void (^SendKeyValue)(NSString * key, NSString * value);
@@ -41,25 +41,25 @@ typedef void (^SendStatus)(NSString * key, Operation operation, NSError * status
  * Get the value for the given key
  *
  */
-- (void)GetKeyValue:(NSString *)key handler:(SendKeyValue)completionHandler;
+- (void)CHIPGetKeyValue:(NSString *)key handler:(SendKeyValue)completionHandler;
 
 /**
  * Get the value for the given key
  *
  */
-- (NSString *)GetKeyValue:(NSString *)key;
+- (NSString *)CHIPGetKeyValue:(NSString *)key;
 
 /**
  * Set the value of the key to the given value
  *
  */
-- (void)SetKeyValue:(NSString *)key value:(NSString *)value handler:(SendStatus)completionHandler;
+- (void)CHIPSetKeyValue:(NSString *)key value:(NSString *)value handler:(SendStatus)completionHandler;
 
 /**
  * Delete the key and corresponding value
  *
  */
-- (void)DeleteKeyValue:(NSString *)key handler:(SendStatus)completionHandler;
+- (void)CHIPDeleteKeyValue:(NSString *)key handler:(SendStatus)completionHandler;
 
 @end
 

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
@@ -58,13 +58,13 @@ void CHIPPersistentStorageDelegateBridge::SetDelegate(chip::Controller::Persiste
                     chip::Controller::PersistentStorageResultDelegate::Operation op
                         = chip::Controller::PersistentStorageResultDelegate::Operation::kGET;
                     switch (operation) {
-                    case kGet:
+                    case kCHIPGetKeyValue:
                         op = chip::Controller::PersistentStorageResultDelegate::Operation::kGET;
                         break;
-                    case kSet:
+                    case kCHIPSetKeyValue:
                         op = chip::Controller::PersistentStorageResultDelegate::Operation::kSET;
                         break;
-                    case kDelete:
+                    case kCHIPDeleteKeyValue:
                         op = chip::Controller::PersistentStorageResultDelegate::Operation::kDELETE;
                         break;
                     }
@@ -88,7 +88,7 @@ void CHIPPersistentStorageDelegateBridge::GetKeyValue(const char * key)
         id<CHIPPersistentStorageDelegate> strongDelegate = mDelegate;
         if (strongDelegate && mQueue) {
             dispatch_async(mQueue, ^{
-                [strongDelegate GetKeyValue:keyString handler:mCompletionHandler];
+                [strongDelegate CHIPGetKeyValue:keyString handler:mCompletionHandler];
             });
         } else {
             NSString * value = [mDefaultPersistentStorage objectForKey:keyString];
@@ -109,7 +109,7 @@ CHIP_ERROR CHIPPersistentStorageDelegateBridge::GetKeyValue(const char * key, ch
 
         id<CHIPPersistentStorageDelegate> strongDelegate = mDelegate;
         if (strongDelegate) {
-            valueString = [strongDelegate GetKeyValue:keyString];
+            valueString = [strongDelegate CHIPGetKeyValue:keyString];
         } else {
             valueString = [mDefaultPersistentStorage objectForKey:keyString];
         }
@@ -139,11 +139,11 @@ void CHIPPersistentStorageDelegateBridge::SetKeyValue(const char * key, const ch
         id<CHIPPersistentStorageDelegate> strongDelegate = mDelegate;
         if (strongDelegate && mQueue) {
             dispatch_async(mQueue, ^{
-                [strongDelegate SetKeyValue:keyString value:valueString handler:mStatusHandler];
+                [strongDelegate CHIPSetKeyValue:keyString value:valueString handler:mStatusHandler];
             });
         } else {
             [mDefaultPersistentStorage setObject:valueString forKey:keyString];
-            mStatusHandler(keyString, kSet, [CHIPError errorForCHIPErrorCode:0]);
+            mStatusHandler(keyString, kCHIPSetKeyValue, [CHIPError errorForCHIPErrorCode:0]);
         }
     });
 }
@@ -157,11 +157,11 @@ void CHIPPersistentStorageDelegateBridge::DeleteKeyValue(const char * key)
         id<CHIPPersistentStorageDelegate> strongDelegate = mDelegate;
         if (strongDelegate && mQueue) {
             dispatch_async(mQueue, ^{
-                [strongDelegate DeleteKeyValue:keyString handler:mStatusHandler];
+                [strongDelegate CHIPDeleteKeyValue:keyString handler:mStatusHandler];
             });
         } else {
             [mDefaultPersistentStorage removeObjectForKey:keyString];
-            mStatusHandler(keyString, kDelete, [CHIPError errorForCHIPErrorCode:0]);
+            mStatusHandler(keyString, kCHIPDeleteKeyValue, [CHIPError errorForCHIPErrorCode:0]);
         }
     });
 }


### PR DESCRIPTION
 #### Problem
Some of iOS framework APIs are not using CHIP prefix. This can cause ambiguity when an app uses these APIs along with other libraries.

 #### Summary of Changes
Use CHIP prefix in public facing iOS framework APIs (since it doesn't support namespace constructs).

 Fixes #3503