### PR TITLE
Fix some more uint8_t that should actually be EndpointId.

### DIFF
--- a/src/app/chip-zcl-zpro-codec-api.h
+++ b/src/app/chip-zcl-zpro-codec-api.h
@@ -65,66 +65,72 @@ extern "C" {
  * @brief
  *    Encode an go-to-percent command for BarrierControl server into buffer including the APS frame
  */
-uint16_t encodeBarrierControlClusterGoToPercentCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeBarrierControlClusterGoToPercentCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                        uint8_t percentOpen);
 
 /**
  * @brief
  *    Encode an stop command for BarrierControl server into buffer including the APS frame
  */
-uint16_t encodeBarrierControlClusterStopCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeBarrierControlClusterStopCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a discover command for  server into buffer including the APS frame
  */
-uint16_t encodeBarrierControlClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeBarrierControlClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length,
+                                                       chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the moving-state attribute for  server into buffer including the APS frame
  */
-uint16_t encodeBarrierControlClusterReadMovingStateAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeBarrierControlClusterReadMovingStateAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                             chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a report command for the moving-state attribute for  server into buffer including the APS frame
  */
-uint16_t encodeBarrierControlClusterReportMovingStateAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                               uint16_t min_interval, uint16_t max_interval);
+uint16_t encodeBarrierControlClusterReportMovingStateAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                               chip::EndpointId destination_endpoint, uint16_t min_interval,
+                                                               uint16_t max_interval);
 
 /**
  * @brief
  *    Encode a read command for the safety-status attribute for  server into buffer including the APS frame
  */
-uint16_t encodeBarrierControlClusterReadSafetyStatusAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeBarrierControlClusterReadSafetyStatusAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                              chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a report command for the safety-status attribute for  server into buffer including the APS frame
  */
-uint16_t encodeBarrierControlClusterReportSafetyStatusAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                                uint16_t min_interval, uint16_t max_interval);
+uint16_t encodeBarrierControlClusterReportSafetyStatusAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                                chip::EndpointId destination_endpoint, uint16_t min_interval,
+                                                                uint16_t max_interval);
 
 /**
  * @brief
  *    Encode a read command for the capabilities attribute for  server into buffer including the APS frame
  */
-uint16_t encodeBarrierControlClusterReadCapabilitiesAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeBarrierControlClusterReadCapabilitiesAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                              chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the barrier-position attribute for  server into buffer including the APS frame
  */
 uint16_t encodeBarrierControlClusterReadBarrierPositionAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 uint8_t destination_endpoint);
+                                                                 chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a report command for the barrier-position attribute for  server into buffer including the APS frame
  */
 uint16_t encodeBarrierControlClusterReportBarrierPositionAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                   uint8_t destination_endpoint, uint16_t min_interval,
+                                                                   chip::EndpointId destination_endpoint, uint16_t min_interval,
                                                                    uint16_t max_interval, uint8_t change);
 
 /*----------------------------------------------------------------------------*\
@@ -145,25 +151,26 @@ uint16_t encodeBarrierControlClusterReportBarrierPositionAttribute(uint8_t * buf
  * @brief
  *    Encode an reset-to-factory-defaults command for Basic server into buffer including the APS frame
  */
-uint16_t encodeBasicClusterResetToFactoryDefaultsCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeBasicClusterResetToFactoryDefaultsCommand(uint8_t * buffer, uint16_t buf_length,
+                                                         chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a discover command for  server into buffer including the APS frame
  */
-uint16_t encodeBasicClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeBasicClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the zclversion attribute for  server into buffer including the APS frame
  */
-uint16_t encodeBasicClusterReadZCLVersionAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeBasicClusterReadZCLVersionAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the power-source attribute for  server into buffer including the APS frame
  */
-uint16_t encodeBasicClusterReadPowerSourceAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeBasicClusterReadPowerSourceAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /*----------------------------------------------------------------------------*\
 | Cluster ColorControl                                                | 0x0300 |
@@ -233,16 +240,16 @@ uint16_t encodeBasicClusterReadPowerSourceAttribute(uint8_t * buffer, uint16_t b
  * @brief
  *    Encode an move-color command for ColorControl server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterMoveColorCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeColorControlClusterMoveColorCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                    int16_t rateX, int16_t rateY, uint8_t optionsMask, uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode an move-color-temperature command for ColorControl server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterMoveColorTemperatureCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                              uint8_t moveMode, uint16_t rate,
-                                                              uint16_t colorTemperatureMinimumMireds,
+uint16_t encodeColorControlClusterMoveColorTemperatureCommand(uint8_t * buffer, uint16_t buf_length,
+                                                              chip::EndpointId destination_endpoint, uint8_t moveMode,
+                                                              uint16_t rate, uint16_t colorTemperatureMinimumMireds,
                                                               uint16_t colorTemperatureMaximumMireds, uint8_t optionsMask,
                                                               uint8_t optionsOverride);
 
@@ -250,22 +257,22 @@ uint16_t encodeColorControlClusterMoveColorTemperatureCommand(uint8_t * buffer, 
  * @brief
  *    Encode an move-hue command for ColorControl server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterMoveHueCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeColorControlClusterMoveHueCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                  uint8_t moveMode, uint8_t rate, uint8_t optionsMask, uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode an move-saturation command for ColorControl server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterMoveSaturationCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                        uint8_t moveMode, uint8_t rate, uint8_t optionsMask,
-                                                        uint8_t optionsOverride);
+uint16_t encodeColorControlClusterMoveSaturationCommand(uint8_t * buffer, uint16_t buf_length,
+                                                        chip::EndpointId destination_endpoint, uint8_t moveMode, uint8_t rate,
+                                                        uint8_t optionsMask, uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode an move-to-color command for ColorControl server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterMoveToColorCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeColorControlClusterMoveToColorCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                      uint16_t colorX, uint16_t colorY, uint16_t transitionTime, uint8_t optionsMask,
                                                      uint8_t optionsOverride);
 
@@ -273,7 +280,8 @@ uint16_t encodeColorControlClusterMoveToColorCommand(uint8_t * buffer, uint16_t 
  * @brief
  *    Encode an move-to-color-temperature command for ColorControl server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterMoveToColorTemperatureCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeColorControlClusterMoveToColorTemperatureCommand(uint8_t * buffer, uint16_t buf_length,
+                                                                chip::EndpointId destination_endpoint,
                                                                 uint16_t colorTemperatureMireds, uint16_t transitionTime,
                                                                 uint8_t optionsMask, uint8_t optionsOverride);
 
@@ -281,31 +289,32 @@ uint16_t encodeColorControlClusterMoveToColorTemperatureCommand(uint8_t * buffer
  * @brief
  *    Encode an move-to-hue command for ColorControl server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterMoveToHueCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint8_t hue,
-                                                   uint8_t direction, uint16_t transitionTime, uint8_t optionsMask,
+uint16_t encodeColorControlClusterMoveToHueCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
+                                                   uint8_t hue, uint8_t direction, uint16_t transitionTime, uint8_t optionsMask,
                                                    uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode an move-to-hue-and-saturation command for ColorControl server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterMoveToHueAndSaturationCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                                uint8_t hue, uint8_t saturation, uint16_t transitionTime,
-                                                                uint8_t optionsMask, uint8_t optionsOverride);
+uint16_t encodeColorControlClusterMoveToHueAndSaturationCommand(uint8_t * buffer, uint16_t buf_length,
+                                                                chip::EndpointId destination_endpoint, uint8_t hue,
+                                                                uint8_t saturation, uint16_t transitionTime, uint8_t optionsMask,
+                                                                uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode an move-to-saturation command for ColorControl server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterMoveToSaturationCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                          uint8_t saturation, uint16_t transitionTime, uint8_t optionsMask,
-                                                          uint8_t optionsOverride);
+uint16_t encodeColorControlClusterMoveToSaturationCommand(uint8_t * buffer, uint16_t buf_length,
+                                                          chip::EndpointId destination_endpoint, uint8_t saturation,
+                                                          uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode an step-color command for ColorControl server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterStepColorCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeColorControlClusterStepColorCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                    int16_t stepX, int16_t stepY, uint16_t transitionTime, uint8_t optionsMask,
                                                    uint8_t optionsOverride);
 
@@ -313,8 +322,9 @@ uint16_t encodeColorControlClusterStepColorCommand(uint8_t * buffer, uint16_t bu
  * @brief
  *    Encode an step-color-temperature command for ColorControl server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterStepColorTemperatureCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                              uint8_t stepMode, uint16_t stepSize, uint16_t transitionTime,
+uint16_t encodeColorControlClusterStepColorTemperatureCommand(uint8_t * buffer, uint16_t buf_length,
+                                                              chip::EndpointId destination_endpoint, uint8_t stepMode,
+                                                              uint16_t stepSize, uint16_t transitionTime,
                                                               uint16_t colorTemperatureMinimumMireds,
                                                               uint16_t colorTemperatureMaximumMireds, uint8_t optionsMask,
                                                               uint8_t optionsOverride);
@@ -323,7 +333,7 @@ uint16_t encodeColorControlClusterStepColorTemperatureCommand(uint8_t * buffer, 
  * @brief
  *    Encode an step-hue command for ColorControl server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterStepHueCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeColorControlClusterStepHueCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                  uint8_t stepMode, uint8_t stepSize, uint8_t transitionTime, uint8_t optionsMask,
                                                  uint8_t optionsOverride);
 
@@ -331,326 +341,350 @@ uint16_t encodeColorControlClusterStepHueCommand(uint8_t * buffer, uint16_t buf_
  * @brief
  *    Encode an step-saturation command for ColorControl server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterStepSaturationCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                        uint8_t stepMode, uint8_t stepSize, uint8_t transitionTime,
-                                                        uint8_t optionsMask, uint8_t optionsOverride);
+uint16_t encodeColorControlClusterStepSaturationCommand(uint8_t * buffer, uint16_t buf_length,
+                                                        chip::EndpointId destination_endpoint, uint8_t stepMode, uint8_t stepSize,
+                                                        uint8_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode an stop-move-step command for ColorControl server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterStopMoveStepCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeColorControlClusterStopMoveStepCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                       uint8_t optionsMask, uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode a discover command for  server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeColorControlClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the current-hue attribute for  server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadCurrentHueAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeColorControlClusterReadCurrentHueAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                          chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a report command for the current-hue attribute for  server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReportCurrentHueAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                            uint16_t min_interval, uint16_t max_interval, uint8_t change);
+uint16_t encodeColorControlClusterReportCurrentHueAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                            chip::EndpointId destination_endpoint, uint16_t min_interval,
+                                                            uint16_t max_interval, uint8_t change);
 
 /**
  * @brief
  *    Encode a read command for the current-saturation attribute for  server into buffer including the APS frame
  */
 uint16_t encodeColorControlClusterReadCurrentSaturationAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 uint8_t destination_endpoint);
+                                                                 chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a report command for the current-saturation attribute for  server into buffer including the APS frame
  */
 uint16_t encodeColorControlClusterReportCurrentSaturationAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                   uint8_t destination_endpoint, uint16_t min_interval,
+                                                                   chip::EndpointId destination_endpoint, uint16_t min_interval,
                                                                    uint16_t max_interval, uint8_t change);
 
 /**
  * @brief
  *    Encode a read command for the remaining-time attribute for  server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadRemainingTimeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeColorControlClusterReadRemainingTimeAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                             chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the current-x attribute for  server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadCurrentXAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeColorControlClusterReadCurrentXAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                        chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a report command for the current-x attribute for  server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReportCurrentXAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                          uint16_t min_interval, uint16_t max_interval, uint16_t change);
+uint16_t encodeColorControlClusterReportCurrentXAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                          chip::EndpointId destination_endpoint, uint16_t min_interval,
+                                                          uint16_t max_interval, uint16_t change);
 
 /**
  * @brief
  *    Encode a read command for the current-y attribute for  server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadCurrentYAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeColorControlClusterReadCurrentYAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                        chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a report command for the current-y attribute for  server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReportCurrentYAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                          uint16_t min_interval, uint16_t max_interval, uint16_t change);
+uint16_t encodeColorControlClusterReportCurrentYAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                          chip::EndpointId destination_endpoint, uint16_t min_interval,
+                                                          uint16_t max_interval, uint16_t change);
 
 /**
  * @brief
  *    Encode a read command for the color-temperature-mireds attribute for  server into buffer including the APS frame
  */
 uint16_t encodeColorControlClusterReadColorTemperatureMiredsAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                      uint8_t destination_endpoint);
+                                                                      chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a report command for the color-temperature-mireds attribute for  server into buffer including the APS frame
  */
 uint16_t encodeColorControlClusterReportColorTemperatureMiredsAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                        uint8_t destination_endpoint, uint16_t min_interval,
