### PR TITLE
[cirque] Fix cirque test

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -50,8 +50,6 @@
 	path = third_party/cirque/repo
 	url = https://github.com/openweave/cirque.git
 	branch = master
-	ignore = dirty
-	commit = 905112cbeeda504223209798ec23e3754ce43fca
 [submodule "happy"]
 	path = third_party/happy/repo
 	url = https://github.com/openweave/happy.git


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Cirque test failed today.

 #### Summary of Changes
Update cirque to latest version to fix this issue.

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
