### PR TITLE
Fix CHIPDeviceController when storage delegate is nullptr

### DIFF
--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -268,9 +268,9 @@ exit:
 
 bool Device::GetIpAddress(Inet::IPAddress & addr) const
 {
-    if (mState == ConnectionState::SecureConnected)
+    if (mState != ConnectionState::NotConnected)
         addr = mDeviceAddr;
-    return mState == ConnectionState::SecureConnected;
+    return mState != ConnectionState::NotConnected;
 }
 
 void Device::AddResponseHandler(EndpointId endpoint, ClusterId cluster, Callback::Callback<> * onResponse)

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -268,9 +268,10 @@ exit:
 
 bool Device::GetIpAddress(Inet::IPAddress & addr) const
 {
-    if (mState != ConnectionState::NotConnected)
-        addr = mDeviceAddr;
-    return mState != ConnectionState::NotConnected;
+    if (mState == ConnectionState::NotConnected)
+        return false;
+    addr = mDeviceAddr;
+    return true;
 }
 
 void Device::AddResponseHandler(EndpointId endpoint, ClusterId cluster, Callback::Callback<> * onResponse)

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -636,7 +636,7 @@ void DeviceCommissioner::RendezvousCleanup(CHIP_ERROR status)
         mPairingDelegate->OnPairingComplete(status);
     }
 
-    if (mDeviceBeingPaired != kNumMaxActiveDevices)
+    if (mDeviceBeingPaired != kNumMaxActiveDevices && mStorageDelegate != nullptr)
     {
         // Let's release the device that's being paired.
         // If pairing was successful, its information is

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -636,6 +636,7 @@ void DeviceCommissioner::RendezvousCleanup(CHIP_ERROR status)
         mPairingDelegate->OnPairingComplete(status);
     }
 
+    // TODO: make mStorageDelegate mandatory once all controller applications implement the interface.
     if (mDeviceBeingPaired != kNumMaxActiveDevices && mStorageDelegate != nullptr)
     {
         // Let's release the device that's being paired.

--- a/src/controller/CHIPDeviceController_deprecated.h
+++ b/src/controller/CHIPDeviceController_deprecated.h
@@ -143,7 +143,7 @@ public:
      *
      * @return bool   If IP Address was returned
      */
-    bool GetIpAddress(Inet::IPAddress & addr) const;
+    bool GetIpAddress(Inet::IPAddress & addr);
 
     // ----- Messaging -----
     /**
@@ -185,6 +185,8 @@ public:
     void OnMessage(System::PacketBufferHandle msg) override;
 
 private:
+    CHIP_ERROR InitDevice();
+
     enum
     {
         kState_NotInitialized = 0,


### PR DESCRIPTION
 #### Problem
CHIPDeviceController releases results of the Rendezvous session assuming that they have been persisted. However some platforms, like Android, don't provide implementation of PersistentStorageDelegate yet.

 #### Summary of Changes
- Don't release results of the Rendezvous session when storage delegate is nullptr.
- Make `GetIpAddress` work again after recent refactoring.

If it's desired that CHIPDeviceController rely on the storage delegate (or actually require it), all platforms should implement it first. I filed #4088 to fill the gap on Android side.
