### PR TITLE
Fix passing enum instead of bool to SetBLEAdvertisingEnabled

### DIFF
--- a/examples/all-clusters-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/all-clusters-app/esp32/main/CHIPDeviceManager.cpp
@@ -63,11 +63,11 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     switch (static_cast<RendezvousInformationFlags>(CONFIG_RENDEZVOUS_MODE))
     {
     case RendezvousInformationFlags::kBLE:
-        ConnectivityMgr().SetBLEAdvertisingEnabled(ConnectivityManager::kCHIPoBLEServiceMode_Enabled);
+        ConnectivityMgr().SetBLEAdvertisingEnabled(true);
         break;
 
     case RendezvousInformationFlags::kWiFi:
-        ConnectivityMgr().SetBLEAdvertisingEnabled(ConnectivityManager::kCHIPoBLEServiceMode_Disabled);
+        ConnectivityMgr().SetBLEAdvertisingEnabled(false);
         ConnectivityMgr().SetWiFiAPMode(ConnectivityManager::kWiFiAPMode_Enabled);
         break;
 

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -183,8 +183,7 @@ int main(int argc, char * argv[])
 
     chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureBle(LinuxDeviceOptions::GetInstance().mBleDevice, false);
 
-    chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(
-        chip::DeviceLayer::ConnectivityManager::kCHIPoBLEServiceMode_Enabled);
+    chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(true);
 
     LightingMgr().Init();
 

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -385,7 +385,7 @@ void AppTask::StartBLEAdvertisementHandler(AppEvent * aEvent)
 
     if (!ConnectivityMgr().IsBLEAdvertisingEnabled())
     {
-        ConnectivityMgr().SetBLEAdvertisingEnabled(ConnectivityManager::kCHIPoBLEServiceMode_Enabled);
+        ConnectivityMgr().SetBLEAdvertisingEnabled(true);
         LOG_INF("Enabled BLE Advertisement");
     }
     else

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -387,7 +387,7 @@ void AppTask::StartBLEAdvertisementHandler(AppEvent * aEvent)
 
     if (!ConnectivityMgr().IsBLEAdvertisingEnabled())
     {
-        ConnectivityMgr().SetBLEAdvertisingEnabled(ConnectivityManager::kCHIPoBLEServiceMode_Enabled);
+        ConnectivityMgr().SetBLEAdvertisingEnabled(true);
         LOG_INF("Enabled BLE Advertisement");
     }
     else

--- a/examples/temperature-measurement-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/temperature-measurement-app/esp32/main/CHIPDeviceManager.cpp
@@ -60,11 +60,11 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     switch (static_cast<RendezvousInformationFlags>(CONFIG_RENDEZVOUS_MODE))
     {
     case RendezvousInformationFlags::kBLE:
-        ConnectivityMgr().SetBLEAdvertisingEnabled(ConnectivityManager::kCHIPoBLEServiceMode_Enabled);
+        ConnectivityMgr().SetBLEAdvertisingEnabled(true);
         break;
 
     case RendezvousInformationFlags::kWiFi:
-        ConnectivityMgr().SetBLEAdvertisingEnabled(ConnectivityManager::kCHIPoBLEServiceMode_Disabled);
+        ConnectivityMgr().SetBLEAdvertisingEnabled(false);
         ConnectivityMgr().SetWiFiAPMode(ConnectivityManager::kWiFiAPMode_Enabled);
         break;
 

--- a/src/platform/tests/TestCHIPoBLEStackMgr.cpp
+++ b/src/platform/tests/TestCHIPoBLEStackMgr.cpp
@@ -44,8 +44,7 @@ int TestCHIPoBLEStackManager()
 
     chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureBle(1, false);
 
-    chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(
-        chip::DeviceLayer::ConnectivityManager::kCHIPoBLEServiceMode_Enabled);
+    chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(true);
 
     ChipLogProgress(DeviceLayer, "Start Chip Over Ble stack Done");
 


### PR DESCRIPTION
 #### Problem
Some code fragments pass `CHIPoBLEServiceMode` values to `SetBLEAdvertisingEnabled` while the function takes a bool.
Proposed Solution

 #### Summary of Changes
Pass true/false to SetBLEAdvertisingEnabled

 Fixes #3954