### PR TITLE
Make src/ble compile with -Werror=conversion

### DIFF
--- a/src/ble/BLEEndPoint.cpp
+++ b/src/ble/BLEEndPoint.cpp
@@ -106,8 +106,9 @@ BLE_ERROR BLEEndPoint::StartConnect()
     BLE_ERROR err = BLE_NO_ERROR;
     BleTransportCapabilitiesRequestMessage req;
     PacketBufferHandle buf;
-    int i;
-    int numVersions;
+    constexpr uint8_t numVersions =
+        CHIP_BLE_TRANSPORT_PROTOCOL_MAX_SUPPORTED_VERSION - CHIP_BLE_TRANSPORT_PROTOCOL_MIN_SUPPORTED_VERSION + 1;
+    static_assert(numVersions <= NUM_SUPPORTED_PROTOCOL_VERSIONS, "Incompatibly protocol versions");
 
     // Ensure we're in the correct state.
     VerifyOrExit(mState == kState_Ready, err = BLE_ERROR_INCORRECT_STATE);
@@ -125,11 +126,9 @@ BLE_ERROR BLEEndPoint::StartConnect()
     req.mWindowSize = BLE_MAX_RECEIVE_WINDOW_SIZE;
 
     // Populate request with highest supported protocol versions
-    numVersions = CHIP_BLE_TRANSPORT_PROTOCOL_MAX_SUPPORTED_VERSION - CHIP_BLE_TRANSPORT_PROTOCOL_MIN_SUPPORTED_VERSION + 1;
-    VerifyOrExit(numVersions <= NUM_SUPPORTED_PROTOCOL_VERSIONS, err = BLE_ERROR_INCOMPATIBLE_PROTOCOL_VERSIONS);
-    for (i = 0; i < numVersions; i++)
+    for (uint8_t i = 0; i < numVersions; i++)
     {
-        req.SetSupportedProtocolVersion(i, CHIP_BLE_TRANSPORT_PROTOCOL_MAX_SUPPORTED_VERSION - i);
+        req.SetSupportedProtocolVersion(i, static_cast<uint8_t>(CHIP_BLE_TRANSPORT_PROTOCOL_MAX_SUPPORTED_VERSION - i));
     }
 
     err = req.Encode(buf);
@@ -241,7 +240,7 @@ void BLEEndPoint::HandleSubscribeReceived()
     }
 
     // Shrink remote receive window counter by 1, since we've sent an indication which requires acknowledgement.
-    mRemoteReceiveWindowSize -= 1;
+    mRemoteReceiveWindowSize = static_cast<SequenceNumber_t>(mRemoteReceiveWindowSize - 1);
     ChipLogDebugBleEndPoint(Ble, "decremented remote rx window, new size = %u", mRemoteReceiveWindowSize);
 
     // Start ack recvd timer for handshake indication.
@@ -603,7 +602,7 @@ BLE_ERROR BLEEndPoint::SendCharacteristic(PacketBufferHandle buf)
         else
         {
             // Write succeeded, so shrink remote receive window counter by 1.
-            mRemoteReceiveWindowSize -= 1;
+            mRemoteReceiveWindowSize = static_cast<SequenceNumber_t>(mRemoteReceiveWindowSize - 1);
             ChipLogDebugBleEndPoint(Ble, "decremented remote rx window, new size = %u", mRemoteReceiveWindowSize);
         }
     }
@@ -616,7 +615,7 @@ BLE_ERROR BLEEndPoint::SendCharacteristic(PacketBufferHandle buf)
         else
         {
             // Indication succeeded, so shrink remote receive window counter by 1.
-            mRemoteReceiveWindowSize -= 1;
+            mRemoteReceiveWindowSize = static_cast<SequenceNumber_t>(mRemoteReceiveWindowSize - 1);
             ChipLogDebugBleEndPoint(Ble, "decremented remote rx window, new size = %u", mRemoteReceiveWindowSize);
         }
     }
