### PR TITLE
Groom BufBound

### DIFF
--- a/src/app/encoder.cpp
+++ b/src/app/encoder.cpp
@@ -49,7 +49,7 @@ using namespace chip;
     BufBound buf = BufBound(buffer, buf_length);                                                                                   \
     if (_encodeGlobalCommand(buf, destination_endpoint, cluster_id, 0x02))                                                         \
     {                                                                                                                              \
-        buf.PutLE16(attr_id);                                                                                                      \
+        buf.Put16(attr_id);                                                                                                        \
         buf.Put(attr_type);                                                                                                        \
         switch (attr_type)                                                                                                         \
         {                                                                                                                          \
@@ -57,10 +57,10 @@ using namespace chip;
             buf.Put(static_cast<uint8_t>(value));                                                                                  \
             break;                                                                                                                 \
         case 0x21:                                                                                                                 \
-            buf.PutLE16(static_cast<uint16_t>(value));                                                                             \
+            buf.Put16(static_cast<uint16_t>(value));                                                                               \
             break;                                                                                                                 \
         case 0xF0:                                                                                                                 \
-            buf.PutLE64(static_cast<uint64_t>(value));                                                                             \
+            buf.Put64(static_cast<uint64_t>(value));                                                                               \
             break;                                                                                                                 \
         default:                                                                                                                   \
             ChipLogError(Zcl, "Error encoding %s command", name);                                                                  \
@@ -68,7 +68,7 @@ using namespace chip;
         }                                                                                                                          \
     }                                                                                                                              \
                                                                                                                                    \