-                                                                        uint16_t max_interval, uint16_t change);
+                                                                        chip::EndpointId destination_endpoint,
+                                                                        uint16_t min_interval, uint16_t max_interval,
+                                                                        uint16_t change);
 
 /**
  * @brief
  *    Encode a read command for the color-mode attribute for  server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadColorModeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeColorControlClusterReadColorModeAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                         chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the options attribute for  server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadOptionsAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeColorControlClusterReadOptionsAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                       chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a write command for the options attribute for  server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterWriteOptionsAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                        uint8_t options);
+uint16_t encodeColorControlClusterWriteOptionsAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                        chip::EndpointId destination_endpoint, uint8_t options);
 
 /**
  * @brief
  *    Encode a read command for the number-of-primaries attribute for  server into buffer including the APS frame
  */
 uint16_t encodeColorControlClusterReadNumberOfPrimariesAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 uint8_t destination_endpoint);
+                                                                 chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the primary1-x attribute for  server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary1XAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeColorControlClusterReadPrimary1XAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                         chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the primary1-y attribute for  server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary1YAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeColorControlClusterReadPrimary1YAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                         chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the primary1-intensity attribute for  server into buffer including the APS frame
  */
 uint16_t encodeColorControlClusterReadPrimary1IntensityAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 uint8_t destination_endpoint);
+                                                                 chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the primary2-x attribute for  server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary2XAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeColorControlClusterReadPrimary2XAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                         chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the primary2-y attribute for  server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary2YAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeColorControlClusterReadPrimary2YAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                         chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the primary2-intensity attribute for  server into buffer including the APS frame
  */
 uint16_t encodeColorControlClusterReadPrimary2IntensityAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 uint8_t destination_endpoint);
+                                                                 chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the primary3-x attribute for  server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary3XAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeColorControlClusterReadPrimary3XAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                         chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the primary3-y attribute for  server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary3YAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeColorControlClusterReadPrimary3YAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                         chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the primary3-intensity attribute for  server into buffer including the APS frame
  */
 uint16_t encodeColorControlClusterReadPrimary3IntensityAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 uint8_t destination_endpoint);
+                                                                 chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the primary4-x attribute for  server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary4XAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeColorControlClusterReadPrimary4XAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                         chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the primary4-y attribute for  server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary4YAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeColorControlClusterReadPrimary4YAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                         chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the primary4-intensity attribute for  server into buffer including the APS frame
  */
 uint16_t encodeColorControlClusterReadPrimary4IntensityAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 uint8_t destination_endpoint);
+                                                                 chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the primary5-x attribute for  server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary5XAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeColorControlClusterReadPrimary5XAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                         chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the primary5-y attribute for  server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary5YAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeColorControlClusterReadPrimary5YAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                         chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the primary5-intensity attribute for  server into buffer including the APS frame
  */
 uint16_t encodeColorControlClusterReadPrimary5IntensityAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 uint8_t destination_endpoint);
+                                                                 chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the primary6-x attribute for  server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary6XAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeColorControlClusterReadPrimary6XAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                         chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the primary6-y attribute for  server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary6YAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeColorControlClusterReadPrimary6YAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                         chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the primary6-intensity attribute for  server into buffer including the APS frame
  */
 uint16_t encodeColorControlClusterReadPrimary6IntensityAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 uint8_t destination_endpoint);
+                                                                 chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the enhanced-current-hue attribute for  server into buffer including the APS frame
  */
 uint16_t encodeColorControlClusterReadEnhancedCurrentHueAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                  uint8_t destination_endpoint);
+                                                                  chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the enhanced-color-mode attribute for  server into buffer including the APS frame
  */
 uint16_t encodeColorControlClusterReadEnhancedColorModeAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 uint8_t destination_endpoint);
+                                                                 chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the color-loop-active attribute for  server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadColorLoopActiveAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeColorControlClusterReadColorLoopActiveAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                               chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the color-loop-direction attribute for  server into buffer including the APS frame
  */
 uint16_t encodeColorControlClusterReadColorLoopDirectionAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                  uint8_t destination_endpoint);
+                                                                  chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the color-loop-time attribute for  server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadColorLoopTimeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeColorControlClusterReadColorLoopTimeAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                             chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the color-loop-start-enhanced-hue attribute for  server into buffer including the APS frame
  */
 uint16_t encodeColorControlClusterReadColorLoopStartEnhancedHueAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                         uint8_t destination_endpoint);
+                                                                         chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the color-loop-stored-enhanced-hue attribute for  server into buffer including the APS frame
  */
 uint16_t encodeColorControlClusterReadColorLoopStoredEnhancedHueAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                          uint8_t destination_endpoint);
+                                                                          chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the color-capabilities attribute for  server into buffer including the APS frame
  */
 uint16_t encodeColorControlClusterReadColorCapabilitiesAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 uint8_t destination_endpoint);
+                                                                 chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the color-temp-physical-min-mireds attribute for  server into buffer including the APS frame
  */
 uint16_t encodeColorControlClusterReadColorTempPhysicalMinMiredsAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                          uint8_t destination_endpoint);
+                                                                          chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the color-temp-physical-max-mireds attribute for  server into buffer including the APS frame
  */
 uint16_t encodeColorControlClusterReadColorTempPhysicalMaxMiredsAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                          uint8_t destination_endpoint);
+                                                                          chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the couple-color-temp-to-level-min-mireds attribute for  server into buffer including the APS frame
  */
 uint16_t encodeColorControlClusterReadCoupleColorTempToLevelMinMiredsAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                               uint8_t destination_endpoint);
+                                                                               chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the start-up-color-temperature-mireds attribute for  server into buffer including the APS frame
  */
 uint16_t encodeColorControlClusterReadStartUpColorTemperatureMiredsAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                             uint8_t destination_endpoint);
+                                                                             chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a write command for the start-up-color-temperature-mireds attribute for  server into buffer including the APS frame
  */
 uint16_t encodeColorControlClusterWriteStartUpColorTemperatureMiredsAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                              uint8_t destination_endpoint,
+                                                                              chip::EndpointId destination_endpoint,
                                                                               uint16_t startUpColorTemperatureMireds);
 
 /*----------------------------------------------------------------------------*\
@@ -715,187 +749,193 @@ uint16_t encodeColorControlClusterWriteStartUpColorTemperatureMiredsAttribute(ui
  * @brief
  *    Encode an clear-all-pincodes command for DoorLock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterClearAllPINCodesCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeDoorLockClusterClearAllPINCodesCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode an clear-all-rfidcodes command for DoorLock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterClearAllRFIDCodesCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeDoorLockClusterClearAllRFIDCodesCommand(uint8_t * buffer, uint16_t buf_length,
+                                                       chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode an clear-holiday-schedule command for DoorLock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterClearHolidayScheduleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                          uint8_t holidayScheduleID);
+uint16_t encodeDoorLockClusterClearHolidayScheduleCommand(uint8_t * buffer, uint16_t buf_length,
+                                                          chip::EndpointId destination_endpoint, uint8_t holidayScheduleID);
 
 /**
  * @brief
  *    Encode an clear-pincode command for DoorLock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterClearPINCodeCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterClearPINCodeCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                   uint16_t userID);
 
 /**
  * @brief
  *    Encode an clear-rfidcode command for DoorLock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterClearRFIDCodeCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterClearRFIDCodeCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                    uint16_t userID);
 
 /**
  * @brief
  *    Encode an clear-weekday-schedule command for DoorLock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterClearWeekdayScheduleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                          uint8_t scheduleID, uint16_t userID);
+uint16_t encodeDoorLockClusterClearWeekdayScheduleCommand(uint8_t * buffer, uint16_t buf_length,
+                                                          chip::EndpointId destination_endpoint, uint8_t scheduleID,
+                                                          uint16_t userID);
 
 /**
  * @brief
  *    Encode an clear-year-day-schedule command for DoorLock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterClearYearDayScheduleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                          uint8_t scheduleID, uint16_t userID);
+uint16_t encodeDoorLockClusterClearYearDayScheduleCommand(uint8_t * buffer, uint16_t buf_length,
+                                                          chip::EndpointId destination_endpoint, uint8_t scheduleID,
+                                                          uint16_t userID);
 
 /**
  * @brief
  *    Encode an get-holiday-schedule command for DoorLock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterGetHolidayScheduleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                        uint8_t holidayScheduleID);
+uint16_t encodeDoorLockClusterGetHolidayScheduleCommand(uint8_t * buffer, uint16_t buf_length,
+                                                        chip::EndpointId destination_endpoint, uint8_t holidayScheduleID);
 
 /**
  * @brief
  *    Encode an get-pincode command for DoorLock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterGetPINCodeCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterGetPINCodeCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                 uint16_t userID);
 
 /**
  * @brief
  *    Encode an get-rfidcode command for DoorLock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterGetRFIDCodeCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterGetRFIDCodeCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                  uint16_t userID);
 
 /**
  * @brief
  *    Encode an get-user-type command for DoorLock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterGetUserTypeCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterGetUserTypeCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                  uint16_t userID);
 
 /**
  * @brief
  *    Encode an get-weekday-schedule command for DoorLock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterGetWeekdayScheduleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                        uint8_t scheduleID, uint16_t userID);
+uint16_t encodeDoorLockClusterGetWeekdayScheduleCommand(uint8_t * buffer, uint16_t buf_length,
+                                                        chip::EndpointId destination_endpoint, uint8_t scheduleID, uint16_t userID);
 
 /**
  * @brief
  *    Encode an get-year-day-schedule command for DoorLock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterGetYearDayScheduleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                        uint8_t scheduleID, uint16_t userID);
+uint16_t encodeDoorLockClusterGetYearDayScheduleCommand(uint8_t * buffer, uint16_t buf_length,
+                                                        chip::EndpointId destination_endpoint, uint8_t scheduleID, uint16_t userID);
 
 /**
  * @brief
  *    Encode an lock-door command for DoorLock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterLockDoorCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterLockDoorCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                               char * pINOrRFIDCode);
 
 /**
  * @brief
  *    Encode an set-holiday-schedule command for DoorLock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterSetHolidayScheduleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                        uint8_t holidayScheduleID, uint32_t localStartTime, uint32_t localEndTime,
+uint16_t encodeDoorLockClusterSetHolidayScheduleCommand(uint8_t * buffer, uint16_t buf_length,
+                                                        chip::EndpointId destination_endpoint, uint8_t holidayScheduleID,
+                                                        uint32_t localStartTime, uint32_t localEndTime,
                                                         uint8_t operatingModeDuringHoliday);
 
 /**
  * @brief
  *    Encode an set-pincode command for DoorLock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterSetPINCodeCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterSetPINCodeCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                 uint16_t userID, uint8_t userStatus, uint8_t userType, char * pIN);
 
 /**
  * @brief
  *    Encode an set-rfidcode command for DoorLock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterSetRFIDCodeCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterSetRFIDCodeCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                  uint16_t userID, uint8_t userStatus, uint8_t userType, char * rFIDCode);
 
 /**
  * @brief
  *    Encode an set-user-type command for DoorLock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterSetUserTypeCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterSetUserTypeCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                  uint16_t userID, uint8_t userType);
 
 /**
  * @brief
  *    Encode an set-weekday-schedule command for DoorLock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterSetWeekdayScheduleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                        uint8_t scheduleID, uint16_t userID, uint8_t daysMask, uint8_t startHour,
-                                                        uint8_t startMinute, uint8_t endHour, uint8_t endMinute);
+uint16_t encodeDoorLockClusterSetWeekdayScheduleCommand(uint8_t * buffer, uint16_t buf_length,
+                                                        chip::EndpointId destination_endpoint, uint8_t scheduleID, uint16_t userID,
+                                                        uint8_t daysMask, uint8_t startHour, uint8_t startMinute, uint8_t endHour,
+                                                        uint8_t endMinute);
 
 /**
  * @brief
  *    Encode an set-year-day-schedule command for DoorLock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterSetYearDayScheduleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                        uint8_t scheduleID, uint16_t userID, uint32_t localStartTime,
-                                                        uint32_t localEndTime);
+uint16_t encodeDoorLockClusterSetYearDayScheduleCommand(uint8_t * buffer, uint16_t buf_length,
+                                                        chip::EndpointId destination_endpoint, uint8_t scheduleID, uint16_t userID,
+                                                        uint32_t localStartTime, uint32_t localEndTime);
 
 /**
  * @brief
  *    Encode an unlock-door command for DoorLock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterUnlockDoorCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterUnlockDoorCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                 char * pINOrRFIDCode);
 
 /**
  * @brief
  *    Encode an unlock-with-timeout command for DoorLock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterUnlockWithTimeoutCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterUnlockWithTimeoutCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                        uint16_t timeoutInSeconds, char * pINOrRFIDCode);
 
 /**
  * @brief
  *    Encode a discover command for  server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeDoorLockClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the lock-state attribute for  server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterReadLockStateAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeDoorLockClusterReadLockStateAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a report command for the lock-state attribute for  server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterReportLockStateAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterReportLockStateAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                        uint16_t min_interval, uint16_t max_interval);
 
 /**
  * @brief
  *    Encode a read command for the lock-type attribute for  server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterReadLockTypeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeDoorLockClusterReadLockTypeAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the actuator-enabled attribute for  server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterReadActuatorEnabledAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeDoorLockClusterReadActuatorEnabledAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                           chip::EndpointId destination_endpoint);
 
 /*----------------------------------------------------------------------------*\
 | Cluster Groups                                                      | 0x0004 |
@@ -938,14 +978,14 @@ uint16_t encodeGroupsClusterAddGroupIfIdentifyingCommand(uint8_t * buffer, uint1
  * @brief
  *    Encode an get-group-membership command for Groups server into buffer including the APS frame
  */
