### PR TITLE
Remove explicit "all" target from root build file

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -34,10 +34,6 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
 
   # This is a real toolchain. Build CHIP.
   group("default") {
-    deps = [ ":all" ]
-  }
-
-  group("all") {
     deps = [
       "${chip_root}/src/app",
       "${chip_root}/src/ble",
@@ -249,20 +245,20 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
   group("default") {
     deps = []
     if (enable_host_clang_build) {
-      deps += [ ":all_host_clang" ]
+      deps += [ ":host_clang" ]
     }
     if (enable_host_gcc_build) {
-      deps += [ ":all_host_gcc" ]
+      deps += [ ":host_gcc" ]
     }
     if (enable_host_gcc_mbedtls_build) {
-      deps += [ ":all_host_gcc_mbedtls" ]
+      deps += [ ":host_gcc_mbedtls" ]
     }
     if (enable_android_builds) {
       deps += [
-        ":all_android_arm",
-        ":all_android_arm64",
-        ":all_android_x64",
-        ":all_android_x86",
+        ":android_arm",
+        ":android_arm64",
+        ":android_x64",
+        ":android_x86",
       ]
     }
     if (enable_standalone_chip_tool_build) {

--- a/build/chip/chip_build.gni
+++ b/build/chip/chip_build.gni
@@ -20,8 +20,8 @@ template("chip_build") {
   _build_name = target_name
   _toolchain = invoker.toolchain
 
-  group("all_${_build_name}") {
-    deps = [ ":all(${_toolchain})" ]
+  group("${_build_name}") {
+    deps = [ ":default(${_toolchain})" ]
   }
 
   group("check_${_build_name}") {

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -212,7 +212,7 @@ expensive to build everything for every edit. To save time, you can name the
 configuration to build:
 
 ```
-ninja -C out/unified all_host_gcc
+ninja -C out/unified host_gcc
 ninja -C out/unified check_host_gcc
 ```
 

--- a/scripts/helpers/update_compile_commands.sh
+++ b/scripts/helpers/update_compile_commands.sh
@@ -23,19 +23,19 @@ CHIP_ROOT="$(dirname "$0")/../.."
 
 source "$CHIP_ROOT/scripts/activate.sh"
 
-gn --root="$CHIP_ROOT" gen "$CHIP_ROOT/out/debug" --export-compile-commands=all_host_gcc
+gn --root="$CHIP_ROOT" gen "$CHIP_ROOT/out/debug" --export-compile-commands=host_gcc
 mv "$CHIP_ROOT/out/debug/compile_commands.json" "$CHIP_ROOT/out/debug/compile_commands.gcc.json"
 
-gn --root="$CHIP_ROOT" gen "$CHIP_ROOT/out/debug" --export-compile-commands=all_host_clang
+gn --root="$CHIP_ROOT" gen "$CHIP_ROOT/out/debug" --export-compile-commands=host_clang
 mv "$CHIP_ROOT/out/debug/compile_commands.json" "$CHIP_ROOT/out/debug/compile_commands.clang.json"
 
-gn --root="$CHIP_ROOT" gen "$CHIP_ROOT/out/debug" --export-compile-commands=all_host_gcc_mbedtls
+gn --root="$CHIP_ROOT" gen "$CHIP_ROOT/out/debug" --export-compile-commands=host_gcc_mbedtls
 mv "$CHIP_ROOT/out/debug/compile_commands.json" "$CHIP_ROOT/out/debug/compile_commands.mbedtls.json"
 
-gn --root="$CHIP_ROOT" gen "$CHIP_ROOT/out/debug" --export-compile-commands=all_android_x64
+gn --root="$CHIP_ROOT" gen "$CHIP_ROOT/out/debug" --export-compile-commands=android_x64
 mv "$CHIP_ROOT/out/debug/compile_commands.json" "$CHIP_ROOT/out/debug/compile_commands.android_x64.json"
 
-gn --root="$CHIP_ROOT" gen "$CHIP_ROOT/out/debug" --export-compile-commands=all_android_arm64
+gn --root="$CHIP_ROOT" gen "$CHIP_ROOT/out/debug" --export-compile-commands=android_arm64
 mv "$CHIP_ROOT/out/debug/compile_commands.json" "$CHIP_ROOT/out/debug/compile_commands.android_arm64.json"
 
 gn --root="$CHIP_ROOT" gen "$CHIP_ROOT/out/debug" --export-compile-commands=efr32_lock_app


### PR DESCRIPTION
The "all" target exists implicitly and contains everything. We don't
need to specify one, and it's misleading to do so as specifying deps has
no effect.