### PR TITLE
Add a check to verify if the cluster has any commands enabled prior to creating a parsing function.

### DIFF
--- a/src/app/zap-templates/call-command-handler-src.zapt
+++ b/src/app/zap-templates/call-command-handler-src.zapt
@@ -48,7 +48,7 @@ EmberAfStatus emberAfClusterSpecificCommandParse(EmberAfClusterCommand * cmd)
         switch (cmd->apsFrame->clusterId)
         {
         {{#all_user_clusters}}
-        {{#if (isEnabled enabled)}}
+        {{#if (user_cluster_has_enabled_command name side)}}
         {{#if (isClient side) }}
         case ZCL_{{asDelimitedMacro define}}_ID :
             result = emberAf{{asCamelCased name false}}Cluster{{asCamelCased side false}}CommandParse(cmd);
@@ -67,7 +67,7 @@ EmberAfStatus emberAfClusterSpecificCommandParse(EmberAfClusterCommand * cmd)
         switch (cmd->apsFrame->clusterId)
         {
         {{#all_user_clusters}}
-        {{#if (isEnabled enabled)}}
+        {{#if (user_cluster_has_enabled_command name side)}}
         {{#unless (isClient  side) }}
         case ZCL_{{asDelimitedMacro define}}_ID :
             result = emberAf{{asCamelCased name false}}Cluster{{asCamelCased side false}}CommandParse(cmd);
@@ -86,7 +86,7 @@ EmberAfStatus emberAfClusterSpecificCommandParse(EmberAfClusterCommand * cmd)
 // Cluster specific command parsing
 
 {{#all_user_clusters}}
-{{#if (isEnabled enabled)}}
+{{#if (user_cluster_has_enabled_command name side)}}
 EmberAfStatus emberAf{{asCamelCased name false}}Cluster{{asCamelCased side false}}CommandParse(EmberAfClusterCommand * cmd)
 {
     bool wasHandled = false;

--- a/src/app/zap-templates/call-command-handler-src.zapt
+++ b/src/app/zap-templates/call-command-handler-src.zapt
@@ -48,12 +48,15 @@ EmberAfStatus emberAfClusterSpecificCommandParse(EmberAfClusterCommand * cmd)
         switch (cmd->apsFrame->clusterId)
         {
         {{#all_user_clusters}}
-        {{#if (user_cluster_has_enabled_command name side)}}
         {{#if (isClient side) }}
         case ZCL_{{asDelimitedMacro define}}_ID :
+            {{#if (user_cluster_has_enabled_command name side)}}
             result = emberAf{{asCamelCased name false}}Cluster{{asCamelCased side false}}CommandParse(cmd);
+            {{else}}
+            // No commands are enabled for cluster {{name}}
+            result = status(false, true, cmd->mfgSpecific);
+            {{/if}}
             break;
-        {{/if}}
         {{/if}}
         {{/all_user_clusters}}
         default:
@@ -67,13 +70,16 @@ EmberAfStatus emberAfClusterSpecificCommandParse(EmberAfClusterCommand * cmd)
         switch (cmd->apsFrame->clusterId)
         {
         {{#all_user_clusters}}
-        {{#if (user_cluster_has_enabled_command name side)}}
-        {{#unless (isClient  side) }}
+        {{#unless (isClient side) }}
         case ZCL_{{asDelimitedMacro define}}_ID :
+            {{#if (user_cluster_has_enabled_command name side)}}
             result = emberAf{{asCamelCased name false}}Cluster{{asCamelCased side false}}CommandParse(cmd);
+            {{else}}
+            // No commands are enabled for cluster {{name}}
+            result = status(false, true, cmd->mfgSpecific);
+            {{/if}}
             break;
         {{/unless}}
-        {{/if}}
         {{/all_user_clusters}}
         default:
             // Unrecognized cluster ID, error status will apply.


### PR DESCRIPTION
 #### Problem
New ZAP templates created a cluster command parsing per cluster side even if the cluster didn't have any commands enabled. While this didn't cause any issue executing wise, it did clutter the `call-command-handler.ccp` with useless functions.

 #### Summary of Changes
 Added a check to verify if the cluster has any commands enabled prior to creating a parsing function.

 Fixes #3874 