-    uint16_t result = buf.Fit() && CanCastTo<uint16_t>(buf.Written()) ? static_cast<uint16_t>(buf.Written()) : 0;                  \
+    uint16_t result = buf.Fit() && CanCastTo<uint16_t>(buf.Needed()) ? static_cast<uint16_t>(buf.Needed()) : 0;                    \
     if (result == 0)                                                                                                               \
     {                                                                                                                              \
         ChipLogError(Zcl, "Error encoding %s command", name);                                                                      \
@@ -82,10 +82,10 @@ using namespace chip;
     {                                                                                                                              \
         uint8_t direction = 0x00;                                                                                                  \
         buf.Put(direction);                                                                                                        \
-        buf.PutLE16(attr_id);                                                                                                      \
+        buf.Put16(attr_id);                                                                                                        \
         buf.Put(attr_type);                                                                                                        \
-        buf.PutLE16(min_interval);                                                                                                 \
-        buf.PutLE16(max_interval);                                                                                                 \
+        buf.Put16(min_interval);                                                                                                   \
+        buf.Put16(max_interval);                                                                                                   \
         if (isAnalog)                                                                                                              \
         {                                                                                                                          \
             switch (attr_type)                                                                                                     \
@@ -94,25 +94,25 @@ using namespace chip;
                 buf.Put(static_cast<uint8_t>(value));                                                                              \
                 break;                                                                                                             \
             case 0x21:                                                                                                             \
-                buf.PutLE16(static_cast<uint16_t>(value));                                                                         \
+                buf.Put16(static_cast<uint16_t>(value));                                                                           \
                 break;                                                                                                             \
             case 0x23:                                                                                                             \
-                buf.PutLE32(static_cast<uint32_t>(value));                                                                         \
+                buf.Put32(static_cast<uint32_t>(value));                                                                           \
                 break;                                                                                                             \
             case 0x27:                                                                                                             \
-                buf.PutLE64(static_cast<uint64_t>(value));                                                                         \
+                buf.Put64(static_cast<uint64_t>(value));                                                                           \
                 break;                                                                                                             \
             case 0x28:                                                                                                             \
                 buf.Put(static_cast<uint8_t>(value));                                                                              \
                 break;                                                                                                             \
             case 0x29:                                                                                                             \
-                buf.PutLE16(static_cast<uint16_t>(value));                                                                         \
+                buf.Put16(static_cast<uint16_t>(value));                                                                           \
                 break;                                                                                                             \
             case 0x2B:                                                                                                             \
-                buf.PutLE32(static_cast<uint32_t>(value));                                                                         \
+                buf.Put32(static_cast<uint32_t>(value));                                                                           \
                 break;                                                                                                             \
             case 0x2f:                                                                                                             \
-                buf.PutLE64(static_cast<uint64_t>(value));                                                                         \
+                buf.Put64(static_cast<uint64_t>(value));                                                                           \
                 break;                                                                                                             \
             default:                                                                                                               \
                 ChipLogError(Zcl, "Type is not supported for report attribute: '0x%02x'", attr_type);                              \
@@ -121,7 +121,7 @@ using namespace chip;
         }                                                                                                                          \
     }                                                                                                                              \
                                                                                                                                    \
-    uint16_t result = buf.Fit() && CanCastTo<uint16_t>(buf.Written()) ? static_cast<uint16_t>(buf.Written()) : 0;                  \
+    uint16_t result = buf.Fit() && CanCastTo<uint16_t>(buf.Needed()) ? static_cast<uint16_t>(buf.Needed()) : 0;                    \
     if (result == 0)                                                                                                               \
     {                                                                                                                              \
         ChipLogError(Zcl, "Error encoding %s command", name);                                                                      \
@@ -134,11 +134,11 @@ using namespace chip;
     if (_encodeGlobalCommand(buf, destination_endpoint, cluster_id, 0x0c))                                                         \
     {                                                                                                                              \
         /* Discover all attributes */                                                                                              \
-        buf.PutLE16(0x0000);                                                                                                       \
+        buf.Put16(0x0000);                                                                                                         \
         buf.Put(0xFF);                                                                                                             \
     }                                                                                                                              \
                                                                                                                                    \
-    uint16_t result = buf.Fit() && CanCastTo<uint16_t>(buf.Written()) ? static_cast<uint16_t>(buf.Written()) : 0;                  \
+    uint16_t result = buf.Fit() && CanCastTo<uint16_t>(buf.Needed()) ? static_cast<uint16_t>(buf.Needed()) : 0;                    \
     if (result == 0)                                                                                                               \
     {                                                                                                                              \
         ChipLogError(Zcl, "Error encoding %s command", name);                                                                      \
@@ -156,7 +156,7 @@ using namespace chip;
     }
 
 #define COMMAND_FOOTER(name)                                                                                                       \
-    result = buf.Fit() && CanCastTo<uint16_t>(buf.Written()) ? static_cast<uint16_t>(buf.Written()) : 0;                           \
+    result = buf.Fit() && CanCastTo<uint16_t>(buf.Needed()) ? static_cast<uint16_t>(buf.Needed()) : 0;                             \
     if (result == 0)                                                                                                               \
     {                                                                                                                              \
         ChipLogError(Zcl, "Error encoding %s command", name);                                                                      \
@@ -216,24 +216,24 @@ static uint16_t doEncodeApsFrame(BufBound & buf, ClusterId clusterId, EndpointId
 {
 
     uint8_t control_byte = 0;
-    buf.Put(control_byte); // Put in a control byte
-    buf.PutLE16(clusterId);
-    buf.Put(sourceEndpoint);
-    buf.Put(destinationEndpoint);
-    buf.PutLE(options, sizeof(EmberApsOption));
-    buf.PutLE16(groupId);
-    buf.Put(sequence);
-    buf.Put(radius);
+    buf.Put(control_byte) // Put in a control byte
+        .Put16(clusterId)
+        .Put(sourceEndpoint)
+        .Put(destinationEndpoint)
+        .Put(options, sizeof(EmberApsOption))
+        .Put16(groupId)
+        .Put(sequence)
+        .Put(radius);
 
     size_t result = 0;
     if (isMeasuring)
     {
-        result = buf.Written();
+        result = buf.Needed();
         ChipLogDetail(Zcl, "Measured APS frame size %d", result);
     }
     else
     {
-        result = buf.Fit() ? buf.Written() : 0;
+        result = buf.Fit() ? buf.Needed() : 0;
         CHECK_FRAME_LENGTH(result, "Buffer too small");
         ChipLogDetail(Zcl, "Successfully encoded %d bytes", result);
     }
@@ -268,7 +268,7 @@ uint16_t _encodeCommand(BufBound & buf, EndpointId destination_endpoint, Cluster
         buf.Put(command);
     }
 
-    return buf.Fit() && CanCastTo<uint16_t>(buf.Written()) ? static_cast<uint16_t>(buf.Written()) : 0;
+    return buf.Fit() && CanCastTo<uint16_t>(buf.Needed()) ? static_cast<uint16_t>(buf.Needed()) : 0;
 }
 
 uint16_t _encodeClusterSpecificCommand(BufBound & buf, EndpointId destination_endpoint, ClusterId cluster_id, CommandId command)
@@ -300,11 +300,11 @@ uint16_t encodeReadAttributesCommand(uint8_t * buffer, uint16_t buf_length, Endp
         for (uint16_t i = 0; i < attr_id_count; ++i)
         {
             uint16_t attr_id = attr_ids[i];
-            buf.PutLE16(attr_id);
+            buf.Put16(attr_id);
         }
     }
 
-    return buf.Fit() && CanCastTo<uint16_t>(buf.Written()) ? static_cast<uint16_t>(buf.Written()) : 0;
+    return buf.Fit() && CanCastTo<uint16_t>(buf.Needed()) ? static_cast<uint16_t>(buf.Needed()) : 0;
 }
 
 /*----------------------------------------------------------------------------*\
@@ -536,8 +536,8 @@ uint16_t encodeColorControlClusterMoveColorCommand(uint8_t * buffer, uint16_t bu
 {
     const char * kName = "ColorControlMoveColor";
     COMMAND_HEADER(kName, COLOR_CONTROL_CLUSTER_ID, 0x08);
-    buf.PutLE16(static_cast<uint16_t>(rateX));
-    buf.PutLE16(static_cast<uint16_t>(rateY));
+    buf.Put16(static_cast<uint16_t>(rateX));
+    buf.Put16(static_cast<uint16_t>(rateY));
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
     COMMAND_FOOTER(kName);
@@ -555,9 +555,9 @@ uint16_t encodeColorControlClusterMoveColorTemperatureCommand(uint8_t * buffer, 
     const char * kName = "ColorControlMoveColorTemperature";
     COMMAND_HEADER(kName, COLOR_CONTROL_CLUSTER_ID, 0x4B);
     buf.Put(moveMode);
-    buf.PutLE16(rate);
-    buf.PutLE16(colorTemperatureMinimumMireds);
-    buf.PutLE16(colorTemperatureMaximumMireds);
+    buf.Put16(rate);
+    buf.Put16(colorTemperatureMinimumMireds);
+    buf.Put16(colorTemperatureMaximumMireds);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
     COMMAND_FOOTER(kName);
@@ -603,9 +603,9 @@ uint16_t encodeColorControlClusterMoveToColorCommand(uint8_t * buffer, uint16_t 
 {
     const char * kName = "ColorControlMoveToColor";
     COMMAND_HEADER(kName, COLOR_CONTROL_CLUSTER_ID, 0x07);
-    buf.PutLE16(colorX);
-    buf.PutLE16(colorY);
-    buf.PutLE16(transitionTime);
+    buf.Put16(colorX);
+    buf.Put16(colorY);
+    buf.Put16(transitionTime);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
     COMMAND_FOOTER(kName);
@@ -621,8 +621,8 @@ uint16_t encodeColorControlClusterMoveToColorTemperatureCommand(uint8_t * buffer
 {
     const char * kName = "ColorControlMoveToColorTemperature";
     COMMAND_HEADER(kName, COLOR_CONTROL_CLUSTER_ID, 0x0A);
-    buf.PutLE16(colorTemperatureMireds);
-    buf.PutLE16(transitionTime);
+    buf.Put16(colorTemperatureMireds);
+    buf.Put16(transitionTime);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
     COMMAND_FOOTER(kName);
@@ -639,7 +639,7 @@ uint16_t encodeColorControlClusterMoveToHueCommand(uint8_t * buffer, uint16_t bu
     COMMAND_HEADER(kName, COLOR_CONTROL_CLUSTER_ID, 0x00);
     buf.Put(hue);
     buf.Put(direction);
-    buf.PutLE16(transitionTime);
+    buf.Put16(transitionTime);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
     COMMAND_FOOTER(kName);
@@ -657,7 +657,7 @@ uint16_t encodeColorControlClusterMoveToHueAndSaturationCommand(uint8_t * buffer
     COMMAND_HEADER(kName, COLOR_CONTROL_CLUSTER_ID, 0x06);
     buf.Put(hue);
     buf.Put(saturation);
-    buf.PutLE16(transitionTime);
+    buf.Put16(transitionTime);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
     COMMAND_FOOTER(kName);
@@ -673,7 +673,7 @@ uint16_t encodeColorControlClusterMoveToSaturationCommand(uint8_t * buffer, uint
     const char * kName = "ColorControlMoveToSaturation";
     COMMAND_HEADER(kName, COLOR_CONTROL_CLUSTER_ID, 0x03);
     buf.Put(saturation);
-    buf.PutLE16(transitionTime);
+    buf.Put16(transitionTime);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
     COMMAND_FOOTER(kName);
@@ -688,9 +688,9 @@ uint16_t encodeColorControlClusterStepColorCommand(uint8_t * buffer, uint16_t bu
 {
     const char * kName = "ColorControlStepColor";
     COMMAND_HEADER(kName, COLOR_CONTROL_CLUSTER_ID, 0x09);
-    buf.PutLE16(static_cast<uint16_t>(stepX));
-    buf.PutLE16(static_cast<uint16_t>(stepY));
-    buf.PutLE16(transitionTime);
+    buf.Put16(static_cast<uint16_t>(stepX));
+    buf.Put16(static_cast<uint16_t>(stepY));
+    buf.Put16(transitionTime);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
     COMMAND_FOOTER(kName);
@@ -708,10 +708,10 @@ uint16_t encodeColorControlClusterStepColorTemperatureCommand(uint8_t * buffer, 
     const char * kName = "ColorControlStepColorTemperature";
     COMMAND_HEADER(kName, COLOR_CONTROL_CLUSTER_ID, 0x4C);
     buf.Put(stepMode);
-    buf.PutLE16(stepSize);
-    buf.PutLE16(transitionTime);
-    buf.PutLE16(colorTemperatureMinimumMireds);
-    buf.PutLE16(colorTemperatureMaximumMireds);
+    buf.Put16(stepSize);
+    buf.Put16(transitionTime);
+    buf.Put16(colorTemperatureMinimumMireds);
+    buf.Put16(colorTemperatureMaximumMireds);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
     COMMAND_FOOTER(kName);
@@ -1297,7 +1297,7 @@ uint16_t encodeDoorLockClusterClearPINCodeCommand(uint8_t * buffer, uint16_t buf
 {
     const char * kName = "DoorLockClearPINCode";
     COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x07);
-    buf.PutLE16(userID);
+    buf.Put16(userID);
     COMMAND_FOOTER(kName);
 }
 
@@ -1309,7 +1309,7 @@ uint16_t encodeDoorLockClusterClearRFIDCodeCommand(uint8_t * buffer, uint16_t bu
 {
     const char * kName = "DoorLockClearRFIDCode";
     COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x18);
-    buf.PutLE16(userID);
+    buf.Put16(userID);
     COMMAND_FOOTER(kName);
 }
 
@@ -1322,7 +1322,7 @@ uint16_t encodeDoorLockClusterClearWeekdayScheduleCommand(uint8_t * buffer, uint
     const char * kName = "DoorLockClearWeekdaySchedule";
     COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x0D);
     buf.Put(scheduleID);
-    buf.PutLE16(userID);
+    buf.Put16(userID);
     COMMAND_FOOTER(kName);
 }
 
@@ -1335,7 +1335,7 @@ uint16_t encodeDoorLockClusterClearYearDayScheduleCommand(uint8_t * buffer, uint
     const char * kName = "DoorLockClearYearDaySchedule";
     COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x10);
     buf.Put(scheduleID);
-    buf.PutLE16(userID);
+    buf.Put16(userID);
     COMMAND_FOOTER(kName);
 }
 
@@ -1359,7 +1359,7 @@ uint16_t encodeDoorLockClusterGetPINCodeCommand(uint8_t * buffer, uint16_t buf_l
 {
     const char * kName = "DoorLockGetPINCode";
     COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x06);
-    buf.PutLE16(userID);
+    buf.Put16(userID);
     COMMAND_FOOTER(kName);
 }
 
@@ -1371,7 +1371,7 @@ uint16_t encodeDoorLockClusterGetRFIDCodeCommand(uint8_t * buffer, uint16_t buf_
 {
     const char * kName = "DoorLockGetRFIDCode";
     COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x17);
-    buf.PutLE16(userID);
+    buf.Put16(userID);
     COMMAND_FOOTER(kName);
 }
 
@@ -1383,7 +1383,7 @@ uint16_t encodeDoorLockClusterGetUserTypeCommand(uint8_t * buffer, uint16_t buf_
 {
     const char * kName = "DoorLockGetUserType";
     COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x15);
-    buf.PutLE16(userID);
+    buf.Put16(userID);
     COMMAND_FOOTER(kName);
 }
 
@@ -1396,7 +1396,7 @@ uint16_t encodeDoorLockClusterGetWeekdayScheduleCommand(uint8_t * buffer, uint16
     const char * kName = "DoorLockGetWeekdaySchedule";
     COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x0C);
     buf.Put(scheduleID);
-    buf.PutLE16(userID);
+    buf.Put16(userID);
     COMMAND_FOOTER(kName);
 }
 
@@ -1409,7 +1409,7 @@ uint16_t encodeDoorLockClusterGetYearDayScheduleCommand(uint8_t * buffer, uint16
     const char * kName = "DoorLockGetYearDaySchedule";
     COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x0F);
     buf.Put(scheduleID);
-    buf.PutLE16(userID);
+    buf.Put16(userID);
     COMMAND_FOOTER(kName);
 }
 
@@ -1435,8 +1435,8 @@ uint16_t encodeDoorLockClusterSetHolidayScheduleCommand(uint8_t * buffer, uint16
     const char * kName = "DoorLockSetHolidaySchedule";
     COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x11);
     buf.Put(holidayScheduleID);
-    buf.PutLE32(localStartTime);
-    buf.PutLE32(localEndTime);
+    buf.Put32(localStartTime);
+    buf.Put32(localEndTime);
     buf.Put(operatingModeDuringHoliday);
     COMMAND_FOOTER(kName);
 }
@@ -1449,7 +1449,7 @@ uint16_t encodeDoorLockClusterSetPINCodeCommand(uint8_t * buffer, uint16_t buf_l
 {
     const char * kName = "DoorLockSetPINCode";
     COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x05);
-    buf.PutLE16(userID);
+    buf.Put16(userID);
     buf.Put(userStatus);
     buf.Put(userType);
     COMMAND_INSERT_STRING(kName, pIN);
@@ -1464,7 +1464,7 @@ uint16_t encodeDoorLockClusterSetRFIDCodeCommand(uint8_t * buffer, uint16_t buf_
 {
     const char * kName = "DoorLockSetRFIDCode";
     COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x16);
-    buf.PutLE16(userID);
+    buf.Put16(userID);
     buf.Put(userStatus);
     buf.Put(userType);
     COMMAND_INSERT_STRING(kName, rFIDCode);
@@ -1479,7 +1479,7 @@ uint16_t encodeDoorLockClusterSetUserTypeCommand(uint8_t * buffer, uint16_t buf_
 {
     const char * kName = "DoorLockSetUserType";
     COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x14);
-    buf.PutLE16(userID);
+    buf.Put16(userID);
     buf.Put(userType);
     COMMAND_FOOTER(kName);
 }
@@ -1494,7 +1494,7 @@ uint16_t encodeDoorLockClusterSetWeekdayScheduleCommand(uint8_t * buffer, uint16
     const char * kName = "DoorLockSetWeekdaySchedule";
     COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x0B);
     buf.Put(scheduleID);
-    buf.PutLE16(userID);
+    buf.Put16(userID);
     buf.Put(daysMask);
     buf.Put(startHour);
     buf.Put(startMinute);
@@ -1513,9 +1513,9 @@ uint16_t encodeDoorLockClusterSetYearDayScheduleCommand(uint8_t * buffer, uint16
     const char * kName = "DoorLockSetYearDaySchedule";
     COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x0E);
     buf.Put(scheduleID);
-    buf.PutLE16(userID);
-    buf.PutLE32(localStartTime);
-    buf.PutLE32(localEndTime);
+    buf.Put16(userID);
+    buf.Put32(localStartTime);
+    buf.Put32(localEndTime);
     COMMAND_FOOTER(kName);
 }
 
@@ -1539,7 +1539,7 @@ uint16_t encodeDoorLockClusterUnlockWithTimeoutCommand(uint8_t * buffer, uint16_
 {
     const char * kName = "DoorLockUnlockWithTimeout";
     COMMAND_HEADER(kName, DOOR_LOCK_CLUSTER_ID, 0x03);
-    buf.PutLE16(timeoutInSeconds);
+    buf.Put16(timeoutInSeconds);
     COMMAND_INSERT_STRING(kName, pINOrRFIDCode);
     COMMAND_FOOTER(kName);
 }
@@ -1614,7 +1614,7 @@ uint16_t encodeGroupsClusterAddGroupCommand(uint8_t * buffer, uint16_t buf_lengt
 {
     const char * kName = "GroupsAddGroup";
     COMMAND_HEADER(kName, GROUPS_CLUSTER_ID, 0x00);
-    buf.PutLE16(groupId);
+    buf.Put16(groupId);
     COMMAND_INSERT_STRING(kName, groupName);
     COMMAND_FOOTER(kName);
 }
@@ -1627,7 +1627,7 @@ uint16_t encodeGroupsClusterAddGroupIfIdentifyingCommand(uint8_t * buffer, uint1
 {
     const char * kName = "GroupsAddGroupIfIdentifying";
     COMMAND_HEADER(kName, GROUPS_CLUSTER_ID, 0x05);
-    buf.PutLE16(groupId);
+    buf.Put16(groupId);
     COMMAND_INSERT_STRING(kName, groupName);
     COMMAND_FOOTER(kName);
 }
@@ -1641,7 +1641,7 @@ uint16_t encodeGroupsClusterGetGroupMembershipCommand(uint8_t * buffer, uint16_t
     const char * kName = "GroupsGetGroupMembership";
     COMMAND_HEADER(kName, GROUPS_CLUSTER_ID, 0x02);
     buf.Put(groupCount);
-    buf.PutLE16(groupList);
+    buf.Put16(groupList);
     COMMAND_FOOTER(kName);
 }
 
@@ -1663,7 +1663,7 @@ uint16_t encodeGroupsClusterRemoveGroupCommand(uint8_t * buffer, uint16_t buf_le
 {
     const char * kName = "GroupsRemoveGroup";
     COMMAND_HEADER(kName, GROUPS_CLUSTER_ID, 0x03);
-    buf.PutLE16(groupId);
+    buf.Put16(groupId);
     COMMAND_FOOTER(kName);
 }
 
@@ -1675,7 +1675,7 @@ uint16_t encodeGroupsClusterViewGroupCommand(uint8_t * buffer, uint16_t buf_leng
 {
     const char * kName = "GroupsViewGroup";
     COMMAND_HEADER(kName, GROUPS_CLUSTER_ID, 0x01);
-    buf.PutLE16(groupId);
+    buf.Put16(groupId);
     COMMAND_FOOTER(kName);
 }
 
@@ -1803,7 +1803,7 @@ uint16_t encodeIdentifyClusterIdentifyCommand(uint8_t * buffer, uint16_t buf_len
 {
     const char * kName = "IdentifyIdentify";
     COMMAND_HEADER(kName, IDENTIFY_CLUSTER_ID, 0x00);
-    buf.PutLE16(identifyTime);
+    buf.Put16(identifyTime);
     COMMAND_FOOTER(kName);
 }
 
@@ -1883,7 +1883,7 @@ uint16_t encodeLevelClusterMoveToLevelCommand(uint8_t * buffer, uint16_t buf_len
     const char * kName = "LevelMoveToLevel";
     COMMAND_HEADER(kName, LEVEL_CLUSTER_ID, 0x00);
     buf.Put(level);
-    buf.PutLE16(transitionTime);
+    buf.Put16(transitionTime);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
     COMMAND_FOOTER(kName);
@@ -1899,7 +1899,7 @@ uint16_t encodeLevelClusterMoveToLevelWithOnOffCommand(uint8_t * buffer, uint16_
     const char * kName = "LevelMoveToLevelWithOnOff";
     COMMAND_HEADER(kName, LEVEL_CLUSTER_ID, 0x04);
     buf.Put(level);
-    buf.PutLE16(transitionTime);
+    buf.Put16(transitionTime);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
     COMMAND_FOOTER(kName);
@@ -1930,7 +1930,7 @@ uint16_t encodeLevelClusterStepCommand(uint8_t * buffer, uint16_t buf_length, En
     COMMAND_HEADER(kName, LEVEL_CLUSTER_ID, 0x02);
     buf.Put(stepMode);
     buf.Put(stepSize);
-    buf.PutLE16(transitionTime);
+    buf.Put16(transitionTime);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
     COMMAND_FOOTER(kName);
@@ -1947,7 +1947,7 @@ uint16_t encodeLevelClusterStepWithOnOffCommand(uint8_t * buffer, uint16_t buf_l
     COMMAND_HEADER(kName, LEVEL_CLUSTER_ID, 0x06);
     buf.Put(stepMode);
     buf.Put(stepSize);
-    buf.PutLE16(transitionTime);
+    buf.Put16(transitionTime);
     buf.Put(optionsMask);
     buf.Put(optionsOverride);
     COMMAND_FOOTER(kName);
@@ -2106,11 +2106,11 @@ uint16_t encodeScenesClusterAddSceneCommand(uint8_t * buffer, uint16_t buf_lengt
 {
     const char * kName = "ScenesAddScene";
     COMMAND_HEADER(kName, SCENES_CLUSTER_ID, 0x00);
-    buf.PutLE16(groupID);
+    buf.Put16(groupID);
     buf.Put(sceneID);
-    buf.PutLE16(transitionTime);
+    buf.Put16(transitionTime);
     COMMAND_INSERT_STRING(kName, sceneName);
-    buf.PutLE16(clusterId);
+    buf.Put16(clusterId);
     COMMAND_INSERT_STRING(kName, extensionFieldSet);
     COMMAND_FOOTER(kName);
 }
@@ -2123,7 +2123,7 @@ uint16_t encodeScenesClusterGetSceneMembershipCommand(uint8_t * buffer, uint16_t
 {
     const char * kName = "ScenesGetSceneMembership";
     COMMAND_HEADER(kName, SCENES_CLUSTER_ID, 0x06);
-    buf.PutLE16(groupID);
+    buf.Put16(groupID);
     COMMAND_FOOTER(kName);
 }
 
@@ -2135,9 +2135,9 @@ uint16_t encodeScenesClusterRecallSceneCommand(uint8_t * buffer, uint16_t buf_le
 {
     const char * kName = "ScenesRecallScene";
     COMMAND_HEADER(kName, SCENES_CLUSTER_ID, 0x05);
-    buf.PutLE16(groupID);
+    buf.Put16(groupID);
     buf.Put(sceneID);
-    buf.PutLE16(transitionTime);
+    buf.Put16(transitionTime);
     COMMAND_FOOTER(kName);
 }
 
@@ -2149,7 +2149,7 @@ uint16_t encodeScenesClusterRemoveAllScenesCommand(uint8_t * buffer, uint16_t bu
 {
     const char * kName = "ScenesRemoveAllScenes";
     COMMAND_HEADER(kName, SCENES_CLUSTER_ID, 0x03);
-    buf.PutLE16(groupID);
+    buf.Put16(groupID);
     COMMAND_FOOTER(kName);
 }
 
@@ -2161,7 +2161,7 @@ uint16_t encodeScenesClusterRemoveSceneCommand(uint8_t * buffer, uint16_t buf_le
 {
     const char * kName = "ScenesRemoveScene";
     COMMAND_HEADER(kName, SCENES_CLUSTER_ID, 0x02);
-    buf.PutLE16(groupID);
+    buf.Put16(groupID);
     buf.Put(sceneID);
     COMMAND_FOOTER(kName);
 }
@@ -2174,7 +2174,7 @@ uint16_t encodeScenesClusterStoreSceneCommand(uint8_t * buffer, uint16_t buf_len
 {
     const char * kName = "ScenesStoreScene";
     COMMAND_HEADER(kName, SCENES_CLUSTER_ID, 0x04);
-    buf.PutLE16(groupID);
+    buf.Put16(groupID);
     buf.Put(sceneID);
     COMMAND_FOOTER(kName);
 }
@@ -2187,7 +2187,7 @@ uint16_t encodeScenesClusterViewSceneCommand(uint8_t * buffer, uint16_t buf_leng
 {
     const char * kName = "ScenesViewScene";
     COMMAND_HEADER(kName, SCENES_CLUSTER_ID, 0x01);
-    buf.PutLE16(groupID);
+    buf.Put16(groupID);
     buf.Put(sceneID);
     COMMAND_FOOTER(kName);
 }

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -970,7 +970,7 @@ CHIP_ERROR P256Keypair::Serialize(P256SerializedKeypair & output)
         bbuf.Put(mPublicKey, mPublicKey.Length());
         bbuf.Put(privkey, sizeof(privkey));
         VerifyOrExit(bbuf.Fit(), error = CHIP_ERROR_NO_MEMORY);
-        output.SetLength(bbuf.Written());
+        output.SetLength(bbuf.Needed());
     }
 
 exit:

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -654,7 +654,7 @@ CHIP_ERROR P256Keypair::Serialize(P256SerializedKeypair & output)
     bbuf.Put(privkey, sizeof(privkey));
     VerifyOrExit(bbuf.Fit(), error = CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    output.SetLength(bbuf.Written());
+    output.SetLength(bbuf.Needed());
 
 exit:
     memset(privkey, 0, sizeof(privkey));

--- a/src/lib/support/BufBound.h
+++ b/src/lib/support/BufBound.h
@@ -123,43 +123,35 @@ public:
     /*
      * @brief number of bytes required to satisfy all calls to Put() so far
      */
-    size_t Needed() { return mNeeded; }
+    size_t Needed() const { return mNeeded; }
     /*
      * @brief bytes available
      */
-    size_t Available() { return mSize < mNeeded ? 0 : mSize - mNeeded; }
+    size_t Available() const { return mSize < mNeeded ? 0 : mSize - mNeeded; }
 
     /*
      * @brief whether the input fit in the buffer
      */
-    bool Fit()
+    bool Fit() const
     {
         size_t _;
         return Fit(_);
     }
 
     /*
-     * @brief whether the input fit in the buffer, output what was
+     * @brief returns whether the input fit in the buffer, outputs what was
      *        actually written
      */
-    bool Fit(size_t & written)
+    bool Fit(size_t & actually_written) const
     {
-        if (mSize >= mNeeded)
-        {
-            written = mNeeded;
-            return true;
-        }
-        else
-        {
-            written = mSize;
-            return false;
-        }
+        actually_written = mSize >= mNeeded ? mNeeded : mSize;
+        return mSize >= mNeeded;
     }
 
     /*
      * @brief Size of the buffer
      */
-    size_t Size() { return mSize; }
+    size_t Size() const { return mSize; }
 };
 
 } // namespace chip

--- a/src/lib/support/BufBound.h
+++ b/src/lib/support/BufBound.h
@@ -17,8 +17,9 @@
 
 /**
  *  @file
- *    basic double-ended queue, intended to be embedded as a member
- *     of an object
+ *    BufBound manages serial writes to a buffer, guarding that the bounds of
+ *     the buffer are not exceeded.
+ *
  */
 
 #pragma once

--- a/src/lib/support/BufBound.h
+++ b/src/lib/support/BufBound.h
@@ -38,38 +38,39 @@ class BufBound
 {
 private:
     uint8_t * mBuf;
-    size_t mLen;
-    size_t mWritten;
+    size_t mSize;
+    size_t mNeeded;
 
 public:
-    BufBound(uint8_t * buf, size_t len) : mBuf(buf), mLen(len), mWritten(0) {}
+    BufBound(uint8_t * buf, size_t len) : mBuf(buf), mSize(len), mNeeded(0) {}
 
     /*
      * @brief append a single byte
      */
-    size_t Put(uint8_t c)
+    BufBound & Put(uint8_t c)
     {
-        if (mWritten < mLen)
+        if (mNeeded < mSize)
         {
-            mBuf[mWritten] = c;
+            mBuf[mNeeded] = c;
         }
-        return ++mWritten;
+        ++mNeeded;
+        return *this;
     }
 
     /*
      * @brief append a null terminated string, exclude the null term
      */
-    size_t Put(const char * s)
+    BufBound & Put(const char * s)
     {
         static_assert(CHAR_BIT == 8, "We're assuming char and uint8_t are the same size");
         while (*s != 0)
         {
             Put(static_cast<uint8_t>(*s++));
         }
-        return mWritten;
+        return *this;
     }
 
-    size_t PutLE(uint64_t x, size_t size)
+    BufBound & Put(uint64_t x, size_t size)
     {
         while (size-- > 0)
         {
@@ -77,64 +78,88 @@ public:
             Put(c);
             x >>= 8;
         }
-        return mWritten;
+        return *this;
     }
 
     /*
      * @brief write integer x into the buffer, least significant byte first
      */
-    size_t PutLE64(uint64_t x) { return PutLE(x, sizeof(x)); }
-    size_t PutLE32(uint32_t x) { return PutLE(x, sizeof(x)); }
-    size_t PutLE16(uint16_t x) { return PutLE(x, sizeof(x)); }
+    BufBound & Put64(uint64_t x) { return Put(x, sizeof(x)); }
+    BufBound & Put32(uint32_t x) { return Put(x, sizeof(x)); }
+    BufBound & Put16(uint16_t x) { return Put(x, sizeof(x)); }
 
-    size_t PutBE(uint64_t x, size_t size)
+    BufBound & PutBE(uint64_t x, size_t size)
     {
         while (size-- > 0)
         {
             uint8_t c = (x >> (size * 8)) & 0xff;
             Put(c);
         }
-        return mWritten;
+        return *this;
     }
 
     /*
      * @brief write integer x into the buffer, most significant byte first
      */
-    size_t PutBE64(uint64_t x) { return PutBE(x, sizeof(x)); }
-    size_t PutBE32(uint32_t x) { return PutBE(x, sizeof(x)); }
-    size_t PutBE16(uint16_t x) { return PutBE(x, sizeof(x)); }
+    BufBound & PutBE64(uint64_t x) { return PutBE(x, sizeof(x)); }
+    BufBound & PutBE32(uint32_t x) { return PutBE(x, sizeof(x)); }
+    BufBound & PutBE16(uint16_t x) { return PutBE(x, sizeof(x)); }
 
     /*
      * @brief append a buffer
      */
-    size_t Put(const uint8_t * buf, size_t len) { return Put(reinterpret_cast<const void *>(buf), len); }
-    size_t Put(const void * buf, size_t len)
+    BufBound & Put(const uint8_t * buf, size_t len) { return Put(reinterpret_cast<const void *>(buf), len); }
+    BufBound & Put(const void * buf, size_t len)
     {
         size_t available = Available();
 
-        memmove(mBuf + mWritten, buf, available < len ? available : len);
+        memmove(mBuf + mNeeded, buf, available < len ? available : len);
 
-        mWritten += len;
+        mNeeded += len;
 
-        return mWritten;
+        return *this;
     }
 
     /*
-     * @brief how much was or would have been written
+     * @brief number of bytes required to satisfy all calls to Put() so far
      */
-    size_t Written() { return mWritten; }
+    size_t Needed() { return mNeeded; }
     /*
      * @brief bytes available
      */
-    size_t Available() { return mLen < mWritten ? 0 : mLen - mWritten; }
+    size_t Available() { return mSize < mNeeded ? 0 : mSize - mNeeded; }
+
     /*
      * @brief whether the input fit in the buffer
      */
-    bool Fit() { return mLen >= mWritten; }
+    bool Fit()
+    {
+        size_t _;
+        return Fit(_);
+    }
+
+    /*
+     * @brief whether the input fit in the buffer, output what was
+     *        actually written
+     */
+    bool Fit(size_t & written)
+    {
+        if (mSize >= mNeeded)
+        {
+            written = mNeeded;
+            return true;
+        }
+        else
+        {
+            written = mSize;
+            return false;
+        }
+    }
+
     /*
      * @brief Size of the buffer
      */
-    size_t Size() { return mLen; }
+    size_t Size() { return mSize; }
 };
 
 } // namespace chip

