### PR TITLE
Implement the missing part of Exchange Header in Transport layer

### DIFF
--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -56,8 +56,7 @@ public:
     /// Transports are required to have a constructor that takes exactly one argument
     CHIP_ERROR Init(const char * unused) { return CHIP_NO_ERROR; }
 
-    CHIP_ERROR SendMessage(const PacketHeader & header, Header::Flags payloadFlags, const PeerAddress & address,
-                           System::PacketBuffer * msgBuf) override
+    CHIP_ERROR SendMessage(const PacketHeader & header, const PeerAddress & address, System::PacketBuffer * msgBuf) override
     {
         System::PacketBufferHandle msg_ForNow;
         msg_ForNow.Adopt(msgBuf);

--- a/src/transport/BLE.cpp
+++ b/src/transport/BLE.cpp
@@ -134,8 +134,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR BLE::SendMessage(const PacketHeader & header, Header::Flags payloadFlags, const Transport::PeerAddress & address,
-                            System::PacketBuffer * msgIn)
+CHIP_ERROR BLE::SendMessage(const PacketHeader & header, const Transport::PeerAddress & address, System::PacketBuffer * msgIn)
 {
     CHIP_ERROR err            = CHIP_NO_ERROR;
     const uint16_t headerSize = header.EncodeSizeBytes();
@@ -150,7 +149,7 @@ CHIP_ERROR BLE::SendMessage(const PacketHeader & header, Header::Flags payloadFl
 
     msgBuf->SetStart(msgBuf->Start() - headerSize);
 
-    err = header.Encode(msgBuf->Start(), msgBuf->DataLength(), &actualEncodedHeaderSize, payloadFlags);
+    err = header.Encode(msgBuf->Start(), msgBuf->DataLength(), &actualEncodedHeaderSize);
     SuccessOrExit(err);
 
     VerifyOrExit(headerSize == actualEncodedHeaderSize, err = CHIP_ERROR_INTERNAL);

--- a/src/transport/BLE.h
+++ b/src/transport/BLE.h
@@ -68,7 +68,7 @@ public:
      */
     CHIP_ERROR Init(RendezvousSessionDelegate * delegate, const RendezvousParameters & params);
 
-    CHIP_ERROR SendMessage(const PacketHeader & header, Header::Flags payloadFlags, const Transport::PeerAddress & address,
+    CHIP_ERROR SendMessage(const PacketHeader & header, const Transport::PeerAddress & address,
                            System::PacketBuffer * msgBuf) override;
 
     bool CanSendToPeer(const Transport::PeerAddress & address) override

--- a/src/transport/RendezvousSession.h
+++ b/src/transport/RendezvousSession.h
@@ -102,8 +102,8 @@ public:
     Optional<NodeId> GetRemoteNodeId() const { return mParams.GetRemoteNodeId(); }
 
     //////////// SecurePairingSessionDelegate Implementation ///////////////
-    CHIP_ERROR SendPairingMessage(const PacketHeader & header, Header::Flags payloadFlags,
-                                  const Transport::PeerAddress & peerAddress, System::PacketBuffer * msgBuf) override;
+    CHIP_ERROR SendPairingMessage(const PacketHeader & header, const Transport::PeerAddress & peerAddress,
+                                  System::PacketBuffer * msgBuf) override;
     void OnPairingError(CHIP_ERROR err) override;
     void OnPairingComplete() override;
 

--- a/src/transport/SecurePairingSession.cpp
+++ b/src/transport/SecurePairingSession.cpp
@@ -210,8 +210,8 @@ CHIP_ERROR SecurePairingSession::AttachHeaderAndSend(uint8_t msgType, System::Pa
     SuccessOrExit(err);
     VerifyOrExit(headerSize == actualEncodedHeaderSize, err = CHIP_ERROR_INTERNAL);
 
-    err = mDelegate->SendPairingMessage(PacketHeader().SetSourceNodeId(mLocalNodeId).SetEncryptionKeyID(mLocalKeyId),
-                                        payloadHeader.GetEncodePacketFlags(), mPeerAddress, msgBuf.Release_ForNow());
+    err = mDelegate->SendPairingMessage(PacketHeader().SetSourceNodeId(mLocalNodeId).SetEncryptionKeyID(mLocalKeyId), mPeerAddress,
+                                        msgBuf.Release_ForNow());
     SuccessOrExit(err);
 
 exit:
@@ -437,7 +437,7 @@ CHIP_ERROR SecurePairingSession::HandlePeerMessage(const PacketHeader & packetHe
 
     VerifyOrExit(!msg.IsNull(), err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    err = payloadHeader.Decode(packetHeader.GetFlags(), msg->Start(), msg->DataLength(), &headerSize);
+    err = payloadHeader.Decode(msg->Start(), msg->DataLength(), &headerSize);
     SuccessOrExit(err);
 
     msg->ConsumeHead(headerSize);

--- a/src/transport/SecurePairingSession.h
+++ b/src/transport/SecurePairingSession.h
@@ -48,13 +48,12 @@ public:
      *   Called when pairing session generates a new message that should be sent to peer.
      *
      * @param header the message header for the sent message
-     * @param payloadFlags payload encoding flags
      * @param peerAddress the destination of the message
      * @param msgBuf the raw data for the message being sent
      * @return CHIP_ERROR Error thrown when sending the message
      */
-    virtual CHIP_ERROR SendPairingMessage(const PacketHeader & header, Header::Flags payloadFlags,
-                                          const Transport::PeerAddress & peerAddress, System::PacketBuffer * msgBuf)
+    virtual CHIP_ERROR SendPairingMessage(const PacketHeader & header, const Transport::PeerAddress & peerAddress,
+                                          System::PacketBuffer * msgBuf)
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -80,13 +80,12 @@ public:
      * @param input_length Length of the input data
      * @param output Output buffer for encrypted data
      * @param header message header structure. Encryption type will be set on the header.
-     * @param payloadFlags extra flags for packet header encryption
      * @param mac - output the resulting mac
      *
      * @return CHIP_ERROR The result of encryption
      */
     CHIP_ERROR Encrypt(const uint8_t * input, size_t input_length, uint8_t * output, PacketHeader & header,
-                       Header::Flags payloadFlags, MessageAuthenticationCode & mac);
+                       MessageAuthenticationCode & mac);
 
     /**
      * @brief
@@ -96,12 +95,11 @@ public:
      * @param input_length Length of the input data
      * @param output Output buffer for decrypted data
      * @param header message header structure
-     * @param payloadFlags extra flags for packet header decryption
      * @return CHIP_ERROR The result of decryption
      * @param mac Input mac
      */
     CHIP_ERROR Decrypt(const uint8_t * input, size_t input_length, uint8_t * output, const PacketHeader & header,
-                       Header::Flags payloadFlags, const MessageAuthenticationCode & mac);
+                       const MessageAuthenticationCode & mac);
 
     /**
      * @brief
@@ -128,8 +126,7 @@ private:
     // Use unencrypted header as additional authenticated data (AAD) during encryption and decryption.
     // The encryption operations includes AAD when message authentication tag is generated. This tag
     // is used at the time of decryption to integrity check the received data.
-    static CHIP_ERROR GetAdditionalAuthData(const PacketHeader & header, Header::Flags payloadEncodeFlags, uint8_t * aad,
-                                            uint16_t & len);
+    static CHIP_ERROR GetAdditionalAuthData(const PacketHeader & header, uint8_t * aad, uint16_t & len);
 };
 
 } // namespace chip

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -135,7 +135,7 @@ CHIP_ERROR SecureSessionMgr::SendMessage(PayloadHeader & payloadHeader, NodeId p
             .SetPayloadLength(static_cast<uint16_t>(payloadLength));
         packetHeader.GetFlags().Set(Header::FlagValues::kSecure);
 
-        ChipLogProgress(Inet, "Sending msg from %llu to %llu\n", mLocalNodeId, peerNodeId);
+        ChipLogProgress(Inet, "Sending msg from %llu to %llu", mLocalNodeId, peerNodeId);
 
         VerifyOrExit(msgBuf->EnsureReservedSize(headerSize), err = CHIP_ERROR_NO_MEMORY);
 

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -146,7 +146,7 @@ CHIP_ERROR SecureSessionMgr::SendMessage(PayloadHeader & payloadHeader, NodeId p
         err = payloadHeader.Encode(data, totalLen, &actualEncodedHeaderSize);
         SuccessOrExit(err);
 
-        err = state->GetSecureSession().Encrypt(data, totalLen, data, packetHeader, payloadHeader.GetEncodePacketFlags(), mac);
+        err = state->GetSecureSession().Encrypt(data, totalLen, data, packetHeader, mac);
         SuccessOrExit(err);
 
         err = mac.Encode(packetHeader, &data[totalLen], kMaxTagLen, &taglen);
@@ -157,8 +157,7 @@ CHIP_ERROR SecureSessionMgr::SendMessage(PayloadHeader & payloadHeader, NodeId p
 
         ChipLogDetail(Inet, "Secure transport transmitting msg %u after encryption", state->GetSendMessageIndex());
 
-        err = mTransportMgr->SendMessage(packetHeader, payloadHeader.GetEncodePacketFlags(), state->GetPeerAddress(),
-                                         msgBuf.Release_ForNow());
+        err = mTransportMgr->SendMessage(packetHeader, state->GetPeerAddress(), msgBuf.Release_ForNow());
     }
     SuccessOrExit(err);
     state->IncrementSendMessageIndex();
@@ -306,13 +305,13 @@ void SecureSessionMgr::OnMessageReceived(const PacketHeader & packetHeader, cons
         PayloadHeader payloadHeader;
         MessageAuthenticationCode mac;
 
-        uint8_t * data            = msg->Start();
-        uint8_t * plainText       = nullptr;
-        uint16_t len              = msg->TotalLength();
-        const uint16_t headerSize = payloadHeader.EncodeSizeBytes();
-        uint16_t decodedSize      = 0;
-        uint16_t taglen           = 0;
-        uint16_t payloadlen       = 0;
+        uint8_t * data       = msg->Start();
+        uint8_t * plainText  = nullptr;
+        uint16_t len         = msg->TotalLength();
+        uint16_t headerSize  = 0;
+        uint16_t decodedSize = 0;
+        uint16_t taglen      = 0;
+        uint16_t payloadlen  = 0;
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
         /* This is a workaround for the case where PacketBuffer payload is not
@@ -333,10 +332,11 @@ void SecureSessionMgr::OnMessageReceived(const PacketHeader & packetHeader, cons
         len = static_cast<uint16_t>(len - taglen);
         msg->SetDataLength(len, nullptr);
 
-        err = state->GetSecureSession().Decrypt(data, len, plainText, packetHeader, payloadHeader.GetEncodePacketFlags(), mac);
+        err = state->GetSecureSession().Decrypt(data, len, plainText, packetHeader, mac);
         VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Inet, "Secure transport failed to decrypt msg: err %d", err));
 
-        err = payloadHeader.Decode(packetHeader.GetFlags(), plainText, len, &decodedSize);
+        err        = payloadHeader.Decode(plainText, len, &decodedSize);
+        headerSize = payloadHeader.EncodeSizeBytes();
         VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Inet, "Secure transport failed to decode encrypted header: err %d", err));
         VerifyOrExit(headerSize == decodedSize, ChipLogError(Inet, "Secure transport decode encrypted header length mismatched"));
 

--- a/src/transport/TransportMgr.h
+++ b/src/transport/TransportMgr.h
@@ -59,10 +59,9 @@ class TransportMgrBase
 public:
     CHIP_ERROR Init(Transport::Base * transport);
 
-    CHIP_ERROR SendMessage(const PacketHeader & header, Header::Flags payloadFlags, const Transport::PeerAddress & address,
-                           System::PacketBuffer * msgBuf)
+    CHIP_ERROR SendMessage(const PacketHeader & header, const Transport::PeerAddress & address, System::PacketBuffer * msgBuf)
     {
-        return mTransport->SendMessage(header, payloadFlags, address, msgBuf);
+        return mTransport->SendMessage(header, address, msgBuf);
     }
 
     void Disconnect(const Transport::PeerAddress & address) { mTransport->Disconnect(address); }

--- a/src/transport/raw/Base.h
+++ b/src/transport/raw/Base.h
@@ -67,8 +67,7 @@ public:
      *   This method calls <tt>chip::System::PacketBuffer::Free</tt> on
      *   behalf of the caller regardless of the return status.
      */
-    virtual CHIP_ERROR SendMessage(const PacketHeader & header, Header::Flags payloadFlags, const PeerAddress & address,
-                                   System::PacketBuffer * msgBuf) = 0;
+    virtual CHIP_ERROR SendMessage(const PacketHeader & header, const PeerAddress & address, System::PacketBuffer * msgBuf) = 0;
 
     /**
      * Determine if this transport can SendMessage to the specified peer address.

--- a/src/transport/raw/MessageHeader.cpp
+++ b/src/transport/raw/MessageHeader.cpp
@@ -39,8 +39,8 @@
  * -------- Unencrypted header -----------------------------------------------------
  *  16 bit: | VERSION: 4 bit | FLAGS: 4 bit | ENCRYPTTYPE: 4 bit | RESERVED: 4 bit |
  *  32 bit: | MESSAGE_ID                                                           |
- *  64 bit: | SOURCE_NODE_ID (iff source node flag is set)                         |
- *  64 bit: | DEST_NODE_ID (iff destination node flag is set)                      |
+ *  64 bit: | SOURCE_NODE_ID (if source node flag is set)                          |
+ *  64 bit: | DEST_NODE_ID (if destination node flag is set)                       |
  *  16 bit: | Encryption Key ID                                                    |
  *  16 bit: | Payload Length                                                       |
  * -------- Encrypted header -------------------------------------------------------
@@ -49,6 +49,7 @@
  *  16 bit: | Exchange ID                                                          |
  *  16 bit: | Optional Vendor ID                                                   |
  *  16 bit: | Protocol ID                                                          |
+ *  32 bit: | Acknowledged Message Counter (if A flag in the Header is set)        |
  * -------- Encrypted Application Data Start ---------------------------------------
  *  <var>:  | Encrypted Data                                                       |
  * -------- Encrypted Application Data End -----------------------------------------
@@ -72,6 +73,9 @@ constexpr size_t kNodeIdSizeBytes = 8;
 
 /// size of a serialized vendor id inside a header
 constexpr size_t kVendorIdSizeBytes = 2;
+
+/// size of a serialized ack id inside a header
+constexpr size_t kAckIdSizeBytes = 4;
 
 /// Mask to extract just the version part from a 16bit header prefix.
 constexpr uint16_t kVersionMask = 0xF000;
@@ -113,7 +117,13 @@ uint16_t PayloadHeader::EncodeSizeBytes() const
         size += kVendorIdSizeBytes;
     }
 
-    static_assert(kEncryptedHeaderSizeBytes + kVendorIdSizeBytes <= UINT16_MAX, "Header size does not fit in uint16_t");
+    if (mAckId.HasValue())
+    {
+        size += kAckIdSizeBytes;
+    }
+
+    static_assert(kEncryptedHeaderSizeBytes + kVendorIdSizeBytes + kAckIdSizeBytes <= UINT16_MAX,
+                  "Header size does not fit in uint16_t");
     return static_cast<uint16_t>(size);
 }
 
@@ -190,7 +200,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR PayloadHeader::Decode(Header::Flags flags, const uint8_t * const data, uint16_t size, uint16_t * decode_len)
+CHIP_ERROR PayloadHeader::Decode(const uint8_t * const data, uint16_t size, uint16_t * decode_len)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     LittleEndian::Reader reader(data, size);
@@ -200,7 +210,9 @@ CHIP_ERROR PayloadHeader::Decode(Header::Flags flags, const uint8_t * const data
     err = reader.Read8(&header).Read8(&mMessageType).Read16(&mExchangeID).StatusCode();
     SuccessOrExit(err);
 
-    if (flags.Has(Header::FlagValues::kVendorIdPresent))
+    mExchangeFlags.SetRaw(header);
+
+    if (mExchangeFlags.Has(Header::ExFlagValues::kExchangeFlag_VendorIdPresent))
     {
         uint16_t vendor_id;
         err = reader.Read16(&vendor_id).StatusCode();
@@ -212,10 +224,20 @@ CHIP_ERROR PayloadHeader::Decode(Header::Flags flags, const uint8_t * const data
         mVendorId.ClearValue();
     }
 
-    mExchangeFlags.SetRaw(header);
-
     err = reader.Read16(&mProtocolID).StatusCode();
     SuccessOrExit(err);
+
+    if (mExchangeFlags.Has(Header::ExFlagValues::kExchangeFlag_AckMsg))
+    {
+        uint32_t ack_id;
+        err = reader.Read32(&ack_id).StatusCode();
+        SuccessOrExit(err);
+        mAckId.SetValue(ack_id);
+    }
+    else
+    {
+        mAckId.ClearValue();
+    }
 
     octets_read = reader.OctetsRead();
     VerifyOrExit(octets_read == EncodeSizeBytes(), err = CHIP_ERROR_INTERNAL);
@@ -226,7 +248,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR PacketHeader::Encode(uint8_t * data, uint16_t size, uint16_t * encode_size, Header::Flags payloadFlags) const
+CHIP_ERROR PacketHeader::Encode(uint8_t * data, uint16_t size, uint16_t * encode_size) const
 {
     CHIP_ERROR err  = CHIP_NO_ERROR;
     uint8_t * p     = data;
@@ -235,12 +257,8 @@ CHIP_ERROR PacketHeader::Encode(uint8_t * data, uint16_t size, uint16_t * encode
     VerifyOrExit(size >= EncodeSizeBytes(), err = CHIP_ERROR_INVALID_ARGUMENT);
 
     {
-        // Payload flags are restricted.
-        VerifyOrExit(payloadFlags.HasOnly(Header::FlagValues::kVendorIdPresent), err = CHIP_ERROR_INVALID_ARGUMENT);
-
         Header::Flags encodeFlags = mFlags;
-        encodeFlags.Set(payloadFlags)
-            .Set(Header::FlagValues::kSourceNodeIdPresent, mSourceNodeId.HasValue())
+        encodeFlags.Set(Header::FlagValues::kSourceNodeIdPresent, mSourceNodeId.HasValue())
             .Set(Header::FlagValues::kDestinationNodeIdPresent, mDestinationNodeId.HasValue());
 
         header = header | encodeFlags.Raw();
@@ -286,6 +304,10 @@ CHIP_ERROR PayloadHeader::Encode(uint8_t * data, uint16_t size, uint16_t * encod
         LittleEndian::Write16(p, mVendorId.Value());
     }
     LittleEndian::Write16(p, mProtocolID);
+    if (mAckId.HasValue())
+    {
+        LittleEndian::Write32(p, mAckId.Value());
+    }
 
     // Written data size provided to caller on success
     VerifyOrExit(p - data == EncodeSizeBytes(), err = CHIP_ERROR_INTERNAL);
@@ -293,11 +315,6 @@ CHIP_ERROR PayloadHeader::Encode(uint8_t * data, uint16_t size, uint16_t * encod
 
 exit:
     return err;
-}
-
-Header::Flags PayloadHeader::GetEncodePacketFlags() const
-{
-    return Header::Flags().Set(Header::FlagValues::kVendorIdPresent, mVendorId.HasValue());
 }
 
 CHIP_ERROR MessageAuthenticationCode::Decode(const PacketHeader & packetHeader, const uint8_t * const data, uint16_t size,

--- a/src/transport/raw/MessageHeader.cpp
+++ b/src/transport/raw/MessageHeader.cpp
@@ -39,8 +39,8 @@
  * -------- Unencrypted header -----------------------------------------------------
  *  16 bit: | VERSION: 4 bit | FLAGS: 4 bit | ENCRYPTTYPE: 4 bit | RESERVED: 4 bit |
  *  32 bit: | MESSAGE_ID                                                           |
- *  64 bit: | SOURCE_NODE_ID (if source node flag is set)                          |
- *  64 bit: | DEST_NODE_ID (if destination node flag is set)                       |
+ *  64 bit: | SOURCE_NODE_ID (iff source node flag is set)                         |
+ *  64 bit: | DEST_NODE_ID (iff destination node flag is set)                      |
  *  16 bit: | Encryption Key ID                                                    |
  *  16 bit: | Payload Length                                                       |
  * -------- Encrypted header -------------------------------------------------------

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -58,6 +58,15 @@ enum class ExFlagValues : uint8_t
 {
     /// Set when current message is sent by the initiator of an exchange.
     kExchangeFlag_Initiator = 0x01,
+
+    /// Set when current message is an acknowledgment for a previously received message.
+    kExchangeFlag_AckMsg = 0x02,
+
+    /// Set when current message is requesting an acknowledgment from the recipient.
+    kExchangeFlag_NeedsAck = 0x04,
+
+    /// Set when a vendor id is prepended to the Message Protocol Id field.
+    kExchangeFlag_VendorIdPresent = 0x10,
 };
 
 enum class FlagValues : uint16_t
@@ -67,9 +76,6 @@ enum class FlagValues : uint16_t
 
     /// Header flag specifying that a source node id is included in the header.
     kSourceNodeIdPresent = 0x0200,
-
-    /// Header flag specifying that a source vendor id is included in the header.
-    kVendorIdPresent = 0x0400,
 
     /// Header flag specifying that it is a control message for secure session.
     kSecureSessionControlMessage = 0x0800,
@@ -240,14 +246,13 @@ public:
      * @param data - the buffer to write to
      * @param size - space available in the buffer (in bytes)
      * @param encode_size - number of bytes written to the buffer.
-     * @param payloadFlags extra flags for packet header encoding
      *
      * @return CHIP_NO_ERROR on success.
      *
      * Possible failures:
      *    CHIP_ERROR_INVALID_ARGUMENT on insufficient buffer size
      */
-    CHIP_ERROR Encode(uint8_t * data, uint16_t size, uint16_t * encode_size, Header::Flags payloadFlags) const;
+    CHIP_ERROR Encode(uint8_t * data, uint16_t size, uint16_t * encode_size) const;
 
 private:
     /// Represents the current encode/decode header version
@@ -284,6 +289,8 @@ private:
 class PayloadHeader
 {
 public:
+    PayloadHeader & operator=(const PayloadHeader &) = default;
+
     /**
      * Gets the vendor id in the current message.
      *
@@ -300,10 +307,18 @@ public:
     /** Get the secure msg type from this header. */
     uint8_t GetMessageType() const { return mMessageType; }
 
+    /**
+     * Gets the Acknowledged Message Counter from this header.
+     *
+     * NOTE: the Acknowledged Message Counter is optional and may be missing.
+     */
+    const Optional<uint32_t> & GetAckId() const { return mAckId; }
+
     /** Set the vendor id for this header. */
     PayloadHeader & SetVendorId(uint16_t id)
     {
         mVendorId.SetValue(id);
+        mExchangeFlags.Set(Header::ExFlagValues::kExchangeFlag_VendorIdPresent);
 
         return *this;
     }
@@ -312,6 +327,7 @@ public:
     PayloadHeader & SetVendorId(Optional<uint16_t> id)
     {
         mVendorId = id;
+        mExchangeFlags.Set(Header::ExFlagValues::kExchangeFlag_VendorIdPresent, id.HasValue());
 
         return *this;
     }
@@ -352,6 +368,28 @@ public:
         return *this;
     }
 
+    PayloadHeader & SetAckId(uint32_t id)
+    {
+        mAckId.SetValue(id);
+        mExchangeFlags.Set(Header::ExFlagValues::kExchangeFlag_AckMsg);
+        return *this;
+    }
+
+    /** Set the AckMsg flag bit. */
+    PayloadHeader & SetAckId(Optional<uint32_t> id)
+    {
+        mAckId = id;
+        mExchangeFlags.Set(Header::ExFlagValues::kExchangeFlag_AckMsg, id.HasValue());
+        return *this;
+    }
+
+    /** Set the NeedsAck flag bit. */
+    PayloadHeader & SetNeedsAck(bool inNeedsAck)
+    {
+        mExchangeFlags.Set(Header::ExFlagValues::kExchangeFlag_NeedsAck, inNeedsAck);
+        return *this;
+    }
+
     /**
      *  Determine whether the initiator of the exchange.
      *
@@ -359,6 +397,22 @@ public:
      *
      */
     bool IsInitiator() const { return mExchangeFlags.Has(Header::ExFlagValues::kExchangeFlag_Initiator); }
+
+    /**
+     *  Determine whether the current message is an acknowledgment for a previously received message.
+     *
+     *  @return Returns 'true' if current message is an acknowledgment, else 'false'.
+     *
+     */
+    bool IsAckMsg() const { return mExchangeFlags.Has(Header::ExFlagValues::kExchangeFlag_AckMsg); }
+
+    /**
+     *  Determine whether current message is requesting an acknowledgment from the recipient.
+     *
+     *  @return Returns 'true' if the current message is requesting an acknowledgment from the recipient, else 'false'.
+     *
+     */
+    bool IsNeedsAck() const { return mExchangeFlags.Has(Header::ExFlagValues::kExchangeFlag_NeedsAck); }
 
     /**
      * A call to `Encode` will require at least this many bytes on the current
@@ -371,7 +425,6 @@ public:
     /**
      * Decodes the encrypted header fields from the given buffer.
      *
-     * @param flags - decode flags
      * @param data - the buffer to read from
      * @param size - bytes available in the buffer
      * @param decode_size - number of bytes read from the buffer to decode the
@@ -383,7 +436,7 @@ public:
      *    CHIP_ERROR_INVALID_ARGUMENT on insufficient buffer size
      *    CHIP_ERROR_VERSION_MISMATCH if header version is not supported.
      */
-    CHIP_ERROR Decode(Header::Flags flags, const uint8_t * data, uint16_t size, uint16_t * decode_size);
+    CHIP_ERROR Decode(const uint8_t * data, uint16_t size, uint16_t * decode_size);
 
     /**
      * Encodes the encrypted part of the header into the given buffer.
@@ -398,9 +451,6 @@ public:
      *    CHIP_ERROR_INVALID_ARGUMENT on insufficient buffer size
      */
     CHIP_ERROR Encode(uint8_t * data, uint16_t size, uint16_t * encode_size) const;
-
-    /** Flags required for encoding this payload. */
-    Header::Flags GetEncodePacketFlags() const;
 
 private:
     /// Packet type (application data, security control packets, e.g. pairing,
@@ -418,6 +468,9 @@ private:
 
     /// Bit flag indicators for CHIP Exchange header
     Header::ExFlags mExchangeFlags;
+
+    /// Message counter of a previous message that is being acknowledged by the current message
+    Optional<uint32_t> mAckId;
 };
 
 /** Handles encoding/decoding of CHIP message headers */

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -171,8 +171,7 @@ Inet::TCPEndPoint * TCPBase::FindActiveConnection(const PeerAddress & address)
     return nullptr;
 }
 
-CHIP_ERROR TCPBase::SendMessage(const PacketHeader & header, Header::Flags payloadFlags, const Transport::PeerAddress & address,
-                                System::PacketBuffer * msgBuf)
+CHIP_ERROR TCPBase::SendMessage(const PacketHeader & header, const Transport::PeerAddress & address, System::PacketBuffer * msgBuf)
 {
     System::PacketBufferHandle autofree;
     autofree.Adopt(msgBuf);
@@ -200,7 +199,7 @@ CHIP_ERROR TCPBase::SendMessage(const PacketHeader & header, Header::Flags paylo
     LittleEndian::Write16(output, static_cast<uint16_t>(msgBuf->DataLength() - kPacketSizeBytes));
 
     uint16_t actualEncodedHeaderSize;
-    ReturnErrorOnFailure(header.Encode(output, msgBuf->DataLength(), &actualEncodedHeaderSize, payloadFlags));
+    ReturnErrorOnFailure(header.Encode(output, msgBuf->DataLength(), &actualEncodedHeaderSize));
 
     // header encoding has to match space that we allocated
     VerifyOrReturnError(prefixSize == actualEncodedHeaderSize + kPacketSizeBytes, CHIP_ERROR_INTERNAL);

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -127,8 +127,7 @@ public:
      */
     CHIP_ERROR Init(TcpListenParameters & params);
 
-    CHIP_ERROR SendMessage(const PacketHeader & header, Header::Flags payloadFlags, const PeerAddress & address,
-                           System::PacketBuffer * msgBuf) override;
+    CHIP_ERROR SendMessage(const PacketHeader & header, const PeerAddress & address, System::PacketBuffer * msgBuf) override;
 
     void Disconnect(const PeerAddress & address) override;
 

--- a/src/transport/raw/Tuple.h
+++ b/src/transport/raw/Tuple.h
@@ -81,10 +81,9 @@ template <typename... TransportTypes>
 class Tuple : public Base
 {
 public:
-    CHIP_ERROR SendMessage(const PacketHeader & header, Header::Flags payloadFlags, const PeerAddress & address,
-                           System::PacketBuffer * msgBuf) override
+    CHIP_ERROR SendMessage(const PacketHeader & header, const PeerAddress & address, System::PacketBuffer * msgBuf) override
     {
-        return SendMessageImpl<0>(header, payloadFlags, address, msgBuf);
+        return SendMessageImpl<0>(header, address, msgBuf);
     }
 
     bool CanSendToPeer(const PeerAddress & address) override { return CanSendToPeerImpl<0>(address); }
@@ -164,23 +163,21 @@ private:
      * @param msgBuf the data to send.
      */
     template <size_t N, typename std::enable_if<(N < sizeof...(TransportTypes))>::type * = nullptr>
-    CHIP_ERROR SendMessageImpl(const PacketHeader & header, Header::Flags payloadFlags, const PeerAddress & address,
-                               System::PacketBuffer * msgBuf)
+    CHIP_ERROR SendMessageImpl(const PacketHeader & header, const PeerAddress & address, System::PacketBuffer * msgBuf)
     {
         Base * base = &std::get<N>(mTransports);
         if (base->CanSendToPeer(address))
         {
-            return base->SendMessage(header, payloadFlags, address, msgBuf);
+            return base->SendMessage(header, address, msgBuf);
         }
-        return SendMessageImpl<N + 1>(header, payloadFlags, address, msgBuf);
+        return SendMessageImpl<N + 1>(header, address, msgBuf);
     }
 
     /**
      * SendMessageImpl when N is out of range. Always returns an error code.
      */
     template <size_t N, typename std::enable_if<(N >= sizeof...(TransportTypes))>::type * = nullptr>
-    CHIP_ERROR SendMessageImpl(const PacketHeader & header, Header::Flags payloadFlags, const PeerAddress & address,
-                               System::PacketBuffer * msgBuf)
+    CHIP_ERROR SendMessageImpl(const PacketHeader & header, const PeerAddress & address, System::PacketBuffer * msgBuf)
     {
         System::PacketBuffer::Free(msgBuf);
         return CHIP_ERROR_NO_MESSAGE_HANDLER;

--- a/src/transport/raw/UDP.cpp
+++ b/src/transport/raw/UDP.cpp
@@ -88,8 +88,7 @@ void UDP::Close()
     mState = State::kNotReady;
 }
 
-CHIP_ERROR UDP::SendMessage(const PacketHeader & header, Header::Flags payloadFlags, const Transport::PeerAddress & address,
-                            System::PacketBuffer * msgIn)
+CHIP_ERROR UDP::SendMessage(const PacketHeader & header, const Transport::PeerAddress & address, System::PacketBuffer * msgIn)
 {
     System::PacketBufferHandle msgBuf;
     msgBuf.Adopt(msgIn);
@@ -112,7 +111,7 @@ CHIP_ERROR UDP::SendMessage(const PacketHeader & header, Header::Flags payloadFl
     msgBuf->SetStart(msgBuf->Start() - headerSize);
 
     uint16_t actualEncodedHeaderSize;
-    ReturnErrorOnFailure(header.Encode(msgBuf->Start(), msgBuf->DataLength(), &actualEncodedHeaderSize, payloadFlags));
+    ReturnErrorOnFailure(header.Encode(msgBuf->Start(), msgBuf->DataLength(), &actualEncodedHeaderSize));
 
     VerifyOrReturnError(headerSize == actualEncodedHeaderSize, CHIP_ERROR_INTERNAL);
 

--- a/src/transport/raw/UDP.h
+++ b/src/transport/raw/UDP.h
@@ -110,7 +110,7 @@ public:
      */
     void Close() override;
 
-    CHIP_ERROR SendMessage(const PacketHeader & header, Header::Flags payloadFlags, const Transport::PeerAddress & address,
+    CHIP_ERROR SendMessage(const PacketHeader & header, const Transport::PeerAddress & address,
                            System::PacketBuffer * msgBuf) override;
 
     bool CanSendToPeer(const Transport::PeerAddress & address) override

--- a/src/transport/raw/tests/TestMessageHeader.cpp
+++ b/src/transport/raw/tests/TestMessageHeader.cpp
@@ -62,7 +62,7 @@ void TestPacketHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     uint16_t decodeLen;
 
     header.SetMessageId(123).SetPayloadLength(16);
-    NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen, Header::Flags()) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
 
     // change it to verify decoding
     header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
@@ -73,7 +73,7 @@ void TestPacketHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, !header.GetDestinationNodeId().HasValue());
 
     header.SetSourceNodeId(55);
-    NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen, Header::Flags()) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
 
     // change it to verify decoding
     header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
@@ -85,7 +85,7 @@ void TestPacketHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(55));
 
     header.ClearSourceNodeId().SetDestinationNodeId(11);
-    NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen, Header::Flags()) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
 
     // change it to verify decoding
     header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
@@ -96,7 +96,7 @@ void TestPacketHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, !header.GetSourceNodeId().HasValue());
 
     header.SetMessageId(234).SetSourceNodeId(77).SetDestinationNodeId(88);
-    NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen, Header::Flags()) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
 
     // change it to verify decoding
     header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
@@ -107,7 +107,7 @@ void TestPacketHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77));
 
     header.SetMessageId(234).SetSourceNodeId(77).SetDestinationNodeId(88).SetSecureSessionControlMsg(true);
