### PR TITLE
Add #idfef for DEVICE_LAYER for minimal mdns, Update to latest PacketBufferHandle parameters

### DIFF
--- a/src/lib/mdns/minimal/Server.cpp
+++ b/src/lib/mdns/minimal/Server.cpp
@@ -215,12 +215,9 @@ CHIP_ERROR ServerBase::BroadcastSend(chip::System::PacketBuffer * data, uint16_t
     return CHIP_NO_ERROR;
 }
 
-void ServerBase::OnUdpPacketReceived(chip::Inet::IPEndPointBasis * endPoint, chip::System::PacketBuffer * buffer,
+void ServerBase::OnUdpPacketReceived(chip::Inet::IPEndPointBasis * endPoint, chip::System::PacketBufferHandle buffer,
                                      const chip::Inet::IPPacketInfo * info)
 {
-    chip::System::PacketBufferHandle autoFree;
-    autoFree.Adopt(buffer);
-
     ServerBase * srv = static_cast<ServerBase *>(endPoint->AppState);
     if (!srv->mDelegate)
     {

--- a/src/lib/mdns/minimal/Server.cpp
+++ b/src/lib/mdns/minimal/Server.cpp
@@ -19,7 +19,9 @@
 
 #include <errno.h>
 
+#if CONFIG_DEVICE_LAYER
 #include <platform/CHIPDeviceLayer.h>
+#endif
 
 #include "DnsHeader.h"
 
@@ -86,6 +88,7 @@ CHIP_ERROR ServerBase::Listen(ListenIterator * it, uint16_t port)
 {
     Shutdown(); // ensure everything starts fresh
 
+#if CONFIG_DEVICE_LAYER
     size_t endpointIndex                = 0;
     chip::Inet::InterfaceId interfaceId = INET_NULL_INTERFACEID;
     chip::Inet::IPAddressType addressType;
@@ -127,6 +130,9 @@ CHIP_ERROR ServerBase::Listen(ListenIterator * it, uint16_t port)
     }
 
     return autoShutdown.ReturnSuccess();
+#else // #if CONFIG_DEVICE_LAYER
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+#endif
 }
 
 CHIP_ERROR ServerBase::DirectSend(chip::System::PacketBuffer * data, const chip::Inet::IPAddress & addr, uint16_t port,

--- a/src/lib/mdns/minimal/Server.cpp
+++ b/src/lib/mdns/minimal/Server.cpp
@@ -223,8 +223,8 @@ void ServerBase::OnUdpPacketReceived(chip::Inet::IPEndPointBasis * endPoint, chi
     {
         return;
     }
-    mdns::Minimal::BytesRange data(buffer->Start(), buffer->Start() + buffer->DataLength());
 
+    mdns::Minimal::BytesRange data(buffer->Start(), buffer->Start() + buffer->DataLength());
     if (data.Size() < HeaderRef::kSizeBytes)
     {
         ChipLogError(Discovery, "Packet to small for mDNS data: %d bytes", static_cast<int>(data.Size()));

--- a/src/lib/mdns/minimal/Server.h
+++ b/src/lib/mdns/minimal/Server.h
@@ -103,7 +103,7 @@ public:
     }
 
 private:
-    static void OnUdpPacketReceived(chip::Inet::IPEndPointBasis * endPoint, chip::System::PacketBuffer * buffer,
+    static void OnUdpPacketReceived(chip::Inet::IPEndPointBasis * endPoint, chip::System::PacketBufferHandle buffer,
                                     const chip::Inet::IPPacketInfo * info);
 
     EndpointInfo * mEndpoints;   // possible endpoints, to listen on multiple interfaces


### PR DESCRIPTION
Fix Build breakage:
  - android does not have devicelayer.
  - Commit merges crossed paths and arguments for UDP receiving changed

This adds a #ifdef on DEVICE_LAYER. Future full fix would be to pass in the inetlayer to use (so android can pass its own if needed).

Change parameters for UDP receiving to use a packetbufferhandle