### PR TITLE
[Build Bustage] error: 'chip::BufBound' has not been declared

### DIFF
--- a/src/lib/mdns/minimal/core/QName.h
+++ b/src/lib/mdns/minimal/core/QName.h
@@ -25,6 +25,7 @@
 #include <utility>
 
 #include <core/CHIPEncoding.h>
+#include <support/BufBound.h>
 #include <support/BufferWriter.h>
 
 #include <mdns/minimal/core/BytesRange.h>


### PR DESCRIPTION
 #### Problem

Tip can not build anymore. There is a missing header in `src/lib/mdns/minimal/core/QName.h`
It has been introduced by `MinMDNS refactor` (#4102)

 #### Summary of Changes
 * Add the missing line
 