--- a/src/lib/support/tests/TestBufBound.cpp
+++ b/src/lib/support/tests/TestBufBound.cpp
@@ -41,7 +41,7 @@ public:
 
     BBTest(size_t len) : BufBound(mBuf + 1, len), mLen(len) { memset(mBuf, kGuard, kLen); }
 
-    bool expect(const void * val, size_t written, size_t available)
+    bool expect(const void * val, size_t needed, size_t available)
     {
         // check guards
         for (size_t i = mLen + 1; i < sizeof(mBuf); i++)
@@ -56,19 +56,22 @@ public:
             return false;
         }
 
-        if ((mLen < written && Fit()) || (mLen >= written && !Fit()))
+        size_t written;
+        bool fit = Fit(written);
+        if ((fit && (mLen < needed || written != needed)) || (fit && (mLen >= needed || written != mLen)))
         {
-            printf("fit is wrong mLen == %zu, written == %zu, Fit() == %s\n", mLen, written, Fit() ? "true" : "false");
+            printf("Fit(written) is wrong: mLen == %zu, needed == %zu, written == %zu, Fit() == %s\n", mLen, needed, written,
+                   fit ? "true" : "false");
             return false;
         }
 
         // check everything else
-        if (memcmp(mBuf + 1, val, written < mLen ? written : mLen) != 0)
+        if (memcmp(mBuf + 1, val, needed < mLen ? needed : mLen) != 0)
         {
             return false;
         }
 
