### PR TITLE
Add Workflow for ZAP templates generation

### DIFF
--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -1,0 +1,53 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: ZAP
+
+on:
+    push:
+    pull_request:
+
+jobs:
+    templates:
+        name: ZAP templates generation
+
+        runs-on: ubuntu-latest
+
+        strategy:
+           matrix:
+            node-version: [12.x]
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  submodules: true
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v1
+              with:
+                node-version: ${{ matrix.node-version }}
+
+            - run: sudo apt-get update
+            - run: sudo apt-get install --fix-missing libpixman-1-dev libcairo-dev libsdl-pango-dev libjpeg-dev libgif-dev
+            - name: Setup ZAP
+              run: |
+                cd third_party/zap/repo/
+                git checkout master
+                git pull
+                npm ci
+                npm run version-stamp
+                npm rebuild canvas --update-binary
+                npm run build-spa
+            - name: Generate
+              run: scripts/tools/zap_generate.sh examples/all-clusters-app/all-clusters-common/all-clusters-app.zap

--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -43,8 +43,6 @@ jobs:
             - name: Setup ZAP
               run: |
                 cd third_party/zap/repo/
-                git checkout master
-                git pull
                 npm ci
                 npm run version-stamp
                 npm rebuild canvas --update-binary

--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -22,21 +22,17 @@ jobs:
     templates:
         name: ZAP templates generation
 
-        runs-on: ubuntu-latest
-
-        strategy:
-           matrix:
-            node-version: [12.x]
+        runs-on: ubuntu-18.04
 
         steps:
             - name: Checkout
               uses: actions/checkout@v2
               with:
                   submodules: true
-            - name: Use Node.js ${{ matrix.node-version }}
+            - name: Use Node.js 12.x
               uses: actions/setup-node@v1
               with:
-                node-version: ${{ matrix.node-version }}
+                node-version: '12.x'
 
             - run: sudo apt-get update
             - run: sudo apt-get install --fix-missing libpixman-1-dev libcairo-dev libsdl-pango-dev libjpeg-dev libgif-dev


### PR DESCRIPTION
 #### Problem
 Since the ZAP templates are now within the CHIP repo, we needed a way to make sure that no could can break them.

 #### Summary of Changes
Added a GitHub workflow to generate all the files needed for the `all_clusters_app` since it's the most complex configuration that we have. This workflow is an adaptation of the one found in the ZAP repo. Unfortunately node wasn't able to run on the chip-build container. Probably because of permission issues ( Issue #3928)

 Fixes #3885 