@@ -1215,7 +1214,7 @@ BLE_ERROR BLEEndPoint::HandleCapabilitiesResponseReceived(PacketBufferHandle dat
     ChipLogProgress(Ble, "local and remote recv window size = %u", resp.mWindowSize);
 
     // Shrink local receive window counter by 1, since connect handshake indication requires acknowledgement.
-    mLocalReceiveWindowSize -= 1;
+    mLocalReceiveWindowSize = static_cast<SequenceNumber_t>(mLocalReceiveWindowSize - 1);
     ChipLogDebugBleEndPoint(Ble, "decremented local rx window, new size = %u", mLocalReceiveWindowSize);
 
     // Send ack for connection handshake indication when timer expires. Sequence numbers always start at 0,
@@ -1245,17 +1244,17 @@ SequenceNumber_t BLEEndPoint::AdjustRemoteReceiveWindow(SequenceNumber_t lastRec
     //             also wrap.
 
     // Define new window boundary (inclusive) as uint16_t, so its value can temporarily exceed UINT8_MAX.
-    uint16_t newRemoteWindowBoundary = lastReceivedAck + maxRemoteWindowSize;
+    uint16_t newRemoteWindowBoundary = static_cast<uint16_t>(lastReceivedAck + maxRemoteWindowSize);
 
     if (newRemoteWindowBoundary > UINT8_MAX && newestUnackedSentSeqNum < lastReceivedAck)
     {
         // New window boundary WOULD wrap, and latest unacked seq num already HAS wrapped, so add offset to difference.
-        return (newRemoteWindowBoundary - (newestUnackedSentSeqNum + UINT8_MAX));
+        return static_cast<uint8_t>(newRemoteWindowBoundary - (newestUnackedSentSeqNum + UINT8_MAX));
     }
 
     // Neither values would or have wrapped, OR new boundary WOULD wrap but latest unacked seq num does not, so no
     // offset required.
-    return (newRemoteWindowBoundary - newestUnackedSentSeqNum);
+    return static_cast<uint8_t>(newRemoteWindowBoundary - newestUnackedSentSeqNum);
 }
 
 BLE_ERROR BLEEndPoint::Receive(PacketBufferHandle data)
@@ -1340,7 +1339,7 @@ BLE_ERROR BLEEndPoint::Receive(PacketBufferHandle data)
     SuccessOrExit(err);
 
     // Protocol engine accepted the fragment, so shrink local receive window counter by 1.
-    mLocalReceiveWindowSize -= 1;
+    mLocalReceiveWindowSize = static_cast<SequenceNumber_t>(mLocalReceiveWindowSize - 1);
     ChipLogDebugBleEndPoint(Ble, "decremented local rx window, new size = %u", mLocalReceiveWindowSize);
 
     // Respond to received ack, if any.

--- a/src/ble/BUILD.gn
+++ b/src/ble/BUILD.gn
@@ -77,6 +77,8 @@ if (chip_config_network_layer_ble) {
       "CHIPBleServiceData.h",
     ]
 
+    cflags = [ "-Wconversion" ]
+
     public_deps = [
       ":ble_config_header",
       "${chip_root}/src/inet",

--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -100,7 +100,7 @@ class BleEndPointPool
 public:
     int Size() const { return BLE_LAYER_NUM_BLE_ENDPOINTS; }
 
-    BLEEndPoint * Get(int i) const
+    BLEEndPoint * Get(size_t i) const
     {
         static union
         {
@@ -123,7 +123,7 @@ public:
             return nullptr;
         }
 
-        for (int i = 0; i < BLE_LAYER_NUM_BLE_ENDPOINTS; i++)
+        for (size_t i = 0; i < BLE_LAYER_NUM_BLE_ENDPOINTS; i++)
         {
             BLEEndPoint * elem = Get(i);
             if (elem->mBle != nullptr && elem->mConnObj == c)
@@ -137,7 +137,7 @@ public:
 
     BLEEndPoint * GetFree() const
     {
-        for (int i = 0; i < BLE_LAYER_NUM_BLE_ENDPOINTS; i++)
+        for (size_t i = 0; i < BLE_LAYER_NUM_BLE_ENDPOINTS; i++)
         {
             BLEEndPoint * elem = Get(i);
             if (elem->mBle == nullptr)
@@ -188,13 +188,14 @@ void BleTransportCapabilitiesRequestMessage::SetSupportedProtocolVersion(uint8_t
     else
     {
         mask    = 0xF0;
-        version = version << 4;
+        version = static_cast<uint8_t>(version << 4);
     }
 
     version &= mask;
 
-    mSupportedProtocolVersions[(index / 2)] &= ~mask; // Clear version at index; leave other version in same byte alone
-    mSupportedProtocolVersions[(index / 2)] |= version;
+    uint8_t & slot = mSupportedProtocolVersions[(index / 2)];
+    slot           = static_cast<uint8_t>(slot & ~mask); // Clear version at index; leave other version in same byte alone
+    slot |= version;
 }
 
 BLE_ERROR BleTransportCapabilitiesRequestMessage::Encode(const PacketBufferHandle & msgBuf) const
@@ -342,7 +343,7 @@ BLE_ERROR BleLayer::Shutdown()
     mState = kState_NotInitialized;
 
     // Close and free all BLE end points.
-    for (int i = 0; i < BLE_LAYER_NUM_BLE_ENDPOINTS; i++)
+    for (size_t i = 0; i < BLE_LAYER_NUM_BLE_ENDPOINTS; i++)
     {
         BLEEndPoint * elem = sBLEEndPointPool.Get(i);
 

--- a/src/ble/BleUUID.cpp
+++ b/src/ble/BleUUID.cpp
@@ -63,10 +63,11 @@ bool StringToUUID(const char * str, ChipBleUUID & uuid)
         if (nibbleId >= NUM_UUID_NIBBLES) // too long string!
             return false;
 
+        uint8_t & byte = uuid.bytes[nibbleId / 2];
         if (nibbleId % 2 == 0)
-            uuid.bytes[nibbleId / 2] = static_cast<uint8_t>(HexDigitToInt(*str) << 4);
+            byte = static_cast<uint8_t>(HexDigitToInt(*str) << 4);
         else
-            uuid.bytes[nibbleId / 2] |= HexDigitToInt(*str);
+            byte = static_cast<uint8_t>(byte | HexDigitToInt(*str));
 
         ++nibbleId;
     }

--- a/src/ble/BtpEngine.cpp
+++ b/src/ble/BtpEngine.cpp
@@ -69,7 +69,7 @@ namespace Ble {
 
 static inline void IncSeqNum(SequenceNumber_t & a_seq_num)
 {
-    a_seq_num = 0xff & ((a_seq_num) + 1);
+    a_seq_num = static_cast<SequenceNumber_t>(0xff & ((a_seq_num) + 1));
 }
 
 static inline bool DidReceiveData(uint8_t rx_flags)
@@ -490,12 +490,12 @@ bool BtpEngine::HandleCharacteristicSend(System::PacketBufferHandle data, bool s
         }
 
         characteristic[cursor++] = GetAndIncrementNextTxSeqNum();
-        characteristic[cursor++] = mTxLength & 0xff;
-        characteristic[cursor++] = mTxLength >> 8;
+        characteristic[cursor++] = static_cast<uint8_t>(mTxLength & 0xff);
+        characteristic[cursor++] = static_cast<uint8_t>(mTxLength >> 8);
 
         if ((mTxLength + cursor) <= mTxFragmentSize)
         {
-            mTxBuf->SetDataLength(mTxLength + cursor);
+            mTxBuf->SetDataLength(static_cast<uint16_t>(mTxLength + cursor));
             mTxLength = 0;
             SetFlag(characteristic[0], kHeaderFlag_EndMessage, true);
             mTxState = kState_Complete;
@@ -504,7 +504,7 @@ bool BtpEngine::HandleCharacteristicSend(System::PacketBufferHandle data, bool s
         else
         {
             mTxBuf->SetDataLength(mTxFragmentSize);
-            mTxLength -= mTxFragmentSize - cursor;
+            mTxLength = static_cast<uint16_t>((mTxLength + cursor) - mTxFragmentSize);
         }
 
         ChipLogDebugBtpEngine(Ble, ">>> CHIPoBle preparing to send first fragment:");
@@ -546,7 +546,7 @@ bool BtpEngine::HandleCharacteristicSend(System::PacketBufferHandle data, bool s
 
         if ((mTxLength + cursor) <= mTxFragmentSize)
         {
-            mTxBuf->SetDataLength(mTxLength + cursor);
+            mTxBuf->SetDataLength(static_cast<uint16_t>(mTxLength + cursor));
             mTxLength = 0;
             SetFlag(characteristic[0], kHeaderFlag_EndMessage, true);
             mTxState = kState_Complete;
@@ -555,7 +555,7 @@ bool BtpEngine::HandleCharacteristicSend(System::PacketBufferHandle data, bool s
         else
         {
             mTxBuf->SetDataLength(mTxFragmentSize);
-            mTxLength -= mTxFragmentSize - cursor;
+            mTxLength = static_cast<uint16_t>((mTxLength + cursor) - mTxFragmentSize);
         }
 
         ChipLogDebugBtpEngine(Ble, ">>> CHIPoBle preparing to send additional fragment:");

--- a/src/ble/BtpEngine.h
+++ b/src/ble/BtpEngine.h
@@ -93,8 +93,8 @@ public:
     // Public functions:
     BLE_ERROR Init(void * an_app_state, bool expect_first_ack);
 
-    inline void SetTxFragmentSize(uint8_t size) { mTxFragmentSize = size; }
-    inline void SetRxFragmentSize(uint8_t size) { mRxFragmentSize = size; }
+    inline void SetTxFragmentSize(uint16_t size) { mTxFragmentSize = size; }
+    inline void SetRxFragmentSize(uint16_t size) { mRxFragmentSize = size; }
 
     uint16_t GetRxFragmentSize() { return mRxFragmentSize; }
     uint16_t GetTxFragmentSize() { return mTxFragmentSize; }

--- a/src/ble/tests/BUILD.gn
+++ b/src/ble/tests/BUILD.gn
@@ -25,6 +25,8 @@ chip_test_suite("tests") {
     "TestBleUUID.cpp",
   ]
 
+  cflags = [ "-Wconversion" ]
+
   public_deps = [
     "${chip_root}/src/ble",
     "${nlunit_test_root}:nlunit-test",


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Various `-Wconversion` warnings in `src/ble`, some of which indicate real bugs.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
* Fix the `SetTxFragmentSize` and `SetRxFragmentSize` APIS to not drop the high byte from the size.
* Adjust some types to use unsigned types instead of `int` as appropriate
* Add various casts as needed

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->


<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
