### PR TITLE
Fix empty struct generation

### DIFF
--- a/src/app/zap-templates/af-structs.zapt
+++ b/src/app/zap-templates/af-structs.zapt
@@ -9,20 +9,16 @@
 
 {{#zcl_structs}}
 
+{{#if itemCnt}}
 // Struct for {{label}}
 typedef struct _{{asType label}} {
 {{#zcl_struct_items}}
-{{#if (isStrEqual label "endpoint")}}
-{{ident}}chip::EndpointId {{asSymbol label}};
-{{else if (isStrEqual label "endpointId")}}
-{{ident}}chip::EndpointId {{asSymbol label}};
-{{else if (isStrEqual label "groupId")}}
-{{ident}}chip::GroupId {{asSymbol label}};
-{{else if (isStrEqual label "commandId")}}
-{{ident}}chip::CommandId {{asSymbol label}};
-{{else}}
-{{ident}}{{asUnderlyingZclType type}} {{asSymbol label}};
-{{/if}}
+{{ident}}{{asChipUnderlyingType label type}} {{asSymbol label}};
 {{/zcl_struct_items}}
 } {{asUnderlyingType label}};
+{{else}}
+// Void typedef for {{asUnderlyingType label}} which is empty.
+// this will result in all the references to the data being as uint8_t*
+typedef uint8_t {{asUnderlyingType label}};
+{{/if}}
 {{/zcl_structs}}

--- a/src/app/zap-templates/helper-chip.js
+++ b/src/app/zap-templates/helper-chip.js
@@ -195,7 +195,7 @@ function asChipUnderlyingType(label, type) {
     return 'chip::EndpointId'
   } else if (zclHelper.isStrEqual(type, "CLUSTER_ID")) {
     return 'chip::ClusterId'
-  } else if (zclHelper.isStrEqual(type, "ATTRIBUTE_ID")){
+  } else if (zclHelper.isStrEqual(type, "ATTRIBUTE_ID")) {
     return 'chip::AttributeId'
   } else if (zclHelper.isStrEqual(label, "groupId")) {
     return 'chip::GroupId'

--- a/src/app/zap-templates/helper-chip.js
+++ b/src/app/zap-templates/helper-chip.js
@@ -187,7 +187,8 @@ function asReadType(type)
  * @param {*} label : The xml label of the type.
  * @param {*} type : The xml type to be converted
  */
-function asChipUnderlyingType(label, type) {
+function asChipUnderlyingType(label, type)
+{
 
   if (zclHelper.isStrEqual(label, "endpoint")) {
     return 'chip::EndpointId'
@@ -212,9 +213,9 @@ function asChipUnderlyingType(label, type) {
 // Note: these exports are public API. Templates that might have been created in the past and are
 // available in the wild might depend on these names.
 // If you rename the functions, you need to still maintain old exports list.
-exports.chip_header         = chip_header;
-exports.isString            = isString;
-exports.asReadType          = asReadType;
-exports.asReadTypeLength    = asReadTypeLength;
-exports.asValueIfNotPresent = asValueIfNotPresent;
+exports.chip_header          = chip_header;
+exports.isString             = isString;
+exports.asReadType           = asReadType;
+exports.asReadTypeLength     = asReadTypeLength;
+exports.asValueIfNotPresent  = asValueIfNotPresent;
 exports.asChipUnderlyingType = asChipUnderlyingType;

--- a/src/app/zap-templates/helper-chip.js
+++ b/src/app/zap-templates/helper-chip.js
@@ -178,6 +178,34 @@ function asReadType(type)
   return templateUtil.templatePromise(this.global, promise)
 }
 
+/**
+ * Returns CHIP specific type for ZCL framework
+ * This function is flawed since it relies on the
+ * type label for CHIP type conversion. CHIP specific XML should have the
+ * correct type directly embedded inside.
+ *
+ * @param {*} type : The xml type to be converted
+ */
+function asChipUnderlyingType(label, type) {
+
+  if (zclHelper.isStrEqual(label, "endpoint")) {
+    return 'chip::EndpointId'
+  } else if (zclHelper.isStrEqual(label, "endpointId")) {
+    return 'chip::EndpointId'
+  } else if (zclHelper.isStrEqual(label, "CLUSTER_ID")) {
+    return 'chip::ClusterId'
+  } else if (zclHelper.isStrEqual(label, "ATTRIBUTE_ID")){
+    return 'chip::AttributeId'
+  } else if (zclHelper.isStrEqual(label, "groupId")) {
+    return 'chip::GroupId'
+  } else if (zclHelper.isStrEqual(label, "commandId")) {
+    return 'chip::CommandId'
+  } else {
+    // Might want to use asZclUnderlyingType instead. TBD
+    return cHelper.asUnderlyingType.call(this, type)
+  }
+}
+
 // WARNING! WARNING! WARNING! WARNING! WARNING! WARNING!
 //
 // Note: these exports are public API. Templates that might have been created in the past and are
@@ -188,3 +216,4 @@ exports.isString            = isString;
 exports.asReadType          = asReadType;
 exports.asReadTypeLength    = asReadTypeLength;
 exports.asValueIfNotPresent = asValueIfNotPresent;
+exports.asChipUnderlyingType = asChipUnderlyingType;

--- a/src/app/zap-templates/helper-chip.js
+++ b/src/app/zap-templates/helper-chip.js
@@ -184,6 +184,7 @@ function asReadType(type)
  * type label for CHIP type conversion. CHIP specific XML should have the
  * correct type directly embedded inside.
  *
+ * @param {*} label : The xml label of the type.
  * @param {*} type : The xml type to be converted
  */
 function asChipUnderlyingType(label, type) {
@@ -192,16 +193,16 @@ function asChipUnderlyingType(label, type) {
     return 'chip::EndpointId'
   } else if (zclHelper.isStrEqual(label, "endpointId")) {
     return 'chip::EndpointId'
-  } else if (zclHelper.isStrEqual(label, "CLUSTER_ID")) {
+  } else if (zclHelper.isStrEqual(type, "CLUSTER_ID")) {
     return 'chip::ClusterId'
-  } else if (zclHelper.isStrEqual(label, "ATTRIBUTE_ID")){
+  } else if (zclHelper.isStrEqual(type, "ATTRIBUTE_ID")){
     return 'chip::AttributeId'
   } else if (zclHelper.isStrEqual(label, "groupId")) {
     return 'chip::GroupId'
   } else if (zclHelper.isStrEqual(label, "commandId")) {
     return 'chip::CommandId'
   } else {
-    // Might want to use asZclUnderlyingType instead. TBD
+    // Might want to use asUnderlyingZclType instead. TBD
     return cHelper.asUnderlyingType.call(this, type)
   }
 }


### PR DESCRIPTION
 #### Problem
ZAP was generating empty struct instead of defaulting them to `uint8_t` 


 #### Summary of Changes
Check the number of item within the struct before generating a `typedef struct`

Cleanup the code in the template by adding a new helper in `chip-helper.js`

 Fixes #3873 
