### PR TITLE
Fix Rendezvous over BLE after recent changes

### DIFF
--- a/examples/common/chip-app-server/Server.cpp
+++ b/examples/common/chip-app-server/Server.cpp
@@ -112,7 +112,8 @@ void InitServer()
         SuccessOrExit(err = DeviceLayer::ConfigurationMgr().GetSetupPinCode(pinCode));
         params.SetSetupPINCode(pinCode)
             .SetLocalNodeId(chip::kTestDeviceNodeId)
-            .SetBleLayer(DeviceLayer::ConnectivityMgr().GetBleLayer());
+            .SetBleLayer(DeviceLayer::ConnectivityMgr().GetBleLayer())
+            .SetPeerAddress(Transport::PeerAddress::BLE());
         SuccessOrExit(err = gRendezvousServer.Init(params, &gTransports));
     }
 #endif

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -467,7 +467,6 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, RendezvousParam
 
     VerifyOrExit(mState == State::Initialized, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mDeviceBeingPaired == kNumMaxActiveDevices, err = CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrExit(mStorageDelegate != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
 #if CONFIG_DEVICE_LAYER && CONFIG_NETWORK_LAYER_BLE
     if (!params.HasBleLayer())

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -288,7 +288,8 @@ JNI_METHOD(void, beginConnectDevice)(JNIEnv * env, jobject self, jlong handle, j
         RendezvousParameters params = RendezvousParameters()
                                           .SetSetupPINCode(pinCode)
                                           .SetConnectionObject(reinterpret_cast<BLE_CONNECTION_OBJECT>(connObj))
-                                          .SetBleLayer(&sBleLayer);
+                                          .SetBleLayer(&sBleLayer)
+                                          .SetPeerAddress(Transport::PeerAddress::BLE());
         err = wrapper->Controller()->ConnectDevice(kRemoteDeviceId, params, (void *) "ConnectDevice", HandleKeyExchange,
                                                    HandleEchoResponse, HandleError);
     }


### PR DESCRIPTION
 #### Problem
PR #3704 introduced a change that the BLE transport in RendezvousSession is only initialized when PeerAddress in RendezvousParams is of type BLE. However, PeerAddress isn't initialized anywhere. As a result Rendezvous over BLE stopped working between Android CHIPTool and accessories.

 #### Summary of Changes
* Initialize PeerAddress in RendezvousParams for apps that surely use BLE for Rendezvous
* Remove an assert related to the storage delegate as it seems an optional member of the device controller.