-uint16_t encodeGroupsClusterGetGroupMembershipCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeGroupsClusterGetGroupMembershipCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                       uint8_t groupCount, uint16_t groupList);
 
 /**
  * @brief
  *    Encode an remove-all-groups command for Groups server into buffer including the APS frame
  */
-uint16_t encodeGroupsClusterRemoveAllGroupsCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeGroupsClusterRemoveAllGroupsCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
@@ -965,13 +1005,13 @@ uint16_t encodeGroupsClusterViewGroupCommand(uint8_t * buffer, uint16_t buf_leng
  * @brief
  *    Encode a discover command for  server into buffer including the APS frame
  */
-uint16_t encodeGroupsClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeGroupsClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the name-support attribute for  server into buffer including the APS frame
  */
-uint16_t encodeGroupsClusterReadNameSupportAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeGroupsClusterReadNameSupportAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /*----------------------------------------------------------------------------*\
 | Cluster IASZone                                                     | 0x0500 |
@@ -993,51 +1033,52 @@ uint16_t encodeGroupsClusterReadNameSupportAttribute(uint8_t * buffer, uint16_t 
  * @brief
  *    Encode an zone-enroll-response command for IASZone server into buffer including the APS frame
  */
-uint16_t encodeIASZoneClusterZoneEnrollResponseCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeIASZoneClusterZoneEnrollResponseCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                        uint8_t enrollResponseCode, uint8_t zoneID);
 
 /**
  * @brief
  *    Encode a discover command for  server into buffer including the APS frame
  */
-uint16_t encodeIASZoneClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeIASZoneClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the zone-state attribute for  server into buffer including the APS frame
  */
-uint16_t encodeIASZoneClusterReadZoneStateAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeIASZoneClusterReadZoneStateAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the zone-type attribute for  server into buffer including the APS frame
  */
-uint16_t encodeIASZoneClusterReadZoneTypeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeIASZoneClusterReadZoneTypeAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the zone-status attribute for  server into buffer including the APS frame
  */
-uint16_t encodeIASZoneClusterReadZoneStatusAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeIASZoneClusterReadZoneStatusAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the iascieaddress attribute for  server into buffer including the APS frame
  */
-uint16_t encodeIASZoneClusterReadIASCIEAddressAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeIASZoneClusterReadIASCIEAddressAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                        chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a write command for the iascieaddress attribute for  server into buffer including the APS frame
  */
-uint16_t encodeIASZoneClusterWriteIASCIEAddressAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                         uint64_t iASCIEAddress);
+uint16_t encodeIASZoneClusterWriteIASCIEAddressAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                         chip::EndpointId destination_endpoint, uint64_t iASCIEAddress);
 
 /**
  * @brief
  *    Encode a read command for the zone-id attribute for  server into buffer including the APS frame
  */
-uint16_t encodeIASZoneClusterReadZoneIDAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeIASZoneClusterReadZoneIDAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /*----------------------------------------------------------------------------*\
 | Cluster Identify                                                    | 0x0003 |
@@ -1058,33 +1099,34 @@ uint16_t encodeIASZoneClusterReadZoneIDAttribute(uint8_t * buffer, uint16_t buf_
  * @brief
  *    Encode an identify command for Identify server into buffer including the APS frame
  */
-uint16_t encodeIdentifyClusterIdentifyCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeIdentifyClusterIdentifyCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                               uint16_t identifyTime);
 
 /**
  * @brief
  *    Encode an identify-query command for Identify server into buffer including the APS frame
  */
-uint16_t encodeIdentifyClusterIdentifyQueryCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeIdentifyClusterIdentifyQueryCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a discover command for  server into buffer including the APS frame
  */
-uint16_t encodeIdentifyClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeIdentifyClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the identify-time attribute for  server into buffer including the APS frame
  */
-uint16_t encodeIdentifyClusterReadIdentifyTimeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeIdentifyClusterReadIdentifyTimeAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                        chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a write command for the identify-time attribute for  server into buffer including the APS frame
  */
-uint16_t encodeIdentifyClusterWriteIdentifyTimeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                         uint16_t identifyTime);
+uint16_t encodeIdentifyClusterWriteIdentifyTimeAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                         chip::EndpointId destination_endpoint, uint16_t identifyTime);
 
 /*----------------------------------------------------------------------------*\
 | Cluster Level                                                       | 0x0008 |
@@ -1110,21 +1152,21 @@ uint16_t encodeIdentifyClusterWriteIdentifyTimeAttribute(uint8_t * buffer, uint1
  * @brief
  *    Encode an move command for Level server into buffer including the APS frame
  */
-uint16_t encodeLevelClusterMoveCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint8_t moveMode,
-                                       uint8_t rate, uint8_t optionsMask, uint8_t optionsOverride);
+uint16_t encodeLevelClusterMoveCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
+                                       uint8_t moveMode, uint8_t rate, uint8_t optionsMask, uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode an move-to-level command for Level server into buffer including the APS frame
  */
-uint16_t encodeLevelClusterMoveToLevelCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint8_t level,
-                                              uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride);
+uint16_t encodeLevelClusterMoveToLevelCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
+                                              uint8_t level, uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode an move-to-level-with-on-off command for Level server into buffer including the APS frame
  */
-uint16_t encodeLevelClusterMoveToLevelWithOnOffCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeLevelClusterMoveToLevelWithOnOffCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                        uint8_t level, uint16_t transitionTime, uint8_t optionsMask,
                                                        uint8_t optionsOverride);
 
@@ -1132,21 +1174,22 @@ uint16_t encodeLevelClusterMoveToLevelWithOnOffCommand(uint8_t * buffer, uint16_
  * @brief
  *    Encode an move-with-on-off command for Level server into buffer including the APS frame
  */
-uint16_t encodeLevelClusterMoveWithOnOffCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeLevelClusterMoveWithOnOffCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                 uint8_t moveMode, uint8_t rate, uint8_t optionsMask, uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode an step command for Level server into buffer including the APS frame
  */
-uint16_t encodeLevelClusterStepCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint8_t stepMode,
-                                       uint8_t stepSize, uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride);
+uint16_t encodeLevelClusterStepCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
+                                       uint8_t stepMode, uint8_t stepSize, uint16_t transitionTime, uint8_t optionsMask,
+                                       uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode an step-with-on-off command for Level server into buffer including the APS frame
  */
-uint16_t encodeLevelClusterStepWithOnOffCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeLevelClusterStepWithOnOffCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                 uint8_t stepMode, uint8_t stepSize, uint16_t transitionTime, uint8_t optionsMask,
                                                 uint8_t optionsOverride);
 
@@ -1154,33 +1197,33 @@ uint16_t encodeLevelClusterStepWithOnOffCommand(uint8_t * buffer, uint16_t buf_l
  * @brief
  *    Encode an stop command for Level server into buffer including the APS frame
  */
-uint16_t encodeLevelClusterStopCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint8_t optionsMask,
-                                       uint8_t optionsOverride);
+uint16_t encodeLevelClusterStopCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
+                                       uint8_t optionsMask, uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode an stop-with-on-off command for Level server into buffer including the APS frame
  */
-uint16_t encodeLevelClusterStopWithOnOffCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeLevelClusterStopWithOnOffCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                 uint8_t optionsMask, uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode a discover command for  server into buffer including the APS frame
  */
-uint16_t encodeLevelClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeLevelClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the current-level attribute for  server into buffer including the APS frame
  */
-uint16_t encodeLevelClusterReadCurrentLevelAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeLevelClusterReadCurrentLevelAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a report command for the current-level attribute for  server into buffer including the APS frame
  */
-uint16_t encodeLevelClusterReportCurrentLevelAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeLevelClusterReportCurrentLevelAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                        uint16_t min_interval, uint16_t max_interval, uint8_t change);
 
 /*----------------------------------------------------------------------------*\
@@ -1202,37 +1245,37 @@ uint16_t encodeLevelClusterReportCurrentLevelAttribute(uint8_t * buffer, uint16_
  * @brief
  *    Encode an off command for OnOff server into buffer including the APS frame
  */
-uint16_t encodeOnOffClusterOffCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeOnOffClusterOffCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode an on command for OnOff server into buffer including the APS frame
  */
-uint16_t encodeOnOffClusterOnCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeOnOffClusterOnCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode an toggle command for OnOff server into buffer including the APS frame
  */
-uint16_t encodeOnOffClusterToggleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeOnOffClusterToggleCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a discover command for  server into buffer including the APS frame
  */
-uint16_t encodeOnOffClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeOnOffClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the on-off attribute for  server into buffer including the APS frame
  */
-uint16_t encodeOnOffClusterReadOnOffAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeOnOffClusterReadOnOffAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a report command for the on-off attribute for  server into buffer including the APS frame
  */
-uint16_t encodeOnOffClusterReportOnOffAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeOnOffClusterReportOnOffAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
                                                 uint16_t min_interval, uint16_t max_interval);
 
 /*----------------------------------------------------------------------------*\
@@ -1318,37 +1361,37 @@ uint16_t encodeScenesClusterViewSceneCommand(uint8_t * buffer, uint16_t buf_leng
  * @brief
  *    Encode a discover command for  server into buffer including the APS frame
  */
-uint16_t encodeScenesClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeScenesClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the scene-count attribute for  server into buffer including the APS frame
  */
-uint16_t encodeScenesClusterReadSceneCountAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeScenesClusterReadSceneCountAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the current-scene attribute for  server into buffer including the APS frame
  */
-uint16_t encodeScenesClusterReadCurrentSceneAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeScenesClusterReadCurrentSceneAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the current-group attribute for  server into buffer including the APS frame
  */
-uint16_t encodeScenesClusterReadCurrentGroupAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeScenesClusterReadCurrentGroupAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the scene-valid attribute for  server into buffer including the APS frame
  */
-uint16_t encodeScenesClusterReadSceneValidAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeScenesClusterReadSceneValidAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the name-support attribute for  server into buffer including the APS frame
  */
-uint16_t encodeScenesClusterReadNameSupportAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeScenesClusterReadNameSupportAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
 
 /*----------------------------------------------------------------------------*\
 | Cluster TemperatureMeasurement                                      | 0x0402 |
@@ -1368,36 +1411,38 @@ uint16_t encodeScenesClusterReadNameSupportAttribute(uint8_t * buffer, uint16_t 
  * @brief
  *    Encode a discover command for  server into buffer including the APS frame
  */
-uint16_t encodeTemperatureMeasurementClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint);
+uint16_t encodeTemperatureMeasurementClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length,
+                                                               chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the measured-value attribute for  server into buffer including the APS frame
  */
 uint16_t encodeTemperatureMeasurementClusterReadMeasuredValueAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                       uint8_t destination_endpoint);
+                                                                       chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a report command for the measured-value attribute for  server into buffer including the APS frame
  */
 uint16_t encodeTemperatureMeasurementClusterReportMeasuredValueAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                         uint8_t destination_endpoint, uint16_t min_interval,
-                                                                         uint16_t max_interval, int16_t change);
+                                                                         chip::EndpointId destination_endpoint,
+                                                                         uint16_t min_interval, uint16_t max_interval,
+                                                                         int16_t change);
 
 /**
  * @brief
  *    Encode a read command for the min-measured-value attribute for  server into buffer including the APS frame
  */
 uint16_t encodeTemperatureMeasurementClusterReadMinMeasuredValueAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                          uint8_t destination_endpoint);
+                                                                          chip::EndpointId destination_endpoint);
 
 /**
  * @brief
  *    Encode a read command for the max-measured-value attribute for  server into buffer including the APS frame
  */
 uint16_t encodeTemperatureMeasurementClusterReadMaxMeasuredValueAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                          uint8_t destination_endpoint);
+                                                                          chip::EndpointId destination_endpoint);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/app/clusters/ias-zone-client/ias-zone-client.h
+++ b/src/app/clusters/ias-zone-client/ias-zone-client.h
@@ -40,14 +40,16 @@
 
 #pragma once
 
+#include <app/util/basic-types.h>
+
 typedef struct
 {
     EmberEUI64 ieeeAddress;
-    EmberNodeId nodeId;
+    chip::NodeId nodeId;
     uint16_t zoneType;
     uint16_t zoneStatus;
     uint8_t zoneState;
-    uint8_t endpoint;
+    chip::EndpointId endpoint;
     uint8_t zoneId;
 } IasZoneDevice;
 

