### PR TITLE
Properly update chip_tool_config.ini when a device is unpaired or paired

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -82,6 +82,7 @@ CHIP_ERROR PairingCommand::PairWithoutSecurity(NodeId remoteId, PeerAddress addr
 
 CHIP_ERROR PairingCommand::Unpair(NodeId remoteId)
 {
+    UpdateWaitForResponse(false);
     return mCommissioner.UnpairDevice(remoteId);
 }
 

--- a/examples/chip-tool/config/PersistentStorage.cpp
+++ b/examples/chip-tool/config/PersistentStorage.cpp
@@ -80,7 +80,7 @@ void PersistentStorage::SetKeyValue(const char * key, const char * value)
     auto section = mConfig.sections[kDefaultSectionName];
     section[key] = std::string(value);
 
-    mConfig.default_section(section);
+    mConfig.sections[kDefaultSectionName] = section;
     CommitConfig();
 }
 
@@ -89,7 +89,7 @@ void PersistentStorage::DeleteKeyValue(const char * key)
     auto section = mConfig.sections[kDefaultSectionName];
     section.erase(key);
 
-    mConfig.default_section(section);
+    mConfig.sections[kDefaultSectionName] = section;
     CommitConfig();
 }
 


### PR DESCRIPTION
 #### Problem

When pairing a device over BLE with `chip-tool`, the association is stored into `chip_tool_config.ini`. It is created fine, but when you try to unpair or pair again the `.ini` file is not updated correctly.

 #### Summary of Changes
 * Fix `SetKeyValue` and `DeleteKeyValue` to properly update the `ini` file.
 * Fix the `Unpair` command to not wait a response from the device...