-    NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen, Header::Flags()) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
 
     // change it to verify decoding
     header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
@@ -118,7 +118,7 @@ void TestPacketHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.IsSecureSessionControlMsg());
 
     header.SetMessageId(234).SetSourceNodeId(77).SetDestinationNodeId(88).SetEncryptionKeyID(2);
-    NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen, Header::Flags()) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
 
     // change it to verify decoding
     header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
@@ -129,7 +129,7 @@ void TestPacketHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.GetEncryptionKeyID() == 2);
 
     header.SetMessageId(234).SetSourceNodeId(77).SetDestinationNodeId(88);
-    NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen, Header::Flags()) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
 
     // change it to verify decoding
     header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
@@ -153,7 +153,7 @@ void TestPayloadHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
 
     header.SetMessageType(221).SetExchangeID(3322).SetProtocolID(4567);
-    NL_TEST_ASSERT(inSuite, header.Decode(Header::Flags(), buffer, sizeof(buffer), &decodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.Decode(buffer, sizeof(buffer), &decodeLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, encodeLen == decodeLen);
     NL_TEST_ASSERT(inSuite, header.GetMessageType() == 112);
     NL_TEST_ASSERT(inSuite, header.GetExchangeID() == 2233);
@@ -164,12 +164,11 @@ void TestPayloadHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     header.SetMessageType(112).SetExchangeID(2233).SetProtocolID(1221);
     header.SetVendorId(6789);
 
-    Header::Flags encodeFlags = header.GetEncodePacketFlags();
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
 
     header.SetMessageType(111).SetExchangeID(222);
 
-    NL_TEST_ASSERT(inSuite, header.Decode(encodeFlags, buffer, sizeof(buffer), &decodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.Decode(buffer, sizeof(buffer), &decodeLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, encodeLen == decodeLen);
     NL_TEST_ASSERT(inSuite, header.GetExchangeID() == 2233);
     NL_TEST_ASSERT(inSuite, header.GetVendorId() == Optional<uint16_t>::Value(6789));
@@ -177,7 +176,7 @@ void TestPayloadHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     header.SetMessageType(221).SetExchangeID(3322).SetProtocolID(4567);
     header.SetVendorId(8976);
 
-    NL_TEST_ASSERT(inSuite, header.Decode(encodeFlags, buffer, sizeof(buffer), &decodeLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.Decode(buffer, sizeof(buffer), &decodeLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, encodeLen == decodeLen);
     NL_TEST_ASSERT(inSuite, header.GetExchangeID() == 2233);
     NL_TEST_ASSERT(inSuite, header.GetProtocolID() == 1221);
@@ -192,7 +191,7 @@ void TestPacketHeaderEncodeDecodeBounds(nlTestSuite * inSuite, void * inContext)
 
     for (uint16_t shortLen = 0; shortLen < 10; shortLen++)
     {
-        NL_TEST_ASSERT(inSuite, header.Encode(buffer, shortLen, &unusedLen, Header::Flags()) != CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, header.Encode(buffer, shortLen, &unusedLen) != CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, header.Decode(buffer, shortLen, &unusedLen) != CHIP_NO_ERROR);
     }
 
@@ -200,7 +199,7 @@ void TestPacketHeaderEncodeDecodeBounds(nlTestSuite * inSuite, void * inContext)
     // default-constructed PacketHeader.
     static const size_t minLen = 10;
     uint16_t encoded_len;
-    NL_TEST_ASSERT(inSuite, header.Encode(buffer, minLen, &encoded_len, Header::Flags()) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.Encode(buffer, minLen, &encoded_len) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, encoded_len == minLen);
     // Verify that decoding at any smaller length fails.
     for (uint16_t shortLen = 0; shortLen < encoded_len; shortLen++)
@@ -215,9 +214,9 @@ void TestPacketHeaderEncodeDecodeBounds(nlTestSuite * inSuite, void * inContext)
     header.SetSourceNodeId(1);
     for (uint16_t shortLen = minLen; shortLen < minLen + 8; shortLen++)
     {
-        NL_TEST_ASSERT(inSuite, header.Encode(buffer, shortLen, &unusedLen, Header::Flags()) != CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, header.Encode(buffer, shortLen, &unusedLen) != CHIP_NO_ERROR);
     }
-    NL_TEST_ASSERT(inSuite, header.Encode(buffer, minLen + 8, &encoded_len, Header::Flags()) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.Encode(buffer, minLen + 8, &encoded_len) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, encoded_len == minLen + 8);
     for (uint16_t shortLen = 0; shortLen < encoded_len; shortLen++)
     {
@@ -230,9 +229,9 @@ void TestPacketHeaderEncodeDecodeBounds(nlTestSuite * inSuite, void * inContext)
     header.SetDestinationNodeId(1);
     for (uint16_t shortLen = minLen; shortLen < minLen + 16; shortLen++)
     {
-        NL_TEST_ASSERT(inSuite, header.Encode(buffer, shortLen, &unusedLen, Header::Flags()) != CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, header.Encode(buffer, shortLen, &unusedLen) != CHIP_NO_ERROR);
     }
-    NL_TEST_ASSERT(inSuite, header.Encode(buffer, minLen + 16, &encoded_len, Header::Flags()) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.Encode(buffer, minLen + 16, &encoded_len) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, encoded_len == minLen + 16);
     for (uint16_t shortLen = 0; shortLen < encoded_len; shortLen++)
     {
@@ -251,7 +250,7 @@ void TestPayloadHeaderEncodeDecodeBounds(nlTestSuite * inSuite, void * inContext
     for (uint16_t shortLen = 0; shortLen < 6; shortLen++)
     {
         NL_TEST_ASSERT(inSuite, header.Encode(buffer, shortLen, &unusedLen) != CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, header.Decode(Header::Flags(), buffer, shortLen, &unusedLen) != CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, header.Decode(buffer, shortLen, &unusedLen) != CHIP_NO_ERROR);
     }
 }
 

--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -123,7 +123,7 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext, const IPAddress &
     header.SetSourceNodeId(kSourceNodeId).SetDestinationNodeId(kDestinationNodeId).SetMessageId(kMessageId);
 
     // Should be able to send a message to itself by just calling send.
-    err = tcp.SendMessage(header, Header::Flags(), Transport::PeerAddress::TCP(addr), buffer.Release_ForNow());
+    err = tcp.SendMessage(header, Transport::PeerAddress::TCP(addr), buffer.Release_ForNow());
     if (err == System::MapErrorPOSIX(EADDRNOTAVAIL))
     {
         // TODO(#2698): the underlying system does not support IPV6. This early return

--- a/src/transport/raw/tests/TestUDP.cpp
+++ b/src/transport/raw/tests/TestUDP.cpp
@@ -120,7 +120,7 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext, const IPAddress &
     header.SetSourceNodeId(kSourceNodeId).SetDestinationNodeId(kDestinationNodeId).SetMessageId(kMessageId);
 
     // Should be able to send a message to itself by just calling send.
-    err = udp.SendMessage(header, Header::Flags(), Transport::PeerAddress::UDP(addr), buffer.Release_ForNow());
+    err = udp.SendMessage(header, Transport::PeerAddress::UDP(addr), buffer.Release_ForNow());
     if (err == System::MapErrorPOSIX(EADDRNOTAVAIL))
     {
         // TODO(#2698): the underlying system does not support IPV6. This early return

--- a/src/transport/tests/TestSecurePairingSession.cpp
+++ b/src/transport/tests/TestSecurePairingSession.cpp
@@ -39,8 +39,8 @@ using namespace chip;
 class TestSecurePairingDelegate : public SecurePairingSessionDelegate
 {
 public:
-    CHIP_ERROR SendPairingMessage(const PacketHeader & header, Header::Flags payloadFlags,
-                                  const Transport::PeerAddress & peerAddress, System::PacketBuffer * msgBuf) override
+    CHIP_ERROR SendPairingMessage(const PacketHeader & header, const Transport::PeerAddress & peerAddress,
+                                  System::PacketBuffer * msgBuf) override
     {
         mNumMessageSend++;
         System::PacketBufferHandle msg_ForNow;
@@ -173,8 +173,7 @@ void SecurePairingSerializeTest(nlTestSuite * inSuite, void * inContext)
         NL_TEST_ASSERT(inSuite,
                        testPairingSession1->DeriveSecureSession(Uint8::from_const_char("abc"), 3, session1) == CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT(inSuite,
-                       session1.Encrypt(plain_text, sizeof(plain_text), encrypted, header, Header::Flags(), mac) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, session1.Encrypt(plain_text, sizeof(plain_text), encrypted, header, mac) == CHIP_NO_ERROR);
     }
 
     {
@@ -183,8 +182,7 @@ void SecurePairingSerializeTest(nlTestSuite * inSuite, void * inContext)
                        testPairingSession2->DeriveSecureSession(Uint8::from_const_char("abc"), 3, session2) == CHIP_NO_ERROR);
 
         uint8_t decrypted[64];
-        NL_TEST_ASSERT(inSuite,
-                       session2.Decrypt(encrypted, sizeof(plain_text), decrypted, header, Header::Flags(), mac) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, session2.Decrypt(encrypted, sizeof(plain_text), decrypted, header, mac) == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, memcmp(plain_text, decrypted, sizeof(plain_text)) == 0);
     }
 

--- a/src/transport/tests/TestSecureSession.cpp
+++ b/src/transport/tests/TestSecureSession.cpp
@@ -84,7 +84,7 @@ void SecureChannelEncryptTest(nlTestSuite * inSuite, void * inContext)
 
     // Test uninitialized channel
     NL_TEST_ASSERT(inSuite,
-                   channel.Encrypt(plain_text, sizeof(plain_text), output, packetHeader, Header::Flags(), mac) ==
+                   channel.Encrypt(plain_text, sizeof(plain_text), output, packetHeader, mac) ==
                        CHIP_ERROR_INVALID_USE_OF_SESSION_KEY);
 
     const char * info = "Test Info";
@@ -94,17 +94,13 @@ void SecureChannelEncryptTest(nlTestSuite * inSuite, void * inContext)
                                 sizeof(info)) == CHIP_NO_ERROR);
 
     // Test initialized channel, but invalid arguments
+    NL_TEST_ASSERT(inSuite, channel.Encrypt(nullptr, 0, nullptr, packetHeader, mac) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, channel.Encrypt(plain_text, 0, nullptr, packetHeader, mac) == CHIP_ERROR_INVALID_ARGUMENT);
     NL_TEST_ASSERT(inSuite,
-                   channel.Encrypt(nullptr, 0, nullptr, packetHeader, Header::Flags(), mac) == CHIP_ERROR_INVALID_ARGUMENT);
-    NL_TEST_ASSERT(inSuite,
-                   channel.Encrypt(plain_text, 0, nullptr, packetHeader, Header::Flags(), mac) == CHIP_ERROR_INVALID_ARGUMENT);
-    NL_TEST_ASSERT(inSuite,
-                   channel.Encrypt(plain_text, sizeof(plain_text), nullptr, packetHeader, Header::Flags(), mac) ==
-                       CHIP_ERROR_INVALID_ARGUMENT);
+                   channel.Encrypt(plain_text, sizeof(plain_text), nullptr, packetHeader, mac) == CHIP_ERROR_INVALID_ARGUMENT);
 
     // Valid arguments
-    NL_TEST_ASSERT(inSuite,
-                   channel.Encrypt(plain_text, sizeof(plain_text), output, packetHeader, Header::Flags(), mac) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, channel.Encrypt(plain_text, sizeof(plain_text), output, packetHeader, mac) == CHIP_NO_ERROR);
 }
 
 void SecureChannelDecryptTest(nlTestSuite * inSuite, void * inContext)
@@ -127,31 +123,26 @@ void SecureChannelDecryptTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite,
                    channel.Init(keypair, keypair2.Pubkey(), (const uint8_t *) salt, sizeof(salt), (const uint8_t *) info,
                                 sizeof(info)) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite,
-                   channel.Encrypt(plain_text, sizeof(plain_text), encrypted, packetHeader, Header::Flags(), mac) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, channel.Encrypt(plain_text, sizeof(plain_text), encrypted, packetHeader, mac) == CHIP_NO_ERROR);
 
     SecureSession channel2;
     uint8_t output[128];
     // Uninitialized channel
     NL_TEST_ASSERT(inSuite,
-                   channel2.Decrypt(encrypted, sizeof(plain_text), output, packetHeader, Header::Flags(), mac) ==
+                   channel2.Decrypt(encrypted, sizeof(plain_text), output, packetHeader, mac) ==
                        CHIP_ERROR_INVALID_USE_OF_SESSION_KEY);
     NL_TEST_ASSERT(inSuite,
                    channel2.Init(keypair2, keypair.Pubkey(), (const uint8_t *) salt, sizeof(salt), (const uint8_t *) info,
                                  sizeof(info)) == CHIP_NO_ERROR);
 
     // Channel initialized, but invalid arguments to decrypt
+    NL_TEST_ASSERT(inSuite, channel2.Decrypt(nullptr, 0, nullptr, packetHeader, mac) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, channel2.Decrypt(encrypted, 0, nullptr, packetHeader, mac) == CHIP_ERROR_INVALID_ARGUMENT);
     NL_TEST_ASSERT(inSuite,
-                   channel2.Decrypt(nullptr, 0, nullptr, packetHeader, Header::Flags(), mac) == CHIP_ERROR_INVALID_ARGUMENT);
-    NL_TEST_ASSERT(inSuite,
-                   channel2.Decrypt(encrypted, 0, nullptr, packetHeader, Header::Flags(), mac) == CHIP_ERROR_INVALID_ARGUMENT);
-    NL_TEST_ASSERT(inSuite,
-                   channel2.Decrypt(encrypted, sizeof(encrypted), nullptr, packetHeader, Header::Flags(), mac) ==
-                       CHIP_ERROR_INVALID_ARGUMENT);
+                   channel2.Decrypt(encrypted, sizeof(encrypted), nullptr, packetHeader, mac) == CHIP_ERROR_INVALID_ARGUMENT);
 
     // Valid arguments
-    NL_TEST_ASSERT(inSuite,
-                   channel2.Decrypt(encrypted, sizeof(plain_text), output, packetHeader, Header::Flags(), mac) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, channel2.Decrypt(encrypted, sizeof(plain_text), output, packetHeader, mac) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, memcmp(plain_text, output, sizeof(plain_text)) == 0);
 }

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -54,8 +54,7 @@ public:
     /// Transports are required to have a constructor that takes exactly one argument
     CHIP_ERROR Init(const char * unused) { return CHIP_NO_ERROR; }
 
-    CHIP_ERROR SendMessage(const PacketHeader & header, Header::Flags payloadFlags, const PeerAddress & address,
-                           System::PacketBuffer * msgBuf) override
+    CHIP_ERROR SendMessage(const PacketHeader & header, const PeerAddress & address, System::PacketBuffer * msgBuf) override
     {
         System::PacketBufferHandle msg_ForNow;
         msg_ForNow.Adopt(msgBuf);


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Currently, only I Flag (A single bit field indicating that the message was sent by the initiator of the exchange) is implemented in transport layer. Vendor Id is implemented in the Payload part but its flag is implemented in the Packet part, this separation cause the payload header need to be passed throughout the transport stack.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
1. Add support for A Flag (1 bit, position 1) and R Flag (1 bit, position 2) in Exchange Header (8 bits)
2. Move V flag from Packet Header to Payload Header to align with the spec and avoid passing Payload header throughout the transport layer


<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #4016

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
