### PR TITLE
Add separate transport for IPv4 and IPv6 in controller

### DIFF
--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -59,7 +59,7 @@ CHIP_ERROR Device::SendMessage(System::PacketBufferHandle buffer)
     // If there is no secure connection to the device, try establishing it
     if (mState != ConnectionState::SecureConnected)
     {
-        err = LoadSecureSessionParameters(false);
+        err = LoadSecureSessionParameters(ResetTransport::kNo);
         SuccessOrExit(err);
     }
     else
@@ -79,7 +79,7 @@ CHIP_ERROR Device::SendMessage(System::PacketBufferHandle buffer)
     {
         mState = ConnectionState::NotConnected;
 
-        err = LoadSecureSessionParameters(true);
+        err = LoadSecureSessionParameters(ResetTransport::kYes);
         SuccessOrExit(err);
 
         err = mSessionManager->SendMessage(mDeviceId, std::move(resend));
@@ -202,7 +202,7 @@ void Device::OnMessageReceived(const PacketHeader & header, const PayloadHeader 
     }
 }
 
-CHIP_ERROR Device::LoadSecureSessionParameters(bool resetNeeded)
+CHIP_ERROR Device::LoadSecureSessionParameters(ResetTransport resetNeeded)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     SecurePairingSession pairingSession;
@@ -215,7 +215,7 @@ CHIP_ERROR Device::LoadSecureSessionParameters(bool resetNeeded)
     err = pairingSession.FromSerializable(mPairing);
     SuccessOrExit(err);
 
-    if (resetNeeded)
+    if (resetNeeded == ResetTransport::kYes)
     {
         err = mTransportMgr->ResetTransport(Transport::UdpListenParameters(mInetLayer).SetAddressType(kIPAddressType_IPv6)
 #if INET_CONFIG_ENABLE_IPV4

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -217,8 +217,12 @@ CHIP_ERROR Device::LoadSecureSessionParameters(bool resetNeeded)
 
     if (resetNeeded)
     {
-        err = mTransportMgr->ResetTransport(Transport::UdpListenParameters(mInetLayer).SetAddressType(kIPAddressType_IPv6),
-                                            Transport::UdpListenParameters(mInetLayer).SetAddressType(kIPAddressType_IPv4));
+        err = mTransportMgr->ResetTransport(Transport::UdpListenParameters(mInetLayer).SetAddressType(kIPAddressType_IPv6)
+#if INET_CONFIG_ENABLE_IPV4
+                                                ,
+                                            Transport::UdpListenParameters(mInetLayer).SetAddressType(kIPAddressType_IPv4)
+#endif
+        );
         SuccessOrExit(err);
     }
 

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -44,7 +44,7 @@ class DeviceController;
 class DeviceStatusDelegate;
 struct SerializedDevice;
 
-using DeviceTransportMgr = TransportMgr<Transport::UDP>;
+using DeviceTransportMgr = TransportMgr<Transport::UDP /* IPv6 */, Transport::UDP /* IPv4 */>;
 
 class DLL_EXPORT Device
 {
@@ -242,8 +242,10 @@ private:
      *   This function loads the secure session object from the serialized operational
      *   credentials corresponding to the device. This is typically done when the device
      *   does not have an active secure channel.
+     *
+     * @param[in] resetNeeded   Does the underlying network socket require a reset
      */
-    CHIP_ERROR LoadSecureSessionParameters();
+    CHIP_ERROR LoadSecureSessionParameters(bool resetNeeded);
 };
 
 /**

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -209,6 +209,11 @@ private:
         ClusterId cluster;
     };
 
+    enum class ResetTransport
+    {
+        kYes,
+        kNo,
+    };
     /* Node ID assigned to the CHIP device */
     NodeId mDeviceId;
 
@@ -250,7 +255,7 @@ private:
      *
      * @param[in] resetNeeded   Does the underlying network socket require a reset
      */
-    CHIP_ERROR LoadSecureSessionParameters(bool resetNeeded);
+    CHIP_ERROR LoadSecureSessionParameters(ResetTransport resetNeeded);
 };
 
 /**

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -44,7 +44,12 @@ class DeviceController;
 class DeviceStatusDelegate;
 struct SerializedDevice;
 
-using DeviceTransportMgr = TransportMgr<Transport::UDP /* IPv6 */, Transport::UDP /* IPv4 */>;
+using DeviceTransportMgr = TransportMgr<Transport::UDP /* IPv6 */
+#if INET_CONFIG_ENABLE_IPV4
+                                        ,
+                                        Transport::UDP /* IPv4 */
+#endif
+                                        >;
 
 class DLL_EXPORT Device
 {

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -126,8 +126,12 @@ CHIP_ERROR DeviceController::Init(NodeId localDeviceId, PersistentStorageDelegat
     mTransportMgr   = chip::Platform::New<DeviceTransportMgr>();
     mSessionManager = chip::Platform::New<SecureSessionMgr>();
 
-    err = mTransportMgr->Init(Transport::UdpListenParameters(mInetLayer).SetAddressType(Inet::kIPAddressType_IPv6),
-                              Transport::UdpListenParameters(mInetLayer).SetAddressType(Inet::kIPAddressType_IPv4));
+    err = mTransportMgr->Init(Transport::UdpListenParameters(mInetLayer).SetAddressType(Inet::kIPAddressType_IPv6)
+#if INET_CONFIG_ENABLE_IPV4
+                                  ,
+                              Transport::UdpListenParameters(mInetLayer).SetAddressType(Inet::kIPAddressType_IPv4)
+#endif
+    );
     SuccessOrExit(err);
 
     err = mSessionManager->Init(localDeviceId, mSystemLayer, mTransportMgr);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -126,7 +126,8 @@ CHIP_ERROR DeviceController::Init(NodeId localDeviceId, PersistentStorageDelegat
     mTransportMgr   = chip::Platform::New<DeviceTransportMgr>();
     mSessionManager = chip::Platform::New<SecureSessionMgr>();
 
-    err = mTransportMgr->Init(Transport::UdpListenParameters(mInetLayer).SetAddressType(Inet::kIPAddressType_IPv6));
+    err = mTransportMgr->Init(Transport::UdpListenParameters(mInetLayer).SetAddressType(Inet::kIPAddressType_IPv6),
+                              Transport::UdpListenParameters(mInetLayer).SetAddressType(Inet::kIPAddressType_IPv4));
     SuccessOrExit(err);
 
     err = mSessionManager->Init(localDeviceId, mSystemLayer, mTransportMgr);


### PR DESCRIPTION
 #### Problem
CHIP Tool is printing the following error message when it is run. The command runs successfully, but the error message seems to indicate some issue that should be debugged.

```
CHIP: [DL] CHIP task running
CHIP: [TOO] OnConnect
CHIP: [TOO] Endpoint id: '0x01', Cluster id: '0x0006', Command id: '0x01'
CHIP: [ZCL] Successfully encoded 13 bytes
CHIP: [TOO] Encoded data of length 16
CHIP: [DL] select failed: OS Error 2009 (0x000007D9): Bad file descriptor
```

 #### Summary of Changes
- The controller was using IPv6 by default. However the demos accessories
  still use/support IPv4. The controller code was detecting this using
  device's IP address, and closing and reopening the socket. This however,
  caused select loop to error out sometimes (race condition between when
  select loop picked up the sock FD, and when the controller closed it).

- Changing controller code to use two separate transports, one for IPv6 and
  the other for IPv4.

- The controller can still close the socket, but this happens only when the
  current socket times out.

 Fixes #4026
