### PR TITLE
Begin SystemPacketBuffer.h cleanup

### DIFF
--- a/src/ble/BLEEndPoint.cpp
+++ b/src/ble/BLEEndPoint.cpp
@@ -662,11 +662,11 @@ BLE_ERROR BLEEndPoint::Send(PacketBufferHandle data)
 
     // Ensure outgoing message fits in a single contiguous PacketBuffer, as currently required by the
     // message fragmentation and reassembly engine.
-    if (data->Next() != nullptr)
+    if (data->HasChainedBuffer())
     {
         data->CompactHead();
 
-        if (data->Next() != nullptr)
+        if (data->HasChainedBuffer())
         {
             err = BLE_ERROR_OUTBOUND_MESSAGE_TOO_BIG;
             ExitNow();
@@ -1056,7 +1056,6 @@ BLE_ERROR BLEEndPoint::DriveSending()
 #if CHIP_ENABLE_CHIPOBLE_TEST
         mBtpEngineTest.DoTxTiming(sentBuf, BTP_TX_DONE);
 #endif // CHIP_ENABLE_CHIPOBLE_TEST
-        mBtpEngine.ClearTxPacket();
 
         if (!mSendQueue.IsNull())
         {
@@ -1420,7 +1419,6 @@ BLE_ERROR BLEEndPoint::Receive(PacketBufferHandle data)
     {
         // Take ownership of message PacketBuffer
         System::PacketBufferHandle full_packet = mBtpEngine.TakeRxPacket();
-        mBtpEngine.ClearRxPacket();
 
         ChipLogDebugBleEndPoint(Ble, "reassembled whole msg, len = %d", full_packet->DataLength());
 

--- a/src/ble/BtpEngine.cpp
+++ b/src/ble/BtpEngine.cpp
@@ -357,7 +357,7 @@ BLE_ERROR BtpEngine::HandleCharacteristicReceived(System::PacketBufferHandle dat
 
         // For now, limit BtpEngine message size to max length of 1 pbuf, as we do for chip messages sent via IP.
         // TODO add support for BtpEngine messages longer than 1 pbuf
-        VerifyOrExit(mRxBuf->Next() == nullptr, err = BLE_ERROR_RECEIVED_MESSAGE_TOO_BIG);
+        VerifyOrExit(!mRxBuf->HasChainedBuffer(), err = BLE_ERROR_RECEIVED_MESSAGE_TOO_BIG);
     }
     else
     {
@@ -417,13 +417,13 @@ exit:
     return err;
 }
 
-void BtpEngine::ClearRxPacket()
+PacketBufferHandle BtpEngine::TakeRxPacket()
 {
     if (mRxState == kState_Complete)
     {
         mRxState = kState_Idle;
     }
-    mRxBuf = nullptr;
+    return std::move(mRxBuf);
 }
 
 // Calling convention:
@@ -570,13 +570,13 @@ bool BtpEngine::HandleCharacteristicSend(System::PacketBufferHandle data, bool s
     return true;
 }
 
-void BtpEngine::ClearTxPacket()
+PacketBufferHandle BtpEngine::TakeTxPacket()
 {
     if (mTxState == kState_Complete)
     {
         mTxState = kState_Idle;
     }
-    mTxBuf = nullptr;
+    return std::move(mTxBuf);
 }
 
 void BtpEngine::LogState() const

--- a/src/ble/BtpEngine.h
+++ b/src/ble/BtpEngine.h
@@ -139,12 +139,12 @@ public:
     bool HandleCharacteristicSend(System::PacketBufferHandle data, bool send_ack);
     BLE_ERROR EncodeStandAloneAck(const PacketBufferHandle & data);
 
-    void ClearRxPacket();
-    PacketBufferHandle TakeRxPacket() { return std::move(mRxBuf); }
+    PacketBufferHandle TakeRxPacket();
     PacketBufferHandle BorrowRxPacket() { return mRxBuf.Retain(); }
-    void ClearTxPacket();
-    PacketBufferHandle TakeTxPacket() { return std::move(mTxBuf); }
+    void ClearRxPacket() { (void) TakeRxPacket(); }
+    PacketBufferHandle TakeTxPacket();
     PacketBufferHandle BorrowTxPacket() { return mTxBuf.Retain(); }
+    void ClearTxPacket() { (void) TakeTxPacket(); }
 
     void LogState() const;
     void LogStateDebug() const;

--- a/src/inet/IPEndPointBasis.cpp
+++ b/src/inet/IPEndPointBasis.cpp
@@ -806,7 +806,7 @@ INET_ERROR IPEndPointBasis::SendMsg(const IPPacketInfo * aPktInfo, chip::System:
     VerifyOrExit(mAddrType == aPktInfo->DestAddress.Type(), res = INET_ERROR_BAD_ARGS);
 
     // For now the entire message must fit within a single buffer.
-    VerifyOrExit(aBuffer->Next() == nullptr, res = INET_ERROR_MESSAGE_TOO_LONG);
+    VerifyOrExit(!aBuffer->HasChainedBuffer(), res = INET_ERROR_MESSAGE_TOO_LONG);
 
     memset(&msgHeader, 0, sizeof(msgHeader));
 

--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -100,27 +100,6 @@ static Mutex sBufferPoolMutex;
 
 #endif // !CHIP_SYSTEM_CONFIG_USE_LWIP
 
-/**
- * Get pointer to start of data in buffer.
- *
- *  @return pointer to the start of data.
- */
-uint8_t * PacketBuffer::Start() const
-{
-    return static_cast<uint8_t *>(this->payload);
-}
-
-/**
- *  Set the start data in buffer, adjusting length and total length accordingly.
- *
- *  @note The data within the buffer is not moved, only accounting information is changed.  The function is commonly used to either
- *  strip or prepend protocol headers in a zero-copy way.
- *
- *  @note This call should not be used on any buffer that is not the head of a buffer chain, as it only alters the current buffer.
- *
- *  @param[in] aNewStart - A pointer to where the new payload should start.  newStart will be adjusted internally to fall within
- *      the boundaries of the first buffer in the PacketBuffer chain.
- */
 void PacketBuffer::SetStart(uint8_t * aNewStart)
 {
     uint8_t * const kStart = reinterpret_cast<uint8_t *>(this) + CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE;
@@ -140,29 +119,6 @@ void PacketBuffer::SetStart(uint8_t * aNewStart)
     this->payload = aNewStart;
 }
 
-/**
- * Get length, in bytes, of data in packet buffer.
- *
- *  @return length, in bytes (current payload length).
- */
-uint16_t PacketBuffer::DataLength() const
-{
-    return this->len;
-}
-
-/**
- * Set length, in bytes, of data in buffer, adjusting total length accordingly.
- *
- *  The function sets the length, in bytes, of the data in the buffer, adjusting the total length appropriately.  When the buffer
- *  is not the head of the buffer chain (common case: the caller adds data to the last buffer in the PacketBuffer chain prior to
- *  calling higher layers), the aChainHead __must__ be passed in to properly adjust the total lengths of each buffer ahead of the
- *  current buffer.
- *
- *  @param[in] aNewLen - new length, in bytes, of this buffer.
- *
- *  @param[in,out] aChainHead - the head of the buffer chain the current buffer belongs to.  May be NULL if the current buffer is
- *      the head of the buffer chain.
- */
 void PacketBuffer::SetDataLength(uint16_t aNewLen, PacketBuffer * aChainHead)
 {
     const uint16_t kMaxDataLen = this->MaxDataLength();
@@ -182,21 +138,6 @@ void PacketBuffer::SetDataLength(uint16_t aNewLen, PacketBuffer * aChainHead)
     }
 }
 
-/**
- * Get total length of packet data in the buffer chain.
- *
- * @return total length, in octets.
- */
-uint16_t PacketBuffer::TotalLength() const
-{
-    return this->tot_len;
-}
-
-/**
- * Get the maximum amount, in bytes, of data that will fit in the buffer given the current start position and buffer size.
- *
- * @return number of bytes that fits in the buffer given the current start position.
- */
 uint16_t PacketBuffer::MaxDataLength() const
 {
     const uint8_t * const kStart = reinterpret_cast<const uint8_t *>(this) + CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE;
@@ -204,21 +145,11 @@ uint16_t PacketBuffer::MaxDataLength() const
     return static_cast<uint16_t>(this->AllocSize() - kDelta);
 }
 
-/**
- * Get the number of bytes of data that can be added to the current buffer given the current start position and data length.
- *
- * @return the length, in bytes, of data that will fit in the current buffer given the current start position and data length.
- */
 uint16_t PacketBuffer::AvailableDataLength() const
 {
     return static_cast<uint16_t>(this->MaxDataLength() - this->DataLength());
 }
 
-/**
- * Get the number of bytes within the current buffer between the start of the buffer and the current data start position.
- *
- * @return the amount, in bytes, of space between the start of the buffer and the current data start position.
- */
 uint16_t PacketBuffer::ReservedSize() const
 {
     // Cast to size_t is safe because this->payload always points to "after"
@@ -227,15 +158,6 @@ uint16_t PacketBuffer::ReservedSize() const
     return static_cast<uint16_t>(kDelta - CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE);
 }
 
-/**
- *
- * Add the given packet buffer to the end of the buffer chain, adjusting the total length of each buffer in the chain accordingly.
- *
- *  @note The current packet buffer must be the head of the buffer chain for the lengths to be adjusted properly. The caller MUST
- *  NOT reference the given packet buffer afterwards.
- *
- * @param[in] aPacket - the packet buffer to be added to the end of the current chain.
- */
 void PacketBuffer::AddToEnd_ForNow(PacketBuffer * aPacket)
 {
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
@@ -257,35 +179,11 @@ void PacketBuffer::AddToEnd_ForNow(PacketBuffer * aPacket)
 #endif // !CHIP_SYSTEM_CONFIG_USE_LWIP
 }
 
-void PacketBuffer::AddToEnd(PacketBufferHandle aPacket)
+void PacketBuffer::AddToEnd(PacketBufferHandle aPacketHandle)
 {
-    AddToEnd_ForNow(aPacket.Release_ForNow());
+    AddToEnd_ForNow(aPacketHandle.Release_ForNow());
 }
 
-/**
- *  Detach the current buffer from its chain and return a pointer to the remaining buffers.  The current buffer must be the head of
- *  the chain.
- *
- *  @return the tail of the current buffer chain or NULL if the current buffer is the only buffer in the chain.
- */
-PacketBuffer * PacketBuffer::DetachTail_ForNow()
-{
-    PacketBuffer & lReturn = *static_cast<PacketBuffer *>(this->next);
-
-    this->next    = nullptr;
-    this->tot_len = this->len;
-
-    return &lReturn;
-}
-
-/**
- * Move data from subsequent buffers in the chain into the current buffer until it is full.
- *
- *  Only the current buffer is compacted: the data within the current buffer is moved to the front of the buffer, eliminating any
- *  reserved space.  The remaining available space is filled with data moved from subsequent buffers in the chain, until the
- *  current buffer is full.  If a subsequent buffer in the chain is moved into the current buffer in its entirety, it is removed
- *  from the chain and freed.  The method takes no parameters, returns no results and cannot fail.
- */
 void PacketBuffer::CompactHead()
 {
     uint8_t * const kStart = reinterpret_cast<uint8_t *>(this) + CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE;
@@ -320,14 +218,6 @@ void PacketBuffer::CompactHead()
     }
 }
 
-/**
- * Adjust the current buffer to indicate the amount of data consumed.
- *
- *  Advance the data start position in the current buffer by the specified amount, in bytes, up to the length of data in the
- *  buffer. Decrease the length and total length by the amount consumed.
- *
- *  @param[in] aConsumeLength - number of bytes to consume from the current buffer.
- */
 void PacketBuffer::ConsumeHead(uint16_t aConsumeLength)
 {
     if (aConsumeLength > this->len)
@@ -340,13 +230,13 @@ void PacketBuffer::ConsumeHead(uint16_t aConsumeLength)
 /**
  * Consume data in a chain of buffers.
  *
- *  Consume data in a chain of buffers starting with the current buffer and proceeding through the remaining buffers in the chain.
- *  Each buffer that is completely consumed is freed and the function returns the first buffer (if any) containing the remaining
- *  data. The current buffer must be the head of the buffer chain.
+ *  Consume data in a chain of buffers starting with the current buffer and proceeding through the remaining buffers in the
+ * chain. Each buffer that is completely consumed is freed and the function returns the first buffer (if any) containing the
+ * remaining data. The current buffer must be the head of the buffer chain.
  *
  *  @param[in] aConsumeLength - number of bytes to consume from the current chain.
  *
- *  @return the first buffer from the current chain that contains any remaining data.  If no data remains, a NULL is returned.
+ *  @return the first buffer from the current chain that contains any remaining data.  If no data remains, nullptr is returned.
  */
 PacketBuffer * PacketBuffer::Consume(uint16_t aConsumeLength)
 {
@@ -371,16 +261,6 @@ PacketBuffer * PacketBuffer::Consume(uint16_t aConsumeLength)
     return lPacket;
 }
 
-/**
- * Ensure the buffer has at least the specified amount of reserved space.
- *
- *  Ensure the buffer has at least the specified amount of reserved space moving the data in the buffer forward to make room if
- *  necessary.
- *
- *  @param[in] aReservedSize - number of bytes desired for the headers.
- *
- *  @return \c true if the requested reserved size is available, \c false if there's not enough room in the buffer.
- */
 bool PacketBuffer::EnsureReservedSize(uint16_t aReservedSize)
 {
     const uint16_t kCurrentReservedSize = this->ReservedSize();
@@ -398,15 +278,6 @@ bool PacketBuffer::EnsureReservedSize(uint16_t aReservedSize)
     return true;
 }
 
-/**
- * Align the buffer payload on the specified bytes boundary.
- *
- *  Moving the payload in the buffer forward if necessary.
- *
- *  @param[in] aAlignBytes - specifies number of bytes alignment for the payload start pointer.
- *
- *  @return \c true if alignment is successful, \c false if there's not enough room in the buffer.
- */
 bool PacketBuffer::AlignPayload(uint16_t aAlignBytes)
 {
     if (aAlignBytes == 0)
@@ -429,16 +300,6 @@ bool PacketBuffer::AlignPayload(uint16_t aAlignBytes)
 }
 
 /**
- * Get pointer to next buffer in chain.
- *
- *  @return a pointer to the next buffer in the chain.  \c NULL is returned when there is no buffers in the chain.
- */
-PacketBuffer * PacketBuffer::Next() const
-{
-    return static_cast<PacketBuffer *>(this->next);
-}
-
-/**
  * Increment the reference count of the current buffer.
  */
 void PacketBuffer::AddRef()
@@ -452,15 +313,6 @@ void PacketBuffer::AddRef()
 #endif // !CHIP_SYSTEM_CONFIG_USE_LWIP
 }
 
-/**
- * Allocates a PacketBuffer object with at least \c aReservedSize bytes reserved in the payload for headers, and at least
- *  \c aAllocSize bytes of space for additional data after the initial cursor pointer.
- *
- *  @param[in]  aReservedSize   Number of octets to reserve behind the cursor.
- *  @param[in]  aAvailableSize  Number of octets to allocate after the cursor.
- *
- *  @return     On success, a pointer to the PacketBuffer in the allocated block. On fail, \c NULL.
- */
 PacketBufferHandle PacketBuffer::NewWithAvailableSize(uint16_t aReservedSize, uint16_t aAvailableSize)
 {
     // Adding three 16-bit-int sized numbers together will never overflow
@@ -529,37 +381,11 @@ PacketBufferHandle PacketBuffer::NewWithAvailableSize(uint16_t aReservedSize, ui
     return PacketBufferHandle(lPacket);
 }
 
-/**
- * Allocates a PacketBuffer with default reserved size (#CHIP_SYSTEM_CONFIG_HEADER_RESERVE_SIZE) in the payload for headers,
- * and at least \c aAllocSize bytes of space for additional data after the initial cursor pointer.
- *
- * This usage is most appropriate when allocating a PacketBuffer for an application-layer message.
- *
- *  @param[in]  aAvailableSize  Number of octets to allocate after the cursor.
- *
- *  @return     On success, a pointer to the PacketBuffer in the allocated block. On fail, \c NULL. *
- */
 PacketBufferHandle PacketBuffer::NewWithAvailableSize(uint16_t aAvailableSize)
 {
     return PacketBuffer::NewWithAvailableSize(CHIP_SYSTEM_CONFIG_HEADER_RESERVE_SIZE, aAvailableSize);
 }
 
-/**
- * Allocates a single PacketBuffer of maximum total size with a specific header reserve size.
- *
- *  The parameter passed in is the size reserved prior to the payload to accomodate packet headers from different stack layers,
- *  __not__ the overall size of the buffer to allocate. The size of the buffer #CHIP_SYSTEM_CONFIG_PACKETBUFFER_CAPACITY_MAX
- *  and not, specified in the call.
- *
- * - `PacketBuffer::New(0)` : when called in this fashion, the buffer will be returned without any header reserved, consequently
- *      the entire payload is usable by the caller. This pattern is particularly useful at the lower layers of networking stacks,
- *      in cases where the user knows the payload will be copied out into the final message with appropriate header reserves or in
- *      creating PacketBuffer that are appended to a chain of PacketBuffer via `PacketBuffer::AddToEnd()`.
- *
- *  @param[in] aReservedSize  amount of header space to reserve.
- *
- *  @return On success, a pointer to the PacketBuffer, on failure \c NULL.
- */
 PacketBufferHandle PacketBuffer::New(uint16_t aReservedSize)
 {
     static_assert(CHIP_SYSTEM_CONFIG_PACKETBUFFER_CAPACITY_MAX <= UINT16_MAX, "Our available size won't fit in uint16_t");
@@ -570,13 +396,6 @@ PacketBufferHandle PacketBuffer::New(uint16_t aReservedSize)
     return PacketBuffer::NewWithAvailableSize(aReservedSize, lAvailableSize);
 }
 
-/**
- * Allocates a single PacketBuffer of default max size (#CHIP_SYSTEM_CONFIG_PACKETBUFFER_CAPACITY_MAX) with default reserved size
- * (#CHIP_SYSTEM_CONFIG_HEADER_RESERVE_SIZE) in the payload.
- *
- * The reserved size (#CHIP_SYSTEM_CONFIG_HEADER_RESERVE_SIZE) is large enough to hold transport layer headers as well as headers
- * required by \c chipMessageLayer and \c chipExchangeLayer.
- */
 PacketBufferHandle PacketBuffer::New()
 {
     return PacketBuffer::New(CHIP_SYSTEM_CONFIG_HEADER_RESERVE_SIZE);
@@ -595,7 +414,7 @@ void PacketBuffer::Free(PacketBuffer * aPacket)
 {
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 
-    if (aPacket != NULL)
+    if (aPacket != nullptr)
     {
         pbuf_free(aPacket);
 
@@ -658,7 +477,7 @@ void PacketBuffer::Clear()
  *
  *  @param[in] aPacket - buffer chain.
  *
- *  @return packet buffer chain consisting of the tail of the input buffer (may be \c NULL).
+ *  @return packet buffer chain consisting of the tail of the input buffer (may be \c nullptr).
  */
 PacketBuffer * PacketBuffer::FreeHead(PacketBuffer * aPacket)
 {
@@ -668,28 +487,19 @@ PacketBuffer * PacketBuffer::FreeHead(PacketBuffer * aPacket)
     return lNextPacket;
 }
 
-/**
- * Copy the given buffer to a right-sized buffer if applicable.
- * This function is a no-op for sockets.
- *
- *  @param[in] aPacket - buffer or buffer chain.
- *
- *  @return new packet buffer or the original buffer
- */
+#if CHIP_SYSTEM_CONFIG_USE_LWIP && LWIP_PBUF_FROM_CUSTOM_POOLS
 PacketBuffer * PacketBuffer::RightSize(PacketBuffer * aPacket)
 {
-    PacketBuffer * lNewPacket = aPacket;
-#if CHIP_SYSTEM_CONFIG_USE_LWIP && LWIP_PBUF_FROM_CUSTOM_POOLS
-    lNewPacket = static_cast<PacketBuffer *>(pbuf_rightsize((struct pbuf *) aPacket, -1));
+    PacketBuffer * lNewPacket = static_cast<PacketBuffer *>(pbuf_rightsize((struct pbuf *) aPacket, -1));
     if (lNewPacket != aPacket)
     {
         SYSTEM_STATS_UPDATE_LWIP_PBUF_COUNTS();
 
         ChipLogProgress(chipSystemLayer, "PacketBuffer: RightSize Copied");
     }
-#endif
     return lNewPacket;
 }
+#endif
 
 #if !CHIP_SYSTEM_CONFIG_USE_LWIP && CHIP_SYSTEM_CONFIG_PACKETBUFFER_MAXALLOC
 

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -100,21 +100,21 @@ public:
      * Return the size of the allocation including the reserved and payload data spaces but not including space
      * allocated for the PacketBuffer structure.
      *
-     *  @note    The allocation size is equal or to greater than \c aAllocSize parameter to the \c Create method).
+     *  @note    The allocation size is equal to or greater than the \c aAllocSize parameter to the \c Create method).
      *
      *  @return     size of the allocation
      */
     uint16_t AllocSize() const;
 
     /**
-     * Get pointer to start of data in buffer.
+     * Get a pointer to the start of data in a buffer.
      *
      *  @return pointer to the start of data.
      */
     uint8_t * Start() const { return static_cast<uint8_t *>(this->payload); }
 
     /**
-     *  Set the start data in buffer, adjusting length and total length accordingly.
+     *  Set the the start of data in a buffer, adjusting length and total length accordingly.
      *
      *  @note The data within the buffer is not moved, only accounting information is changed.  The function is commonly used to
      *      either strip or prepend protocol headers in a zero-copy way.
@@ -128,14 +128,14 @@ public:
     void SetStart(uint8_t * aNewStart);
 
     /**
-     * Get length, in bytes, of data in packet buffer.
+     * Get the length, in bytes, of data in a packet buffer.
      *
      *  @return length, in bytes (current payload length).
      */
     uint16_t DataLength() const { return this->len; }
 
     /**
-     * Set length, in bytes, of data in buffer, adjusting total length accordingly.
+     * Set the length, in bytes, of data in a packet buffer, adjusting total length accordingly.
      *
      *  The function sets the length, in bytes, of the data in the buffer, adjusting the total length appropriately. When the buffer
      *  is not the head of the buffer chain (common case: the caller adds data to the last buffer in the PacketBuffer chain prior to
@@ -144,7 +144,7 @@ public:
      *
      *  @param[in] aNewLen - new length, in bytes, of this buffer.
      *
-     *  @param[in,out] aChainHead - the head of the buffer chain the current buffer belongs to.  May be nullptr if the current
+     *  @param[in,out] aChainHead - the head of the buffer chain the current buffer belongs to.  May be \c nullptr if the current
      *      buffer is the head of the buffer chain.
      */
     void SetDataLength(uint16_t aNewLen, const PacketBufferHandle & aChainHead);
@@ -153,7 +153,7 @@ public:
     void SetDataLength(uint16_t aNewLen, PacketBuffer * aChainHead);
 
     /**
-     * Get total length of packet data in the buffer chain.
+     * Get the total length of packet data in the buffer chain.
      *
      *  @return total length, in octets.
      */
@@ -222,7 +222,7 @@ public:
     /**
      * Ensure the buffer has at least the specified amount of reserved space.
      *
-     *  Ensure the buffer has at least the specified amount of reserved space moving the data in the buffer forward to make room if
+     *  Ensure the buffer has at least the specified amount of reserved space, moving the data in the buffer forward to make room if
      *  necessary.
      *
      *  @param[in] aReservedSize - number of bytes desired for the headers.

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -42,6 +42,8 @@
 #include <lwip/pbuf.h>
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
+class PacketBufferTest;
+
 namespace chip {
 namespace System {
 
@@ -75,19 +77,9 @@ struct pbuf
  *      for protocol headers at each layer of a configurable communication stack.  For details, see `PacketBuffer::New()` as well
  *      as LwIP documentation.
  *
- *      FIXME: CHIP is in the middle of a transition to use PacketBufferHandle to manage PacketBuffer ownership, so the following
- *      paragraph is neither entirely correct nor entirely wrong.
- *
- *        PacketBuffer objects are reference-counted, and the prevailing usage mode within chip is "fire-and-forget".  As the packet
- *        (and its underlying PacketBuffer object) is dispatched through various protocol layers, the successful upcall or downcall
- *        between layers implies ownership transfer, and the callee is responsible for freeing the buffer.  On failure of a
- *        cross-layer call, the responsibilty for freeing the buffer rests with the caller.
- *
- *      The end goal is:
- *
- *        PacketBuffer objects are reference-counted, and held through `PacketBufferHandle`s. When a PacketBufferHandle goes out
- *        of scope, its reference is released. To transfer ownership, a function takes a PacketBufferHandle by value. To borrow
- *        ownership, a function takes a `const PacketBufferHandle &`.
+ *      PacketBuffer objects are reference-counted, and normally held and used through a PacketBufferHandle that owns one of the
+ *      counted references. When a PacketBufferHandle goes out of scope, its reference is released. To take ownership, a function
+ *      takes a PacketBufferHandle by value. To borrow ownership, a function takes a `const PacketBufferHandle &`.
  *
  *      New objects of PacketBuffer class are initialized at the beginning of an allocation of memory obtained from the underlying
  *      environment, e.g. from LwIP pbuf target pools, from the standard C library heap, from an internal buffer pool. In the
@@ -104,48 +96,209 @@ struct pbuf
 class DLL_EXPORT PacketBuffer : private pbuf
 {
 public:
+    /**
+     * Return the size of the allocation including the reserved and payload data spaces but not including space
+     * allocated for the PacketBuffer structure.
+     *
+     *  @note    The allocation size is equal or greater than \c aAllocSize paramater to \c Create method).
+     *
+     *  @return     size of the allocation
+     */
     uint16_t AllocSize() const;
 
-    uint8_t * Start() const;
+    /**
+     * Get pointer to start of data in buffer.
+     *
+     *  @return pointer to the start of data.
+     */
+    uint8_t * Start() const { return static_cast<uint8_t *>(this->payload); }
+
+    /**
+     *  Set the start data in buffer, adjusting length and total length accordingly.
+     *
+     *  @note The data within the buffer is not moved, only accounting information is changed.  The function is commonly used to
+     *      either strip or prepend protocol headers in a zero-copy way.
+     *
+     *  @note This call should not be used on any buffer that is not the head of a buffer chain, as it only alters the current
+     *      buffer.
+     *
+     *  @param[in] aNewStart - A pointer to where the new payload should start.  newStart will be adjusted internally to fall within
+     *      the boundaries of the first buffer in the PacketBuffer chain.
+     */
     void SetStart(uint8_t * aNewStart);
 
-    uint16_t DataLength() const;
-    void SetDataLength(uint16_t aNewLen, PacketBuffer * aChainHead = nullptr);
+    /**
+     * Get length, in bytes, of data in packet buffer.
+     *
+     *  @return length, in bytes (current payload length).
+     */
+    uint16_t DataLength() const { return this->len; }
 
-    uint16_t TotalLength() const;
+    /**
+     * Set length, in bytes, of data in buffer, adjusting total length accordingly.
+     *
+     *  The function sets the length, in bytes, of the data in the buffer, adjusting the total length appropriately. When the buffer
+     *  is not the head of the buffer chain (common case: the caller adds data to the last buffer in the PacketBuffer chain prior to
+     *  calling higher layers), the aChainHead __must__ be passed in to properly adjust the total lengths of each buffer ahead of
+     *  the current buffer.
+     *
+     *  @param[in] aNewLen - new length, in bytes, of this buffer.
+     *
+     *  @param[in,out] aChainHead - the head of the buffer chain the current buffer belongs to.  May be nullptr if the current
+     *      buffer is the head of the buffer chain.
+     */
+    void SetDataLength(uint16_t aNewLen) { SetDataLength(aNewLen, nullptr); }
+    void SetDataLength(uint16_t aNewLen, const PacketBufferHandle & aChainHead);
+    // This version will shortly be made private; do not use in new code.
+    void SetDataLength(uint16_t aNewLen, PacketBuffer * aChainHead);
 
+    /**
+     * Get total length of packet data in the buffer chain.
+     *
+     *  @return total length, in octets.
+     */
+    uint16_t TotalLength() const { return this->tot_len; }
+
+    /**
+     * Get the maximum amount, in bytes, of data that will fit in the buffer given the current start position and buffer size.
+     *
+     *  @return number of bytes that fits in the buffer given the current start position.
+     */
     uint16_t MaxDataLength() const;
+
+    /**
+     * Get the number of bytes of data that can be added to the current buffer given the current start position and data length.
+     *
+     *  @return the length, in bytes, of data that will fit in the current buffer given the current start position and data length.
+     */
     uint16_t AvailableDataLength() const;
 
+    /**
+     * Get the number of bytes within the current buffer between the start of the buffer and the current data start position.
+     *
+     *  @return the amount, in bytes, of space between the start of the buffer and the current data start position.
+     */
     uint16_t ReservedSize() const;
 
-    PacketBuffer * Next() const;
+    /**
+     * Determine whether there are any additional buffers chained to the current buffer.
+     *
+     *  @return \c true if there is a chained buffer.
+     */
+    bool HasChainedBuffer() const { return this->next != nullptr; }
 
-    // The raw PacketBuffer version of AddToEnd() will be removed when conversion to PacketBufferHandle is complete.
-    void AddToEnd_ForNow(PacketBuffer * aPacket);
-    // The PacketBufferHandle's ownership is transferred to the `next` link at the end of the current chain.
+    /**
+     * Add the given packet buffer to the end of the buffer chain, adjusting the total length of each buffer in the chain
+     * accordingly.
+     *
+     *  @note The current packet buffer must be the head of the buffer chain for the lengths to be adjusted properly.
+     *
+     *  @note Ownership is transferred from the argument to the `next` link at the end of the current chain.
+     *
+     *  @param[in] aPacketHandle - the packet buffer to be added to the end of the current chain.
+     */
     void AddToEnd(PacketBufferHandle aPacket);
-    // The raw PacketBuffer version of DetachTail() will be removed when conversion to PacketBufferHandle is complete.
-    PacketBuffer * DetachTail_ForNow();
+
+    /**
+     * Move data from subsequent buffers in the chain into the current buffer until it is full.
+     *
+     *  Only the current buffer is compacted: the data within the current buffer is moved to the front of the buffer, eliminating
+     *  any reserved space. The remaining available space is filled with data moved from subsequent buffers in the chain, until the
+     *  current buffer is full. If a subsequent buffer in the chain is moved into the current buffer in its entirety, it is removed
+     *  from the chain and freed. The method takes no parameters, returns no results and cannot fail.
+     */
     void CompactHead();
-    PacketBuffer * Consume(uint16_t aConsumeLength);
+
+    /**
+     * Adjust the current buffer to indicate the amount of data consumed.
+     *
+     *  Advance the data start position in the current buffer by the specified amount, in bytes, up to the length of data in the
+     *  buffer. Decrease the length and total length by the amount consumed.
+     *
+     *  @param[in] aConsumeLength - number of bytes to consume from the current buffer.
+     */
     void ConsumeHead(uint16_t aConsumeLength);
+
+    /**
+     * Ensure the buffer has at least the specified amount of reserved space.
+     *
+     *  Ensure the buffer has at least the specified amount of reserved space moving the data in the buffer forward to make room if
+     *  necessary.
+     *
+     *  @param[in] aReservedSize - number of bytes desired for the headers.
+     *
+     *  @return \c true if the requested reserved size is available, \c false if there's not enough room in the buffer.
+     */
     bool EnsureReservedSize(uint16_t aReservedSize);
+
+    /**
+     * Align the buffer payload on the specified bytes boundary.
+     *
+     *  Moving the payload in the buffer forward if necessary.
+     *
+     *  @param[in] aAlignBytes - specifies number of bytes alignment for the payload start pointer.
+     *
+     *  @return \c true if alignment is successful, \c false if there's not enough room in the buffer.
+     */
     bool AlignPayload(uint16_t aAlignBytes);
 
-    void AddRef();
-
-    static PacketBufferHandle NewWithAvailableSize(uint16_t aAvailableSize);
+    /**
+     * Allocates a PacketBuffer object with at least \c aReservedSize bytes reserved in the payload for headers, and at least
+     *  \c aAllocSize bytes of space for additional data after the initial cursor pointer.
+     *
+     *  @param[in]  aReservedSize   Number of octets to reserve behind the cursor.
+     *  @param[in]  aAvailableSize  Number of octets to allocate after the cursor.
+     *
+     *  @return     On success, a pointer to the PacketBuffer in the allocated block. On fail, \c nullptr.
+     */
     static PacketBufferHandle NewWithAvailableSize(uint16_t aReservedSize, uint16_t aAvailableSize);
 
-    static PacketBufferHandle New();
+    /**
+     * Allocates a PacketBuffer with default reserved size (#CHIP_SYSTEM_CONFIG_HEADER_RESERVE_SIZE) in the payload for headers,
+     * and at least \c aAllocSize bytes of space for additional data after the initial cursor pointer.
+     *
+     * This usage is most appropriate when allocating a PacketBuffer for an application-layer message.
+     *
+     *  @param[in]  aAvailableSize  Number of octets to allocate after the cursor.
+     *
+     *  @return     On success, a pointer to the PacketBuffer in the allocated block. On fail, \c nullptr.
+     */
+    static PacketBufferHandle NewWithAvailableSize(uint16_t aAvailableSize);
+
+    /**
+     * Allocates a single PacketBuffer of maximum total size with a specific header reserve size.
+     *
+     *  The parameter passed in is the size reserved prior to the payload to accomodate packet headers from different stack layers,
+     *  __not__ the overall size of the buffer to allocate. The size of the buffer #CHIP_SYSTEM_CONFIG_PACKETBUFFER_CAPACITY_MAX
+     *  and not, specified in the call.
+     *
+     *  `PacketBuffer::New(0)` : when called in this fashion, the buffer will be returned without any header reserved, consequently
+     *  the entire payload is usable by the caller. This pattern is particularly useful at the lower layers of networking stacks,
+     *  in cases where the user knows the payload will be copied out into the final message with appropriate header reserves or in
+     *  creating PacketBuffer that are appended to a chain of PacketBuffer via `PacketBuffer::AddToEnd()`.
+     *
+     *  @param[in] aReservedSize  amount of header space to reserve.
+     *
+     *  @return On success, a pointer to the PacketBuffer, on failure \c nullptr.
+     */
     static PacketBufferHandle New(uint16_t aReservedSize);
 
-    static PacketBuffer * RightSize(PacketBuffer * aPacket);
+    /**
+     * Allocates a single PacketBuffer of default max size (#CHIP_SYSTEM_CONFIG_PACKETBUFFER_CAPACITY_MAX) with default reserved
+     * size (#CHIP_SYSTEM_CONFIG_HEADER_RESERVE_SIZE) in the payload.
+     *
+     * The reserved size (#CHIP_SYSTEM_CONFIG_HEADER_RESERVE_SIZE) is large enough to hold transport layer headers as well as
+     * headers required by \c chipMessageLayer and \c chipExchangeLayer.
+     */
+    static PacketBufferHandle New();
 
+    // The following will shortly be removed or made private; do not use in new code.
+    PacketBuffer * Next() const { return static_cast<PacketBuffer *>(this->next); }
+    void AddToEnd_ForNow(PacketBuffer * aPacket);
+    void AddRef();
     static void Free(PacketBuffer * aPacket);
-    // To be removed when conversion to PacketBufferHandle is complete:
     static PacketBuffer * FreeHead_ForNow(PacketBuffer * aPacket) { return FreeHead(aPacket); }
+    PacketBuffer * Consume(uint16_t aConsumeLength);
 
 private:
 #if !CHIP_SYSTEM_CONFIG_USE_LWIP && CHIP_SYSTEM_CONFIG_PACKETBUFFER_MAXALLOC
@@ -154,9 +307,16 @@ private:
     static PacketBuffer * BuildFreeList();
 #endif // !CHIP_SYSTEM_CONFIG_USE_LWIP && CHIP_SYSTEM_CONFIG_PACKETBUFFER_MAXALLOC
 
+#if CHIP_SYSTEM_CONFIG_USE_LWIP && LWIP_PBUF_FROM_CUSTOM_POOLS
+    static PacketBuffer * RightSize(PacketBuffer * aPacket);
+#endif
+
     static PacketBuffer * FreeHead(PacketBuffer * aPacket);
+
     void Clear();
+
     friend class PacketBufferHandle;
+    friend class ::PacketBufferTest;
 };
 
 } // namespace System
@@ -217,14 +377,6 @@ typedef union
 
 #endif // !CHIP_SYSTEM_CONFIG_USE_LWIP && CHIP_SYSTEM_CONFIG_PACKETBUFFER_MAXALLOC
 
-/**
- * Return the size of the allocation including the reserved and payload data spaces but not including space
- * allocated for the PacketBuffer structure.
- *
- *  @note    The allocation size is equal or greater than \c aAllocSize paramater to \c Create method).
- *
- *  @return     size of the allocation
- */
 inline uint16_t PacketBuffer::AllocSize() const
 {
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
@@ -253,13 +405,28 @@ inline uint16_t PacketBuffer::AllocSize() const
 namespace chip {
 namespace System {
 
-/// Tracks ownership of a System::PacketBuffer.
+/**
+ * @class PacketBufferHandle
+ *
+ * @brief
+ *  Tracks ownership of a PacketBuffer.
+ *
+ *  PacketBuffer objects are reference-counted, and normally held and used through a PacketBufferHandle that owns one of the
+ *  counted references. When a PacketBufferHandle goes out of scope, its reference is released. To take ownership, a function
+ *  takes a PacketBufferHandle by value. To borrow ownership, a function takes a `const PacketBufferHandle &`.
+ */
 class DLL_EXPORT PacketBufferHandle
 {
 public:
+    /**
+     * Construct an empty PacketBufferHandle.
+     */
     PacketBufferHandle() : mBuffer(nullptr) {}
     PacketBufferHandle(decltype(nullptr)) : mBuffer(nullptr) {}
 
+    /**
+     * Construct a PacketBufferHandle that takes ownership of a PacketBuffer from another.
+     */
     PacketBufferHandle(PacketBufferHandle && aOther)
     {
         mBuffer        = aOther.mBuffer;
@@ -268,6 +435,9 @@ public:
 
     ~PacketBufferHandle() { Adopt(nullptr); }
 
+    /**
+     * Take ownership of a PacketBuffer from another PacketBufferHandle, freeing any existing owned buffer.
+     */
     PacketBufferHandle & operator=(PacketBufferHandle && aOther)
     {
         if (mBuffer != nullptr)
@@ -278,22 +448,96 @@ public:
         aOther.mBuffer = nullptr;
         return *this;
     }
+
+    /**
+     * Free any buffer owned by this handle.
+     */
     PacketBufferHandle & operator=(decltype(nullptr))
     {
         Adopt(nullptr);
         return *this;
     }
 
+    /**
+     * Get a new handle to an existing buffer.
+     *
+     * @return a PacketBufferHandle that shares ownership with this.
+     */
     PacketBufferHandle Retain() const
     {
         mBuffer->AddRef();
         return PacketBufferHandle(mBuffer);
     }
 
+    /**
+     * Access a PackerBuffer's public methods.
+     */
     PacketBuffer * operator->() const { return mBuffer; }
     PacketBuffer & operator*() const { return *mBuffer; }
 
-    // The caller's ownership is transferred to this.
+    /**
+     * Test whether this PacketBufferHandle is empty, or owns a PacketBuffer.
+     *
+     * @return \c true if this PacketBufferHandle is empty; return \c false if it owns a PacketBuffer.
+     */
+    bool IsNull() const { return mBuffer == nullptr; }
+
+    /**
+     *  Detach and return the head of a buffer chain while updating this handle to point to the remaining buffers.
+     *  The current buffer must be the head of the chain.
+     *
+     *  This PacketBufferHandle now holds the ownership formerly held by the head of the chain.
+     *  The returned PacketBufferHandle holds the ownership formerly held by this.
+     *
+     *  @return the detached buffer formerly at the head of the buffer chain.
+     */
+    CHECK_RETURN_VALUE PacketBufferHandle PopHead();
+
+    /**
+     * Free the first buffer in a chain.
+     *
+     *  @note When the buffer chain is referenced by multiple handles, `FreeHead()` will detach the head, but will not forcibly
+     *  deallocate the head buffer.
+     */
+    void FreeHead()
+    {
+        // `PacketBuffer::FreeHead()` frees the current head; this takes ownership from the `next` link.
+        mBuffer = PacketBuffer::FreeHead(mBuffer);
+    }
+
+    /**
+     * Consume data in a chain of buffers.
+     *
+     *  Consume data in a chain of buffers starting with the current buffer and proceeding through the remaining buffers in the
+     *  chain. Each buffer that is completely consumed is freed and the handle holds the first buffer (if any) containing the
+     *  remaining data. The current buffer must be the head of the buffer chain.
+     *
+     *  @param[in] aConsumeLength - number of bytes to consume from the current chain.
+     */
+    void Consume(uint16_t aConsumeLength) { mBuffer = mBuffer->Consume(aConsumeLength); }
+
+    /**
+     * Copy the given buffer to a right-sized buffer if applicable.
+     * This function is a no-op for sockets.
+     *
+     *  @param[in] aPacket - buffer or buffer chain.
+     *
+     *  @return new packet buffer or the original buffer
+     */
+    void RightSize()
+    {
+#if CHIP_SYSTEM_CONFIG_USE_LWIP && LWIP_PBUF_FROM_CUSTOM_POOLS
+        mBuffer = PacketBuffer::RightSize(mBuffer);
+#endif
+    }
+
+    /**
+     * Take ownership of a raw PacketBuffer pointer.
+     *
+     * @brief The caller's ownership is transferred to this. An existing owned buffer is freed.
+     *
+     * @note This should only be used in low-level code, e.g. to import buffers from LwIP or a similar stack.
+     */
     void Adopt(PacketBuffer * buffer)
     {
         if (mBuffer != nullptr)
@@ -303,9 +547,22 @@ public:
         mBuffer = buffer;
     }
 
-    // The PacketBufferHandle's ownership is transferred to the caller.
-    // This is intended to be used only to call functions that have not yet been converted; a permanent version may be created
-    // if/when the need is clear. Most uses will be converted to take a `PacketBufferHandle` by value.
+    /**
+     * Get a new handle to a raw PacketBuffer pointer.
+     *
+     * @brief The caller's ownership is transferred to this.
+     *
+     * @note This should only be used in low-level code, e.g. to import buffers from LwIP or a similar stack.
+     */
+    static PacketBufferHandle Create(PacketBuffer * buffer) { return PacketBufferHandle(buffer); }
+
+    /**
+     * Export a raw PacketBuffer pointer.
+     *
+     * @brief The PacketBufferHandle's ownership is transferred to the caller.
+     *
+     * @note This should only be used in low-level code, e.g. to export buffers from LwIP or a similar stack.
+     */
     CHECK_RETURN_VALUE PacketBuffer * Release_ForNow()
     {
         PacketBuffer * buffer = mBuffer;
@@ -313,33 +570,21 @@ public:
         return buffer;
     }
 
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+    /**
+     * Borrow a raw LwIP `pbuf *`.
+     *
+     * @brief The caller has access but no ownership.
+     *
+     * @note This should be used ONLY by low-level code interfacing with LwIP.
+     */
+    struct pbuf * GetLwIPpbuf() { return static_cast<struct pbuf *>(mBuffer); }
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+
+    // DO NOT USE. This is intended to be used only to call existing TLV::Init() functions that have not yet been converted
+    // to take a PacketBufferHandle, and will be removed soon.
     // The caller has access but no ownership.
-    // This is intended to be used only to call functions that have not yet been converted to take a PacketBufferHandle;
-    // a permanent version may be created if/when the need is clear. Most uses will be converted to take a
-    // `const PacketBufferHandle &`.
     PacketBuffer * Get_ForNow() const { return mBuffer; }
-
-    bool IsNull() const { return mBuffer == nullptr; }
-
-    /**
-     *  Detach and return the head of a buffer chain while updating this handle to point to the remaining buffers.
-     *  The current buffer must be the head of the chain.
-     *
-     *  @return the detached buffer formerly at the head of the buffer chain.
-     */
-    PacketBufferHandle PopHead();
-
-    /**
-     * Free the first buffer in a chain.
-     *
-     *  @note When the buffer chain is referenced by multiple callers, `FreeHead()` will detach the head, but will not forcibly
-     *  deallocate the head buffer.
-     */
-    void FreeHead()
-    {
-        // `PacketBuffer::FreeHead()` frees the current head; this takes ownership from the `next` link.
-        mBuffer = PacketBuffer::FreeHead(mBuffer);
-    }
 
 private:
     PacketBufferHandle(const PacketBufferHandle &) = delete;
@@ -348,9 +593,18 @@ private:
     // The caller's ownership is transferred to this.
     explicit PacketBufferHandle(PacketBuffer * buffer) : mBuffer(buffer) {}
 
+    PacketBuffer * Get() const { return mBuffer; }
+
     PacketBuffer * mBuffer;
+
     friend class PacketBuffer;
+    friend class ::PacketBufferTest;
 };
+
+inline void PacketBuffer::SetDataLength(uint16_t aNewLen, const PacketBufferHandle & aChainHead)
+{
+    SetDataLength(aNewLen, aChainHead.mBuffer);
+}
 
 } // namespace System
 } // namespace chip

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -195,7 +195,7 @@ public:
      *
      *  @note Ownership is transferred from the argument to the `next` link at the end of the current chain.
      *
-     *  @param[in] aPacketHandle - the packet buffer to be added to the end of the current chain.
+     *  @param[in] aPacket - the packet buffer to be added to the end of the current chain.
      */
     void AddToEnd(PacketBufferHandle aPacket);
 

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -147,8 +147,8 @@ public:
      *  @param[in,out] aChainHead - the head of the buffer chain the current buffer belongs to.  May be nullptr if the current
      *      buffer is the head of the buffer chain.
      */
-    void SetDataLength(uint16_t aNewLen) { SetDataLength(aNewLen, nullptr); }
     void SetDataLength(uint16_t aNewLen, const PacketBufferHandle & aChainHead);
+    void SetDataLength(uint16_t aNewLen) { SetDataLength(aNewLen, nullptr); }
     // This version will shortly be made private; do not use in new code.
     void SetDataLength(uint16_t aNewLen, PacketBuffer * aChainHead);
 

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -100,7 +100,7 @@ public:
      * Return the size of the allocation including the reserved and payload data spaces but not including space
      * allocated for the PacketBuffer structure.
      *
-     *  @note    The allocation size is equal or greater than \c aAllocSize paramater to \c Create method).
+     *  @note    The allocation size is equal or to greater than \c aAllocSize parameter to the \c Create method).
      *
      *  @return     size of the allocation
      */

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -58,7 +58,127 @@ using ::chip::System::PacketBufferHandle;
 using ::chip::System::pbuf;
 #endif
 
+// Utility functions.
+
+#define TO_LWIP_PBUF(x) (reinterpret_cast<struct pbuf *>(reinterpret_cast<void *>(x)))
+#define OF_LWIP_PBUF(x) (reinterpret_cast<PacketBuffer *>(reinterpret_cast<void *>(x)))
+
+class PacketBufferTest
+{
+public:
+    static void CheckNewWithAvailableSizeAndFree(nlTestSuite * inSuite, void * inContext);
+    static void CheckStart(nlTestSuite * inSuite, void * inContext);
+    static void CheckSetStart(nlTestSuite * inSuite, void * inContext);
+    static void CheckDataLength(nlTestSuite * inSuite, void * inContext);
+    static void CheckSetDataLength(nlTestSuite * inSuite, void * inContext);
+    static void CheckTotalLength(nlTestSuite * inSuite, void * inContext);
+    static void CheckMaxDataLength(nlTestSuite * inSuite, void * inContext);
+    static void CheckAvailableDataLength(nlTestSuite * inSuite, void * inContext);
+    static void CheckReservedSize(nlTestSuite * inSuite, void * inContext);
+    static void CheckAddToEnd(nlTestSuite * inSuite, void * inContext);
+    static void CheckDetachTail(nlTestSuite * inSuite, void * inContext);
+    static void CheckCompactHead(nlTestSuite * inSuite, void * inContext);
+    static void CheckConsumeHead(nlTestSuite * inSuite, void * inContext);
+    static void CheckConsume(nlTestSuite * inSuite, void * inContext);
+    static void CheckEnsureReservedSize(nlTestSuite * inSuite, void * inContext);
+    static void CheckAlignPayload(nlTestSuite * inSuite, void * inContext);
+    static void CheckNext(nlTestSuite * inSuite, void * inContext);
+    static void CheckAddRef(nlTestSuite * inSuite, void * inContext);
+    static void CheckFree(nlTestSuite * inSuite, void * inContext);
+    static void CheckFreeHead(nlTestSuite * inSuite, void * inContext);
+    static void CheckBuildFreeList(nlTestSuite * inSuite, void * inContext);
+
+    static void BufferFree(struct TestContext * theContext);
+};
+
 namespace {
+
+void CheckNewWithAvailableSizeAndFree(nlTestSuite * inSuite, void * inContext)
+{
+    PacketBufferTest::CheckNewWithAvailableSizeAndFree(inSuite, inContext);
+}
+void CheckStart(nlTestSuite * inSuite, void * inContext)
+{
+    PacketBufferTest::CheckStart(inSuite, inContext);
+}
+void CheckSetStart(nlTestSuite * inSuite, void * inContext)
+{
+    PacketBufferTest::CheckSetStart(inSuite, inContext);
+}
+void CheckDataLength(nlTestSuite * inSuite, void * inContext)
+{
+    PacketBufferTest::CheckDataLength(inSuite, inContext);
+}
+void CheckSetDataLength(nlTestSuite * inSuite, void * inContext)
+{
+    PacketBufferTest::CheckSetDataLength(inSuite, inContext);
+}
+void CheckTotalLength(nlTestSuite * inSuite, void * inContext)
+{
+    PacketBufferTest::CheckTotalLength(inSuite, inContext);
+}
+void CheckMaxDataLength(nlTestSuite * inSuite, void * inContext)
+{
+    PacketBufferTest::CheckMaxDataLength(inSuite, inContext);
+}
+void CheckAvailableDataLength(nlTestSuite * inSuite, void * inContext)
+{
+    PacketBufferTest::CheckAvailableDataLength(inSuite, inContext);
+}
+void CheckReservedSize(nlTestSuite * inSuite, void * inContext)
+{
+    PacketBufferTest::CheckReservedSize(inSuite, inContext);
+}
+void CheckAddToEnd(nlTestSuite * inSuite, void * inContext)
+{
+    PacketBufferTest::CheckAddToEnd(inSuite, inContext);
+}
+void CheckDetachTail(nlTestSuite * inSuite, void * inContext)
+{
+    PacketBufferTest::CheckDetachTail(inSuite, inContext);
+}
+void CheckCompactHead(nlTestSuite * inSuite, void * inContext)
+{
+    PacketBufferTest::CheckCompactHead(inSuite, inContext);
+}
+void CheckConsumeHead(nlTestSuite * inSuite, void * inContext)
+{
+    PacketBufferTest::CheckConsumeHead(inSuite, inContext);
+}
+void CheckConsume(nlTestSuite * inSuite, void * inContext)
+{
+    PacketBufferTest::CheckConsume(inSuite, inContext);
+}
+void CheckEnsureReservedSize(nlTestSuite * inSuite, void * inContext)
+{
+    PacketBufferTest::CheckEnsureReservedSize(inSuite, inContext);
+}
+void CheckAlignPayload(nlTestSuite * inSuite, void * inContext)
+{
+    PacketBufferTest::CheckAlignPayload(inSuite, inContext);
+}
+void CheckNext(nlTestSuite * inSuite, void * inContext)
+{
+    PacketBufferTest::CheckNext(inSuite, inContext);
+}
+void CheckAddRef(nlTestSuite * inSuite, void * inContext)
+{
+    PacketBufferTest::CheckAddRef(inSuite, inContext);
+}
+void CheckFree(nlTestSuite * inSuite, void * inContext)
+{
+    PacketBufferTest::CheckFree(inSuite, inContext);
+}
+void CheckFreeHead(nlTestSuite * inSuite, void * inContext)
+{
+    PacketBufferTest::CheckFreeHead(inSuite, inContext);
+}
+void CheckBuildFreeList(nlTestSuite * inSuite, void * inContext)
+{
+    PacketBufferTest::CheckBuildFreeList(inSuite, inContext);
+}
+
+} // namespace
 
 // Test input vector format.
 
@@ -91,15 +211,10 @@ const uint16_t sLengths[] = { 0, 1, 10, 128, CHIP_SYSTEM_PACKETBUFFER_SIZE, UINT
 const size_t kTestElements = sizeof(sContext) / sizeof(struct TestContext);
 const size_t kTestLengths  = sizeof(sLengths) / sizeof(uint16_t);
 
-// Utility functions.
-
-#define TO_LWIP_PBUF(x) (reinterpret_cast<struct pbuf *>(reinterpret_cast<void *>(x)))
-#define OF_LWIP_PBUF(x) (reinterpret_cast<PacketBuffer *>(reinterpret_cast<void *>(x)))
-
 /**
  *  Free allocated test buffer memory.
  */
-void BufferFree(struct TestContext * theContext)
+void PacketBufferTest::BufferFree(struct TestContext * theContext)
 {
     if (theContext->buf != nullptr)
     {
@@ -186,7 +301,7 @@ PacketBuffer * PrepareTestBuffer(struct TestContext * theContext)
 /**
  *  Test PacketBuffer::Start() function.
  */
-void CheckStart(nlTestSuite * inSuite, void * inContext)
+void PacketBufferTest::CheckStart(nlTestSuite * inSuite, void * inContext)
 {
     struct TestContext * theContext = static_cast<struct TestContext *>(inContext);
 
@@ -211,7 +326,7 @@ void CheckStart(nlTestSuite * inSuite, void * inContext)
  *               adjusted according to the offset value passed into the
  *               SetStart() method.
  */
-void CheckSetStart(nlTestSuite * inSuite, void * inContext)
+void PacketBufferTest::CheckSetStart(nlTestSuite * inSuite, void * inContext)
 {
     struct TestContext * theContext          = static_cast<struct TestContext *>(inContext);
     static const ptrdiff_t sSizePacketBuffer = CHIP_SYSTEM_PACKETBUFFER_SIZE;
@@ -272,7 +387,7 @@ void CheckSetStart(nlTestSuite * inSuite, void * inContext)
 /**
  *  Test PacketBuffer::DataLength() function.
  */
-void CheckDataLength(nlTestSuite * inSuite, void * inContext)
+void PacketBufferTest::CheckDataLength(nlTestSuite * inSuite, void * inContext)
 {
     struct TestContext * theContext = static_cast<struct TestContext *>(inContext);
 
@@ -299,7 +414,7 @@ void CheckDataLength(nlTestSuite * inSuite, void * inContext)
  *               other one being passed as the head of the chain. After calling
  *               the method verify that data lenghts were correctly adjusted.
  */
-void CheckSetDataLength(nlTestSuite * inSuite, void * inContext)
+void PacketBufferTest::CheckSetDataLength(nlTestSuite * inSuite, void * inContext)
 {
     struct TestContext * theFirstContext = static_cast<struct TestContext *>(inContext);
 
@@ -379,7 +494,7 @@ void CheckSetDataLength(nlTestSuite * inSuite, void * inContext)
 /**
  *  Test PacketBuffer::TotalLength() function.
  */
-void CheckTotalLength(nlTestSuite * inSuite, void * inContext)
+void PacketBufferTest::CheckTotalLength(nlTestSuite * inSuite, void * inContext)
 {
     struct TestContext * theContext = static_cast<struct TestContext *>(inContext);
 
@@ -396,7 +511,7 @@ void CheckTotalLength(nlTestSuite * inSuite, void * inContext)
 /**
  *  Test PacketBuffer::MaxDataLength() function.
  */
-void CheckMaxDataLength(nlTestSuite * inSuite, void * inContext)
+void PacketBufferTest::CheckMaxDataLength(nlTestSuite * inSuite, void * inContext)
 {
     struct TestContext * theContext = static_cast<struct TestContext *>(inContext);
 
@@ -413,7 +528,7 @@ void CheckMaxDataLength(nlTestSuite * inSuite, void * inContext)
 /**
  *  Test PacketBuffer::AvailableDataLength() function.
  */
-void CheckAvailableDataLength(nlTestSuite * inSuite, void * inContext)
+void PacketBufferTest::CheckAvailableDataLength(nlTestSuite * inSuite, void * inContext)
 {
     struct TestContext * theContext = static_cast<struct TestContext *>(inContext);
 
@@ -431,7 +546,7 @@ void CheckAvailableDataLength(nlTestSuite * inSuite, void * inContext)
 /**
  *  Test PacketBuffer::ReservedSize() function.
  */
-void CheckReservedSize(nlTestSuite * inSuite, void * inContext)
+void PacketBufferTest::CheckReservedSize(nlTestSuite * inSuite, void * inContext)
 {
     struct TestContext * theContext = static_cast<struct TestContext *>(inContext);
 
@@ -464,7 +579,7 @@ void CheckReservedSize(nlTestSuite * inSuite, void * inContext)
  *               This test function tests linking any combination of three
  *               buffer-configurations passed within inContext.
  */
-void CheckAddToEnd(nlTestSuite * inSuite, void * inContext)
+void PacketBufferTest::CheckAddToEnd(nlTestSuite * inSuite, void * inContext)
 {
     struct TestContext * theFirstContext = static_cast<struct TestContext *>(inContext);
 
@@ -530,7 +645,7 @@ void CheckAddToEnd(nlTestSuite * inSuite, void * inContext)
  *               on the first buffer to unlink the second buffer. After the call,
  *               verify correct internal state of the first buffer.
  */
-void CheckDetachTail(nlTestSuite * inSuite, void * inContext)
+void PacketBufferTest::CheckDetachTail(nlTestSuite * inSuite, void * inContext)
 {
     struct TestContext * theFirstContext = static_cast<struct TestContext *>(inContext);
 
@@ -543,6 +658,8 @@ void CheckDetachTail(nlTestSuite * inSuite, void * inContext)
             PacketBuffer * buffer_1 = PrepareTestBuffer(theFirstContext);
             PacketBuffer * buffer_2 = PrepareTestBuffer(theSecondContext);
             PacketBuffer * returned = nullptr;
+            buffer_1->AddRef(); // The test still holds ownership via buffer_1.
+            PacketBufferHandle buffer_handle = PacketBufferHandle::Create(buffer_1);
 
             if (theFirstContext != theSecondContext)
             {
@@ -550,7 +667,8 @@ void CheckDetachTail(nlTestSuite * inSuite, void * inContext)
                 theFirstContext->buf->tot_len = static_cast<uint16_t>(theFirstContext->buf->tot_len + theSecondContext->init_len);
             }
 
-            returned = buffer_1->DetachTail_ForNow();
+            PacketBufferHandle popped = buffer_handle.PopHead();
+            returned                  = buffer_handle.Release_ForNow();
 
             NL_TEST_ASSERT(inSuite, theFirstContext->buf->next == nullptr);
             NL_TEST_ASSERT(inSuite, theFirstContext->buf->tot_len == theFirstContext->init_len);
@@ -578,7 +696,7 @@ void CheckDetachTail(nlTestSuite * inSuite, void * inContext)
  *               the chain. After calling the method, verify correctly adjusted
  *               state of the first buffer.
  */
-void CheckCompactHead(nlTestSuite * inSuite, void * inContext)
+void PacketBufferTest::CheckCompactHead(nlTestSuite * inSuite, void * inContext)
 {
     struct TestContext * theFirstContext = static_cast<struct TestContext *>(inContext);
 
@@ -662,7 +780,7 @@ void CheckCompactHead(nlTestSuite * inSuite, void * inContext)
  *               the internal state of the buffer has been correctly
  *               adjusted according to the value passed into the method.
  */
-void CheckConsumeHead(nlTestSuite * inSuite, void * inContext)
+void PacketBufferTest::CheckConsumeHead(nlTestSuite * inSuite, void * inContext)
 {
     struct TestContext * theContext = static_cast<struct TestContext *>(inContext);
 
@@ -709,7 +827,7 @@ void CheckConsumeHead(nlTestSuite * inSuite, void * inContext)
  *               method, verify correctly adjusted the state of the first
  *               buffer and appropriate return pointer from the method's call.
  */
-void CheckConsume(nlTestSuite * inSuite, void * inContext)
+void PacketBufferTest::CheckConsume(nlTestSuite * inSuite, void * inContext)
 {
     struct TestContext * theFirstContext = static_cast<struct TestContext *>(inContext);
 
@@ -796,7 +914,7 @@ void CheckConsume(nlTestSuite * inSuite, void * inContext)
  *               Then, verify that EnsureReservedSize() method correctly
  *               retrieves the amount of the reserved space.
  */
-void CheckEnsureReservedSize(nlTestSuite * inSuite, void * inContext)
+void PacketBufferTest::CheckEnsureReservedSize(nlTestSuite * inSuite, void * inContext)
 {
     struct TestContext * theContext = static_cast<struct TestContext *>(inContext);
 
@@ -842,7 +960,7 @@ void CheckEnsureReservedSize(nlTestSuite * inSuite, void * inContext)
  *               required payload shift. Then, verify that AlignPayload()
  *               method correctly aligns the payload start pointer.
  */
-void CheckAlignPayload(nlTestSuite * inSuite, void * inContext)
+void PacketBufferTest::CheckAlignPayload(nlTestSuite * inSuite, void * inContext)
 {
     struct TestContext * theContext = static_cast<struct TestContext *>(inContext);
 
@@ -888,7 +1006,7 @@ void CheckAlignPayload(nlTestSuite * inSuite, void * inContext)
 /**
  *  Test PacketBuffer::Next() function.
  */
-void CheckNext(nlTestSuite * inSuite, void * inContext)
+void PacketBufferTest::CheckNext(nlTestSuite * inSuite, void * inContext)
 {
     struct TestContext * theFirstContext = static_cast<struct TestContext *>(inContext);
 
@@ -909,10 +1027,10 @@ void CheckNext(nlTestSuite * inSuite, void * inContext)
             }
             else
             {
-                NL_TEST_ASSERT(inSuite, buffer_1->Next() == nullptr);
+                NL_TEST_ASSERT(inSuite, !buffer_1->HasChainedBuffer());
             }
 
-            NL_TEST_ASSERT(inSuite, buffer_2->Next() == nullptr);
+            NL_TEST_ASSERT(inSuite, !buffer_2->HasChainedBuffer());
             theSecondContext++;
         }
 
@@ -923,7 +1041,7 @@ void CheckNext(nlTestSuite * inSuite, void * inContext)
 /**
  *  Test PacketBuffer::AddRef() function.
  */
-void CheckAddRef(nlTestSuite * inSuite, void * inContext)
+void PacketBufferTest::CheckAddRef(nlTestSuite * inSuite, void * inContext)
 {
     struct TestContext * theContext = static_cast<struct TestContext *>(inContext);
 
@@ -948,7 +1066,7 @@ void CheckAddRef(nlTestSuite * inSuite, void * inContext)
  *               returns NULL. Otherwise, check for correctness of initializing
  *               the new buffer's internal state. Finally, free the buffer.
  */
-void CheckNewWithAvailableSizeAndFree(nlTestSuite * inSuite, void * inContext)
+void PacketBufferTest::CheckNewWithAvailableSizeAndFree(nlTestSuite * inSuite, void * inContext)
 {
     struct TestContext * theContext = static_cast<struct TestContext *>(inContext);
     PacketBufferHandle buffer;
@@ -971,7 +1089,7 @@ void CheckNewWithAvailableSizeAndFree(nlTestSuite * inSuite, void * inContext)
 
         if (!buffer.IsNull())
         {
-            pb = TO_LWIP_PBUF(buffer.Get_ForNow());
+            pb = TO_LWIP_PBUF(buffer.Get());
 
             NL_TEST_ASSERT(inSuite, pb->len == 0);
             NL_TEST_ASSERT(inSuite, pb->tot_len == 0);
@@ -1010,7 +1128,7 @@ void CheckNewWithAvailableSizeAndFree(nlTestSuite * inSuite, void * inContext)
  *               the chain and verify correctly adjusted states of the two
  *               buffers.
  */
-void CheckFree(nlTestSuite * inSuite, void * inContext)
+void PacketBufferTest::CheckFree(nlTestSuite * inSuite, void * inContext)
 {
     struct TestContext * theFirstContext = static_cast<struct TestContext *>(inContext);
 
@@ -1087,7 +1205,7 @@ void CheckFree(nlTestSuite * inSuite, void * inContext)
  *               FreeHead() on the first buffer in the chain and verify that
  *               the method returned pointer to the second buffer.
  */
-void CheckFreeHead(nlTestSuite * inSuite, void * inContext)
+void PacketBufferTest::CheckFreeHead(nlTestSuite * inSuite, void * inContext)
 {
     struct TestContext * theFirstContext = static_cast<struct TestContext *>(inContext);
 
@@ -1111,7 +1229,7 @@ void CheckFreeHead(nlTestSuite * inSuite, void * inContext)
 
             theFirstContext->buf->next = theSecondContext->buf;
 
-            returned = PacketBuffer::FreeHead_ForNow(buffer_1);
+            returned = PacketBuffer::FreeHead(buffer_1);
 
             NL_TEST_ASSERT(inSuite, returned == buffer_2);
 
@@ -1126,7 +1244,7 @@ void CheckFreeHead(nlTestSuite * inSuite, void * inContext)
 /**
  *  Test PacketBuffer::BuildFreeList() function.
  */
-void CheckBuildFreeList(nlTestSuite * inSuite, void * inContext)
+void PacketBufferTest::CheckBuildFreeList(nlTestSuite * inSuite, void * inContext)
 {
     // BuildFreeList() is a private method called automatically.
     (void) inSuite;
@@ -1195,14 +1313,12 @@ int TestTeardown(void * inContext)
 
     for (size_t ith = 0; ith < kTestElements; ith++)
     {
-        BufferFree(theContext);
+        PacketBufferTest::BufferFree(theContext);
         theContext++;
     }
 
     return (SUCCESS);
 }
-
-} // namespace
 
 int TestSystemPacketBuffer(void)
 { /*

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -127,8 +127,8 @@ CHIP_ERROR RendezvousSession::SendSecureMessage(Protocols::CHIPProtocolId protoc
 
     const uint16_t headerSize = payloadHeader.EncodeSizeBytes();
 
-    VerifyOrReturnError(msgIn != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(msgBuf->Next() == nullptr, CHIP_ERROR_INVALID_MESSAGE_LENGTH);
+    VerifyOrReturnError(!msgBuf.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(!msgBuf->HasChainedBuffer(), CHIP_ERROR_INVALID_MESSAGE_LENGTH);
     VerifyOrReturnError(msgBuf->TotalLength() < kMax_SecureSDU_Length, CHIP_ERROR_INVALID_MESSAGE_LENGTH);
     VerifyOrReturnError(CanCastTo<uint16_t>(headerSize + msgBuf->TotalLength()), CHIP_ERROR_INVALID_MESSAGE_LENGTH);
 

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -100,7 +100,7 @@ CHIP_ERROR SecureSessionMgr::SendMessage(PayloadHeader & payloadHeader, NodeId p
     VerifyOrExit(mState == State::kInitialized, err = CHIP_ERROR_INCORRECT_STATE);
 
     VerifyOrExit(!msgBuf.IsNull(), err = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(msgBuf->Next() == nullptr, err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
+    VerifyOrExit(!msgBuf->HasChainedBuffer(), err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
     VerifyOrExit(msgBuf->TotalLength() < kMax_SecureSDU_Length, err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
 
     // Find an active connection to the specified peer node

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -372,7 +372,7 @@ CHIP_ERROR TCPBase::ProcessReceivedBuffer(Inet::TCPEndPoint * endPoint, const Pe
         }
 
         // Buffer is incomplete if we reach this point
-        if (buffer->Next() != nullptr)
+        if (buffer->HasChainedBuffer())
         {
             buffer->CompactHead();
             continue;


### PR DESCRIPTION
#### Problem

Code should use `PacketBufferHandle` rather than `PacketBuffer *`.
Some existing methods should be removed or made private so that code
does not have unnecessary access to the raw pointer.

#### Summary of Changes

- Consolidated `PacketBuffer` and `PacketBufferHeader` method descriptions
  into the header, and clarified which are in transition.
- Moved trivial `PacketBuffer` getters inline.
- Most uses of `Next()`, which returns a raw pointer, only checked
  for existence; added `HasChainedBuffer()` to replace these.
- Removed `DetachTail_ForNow()`, as it has no remaining callers.
- Converted `TestSystemPacketBuffer.cpp` to use a friend class, so that
   it can continue to use and test private methods. (Refactoring to focus
   on the `PacketBufferHandle` interface will follow.)

Part of issue #2707 - Figure out a way to express PacketBuffer ownership in the type system
