### PR TITLE
Fix rendezvous flow that uses BLE in CHIPTool 

### DIFF
--- a/examples/common/chip-app-server/Server.cpp
+++ b/examples/common/chip-app-server/Server.cpp
@@ -153,7 +153,6 @@ void InitServer(AppDelegate * delegate)
 
         SuccessOrExit(err = DeviceLayer::ConfigurationMgr().GetSetupPinCode(pinCode));
         params.SetSetupPINCode(pinCode)
-            .SetLocalNodeId(chip::kTestDeviceNodeId)
             .SetBleLayer(DeviceLayer::ConnectivityMgr().GetBleLayer())
             .SetPeerAddress(Transport::PeerAddress::BLE());
         SuccessOrExit(err = gRendezvousServer.Init(params, &gTransports));

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -477,6 +477,7 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, RendezvousParam
     if (!params.HasBleLayer())
     {
         params.SetBleLayer(DeviceLayer::ConnectivityMgr().GetBleLayer());
+        params.SetPeerAddress(Transport::PeerAddress::BLE());
     }
 #endif // CONFIG_DEVICE_LAYER && CONFIG_NETWORK_LAYER_BLE
 


### PR DESCRIPTION
 #### Problem
Rendezvous over BLE is broken in iOS CHIPTool.

 #### Summary of Changes
There were two issues
1. The transport type was not being set to BLE, when BLE was being used for rendezvous
2. Hardcoded node ID is being used in the example device application.

This PR fixes these two issues.
