### PR TITLE
Remove "Show tree" step from CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,8 +76,6 @@ jobs:
             # - name: Upload Code Coverage
             #   if: ${{ contains('main', env.BUILD_TYPE) }}
             #   run: bash <(curl -s https://codecov.io/bash)
-            - name: Show tree
-              run: find .
             - name: Remove third_party binaries for CodeQL Analysis
               run: find out -type d -name "third_party" -exec rm -rf {} +
             - name: Remove dbus binaries for CodeQL Analysis

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -69,8 +69,6 @@ jobs:
                   path: |
                       out/lock_app_debug/BRD4161A/chip-efr32-lock-example.out
                       out/lighting_app_debug/BRD4161A/chip-efr32-lighting-example.out
-            - name: Show tree
-              run: find .
             - name: Remove third_party binaries for CodeQL Analysis
               run: find out -type d -name "third_party" -exec rm -rf {} +
             - name: Remove SiliconLabs binaries for CodeQL Analysis

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -70,8 +70,6 @@ jobs:
                       ${{ env.BUILD_TYPE }}-example-build-${{
                       steps.outsuffix.outputs.value }}
                   path: /tmp/output_binaries/${{ env.BUILD_TYPE }}-build
-            - name: Show tree
-              run: find .
             # - name: Remove third_party binaries for CodeQL Analysis
             #   run: find . -type d -name "third_party" -exec rm -rf {} +
             # - name: Remove m5stack-tft binaries for CodeQL Analysis

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -78,8 +78,6 @@ jobs:
                   path: |
                       out/chip_tool_debug/chip-tool
                       out/shell_debug/chip-shell
-            - name: Show tree
-              run: find .
             - name: Remove third_party binaries for CodeQL Analysis
               run: find out -type d -name "third_party" -exec rm -rf {} +
             - name: Remove dbus binaries for CodeQL Analysis

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -78,8 +78,6 @@ jobs:
                       steps.outsuffix.outputs.value }}
                   path: /tmp/output_binaries/${{ env.BUILD_TYPE }}-build
             # https://github.com/project-chip/connectedhomeip/issues/3100
-            # - name: Show tree
-            #   run: find .
             # - name: Remove third_party binaries for CodeQL Analysis
             #   run: find examples -type d -name "third_party" -exec rm -rf {} +
             # - name: Remove nrfxlib binaries for CodeQL Analysis

--- a/.github/workflows/examples-qpg6100.yaml
+++ b/.github/workflows/examples-qpg6100.yaml
@@ -65,8 +65,6 @@ jobs:
                   path: |
                       out/lock_app_debug/chip-qpg6100-lock-example.out
                       out/shell_app/shell-qpg6100.out
-            - name: Show tree
-              run: find .
             - name: Remove third_party binaries for CodeQL Analysis
               run: find out -type d -name "third_party" -exec rm -rf {} +
             - name: Perform CodeQL Analysis


### PR DESCRIPTION
 #### Problem
"Show tree" step was probably used for debuggin CI, however it is not useful now (and delays all CI by a few seconds).

 #### Summary of Changes
Delete the "Show tree" step from CI