### PR TITLE
Add persistent storage delegate to chip tool

### DIFF
--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -47,8 +47,9 @@ int Commands::Run(NodeId localId, NodeId remoteId, int argc, char ** argv)
     {
 
         ChipDeviceController dc;
+        ChipToolPersistentStorageDelegate storage;
 
-        err = dc.Init(localId);
+        err = dc.Init(localId, nullptr, &storage);
         VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure: %s", chip::ErrorStr(err)));
 
         err = dc.ServiceEvents();

--- a/examples/chip-tool/commands/common/Commands.h
+++ b/examples/chip-tool/commands/common/Commands.h
@@ -23,6 +23,15 @@
 
 #include <controller/CHIPDeviceController_deprecated.h>
 
+class ChipToolPersistentStorageDelegate : public chip::Controller::PersistentStorageDelegate
+{
+    void SetDelegate(chip::Controller::PersistentStorageResultDelegate * delegate) override {}
+    void GetKeyValue(const char * key) override {}
+    CHIP_ERROR GetKeyValue(const char * key, char * value, uint16_t & size) override { return CHIP_NO_ERROR; }
+    void SetKeyValue(const char * key, const char * value) override {}
+    void DeleteKeyValue(const char * key) override {}
+};
+
 class Commands
 {
 public:


### PR DESCRIPTION
 #### Problem
`chip-tool echo ble` command fails with the following errors.
```
$ ./out/debug/chip-tool echo ble 12345678 3840
CHIP: [DL] _Init
CHIP: [IN] local node id is 112233
CHIP: [DL] CHIP task running
CHIP: [TOO] Failed to connect to the device
CHIP: [TOO] Run command failure: Error 4003 (0x00000FA3)
CHIP: [CTL] Shutting down the commissioner
CHIP: [CTL] Shutting down the controller
``` 

 #### Summary of Changes
The new Controller API requires the caller to provide a storage delegate. The `chip-tool` was not registering one, so it failed to trigger the device pairing.