-        return Available() == available && Written() == written;
+        return Available() == available && Needed() == needed;
     }
 };
 
@@ -109,20 +112,20 @@ static void TestBufBound_Buf(nlTestSuite * inSuite, void * inContext)
     }
 }
 
-static void TestBufBound_PutLE(nlTestSuite * inSuite, void * inContext)
+static void TestBufBound_Put(nlTestSuite * inSuite, void * inContext)
 {
     (void) inContext;
     {
         BBTest bb(2);
 
-        bb.PutLE16('h' + 'i' * 256);
+        bb.Put16('h' + 'i' * 256);
 
         NL_TEST_ASSERT(inSuite, bb.expect("hi", 2, 0));
     }
     {
         BBTest bb(4);
 
-        bb.PutLE32(0x01020304);
+        bb.Put32(0x01020304);
 
         NL_TEST_ASSERT(inSuite, bb.expect("\x04\x03\x02\x01", 4, 0));
     }
@@ -130,7 +133,7 @@ static void TestBufBound_PutLE(nlTestSuite * inSuite, void * inContext)
     {
         BBTest bb(8);
 
-        bb.PutLE64(0x0102030405060708);
+        bb.Put64(0x0102030405060708);
 
         NL_TEST_ASSERT(inSuite, bb.expect("\x08\x07\x06\x05\x04\x03\x02\x01", 8, 0));
     }
@@ -138,7 +141,7 @@ static void TestBufBound_PutLE(nlTestSuite * inSuite, void * inContext)
     {
         BBTest bb(3);
 
-        bb.PutLE(0x0102030405060708u, 3);
+        bb.Put(0x0102030405060708u, 3);
 
         NL_TEST_ASSERT(inSuite, bb.expect("\x08\x07\x06", 3, 0));
     }
@@ -185,7 +188,7 @@ static void TestBufBound_PutBE(nlTestSuite * inSuite, void * inContext)
  *   Test Suite. It lists all the test functions.
  */
 static const nlTest sTests[] = { NL_TEST_DEF_FN(TestBufBound_Str), NL_TEST_DEF_FN(TestBufBound_Buf),
-                                 NL_TEST_DEF_FN(TestBufBound_PutLE), NL_TEST_DEF_FN(TestBufBound_PutBE), NL_TEST_SENTINEL() };
+                                 NL_TEST_DEF_FN(TestBufBound_Put), NL_TEST_DEF_FN(TestBufBound_PutBE), NL_TEST_SENTINEL() };
 
 int TestBufBound(void)
 {

--- a/src/lib/support/tests/TestBufBound.cpp
+++ b/src/lib/support/tests/TestBufBound.cpp
@@ -56,9 +56,14 @@ public:
             return false;
         }
 
