### PR TITLE
Add light button control RPC to lighting-app

### DIFF
--- a/examples/lighting-app/lighting-common/pigweed_lighting.proto
+++ b/examples/lighting-app/lighting-common/pigweed_lighting.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package chip.rpc;
+
+message Empty {
+}
+
+message Button {
+  //0=FUNCTION 1=LIGHTING 2=THREAD_START 3=BLE_START
+  uint32 idx = 1;
+
+  // 0=release 1=push
+  uint32 action = 2;
+}
+
+service LightingService {
+  rpc ButtonEvent(Button) returns (Empty){}
+}

--- a/examples/lighting-app/nrfconnect/CMakeLists.txt
+++ b/examples/lighting-app/nrfconnect/CMakeLists.txt
@@ -32,6 +32,7 @@ target_sources(app PRIVATE
                main/AppTask.cpp
                main/LightingManager.cpp
                main/main.cpp
+               main/Rpc.cpp
                main/ZclCallbacks.cpp
                ${LIGHTING_COMMON}/gen/call-command-handler.cpp
                ${LIGHTING_COMMON}/gen/callback-stub.cpp
@@ -61,3 +62,33 @@ target_sources(app PRIVATE
                ${CHIP_ROOT}/src/app/clusters/on-off-server/on-off.cpp
                ${CHIP_ROOT}/src/app/clusters/level-control/level-control.cpp
                )
+
+if (CONFIG_CHIP_PW_RPC)
+
+set(PIGWEED_ROOT "${CHIP_ROOT}/third_party/pigweed/repo")
+include(${PIGWEED_ROOT}/pw_build/pigweed.cmake)
+include(${PIGWEED_ROOT}/pw_protobuf_compiler/proto.cmake)
+
+pw_set_backend(pw_log pw_log_basic)
+pw_set_backend(pw_assert pw_assert_log)
+pw_set_backend(pw_sys_io pw_sys_io.nrfconnect)
+set(dir_pw_third_party_nanopb PRESENT CACHE STRING ${CHIP_ROOT}/third_party/nanopb/repo FORCE)
+
+add_subdirectory(third_party/connectedhomeip/examples/platform/nrfconnect/pw_sys_io)
+add_subdirectory(third_party/connectedhomeip/third_party/nanopb/repo)
+add_subdirectory(third_party/connectedhomeip/third_party/pigweed/repo)
+
+pw_proto_library(pigweed_lighting_protolib
+  SOURCES
+    main/pigweed_lighting.proto
+)
+
+target_link_libraries(app PRIVATE
+   pigweed_lighting_protolib.nanopb_rpc
+   pw_hdlc_lite
+    pw_log
+    pw_rpc.nanopb.echo_service
+    pw_rpc.server
+)
+
+endif(CONFIG_CHIP_PW_RPC)

--- a/examples/lighting-app/nrfconnect/README.md
+++ b/examples/lighting-app/nrfconnect/README.md
@@ -14,18 +14,23 @@ into an existing CHIP network and can be controlled by this network.
 
 <hr>
 
--   [Overview](#overview)
-    -   [Bluetooth LE advertising](#bluetooth-le-advertising)
-    -   [Bluetooth LE rendezvous](#bluetooth-le-rendezvous)
--   [Requirements](#requirements)
--   [Device UI](#device-ui)
--   [Setting up the environment](#setting-up-the-environment)
-    -   [Using Docker container for setup](#using-docker-container-for-setup)
-    -   [Using native shell for setup](#using-native-shell-for-setup)
--   [Building](#building)
--   [Configuring the example](#configuring-the-example)
--   [Flashing and debugging](#flashing-and-debugging)
--   [Testing the example](#testing-the-example)
+-   [CHIP nRF Connect Lighting Example Application](#chip-nrf-connect-lighting-example-application)
+    -   [Overview](#overview)
+        -   [Bluetooth LE advertising](#bluetooth-le-advertising)
+        -   [Bluetooth LE rendezvous](#bluetooth-le-rendezvous)
+            -   [Thread provisioning](#thread-provisioning)
+    -   [Requirements](#requirements)
+    -   [Device UI](#device-ui)
+    -   [Setting up the environment](#setting-up-the-environment)
+        -   [Using Docker container for setup](#using-docker-container-for-setup)
+        -   [Using native shell for setup](#using-native-shell-for-setup)
+    -   [Building](#building)
+        -   [Removing build artifacts](#removing-build-artifacts)
+        -   [Building with release configuration](#building-with-release-configuration)
+    -   [Configuring the example](#configuring-the-example)
+    -   [Building with Pigweed RPCs](#building-with-pigweed-rpcs)
+    -   [Flashing and debugging](#flashing-and-debugging)
+    -   [Testing the example](#testing-the-example)
 
 <hr>
 
@@ -320,6 +325,18 @@ page.
 <hr>
 
 <a name="flashing"></a>
+
+## Building with Pigweed RPCs
+
+The RPCs in lighting-common/pigweed-lighting.proto can be used to control
+various functionalities of the lighting app from a USB-connected host computer.
+
+        $ cd <example-dir>
+        # First time build
+        $ west build -b nrf52840dk_nrf52840 -- -DOVERLAY_CONFIG=rpc.overlay
+
+        # Any subsequent build
+        $ west build -- -DOVERLAY_CONFIG=rpc.overlay
 
 ## Flashing and debugging
 

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -22,6 +22,7 @@
 #include "AppEvent.h"
 #include "LEDWidget.h"
 #include "LightingManager.h"
+#include "LogUtils.h"
 #include "QRCodeUtil.h"
 #include "Server.h"
 #include "Service.h"
@@ -42,10 +43,7 @@
 #include <system/SystemClock.h>
 
 #include <dk_buttons_and_leds.h>
-#include <logging/log.h>
 #include <zephyr.h>
-
-LOG_MODULE_DECLARE(app);
 
 namespace {
 

--- a/examples/lighting-app/nrfconnect/main/LightingManager.cpp
+++ b/examples/lighting-app/nrfconnect/main/LightingManager.cpp
@@ -19,11 +19,9 @@
 #include "LightingManager.h"
 
 #include "AppConfig.h"
+#include "LogUtils.h"
 
-#include <logging/log.h>
 #include <zephyr.h>
-
-LOG_MODULE_DECLARE(app);
 
 LightingManager LightingManager::sLight;
 
@@ -38,7 +36,7 @@ int LightingManager::Init(const char * gpioDeviceName, gpio_pin_t gpioPin)
 
     if (!mGPIODevice)
     {
-        LOG_ERR("Cannot find GPIO port %s", log_strdup(gpioDeviceName));
+        LOG_ERR("Cannot find GPIO port %s", LOG_STRDUP(gpioDeviceName));
         return -ENODEV;
     }
 

--- a/examples/lighting-app/nrfconnect/main/Rpc.cpp
+++ b/examples/lighting-app/nrfconnect/main/Rpc.cpp
@@ -1,0 +1,126 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "Rpc.h"
+#ifdef CONFIG_CHIP_PW_RPC
+#include "AppTask.h"
+#include "main/pigweed_lighting.rpc.pb.h"
+#include "pw_hdlc_lite/encoder.h"
+#include "pw_hdlc_lite/rpc_channel.h"
+#include "pw_hdlc_lite/rpc_packets.h"
+#include "pw_hdlc_lite/sys_io_stream.h"
+#include "pw_rpc/echo_service_nanopb.h"
+#include "pw_rpc/server.h"
+#include "pw_sys_io/sys_io.h"
+#include "pw_sys_io_nrfconnect/init.h"
+#include <array>
+#include <span>
+#include <string_view>
+#endif
+
+namespace chip {
+namespace rpc {
+
+#ifdef CONFIG_CHIP_PW_RPC
+
+class LightingService final : public generated::LightingService<LightingService>
+{
+public:
+    pw::Status ButtonEvent(ServerContext & ctx, const chip_rpc_Button & request, chip_rpc_Empty & response)
+    {
+        GetAppTask().ButtonEventHandler(request.action << request.idx /* button_state */, 1 << request.idx /* has_changed */);
+        return pw::Status::OK;
+    }
+};
+
+namespace {
+
+using std::byte;
+
+constexpr size_t kRpcTaskSize         = 4096;
+constexpr int kRpcPriority            = 5;
+constexpr size_t kMaxTransmissionUnit = 1500;
+
+K_THREAD_STACK_DEFINE(rpc_stack_area, kRpcTaskSize);
+struct k_thread rpc_thread_data;
+
+// Used to write HDLC data to pw::sys_io.
+pw::stream::SysIoWriter writer;
+
+// Set up the output channel for the pw_rpc server to use.
+pw::hdlc_lite::RpcChannelOutputBuffer<kMaxTransmissionUnit> hdlc_channel_output(writer, pw::hdlc_lite::kDefaultRpcAddress,
+                                                                                "HDLC channel");
+
+pw::rpc::Channel channels[] = { pw::rpc::Channel::Create<1>(&hdlc_channel_output) };
+
+// pw_rpc server with the HDLC channel.
+pw::rpc::Server server(channels);
+
+chip::rpc::LightingService lighting_service;
+
+void RegisterServices()
+{
+    server.RegisterService(lighting_service);
+}
+
+void Start()
+{
+    // Send log messages to HDLC address 1. This prevents logs from interfering
+    // with pw_rpc communications.
+    pw::log_basic::SetOutput(
+        [](std::string_view log) { pw::hdlc_lite::WriteInformationFrame(1, std::as_bytes(std::span(log)), writer); });
+
+    // Set up the server and start processing data.
+    RegisterServices();
+
+    // Buffer for decoding incoming HDLC frames.
+    std::array<std::byte, kMaxTransmissionUnit> input_buffer;
+
+    PW_LOG_INFO("Starting pw_rpc server");
+    pw::hdlc_lite::ReadAndProcessPackets(server, hdlc_channel_output, input_buffer);
+}
+
+} // namespace
+
+k_tid_t Init()
+{
+    pw_sys_io_Init();
+    k_tid_t tid = k_thread_create(&rpc_thread_data, rpc_stack_area, K_THREAD_STACK_SIZEOF(rpc_stack_area), RunRpcService, NULL,
+                                  NULL, NULL, kRpcPriority, 0, K_NO_WAIT);
+    return tid;
+}
+
+void RunRpcService(void *, void *, void *)
+{
+    Start();
+}
+
+#else // CONFIG_CHIP_PW_RPC
+class LightingService
+{
+};
+
+k_tid_t Init()
+{
+    return nullptr;
+}
+
+#endif
+
+} // namespace rpc
+} // namespace chip

--- a/examples/lighting-app/nrfconnect/main/include/AppTask.h
+++ b/examples/lighting-app/nrfconnect/main/include/AppTask.h
@@ -20,6 +20,7 @@
 
 #include "AppEvent.h"
 #include "LightingManager.h"
+#include "Rpc.h"
 
 #include <platform/CHIPDeviceLayer.h>
 
@@ -37,6 +38,7 @@ public:
     void UpdateClusterState();
 
 private:
+    friend class chip::rpc::LightingService;
     friend AppTask & GetAppTask(void);
 
     int Init();

--- a/examples/lighting-app/nrfconnect/main/include/Rpc.h
+++ b/examples/lighting-app/nrfconnect/main/include/Rpc.h
@@ -1,0 +1,33 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <kernel.h>
+
+namespace chip {
+namespace rpc {
+
+class LightingService;
+
+void RunRpcService(void *, void *, void *);
+
+k_tid_t Init();
+
+} // namespace rpc
+} // namespace chip

--- a/examples/lighting-app/nrfconnect/main/main.cpp
+++ b/examples/lighting-app/nrfconnect/main/main.cpp
@@ -17,13 +17,13 @@
  */
 
 #include "AppTask.h"
+#include "LogUtils.h"
+#include "Rpc.h"
 
 #include <platform/CHIPDeviceLayer.h>
 #include <support/CHIPMem.h>
 
-#include <logging/log.h>
-
-LOG_MODULE_REGISTER(app);
+#include <kernel.h>
 
 using namespace ::chip;
 using namespace ::chip::Inet;
@@ -31,6 +31,7 @@ using namespace ::chip::DeviceLayer;
 
 int main(void)
 {
+    chip::rpc::Init();
     int ret = 0;
 
     k_thread_priority_set(k_current_get(), K_PRIO_COOP(CONFIG_NUM_COOP_PRIORITIES - 1));

--- a/examples/lighting-app/nrfconnect/main/pigweed_lighting.options
+++ b/examples/lighting-app/nrfconnect/main/pigweed_lighting.options
@@ -1,0 +1,1 @@
+../../lighting-common/pigweed_lighting.options

--- a/examples/lighting-app/nrfconnect/main/pigweed_lighting.proto
+++ b/examples/lighting-app/nrfconnect/main/pigweed_lighting.proto
@@ -1,0 +1,1 @@
+../../lighting-common/pigweed_lighting.proto

--- a/examples/lighting-app/nrfconnect/rpc.overlay
+++ b/examples/lighting-app/nrfconnect/rpc.overlay
@@ -1,0 +1,34 @@
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# This file should be used as a configuration overlay to build Pigweed RPCs to
+# lighting-app:
+#
+# west build -b nrf52840dk_nrf52840 -- -DOVERLAY_CONFIG=rpc.overlay
+
+# Enable Pigweed RPC
+CONFIG_CHIP_PW_RPC=y
+
+# Add support for C++17 to build Pigweed components
+CONFIG_STD_CPP17=y
+
+# Add support for Zephyr console component to use it for Pigweed console purposes
+CONFIG_CONSOLE_SUBSYS=y
+CONFIG_CONSOLE_GETCHAR=y
+
+CONFIG_BOOT_BANNER=n
+CONFIG_LOG=n
+CONFIG_SHELL=n

--- a/examples/platform/nrfconnect/pw_sys_io/CMakeLists.txt
+++ b/examples/platform/nrfconnect/pw_sys_io/CMakeLists.txt
@@ -1,0 +1,21 @@
+include(chip-lib)
+include($ENV{PW_ROOT}/pw_build/pigweed.cmake)
+
+pw_add_module_library(pw_sys_io.nrfconnect
+    SOURCES
+      sys_io_nrfconnect.cc
+)
+
+target_include_directories(pw_sys_io.nrfconnect INTERFACE
+    $ENV{ZEPHYR_BASE}/include
+    include/
+)
+
+target_link_libraries(pw_sys_io.nrfconnect PUBLIC
+    zephyr_interface
+    pw_sys_io
+)
+
+target_compile_options(pw_sys_io.nrfconnect PUBLIC
+    -Wno-error=redundant-decls
+)

--- a/examples/platform/nrfconnect/util/include/LogUtils.h
+++ b/examples/platform/nrfconnect/util/include/LogUtils.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#ifndef CONFIG_CHIP_PW_RPC
+#include <logging/log.h>
+LOG_MODULE_DECLARE(app);
+#define LOG_STRDUP log_strdup
+#else
+#include "pw_log/log.h"
+#define LOG_INF(message, ...) PW_LOG_INFO(message, __VA_ARGS__)
+#define LOG_ERR(message, ...) PW_LOG_ERROR(message, __VA_ARGS__)
+#define LOG_STRDUP
+#endif


### PR DESCRIPTION

 #### Problem
Testing needs Pigweed RPC services in various (example) apps.

 #### Summary of Changes
This change provides an example of how to add new Pigweed RPC services to an app.
Implemented for nrfconnect only (for now).

Also rolls up third_party/pigweed/repo to ToT.