### PR TITLE
Bump Docker image version in VSCode Devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
         "dockerfile": "Dockerfile",
         "args": {
             //  "BUILD_VERSION": "$(cat integrations/docker/images/chip-build/version)" // trying to get this to work
-            "BUILD_VERSION": "0.4.16"
+            "BUILD_VERSION": "0.4.18"
         }
     },
     "remoteUser": "vscode",


### PR DESCRIPTION
 #### Problem
`.devcontainer/Dockerfile` assumes that it is built on top of `chip-build-vscode:0.4.17` (or higher) while `devcontainer.json` specifies version `0.4.16`.

 #### Summary of Changes
Bump version of `chip-build-vscode` Docker image in `devcontainer.json`.

 Fixes #3949