--- a/src/app/encoder.cpp
+++ b/src/app/encoder.cpp
@@ -258,8 +258,8 @@ uint16_t _encodeCommand(BufBound & buf, EndpointId destination_endpoint, Cluster
 {
     CHECK_FRAME_LENGTH(buf.Size(), "Buffer is empty");
 
-    uint8_t seq_num         = 1; // Transaction sequence number.  Just pick something.
-    uint8_t source_endpoint = 1; // Pick source endpoint as 1 for now.
+    uint8_t seq_num            = 1; // Transaction sequence number.  Just pick something.
+    EndpointId source_endpoint = 1; // Pick source endpoint as 1 for now.
 
     if (doEncodeApsFrame(buf, cluster_id, source_endpoint, destination_endpoint, 0, 0, 0, 0, false))
     {
@@ -291,7 +291,7 @@ uint16_t _encodeGlobalCommand(BufBound & buf, EndpointId destination_endpoint, C
     return _encodeCommand(buf, destination_endpoint, cluster_id, command, frame_control);
 }
 
-uint16_t encodeReadAttributesCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint16_t cluster_id,
+uint16_t encodeReadAttributesCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint, ClusterId cluster_id,
                                      const uint16_t * attr_ids, uint16_t attr_id_count)
 {
     BufBound buf = BufBound(buffer, buf_length);
@@ -327,7 +327,7 @@ uint16_t encodeReadAttributesCommand(uint8_t * buffer, uint16_t buf_length, uint
 /*
  * Command GoToPercent
  */
-uint16_t encodeBarrierControlClusterGoToPercentCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeBarrierControlClusterGoToPercentCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                        uint8_t percentOpen)
 {
     const char * kName = "BarrierControlGoToPercent";
@@ -339,14 +339,14 @@ uint16_t encodeBarrierControlClusterGoToPercentCommand(uint8_t * buffer, uint16_
 /*
  * Command Stop
  */
-uint16_t encodeBarrierControlClusterStopCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeBarrierControlClusterStopCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     const char * kName = "BarrierControlStop";
     COMMAND_HEADER(kName, BARRIER_CONTROL_CLUSTER_ID, 0x01);
     COMMAND_FOOTER(kName);
 }
 
-uint16_t encodeBarrierControlClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeBarrierControlClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     DISCOVER_ATTRIBUTES("DiscoverBarrierControlAttributes", BARRIER_CONTROL_CLUSTER_ID);
 }
@@ -354,14 +354,15 @@ uint16_t encodeBarrierControlClusterDiscoverAttributes(uint8_t * buffer, uint16_
 /*
  * Attribute MovingState
  */
-uint16_t encodeBarrierControlClusterReadMovingStateAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeBarrierControlClusterReadMovingStateAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0001 };
     READ_ATTRIBUTES("ReadBarrierControlMovingState", BARRIER_CONTROL_CLUSTER_ID);
 }
 
-uint16_t encodeBarrierControlClusterReportMovingStateAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                               uint16_t min_interval, uint16_t max_interval)
+uint16_t encodeBarrierControlClusterReportMovingStateAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                               EndpointId destination_endpoint, uint16_t min_interval,
+                                                               uint16_t max_interval)
 {
     uint16_t attr_id  = 0x0001;
     uint8_t attr_type = { 0x30 };
@@ -371,14 +372,16 @@ uint16_t encodeBarrierControlClusterReportMovingStateAttribute(uint8_t * buffer,
 /*
  * Attribute SafetyStatus
  */
-uint16_t encodeBarrierControlClusterReadSafetyStatusAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeBarrierControlClusterReadSafetyStatusAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                              EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0002 };
     READ_ATTRIBUTES("ReadBarrierControlSafetyStatus", BARRIER_CONTROL_CLUSTER_ID);
 }
 
-uint16_t encodeBarrierControlClusterReportSafetyStatusAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                                uint16_t min_interval, uint16_t max_interval)
+uint16_t encodeBarrierControlClusterReportSafetyStatusAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                                EndpointId destination_endpoint, uint16_t min_interval,
+                                                                uint16_t max_interval)
 {
     uint16_t attr_id  = 0x0002;
     uint8_t attr_type = { 0x19 };
@@ -388,7 +391,8 @@ uint16_t encodeBarrierControlClusterReportSafetyStatusAttribute(uint8_t * buffer
 /*
  * Attribute Capabilities
  */
-uint16_t encodeBarrierControlClusterReadCapabilitiesAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeBarrierControlClusterReadCapabilitiesAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                              EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0003 };
     READ_ATTRIBUTES("ReadBarrierControlCapabilities", BARRIER_CONTROL_CLUSTER_ID);
@@ -398,14 +402,14 @@ uint16_t encodeBarrierControlClusterReadCapabilitiesAttribute(uint8_t * buffer, 
  * Attribute BarrierPosition
  */
 uint16_t encodeBarrierControlClusterReadBarrierPositionAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 uint8_t destination_endpoint)
+                                                                 EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x000A };
     READ_ATTRIBUTES("ReadBarrierControlBarrierPosition", BARRIER_CONTROL_CLUSTER_ID);
 }
 
 uint16_t encodeBarrierControlClusterReportBarrierPositionAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                   uint8_t destination_endpoint, uint16_t min_interval,
+                                                                   EndpointId destination_endpoint, uint16_t min_interval,
                                                                    uint16_t max_interval, uint8_t change)
 {
     uint16_t attr_id  = 0x000A;
@@ -430,14 +434,14 @@ uint16_t encodeBarrierControlClusterReportBarrierPositionAttribute(uint8_t * buf
 /*
  * Command ResetToFactoryDefaults
  */
-uint16_t encodeBasicClusterResetToFactoryDefaultsCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeBasicClusterResetToFactoryDefaultsCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     const char * kName = "BasicResetToFactoryDefaults";
     COMMAND_HEADER(kName, BASIC_CLUSTER_ID, 0x00);
     COMMAND_FOOTER(kName);
 }
 
-uint16_t encodeBasicClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeBasicClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     DISCOVER_ATTRIBUTES("DiscoverBasicAttributes", BASIC_CLUSTER_ID);
 }
@@ -445,7 +449,7 @@ uint16_t encodeBasicClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_len
 /*
  * Attribute ZCLVersion
  */
-uint16_t encodeBasicClusterReadZCLVersionAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeBasicClusterReadZCLVersionAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0000 };
     READ_ATTRIBUTES("ReadBasicZCLVersion", BASIC_CLUSTER_ID);
@@ -454,7 +458,7 @@ uint16_t encodeBasicClusterReadZCLVersionAttribute(uint8_t * buffer, uint16_t bu
 /*
  * Attribute PowerSource
  */
-uint16_t encodeBasicClusterReadPowerSourceAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeBasicClusterReadPowerSourceAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0007 };
     READ_ATTRIBUTES("ReadBasicPowerSource", BASIC_CLUSTER_ID);
