### PR TITLE
More cleanup in persistent storage delegate in iOS framework

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
@@ -79,16 +79,16 @@ void CHIPSetNextAvailableDeviceID(uint64_t id)
     return value;
 }
 
-- (void)CHIPSetKeyValue:(NSString *)key value:(NSString *)value handler:(SendStatus)completionHandler
+- (void)CHIPSetKeyValue:(NSString *)key value:(NSString *)value handler:(CHIPSendSetStatus)completionHandler
 {
     CHIPSetDomainValueForKey(kCHIPToolDefaultsDomain, key, value);
-    completionHandler(key, kCHIPSetKeyValue, [CHIPError errorForCHIPErrorCode:0]);
+    completionHandler(key, [CHIPError errorForCHIPErrorCode:0]);
 }
 
-- (void)CHIPDeleteKeyValue:(NSString *)key handler:(SendStatus)completionHandler
+- (void)CHIPDeleteKeyValue:(NSString *)key handler:(CHIPSendDeleteStatus)completionHandler
 {
     CHIPRemoveDomainValueForKey(kCHIPToolDefaultsDomain, key);
-    completionHandler(key, kCHIPDeleteKeyValue, [CHIPError errorForCHIPErrorCode:0]);
+    completionHandler(key, [CHIPError errorForCHIPErrorCode:0]);
 }
 
 @end

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegate.h
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegate.h
@@ -20,14 +20,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NS_ENUM(NSUInteger, Operation) {
-    kCHIPGetKeyValue = 0,
-    kCHIPSetKeyValue,
-    kCHIPDeleteKeyValue,
-};
-
 typedef void (^SendKeyValue)(NSString * key, NSString * value);
-typedef void (^SendStatus)(NSString * key, Operation operation, NSError * status);
+typedef void (^CHIPSendSetStatus)(NSString * key, NSError * status);
+typedef void (^CHIPSendDeleteStatus)(NSString * key, NSError * status);
 
 /**
  * The protocol definition for the CHIPPersistenStorageDelegate
@@ -53,13 +48,13 @@ typedef void (^SendStatus)(NSString * key, Operation operation, NSError * status
  * Set the value of the key to the given value
  *
  */
-- (void)CHIPSetKeyValue:(NSString *)key value:(NSString *)value handler:(SendStatus)completionHandler;
+- (void)CHIPSetKeyValue:(NSString *)key value:(NSString *)value handler:(CHIPSendSetStatus)completionHandler;
 
 /**
  * Delete the key and corresponding value
  *
  */
-- (void)CHIPDeleteKeyValue:(NSString *)key handler:(SendStatus)completionHandler;
+- (void)CHIPDeleteKeyValue:(NSString *)key handler:(CHIPSendDeleteStatus)completionHandler;
 
 @end
 

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
@@ -46,7 +46,8 @@ private:
 
     chip::Controller::PersistentStorageResultDelegate * mCallback;
     SendKeyValue mCompletionHandler;
-    SendStatus mStatusHandler;
+    CHIPSendSetStatus mSetStatusHandler;
+    CHIPSendDeleteStatus mDeleteStatusHandler;
     NSUserDefaults * mDefaultPersistentStorage;
     dispatch_queue_t mWorkQueue;
 };


### PR DESCRIPTION
 #### Problem
The iOS framework persistent storage API could be further cleaned up to remove unnecessary Enum. Also, there is a chance where the callback is not set, but the CPP layer calls for persistent storage operation. The framework should check before calling the callback functions. 

 #### Summary of Changes
- Address the leftover cleanup
- Check for callback object before using it.