### PR TITLE
Fix bounds checks in PeerConnections

### DIFF
--- a/src/transport/PeerConnections.h
+++ b/src/transport/PeerConnections.h
@@ -141,12 +141,12 @@ public:
         PeerConnectionState * state = nullptr;
         PeerConnectionState * iter  = &mStates[0];
 
-        if (begin >= iter && begin <= &mStates[kMaxConnectionCount])
+        if (begin >= iter && begin < &mStates[kMaxConnectionCount])
         {
             iter = begin + 1;
         }
 
-        for (; iter <= &mStates[kMaxConnectionCount]; iter++)
+        for (; iter < &mStates[kMaxConnectionCount]; iter++)
         {
             if (iter->GetPeerAddress() == address)
             {
@@ -172,12 +172,12 @@ public:
         PeerConnectionState * state = nullptr;
         PeerConnectionState * iter  = &mStates[0];
 
-        if (begin >= iter && begin <= &mStates[kMaxConnectionCount])
+        if (begin >= iter && begin < &mStates[kMaxConnectionCount])
         {
             iter = begin + 1;
         }
 
-        for (; iter <= &mStates[kMaxConnectionCount]; iter++)
+        for (; iter < &mStates[kMaxConnectionCount]; iter++)
         {
             if (!iter->IsInitialized())
             {
@@ -208,12 +208,12 @@ public:
         PeerConnectionState * state = nullptr;
         PeerConnectionState * iter  = &mStates[0];
 
-        if (begin >= iter && begin <= &mStates[kMaxConnectionCount])
+        if (begin >= iter && begin < &mStates[kMaxConnectionCount])
         {
             iter = begin + 1;
         }
 
-        for (; iter <= &mStates[kMaxConnectionCount]; iter++)
+        for (; iter < &mStates[kMaxConnectionCount]; iter++)
         {
             if (!iter->IsInitialized())
             {
@@ -248,12 +248,12 @@ public:
         PeerConnectionState * state = nullptr;
         PeerConnectionState * iter  = &mStates[0];
 
-        if (begin >= iter && begin <= &mStates[kMaxConnectionCount])
+        if (begin >= iter && begin < &mStates[kMaxConnectionCount])
         {
             iter = begin + 1;
         }
 
-        for (; iter <= &mStates[kMaxConnectionCount]; iter++)
+        for (; iter < &mStates[kMaxConnectionCount]; iter++)
         {
             if (!iter->IsInitialized())
             {


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Our bounds checks are off, so we read past the end of the array.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Fix the bounds checks.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes https://github.com/project-chip/connectedhomeip/issues/3938

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
