### PR TITLE
Release all active device handles on controller shutdown

### DIFF
--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -167,6 +167,15 @@ public:
 
     void SetActive(bool active) { mActive = active; }
 
+    void Reset()
+    {
+        SetActive(false);
+        mState          = ConnectionState::NotConnected;
+        mSessionManager = nullptr;
+        mStatusDelegate = nullptr;
+        mInetLayer      = nullptr;
+    }
+
     NodeId GetDeviceId() const { return mDeviceId; }
 
     void SetAddress(const Inet::IPAddress & deviceAddr) { mDeviceAddr = deviceAddr; }

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -134,6 +134,8 @@ CHIP_ERROR DeviceController::Init(NodeId localDeviceId, PersistentStorageDelegat
     mState         = State::Initialized;
     mLocalDeviceId = localDeviceId;
 
+    ReleaseAllDevices();
+
 exit:
     return err;
 }
@@ -173,6 +175,8 @@ CHIP_ERROR DeviceController::Shutdown()
         chip::Platform::Delete(mSessionManager);
         mSessionManager = nullptr;
     }
+
+    ReleaseAllDevices();
 
 exit:
     return err;
@@ -351,7 +355,7 @@ uint16_t DeviceController::GetInactiveDeviceIndex()
 
 void DeviceController::ReleaseDevice(Device * device)
 {
-    device->SetActive(false);
+    device->Reset();
 }
 
 void DeviceController::ReleaseDevice(uint16_t index)
@@ -359,6 +363,14 @@ void DeviceController::ReleaseDevice(uint16_t index)
     if (index < kNumMaxActiveDevices)
     {
         ReleaseDevice(&mActiveDevices[index]);
+    }
+}
+
+void DeviceController::ReleaseAllDevices()
+{
+    for (uint16_t i = 0; i < kNumMaxActiveDevices; i++)
+    {
+        ReleaseDevice(&mActiveDevices[i]);
     }
 }
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -203,6 +203,8 @@ private:
     void OnValue(const char * key, const char * value) override;
     void OnStatus(const char * key, Operation op, CHIP_ERROR err) override;
 
+    void ReleaseAllDevices();
+
     System::Layer * mSystemLayer;
 };
 


### PR DESCRIPTION
 #### Problem
`DeviceController::Shutdown()/Init()` does not release device handles. If the user calls `Init` followed by a `Shutdown`, it can have stale device handles from last session.

 #### Summary of Changes
Release all device handles on shutdown and init. Also, reset the device state, instead of just marking it inactive.
