### PR TITLE
Add '-Wextra' to compiler flags

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -138,6 +138,7 @@ config("disabled_warnings") {
     "-Wno-deprecated-declarations",
     "-Wno-unknown-warning-option",
     "-Wno-missing-field-initializers",
+    "-Wno-unused-parameter",
   ]
   if (!is_debug) {
     # assert() causes unused variable warnings in release.
@@ -154,6 +155,7 @@ config("disabled_warnings") {
 config("strict_warnings") {
   cflags = [
     "-Wall",
+    "-Wextra",
     "-Wshadow",
   ]
 

--- a/examples/common/QRCode/BUILD.gn
+++ b/examples/common/QRCode/BUILD.gn
@@ -1,0 +1,29 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+config("qrcode-common_config") {
+  include_dirs = [ "repo/c" ]
+
+  cflags = [ "-Wno-type-limits" ]
+}
+
+static_library("QRCode") {
+  output_name = "libqrcode-common"
+
+  output_dir = "${root_out_dir}/lib"
+
+  sources = [ "repo/c/qrcodegen.c" ]
+
+  public_configs = [ ":qrcode-common_config" ]
+}

--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -67,6 +67,7 @@ efr32_executable("lighting_app") {
 
   public_deps = [
     ":sdk",
+    "${chip_root}/examples/common/QRCode",
     "${chip_root}/examples/common/chip-app-server:chip-app-server",
     "${chip_root}/examples/lighting-app/lighting-common",
     "${chip_root}/src/lib",
@@ -81,11 +82,9 @@ efr32_executable("lighting_app") {
     "${efr32_project_dir}/include",
     "${chip_root}/src/app/util",
     "${examples_plat_dir}",
-    "${chip_root}/examples/common/QRCode/repo/c",
   ]
 
   sources = [
-    "${chip_root}/examples/common/QRCode/repo/c/qrcodegen.c",
     "${examples_plat_dir}/${efr32_family}/${efr32_board}/hal-config.h",
     "${examples_plat_dir}/${efr32_family}/${efr32_board}/init_board.c",
     "${examples_plat_dir}/${efr32_family}/${efr32_board}/init_mcu.c",

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -67,6 +67,7 @@ efr32_executable("lock_app") {
 
   public_deps = [
     ":sdk",
+    "${chip_root}/examples/common/QRCode",
     "${chip_root}/examples/common/chip-app-server:chip-app-server",
     "${chip_root}/examples/lock-app/lock-common",
     "${chip_root}/src/lib",
@@ -81,11 +82,9 @@ efr32_executable("lock_app") {
     "${efr32_project_dir}/include",
     "${chip_root}/src/app/util",
     "${examples_plat_dir}",
-    "${chip_root}/examples/common/QRCode/repo/c",
   ]
 
   sources = [
-    "${chip_root}/examples/common/QRCode/repo/c/qrcodegen.c",
     "${examples_plat_dir}/${efr32_family}/${efr32_board}/hal-config.h",
     "${examples_plat_dir}/${efr32_family}/${efr32_board}/init_board.c",
     "${examples_plat_dir}/${efr32_family}/${efr32_board}/init_mcu.c",

--- a/src/lib/core/CHIPKeyIds.cpp
+++ b/src/lib/core/CHIPKeyIds.cpp
@@ -97,7 +97,7 @@ uint32_t ChipKeyId::MakeAppKeyId(uint32_t keyType, uint32_t rootKeyId, uint32_t 
                                  bool useCurrentEpochKey)
 {
     return (keyType | (rootKeyId & kMask_RootKeyNumber) | (appGroupMasterKeyId & kMask_GroupLocalNumber) |
-            (useCurrentEpochKey ? kFlag_UseCurrentEpochKey : (epochKeyId & kMask_EpochKeyNumber)));
+            (useCurrentEpochKey ? static_cast<uint32_t>(kFlag_UseCurrentEpochKey) : (epochKeyId & kMask_EpochKeyNumber)));
 }
 
 /**

--- a/src/lib/support/logging/CHIPLoggingLogV.cpp
+++ b/src/lib/support/logging/CHIPLoggingLogV.cpp
@@ -123,7 +123,7 @@ DLL_EXPORT __CHIP_LOGGING_LINK_ATTRIBUTE void LogV(uint8_t module, uint8_t categ
             return;
         }
 
-        if (prefixLen >= sizeof(formattedMsg))
+        if (static_cast<size_t>(prefixLen) >= sizeof(formattedMsg))
         {
             prefixLen = sizeof(formattedMsg) - 1;
         }

--- a/src/platform/EFR32/freertos_bluetooth.c
+++ b/src/platform/EFR32/freertos_bluetooth.c
@@ -34,9 +34,9 @@ void BluetoothUpdate();
 volatile struct gecko_cmd_packet * bluetooth_evt;
 SemaphoreHandle_t BluetoothMutex = NULL;
 
-volatile static uint32_t command_header;
-volatile static void * command_data;
-volatile static gecko_cmd_handler command_handler_func = NULL;
+static volatile uint32_t command_header;
+static volatile void * command_data;
+static volatile gecko_cmd_handler command_handler_func = NULL;
 
 // Bluetooth task
 #ifndef BLUETOOTH_STACK_SIZE

--- a/third_party/mbedtls/mbedtls.gni
+++ b/third_party/mbedtls/mbedtls.gni
@@ -20,7 +20,10 @@ template("mbedtls_target") {
   _mbedtls_root = "${mbedtls_root}/repo"
 
   config("${mbedtls_target_name}_warnings") {
-    cflags = [ "-Wno-maybe-uninitialized" ]
+    cflags = [
+      "-Wno-maybe-uninitialized",
+      "-Wno-string-concatenation",
+    ]
   }
 
   config("${mbedtls_target_name}_config") {


### PR DESCRIPTION

 #### Problem

This PR adds `-Wextra` to the compiler flags. It adds `-Wno-unused-parameters` because there a bunch of them related to `src/ble` and `src/platform`. It also adds `-Wno-string-concatenation` to the `mbedtls` cflags since there are some occurrences of them (fixed in recent version of mbedtls, but not in the one we use).

 #### Summary of Changes
 * Add `-Wextra` to the compiler flags