### PR TITLE
Serialize and initlaize network interface ID used to communicate with device

### DIFF
--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -106,6 +106,7 @@ CHIP_ERROR Device::Serialize(SerializedDevice & output)
     serializable.mDeviceId   = Encoding::LittleEndian::HostSwap64(mDeviceId);
     serializable.mDevicePort = Encoding::LittleEndian::HostSwap16(mDevicePort);
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
+    // TODO: https://github.com/project-chip/connectedhomeip/issues/4106
     serializable.mInterfaceId = 0;
 #else
     static_assert(sizeof(serializable.mInterfaceId) >= sizeof(mInterface), "Size of network interface ID must fit");
@@ -157,6 +158,7 @@ CHIP_ERROR Device::Deserialize(const SerializedDevice & input)
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     // We cannot deserialize interface ID for CHIP builds with LWIP stack.
     // Inteface ID for LWIP stack points to a `netif` structure, instead of an interface ID.
+    // TODO: https://github.com/project-chip/connectedhomeip/issues/4106
     mInterface = INET_NULL_INTERFACEID;
 #else
     mInterface                = static_cast<Inet::InterfaceId>(Encoding::LittleEndian::HostSwap64(serializable.mInterfaceId));

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -97,8 +97,8 @@ CHIP_ERROR Device::Serialize(SerializedDevice & output)
     uint16_t serializedLen = 0;
     SerializableDevice serializable;
 
-    nlSTATIC_ASSERT_PRINT(BASE64_ENCODED_LEN(sizeof(serializable)) <= sizeof(output.inner),
-                          "Size of serializable should be <= size of output");
+    static_assert(BASE64_ENCODED_LEN(sizeof(serializable)) <= sizeof(output.inner),
+                  "Size of serializable should be <= size of output");
 
     CHIP_ZERO_AT(serializable);
 
@@ -108,12 +108,11 @@ CHIP_ERROR Device::Serialize(SerializedDevice & output)
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     serializable.mInterfaceId = 0;
 #else
-    nlSTATIC_ASSERT_PRINT(sizeof(serializable.mInterfaceId) >= sizeof(mInterface), "Size of network interface ID must fit");
+    static_assert(sizeof(serializable.mInterfaceId) >= sizeof(mInterface), "Size of network interface ID must fit");
     // TODO: https://github.com/project-chip/connectedhomeip/issues/3762
     serializable.mInterfaceId = Encoding::LittleEndian::HostSwap64(mInterface);
 #endif
