### PR TITLE
Update the ZAP template to encode/decode commands

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -232,5 +232,9 @@ TabWidth:        8
 UseTab:          Never
 ---
 Language: JavaScript
+BasedOnStyle: WebKit
+AlignConsecutiveAssignments: true
+AllowShortFunctionsOnASingleLine: None
+IndentWidth:     2
 ColumnLimit:     132
 ...

--- a/src/app/zap-templates/af-structs.zapt
+++ b/src/app/zap-templates/af-structs.zapt
@@ -16,16 +16,12 @@ typedef struct _{{asType label}} {
 {{ident}}chip::EndpointId {{asSymbol label}};
 {{else if (isStrEqual label "endpointId")}}
 {{ident}}chip::EndpointId {{asSymbol label}};
-{{else if (isStrEqual type "CLUSTER_ID")}}
-{{ident}}chip::ClusterId {{asSymbol label}};
-{{else if (isStrEqual type "ATTRIBUTE_ID")}}
-{{ident}}chip::AttributeId {{asSymbol label}};
 {{else if (isStrEqual label "groupId")}}
 {{ident}}chip::GroupId {{asSymbol label}};
 {{else if (isStrEqual label "commandId")}}
 {{ident}}chip::CommandId {{asSymbol label}};
 {{else}}
-{{ident}}{{asUnderlyingType type}} {{asSymbol label}};
+{{ident}}{{asUnderlyingZclType type}} {{asSymbol label}};
 {{/if}}
 {{/zcl_struct_items}}
 } {{asUnderlyingType label}};

--- a/src/app/zap-templates/attribute-size.zapt
+++ b/src/app/zap-templates/attribute-size.zapt
@@ -6,6 +6,6 @@
 // ZCL attribute sizes
 {{#zcl_atomics}}
 {{#if size}}
-{{ident}}ZCL_{{asDelimitedMacro name}}_ATTRIBUTE_TYPE, {{size}}, \
+{{ident}}ZCL_{{asDelimitedMacro name}}_ATTRIBUTE_TYPE, {{size}},
 {{/if}}
 {{/zcl_atomics}}

--- a/src/app/zap-templates/call-command-handler-src.zapt
+++ b/src/app/zap-templates/call-command-handler-src.zapt
@@ -100,18 +100,43 @@ EmberAfStatus emberAf{{asCamelCased name false}}Cluster{{asCamelCased side false
         {{#if (isCommandAvailable parent.side incoming outgoing commandSource name)}}
         case ZCL_{{asDelimitedMacro name}}_COMMAND_ID: {
             {{#if (zcl_command_arguments_count this.id)}}
-            uint32_t argOffset = 0;
+            uint32_t payloadOffset = cmd->payloadStartIndex;
             {{#zcl_command_arguments}}
-            {{asUnderlyingType type}} * {{asSymbol label}} = ({{asUnderlyingType type}} *)(cmd->buffer + argOffset);
-            {{#unless (isLastElement index count)}}
-            argOffset+= sizeof({{asUnderlyingType type}});
-            {{/unless}}
+            {{asUnderlyingZclType type}} {{asSymbol label}};
             {{/zcl_command_arguments}}
 
-            wasHandled = emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback({{#zcl_command_arguments}} *{{asSymbol label}}{{#unless (isLastElement index count)}}, {{/unless}}{{/zcl_command_arguments}});
-            {{else}}
-            wasHandled = emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback();
+            {{#zcl_command_arguments}}
+            {{#if presentIf}}
+            if ({{presentIf}})
+            {
             {{/if}}
+                {{#if isArray}}
+                {{asSymbol label}} = cmd->buffer + payloadOffset;
+                {{else}}
+                if (cmd->bufLen < payloadOffset + {{asReadTypeLength type}})
+                {
+                    return EMBER_ZCL_STATUS_MALFORMED_COMMAND;
+                }
+                {{asSymbol label}} = emberAfGet{{asReadType type}}(cmd->buffer, payloadOffset, cmd->bufLen);
+                {{#unless (isLastElement index count)}}
+                {{#if (isString type)}}
+                payloadOffset += emberAf{{asReadType type}}Length({{asSymbol label}}) + {{asReadTypeLength type}};
+                {{else}}
+                payloadOffset += {{asReadTypeLength type}};
+                {{/if}}
+                {{/unless}}
+                {{/if}}
+            {{#if presentIf}}
+            }
+            else
+            {
+                {{asSymbol label}} = {{asValueIfNotPresent type}};
+            }
+            {{/if}}
+            {{/zcl_command_arguments}}
+
+            {{/if}}
+            wasHandled = emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback({{#zcl_command_arguments}}{{asSymbol label}}{{#unless (isLastElement index count)}}, {{/unless}}{{/zcl_command_arguments}});
             break;
         }
         {{/if}}

--- a/src/app/zap-templates/callback.zapt
+++ b/src/app/zap-templates/callback.zapt
@@ -117,12 +117,7 @@ void emberAf{{asCamelCased name false}}Cluster{{asCamelCased side false}}TickCal
 {{/if}}
 */
 
-{{#if (zcl_command_arguments_count this.id)}}
-bool emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback({{#zcl_command_arguments}} {{asUnderlyingType type}} {{asSymbol label}}{{#unless (isLastElement index count)}}, {{/unless}}{{/zcl_command_arguments}});
-{{else}}
-bool emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback();
-{{/if}}
-
+bool emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback({{#zcl_command_arguments}}{{asUnderlyingZclType type}} {{asSymbol label}}{{#unless (isLastElement index count)}}, {{/unless}}{{/zcl_command_arguments}});
 
 {{/if}}
 {{/if}}

--- a/src/app/zap-templates/chip-templates.json
+++ b/src/app/zap-templates/chip-templates.json
@@ -2,6 +2,7 @@
     "name": "CHIP templates",
     "version": "chip-v1",
     "helpers": ["helper-chip.js"],
+    "override": "override.js",
     "templates": [
         {
             "path": "af-structs.zapt",

--- a/src/app/zap-templates/override.js
+++ b/src/app/zap-templates/override.js
@@ -1,0 +1,30 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+function atomicType(arg)
+{
+  switch (arg.name) {
+  case 'attribute_id':
+    return 'chip::AttributeId';
+  case 'cluster_id':
+    return 'chip::ClusterId';
+  default:
+    throw 'not overriding';
+  }
+}
+
+exports.atomicType = atomicType


### PR DESCRIPTION
 #### Problem

There are a few issues with the current template.
 1. `{{isArray}}` is not taken into account. It results into a mismatch between
    the signatures of some clusters methods
 2. Instead of using raw types, such as `uint8_t`, `uint16_t`, the current template
    uses `enum`. It creates 2 types of issues:
     * The current template generates code that rely on `sizeof(type)` to move the
       pointer for the payload buffer. It does not work well with `enum`.
     * The signatures of methods are using raw types. So it ask for a change
       in all the cluster signatures.
  3. The buffer start pointer is mispositioned: It uses `0` instead of `cmd->payloadStartIndex`
  4. String are using `uint8_t *`, which is OK but the pointer to the payload buffer is not
     moved to take into account the additional bytes with the size of the string

I'm not fully happy with this PR. It shows the need to add a new helper to ZAP in order to make things easier here. But I don't want to wait for it to be ready before landing this PR since this is the last missing piece that gets me a working `all-clusters-app` application based on ZAP generated (#3464).

So I will open an issue to track that.

Furthermore there is still an issue with the client side of cluster. It does not matter to land this piece of code but I noticed that the templates does not use the `presentIf` field from the `Silabs` XML. It will be needed to implement properly the client side decoding.
