### PR TITLE
[WIP][mdns] add support for unprovisioned devices in discovery manager

### DIFF
--- a/scripts/tests/cirque_tests.sh
+++ b/scripts/tests/cirque_tests.sh
@@ -56,7 +56,7 @@ function __cirquetest_start_flask() {
     echo 'Start Flask'
     cd "$REPO_DIR"/third_party/cirque/repo
     FLASK_APP='cirque/restservice/service.py' \
-        PATH="$PATH":"$REPO_DIR"/third_party/cirque/repo/openthread/output/x86_64-unknown-linux-gnu/bin/ \
+        PATH="$PATH":"$REPO_DIR"/third_party/cirque/repo/openthread/output/simulation/bin/ \
         python3 -m flask run >"$LOG_DIR/$CURRENT_TEST/flask.log" 2>&1
 }
 

--- a/src/lib/mdns/DiscoveryManager.h
+++ b/src/lib/mdns/DiscoveryManager.h
@@ -28,7 +28,9 @@ namespace Mdns {
 class ResolveDelegate
 {
 public:
-    virtual void HandleNodeIdResolve(CHIP_ERROR error, uint64_t nodeId, const MdnsService & address) = 0;
+    virtual void HandleNodeIdResolve(CHIP_ERROR error, uint64_t nodeId, const MdnsService & address) {}
+    virtual void HandleUnprovisionedDeviceResolve(CHIP_ERROR error, uint64_t name, const MdnsService & address) {}
+    virtual void HandleUnprovisionedDeviceBrowse(CHIP_ERROR error, const MdnsService * devices, size_t devicesSize) {}
     virtual ~ResolveDelegate() {}
 };
 
@@ -67,11 +69,18 @@ public:
      */
     CHIP_ERROR RegisterResolveDelegate(ResolveDelegate * delegate);
 
+    CHIP_ERROR BrowseUnprovisionedDevice(Inet::IPAddressType type    = Inet::IPAddressType::kIPAddressType_Any,
+                                         Inet::InterfaceId interface = INET_NULL_INTERFACEID);
+
+    CHIP_ERROR ResolveUnprovisionedDevice(uint64_t name, Inet::IPAddressType type = Inet::IPAddressType::kIPAddressType_Any,
+                                          Inet::InterfaceId interface = INET_NULL_INTERFACEID);
+
     /**
      * This function resolves a node id to its address.
      *
      */
-    CHIP_ERROR ResolveNodeId(uint64_t nodeId, uint64_t fabricId, chip::Inet::IPAddressType type = chip::Inet::kIPAddressType_Any);
+    CHIP_ERROR ResolveNodeId(uint64_t nodeId, uint64_t fabricId, chip::Inet::IPAddressType type = chip::Inet::kIPAddressType_Any,
+                             Inet::InterfaceId interface = INET_NULL_INTERFACEID);
 
     static DiscoveryManager & GetInstance() { return sManager; }
 
@@ -86,6 +95,8 @@ private:
     CHIP_ERROR SetupHostname();
 
     static void HandleNodeIdResolve(void * context, MdnsService * result, CHIP_ERROR error);
+    static void HandleDiscriminatorResolve(void * context, MdnsService * result, CHIP_ERROR error);
+    static void HandleUnprovisionedDeviceBrowse(void * context, MdnsService * services, size_t servicesSize, CHIP_ERROR error);
     static void HandleMdnsInit(void * context, CHIP_ERROR initError);
     static void HandleMdnsError(void * context, CHIP_ERROR initError);
 


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

We do not support finding unprovisioned devices in DiscoveryManager, which is required for IP rendezvous.

 #### Summary of Changes

Add support for unprovisioned devices.