### PR TITLE
Use 16 bits service UUID on esp32 platform

### DIFF
--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -236,6 +236,8 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
           "Darwin/BleConnectionDelegateImpl.mm",
           "Darwin/BlePlatformDelegate.h",
           "Darwin/BlePlatformDelegateImpl.mm",
+          "Darwin/UUIDHelper.h",
+          "Darwin/UUIDHelperImpl.mm",
         ]
       }
     } else if (chip_device_platform == "efr32") {

--- a/src/platform/Darwin/BleConnectionDelegateImpl.mm
+++ b/src/platform/Darwin/BleConnectionDelegateImpl.mm
@@ -29,7 +29,7 @@
 #include <setup_payload/SetupPayload.h>
 #include <support/logging/CHIPLogging.h>
 
-#import <CoreBluetooth/CoreBluetooth.h>
+#import "UUIDHelper.h"
 
 @interface BleConnection : NSObject <CBCentralManagerDelegate, CBPeripheralDelegate>
 
@@ -75,7 +75,7 @@ namespace DeviceLayer {
 {
     self = [super init];
     if (self) {
-        self.shortServiceUUID = [BleConnection getShortestServiceUUID:&chip::Ble::CHIP_BLE_SVC_ID];
+        self.shortServiceUUID = [UUIDHelper GetShortestServiceUUID:&chip::Ble::CHIP_BLE_SVC_ID];
         _deviceDiscriminator = deviceDiscriminator;
         _workQueue = dispatch_queue_create("com.chip.ble.work_queue", DISPATCH_QUEUE_SERIAL);
         _centralManager = [CBCentralManager alloc];
@@ -126,20 +126,13 @@ namespace DeviceLayer {
                 NSData * serviceData = [servicesData objectForKey:serviceUUID];
 
                 NSUInteger length = [serviceData length];
-                if (length == 3 || length == 7) {
+                if (length == 7) {
                     const uint8_t * bytes = (const uint8_t *) [serviceData bytes];
                     uint8_t opCode = bytes[0];
-                    uint16_t discriminator;
-                    if (length == 7) {
-                        discriminator = (bytes[1] | (bytes[2] << 8)) & 0xfff;
-                    } else {
-                        // TODO - Remove this incorrect format.
-                        ChipLogError(Ble, "Using deprecated BLE advertisement format");
-                        discriminator = static_cast<uint16_t>(((bytes[1] & 0x0F) << 8) | bytes[2]);
-                    }
+                    uint16_t discriminator = (bytes[1] | (bytes[2] << 8)) & 0xfff;
 
                     if (opCode == 0 && [self checkDiscriminator:discriminator]) {
-                        ChipLogProgress(Ble, "Connecting to device: %@", peripheral);
+                        ChipLogProgress(Ble, "Connecting to device with discriminator: %d", discriminator);
                         [self connect:peripheral];
                         [self stopScanning];
                     }
@@ -180,9 +173,8 @@ namespace DeviceLayer {
 
     bool found;
 
-    CBUUID * chipServiceUUID = [CBUUID UUIDWithData:[NSData dataWithBytes:&chip::Ble::CHIP_BLE_SVC_ID.bytes length:16]];
     for (CBService * service in peripheral.services) {
-        if ([service.UUID.data isEqualToData:chipServiceUUID.data]) {
+        if ([service.UUID.data isEqualToData:_shortServiceUUID.data]) {
             found = true;
             [peripheral discoverCharacteristics:nil forService:service];
             break;
@@ -190,6 +182,7 @@ namespace DeviceLayer {
     }
 
     if (!found || error != nil) {
+        ChipLogError(Ble, "Service not found on the device.");
         _onConnectionError(_appState, BLE_ERROR_INCORRECT_STATE);
     }
 }
@@ -386,27 +379,6 @@ namespace DeviceLayer {
         ChipLogError(Ble, "Service UUIDs are incompatible");
     }
     memcpy(svcId->bytes, serviceFullUUID, sizeof(svcId->bytes));
-}
-
-+ (CBUUID *)getShortestServiceUUID:(const chip::Ble::ChipBleUUID *)svcId
-{
-    // shorten the 16-byte UUID reported by BLE Layer to shortest possible, 2 or 4 bytes
-    // this is the BLE Service UUID Base. If a 16-byte service UUID partially matches with this 12 bytes,
-    // it could be shorten to 2 or 4 bytes.
-    static const uint8_t bleBaseUUID[12] = { 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0x80, 0x5F, 0x9B, 0x34, 0xFB };
-    if (0 == memcmp(svcId->bytes + 4, bleBaseUUID, sizeof(bleBaseUUID))) {
-        // okay, let's try to shorten it
-        if ((0 == svcId->bytes[0]) && (0 == svcId->bytes[1])) {
-            // the highest 2 bytes are both 0, so we just need 2 bytes
-            return [CBUUID UUIDWithData:[NSData dataWithBytes:(svcId->bytes + 2) length:2]];
-        } else {
-            // we need to use 4 bytes
-            return [CBUUID UUIDWithData:[NSData dataWithBytes:svcId->bytes length:4]];
-        }
-    } else {
-        // it cannot be shorten as it doesn't match with the BLE Service UUID Base
-        return [CBUUID UUIDWithData:[NSData dataWithBytes:svcId->bytes length:16]];
-    }
 }
 
 - (void)setBleLayer:(chip::Ble::BleLayer *)bleLayer

--- a/src/platform/Darwin/BlePlatformDelegateImpl.mm
+++ b/src/platform/Darwin/BlePlatformDelegateImpl.mm
@@ -28,7 +28,7 @@
 #include <platform/Darwin/BlePlatformDelegate.h>
 #include <support/logging/CHIPLogging.h>
 
-#import <CoreBluetooth/CoreBluetooth.h>
+#import "UUIDHelper.h"
 
 using namespace ::chip;
 using namespace ::chip::Ble;
@@ -46,7 +46,7 @@ namespace DeviceLayer {
             CBPeripheral * peripheral = (CBPeripheral *) connObj;
 
             if (NULL != svcId) {
-                serviceId = [CBUUID UUIDWithData:[NSData dataWithBytes:svcId->bytes length:16]];
+                serviceId = [UUIDHelper GetShortestServiceUUID:svcId];
             }
 
             if (NULL != charId) {
@@ -77,7 +77,7 @@ namespace DeviceLayer {
             CBPeripheral * peripheral = (CBPeripheral *) connObj;
 
             if (NULL != svcId) {
-                serviceId = [CBUUID UUIDWithData:[NSData dataWithBytes:svcId->bytes length:16]];
+                serviceId = [UUIDHelper GetShortestServiceUUID:svcId];
             }
             if (NULL != charId) {
                 characteristicId = [CBUUID UUIDWithData:[NSData dataWithBytes:charId->bytes length:sizeof(charId->bytes)]];
@@ -118,7 +118,7 @@ namespace DeviceLayer {
             CBPeripheral * peripheral = (CBPeripheral *) connObj;
 
             if (NULL != svcId) {
-                serviceId = [CBUUID UUIDWithData:[NSData dataWithBytes:svcId->bytes length:16]];
+                serviceId = [UUIDHelper GetShortestServiceUUID:svcId];
             }
             if (NULL != charId) {
                 characteristicId = [CBUUID UUIDWithData:[NSData dataWithBytes:charId->bytes length:sizeof(charId->bytes)]];

--- a/src/platform/Darwin/UUIDHelper.h
+++ b/src/platform/Darwin/UUIDHelper.h
@@ -1,0 +1,26 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <ble/BleUUID.h>
+
+#import <CoreBluetooth/CoreBluetooth.h>
+
+@interface UUIDHelper : NSObject
++ (CBUUID *)GetShortestServiceUUID:(const chip::Ble::ChipBleUUID *)svcId;
+@end

--- a/src/platform/Darwin/UUIDHelperImpl.mm
+++ b/src/platform/Darwin/UUIDHelperImpl.mm
@@ -36,7 +36,7 @@
             return [CBUUID UUIDWithData:[NSData dataWithBytes:svcId->bytes length:4]];
         }
     } else {
-        // it cannot be shorten as it doesn't match with the BLE Service UUID Base
+        // it cannot be shortened as it doesn't match with the BLE Service UUID Base
         return [CBUUID UUIDWithData:[NSData dataWithBytes:svcId->bytes length:16]];
     }
 }

--- a/src/platform/Darwin/UUIDHelperImpl.mm
+++ b/src/platform/Darwin/UUIDHelperImpl.mm
@@ -23,7 +23,7 @@
 + (CBUUID *)GetShortestServiceUUID:(const chip::Ble::ChipBleUUID *)svcId
 {
     // shorten the 16-byte UUID reported by BLE Layer to shortest possible, 2 or 4 bytes
-    // this is the BLE Service UUID Base. If a 16-byte service UUID partially matches with this 12 bytes,
+    // this is the BLE Service UUID Base. If a 16-byte service UUID partially matches with these 12 bytes,
     // it can be shortened to 2 or 4 bytes.
     static const uint8_t bleBaseUUID[12] = { 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0x80, 0x5F, 0x9B, 0x34, 0xFB };
     if (0 == memcmp(svcId->bytes + 4, bleBaseUUID, sizeof(bleBaseUUID))) {

--- a/src/platform/Darwin/UUIDHelperImpl.mm
+++ b/src/platform/Darwin/UUIDHelperImpl.mm
@@ -1,0 +1,43 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2015-2017 Nest Labs, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "UUIDHelper.h"
+
+@implementation UUIDHelper
+
++ (CBUUID *)GetShortestServiceUUID:(const chip::Ble::ChipBleUUID *)svcId
+{
+    // shorten the 16-byte UUID reported by BLE Layer to shortest possible, 2 or 4 bytes
+    // this is the BLE Service UUID Base. If a 16-byte service UUID partially matches with this 12 bytes,
+    // it could be shorten to 2 or 4 bytes.
+    static const uint8_t bleBaseUUID[12] = { 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0x80, 0x5F, 0x9B, 0x34, 0xFB };
+    if (0 == memcmp(svcId->bytes + 4, bleBaseUUID, sizeof(bleBaseUUID))) {
+        // okay, let's try to shorten it
+        if ((0 == svcId->bytes[0]) && (0 == svcId->bytes[1])) {
+            // the highest 2 bytes are both 0, so we just need 2 bytes
+            return [CBUUID UUIDWithData:[NSData dataWithBytes:(svcId->bytes + 2) length:2]];
+        } else {
+            // we need to use 4 bytes
+            return [CBUUID UUIDWithData:[NSData dataWithBytes:svcId->bytes length:4]];
+        }
+    } else {
+        // it cannot be shorten as it doesn't match with the BLE Service UUID Base
+        return [CBUUID UUIDWithData:[NSData dataWithBytes:svcId->bytes length:16]];
+    }
+}
+@end

--- a/src/platform/Darwin/UUIDHelperImpl.mm
+++ b/src/platform/Darwin/UUIDHelperImpl.mm
@@ -24,7 +24,7 @@
 {
     // shorten the 16-byte UUID reported by BLE Layer to shortest possible, 2 or 4 bytes
     // this is the BLE Service UUID Base. If a 16-byte service UUID partially matches with this 12 bytes,
-    // it could be shorten to 2 or 4 bytes.
+    // it can be shortened to 2 or 4 bytes.
     static const uint8_t bleBaseUUID[12] = { 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0x80, 0x5F, 0x9B, 0x34, 0xFB };
     if (0 == memcmp(svcId->bytes + 4, bleBaseUUID, sizeof(bleBaseUUID))) {
         // okay, let's try to shorten it

--- a/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
@@ -96,8 +96,8 @@ enum
 const esp_gatts_attr_db_t CHIPoBLEGATTAttrs[] = {
     // Service Declaration for Chip over BLE Service
     { { ESP_GATT_AUTO_RSP },
-      { ESP_UUID_LEN_16, (uint8_t *) UUID_PrimaryService, ESP_GATT_PERM_READ, ESP_UUID_LEN_128, ESP_UUID_LEN_128,
-        (uint8_t *) UUID_CHIPoBLEService } },
+      { ESP_UUID_LEN_16, (uint8_t *) UUID_PrimaryService, ESP_GATT_PERM_READ, ESP_UUID_LEN_16, ESP_UUID_LEN_16,
+        (uint8_t *) ShortUUID_CHIPoBLEService } },
 
     // ----- Chip over BLE RX Characteristic -----
 

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -68,7 +68,7 @@ struct ESP32ChipServiceData
 const ble_uuid128_t UUID_CHIPoBLEService = {
     BLE_UUID_TYPE_128, { 0xFB, 0x34, 0x9B, 0x5F, 0x80, 0x00, 0x00, 0x80, 0x00, 0x10, 0x00, 0x00, 0xAF, 0xFE, 0x00, 0x00 }
 };
-const uint8_t ShortUUID_CHIPoBLEService[] = { 0xAF, 0xFE };
+const ble_uuid16_t ShortUUID_CHIPoBLEService = { BLE_UUID_TYPE_16, 0xFEAF };
 
 const ble_uuid128_t UUID128_CHIPoBLEChar_RX = {
     BLE_UUID_TYPE_128, { 0x11, 0x9D, 0x9F, 0x42, 0x9C, 0x4F, 0x9F, 0x95, 0x59, 0x45, 0x3D, 0x26, 0xF5, 0x2E, 0xEE, 0x18 }
@@ -94,7 +94,7 @@ BLEManagerImpl BLEManagerImpl::sInstance;
 
 const struct ble_gatt_svc_def BLEManagerImpl::CHIPoBLEGATTAttrs[] = {
     { .type = BLE_GATT_SVC_TYPE_PRIMARY,
-      .uuid = (ble_uuid_t *) (&UUID_CHIPoBLEService),
+      .uuid = (ble_uuid_t *) (&ShortUUID_CHIPoBLEService),
       .characteristics =
           (struct ble_gatt_chr_def[]){
               {
@@ -625,13 +625,13 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     }
 
     memset(advData, 0, sizeof(advData));
-    advData[index++] = 0x02;                            // length
-    advData[index++] = CHIP_ADV_DATA_TYPE_FLAGS;        // AD type : flags
-    advData[index++] = CHIP_ADV_DATA_FLAGS;             // AD value
-    advData[index++] = 0x0A;                            // length
-    advData[index++] = CHIP_ADV_DATA_TYPE_SERVICE_DATA; // AD type: (Service Data - 16-bit UUID)
-    advData[index++] = ShortUUID_CHIPoBLEService[0];    // AD value
-    advData[index++] = ShortUUID_CHIPoBLEService[1];    // AD value
+    advData[index++] = 0x02;                                                                // length
+    advData[index++] = CHIP_ADV_DATA_TYPE_FLAGS;                                            // AD type : flags
+    advData[index++] = CHIP_ADV_DATA_FLAGS;                                                 // AD value
+    advData[index++] = 0x0A;                                                                // length
+    advData[index++] = CHIP_ADV_DATA_TYPE_SERVICE_DATA;                                     // AD type: (Service Data - 16-bit UUID)
+    advData[index++] = static_cast<uint8_t>(ShortUUID_CHIPoBLEService.value & 0xFF);        // AD value
+    advData[index++] = static_cast<uint8_t>((ShortUUID_CHIPoBLEService.value >> 8) & 0xFF); // AD value
 
     chip::Ble::ChipBLEDeviceIdentificationInfo deviceIdInfo;
     err = ConfigurationMgr().GetBLEDeviceIdentificationInfo(deviceIdInfo);


### PR DESCRIPTION
 #### Problem

It seems like some platforms use 16 bits service UUIDs while the esp32 uses 128 bits.

This is a partial fix for #4061 since at the moment, `chip-tool` does not pass https://github.com/project-chip/connectedhomeip/blob/90df58f7367fbbc3f567c8b503fb67adab562d6d/src/platform/Darwin/BleConnectionDelegateImpl.mm#L175

 #### Summary of Changes
 * Update esp32 to use 16 bits service UUIDs for both `nimble` and `bluedroid`
 * Update `src/platform/Darwin` code