### PR TITLE
Add back Android default build coverage & fix the build

### DIFF
--- a/scripts/examples/android_app.sh
+++ b/scripts/examples/android_app.sh
@@ -16,6 +16,7 @@
 #    limitations under the License.
 #
 
+set -e
 set -x
 env
 
@@ -37,7 +38,7 @@ fi
 # Build shared CHIP libs
 source scripts/activate.sh
 gn gen --check --fail-on-unused-args out/"android_$TARGET_CPU" --args="target_os=\"android\" target_cpu=\"$TARGET_CPU\" android_ndk_root=\"$ANDROID_NDK_HOME\" android_sdk_root=\"$ANDROID_HOME\""
-ninja -C out/"android_$TARGET_CPU" src/setup_payload/java src/controller/java
+ninja -C out/"android_$TARGET_CPU" src/setup_payload/java src/controller/java default
 
 rsync -a out/"android_$TARGET_CPU"/lib/*.jar src/android/CHIPTool/app/libs
 rsync -a out/"android_$TARGET_CPU"/lib/jni/* src/android/CHIPTool/app/src/main/jniLibs

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -41,7 +41,6 @@ if (chip_build_tests) {
       "${chip_root}/src/app/tests",
       "${chip_root}/src/crypto/tests",
       "${chip_root}/src/inet/tests",
-      "${chip_root}/src/lib/mdns/minimal/tests",
       "${chip_root}/src/messaging/tests",
       "${chip_root}/src/protocols/bdx/tests",
       "${chip_root}/src/system/tests",
@@ -49,6 +48,10 @@ if (chip_build_tests) {
       "${chip_root}/src/transport/retransmit/tests",
       "${chip_root}/src/transport/tests",
     ]
+
+    if (chip_device_platform != "none") {
+      deps += [ "${chip_root}/src/lib/mdns/minimal/tests" ]
+    }
 
     if (chip_device_platform != "esp32") {
       deps += [


### PR DESCRIPTION
mDNS doesn't build with no device layer. Remove it from the build and
add back the coverage that would catch this that was lost in #3340.