### PR TITLE
build: Fix inputs to generated test drivers

### DIFF
--- a/build/chip/chip_test_suite.gni
+++ b/build/chip/chip_test_suite.gni
@@ -92,11 +92,12 @@ template("chip_test_suite") {
       foreach(_test, invoker.test_sources) {
         _test_name = string_replace(_test, ".cpp", "")
 
-        _driver_name = "${root_gen_dir}/${_test_name}.GeneratedDriver.cpp"
+        _driver_name = "${root_gen_dir}/${_test_name}.driver.cpp"
 
         action("${_test_name}_generate_driver") {
           script = "${chip_root}/scripts/gen_test_driver.py"
 
+          inputs = [ _test ]
           outputs = [ _driver_name ]
           args = [
             "--input_file=" + rebase_path(_test, root_build_dir),


### PR DESCRIPTION
Test drivers will not be regenerated when the cpp file changes. Fix it
by adding the source file to inputs.

And remove redundant "generated" string from the name. The gen dir only
contains generated files.

Tested by:
```
  touch src/transport/raw/tests/TestTCP.cpp
  ninja -C out/host -d explain gen/TestTCP.driver.cpp
```