@@ -527,7 +531,7 @@ uint16_t encodeBasicClusterReadPowerSourceAttribute(uint8_t * buffer, uint16_t b
 /*
  * Command MoveColor
  */
-uint16_t encodeColorControlClusterMoveColorCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeColorControlClusterMoveColorCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                    int16_t rateX, int16_t rateY, uint8_t optionsMask, uint8_t optionsOverride)
 {
     const char * kName = "ColorControlMoveColor";
@@ -542,8 +546,8 @@ uint16_t encodeColorControlClusterMoveColorCommand(uint8_t * buffer, uint16_t bu
 /*
  * Command MoveColorTemperature
  */
-uint16_t encodeColorControlClusterMoveColorTemperatureCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                              uint8_t moveMode, uint16_t rate,
+uint16_t encodeColorControlClusterMoveColorTemperatureCommand(uint8_t * buffer, uint16_t buf_length,
+                                                              EndpointId destination_endpoint, uint8_t moveMode, uint16_t rate,
                                                               uint16_t colorTemperatureMinimumMireds,
                                                               uint16_t colorTemperatureMaximumMireds, uint8_t optionsMask,
                                                               uint8_t optionsOverride)
@@ -562,7 +566,7 @@ uint16_t encodeColorControlClusterMoveColorTemperatureCommand(uint8_t * buffer, 
 /*
  * Command MoveHue
  */
-uint16_t encodeColorControlClusterMoveHueCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeColorControlClusterMoveHueCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                  uint8_t moveMode, uint8_t rate, uint8_t optionsMask, uint8_t optionsOverride)
 {
     const char * kName = "ColorControlMoveHue";
@@ -577,7 +581,7 @@ uint16_t encodeColorControlClusterMoveHueCommand(uint8_t * buffer, uint16_t buf_
 /*
  * Command MoveSaturation
  */
-uint16_t encodeColorControlClusterMoveSaturationCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeColorControlClusterMoveSaturationCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                         uint8_t moveMode, uint8_t rate, uint8_t optionsMask,
                                                         uint8_t optionsOverride)
 {
@@ -593,7 +597,7 @@ uint16_t encodeColorControlClusterMoveSaturationCommand(uint8_t * buffer, uint16
 /*
  * Command MoveToColor
  */
-uint16_t encodeColorControlClusterMoveToColorCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeColorControlClusterMoveToColorCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                      uint16_t colorX, uint16_t colorY, uint16_t transitionTime, uint8_t optionsMask,
                                                      uint8_t optionsOverride)
 {
@@ -610,9 +614,10 @@ uint16_t encodeColorControlClusterMoveToColorCommand(uint8_t * buffer, uint16_t 
 /*
  * Command MoveToColorTemperature
  */
-uint16_t encodeColorControlClusterMoveToColorTemperatureCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                                uint16_t colorTemperatureMireds, uint16_t transitionTime,
-                                                                uint8_t optionsMask, uint8_t optionsOverride)
+uint16_t encodeColorControlClusterMoveToColorTemperatureCommand(uint8_t * buffer, uint16_t buf_length,
+                                                                EndpointId destination_endpoint, uint16_t colorTemperatureMireds,
+                                                                uint16_t transitionTime, uint8_t optionsMask,
+                                                                uint8_t optionsOverride)
 {
     const char * kName = "ColorControlMoveToColorTemperature";
     COMMAND_HEADER(kName, COLOR_CONTROL_CLUSTER_ID, 0x0A);
@@ -626,8 +631,8 @@ uint16_t encodeColorControlClusterMoveToColorTemperatureCommand(uint8_t * buffer
 /*
  * Command MoveToHue
  */
-uint16_t encodeColorControlClusterMoveToHueCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint8_t hue,
-                                                   uint8_t direction, uint16_t transitionTime, uint8_t optionsMask,
+uint16_t encodeColorControlClusterMoveToHueCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
+                                                   uint8_t hue, uint8_t direction, uint16_t transitionTime, uint8_t optionsMask,
                                                    uint8_t optionsOverride)
 {
     const char * kName = "ColorControlMoveToHue";
@@ -643,9 +648,10 @@ uint16_t encodeColorControlClusterMoveToHueCommand(uint8_t * buffer, uint16_t bu
 /*
  * Command MoveToHueAndSaturation
  */
-uint16_t encodeColorControlClusterMoveToHueAndSaturationCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                                uint8_t hue, uint8_t saturation, uint16_t transitionTime,
-                                                                uint8_t optionsMask, uint8_t optionsOverride)
+uint16_t encodeColorControlClusterMoveToHueAndSaturationCommand(uint8_t * buffer, uint16_t buf_length,
+                                                                EndpointId destination_endpoint, uint8_t hue, uint8_t saturation,
+                                                                uint16_t transitionTime, uint8_t optionsMask,
+                                                                uint8_t optionsOverride)
 {
     const char * kName = "ColorControlMoveToHueAndSaturation";
     COMMAND_HEADER(kName, COLOR_CONTROL_CLUSTER_ID, 0x06);
@@ -660,7 +666,7 @@ uint16_t encodeColorControlClusterMoveToHueAndSaturationCommand(uint8_t * buffer
 /*
  * Command MoveToSaturation
  */
-uint16_t encodeColorControlClusterMoveToSaturationCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeColorControlClusterMoveToSaturationCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                           uint8_t saturation, uint16_t transitionTime, uint8_t optionsMask,
                                                           uint8_t optionsOverride)
 {
@@ -676,7 +682,7 @@ uint16_t encodeColorControlClusterMoveToSaturationCommand(uint8_t * buffer, uint
 /*
  * Command StepColor
  */
-uint16_t encodeColorControlClusterStepColorCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeColorControlClusterStepColorCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                    int16_t stepX, int16_t stepY, uint16_t transitionTime, uint8_t optionsMask,
                                                    uint8_t optionsOverride)
 {
@@ -693,9 +699,9 @@ uint16_t encodeColorControlClusterStepColorCommand(uint8_t * buffer, uint16_t bu
 /*
  * Command StepColorTemperature
  */
-uint16_t encodeColorControlClusterStepColorTemperatureCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
-                                                              uint8_t stepMode, uint16_t stepSize, uint16_t transitionTime,
-                                                              uint16_t colorTemperatureMinimumMireds,
+uint16_t encodeColorControlClusterStepColorTemperatureCommand(uint8_t * buffer, uint16_t buf_length,
+                                                              EndpointId destination_endpoint, uint8_t stepMode, uint16_t stepSize,
+                                                              uint16_t transitionTime, uint16_t colorTemperatureMinimumMireds,
                                                               uint16_t colorTemperatureMaximumMireds, uint8_t optionsMask,
                                                               uint8_t optionsOverride)
 {
@@ -714,7 +720,7 @@ uint16_t encodeColorControlClusterStepColorTemperatureCommand(uint8_t * buffer, 
 /*
  * Command StepHue
  */
-uint16_t encodeColorControlClusterStepHueCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeColorControlClusterStepHueCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                  uint8_t stepMode, uint8_t stepSize, uint8_t transitionTime, uint8_t optionsMask,
                                                  uint8_t optionsOverride)
 {
@@ -731,7 +737,7 @@ uint16_t encodeColorControlClusterStepHueCommand(uint8_t * buffer, uint16_t buf_
 /*
  * Command StepSaturation
  */
-uint16_t encodeColorControlClusterStepSaturationCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeColorControlClusterStepSaturationCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                         uint8_t stepMode, uint8_t stepSize, uint8_t transitionTime,
                                                         uint8_t optionsMask, uint8_t optionsOverride)
 {
@@ -748,7 +754,7 @@ uint16_t encodeColorControlClusterStepSaturationCommand(uint8_t * buffer, uint16
 /*
  * Command StopMoveStep
  */
-uint16_t encodeColorControlClusterStopMoveStepCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeColorControlClusterStopMoveStepCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                       uint8_t optionsMask, uint8_t optionsOverride)
 {
     const char * kName = "ColorControlStopMoveStep";
@@ -758,7 +764,7 @@ uint16_t encodeColorControlClusterStopMoveStepCommand(uint8_t * buffer, uint16_t
     COMMAND_FOOTER(kName);
 }
 
-uint16_t encodeColorControlClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeColorControlClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     DISCOVER_ATTRIBUTES("DiscoverColorControlAttributes", COLOR_CONTROL_CLUSTER_ID);
 }
@@ -766,13 +772,13 @@ uint16_t encodeColorControlClusterDiscoverAttributes(uint8_t * buffer, uint16_t 
 /*
  * Attribute CurrentHue
  */
-uint16_t encodeColorControlClusterReadCurrentHueAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeColorControlClusterReadCurrentHueAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0000 };
     READ_ATTRIBUTES("ReadColorControlCurrentHue", COLOR_CONTROL_CLUSTER_ID);
 }
 
-uint16_t encodeColorControlClusterReportCurrentHueAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeColorControlClusterReportCurrentHueAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                             uint16_t min_interval, uint16_t max_interval, uint8_t change)
 {
     uint16_t attr_id  = 0x0000;
@@ -784,14 +790,14 @@ uint16_t encodeColorControlClusterReportCurrentHueAttribute(uint8_t * buffer, ui
  * Attribute CurrentSaturation
  */
 uint16_t encodeColorControlClusterReadCurrentSaturationAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 uint8_t destination_endpoint)
+                                                                 EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0001 };
     READ_ATTRIBUTES("ReadColorControlCurrentSaturation", COLOR_CONTROL_CLUSTER_ID);
 }
 
 uint16_t encodeColorControlClusterReportCurrentSaturationAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                   uint8_t destination_endpoint, uint16_t min_interval,
+                                                                   EndpointId destination_endpoint, uint16_t min_interval,
                                                                    uint16_t max_interval, uint8_t change)
 {
     uint16_t attr_id  = 0x0001;
@@ -802,7 +808,7 @@ uint16_t encodeColorControlClusterReportCurrentSaturationAttribute(uint8_t * buf
 /*
  * Attribute RemainingTime
  */
-uint16_t encodeColorControlClusterReadRemainingTimeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeColorControlClusterReadRemainingTimeAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0002 };
     READ_ATTRIBUTES("ReadColorControlRemainingTime", COLOR_CONTROL_CLUSTER_ID);
@@ -811,13 +817,13 @@ uint16_t encodeColorControlClusterReadRemainingTimeAttribute(uint8_t * buffer, u
 /*
  * Attribute CurrentX
  */
-uint16_t encodeColorControlClusterReadCurrentXAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeColorControlClusterReadCurrentXAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0003 };
     READ_ATTRIBUTES("ReadColorControlCurrentX", COLOR_CONTROL_CLUSTER_ID);
 }
 
-uint16_t encodeColorControlClusterReportCurrentXAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeColorControlClusterReportCurrentXAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                           uint16_t min_interval, uint16_t max_interval, uint16_t change)
 {
     uint16_t attr_id  = 0x0003;
@@ -828,13 +834,13 @@ uint16_t encodeColorControlClusterReportCurrentXAttribute(uint8_t * buffer, uint
 /*
  * Attribute CurrentY
  */
-uint16_t encodeColorControlClusterReadCurrentYAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeColorControlClusterReadCurrentYAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0004 };
     READ_ATTRIBUTES("ReadColorControlCurrentY", COLOR_CONTROL_CLUSTER_ID);
 }
 
-uint16_t encodeColorControlClusterReportCurrentYAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeColorControlClusterReportCurrentYAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                           uint16_t min_interval, uint16_t max_interval, uint16_t change)
 {
     uint16_t attr_id  = 0x0004;
@@ -846,14 +852,14 @@ uint16_t encodeColorControlClusterReportCurrentYAttribute(uint8_t * buffer, uint
  * Attribute ColorTemperatureMireds
  */
 uint16_t encodeColorControlClusterReadColorTemperatureMiredsAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                      uint8_t destination_endpoint)
+                                                                      EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0007 };
     READ_ATTRIBUTES("ReadColorControlColorTemperatureMireds", COLOR_CONTROL_CLUSTER_ID);
 }
 
 uint16_t encodeColorControlClusterReportColorTemperatureMiredsAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                        uint8_t destination_endpoint, uint16_t min_interval,
+                                                                        EndpointId destination_endpoint, uint16_t min_interval,
                                                                         uint16_t max_interval, uint16_t change)
 {
     uint16_t attr_id  = 0x0007;
@@ -864,7 +870,7 @@ uint16_t encodeColorControlClusterReportColorTemperatureMiredsAttribute(uint8_t 
 /*
  * Attribute ColorMode
  */
-uint16_t encodeColorControlClusterReadColorModeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeColorControlClusterReadColorModeAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0008 };
     READ_ATTRIBUTES("ReadColorControlColorMode", COLOR_CONTROL_CLUSTER_ID);
@@ -873,13 +879,13 @@ uint16_t encodeColorControlClusterReadColorModeAttribute(uint8_t * buffer, uint1
 /*
  * Attribute Options
  */
-uint16_t encodeColorControlClusterReadOptionsAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeColorControlClusterReadOptionsAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x000F };
     READ_ATTRIBUTES("ReadColorControlOptions", COLOR_CONTROL_CLUSTER_ID);
 }
 
-uint16_t encodeColorControlClusterWriteOptionsAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeColorControlClusterWriteOptionsAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                         uint8_t options)
 {
     uint16_t attr_id  = 0x000F;
@@ -891,7 +897,7 @@ uint16_t encodeColorControlClusterWriteOptionsAttribute(uint8_t * buffer, uint16
  * Attribute NumberOfPrimaries
  */
 uint16_t encodeColorControlClusterReadNumberOfPrimariesAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 uint8_t destination_endpoint)
+                                                                 EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0010 };
     READ_ATTRIBUTES("ReadColorControlNumberOfPrimaries", COLOR_CONTROL_CLUSTER_ID);
@@ -900,7 +906,7 @@ uint16_t encodeColorControlClusterReadNumberOfPrimariesAttribute(uint8_t * buffe
 /*
  * Attribute Primary1X
  */
-uint16_t encodeColorControlClusterReadPrimary1XAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeColorControlClusterReadPrimary1XAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0011 };
     READ_ATTRIBUTES("ReadColorControlPrimary1X", COLOR_CONTROL_CLUSTER_ID);
@@ -909,7 +915,7 @@ uint16_t encodeColorControlClusterReadPrimary1XAttribute(uint8_t * buffer, uint1
 /*
  * Attribute Primary1Y
  */
-uint16_t encodeColorControlClusterReadPrimary1YAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeColorControlClusterReadPrimary1YAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0012 };
     READ_ATTRIBUTES("ReadColorControlPrimary1Y", COLOR_CONTROL_CLUSTER_ID);
@@ -919,7 +925,7 @@ uint16_t encodeColorControlClusterReadPrimary1YAttribute(uint8_t * buffer, uint1
  * Attribute Primary1Intensity
  */
 uint16_t encodeColorControlClusterReadPrimary1IntensityAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 uint8_t destination_endpoint)
+                                                                 EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0013 };
     READ_ATTRIBUTES("ReadColorControlPrimary1Intensity", COLOR_CONTROL_CLUSTER_ID);
@@ -928,7 +934,7 @@ uint16_t encodeColorControlClusterReadPrimary1IntensityAttribute(uint8_t * buffe
 /*
  * Attribute Primary2X
  */
-uint16_t encodeColorControlClusterReadPrimary2XAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeColorControlClusterReadPrimary2XAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0015 };
     READ_ATTRIBUTES("ReadColorControlPrimary2X", COLOR_CONTROL_CLUSTER_ID);
@@ -937,7 +943,7 @@ uint16_t encodeColorControlClusterReadPrimary2XAttribute(uint8_t * buffer, uint1
 /*
  * Attribute Primary2Y
  */
-uint16_t encodeColorControlClusterReadPrimary2YAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeColorControlClusterReadPrimary2YAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0016 };
     READ_ATTRIBUTES("ReadColorControlPrimary2Y", COLOR_CONTROL_CLUSTER_ID);
@@ -947,7 +953,7 @@ uint16_t encodeColorControlClusterReadPrimary2YAttribute(uint8_t * buffer, uint1
  * Attribute Primary2Intensity
  */
 uint16_t encodeColorControlClusterReadPrimary2IntensityAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 uint8_t destination_endpoint)
+                                                                 EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0017 };
     READ_ATTRIBUTES("ReadColorControlPrimary2Intensity", COLOR_CONTROL_CLUSTER_ID);
@@ -956,7 +962,7 @@ uint16_t encodeColorControlClusterReadPrimary2IntensityAttribute(uint8_t * buffe
 /*
  * Attribute Primary3X
  */
-uint16_t encodeColorControlClusterReadPrimary3XAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeColorControlClusterReadPrimary3XAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0019 };
     READ_ATTRIBUTES("ReadColorControlPrimary3X", COLOR_CONTROL_CLUSTER_ID);
@@ -965,7 +971,7 @@ uint16_t encodeColorControlClusterReadPrimary3XAttribute(uint8_t * buffer, uint1
 /*
  * Attribute Primary3Y
  */
-uint16_t encodeColorControlClusterReadPrimary3YAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeColorControlClusterReadPrimary3YAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x001A };
     READ_ATTRIBUTES("ReadColorControlPrimary3Y", COLOR_CONTROL_CLUSTER_ID);
@@ -975,7 +981,7 @@ uint16_t encodeColorControlClusterReadPrimary3YAttribute(uint8_t * buffer, uint1
  * Attribute Primary3Intensity
  */
 uint16_t encodeColorControlClusterReadPrimary3IntensityAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 uint8_t destination_endpoint)
+                                                                 EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x001B };
     READ_ATTRIBUTES("ReadColorControlPrimary3Intensity", COLOR_CONTROL_CLUSTER_ID);
@@ -984,7 +990,7 @@ uint16_t encodeColorControlClusterReadPrimary3IntensityAttribute(uint8_t * buffe
 /*
  * Attribute Primary4X
  */
-uint16_t encodeColorControlClusterReadPrimary4XAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeColorControlClusterReadPrimary4XAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0020 };
     READ_ATTRIBUTES("ReadColorControlPrimary4X", COLOR_CONTROL_CLUSTER_ID);
@@ -993,7 +999,7 @@ uint16_t encodeColorControlClusterReadPrimary4XAttribute(uint8_t * buffer, uint1
 /*
  * Attribute Primary4Y
  */
-uint16_t encodeColorControlClusterReadPrimary4YAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeColorControlClusterReadPrimary4YAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0021 };
     READ_ATTRIBUTES("ReadColorControlPrimary4Y", COLOR_CONTROL_CLUSTER_ID);
@@ -1003,7 +1009,7 @@ uint16_t encodeColorControlClusterReadPrimary4YAttribute(uint8_t * buffer, uint1
  * Attribute Primary4Intensity
  */
 uint16_t encodeColorControlClusterReadPrimary4IntensityAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 uint8_t destination_endpoint)
+                                                                 EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0022 };
     READ_ATTRIBUTES("ReadColorControlPrimary4Intensity", COLOR_CONTROL_CLUSTER_ID);
@@ -1012,7 +1018,7 @@ uint16_t encodeColorControlClusterReadPrimary4IntensityAttribute(uint8_t * buffe
 /*
  * Attribute Primary5X
  */
-uint16_t encodeColorControlClusterReadPrimary5XAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeColorControlClusterReadPrimary5XAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0024 };
     READ_ATTRIBUTES("ReadColorControlPrimary5X", COLOR_CONTROL_CLUSTER_ID);
@@ -1021,7 +1027,7 @@ uint16_t encodeColorControlClusterReadPrimary5XAttribute(uint8_t * buffer, uint1
 /*
  * Attribute Primary5Y
  */
-uint16_t encodeColorControlClusterReadPrimary5YAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeColorControlClusterReadPrimary5YAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0025 };
     READ_ATTRIBUTES("ReadColorControlPrimary5Y", COLOR_CONTROL_CLUSTER_ID);
@@ -1031,7 +1037,7 @@ uint16_t encodeColorControlClusterReadPrimary5YAttribute(uint8_t * buffer, uint1
  * Attribute Primary5Intensity
  */
 uint16_t encodeColorControlClusterReadPrimary5IntensityAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 uint8_t destination_endpoint)
+                                                                 EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0026 };
     READ_ATTRIBUTES("ReadColorControlPrimary5Intensity", COLOR_CONTROL_CLUSTER_ID);
