### PR TITLE
Fix build breakage - test usage of System::PacketBuffer

### DIFF
--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -227,11 +227,11 @@ void CheckExchangeMessages(nlTestSuite * inSuite, void * inContext)
     err = exchangeMgr.RegisterUnsolicitedMessageHandler(0x0001, 0x0001, &mockUnsolicitedAppDelegate);
 
     // send a malicious packet
-    ec1->SendMessage(0x0001, 0x0002, System::PacketBuffer::New());
+    ec1->SendMessage(0x0001, 0x0002, System::PacketBuffer::New().Release_ForNow());
     NL_TEST_ASSERT(inSuite, !mockUnsolicitedAppDelegate.IsOnMessageReceivedCalled);
 
     // send a good packet
-    ec1->SendMessage(0x0001, 0x0001, System::PacketBuffer::New());
+    ec1->SendMessage(0x0001, 0x0001, System::PacketBuffer::New().Release_ForNow());
     NL_TEST_ASSERT(inSuite, mockUnsolicitedAppDelegate.IsOnMessageReceivedCalled);
 }
 


### PR DESCRIPTION
 #### Problem
 Build breakage due to cross commits - Tests using system packet buffer and system packet buffer refactoring
