### PR TITLE
Add SSID and password to chip-tool pairing

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -107,6 +107,7 @@ void PairingCommand::OnStatusUpdate(RendezvousSessionDelegate::Status status)
 void PairingCommand::OnNetworkCredentialsRequested(RendezvousDeviceCredentialsDelegate * callback)
 {
     ChipLogProgress(chipTool, "OnNetworkCredentialsRequested");
+    callback->SendNetworkCredentials(mSSID, mPassword);
 }
 
 void PairingCommand::OnOperationalCredentialsRequested(const char * csr, size_t csr_length,

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -44,6 +44,8 @@ public:
             AddArgument("device-remote-port", 0, UINT16_MAX, &mRemotePort);
             break;
         case PairingMode::Ble:
+            AddArgument("ssid", &mSSID);
+            AddArgument("password", &mPassword);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
             AddArgument("discriminator", 0, 4096, &mDiscriminator);
             break;


### PR DESCRIPTION
#### Problem

Chip-tool was missing fields.

#### Summary of Changes

Add them.