@@ -1040,7 +1046,7 @@ uint16_t encodeColorControlClusterReadPrimary5IntensityAttribute(uint8_t * buffe
 /*
  * Attribute Primary6X
  */
-uint16_t encodeColorControlClusterReadPrimary6XAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeColorControlClusterReadPrimary6XAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0028 };
     READ_ATTRIBUTES("ReadColorControlPrimary6X", COLOR_CONTROL_CLUSTER_ID);
@@ -1049,7 +1055,7 @@ uint16_t encodeColorControlClusterReadPrimary6XAttribute(uint8_t * buffer, uint1
 /*
  * Attribute Primary6Y
  */
-uint16_t encodeColorControlClusterReadPrimary6YAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeColorControlClusterReadPrimary6YAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0029 };
     READ_ATTRIBUTES("ReadColorControlPrimary6Y", COLOR_CONTROL_CLUSTER_ID);
@@ -1059,7 +1065,7 @@ uint16_t encodeColorControlClusterReadPrimary6YAttribute(uint8_t * buffer, uint1
  * Attribute Primary6Intensity
  */
 uint16_t encodeColorControlClusterReadPrimary6IntensityAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 uint8_t destination_endpoint)
+                                                                 EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x002A };
     READ_ATTRIBUTES("ReadColorControlPrimary6Intensity", COLOR_CONTROL_CLUSTER_ID);
@@ -1069,7 +1075,7 @@ uint16_t encodeColorControlClusterReadPrimary6IntensityAttribute(uint8_t * buffe
  * Attribute EnhancedCurrentHue
  */
 uint16_t encodeColorControlClusterReadEnhancedCurrentHueAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                  uint8_t destination_endpoint)
+                                                                  EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x4000 };
     READ_ATTRIBUTES("ReadColorControlEnhancedCurrentHue", COLOR_CONTROL_CLUSTER_ID);
@@ -1079,7 +1085,7 @@ uint16_t encodeColorControlClusterReadEnhancedCurrentHueAttribute(uint8_t * buff
  * Attribute EnhancedColorMode
  */
 uint16_t encodeColorControlClusterReadEnhancedColorModeAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 uint8_t destination_endpoint)
+                                                                 EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x4001 };
     READ_ATTRIBUTES("ReadColorControlEnhancedColorMode", COLOR_CONTROL_CLUSTER_ID);
@@ -1088,7 +1094,8 @@ uint16_t encodeColorControlClusterReadEnhancedColorModeAttribute(uint8_t * buffe
 /*
  * Attribute ColorLoopActive
  */
-uint16_t encodeColorControlClusterReadColorLoopActiveAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeColorControlClusterReadColorLoopActiveAttribute(uint8_t * buffer, uint16_t buf_length,
+                                                               EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x4002 };
     READ_ATTRIBUTES("ReadColorControlColorLoopActive", COLOR_CONTROL_CLUSTER_ID);
@@ -1098,7 +1105,7 @@ uint16_t encodeColorControlClusterReadColorLoopActiveAttribute(uint8_t * buffer,
  * Attribute ColorLoopDirection
  */
 uint16_t encodeColorControlClusterReadColorLoopDirectionAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                  uint8_t destination_endpoint)
+                                                                  EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x4003 };
     READ_ATTRIBUTES("ReadColorControlColorLoopDirection", COLOR_CONTROL_CLUSTER_ID);
@@ -1107,7 +1114,7 @@ uint16_t encodeColorControlClusterReadColorLoopDirectionAttribute(uint8_t * buff
 /*
  * Attribute ColorLoopTime
  */
-uint16_t encodeColorControlClusterReadColorLoopTimeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeColorControlClusterReadColorLoopTimeAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x4004 };
     READ_ATTRIBUTES("ReadColorControlColorLoopTime", COLOR_CONTROL_CLUSTER_ID);
@@ -1117,7 +1124,7 @@ uint16_t encodeColorControlClusterReadColorLoopTimeAttribute(uint8_t * buffer, u
  * Attribute ColorLoopStartEnhancedHue
  */
 uint16_t encodeColorControlClusterReadColorLoopStartEnhancedHueAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                         uint8_t destination_endpoint)
+                                                                         EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x4005 };
     READ_ATTRIBUTES("ReadColorControlColorLoopStartEnhancedHue", COLOR_CONTROL_CLUSTER_ID);
@@ -1127,7 +1134,7 @@ uint16_t encodeColorControlClusterReadColorLoopStartEnhancedHueAttribute(uint8_t
  * Attribute ColorLoopStoredEnhancedHue
  */
 uint16_t encodeColorControlClusterReadColorLoopStoredEnhancedHueAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                          uint8_t destination_endpoint)
+                                                                          EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x4006 };
     READ_ATTRIBUTES("ReadColorControlColorLoopStoredEnhancedHue", COLOR_CONTROL_CLUSTER_ID);
@@ -1137,7 +1144,7 @@ uint16_t encodeColorControlClusterReadColorLoopStoredEnhancedHueAttribute(uint8_
  * Attribute ColorCapabilities
  */
 uint16_t encodeColorControlClusterReadColorCapabilitiesAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 uint8_t destination_endpoint)
+                                                                 EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x400A };
     READ_ATTRIBUTES("ReadColorControlColorCapabilities", COLOR_CONTROL_CLUSTER_ID);
@@ -1147,7 +1154,7 @@ uint16_t encodeColorControlClusterReadColorCapabilitiesAttribute(uint8_t * buffe
  * Attribute ColorTempPhysicalMinMireds
  */
 uint16_t encodeColorControlClusterReadColorTempPhysicalMinMiredsAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                          uint8_t destination_endpoint)
+                                                                          EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x400B };
     READ_ATTRIBUTES("ReadColorControlColorTempPhysicalMinMireds", COLOR_CONTROL_CLUSTER_ID);
@@ -1157,7 +1164,7 @@ uint16_t encodeColorControlClusterReadColorTempPhysicalMinMiredsAttribute(uint8_
  * Attribute ColorTempPhysicalMaxMireds
  */
 uint16_t encodeColorControlClusterReadColorTempPhysicalMaxMiredsAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                          uint8_t destination_endpoint)
+                                                                          EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x400C };
     READ_ATTRIBUTES("ReadColorControlColorTempPhysicalMaxMireds", COLOR_CONTROL_CLUSTER_ID);
@@ -1167,7 +1174,7 @@ uint16_t encodeColorControlClusterReadColorTempPhysicalMaxMiredsAttribute(uint8_
  * Attribute CoupleColorTempToLevelMinMireds
  */
 uint16_t encodeColorControlClusterReadCoupleColorTempToLevelMinMiredsAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                               uint8_t destination_endpoint)
+                                                                               EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x400D };
     READ_ATTRIBUTES("ReadColorControlCoupleColorTempToLevelMinMireds", COLOR_CONTROL_CLUSTER_ID);
@@ -1177,14 +1184,14 @@ uint16_t encodeColorControlClusterReadCoupleColorTempToLevelMinMiredsAttribute(u
  * Attribute StartUpColorTemperatureMireds
  */
 uint16_t encodeColorControlClusterReadStartUpColorTemperatureMiredsAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                             uint8_t destination_endpoint)
+                                                                             EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x4010 };
     READ_ATTRIBUTES("ReadColorControlStartUpColorTemperatureMireds", COLOR_CONTROL_CLUSTER_ID);
 }
 
 uint16_t encodeColorControlClusterWriteStartUpColorTemperatureMiredsAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                              uint8_t destination_endpoint,