-        size_t written;
-        bool fit = Fit(written);
-        if ((fit && (mLen < needed || written != needed)) || (fit && (mLen >= needed || written != mLen)))
+        size_t written = 0xcafebabe;
+        bool fit       = Fit(written);
+        if (written == 0xcafebabe)
+        {
+            printf("Fit(written) didn't set written\n");
+            return false;
+        }
+        if ((fit && (mLen < needed || written != needed)) || (!fit && (mLen >= needed || written != mLen)))
         {
             printf("Fit(written) is wrong: mLen == %zu, needed == %zu, written == %zu, Fit() == %s\n", mLen, needed, written,
                    fit ? "true" : "false");

--- a/src/protocols/bdx/BdxMessages.cpp
+++ b/src/protocols/bdx/BdxMessages.cpp
@@ -39,7 +39,7 @@ using namespace chip::Encoding::LittleEndian;
 
 // WARNING: this function should never return early, since MessageSize() relies on it to calculate
 // the size of the message (even if the message is incomplete or filled out incorrectly).
-void TransferInit::WriteToBuffer(BufBound & aBuffer) const
+BufBound & TransferInit::WriteToBuffer(BufBound & aBuffer) const
 {
     uint8_t proposedTransferCtl = 0;
     bool widerange = (StartOffset > std::numeric_limits<uint32_t>::max()) || (MaxLength > std::numeric_limits<uint32_t>::max());
@@ -54,17 +54,17 @@ void TransferInit::WriteToBuffer(BufBound & aBuffer) const
 
     aBuffer.Put(proposedTransferCtl);
     aBuffer.Put(rangeCtlFlags.Raw());
-    aBuffer.PutLE16(MaxBlockSize);
+    aBuffer.Put16(MaxBlockSize);
 
     if (StartOffset > 0)
     {
         if (widerange)
         {
-            aBuffer.PutLE64(StartOffset);
+            aBuffer.Put64(StartOffset);
         }
         else
         {
-            aBuffer.PutLE32(static_cast<uint32_t>(StartOffset));
+            aBuffer.Put32(static_cast<uint32_t>(StartOffset));
         }
     }
 
@@ -72,15 +72,15 @@ void TransferInit::WriteToBuffer(BufBound & aBuffer) const
     {
         if (widerange)
         {
-            aBuffer.PutLE64(MaxLength);
+            aBuffer.Put64(MaxLength);
         }
         else
         {
-            aBuffer.PutLE32(static_cast<uint32_t>(MaxLength));
+            aBuffer.Put32(static_cast<uint32_t>(MaxLength));
         }
     }
 
-    aBuffer.PutLE16(FileDesLength);
+    aBuffer.Put16(FileDesLength);
     if (FileDesignator != nullptr)
     {
         aBuffer.Put(FileDesignator, static_cast<size_t>(FileDesLength));
@@ -90,6 +90,7 @@ void TransferInit::WriteToBuffer(BufBound & aBuffer) const
     {
         aBuffer.Put(Metadata, static_cast<size_t>(MetadataLength));
     }
+    return aBuffer;
 }
 
 CHIP_ERROR TransferInit::Parse(const System::PacketBuffer & aBuffer)
@@ -167,10 +168,8 @@ exit:
 
 size_t TransferInit::MessageSize() const
 {
-    uint8_t dummy[0];
-    BufBound emptyBuf(static_cast<uint8_t *>(dummy), 0);
-    WriteToBuffer(emptyBuf);
-    return emptyBuf.Written();
+    BufBound emptyBuf(nullptr, 0);
+    return WriteToBuffer(emptyBuf).Needed();
 }
 
 bool TransferInit::operator==(const TransferInit & another) const
@@ -199,7 +198,7 @@ bool TransferInit::operator==(const TransferInit & another) const
 
 // WARNING: this function should never return early, since MessageSize() relies on it to calculate
 // the size of the message (even if the message is incomplete or filled out incorrectly).
-void SendAccept::WriteToBuffer(BufBound & aBuffer) const
+BufBound & SendAccept::WriteToBuffer(BufBound & aBuffer) const
 {
     uint8_t transferCtl = 0;
 
@@ -207,12 +206,13 @@ void SendAccept::WriteToBuffer(BufBound & aBuffer) const
     transferCtl = transferCtl | TransferCtlFlags.Raw();
 
     aBuffer.Put(transferCtl);
-    aBuffer.PutLE16(MaxBlockSize);
+    aBuffer.Put16(MaxBlockSize);
 
     if (Metadata != nullptr)
     {
         aBuffer.Put(Metadata, static_cast<size_t>(MetadataLength));
     }
+    return aBuffer;
 }
 
 CHIP_ERROR SendAccept::Parse(const System::PacketBuffer & aBuffer)
@@ -251,11 +251,8 @@ exit:
 
 size_t SendAccept::MessageSize() const
 {
-    uint8_t dummy[0];
-    BufBound emptyBuf(static_cast<uint8_t *>(dummy), 0);
-    WriteToBuffer(emptyBuf);
-    return emptyBuf.Written();
-    ;
+    BufBound emptyBuf(nullptr, 0);
+    return WriteToBuffer(emptyBuf).Needed();
 }
 
 bool SendAccept::operator==(const SendAccept & another) const
@@ -277,7 +274,7 @@ bool SendAccept::operator==(const SendAccept & another) const
 
 // WARNING: this function should never return early, since MessageSize() relies on it to calculate
 // the size of the message (even if the message is incomplete or filled out incorrectly).
-void ReceiveAccept::WriteToBuffer(BufBound & aBuffer) const
+BufBound & ReceiveAccept::WriteToBuffer(BufBound & aBuffer) const
 {
     uint8_t transferCtl = 0;
     bool widerange      = (StartOffset > std::numeric_limits<uint32_t>::max()) || (Length > std::numeric_limits<uint32_t>::max());
@@ -292,17 +289,17 @@ void ReceiveAccept::WriteToBuffer(BufBound & aBuffer) const
 
     aBuffer.Put(transferCtl);
     aBuffer.Put(rangeCtlFlags.Raw());
-    aBuffer.PutLE16(MaxBlockSize);
+    aBuffer.Put16(MaxBlockSize);
 
     if (StartOffset > 0)
     {
         if (widerange)
         {
-            aBuffer.PutLE64(StartOffset);
+            aBuffer.Put64(StartOffset);
         }
         else
         {
-            aBuffer.PutLE32(static_cast<uint32_t>(StartOffset));
+            aBuffer.Put32(static_cast<uint32_t>(StartOffset));
         }
     }
 
@@ -310,11 +307,11 @@ void ReceiveAccept::WriteToBuffer(BufBound & aBuffer) const
     {
         if (widerange)
         {
-            aBuffer.PutLE64(Length);
+            aBuffer.Put64(Length);
         }
         else
         {
-            aBuffer.PutLE32(static_cast<uint32_t>(Length));
+            aBuffer.Put32(static_cast<uint32_t>(Length));
         }
     }
 
@@ -322,6 +319,7 @@ void ReceiveAccept::WriteToBuffer(BufBound & aBuffer) const
     {
         aBuffer.Put(Metadata, static_cast<size_t>(MetadataLength));
     }
+    return aBuffer;
 }
 
 CHIP_ERROR ReceiveAccept::Parse(const System::PacketBuffer & aBuffer)
@@ -393,10 +391,8 @@ exit:
 
 size_t ReceiveAccept::MessageSize() const
 {
-    uint8_t dummy[0];
-    BufBound emptyBuf(static_cast<uint8_t *>(dummy), 0);
-    WriteToBuffer(emptyBuf);
-    return emptyBuf.Written();
+    BufBound emptyBuf(nullptr, 0);
+    return WriteToBuffer(emptyBuf).Needed();
 }
 
 bool ReceiveAccept::operator==(const ReceiveAccept & another) const
@@ -419,9 +415,9 @@ bool ReceiveAccept::operator==(const ReceiveAccept & another) const
 
 // WARNING: this function should never return early, since MessageSize() relies on it to calculate
 // the size of the message (even if the message is incomplete or filled out incorrectly).
-void CounterMessage::WriteToBuffer(BufBound & aBuffer) const
+BufBound & CounterMessage::WriteToBuffer(BufBound & aBuffer) const
 {
-    aBuffer.PutLE32(BlockCounter);
+    return aBuffer.Put32(BlockCounter);
 }
 
 CHIP_ERROR CounterMessage::Parse(const System::PacketBuffer & aBuffer)
@@ -433,10 +429,8 @@ CHIP_ERROR CounterMessage::Parse(const System::PacketBuffer & aBuffer)
 
 size_t CounterMessage::MessageSize() const
 {
-    uint8_t dummy[0];
-    BufBound emptyBuf(static_cast<uint8_t *>(dummy), 0);
-    WriteToBuffer(emptyBuf);
-    return emptyBuf.Written();
+    BufBound emptyBuf(nullptr, 0);
+    return WriteToBuffer(emptyBuf).Needed();
 }
 
 bool CounterMessage::operator==(const CounterMessage & another) const
@@ -446,13 +440,14 @@ bool CounterMessage::operator==(const CounterMessage & another) const
 
 // WARNING: this function should never return early, since MessageSize() relies on it to calculate
 // the size of the message (even if the message is incomplete or filled out incorrectly).
-void DataBlock::WriteToBuffer(BufBound & aBuffer) const
+BufBound & DataBlock::WriteToBuffer(BufBound & aBuffer) const
 {
-    aBuffer.PutLE32(BlockCounter);
+    aBuffer.Put32(BlockCounter);
     if (Data != nullptr)
     {
         aBuffer.Put(Data, DataLength);
     }
+    return aBuffer;
 }
 
 CHIP_ERROR DataBlock::Parse(const System::PacketBuffer & aBuffer)
@@ -485,10 +480,8 @@ exit:
 
 size_t DataBlock::MessageSize() const
 {
-    uint8_t dummy[0];
-    BufBound emptyBuf(static_cast<uint8_t *>(dummy), 0);
-    WriteToBuffer(emptyBuf);
-    return emptyBuf.Written();
+    BufBound emptyBuf(nullptr, 0);
+    return WriteToBuffer(emptyBuf).Needed();
 }
 
 bool DataBlock::operator==(const DataBlock & another) const

--- a/src/protocols/bdx/BdxMessages.h
+++ b/src/protocols/bdx/BdxMessages.h
@@ -64,7 +64,7 @@ struct TransferInit
      *
      * @param aBuffer A BufBound object that will be used to write the message
      */
-    void WriteToBuffer(BufBound & aBuffer) const;
+    BufBound & WriteToBuffer(BufBound & aBuffer) const;
 
     /**
      * @brief
@@ -134,7 +134,7 @@ struct SendAccept
      *
      * @param aBuffer A BufBound object that will be used to write the message
      */
-    void WriteToBuffer(BufBound & aBuffer) const;
+    BufBound & WriteToBuffer(BufBound & aBuffer) const;
 
     /**
      * @brief
@@ -192,7 +192,7 @@ struct ReceiveAccept
      *
      * @param aBuffer A BufBound object that will be used to write the message
      */
-    void WriteToBuffer(BufBound & aBuffer) const;
+    BufBound & WriteToBuffer(BufBound & aBuffer) const;
 
     /**
      * @brief
@@ -254,7 +254,7 @@ struct CounterMessage
      *
      * @param aBuffer A BufBound object that will be used to write the message
      */
-    void WriteToBuffer(BufBound & aBuffer) const;
+    BufBound & WriteToBuffer(BufBound & aBuffer) const;
 
     /**
      * @brief
@@ -302,7 +302,7 @@ struct DataBlock
      *
      * @param aBuffer A BufBound object that will be used to write the message
      */
-    void WriteToBuffer(BufBound & aBuffer) const;
+    BufBound & WriteToBuffer(BufBound & aBuffer) const;
 
     /**
      * @brief

--- a/src/protocols/bdx/tests/TestBdxMessages.cpp
+++ b/src/protocols/bdx/tests/TestBdxMessages.cpp
@@ -27,7 +27,7 @@ void TestHelperWrittenAndParsedMatch(nlTestSuite * inSuite, void * inContext, Ms
     BufBound bbuf(msgBuf->Start(), msgBuf->AvailableDataLength());
     testMsg.WriteToBuffer(bbuf);
     NL_TEST_ASSERT(inSuite, bbuf.Fit());
-    msgBuf->SetDataLength(static_cast<uint16_t>(bbuf.Written()));
+    msgBuf->SetDataLength(static_cast<uint16_t>(bbuf.Needed()));
 
     System::PacketBufferHandle rcvBuf = System::PacketBuffer::NewWithAvailableSize(static_cast<uint16_t>(msgSize));
     NL_TEST_ASSERT(inSuite, !rcvBuf.IsNull());

--- a/src/transport/NetworkProvisioning.cpp
+++ b/src/transport/NetworkProvisioning.cpp
@@ -131,7 +131,7 @@ CHIP_ERROR NetworkProvisioning::EncodeString(const char * str, BufBound & bbuf)
     uint16_t u16len = static_cast<uint16_t>(length);
     VerifyOrExit(CanCastTo<uint16_t>(length), err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    bbuf.PutLE16(u16len);
+    bbuf.Put16(u16len);
     bbuf.Put(str);
 
 exit:
@@ -150,7 +150,7 @@ CHIP_ERROR NetworkProvisioning::DecodeString(const uint8_t * input, size_t input
     VerifyOrExit(input_len - consumed >= length, err = CHIP_ERROR_BUFFER_TOO_SMALL);
     bbuf.Put(&input[consumed], length);
 
-    consumed += bbuf.Written();
+    consumed += bbuf.Needed();
     bbuf.Put('\0');
 
     VerifyOrExit(bbuf.Fit(), err = CHIP_ERROR_BUFFER_TOO_SMALL);
@@ -198,8 +198,8 @@ CHIP_ERROR NetworkProvisioning::SendNetworkCredentials(const char * ssid, const 
     SuccessOrExit(EncodeString(passwd, bbuf));
     VerifyOrExit(bbuf.Fit(), err = CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    VerifyOrExit(CanCastTo<uint16_t>(bbuf.Written()), err = CHIP_ERROR_INVALID_ARGUMENT);
-    buffer->SetDataLength(static_cast<uint16_t>(bbuf.Written()));
+    VerifyOrExit(CanCastTo<uint16_t>(bbuf.Needed()), err = CHIP_ERROR_INVALID_ARGUMENT);
+    buffer->SetDataLength(static_cast<uint16_t>(bbuf.Needed()));
 
     err = mDelegate->SendSecureMessage(Protocols::kProtocol_NetworkProvisioning,
                                        NetworkProvisioning::MsgTypes::kWiFiAssociationRequest, buffer.Release_ForNow());
@@ -227,14 +227,14 @@ CHIP_ERROR NetworkProvisioning::SendThreadCredentials(const DeviceLayer::Interna
         bbuf.Put(threadData.ThreadMeshPrefix, sizeof(threadData.ThreadMeshPrefix));
         bbuf.Put(threadData.ThreadMasterKey, sizeof(threadData.ThreadMasterKey));
         bbuf.Put(threadData.ThreadPSKc, sizeof(threadData.ThreadPSKc));
-        bbuf.PutLE16(threadData.ThreadPANId);
+        bbuf.Put16(threadData.ThreadPANId);
         bbuf.Put(threadData.ThreadChannel);
         bbuf.Put(static_cast<uint8_t>(threadData.FieldPresent.ThreadExtendedPANId));
         bbuf.Put(static_cast<uint8_t>(threadData.FieldPresent.ThreadMeshPrefix));
         bbuf.Put(static_cast<uint8_t>(threadData.FieldPresent.ThreadPSKc));
 
         VerifyOrExit(bbuf.Fit(), err = CHIP_ERROR_BUFFER_TOO_SMALL);
-        buffer->SetDataLength(static_cast<uint16_t>(bbuf.Written()));
+        buffer->SetDataLength(static_cast<uint16_t>(bbuf.Needed()));
 
         err = mDelegate->SendSecureMessage(Protocols::kProtocol_NetworkProvisioning,
                                            NetworkProvisioning::MsgTypes::kThreadAssociationRequest, buffer.Release_ForNow());

--- a/src/transport/SecurePairingSession.cpp
+++ b/src/transport/SecurePairingSession.cpp
@@ -244,7 +244,7 @@ CHIP_ERROR SecurePairingSession::Pair(uint32_t peerSetUpPINCode, uint32_t pbkdf2
 
     {
         BufBound bbuf(resp->Start(), data_len);
-        VerifyOrExit(bbuf.Put(&X[0], X_len) == X_len, err = CHIP_ERROR_NO_MEMORY);
+        bbuf.Put(&X[0], X_len);
         VerifyOrExit(bbuf.Fit(), err = CHIP_ERROR_NO_MEMORY);
     }
 

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -90,8 +90,8 @@ CHIP_ERROR SecureSession::GetIV(const PacketHeader & header, uint8_t * iv, size_
 
     BufBound bbuf(iv, len);
 
-    bbuf.PutLE64(header.GetSourceNodeId().ValueOr(0));
-    bbuf.PutLE32(header.GetMessageId());
+    bbuf.Put64(header.GetSourceNodeId().ValueOr(0));
+    bbuf.Put32(header.GetMessageId());
 
     return bbuf.Fit() ? CHIP_NO_ERROR : CHIP_ERROR_NO_MEMORY;
 }


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problems
 * Written() considered harmful, really means "Needed()", trips up some users
 * Fit() should always be checked before looking at what was actually written, but there's no guard enforcing this
 * BufBound returning "needed" on each Put() isn't necessary, also confuses folks wanting to check the return value on every Put().  Return *this instead to enable constructor pattern code (a la BufferReader)
 * "LE" names don't match BufferReader, which *only* does LE


<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
 * whack "LE" prefix for LE methods to match BufferReader
 * rename `Written()` to `Needed()`
 * return *this from `Put()`
 * output `written` from `Fit()` to force the customer to check `Fit()` to get this value

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->



<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->