### PR TITLE
Remove duplicated send flag defines and put ExchangeMgr/ExchangeConte…

### DIFF
--- a/src/messaging/ErrorCategory.cpp
+++ b/src/messaging/ErrorCategory.cpp
@@ -29,7 +29,7 @@
 #include <system/SystemError.h>
 
 namespace chip {
-namespace messaging {
+namespace Messaging {
 
 bool IsIgnoredMulticastSendError(CHIP_ERROR err)
 {
@@ -81,5 +81,5 @@ bool IsSendErrorNonCritical(CHIP_ERROR err)
             err == INET_ERROR_MESSAGE_TOO_LONG || err == INET_ERROR_NO_MEMORY || CHIP_CONFIG_IsPlatformErrorNonCritical(err));
 }
 
-} // namespace messaging
+} // namespace Messaging
 } // namespace chip

--- a/src/messaging/ErrorCategory.h
+++ b/src/messaging/ErrorCategory.h
@@ -27,11 +27,11 @@
 #include <support/DLLUtil.h>
 
 namespace chip {
-namespace messaging {
+namespace Messaging {
 
 CHIP_ERROR FilterUDPSendError(CHIP_ERROR err, bool isMulticast);
 bool IsIgnoredMulticastSendError(CHIP_ERROR err);
 bool IsSendErrorNonCritical(CHIP_ERROR err);
 
-} // namespace messaging
+} // namespace Messaging
 } // namespace chip

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -121,7 +121,7 @@ exit:
         SetResponseExpected(false);
     }
 
