### PR TITLE
Add zap client-macro-template

### DIFF
--- a/src/app/zap-templates/chip-templates.json
+++ b/src/app/zap-templates/chip-templates.json
@@ -49,6 +49,11 @@
             "output": "callback.h"
         },
         {
+            "path": "client-command-macro.zapt",
+            "name": "ZCL client command",
+            "output": "client-command-macro.h"
+        },
+        {
             "path": "cluster-id.zapt",
             "name": "ZCL cluster-id header",
             "output": "cluster-id.h"

--- a/src/app/zap-templates/client-command-macro.zapt
+++ b/src/app/zap-templates/client-command-macro.zapt
@@ -3,4 +3,28 @@
 // Prevent multiple inclusion
 #pragma once
 
-// TODO issue #3637
+{{#zcl_command_tree}}
+
+/** @brief Command description for {{label}}
+ *
+ * Command: {{label}}
+{{#zcl_command_arguments}}
+ * @param {{name}} {{type}} {{toggle isArray '[]' ''}}{{toggle hasLength '
+ * @param ' ''}}{{toggle hasLength nameLength ''}}{{toggle hasLength ' int' ''}}
+{{/zcl_command_arguments}}
+ */
+#define emberAfFillCommand{{clientMacroName}}({{toggle isGlobal 'clusterId,' ''}} \
+{{#zcl_command_arguments}}
+  {{name}}{{toggle hasLength ', ' ''}}{{toggle hasLength nameLength ''}}{{#not_last}},{{/not_last}} \
+{{/zcl_command_arguments}}
+) \
+  emberAfFillExternalBuffer( \
+    mask, \
+    {{toggle isGlobal 'clusterId, ' ''}} \
+    ZCL_{{asDelimitedMacro label}}_COMMAND_ID, \
+    "{{argsstring}}", \
+{{#zcl_command_arguments}}
+    {{name}}{{toggle hasLength ', ' ''}}{{toggle hasLength nameLength ''}}{{#not_last}},{{/not_last}} \
+{{/zcl_command_arguments}}
+  );
+{{/zcl_command_tree}}


### PR DESCRIPTION
 #### Problem
 Some required ZCL templates are missing

 #### Summary of Changes
 Add the client-command-macro template

Partial Fix of #3637 