-    nlSTATIC_ASSERT_PRINT(sizeof(serializable.mDeviceAddr) <= INET6_ADDRSTRLEN,
-                          "Size of device address must fit within INET6_ADDRSTRLEN");
+    static_assert(sizeof(serializable.mDeviceAddr) <= INET6_ADDRSTRLEN, "Size of device address must fit within INET6_ADDRSTRLEN");
     mDeviceAddr.ToString(Uint8::to_char(serializable.mDeviceAddr), sizeof(serializable.mDeviceAddr));
 
     serializedLen = chip::Base64Encode(Uint8::to_const_uchar(reinterpret_cast<uint8_t *>(&serializable)),
@@ -269,7 +268,7 @@ void Device::AddResponseHandler(EndpointId endpoint, ClusterId cluster, Callback
     CallbackInfo info                 = { endpoint, cluster };
     Callback::Cancelable * cancelable = onResponse->Cancel();
 
-    nlSTATIC_ASSERT_PRINT(sizeof(info) <= sizeof(cancelable->mInfoScalar), "Size of CallbackInfo should be <= size of mInfoScalar");
+    static_assert(sizeof(info) <= sizeof(cancelable->mInfoScalar), "Size of CallbackInfo should be <= size of mInfoScalar");
 
     cancelable->mInfoScalar = 0;
     memmove(&cancelable->mInfoScalar, &info, sizeof(info));
@@ -281,7 +280,7 @@ void Device::AddReportHandler(EndpointId endpoint, ClusterId cluster, Callback::
     CallbackInfo info                 = { endpoint, cluster };
     Callback::Cancelable * cancelable = onReport->Cancel();
 
-    nlSTATIC_ASSERT_PRINT(sizeof(info) <= sizeof(cancelable->mInfoScalar), "Size of CallbackInfo should be <= size of mInfoScalar");
+    static_assert(sizeof(info) <= sizeof(cancelable->mInfoScalar), "Size of CallbackInfo should be <= size of mInfoScalar");
 
     cancelable->mInfoScalar = 0;
     memmove(&cancelable->mInfoScalar, &info, sizeof(info));

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -105,10 +105,12 @@ CHIP_ERROR Device::Serialize(SerializedDevice & output)
     memmove(&serializable.mOpsCreds, &mPairing, sizeof(mPairing));
     serializable.mDeviceId   = Encoding::LittleEndian::HostSwap64(mDeviceId);
     serializable.mDevicePort = Encoding::LittleEndian::HostSwap16(mDevicePort);
-
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+    serializable.mInterfaceId = 0;
+#else
     nlSTATIC_ASSERT_PRINT(sizeof(serializable.mInterfaceId) >= sizeof(mInterface), "Size of network interface ID must fit");
     serializable.mInterfaceId = Encoding::LittleEndian::HostSwap64(mInterface);
-
+#endif
     nlSTATIC_ASSERT_PRINT(sizeof(serializable.mDeviceAddr) <= INET6_ADDRSTRLEN,
                           "Size of device address must fit within INET6_ADDRSTRLEN");
     mDeviceAddr.ToString(Uint8::to_char(serializable.mDeviceAddr), sizeof(serializable.mDeviceAddr));
@@ -151,7 +153,14 @@ CHIP_ERROR Device::Deserialize(const SerializedDevice & input)
     memmove(&mPairing, &serializable.mOpsCreds, sizeof(mPairing));
     mDeviceId   = Encoding::LittleEndian::HostSwap64(serializable.mDeviceId);
     mDevicePort = Encoding::LittleEndian::HostSwap16(serializable.mDevicePort);
-    mInterface  = static_cast<Inet::InterfaceId>(Encoding::LittleEndian::HostSwap64(serializable.mInterfaceId));
+
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+    // We cannot deserialize interface ID for CHIP builds with LWIP stack.
+    // Inteface ID for LWIP stack points to a `netif` structure, instead of an interface ID.
+    mInterface = INET_NULL_INTERFACEID;
+#else
+    mInterface                = static_cast<Inet::InterfaceId>(Encoding::LittleEndian::HostSwap64(serializable.mInterfaceId));
+#endif
 
 exit:
     return error;

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -109,6 +109,7 @@ CHIP_ERROR Device::Serialize(SerializedDevice & output)
     serializable.mInterfaceId = 0;
 #else
     nlSTATIC_ASSERT_PRINT(sizeof(serializable.mInterfaceId) >= sizeof(mInterface), "Size of network interface ID must fit");
+    // TODO: https://github.com/project-chip/connectedhomeip/issues/3762
     serializable.mInterfaceId = Encoding::LittleEndian::HostSwap64(mInterface);
 #endif
     nlSTATIC_ASSERT_PRINT(sizeof(serializable.mDeviceAddr) <= INET6_ADDRSTRLEN,

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -30,6 +30,11 @@
 #include <platform/CHIPDeviceLayer.h>
 #endif
 
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+#include <lwip/tcp.h>
+#include <lwip/tcpip.h>
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+
 #include <core/CHIPCore.h>
 #include <core/CHIPEncoding.h>
 #include <core/CHIPSafeCasts.h>

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -105,9 +105,10 @@ CHIP_ERROR Device::Serialize(SerializedDevice & output)
     memmove(&serializable.mOpsCreds, &mPairing, sizeof(mPairing));
     serializable.mDeviceId   = Encoding::LittleEndian::HostSwap64(mDeviceId);
     serializable.mDevicePort = Encoding::LittleEndian::HostSwap16(mDevicePort);
-    VerifyOrExit(CHIP_NO_ERROR ==
-                     Inet::GetInterfaceName(mInterface, serializable.mInterfaceName, sizeof(serializable.mInterfaceName)),
-                 error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(
+        CHIP_NO_ERROR ==
+            Inet::GetInterfaceName(mInterface, Uint8::to_char(serializable.mInterfaceName), sizeof(serializable.mInterfaceName)),
+        error = CHIP_ERROR_INTERNAL);
     static_assert(sizeof(serializable.mDeviceAddr) <= INET6_ADDRSTRLEN, "Size of device address must fit within INET6_ADDRSTRLEN");
     mDeviceAddr.ToString(Uint8::to_char(serializable.mDeviceAddr), sizeof(serializable.mDeviceAddr));
 
@@ -158,7 +159,7 @@ CHIP_ERROR Device::Deserialize(const SerializedDevice & input)
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
         LOCK_TCPIP_CORE();
 #endif
-        INET_ERROR inetErr = Inet::InterfaceNameToId(serializable.mInterfaceName, mInterface);
+        INET_ERROR inetErr = Inet::InterfaceNameToId(Uint8::to_const_char(serializable.mInterfaceName), mInterface);
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
         UNLOCK_TCPIP_CORE();
 #endif

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -105,6 +105,10 @@ CHIP_ERROR Device::Serialize(SerializedDevice & output)
     memmove(&serializable.mOpsCreds, &mPairing, sizeof(mPairing));
     serializable.mDeviceId   = Encoding::LittleEndian::HostSwap64(mDeviceId);
     serializable.mDevicePort = Encoding::LittleEndian::HostSwap16(mDevicePort);
+
+    nlSTATIC_ASSERT_PRINT(sizeof(serializable.mInterfaceId) >= sizeof(mInterface), "Size of network interface ID must fit");
+    serializable.mInterfaceId = Encoding::LittleEndian::HostSwap64(mInterface);
+
     nlSTATIC_ASSERT_PRINT(sizeof(serializable.mDeviceAddr) <= INET6_ADDRSTRLEN,
                           "Size of device address must fit within INET6_ADDRSTRLEN");
     mDeviceAddr.ToString(Uint8::to_char(serializable.mDeviceAddr), sizeof(serializable.mDeviceAddr));
@@ -147,6 +151,7 @@ CHIP_ERROR Device::Deserialize(const SerializedDevice & input)
     memmove(&mPairing, &serializable.mOpsCreds, sizeof(mPairing));
     mDeviceId   = Encoding::LittleEndian::HostSwap64(serializable.mDeviceId);
     mDevicePort = Encoding::LittleEndian::HostSwap16(serializable.mDevicePort);
+    mInterface  = static_cast<Inet::InterfaceId>(Encoding::LittleEndian::HostSwap64(serializable.mInterfaceId));
 
 exit:
     return error;

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -290,8 +290,8 @@ typedef struct SerializableDevice
     SecurePairingSessionSerializable mOpsCreds;
     uint64_t mDeviceId; /* This field is serialized in LittleEndian byte order */
     uint8_t mDeviceAddr[INET6_ADDRSTRLEN];
-    uint16_t mDevicePort;  /* This field is serealized in LittelEndian byte order */
-    uint64_t mInterfaceId; /* This field is serealized in LittelEndian byte order */
+    uint16_t mDevicePort; /* This field is serealized in LittelEndian byte order */
+    uint8_t mInterfaceName[IFNAMSIZ];
 } SerializableDevice;
 
 typedef struct SerializedDevice

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -285,13 +285,19 @@ public:
     virtual void OnStatusChange(void){};
 };
 
+#ifdef IFNAMSIZ
+constexpr uint16_t kMaxInterfaceName = IFNAMSIZ;
+#else
+constexpr uint16_t kMaxInterfaceName = 32;
+#endif
+
 typedef struct SerializableDevice
 {
     SecurePairingSessionSerializable mOpsCreds;
     uint64_t mDeviceId; /* This field is serialized in LittleEndian byte order */
     uint8_t mDeviceAddr[INET6_ADDRSTRLEN];
     uint16_t mDevicePort; /* This field is serealized in LittelEndian byte order */
-    uint8_t mInterfaceName[IFNAMSIZ];
+    uint8_t mInterfaceName[kMaxInterfaceName];
 } SerializableDevice;
 
 typedef struct SerializedDevice

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -54,7 +54,7 @@ using DeviceTransportMgr = TransportMgr<Transport::UDP /* IPv6 */
 class DLL_EXPORT Device
 {
 public:
-    Device() : mActive(false), mState(ConnectionState::NotConnected) {}
+    Device() : mInterface(INET_NULL_INTERFACEID), mActive(false), mState(ConnectionState::NotConnected) {}
     ~Device() {}
 
     /**
@@ -290,7 +290,8 @@ typedef struct SerializableDevice
     SecurePairingSessionSerializable mOpsCreds;
     uint64_t mDeviceId; /* This field is serialized in LittleEndian byte order */
     uint8_t mDeviceAddr[INET6_ADDRSTRLEN];
-    uint16_t mDevicePort; /* This field is serealized in LittelEndian byte order */
+    uint16_t mDevicePort;  /* This field is serealized in LittelEndian byte order */
+    uint64_t mInterfaceId; /* This field is serealized in LittelEndian byte order */
 } SerializableDevice;
 
 typedef struct SerializedDevice


### PR DESCRIPTION
 #### Problem
Controller application is unable to control a previously paired device. The error condition is sporadic, and does not happen on every run. `SendMessage()` API return error `2006`, which maps to Posix error `ENXIO`.


 #### Summary of Changes
The serialized device information did not contain the interface ID that the controller app should use to communicate with the device. Also, the device was not setting the default interface ID in the constructor (default interface ID is typically used by the controller apps).

This change adds both these pieces of code. So by default, the device object (in controller app) will use the default network interface to communicate with the device. The interface ID is also stored in the serialized device information. So if a controller app (or test) chooses to use a different interface ID, the deserialized device object will use the specified interface for communication.