+                                                                              EndpointId destination_endpoint,
                                                                               uint16_t startUpColorTemperatureMireds)
 {
     uint16_t attr_id  = 0x4010;
@@ -1253,7 +1260,7 @@ uint16_t encodeColorControlClusterWriteStartUpColorTemperatureMiredsAttribute(ui
 /*
  * Command ClearAllPINCodes
  */
-uint16_t encodeDoorLockClusterClearAllPINCodesCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeDoorLockClusterClearAllPINCodesCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     const char * kName = "DoorLockClearAllPINCodes";
     COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x08);
@@ -1263,7 +1270,7 @@ uint16_t encodeDoorLockClusterClearAllPINCodesCommand(uint8_t * buffer, uint16_t
 /*
  * Command ClearAllRFIDCodes
  */
-uint16_t encodeDoorLockClusterClearAllRFIDCodesCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeDoorLockClusterClearAllRFIDCodesCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     const char * kName = "DoorLockClearAllRFIDCodes";
     COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x19);
@@ -1273,7 +1280,7 @@ uint16_t encodeDoorLockClusterClearAllRFIDCodesCommand(uint8_t * buffer, uint16_
 /*
  * Command ClearHolidaySchedule
  */
-uint16_t encodeDoorLockClusterClearHolidayScheduleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterClearHolidayScheduleCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                           uint8_t holidayScheduleID)
 {
     const char * kName = "DoorLockClearHolidaySchedule";
@@ -1285,7 +1292,7 @@ uint16_t encodeDoorLockClusterClearHolidayScheduleCommand(uint8_t * buffer, uint
 /*
  * Command ClearPINCode
  */
-uint16_t encodeDoorLockClusterClearPINCodeCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterClearPINCodeCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                   uint16_t userID)
 {
     const char * kName = "DoorLockClearPINCode";
@@ -1297,7 +1304,7 @@ uint16_t encodeDoorLockClusterClearPINCodeCommand(uint8_t * buffer, uint16_t buf
 /*
  * Command ClearRFIDCode
  */
-uint16_t encodeDoorLockClusterClearRFIDCodeCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterClearRFIDCodeCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                    uint16_t userID)
 {
     const char * kName = "DoorLockClearRFIDCode";
@@ -1309,7 +1316,7 @@ uint16_t encodeDoorLockClusterClearRFIDCodeCommand(uint8_t * buffer, uint16_t bu
 /*
  * Command ClearWeekdaySchedule
  */
-uint16_t encodeDoorLockClusterClearWeekdayScheduleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterClearWeekdayScheduleCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                           uint8_t scheduleID, uint16_t userID)
 {
     const char * kName = "DoorLockClearWeekdaySchedule";
@@ -1322,7 +1329,7 @@ uint16_t encodeDoorLockClusterClearWeekdayScheduleCommand(uint8_t * buffer, uint
 /*
  * Command ClearYearDaySchedule
  */
-uint16_t encodeDoorLockClusterClearYearDayScheduleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterClearYearDayScheduleCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                           uint8_t scheduleID, uint16_t userID)
 {
     const char * kName = "DoorLockClearYearDaySchedule";
@@ -1335,7 +1342,7 @@ uint16_t encodeDoorLockClusterClearYearDayScheduleCommand(uint8_t * buffer, uint
 /*
  * Command GetHolidaySchedule
  */
-uint16_t encodeDoorLockClusterGetHolidayScheduleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterGetHolidayScheduleCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                         uint8_t holidayScheduleID)
 {
     const char * kName = "DoorLockGetHolidaySchedule";
@@ -1347,7 +1354,7 @@ uint16_t encodeDoorLockClusterGetHolidayScheduleCommand(uint8_t * buffer, uint16
 /*
  * Command GetPINCode
  */
-uint16_t encodeDoorLockClusterGetPINCodeCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterGetPINCodeCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                 uint16_t userID)
 {
     const char * kName = "DoorLockGetPINCode";
@@ -1359,7 +1366,7 @@ uint16_t encodeDoorLockClusterGetPINCodeCommand(uint8_t * buffer, uint16_t buf_l
 /*
  * Command GetRFIDCode
  */
-uint16_t encodeDoorLockClusterGetRFIDCodeCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterGetRFIDCodeCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                  uint16_t userID)
 {
     const char * kName = "DoorLockGetRFIDCode";
@@ -1371,7 +1378,7 @@ uint16_t encodeDoorLockClusterGetRFIDCodeCommand(uint8_t * buffer, uint16_t buf_
 /*
  * Command GetUserType
  */
-uint16_t encodeDoorLockClusterGetUserTypeCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterGetUserTypeCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                  uint16_t userID)
 {
     const char * kName = "DoorLockGetUserType";
@@ -1383,7 +1390,7 @@ uint16_t encodeDoorLockClusterGetUserTypeCommand(uint8_t * buffer, uint16_t buf_
 /*
  * Command GetWeekdaySchedule
  */
-uint16_t encodeDoorLockClusterGetWeekdayScheduleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterGetWeekdayScheduleCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                         uint8_t scheduleID, uint16_t userID)
 {
     const char * kName = "DoorLockGetWeekdaySchedule";
@@ -1396,7 +1403,7 @@ uint16_t encodeDoorLockClusterGetWeekdayScheduleCommand(uint8_t * buffer, uint16
 /*
  * Command GetYearDaySchedule
  */
-uint16_t encodeDoorLockClusterGetYearDayScheduleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterGetYearDayScheduleCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                         uint8_t scheduleID, uint16_t userID)
 {
     const char * kName = "DoorLockGetYearDaySchedule";
@@ -1409,7 +1416,7 @@ uint16_t encodeDoorLockClusterGetYearDayScheduleCommand(uint8_t * buffer, uint16
 /*
  * Command LockDoor
  */
-uint16_t encodeDoorLockClusterLockDoorCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterLockDoorCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                               char * pINOrRFIDCode)
 {
     const char * kName = "DoorLockLockDoor";
@@ -1421,7 +1428,7 @@ uint16_t encodeDoorLockClusterLockDoorCommand(uint8_t * buffer, uint16_t buf_len
 /*
  * Command SetHolidaySchedule
  */
-uint16_t encodeDoorLockClusterSetHolidayScheduleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterSetHolidayScheduleCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                         uint8_t holidayScheduleID, uint32_t localStartTime, uint32_t localEndTime,
                                                         uint8_t operatingModeDuringHoliday)
 {
@@ -1437,7 +1444,7 @@ uint16_t encodeDoorLockClusterSetHolidayScheduleCommand(uint8_t * buffer, uint16
 /*
  * Command SetPINCode
  */
-uint16_t encodeDoorLockClusterSetPINCodeCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterSetPINCodeCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                 uint16_t userID, uint8_t userStatus, uint8_t userType, char * pIN)
 {
     const char * kName = "DoorLockSetPINCode";
@@ -1452,7 +1459,7 @@ uint16_t encodeDoorLockClusterSetPINCodeCommand(uint8_t * buffer, uint16_t buf_l
 /*
  * Command SetRFIDCode
  */
-uint16_t encodeDoorLockClusterSetRFIDCodeCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterSetRFIDCodeCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                  uint16_t userID, uint8_t userStatus, uint8_t userType, char * rFIDCode)
 {
     const char * kName = "DoorLockSetRFIDCode";
@@ -1467,7 +1474,7 @@ uint16_t encodeDoorLockClusterSetRFIDCodeCommand(uint8_t * buffer, uint16_t buf_
 /*
  * Command SetUserType
  */
-uint16_t encodeDoorLockClusterSetUserTypeCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterSetUserTypeCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                  uint16_t userID, uint8_t userType)
 {
     const char * kName = "DoorLockSetUserType";
@@ -1480,7 +1487,7 @@ uint16_t encodeDoorLockClusterSetUserTypeCommand(uint8_t * buffer, uint16_t buf_
 /*
  * Command SetWeekdaySchedule
  */
-uint16_t encodeDoorLockClusterSetWeekdayScheduleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterSetWeekdayScheduleCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                         uint8_t scheduleID, uint16_t userID, uint8_t daysMask, uint8_t startHour,
                                                         uint8_t startMinute, uint8_t endHour, uint8_t endMinute)
 {
@@ -1499,7 +1506,7 @@ uint16_t encodeDoorLockClusterSetWeekdayScheduleCommand(uint8_t * buffer, uint16
 /*
  * Command SetYearDaySchedule
  */
-uint16_t encodeDoorLockClusterSetYearDayScheduleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterSetYearDayScheduleCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                         uint8_t scheduleID, uint16_t userID, uint32_t localStartTime,
                                                         uint32_t localEndTime)
 {
@@ -1515,7 +1522,7 @@ uint16_t encodeDoorLockClusterSetYearDayScheduleCommand(uint8_t * buffer, uint16
 /*
  * Command UnlockDoor
  */
-uint16_t encodeDoorLockClusterUnlockDoorCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterUnlockDoorCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                 char * pINOrRFIDCode)
 {
     const char * kName = "DoorLockUnlockDoor";
@@ -1527,7 +1534,7 @@ uint16_t encodeDoorLockClusterUnlockDoorCommand(uint8_t * buffer, uint16_t buf_l
 /*
  * Command UnlockWithTimeout
  */
-uint16_t encodeDoorLockClusterUnlockWithTimeoutCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterUnlockWithTimeoutCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                        uint16_t timeoutInSeconds, char * pINOrRFIDCode)
 {
     const char * kName = "DoorLockUnlockWithTimeout";
@@ -1537,7 +1544,7 @@ uint16_t encodeDoorLockClusterUnlockWithTimeoutCommand(uint8_t * buffer, uint16_
     COMMAND_FOOTER(kName);
 }
 
-uint16_t encodeDoorLockClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeDoorLockClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     DISCOVER_ATTRIBUTES("DiscoverDoorLockAttributes", DOOR_LOCK_CLUSTER_ID);
 }
@@ -1545,13 +1552,13 @@ uint16_t encodeDoorLockClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_
 /*
  * Attribute LockState
  */
-uint16_t encodeDoorLockClusterReadLockStateAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeDoorLockClusterReadLockStateAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0000 };
     READ_ATTRIBUTES("ReadDoorLockLockState", DOOR_LOCK_CLUSTER_ID);
 }
 
-uint16_t encodeDoorLockClusterReportLockStateAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeDoorLockClusterReportLockStateAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                        uint16_t min_interval, uint16_t max_interval)
 {
     uint16_t attr_id  = 0x0000;
@@ -1562,7 +1569,7 @@ uint16_t encodeDoorLockClusterReportLockStateAttribute(uint8_t * buffer, uint16_
 /*
  * Attribute LockType
  */
-uint16_t encodeDoorLockClusterReadLockTypeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeDoorLockClusterReadLockTypeAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0001 };
     READ_ATTRIBUTES("ReadDoorLockLockType", DOOR_LOCK_CLUSTER_ID);
@@ -1571,7 +1578,7 @@ uint16_t encodeDoorLockClusterReadLockTypeAttribute(uint8_t * buffer, uint16_t b
 /*
  * Attribute ActuatorEnabled
  */
-uint16_t encodeDoorLockClusterReadActuatorEnabledAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeDoorLockClusterReadActuatorEnabledAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0002 };
     READ_ATTRIBUTES("ReadDoorLockActuatorEnabled", DOOR_LOCK_CLUSTER_ID);
@@ -1628,7 +1635,7 @@ uint16_t encodeGroupsClusterAddGroupIfIdentifyingCommand(uint8_t * buffer, uint1
 /*
  * Command GetGroupMembership
  */
-uint16_t encodeGroupsClusterGetGroupMembershipCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeGroupsClusterGetGroupMembershipCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                       uint8_t groupCount, uint16_t groupList)
 {
     const char * kName = "GroupsGetGroupMembership";
@@ -1641,7 +1648,7 @@ uint16_t encodeGroupsClusterGetGroupMembershipCommand(uint8_t * buffer, uint16_t
 /*
  * Command RemoveAllGroups
  */
-uint16_t encodeGroupsClusterRemoveAllGroupsCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeGroupsClusterRemoveAllGroupsCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     const char * kName = "GroupsRemoveAllGroups";
     COMMAND_HEADER(kName, GROUPS_CLUSTER_ID, 0x04);
@@ -1672,7 +1679,7 @@ uint16_t encodeGroupsClusterViewGroupCommand(uint8_t * buffer, uint16_t buf_leng
     COMMAND_FOOTER(kName);
 }
 
-uint16_t encodeGroupsClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeGroupsClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     DISCOVER_ATTRIBUTES("DiscoverGroupsAttributes", GROUPS_CLUSTER_ID);
 }
@@ -1680,7 +1687,7 @@ uint16_t encodeGroupsClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_le
 /*
  * Attribute NameSupport
  */
-uint16_t encodeGroupsClusterReadNameSupportAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeGroupsClusterReadNameSupportAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0000 };
     READ_ATTRIBUTES("ReadGroupsNameSupport", GROUPS_CLUSTER_ID);
@@ -1705,7 +1712,7 @@ uint16_t encodeGroupsClusterReadNameSupportAttribute(uint8_t * buffer, uint16_t 
 /*
  * Command ZoneEnrollResponse
  */
-uint16_t encodeIASZoneClusterZoneEnrollResponseCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeIASZoneClusterZoneEnrollResponseCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                        uint8_t enrollResponseCode, uint8_t zoneID)
 {
     const char * kName = "IASZoneZoneEnrollResponse";
@@ -1715,7 +1722,7 @@ uint16_t encodeIASZoneClusterZoneEnrollResponseCommand(uint8_t * buffer, uint16_
     COMMAND_FOOTER(kName);
 }
 
-uint16_t encodeIASZoneClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeIASZoneClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     DISCOVER_ATTRIBUTES("DiscoverIASZoneAttributes", IAS_ZONE_CLUSTER_ID);
 }
@@ -1723,7 +1730,7 @@ uint16_t encodeIASZoneClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_l
 /*
  * Attribute ZoneState
  */
-uint16_t encodeIASZoneClusterReadZoneStateAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeIASZoneClusterReadZoneStateAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0000 };
     READ_ATTRIBUTES("ReadIASZoneZoneState", IAS_ZONE_CLUSTER_ID);
@@ -1732,7 +1739,7 @@ uint16_t encodeIASZoneClusterReadZoneStateAttribute(uint8_t * buffer, uint16_t b
 /*
  * Attribute ZoneType
  */
-uint16_t encodeIASZoneClusterReadZoneTypeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeIASZoneClusterReadZoneTypeAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0001 };
     READ_ATTRIBUTES("ReadIASZoneZoneType", IAS_ZONE_CLUSTER_ID);
@@ -1741,7 +1748,7 @@ uint16_t encodeIASZoneClusterReadZoneTypeAttribute(uint8_t * buffer, uint16_t bu
 /*
  * Attribute ZoneStatus
  */
-uint16_t encodeIASZoneClusterReadZoneStatusAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeIASZoneClusterReadZoneStatusAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0002 };
     READ_ATTRIBUTES("ReadIASZoneZoneStatus", IAS_ZONE_CLUSTER_ID);
@@ -1750,13 +1757,13 @@ uint16_t encodeIASZoneClusterReadZoneStatusAttribute(uint8_t * buffer, uint16_t 
 /*
  * Attribute IASCIEAddress
  */
-uint16_t encodeIASZoneClusterReadIASCIEAddressAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeIASZoneClusterReadIASCIEAddressAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0010 };
     READ_ATTRIBUTES("ReadIASZoneIASCIEAddress", IAS_ZONE_CLUSTER_ID);
 }
 
-uint16_t encodeIASZoneClusterWriteIASCIEAddressAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeIASZoneClusterWriteIASCIEAddressAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                          uint64_t iASCIEAddress)
 {
     uint16_t attr_id  = 0x0010;
@@ -1767,7 +1774,7 @@ uint16_t encodeIASZoneClusterWriteIASCIEAddressAttribute(uint8_t * buffer, uint1
 /*
  * Attribute ZoneID
  */
-uint16_t encodeIASZoneClusterReadZoneIDAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeIASZoneClusterReadZoneIDAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0011 };
     READ_ATTRIBUTES("ReadIASZoneZoneID", IAS_ZONE_CLUSTER_ID);
@@ -1791,7 +1798,7 @@ uint16_t encodeIASZoneClusterReadZoneIDAttribute(uint8_t * buffer, uint16_t buf_
 /*
  * Command Identify
  */
-uint16_t encodeIdentifyClusterIdentifyCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeIdentifyClusterIdentifyCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                               uint16_t identifyTime)
 {
     const char * kName = "IdentifyIdentify";
@@ -1803,14 +1810,14 @@ uint16_t encodeIdentifyClusterIdentifyCommand(uint8_t * buffer, uint16_t buf_len
 /*
  * Command IdentifyQuery
  */
-uint16_t encodeIdentifyClusterIdentifyQueryCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeIdentifyClusterIdentifyQueryCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     const char * kName = "IdentifyIdentifyQuery";
     COMMAND_HEADER(kName, IDENTIFY_CLUSTER_ID, 0x01);
     COMMAND_FOOTER(kName);
 }
 
-uint16_t encodeIdentifyClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeIdentifyClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     DISCOVER_ATTRIBUTES("DiscoverIdentifyAttributes", IDENTIFY_CLUSTER_ID);
 }
@@ -1818,13 +1825,13 @@ uint16_t encodeIdentifyClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_
 /*
  * Attribute IdentifyTime
  */
-uint16_t encodeIdentifyClusterReadIdentifyTimeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeIdentifyClusterReadIdentifyTimeAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0000 };
     READ_ATTRIBUTES("ReadIdentifyIdentifyTime", IDENTIFY_CLUSTER_ID);
 }
 
-uint16_t encodeIdentifyClusterWriteIdentifyTimeAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeIdentifyClusterWriteIdentifyTimeAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                          uint16_t identifyTime)
 {
     uint16_t attr_id  = 0x0000;
@@ -1855,7 +1862,7 @@ uint16_t encodeIdentifyClusterWriteIdentifyTimeAttribute(uint8_t * buffer, uint1
 /*
  * Command Move
  */
-uint16_t encodeLevelClusterMoveCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint8_t moveMode,
+uint16_t encodeLevelClusterMoveCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint, uint8_t moveMode,
                                        uint8_t rate, uint8_t optionsMask, uint8_t optionsOverride)
 {
     const char * kName = "LevelMove";
@@ -1870,7 +1877,7 @@ uint16_t encodeLevelClusterMoveCommand(uint8_t * buffer, uint16_t buf_length, ui
 /*
  * Command MoveToLevel
  */
-uint16_t encodeLevelClusterMoveToLevelCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint8_t level,
+uint16_t encodeLevelClusterMoveToLevelCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint, uint8_t level,
                                               uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride)
 {
     const char * kName = "LevelMoveToLevel";
@@ -1885,7 +1892,7 @@ uint16_t encodeLevelClusterMoveToLevelCommand(uint8_t * buffer, uint16_t buf_len
 /*
  * Command MoveToLevelWithOnOff
  */
-uint16_t encodeLevelClusterMoveToLevelWithOnOffCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeLevelClusterMoveToLevelWithOnOffCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                        uint8_t level, uint16_t transitionTime, uint8_t optionsMask,
                                                        uint8_t optionsOverride)
 {
@@ -1901,7 +1908,7 @@ uint16_t encodeLevelClusterMoveToLevelWithOnOffCommand(uint8_t * buffer, uint16_
 /*
  * Command MoveWithOnOff
  */
-uint16_t encodeLevelClusterMoveWithOnOffCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeLevelClusterMoveWithOnOffCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                 uint8_t moveMode, uint8_t rate, uint8_t optionsMask, uint8_t optionsOverride)
 {
     const char * kName = "LevelMoveWithOnOff";
@@ -1916,7 +1923,7 @@ uint16_t encodeLevelClusterMoveWithOnOffCommand(uint8_t * buffer, uint16_t buf_l
 /*
  * Command Step
  */
-uint16_t encodeLevelClusterStepCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint8_t stepMode,
+uint16_t encodeLevelClusterStepCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint, uint8_t stepMode,
                                        uint8_t stepSize, uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride)
 {
     const char * kName = "LevelStep";
@@ -1932,7 +1939,7 @@ uint16_t encodeLevelClusterStepCommand(uint8_t * buffer, uint16_t buf_length, ui
 /*
  * Command StepWithOnOff
  */
-uint16_t encodeLevelClusterStepWithOnOffCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeLevelClusterStepWithOnOffCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                 uint8_t stepMode, uint8_t stepSize, uint16_t transitionTime, uint8_t optionsMask,
                                                 uint8_t optionsOverride)
 {
@@ -1949,7 +1956,7 @@ uint16_t encodeLevelClusterStepWithOnOffCommand(uint8_t * buffer, uint16_t buf_l
 /*
  * Command Stop
  */
-uint16_t encodeLevelClusterStopCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint, uint8_t optionsMask,
+uint16_t encodeLevelClusterStopCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint, uint8_t optionsMask,
                                        uint8_t optionsOverride)
 {
     const char * kName = "LevelStop";
@@ -1962,7 +1969,7 @@ uint16_t encodeLevelClusterStopCommand(uint8_t * buffer, uint16_t buf_length, ui
 /*
  * Command StopWithOnOff
  */
-uint16_t encodeLevelClusterStopWithOnOffCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeLevelClusterStopWithOnOffCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                 uint8_t optionsMask, uint8_t optionsOverride)
 {
     const char * kName = "LevelStopWithOnOff";
@@ -1972,7 +1979,7 @@ uint16_t encodeLevelClusterStopWithOnOffCommand(uint8_t * buffer, uint16_t buf_l
     COMMAND_FOOTER(kName);
 }
 
-uint16_t encodeLevelClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeLevelClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     DISCOVER_ATTRIBUTES("DiscoverLevelAttributes", LEVEL_CLUSTER_ID);
 }
@@ -1980,13 +1987,13 @@ uint16_t encodeLevelClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_len
 /*
  * Attribute CurrentLevel
  */
-uint16_t encodeLevelClusterReadCurrentLevelAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeLevelClusterReadCurrentLevelAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0000 };
     READ_ATTRIBUTES("ReadLevelCurrentLevel", LEVEL_CLUSTER_ID);
 }
 
-uint16_t encodeLevelClusterReportCurrentLevelAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeLevelClusterReportCurrentLevelAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                        uint16_t min_interval, uint16_t max_interval, uint8_t change)
 {
     uint16_t attr_id  = 0x0000;
@@ -2012,7 +2019,7 @@ uint16_t encodeLevelClusterReportCurrentLevelAttribute(uint8_t * buffer, uint16_
 /*
  * Command Off
  */
-uint16_t encodeOnOffClusterOffCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeOnOffClusterOffCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     const char * kName = "OnOffOff";
     COMMAND_HEADER(kName, ON_OFF_CLUSTER_ID, 0x00);
@@ -2022,7 +2029,7 @@ uint16_t encodeOnOffClusterOffCommand(uint8_t * buffer, uint16_t buf_length, uin
 /*
  * Command On
  */
-uint16_t encodeOnOffClusterOnCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeOnOffClusterOnCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     const char * kName = "OnOffOn";
     COMMAND_HEADER(kName, ON_OFF_CLUSTER_ID, 0x01);
@@ -2032,14 +2039,14 @@ uint16_t encodeOnOffClusterOnCommand(uint8_t * buffer, uint16_t buf_length, uint
 /*
  * Command Toggle
  */
-uint16_t encodeOnOffClusterToggleCommand(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeOnOffClusterToggleCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     const char * kName = "OnOffToggle";
     COMMAND_HEADER(kName, ON_OFF_CLUSTER_ID, 0x02);
     COMMAND_FOOTER(kName);
 }
 
-uint16_t encodeOnOffClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeOnOffClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     DISCOVER_ATTRIBUTES("DiscoverOnOffAttributes", ON_OFF_CLUSTER_ID);
 }
@@ -2047,13 +2054,13 @@ uint16_t encodeOnOffClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_len
 /*
  * Attribute OnOff
  */
-uint16_t encodeOnOffClusterReadOnOffAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeOnOffClusterReadOnOffAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0000 };
     READ_ATTRIBUTES("ReadOnOffOnOff", ON_OFF_CLUSTER_ID);
 }
 
-uint16_t encodeOnOffClusterReportOnOffAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint,
+uint16_t encodeOnOffClusterReportOnOffAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint,
                                                 uint16_t min_interval, uint16_t max_interval)
 {
     uint16_t attr_id  = 0x0000;
@@ -2094,7 +2101,7 @@ uint16_t encodeOnOffClusterReportOnOffAttribute(uint8_t * buffer, uint16_t buf_l
  * Command AddScene
  */
 uint16_t encodeScenesClusterAddSceneCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint, GroupId groupID,
-                                            uint8_t sceneID, uint16_t transitionTime, char * sceneName, uint16_t clusterId,
+                                            uint8_t sceneID, uint16_t transitionTime, char * sceneName, ClusterId clusterId,
                                             char * extensionFieldSet)
 {
     const char * kName = "ScenesAddScene";
@@ -2185,7 +2192,7 @@ uint16_t encodeScenesClusterViewSceneCommand(uint8_t * buffer, uint16_t buf_leng
     COMMAND_FOOTER(kName);
 }
 
-uint16_t encodeScenesClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeScenesClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     DISCOVER_ATTRIBUTES("DiscoverScenesAttributes", SCENES_CLUSTER_ID);
 }
@@ -2193,7 +2200,7 @@ uint16_t encodeScenesClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_le
 /*
  * Attribute SceneCount
  */
-uint16_t encodeScenesClusterReadSceneCountAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeScenesClusterReadSceneCountAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0000 };
     READ_ATTRIBUTES("ReadScenesSceneCount", SCENES_CLUSTER_ID);
@@ -2202,7 +2209,7 @@ uint16_t encodeScenesClusterReadSceneCountAttribute(uint8_t * buffer, uint16_t b
 /*
  * Attribute CurrentScene
  */
-uint16_t encodeScenesClusterReadCurrentSceneAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeScenesClusterReadCurrentSceneAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0001 };
     READ_ATTRIBUTES("ReadScenesCurrentScene", SCENES_CLUSTER_ID);
@@ -2211,7 +2218,7 @@ uint16_t encodeScenesClusterReadCurrentSceneAttribute(uint8_t * buffer, uint16_t
 /*
  * Attribute CurrentGroup
  */
-uint16_t encodeScenesClusterReadCurrentGroupAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeScenesClusterReadCurrentGroupAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0002 };
     READ_ATTRIBUTES("ReadScenesCurrentGroup", SCENES_CLUSTER_ID);
@@ -2220,7 +2227,7 @@ uint16_t encodeScenesClusterReadCurrentGroupAttribute(uint8_t * buffer, uint16_t
 /*
  * Attribute SceneValid
  */
-uint16_t encodeScenesClusterReadSceneValidAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeScenesClusterReadSceneValidAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0003 };
     READ_ATTRIBUTES("ReadScenesSceneValid", SCENES_CLUSTER_ID);
@@ -2229,7 +2236,7 @@ uint16_t encodeScenesClusterReadSceneValidAttribute(uint8_t * buffer, uint16_t b
 /*
  * Attribute NameSupport
  */
-uint16_t encodeScenesClusterReadNameSupportAttribute(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeScenesClusterReadNameSupportAttribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0004 };
     READ_ATTRIBUTES("ReadScenesNameSupport", SCENES_CLUSTER_ID);
@@ -2249,7 +2256,8 @@ uint16_t encodeScenesClusterReadNameSupportAttribute(uint8_t * buffer, uint16_t 
 | * MaxMeasuredValue                                                  | 0x0002 |
 \*----------------------------------------------------------------------------*/
 
-uint16_t encodeTemperatureMeasurementClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, uint8_t destination_endpoint)
+uint16_t encodeTemperatureMeasurementClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length,
+                                                               EndpointId destination_endpoint)
 {
     DISCOVER_ATTRIBUTES("DiscoverTemperatureMeasurementAttributes", TEMPERATURE_MEASUREMENT_CLUSTER_ID);
 }
@@ -2258,14 +2266,14 @@ uint16_t encodeTemperatureMeasurementClusterDiscoverAttributes(uint8_t * buffer,
  * Attribute MeasuredValue
  */
 uint16_t encodeTemperatureMeasurementClusterReadMeasuredValueAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                       uint8_t destination_endpoint)
+                                                                       EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0000 };
     READ_ATTRIBUTES("ReadTemperatureMeasurementMeasuredValue", TEMPERATURE_MEASUREMENT_CLUSTER_ID);
 }
 
 uint16_t encodeTemperatureMeasurementClusterReportMeasuredValueAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                         uint8_t destination_endpoint, uint16_t min_interval,
+                                                                         EndpointId destination_endpoint, uint16_t min_interval,
                                                                          uint16_t max_interval, int16_t change)
 {
     uint16_t attr_id  = 0x0000;
@@ -2277,7 +2285,7 @@ uint16_t encodeTemperatureMeasurementClusterReportMeasuredValueAttribute(uint8_t
  * Attribute MinMeasuredValue
  */
 uint16_t encodeTemperatureMeasurementClusterReadMinMeasuredValueAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                          uint8_t destination_endpoint)
+                                                                          EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0001 };
     READ_ATTRIBUTES("ReadTemperatureMeasurementMinMeasuredValue", TEMPERATURE_MEASUREMENT_CLUSTER_ID);
@@ -2287,7 +2295,7 @@ uint16_t encodeTemperatureMeasurementClusterReadMinMeasuredValueAttribute(uint8_
  * Attribute MaxMeasuredValue
  */
 uint16_t encodeTemperatureMeasurementClusterReadMaxMeasuredValueAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                          uint8_t destination_endpoint)
+                                                                          EndpointId destination_endpoint)
 {
     uint16_t attr_ids[] = { 0x0002 };
     READ_ATTRIBUTES("ReadTemperatureMeasurementMaxMeasuredValue", TEMPERATURE_MEASUREMENT_CLUSTER_ID);


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Some code in src/app is still using `uint8_t` when it should use `EndpointId`

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Search-and-replace for `uint8_t destination_endpoint`, plus the little bit at the top of `encoder.cpp` and the ias-client changes.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
