### PR TITLE
[android/CHIPTool] Re-add Thread provisioning

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -29,7 +29,6 @@ import com.google.chip.chiptool.clusterclient.OnOffClientFragment
 import com.google.chip.chiptool.commissioner.CommissionerActivity
 import com.google.chip.chiptool.echoclient.EchoClientFragment
 import com.google.chip.chiptool.provisioning.DeviceProvisioningFragment
-import com.google.chip.chiptool.provisioning.EnterWifiNetworkFragment
 import com.google.chip.chiptool.setuppayloadscanner.BarcodeFragment
 import com.google.chip.chiptool.setuppayloadscanner.CHIPDeviceDetailsFragment
 import com.google.chip.chiptool.setuppayloadscanner.CHIPDeviceInfo

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
@@ -104,13 +104,26 @@ class DeviceProvisioningFragment : Fragment() {
     }
   }
 
+   private fun closeChildFragments() {
+     childFragmentManager.fragments.forEach {
+       f -> childFragmentManager.beginTransaction().remove(f).commit()
+     }
+   }
+
   inner class ConnectionCallback : GenericChipDeviceListener() {
     override fun onConnectDeviceComplete() {
-      showMessage(R.string.rendezvous_over_ble_success_text)
+      Log.d(TAG, "onConnectDeviceComplete")
     }
 
     override fun onStatusUpdate(status: Int) {
       Log.i(TAG, "Pairing status update: $status");
+
+      when (status) {
+        STATUS_NETWORK_PROVISIONING_SUCCESS -> {
+          showMessage(R.string.rendezvous_over_ble_provisioning_success_text)
+          closeChildFragments()
+        }
+      }
     }
 
     override fun onNetworkCredentialsRequested() {
@@ -139,6 +152,7 @@ class DeviceProvisioningFragment : Fragment() {
   companion object {
     private const val TAG = "DeviceProvisioningFragment"
     private const val ARG_DEVICE_INFO = "device_info"
+    private const val STATUS_NETWORK_PROVISIONING_SUCCESS = 2
 
     fun newInstance(deviceInfo: CHIPDeviceInfo): DeviceProvisioningFragment {
       return DeviceProvisioningFragment().apply {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
@@ -30,9 +30,7 @@ import com.google.chip.chiptool.ChipClient
 import com.google.chip.chiptool.GenericChipDeviceListener
 import com.google.chip.chiptool.R
 import com.google.chip.chiptool.bluetooth.BluetoothManager
-import com.google.chip.chiptool.setuppayloadscanner.CHIPDeviceDetailsFragment
 import com.google.chip.chiptool.setuppayloadscanner.CHIPDeviceInfo
-import com.google.chip.chiptool.util.FragmentUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -117,7 +115,7 @@ class DeviceProvisioningFragment : Fragment() {
 
     override fun onNetworkCredentialsRequested() {
       childFragmentManager.beginTransaction()
-          .add(R.id.fragment_container, EnterWifiNetworkFragment.newInstance())
+          .add(R.id.fragment_container, EnterNetworkFragment.newInstance())
           .commit()
     }
 

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/EnterNetworkFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/EnterNetworkFragment.kt
@@ -1,3 +1,21 @@
+/*
+ *   Copyright (c) 2020 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
 package com.google.chip.chiptool.provisioning
 
 import android.os.Bundle

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/EnterNetworkFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/EnterNetworkFragment.kt
@@ -1,0 +1,46 @@
+package com.google.chip.chiptool.provisioning
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.google.android.material.tabs.TabLayout
+import com.google.chip.chiptool.R
+import kotlinx.android.synthetic.main.enter_network_fragment.view.*
+
+class EnterNetworkFragment : Fragment() {
+
+  override fun onCreateView(
+      inflater: LayoutInflater,
+      container: ViewGroup?,
+      savedInstanceState: Bundle?
+  ): View {
+    return inflater.inflate(R.layout.enter_network_fragment, container, false).apply {
+      tabs.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
+        override fun onTabReselected(tab: TabLayout.Tab) = Unit
+        override fun onTabUnselected(tab: TabLayout.Tab) = Unit
+        override fun onTabSelected(tab: TabLayout.Tab) {
+          when (tab.text.toString()) {
+            TAB_CAPTION_WIFI -> selectPage(EnterWifiNetworkFragment.newInstance())
+            TAB_CAPTION_THREAD -> selectPage(EnterThreadNetworkFragment.newInstance())
+          }
+        }
+      })
+
+      selectPage(EnterWifiNetworkFragment.newInstance())
+    }
+  }
+
+  private fun selectPage(fragment: Fragment) {
+    childFragmentManager.beginTransaction().replace(R.id.page, fragment).commit()
+  }
+
+  companion object {
+    private const val TAB_CAPTION_WIFI = "Wi-Fi"
+    private const val TAB_CAPTION_THREAD = "Thread"
+
+    fun newInstance() = EnterNetworkFragment()
+  }
+
+}

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/EnterThreadNetworkFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/EnterThreadNetworkFragment.kt
@@ -1,3 +1,21 @@
+/*
+ *   Copyright (c) 2020 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
 package com.google.chip.chiptool.provisioning
 
 import android.os.Bundle
@@ -54,12 +72,6 @@ class EnterThreadNetworkFragment : Fragment() {
         panIdStr.toInt(16),
         xpanIdStr.hexToByteArray(),
         masterKeyStr.hexToByteArray())
-
-    closeNetworkProvisioningFragment()
-  }
-
-  private fun closeNetworkProvisioningFragment() {
-    requireActivity().supportFragmentManager.popBackStack()
   }
 
   companion object {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/EnterThreadNetworkFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/EnterThreadNetworkFragment.kt
@@ -1,0 +1,75 @@
+package com.google.chip.chiptool.provisioning
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import com.google.chip.chiptool.ChipClient
+import com.google.chip.chiptool.R
+import kotlinx.android.synthetic.main.enter_wifi_network_fragment.view.*
+import kotlinx.android.synthetic.main.enter_thread_network_fragment.*
+
+class EnterThreadNetworkFragment : Fragment() {
+
+  override fun onCreateView(
+      inflater: LayoutInflater,
+      container: ViewGroup?,
+      savedInstanceState: Bundle?): View {
+    // Inflate the layout for this fragment
+    return inflater.inflate(R.layout.enter_thread_network_fragment, container, false).apply {
+      saveNetworkBtn.setOnClickListener { onSaveNetworkClicked() }
+    }
+  }
+
+  private fun onSaveNetworkClicked() {
+    val channelStr = channelEd.text.toString()
+    val panIdStr = panidEd.text.toString()
+    val xpanIdStr = xpanidEd.text.toString().filterNot { c -> c == ':' }
+    val masterKeyStr = masterKeyEd.text.toString().filterNot { c -> c == ':' }
+
+    if (channelStr.isEmpty()) {
+      Toast.makeText(requireContext(), "Channel is empty", Toast.LENGTH_SHORT).show()
+      return
+    }
+
+    if (panIdStr.isEmpty()) {
+      Toast.makeText(requireContext(), "PAN ID is empty", Toast.LENGTH_SHORT).show()
+      return
+    }
+
+    if (xpanIdStr.length != NUM_XPANID_BYTES * 2) {
+      Toast.makeText(requireContext(), "Extended PAN ID is invalid", Toast.LENGTH_SHORT).show()
+      return
+    }
+
+    if (masterKeyStr.length != NUM_MASTER_KEY_BYTES * 2) {
+      Toast.makeText(requireContext(), "Master key is invalid", Toast.LENGTH_SHORT).show()
+      return
+    }
+
+    ChipClient.getDeviceController().sendThreadCredentials(
+        channelStr.toInt(),
+        panIdStr.toInt(16),
+        xpanIdStr.hexToByteArray(),
+        masterKeyStr.hexToByteArray())
+
+    closeNetworkProvisioningFragment()
+  }
+
+  private fun closeNetworkProvisioningFragment() {
+    requireActivity().supportFragmentManager.popBackStack()
+  }
+
+  companion object {
+    private const val NUM_XPANID_BYTES = 8
+    private const val NUM_MASTER_KEY_BYTES = 16
+
+    private fun String.hexToByteArray(): ByteArray {
+      return chunked(2).map{ byteStr -> byteStr.toUByte(16).toByte()}.toByteArray()
+    }
+
+    fun newInstance() = EnterThreadNetworkFragment()
+  }
+}

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/EnterWifiNetworkFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/EnterWifiNetworkFragment.kt
@@ -1,3 +1,21 @@
+/*
+ *   Copyright (c) 2020 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
 package com.google.chip.chiptool.provisioning
 
 import android.os.Bundle

--- a/src/android/CHIPTool/app/src/main/res/layout/enter_network_fragment.xml
+++ b/src/android/CHIPTool/app/src/main/res/layout/enter_network_fragment.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.tabs.TabLayout
+        android:id="@+id/tabs"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.tabs.TabItem
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Wi-Fi" />
+
+        <com.google.android.material.tabs.TabItem
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Thread" />
+
+    </com.google.android.material.tabs.TabLayout>
+
+    <FrameLayout
+        android:id="@+id/page"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="1">
+    </FrameLayout>
+
+</LinearLayout>

--- a/src/android/CHIPTool/app/src/main/res/layout/enter_thread_network_fragment.xml
+++ b/src/android/CHIPTool/app/src/main/res/layout/enter_thread_network_fragment.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <RelativeLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/titleTv"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentTop="true"
+            android:text="@string/enter_thread_credentials_title"
+            android:padding="16dp"
+            android:textSize="20sp"/>
+
+        <TextView
+            android:id="@+id/channelTv"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/titleTv"
+            android:layout_marginTop="16dp"
+            android:layout_marginHorizontal="16dp"
+            android:text="@string/enter_thread_channel_hint"
+            android:textSize="20sp"/>
+
+        <EditText
+            android:id="@+id/channelEd"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/channelTv"
+            android:layout_marginHorizontal="16dp"
+            android:text="@string/enter_thread_channel_text"
+            android:inputType="number"
+            android:textSize="20sp" />
+
+        <TextView
+            android:id="@+id/panidTv"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/channelEd"
+            android:layout_marginTop="16dp"
+            android:layout_marginHorizontal="16dp"
+            android:text="@string/enter_thread_panid_hint"
+            android:textSize="20sp"/>
+
+        <EditText
+            android:id="@+id/panidEd"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/panidTv"
+            android:layout_marginHorizontal="16dp"
+            android:text="@string/enter_thread_panid_text"
+            android:inputType="textCapCharacters"
+            android:digits="0123456789ABCDEF"
+            android:maxLength="4"
+            android:textSize="20sp" />
+
+        <TextView
+            android:id="@+id/xpanidTv"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/panidEd"
+            android:layout_marginTop="16dp"
+            android:layout_marginHorizontal="16dp"
+            android:text="@string/enter_thread_xpanid_hint"
+            android:textSize="20sp"/>
+
+        <EditText
+            android:id="@+id/xpanidEd"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/xpanidTv"
+            android:layout_marginHorizontal="16dp"
+            android:text="@string/enter_thread_xpanid_text"
+            android:inputType="textCapCharacters"
+            android:digits="0123456789ABCDEF:"
+            android:maxLength="24"
+            android:textSize="20sp"
+            />
+
+        <TextView
+            android:id="@+id/masterKeyTv"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/xpanidEd"
+            android:layout_marginTop="16dp"
+            android:layout_marginHorizontal="16dp"
+            android:text="@string/enter_thread_master_key_hint"
+            android:textSize="20sp"/>
+
+        <EditText
+            android:id="@+id/masterKeyEd"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/masterKeyTv"
+            android:layout_marginHorizontal="16dp"
+            android:text="@string/enter_thread_master_key_text"
+            android:inputType="textCapCharacters"
+            android:digits="0123456789ABCDEF:"
+            android:maxLength="48"
+            android:textSize="20sp"
+            />
+
+        <Button
+            android:id="@+id/saveNetworkBtn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/masterKeyEd"
+            android:layout_alignParentBottom="true"
+            android:layout_alignParentEnd="true"
+            android:padding="16dp"
+            android:layout_margin="16dp"
+            android:text="@string/enter_thread_save_network_btn"/>
+
+    </RelativeLayout>
+
+</ScrollView>

--- a/src/android/CHIPTool/app/src/main/res/values/strings.xml
+++ b/src/android/CHIPTool/app/src/main/res/values/strings.xml
@@ -63,8 +63,21 @@
     <string name="attestation_test_btn_text">Attestation Test</string>
     <string name="attestation_fetching_status">Fetching…</string>
     <string name="attestation_app_not_found">No attestation app found</string>
+
     <string name="enter_wifi_credentials_title">Enter your Wi-Fi network and password below that you want to put your CHIP device on.</string>
     <string name="enter_wifi_ssid_hint">Enter Wi-Fi SSID</string>
     <string name="enter_wifi_password_hint">Enter Wi-Fi password</string>
     <string name="enter_wifi_save_network_btn">Save network</string>
+
+    <string name="enter_thread_credentials_title">Enter credentials of the Thread network that you want to put your CHIP device on.</string>
+    <string name="enter_thread_channel_hint">Channel:</string>
+    <string name="enter_thread_panid_hint">PAN ID:</string>
+    <string name="enter_thread_xpanid_hint">Extended PAN ID:</string>
+    <string name="enter_thread_master_key_hint">Master Key:</string>
+    <string name="enter_thread_channel_text">15</string>
+    <string name="enter_thread_panid_text">1234</string>
+    <string name="enter_thread_xpanid_text">11:11:11:11:22:22:22:22</string>
+    <string name="enter_thread_master_key_text">00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF</string>
+    <string name="enter_thread_save_network_btn">Save network</string>
+
 </resources>

--- a/src/android/CHIPTool/app/src/main/res/values/strings.xml
+++ b/src/android/CHIPTool/app/src/main/res/values/strings.xml
@@ -37,7 +37,7 @@
     <string name="rendezvous_over_ble_scanning_failed_text">Device not found</string>
     <string name="rendezvous_over_ble_connecting_text">Connecting to %1$s</string>
     <string name="rendezvous_over_ble_pairing_text">Pairing</string>
-    <string name="rendezvous_over_ble_success_text">Secure channel established. Provisioning</string>
+    <string name="rendezvous_over_ble_provisioning_success_text">Network provisioning completed</string>
 
     <string name="commissioner_commissioning">Commissioning</string>
     <string name="commissioner_name">Commissioner</string>

--- a/src/controller/CHIPDeviceController_deprecated.cpp
+++ b/src/controller/CHIPDeviceController_deprecated.cpp
@@ -105,6 +105,7 @@ CHIP_ERROR ChipDeviceController::ConnectDevice(NodeId remoteDeviceId, Rendezvous
     CHIP_ERROR err = mCommissioner.PairDevice(remoteDeviceId, params, devicePort, interfaceId);
     SuccessOrExit(err);
 
+    mState           = kState_Initialized;
     mRemoteDeviceId  = remoteDeviceId;
     mAppReqState     = appReqState;
     mOnNewConnection = onConnected;
@@ -127,6 +128,7 @@ CHIP_ERROR ChipDeviceController::ConnectDeviceWithoutSecurePairing(NodeId remote
 
     mPairingWithoutSecurity = true;
 
+    mState           = kState_Initialized;
     mRemoteDeviceId  = remoteDeviceId;
     mAppReqState     = appReqState;
     mOnNewConnection = onConnected;

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -214,7 +214,7 @@ void AndroidDeviceControllerWrapper::OnPairingDeleted(CHIP_ERROR error)
     CallVoidInt(GetJavaEnv(), mJavaObjectRef, "onPairingDeleted", static_cast<jint>(error));
 }
 
-void AndroidDeviceControllerWrapper::DeprecatedHardcodeThreadCredentials()
+void AndroidDeviceControllerWrapper::SendThreadCredentials(const DeviceNetworkInfo & threadData)
 {
     if (mCredentialsDelegate == nullptr)
     {
@@ -222,28 +222,7 @@ void AndroidDeviceControllerWrapper::DeprecatedHardcodeThreadCredentials()
         return;
     }
 
-    using namespace chip::DeviceLayer::Internal;
-
-    // This is a dummy implementation of Thread provisioning which allows to test Rendezvous over BLE with
-    // Thread-enabled devices by sending OpenThread Border Router default credentials.
-    //
-    // TODO:
-    // 1. Figure out whether WiFi or Thread provisioning should be performed
-    // 2. Call Java code to prompt a user for credentials or use the commissioner component of the app
-
-    constexpr uint8_t XPAN_ID[kThreadExtendedPANIdLength]  = { 0x11, 0x11, 0x11, 0x11, 0x22, 0x22, 0x22, 0x22 };
-    constexpr uint8_t MESH_PREFIX[kThreadMeshPrefixLength] = { 0xFD, 0x11, 0x11, 0x11, 0x11, 0x22, 0x00, 0x00 };
-    constexpr uint8_t NETWORK_KEY[kThreadMasterKeyLength]  = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
-                                                              0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF };
-
-    DeviceNetworkInfo threadData = {};
-    memcpy(threadData.ThreadExtendedPANId, XPAN_ID, sizeof(XPAN_ID));
-    memcpy(threadData.ThreadMeshPrefix, MESH_PREFIX, sizeof(MESH_PREFIX));
-    memcpy(threadData.ThreadMasterKey, NETWORK_KEY, sizeof(NETWORK_KEY));
-    threadData.ThreadPANId                      = 0x1234;
-    threadData.ThreadChannel                    = 15;
-    threadData.FieldPresent.ThreadExtendedPANId = 1;
-    threadData.FieldPresent.ThreadMeshPrefix    = 1;
-
+    ChipLogProgress(Controller, "Sending Thread credentials for channel %u, PAN ID %x...", threadData.ThreadChannel,
+                    threadData.ThreadPANId);
     mCredentialsDelegate->SendThreadCredentials(threadData);
 }

--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -22,6 +22,7 @@
 #include <jni.h>
 
 #include <controller/CHIPDeviceController_deprecated.h>
+#include <platform/internal/DeviceNetworkInfo.h>
 
 /**
  * This class contains all relevant information for the JNI view of CHIPDeviceController
@@ -32,14 +33,15 @@
 class AndroidDeviceControllerWrapper : public chip::Controller::DevicePairingDelegate
 {
 public:
+    using DeviceNetworkInfo = chip::DeviceLayer::Internal::DeviceNetworkInfo;
+
     ~AndroidDeviceControllerWrapper();
 
     chip::DeviceController::ChipDeviceController * Controller() { return mController.get(); }
     void SetJavaObjectRef(JavaVM * vm, jobject obj);
 
     void SendNetworkCredentials(const char * ssid, const char * password);
-
-    void DeprecatedHardcodeThreadCredentials();
+    void SendThreadCredentials(const DeviceNetworkInfo & threadData);
 
     // DevicePairingDelegate implementation
     void OnNetworkCredentialsRequested(chip::RendezvousDeviceCredentialsDelegate * callback) override;

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -34,6 +34,8 @@
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
 #include <support/ErrorStr.h>
+#include <support/ReturnMacros.h>
+#include <support/SafeInt.h>
 #include <support/logging/CHIPLogging.h>
 
 extern "C" {
@@ -140,6 +142,24 @@ private:
     JNIEnv * mEnv;
     jstring mString;
     const char * mChars;
+};
+
+class JniByteArray
+{
+public:
+    JniByteArray(JNIEnv * env, jbyteArray array) :
+        mEnv(env), mArray(array), mData(env->GetByteArrayElements(array, nullptr)), mDataLength(env->GetArrayLength(array))
+    {}
+    ~JniByteArray() { mEnv->ReleaseByteArrayElements(mArray, mData, 0); }
+
+    const jbyte * data() const { return mData; }
+    jsize size() const { return mDataLength; }
+
+private:
+    JNIEnv * mEnv;
+    jbyteArray mArray;
+    jbyte * mData;
+    jsize mDataLength;
 };
 
 } // namespace
@@ -310,9 +330,30 @@ JNI_METHOD(void, sendWiFiCredentials)(JNIEnv * env, jobject self, jlong handle, 
     AndroidDeviceControllerWrapper::FromJNIHandle(handle)->SendNetworkCredentials(ssidStr.c_str(), passwordStr.c_str());
 }
 
-JNI_METHOD(void, deprecatedHardcodeThreadCredentials)(JNIEnv * env, jobject self, jlong handle)
+JNI_METHOD(void, sendThreadCredentials)
+(JNIEnv * env, jobject self, jlong handle, jint channel, jint panId, jbyteArray xpanId, jbyteArray masterKey)
 {
-    AndroidDeviceControllerWrapper::FromJNIHandle(handle)->DeprecatedHardcodeThreadCredentials();
+    using namespace chip::DeviceLayer::Internal;
+
+    JniByteArray xpanIdBytes(env, xpanId);
+    JniByteArray masterKeyBytes(env, masterKey);
+
+    VerifyOrReturn(CanCastTo<uint8_t>(channel), ChipLogError(Controller, "sendThreadCredentials() called with invalid Channel"));
+    VerifyOrReturn(CanCastTo<uint16_t>(panId), ChipLogError(Controller, "sendThreadCredentials() called with invalid PAN ID"));
+    VerifyOrReturn(xpanIdBytes.size() <= static_cast<jsize>(kThreadExtendedPANIdLength),
+                   ChipLogError(Controller, "sendThreadCredentials() called with invalid XPAN ID"));
+    VerifyOrReturn(masterKeyBytes.size() <= static_cast<jsize>(kThreadMasterKeyLength),
+                   ChipLogError(Controller, "sendThreadCredentials() called with invalid Master Key"));
+
+    DeviceNetworkInfo threadData                = {};
+    threadData.ThreadChannel                    = channel;
+    threadData.ThreadPANId                      = panId;
+    threadData.FieldPresent.ThreadExtendedPANId = 1;
+    memcpy(threadData.ThreadExtendedPANId, xpanIdBytes.data(), xpanIdBytes.size());
+    memcpy(threadData.ThreadMasterKey, masterKeyBytes.data(), masterKeyBytes.size());
+
+    ScopedPthreadLock lock(&sStackLock);
+    AndroidDeviceControllerWrapper::FromJNIHandle(handle)->SendThreadCredentials(threadData);
 }
 
 JNI_METHOD(void, beginConnectDeviceIp)(JNIEnv * env, jobject self, jlong handle, jstring deviceAddr)

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -196,7 +196,8 @@ public class ChipDeviceController {
 
   private native void sendWiFiCredentials(long deviceControllerPtr, String ssid, String password);
 
-  private native void sendThreadCredentials(long deviceControllerPtr, int channel, int panId, byte[] xpanId, byte[] masterKey);
+  private native void sendThreadCredentials(
+      long deviceControllerPtr, int channel, int panId, byte[] xpanId, byte[] masterKey);
 
   private native boolean disconnectDevice(long deviceControllerPtr);
 

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -89,6 +89,10 @@ public class ChipDeviceController {
     sendWiFiCredentials(deviceControllerPtr, ssid, password);
   }
 
+  public void sendThreadCredentials(int channel, int panId, byte[] xpanId, byte[] masterKey) {
+    sendThreadCredentials(deviceControllerPtr, channel, panId, xpanId, masterKey);
+  }
+
   public boolean disconnectDevice() {
     return disconnectDevice(deviceControllerPtr);
   }
@@ -192,7 +196,7 @@ public class ChipDeviceController {
 
   private native void sendWiFiCredentials(long deviceControllerPtr, String ssid, String password);
 
-  private native void deprecatedHardcodeThreadCredentials(long deviceControllerPtr);
+  private native void sendThreadCredentials(long deviceControllerPtr, int channel, int panId, byte[] xpanId, byte[] masterKey);
 
   private native boolean disconnectDevice(long deviceControllerPtr);
 

--- a/src/lib/support/ReturnMacros.h
+++ b/src/lib/support/ReturnMacros.h
@@ -34,6 +34,20 @@
         }                                                                                                                          \
     } while (false)
 
+/// Returns from the void function if expression evaluates to false
+///
+/// Use like:
+///   VerifyOrReturn(param != nullptr, LogError("param is nullptr"));
+#define VerifyOrReturn(expr, ...)                                                                                                  \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        if (!(expr))                                                                                                               \
+        {                                                                                                                          \
+            __VA_ARGS__;                                                                                                           \
+            return;                                                                                                                \
+        }                                                                                                                          \
+    } while (false)
+
 /// Returns a specified error code if expression evaluates to false
 ///
 /// Use like:


### PR DESCRIPTION
 #### Problem
Some time ago, Android CHIPTool got dummy Thread provisioning implementation which was removed during work on Wi-Fi provisioning. Now it's time to re-add it in a better form to enable testing Rendezvous over BLE with Thread devices.

 #### Summary of Changes
1. Implement a function to pass Thread Channel, PAN ID, XPAN ID and Master Key from Java to the C++ code which takes care of sending the credentials over BLE.
2. When network credentials are to be entered during the rendezvous phase, display a screen with two tabs:
  - one with the existing form for entering Wi-Fi credentials
  - one with a new form for entering Thread credentials.

 Fixes #1828 
