### PR TITLE
Set/Reset on CHIPoBLEConState

### DIFF
--- a/src/platform/ESP32/BLEManagerImpl.h
+++ b/src/platform/ESP32/BLEManagerImpl.h
@@ -151,6 +151,25 @@ class BLEManagerImpl final : public BLEManager,
         uint16_t Allocated : 1;
         uint16_t Subscribed : 1;
         uint16_t Unused : 4;
+
+        void Set(uint16_t conId)
+        {
+            PendingIndBuf = nullptr;
+            ConId         = conId;
+            MTU           = 0;
+            Allocated     = 1;
+            Subscribed    = 0;
+            Unused        = 0;
+        }
+        void Reset()
+        {
+            PendingIndBuf = nullptr;
+            ConId         = BLE_CONNECTION_UNINITIALIZED;
+            MTU           = 0;
+            Allocated     = 0;
+            Subscribed    = 0;
+            Unused        = 0;
+        }
     };
 
     CHIPoBLEConState mCons[kMaxConnections];

--- a/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
@@ -1146,12 +1146,7 @@ BLEManagerImpl::CHIPoBLEConState * BLEManagerImpl::GetConnectionState(uint16_t c
     {
         if (freeIndex < kMaxConnections)
         {
-            mCons[freeIndex].PendingIndBuf = nullptr;
-            mCons[freeIndex].ConId         = conId;
-            mCons[freeIndex].MTU           = 0;
-            mCons[freeIndex].Allocated     = 1;
-            mCons[freeIndex].Subscribed    = 0;
-            mCons[freeIndex].Unused        = 0;
+            mCons[freeIndex].Set(conId);
             return &mCons[freeIndex];
         }
 
@@ -1167,8 +1162,7 @@ bool BLEManagerImpl::ReleaseConnectionState(uint16_t conId)
     {
         if (mCons[i].Allocated && mCons[i].ConId == conId)
         {
-            mCons[i].PendingIndBuf = nullptr;
-            mCons[i].Allocated     = 0;
+            mCons[i].Reset();
             return true;
         }
     }


### PR DESCRIPTION
Encapsulate setting ESP32's BLEManagerImpl::CHIPoBLEConState.

(Requested in review comments on PR #4011. Other existing `BLEManagerImpl`s
don't use this pattern.)