-    if (msgBuf != nullptr && sendFlags.Has(SendMessageFlags::kSendFlag_RetainBuffer))
+    if (msgBuf != nullptr && !sendFlags.Has(SendMessageFlags::kSendFlag_RetainBuffer))
     {
         PacketBuffer::Free(msgBuf);
     }

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -45,6 +45,7 @@ using namespace chip::Inet;
 using namespace chip::System;
 
 namespace chip {
+namespace Messaging {
 
 static void DefaultOnMessageReceived(ExchangeContext * ec, const PacketHeader & packetHeader, uint32_t protocolId, uint8_t msgType,
                                      PacketBufferHandle payload)
@@ -68,7 +69,7 @@ void ExchangeContext::SetResponseExpected(bool inResponseExpected)
     mFlags.Set(ExFlagValues::kFlagResponseExpected, inResponseExpected);
 }
 
-CHIP_ERROR ExchangeContext::SendMessage(uint16_t protocolId, uint8_t msgType, PacketBuffer * msgBuf, uint16_t sendFlags,
+CHIP_ERROR ExchangeContext::SendMessage(uint16_t protocolId, uint8_t msgType, PacketBuffer * msgBuf, const SendFlags & sendFlags,
                                         void * msgCtxt)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -92,7 +93,7 @@ CHIP_ERROR ExchangeContext::SendMessage(uint16_t protocolId, uint8_t msgType, Pa
     payloadHeader.SetMessageType(msgType);
 
     // If a response message is expected...
-    if ((sendFlags & kSendFlag_ExpectResponse) != 0)
+    if (sendFlags.Has(SendMessageFlags::kSendFlag_ExpectResponse))
     {
         // Only one 'response expected' message can be outstanding at a time.
         VerifyOrExit(!IsResponseExpected(), err = CHIP_ERROR_INCORRECT_STATE);
@@ -119,7 +120,8 @@ exit:
         CancelResponseTimer();
         SetResponseExpected(false);
     }
-    if (msgBuf != nullptr && (sendFlags & kSendFlag_RetainBuffer) == 0)
+
+    if (msgBuf != nullptr && sendFlags.Has(SendMessageFlags::kSendFlag_RetainBuffer))
     {
         PacketBuffer::Free(msgBuf);
     }
@@ -332,4 +334,5 @@ CHIP_ERROR ExchangeContext::HandleMessage(const PacketHeader & packetHeader, con
     return err;
 }
 
+} // namespace Messaging
 } // namespace chip

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -25,12 +25,14 @@
 
 #include <lib/core/ReferenceCounted.h>
 #include <messaging/ExchangeDelegate.h>
+#include <messaging/Flags.h>
 #include <support/BitFlags.h>
 #include <support/DLLUtil.h>
 #include <system/SystemTimer.h>
 #include <transport/SecureSessionMgr.h>
 
 namespace chip {
+namespace Messaging {
 
 class ExchangeManager;
 class ExchangeContext;
@@ -53,12 +55,6 @@ class DLL_EXPORT ExchangeContext : public ReferenceCounted<ExchangeContext, Exch
     friend class ExchangeContextDeletor;
 
 public:
-    enum
-    {
-        kSendFlag_ExpectResponse = 0x0001, // Used to indicate that a response is expected within a specified timeout.
-        kSendFlag_RetainBuffer   = 0x0002, // Used to indicate that the message buffer should not be freed after sending.
-    };
-
     /**
      *  Determine whether the context is the initiator of the exchange.
      *
@@ -108,7 +104,7 @@ public:
      *  @retval  #CHIP_NO_ERROR                             if the CHIP layer successfully sent the message down to the
      *                                                       network layer.
      */
-    CHIP_ERROR SendMessage(uint16_t protocolId, uint8_t msgType, System::PacketBuffer * msgPayload, uint16_t sendFlags = 0,
+    CHIP_ERROR SendMessage(uint16_t protocolId, uint8_t msgType, System::PacketBuffer * msgPayload, const SendFlags & sendFlags,
                            void * msgCtxt = nullptr);
 
     /**
@@ -192,4 +188,5 @@ inline void ExchangeContextDeletor::Release(ExchangeContext * obj)
     obj->Free();
 }
 
+} // namespace Messaging
 } // namespace chip

--- a/src/messaging/ExchangeDelegate.h
+++ b/src/messaging/ExchangeDelegate.h
@@ -27,6 +27,7 @@
 #include <transport/raw/MessageHeader.h>
 
 namespace chip {
+namespace Messaging {
 
 class ExchangeContext;
 
@@ -74,4 +75,5 @@ public:
     virtual void OnExchangeClosing(ExchangeContext * ec) {}
 };
 
+} // namespace Messaging
 } // namespace chip

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -47,6 +47,7 @@ using namespace chip::Inet;
 using namespace chip::System;
 
 namespace chip {
+namespace Messaging {
 
 /**
  *  Constructor for the ExchangeManager class.
@@ -312,4 +313,5 @@ void ExchangeManager::DecrementContextsInUse()
     }
 }
 
+} // namespace Messaging
 } // namespace chip

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -31,6 +31,7 @@
 #include <transport/SecureSessionMgr.h>
 
 namespace chip {
+namespace Messaging {
 
 class ExchangeContext;
 class ExchangeDelegate;
@@ -206,4 +207,5 @@ private:
     void OnConnectionExpired(const Transport::PeerConnectionState * state, SecureSessionMgr * mgr) override;
 };
 
+} // namespace Messaging
 } // namespace chip

--- a/src/messaging/Flags.h
+++ b/src/messaging/Flags.h
@@ -38,30 +38,32 @@ namespace Messaging {
 enum class MessageFlagValues : uint32_t
 {
     /**< Indicates that the existing source node identifier must be reused. */
-    kChipMessageFlag_ReuseSourceId = 0x00000020,
+    kMessageFlag_ReuseSourceId = 0x00000020,
     /**< Indicates that the sending of the message needs to be delayed. */
-    kChipMessageFlag_DelaySend = 0x00000040,
+    kMessageFlag_DelaySend = 0x00000040,
     /**< Indicates that the message buffer should not be freed after sending. */
-    kChipMessageFlag_RetainBuffer = 0x00000080,
+    kMessageFlag_RetainBuffer = 0x00000080,
     /**< Indicates that the CHIP message is already encoded. */
-    kChipMessageFlag_MessageEncoded = 0x00001000,
+    kMessageFlag_MessageEncoded = 0x00001000,
     /**< Indicates that default IPv6 source address selection should be used when sending IPv6 multicast messages. */
-    kChipMessageFlag_DefaultMulticastSourceAddress = 0x00002000,
+    kMessageFlag_DefaultMulticastSourceAddress = 0x00002000,
     /**< Indicates that the sender of the  message requested an acknowledgment. */
-    kChipMessageFlag_PeerRequestedAck = 0x00004000,
+    kMessageFlag_PeerRequestedAck = 0x00004000,
     /**< Indicates that the message is a duplicate of a previously received message. */
-    kChipMessageFlag_DuplicateMessage = 0x00008000,
+    kMessageFlag_DuplicateMessage = 0x00008000,
     /**< Indicates that the peer's group key message counter is not synchronized. */
-    kChipMessageFlag_PeerGroupMsgIdNotSynchronized = 0x00010000,
+    kMessageFlag_PeerGroupMsgIdNotSynchronized = 0x00010000,
     /**< Indicates that the source of the message is the initiator of the CHIP exchange. */
-    kChipMessageFlag_FromInitiator = 0x00020000,
+    kMessageFlag_FromInitiator = 0x00020000,
     /**< Indicates that message is being sent/received via the local ephemeral UDP port. */
-    kChipMessageFlag_ViaEphemeralUDPPort = 0x00040000,
+    kMessageFlag_ViaEphemeralUDPPort = 0x00040000,
 };
+
+using MessageFlags = BitFlags<uint32_t, MessageFlagValues>;
 
 enum class SendMessageFlags : uint16_t
 {
-    kSendFlag_Default = 0x0000,
+    kSendFlag_None = 0x0000,
     /**< Used to indicate that automatic retransmission is enabled. */
     kSendFlag_AutoRetrans = 0x0001,
     /**< Used to indicate that a response is expected within a specified timeout. */

--- a/src/messaging/Flags.h
+++ b/src/messaging/Flags.h
@@ -24,9 +24,10 @@
 #pragma once
 
 #include <stdint.h>
+#include <support/BitFlags.h>
 
 namespace chip {
-namespace messaging {
+namespace Messaging {
 
 /**
  *  @brief
@@ -60,6 +61,7 @@ enum class MessageFlagValues : uint32_t
 
 enum class SendMessageFlags : uint16_t
 {
+    kSendFlag_Default = 0x0000,
     /**< Used to indicate that automatic retransmission is enabled. */
     kSendFlag_AutoRetrans = 0x0001,
     /**< Used to indicate that a response is expected within a specified timeout. */
@@ -82,5 +84,7 @@ enum class SendMessageFlags : uint16_t
     kSendFlag_NoAutoRequestAck = 0x0800,
 };
 
-} // namespace messaging
+using SendFlags = BitFlags<uint16_t, SendMessageFlags>;
+
+} // namespace Messaging
 } // namespace chip

--- a/src/messaging/ReliableMessageContext.cpp
+++ b/src/messaging/ReliableMessageContext.cpp
@@ -29,7 +29,7 @@
 #include <messaging/ErrorCategory.h>
 #include <messaging/Flags.h>
 #include <messaging/ReliableMessageManager.h>
-#include <protocols/CHIPProtocols.h>
+#include <protocols/Protocols.h>
 #include <protocols/common/CommonProtocol.h>
 #include <support/CodeUtils.h>
 
@@ -221,7 +221,7 @@ CHIP_ERROR ReliableMessageContext::SendThrottleFlow(uint32_t pauseTimeMillis)
     // Send a Throttle Flow message to the peer.  Throttle Flow messages must never request
     // acknowledgment, so suppress the auto-request ACK feature on the exchange in case it has been
     // enabled by the application.
-    err = mManager->SendMessage(this, Protocols::kChipProtocol_Common, Protocols::Common::kMsgType_RMP_Throttle_Flow,
+    err = mManager->SendMessage(this, Protocols::kProtocol_Protocol_Common, Protocols::Common::kMsgType_RMP_Throttle_Flow,
                                 msgBuf.Release_ForNow(),
                                 BitFlags<uint16_t, SendMessageFlags>(SendMessageFlags::kSendFlag_NoAutoRequestAck));
 
@@ -277,7 +277,7 @@ CHIP_ERROR ReliableMessageContext::SendDelayedDelivery(uint32_t pauseTimeMillis,
     // Send a Delayed Delivery message to the peer.  Delayed Delivery messages must never request
     // acknowledgment, so suppress the auto-request ACK feature on the exchange in case it has been
     // enabled by the application.
-    err = mManager->SendMessage(this, Protocols::kChipProtocol_Common, Protocols::Common::kMsgType_RMP_Delayed_Delivery,
+    err = mManager->SendMessage(this, Protocols::kProtocol_Protocol_Common, Protocols::Common::kMsgType_RMP_Delayed_Delivery,
                                 msgBuf.Release_ForNow(),
                                 BitFlags<uint16_t, SendMessageFlags>{ SendMessageFlags::kSendFlag_NoAutoRequestAck });
 
@@ -351,7 +351,7 @@ CHIP_ERROR ReliableMessageContext::HandleNeedsAck(uint32_t MessageId, BitFlags<u
     mManager->ExpireTicks();
 
     // If the message IS a duplicate.
-    if (MsgFlags.Has(MessageFlagValues::kChipMessageFlag_DuplicateMessage))
+    if (MsgFlags.Has(MessageFlagValues::kMessageFlag_DuplicateMessage))
     {
 #if !defined(NDEBUG)
         ChipLogProgress(ExchangeManager, "Forcing tx of solitary ack for duplicate MsgId:%08" PRIX32, MessageId);
@@ -454,7 +454,7 @@ CHIP_ERROR ReliableMessageContext::SendCommonNullMessage()
     VerifyOrExit(!msgBuf.IsNull(), err = CHIP_ERROR_NO_MEMORY);
 
     // Send the null message
-    err = mManager->SendMessage(this, chip::Protocols::kChipProtocol_Common, chip::Protocols::Common::kMsgType_Null,
+    err = mManager->SendMessage(this, chip::Protocols::kProtocol_Protocol_Common, chip::Protocols::Common::kMsgType_Null,
                                 msgBuf.Release_ForNow(),
                                 BitFlags<uint16_t, SendMessageFlags>{ SendMessageFlags::kSendFlag_NoAutoRequestAck });
 

--- a/src/messaging/ReliableMessageContext.cpp
+++ b/src/messaging/ReliableMessageContext.cpp
@@ -34,7 +34,7 @@
 #include <support/CodeUtils.h>
 
 namespace chip {
-namespace messaging {
+namespace Messaging {
 
 void ReliableMessageContextDeletor::Release(ReliableMessageContext * obj)
 {
@@ -472,5 +472,5 @@ exit:
     return err;
 }
 
-} // namespace messaging
+} // namespace Messaging
 } // namespace chip

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -36,7 +36,7 @@
 #include <transport/raw/MessageHeader.h>
 
 namespace chip {
-namespace messaging {
+namespace Messaging {
 
 class ChipMessageInfo;
 enum class MessageFlagValues : uint32_t;
@@ -131,5 +131,5 @@ private:
     ReliableMessageDelegate * mDelegate;
 };
 
-} // namespace messaging
+} // namespace Messaging
 } // namespace chip

--- a/src/messaging/ReliableMessageManager.cpp
+++ b/src/messaging/ReliableMessageManager.cpp
@@ -34,7 +34,7 @@
 #include <support/logging/CHIPLogging.h>
 
 namespace chip {
-namespace messaging {
+namespace Messaging {
 
 ReliableMessageManager::RetransTableEntry::RetransTableEntry() :
     rc(nullptr), msgBuf(nullptr), msgId(0), msgSendFlags(0), nextRetransTimeTick(0), sendCount(0)
@@ -642,5 +642,5 @@ int ReliableMessageManager::TestGetCountRetransTable()
     return count;
 }
 
-} // namespace messaging
+} // namespace Messaging
 } // namespace chip

--- a/src/messaging/ReliableMessageManager.cpp
+++ b/src/messaging/ReliableMessageManager.cpp
@@ -419,7 +419,7 @@ CHIP_ERROR ReliableMessageManager::SendFromRetransTable(RetransTableEntry * entr
 
         // Send the message through
         uint16_t msgSendFlags = entry->msgSendFlags;
-        SetFlag(msgSendFlags, MessageFlagValues::kChipMessageFlag_RetainBuffer);
+        SetFlag(msgSendFlags, MessageFlagValues::kMessageFlag_RetainBuffer);
         err = SendMessage(rc, entry->msgBuf, msgSendFlags);
 
         // Reset the msgBuf start pointer and data length after sending

--- a/src/messaging/ReliableMessageManager.h
+++ b/src/messaging/ReliableMessageManager.h
@@ -35,7 +35,7 @@
 #include <transport/raw/MessageHeader.h>
 
 namespace chip {
-namespace messaging {
+namespace Messaging {
 
 enum class SendMessageFlags : uint16_t;
 class ReliableMessageContext;
@@ -122,5 +122,5 @@ private:
     RetransTableEntry RetransTable[CHIP_CONFIG_RMP_RETRANS_TABLE_SIZE];
 };
 
-} // namespace messaging
+} // namespace Messaging
 } // namespace chip

--- a/src/messaging/ReliableMessageProtocolConfig.h
+++ b/src/messaging/ReliableMessageProtocolConfig.h
@@ -28,7 +28,7 @@
 #include <system/SystemConfig.h>
 
 namespace chip {
-namespace messaging {
+namespace Messaging {
 
 /**
  *  @def CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT
@@ -121,5 +121,5 @@ const ReliableMessageProtocolConfig gDefaultReliableMessageProtocolConfig = { CH
 
 // clang-format on
 
-} // namespace messaging
+} // namespace Messaging
 } // namespace chip

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -26,6 +26,7 @@
 #include <core/CHIPCore.h>
 #include <messaging/ExchangeContext.h>
 #include <messaging/ExchangeMgr.h>
+#include <messaging/Flags.h>
 #include <protocols/Protocols.h>
 #include <support/CodeUtils.h>
 #include <transport/SecureSessionMgr.h>
@@ -42,6 +43,7 @@ namespace {
 using namespace chip;
 using namespace chip::Inet;
 using namespace chip::Transport;
+using namespace chip::Messaging;
 
 using TestContext = chip::Test::IOContext;
 
@@ -246,11 +248,13 @@ void CheckExchangeMessages(nlTestSuite * inSuite, void * inContext)
     err = exchangeMgr.RegisterUnsolicitedMessageHandler(0x0001, 0x0001, &mockUnsolicitedAppDelegate);
 
     // send a malicious packet
-    ec1->SendMessage(0x0001, 0x0002, System::PacketBuffer::New().Release_ForNow());
+    ec1->SendMessage(0x0001, 0x0002, System::PacketBuffer::New().Release_ForNow(),
+                     SendFlags(Messaging::SendMessageFlags::kSendFlag_Default));
     NL_TEST_ASSERT(inSuite, !mockUnsolicitedAppDelegate.IsOnMessageReceivedCalled);
 
     // send a good packet
-    ec1->SendMessage(0x0001, 0x0001, System::PacketBuffer::New().Release_ForNow());
+    ec1->SendMessage(0x0001, 0x0001, System::PacketBuffer::New().Release_ForNow(),
+                     SendFlags(Messaging::SendMessageFlags::kSendFlag_Default));
     NL_TEST_ASSERT(inSuite, mockUnsolicitedAppDelegate.IsOnMessageReceivedCalled);
 }
 

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -249,12 +249,12 @@ void CheckExchangeMessages(nlTestSuite * inSuite, void * inContext)
 
     // send a malicious packet
     ec1->SendMessage(0x0001, 0x0002, System::PacketBuffer::New().Release_ForNow(),
-                     SendFlags(Messaging::SendMessageFlags::kSendFlag_Default));
+                     SendFlags(Messaging::SendMessageFlags::kSendFlag_None));
     NL_TEST_ASSERT(inSuite, !mockUnsolicitedAppDelegate.IsOnMessageReceivedCalled);
 
     // send a good packet
     ec1->SendMessage(0x0001, 0x0001, System::PacketBuffer::New().Release_ForNow(),
-                     SendFlags(Messaging::SendMessageFlags::kSendFlag_Default));
+                     SendFlags(Messaging::SendMessageFlags::kSendFlag_None));
     NL_TEST_ASSERT(inSuite, mockUnsolicitedAppDelegate.IsOnMessageReceivedCalled);
 }
 

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -40,7 +40,7 @@ namespace {
 
 using namespace chip;
 using namespace chip::Inet;
-using namespace chip::messaging;
+using namespace chip::Messaging;
 
 using TestContext = chip::Test::IOContext;
 
@@ -243,7 +243,7 @@ int Finalize(void * aContext)
 } // namespace
 
 namespace chip {
-namespace messaging {
+namespace Messaging {
 
 // Stub implementation
 CHIP_ERROR ReliableMessageManager::SendMessage(ReliableMessageContext * context, System::PacketBuffer * msgBuf, uint16_t sendFlags)
@@ -257,7 +257,7 @@ CHIP_ERROR ReliableMessageManager::SendMessage(ReliableMessageContext * context,
 }
 void ReliableMessageManager::FreeContext(ReliableMessageContext *) {}
 
-} // namespace messaging
+} // namespace Messaging
 } // namespace chip
 
 /**

--- a/src/protocols/Protocols.h
+++ b/src/protocols/Protocols.h
@@ -39,6 +39,7 @@ enum CHIPProtocolId
     //
     // NOTE: Do not attempt to allocate these values yourself.
 
+    kProtocol_Protocol_Common     = (kChipVendor_Common << 16) | 0x0000, // Common Protocol
     kProtocol_SecurityChannel     = (kChipVendor_Common << 16) | 0x0001, // Security Channel Protocol
     kProtocol_Echo                = (kChipVendor_Common << 16) | 0x0002, // Echo Protocol
     kProtocol_BDX                 = (kChipVendor_Common << 16) | 0x0003, // Bulk Data Exchange Protocol

--- a/src/protocols/echo/Echo.h
+++ b/src/protocols/echo/Echo.h
@@ -28,6 +28,7 @@
 #include <core/CHIPCore.h>
 #include <messaging/ExchangeContext.h>
 #include <messaging/ExchangeMgr.h>
+#include <messaging/Flags.h>
 #include <protocols/Protocols.h>
 #include <support/CodeUtils.h>
 #include <support/DLLUtil.h>
@@ -44,7 +45,7 @@ enum
 
 typedef void (*EchoFunct)(NodeId nodeId, System::PacketBufferHandle payload);
 
-class DLL_EXPORT EchoClient : public ExchangeDelegate
+class DLL_EXPORT EchoClient : public Messaging::ExchangeDelegate
 {
 public:
     /**
@@ -60,7 +61,7 @@ public:
      *  @retval #CHIP_NO_ERROR On success.
      *
      */
-    CHIP_ERROR Init(ExchangeManager * exchangeMgr);
+    CHIP_ERROR Init(Messaging::ExchangeManager * exchangeMgr);
 
     /**
      *  Shutdown the EchoClient. This terminates this instance
@@ -90,17 +91,17 @@ public:
     CHIP_ERROR SendEchoRequest(NodeId nodeId, System::PacketBufferHandle payload);
 
 private:
-    ExchangeManager * mExchangeMgr   = nullptr;
-    ExchangeContext * mExchangeCtx   = nullptr;
-    EchoFunct OnEchoResponseReceived = nullptr;
+    Messaging::ExchangeManager * mExchangeMgr = nullptr;
+    Messaging::ExchangeContext * mExchangeCtx = nullptr;
+    EchoFunct OnEchoResponseReceived          = nullptr;
 
     CHIP_ERROR SendEchoRequest(System::PacketBufferHandle payload);
-    void OnMessageReceived(ExchangeContext * ec, const PacketHeader & packetHeader, uint32_t protocolId, uint8_t msgType,
+    void OnMessageReceived(Messaging::ExchangeContext * ec, const PacketHeader & packetHeader, uint32_t protocolId, uint8_t msgType,
                            System::PacketBufferHandle payload) override;
-    void OnResponseTimeout(ExchangeContext * ec) override;
+    void OnResponseTimeout(Messaging::ExchangeContext * ec) override;
 };
 
-class DLL_EXPORT EchoServer : public ExchangeDelegate
+class DLL_EXPORT EchoServer : public Messaging::ExchangeDelegate
 {
 public:
     /**
@@ -116,7 +117,7 @@ public:
      *  @retval #CHIP_NO_ERROR On success.
      *
      */
-    CHIP_ERROR Init(ExchangeManager * exchangeMgr);
+    CHIP_ERROR Init(Messaging::ExchangeManager * exchangeMgr);
 
     /**
      *  Shutdown the EchoServer. This terminates this instance
@@ -134,12 +135,12 @@ public:
     void SetEchoRequestReceived(EchoFunct callback) { OnEchoRequestReceived = callback; }
 
 private:
-    ExchangeManager * mExchangeMgr  = nullptr;
-    EchoFunct OnEchoRequestReceived = nullptr;
+    Messaging::ExchangeManager * mExchangeMgr = nullptr;
+    EchoFunct OnEchoRequestReceived           = nullptr;
 
-    void OnMessageReceived(ExchangeContext * ec, const PacketHeader & packetHeader, uint32_t protocolId, uint8_t msgType,
+    void OnMessageReceived(Messaging::ExchangeContext * ec, const PacketHeader & packetHeader, uint32_t protocolId, uint8_t msgType,
                            System::PacketBufferHandle payload) override;
-    void OnResponseTimeout(ExchangeContext * ec) override {}
+    void OnResponseTimeout(Messaging::ExchangeContext * ec) override {}
 };
 
 } // namespace Protocols

--- a/src/protocols/echo/EchoClient.cpp
+++ b/src/protocols/echo/EchoClient.cpp
@@ -28,7 +28,7 @@
 namespace chip {
 namespace Protocols {
 
-CHIP_ERROR EchoClient::Init(ExchangeManager * exchangeMgr)
+CHIP_ERROR EchoClient::Init(Messaging::ExchangeManager * exchangeMgr)
 {
     // Error if already initialized.
     if (mExchangeMgr != nullptr)
@@ -75,7 +75,8 @@ CHIP_ERROR EchoClient::SendEchoRequest(System::PacketBufferHandle payload)
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     // Send an Echo Request message.  Discard the exchange context if the send fails.
-    err = mExchangeCtx->SendMessage(kProtocol_Echo, kEchoMessageType_EchoRequest, payload.Release_ForNow());
+    err = mExchangeCtx->SendMessage(kProtocol_Echo, kEchoMessageType_EchoRequest, payload.Release_ForNow(),
+                                    Messaging::SendFlags(Messaging::SendMessageFlags::kSendFlag_Default));
 
     if (err != CHIP_NO_ERROR)
     {
@@ -86,8 +87,8 @@ CHIP_ERROR EchoClient::SendEchoRequest(System::PacketBufferHandle payload)
     return err;
 }
 
-void EchoClient::OnMessageReceived(ExchangeContext * ec, const PacketHeader & packetHeader, uint32_t protocolId, uint8_t msgType,
-                                   System::PacketBufferHandle payload)
+void EchoClient::OnMessageReceived(Messaging::ExchangeContext * ec, const PacketHeader & packetHeader, uint32_t protocolId,
+                                   uint8_t msgType, System::PacketBufferHandle payload)
 {
     // Assert that the exchange context matches the client's current context.
     // This should never fail because even if SendEchoRequest is called
@@ -118,7 +119,7 @@ void EchoClient::OnMessageReceived(ExchangeContext * ec, const PacketHeader & pa
     }
 }
 
-void EchoClient::OnResponseTimeout(ExchangeContext * ec)
+void EchoClient::OnResponseTimeout(Messaging::ExchangeContext * ec)
 {
     ChipLogProgress(Echo, "Time out! failed to receive echo response from Node: %llu", ec->GetPeerNodeId());
 }

--- a/src/protocols/echo/EchoClient.cpp
+++ b/src/protocols/echo/EchoClient.cpp
@@ -76,7 +76,7 @@ CHIP_ERROR EchoClient::SendEchoRequest(System::PacketBufferHandle payload)
 
     // Send an Echo Request message.  Discard the exchange context if the send fails.
     err = mExchangeCtx->SendMessage(kProtocol_Echo, kEchoMessageType_EchoRequest, payload.Release_ForNow(),
-                                    Messaging::SendFlags(Messaging::SendMessageFlags::kSendFlag_Default));
+                                    Messaging::SendFlags(Messaging::SendMessageFlags::kSendFlag_None));
 
     if (err != CHIP_NO_ERROR)
     {

--- a/src/protocols/echo/EchoServer.cpp
+++ b/src/protocols/echo/EchoServer.cpp
@@ -28,7 +28,7 @@
 namespace chip {
 namespace Protocols {
 
-CHIP_ERROR EchoServer::Init(ExchangeManager * exchangeMgr)
+CHIP_ERROR EchoServer::Init(Messaging::ExchangeManager * exchangeMgr)
 {
     // Error if already initialized.
     if (mExchangeMgr != nullptr)
@@ -52,8 +52,8 @@ void EchoServer::Shutdown()
     }
 }
 
-void EchoServer::OnMessageReceived(ExchangeContext * ec, const PacketHeader & packetHeader, uint32_t protocolId, uint8_t msgType,
-                                   System::PacketBufferHandle payload)
+void EchoServer::OnMessageReceived(Messaging::ExchangeContext * ec, const PacketHeader & packetHeader, uint32_t protocolId,
+                                   uint8_t msgType, System::PacketBufferHandle payload)
 {
     System::PacketBufferHandle response;
 
@@ -78,7 +78,8 @@ void EchoServer::OnMessageReceived(ExchangeContext * ec, const PacketHeader & pa
     response->EnsureReservedSize(CHIP_SYSTEM_CONFIG_HEADER_RESERVE_SIZE);
 
     // Send an Echo Response back to the sender.
-    ec->SendMessage(kProtocol_Echo, kEchoMessageType_EchoResponse, response.Release_ForNow());
+    ec->SendMessage(kProtocol_Echo, kEchoMessageType_EchoResponse, response.Release_ForNow(),
+                    Messaging::SendFlags(Messaging::SendMessageFlags::kSendFlag_None));
 
     // Discard the exchange context.
     ec->Close();


### PR DESCRIPTION
…xt under the same namespace as CRMP

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Currently, ExchangeManager and ExchangeContext are under different namespace as CRMP, and both components define the send flags.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
1. Remove the internal send flag from ExchangeContext
2. Put ExchangeManager/ExchangeContext under namespace "Messaging"
3. Rename namespace "messaging" to "Messaging" to align with convention

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
