### PR TITLE
Disable multiple BLE connections by default

### DIFF
--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -337,7 +337,7 @@
  * When set, CHIPoBLE advertisements will stop while a CHIPoBLE connection is active.
  */
 #ifndef CHIP_DEVICE_CONFIG_CHIPOBLE_SINGLE_CONNECTION
-#define CHIP_DEVICE_CONFIG_CHIPOBLE_SINGLE_CONNECTION 0
+#define CHIP_DEVICE_CONFIG_CHIPOBLE_SINGLE_CONNECTION 1
 #endif
 
 /**


### PR DESCRIPTION

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

The current BLE handler will send all the packets to the rendezvous
session. Disable multiple BLE connections to avoid collission.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes

Modify the feature flags to enable `CHIP_DEVICE_CONFIG_CHIPOBLE_SINGLE_CONNECTION` by default.