### PR TITLE
Disable IAS Zone Client in the all-clusters-app configuration .zap file

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
@@ -2663,7 +2663,7 @@
           "mfgCode": null,
           "define": "IAS_ZONE_CLUSTER",
           "side": "client",
-          "enabled": 1,
+          "enabled": 0,
           "commands": [
             {
               "name": "ZoneEnrollResponse",


### PR DESCRIPTION
 #### Problem

I removed the IAS Zone Client cluster assumption in #3875 (since the IAS Zone Client cluster code is not enabled anyway).

But when landing #3901 I forgot to turn it off in the new `.zap` configuration file :'(

 #### Summary of Changes
  * Disable IAS Zone Client in the `.zap` configuration file of the `all-clusters-app`