### PR TITLE
Build all-clusters-app and lighting-app by default on macOS

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -141,11 +141,11 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
 
     # Build the Linux all clusters app example.
     enable_linux_all_clusters_app_build =
-        enable_default_builds && host_os == "linux"
+        enable_default_builds && (host_os == "linux" || host_os == "mac")
 
     # Build the Linux lighting app example.
     enable_linux_lighting_app_build =
-        enable_default_builds && host_os == "linux"
+        enable_default_builds && (host_os == "linux" || host_os == "mac")
 
     # Build the efr32 lock app example.
     enable_efr32_lock_app_build = enable_efr32_builds


### PR DESCRIPTION
 #### Problem

While debugging on macOS, it is convenient to build the `all-clusters-app` and `lighting-app` by default with `./gn_build.sh`

I have found myself doing this local hack tons of times, so I guess it may be useful for others as well...

 #### Summary of Changes
 * Update `BUILD.gn` to build the `all-clusters-app` and `lighting-app` by default on macOS.