### PR TITLE
Clusters sync gen folders

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/af-structs.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/af-structs.h
@@ -87,7 +87,7 @@ typedef struct _DebtPayload
 // Struct for DeviceInformationRecord
 typedef struct _DeviceInformationRecord
 {
-    uint8_t * ieeeAddress;
+    uint64_t ieeeAddress;
     chip::EndpointId endpointId;
     uint16_t profileId;
     uint16_t deviceId;
@@ -113,10 +113,9 @@ typedef struct _EndpointInformationRecord
     uint8_t version;
 } EmberAfEndpointInformationRecord;
 
-// Struct for EphemeralData
-typedef struct _EphemeralData
-{
-} EmberAfEphemeralData;
+// Void typedef for EmberAfEphemeralData which is empty.
+// this will result in all the references to the data being as uint8_t*
+typedef uint8_t EmberAfEphemeralData;
 
 // Struct for EventConfigurationPayload
 typedef struct _EventConfigurationPayload
@@ -176,15 +175,14 @@ typedef struct _IasAceZoneStatusResult
     uint16_t zoneStatus;
 } EmberAfIasAceZoneStatusResult;
 
-// Struct for Identity
-typedef struct _Identity
-{
-} EmberAfIdentity;
+// Void typedef for EmberAfIdentity which is empty.
+// this will result in all the references to the data being as uint8_t*
+typedef uint8_t EmberAfIdentity;
 
 // Struct for NeighborInfo
 typedef struct _NeighborInfo
 {
-    uint8_t * neighbor;
+    uint64_t neighbor;
     int16_t x;
     int16_t y;
     int16_t z;
@@ -333,15 +331,13 @@ typedef struct _SeasonEntry
     uint8_t weekIdRef;
 } EmberAfSeasonEntry;
 
-// Struct for Signature
-typedef struct _Signature
-{
-} EmberAfSignature;
+// Void typedef for EmberAfSignature which is empty.
+// this will result in all the references to the data being as uint8_t*
+typedef uint8_t EmberAfSignature;
 
-// Struct for Smac
-typedef struct _Smac
-{
-} EmberAfSmac;
+// Void typedef for EmberAfSmac which is empty.
+// this will result in all the references to the data being as uint8_t*
+typedef uint8_t EmberAfSmac;
 
 // Struct for SnapshotResponsePayload
 typedef struct _SnapshotResponsePayload

--- a/examples/all-clusters-app/all-clusters-common/gen/call-command-handler.cpp
+++ b/examples/all-clusters-app/all-clusters-common/gen/call-command-handler.cpp
@@ -77,13 +77,16 @@ EmberAfStatus emberAfClusterSpecificCommandParse(EmberAfClusterCommand * cmd)
         switch (cmd->apsFrame->clusterId)
         {
         case ZCL_BARRIER_CONTROL_CLUSTER_ID:
-            result = emberAfBarrierControlClusterClientCommandParse(cmd);
+            // No commands are enabled for cluster Barrier Control
+            result = status(false, true, cmd->mfgSpecific);
             break;
         case ZCL_BASIC_CLUSTER_ID:
-            result = emberAfBasicClusterClientCommandParse(cmd);
+            // No commands are enabled for cluster Basic
+            result = status(false, true, cmd->mfgSpecific);
             break;
         case ZCL_COLOR_CONTROL_CLUSTER_ID:
-            result = emberAfColorControlClusterClientCommandParse(cmd);
+            // No commands are enabled for cluster Color Control
+            result = status(false, true, cmd->mfgSpecific);
             break;
         case ZCL_DOOR_LOCK_CLUSTER_ID:
             result = emberAfDoorLockClusterClientCommandParse(cmd);
@@ -95,10 +98,12 @@ EmberAfStatus emberAfClusterSpecificCommandParse(EmberAfClusterCommand * cmd)
             result = emberAfIdentifyClusterClientCommandParse(cmd);
             break;
         case ZCL_LEVEL_CONTROL_CLUSTER_ID:
-            result = emberAfLevelControlClusterClientCommandParse(cmd);
+            // No commands are enabled for cluster Level Control
+            result = status(false, true, cmd->mfgSpecific);
             break;
         case ZCL_ON_OFF_CLUSTER_ID:
-            result = emberAfOnOffClusterClientCommandParse(cmd);
+            // No commands are enabled for cluster On/off
+            result = status(false, true, cmd->mfgSpecific);
             break;
         case ZCL_SCENES_CLUSTER_ID:
             result = emberAfScenesClusterClientCommandParse(cmd);
@@ -144,7 +149,8 @@ EmberAfStatus emberAfClusterSpecificCommandParse(EmberAfClusterCommand * cmd)
             result = emberAfScenesClusterServerCommandParse(cmd);
             break;
         case ZCL_TEMP_MEASUREMENT_CLUSTER_ID:
-            result = emberAfTemperatureMeasurementClusterServerCommandParse(cmd);
+            // No commands are enabled for cluster Temperature Measurement
+            result = status(false, true, cmd->mfgSpecific);
             break;
         default:
             // Unrecognized cluster ID, error status will apply.
@@ -156,22 +162,6 @@ EmberAfStatus emberAfClusterSpecificCommandParse(EmberAfClusterCommand * cmd)
 
 // Cluster specific command parsing
 
-EmberAfStatus emberAfBarrierControlClusterClientCommandParse(EmberAfClusterCommand * cmd)
-{
-    bool wasHandled = false;
-
-    if (!cmd->mfgSpecific)
-    {
-        switch (cmd->commandId)
-        {
-        default: {
-            // Unrecognized command ID, error status will apply.
-            break;
-        }
-        }
-    }
-    return status(wasHandled, true, cmd->mfgSpecific);
-}
 EmberAfStatus emberAfBarrierControlClusterServerCommandParse(EmberAfClusterCommand * cmd)
 {
     bool wasHandled = false;
@@ -205,22 +195,6 @@ EmberAfStatus emberAfBarrierControlClusterServerCommandParse(EmberAfClusterComma
     }
     return status(wasHandled, true, cmd->mfgSpecific);
 }
-EmberAfStatus emberAfBasicClusterClientCommandParse(EmberAfClusterCommand * cmd)
-{
-    bool wasHandled = false;
-
-    if (!cmd->mfgSpecific)
-    {
-        switch (cmd->commandId)
-        {
-        default: {
-            // Unrecognized command ID, error status will apply.
-            break;
-        }
-        }
-    }
-    return status(wasHandled, true, cmd->mfgSpecific);
-}
 EmberAfStatus emberAfBasicClusterServerCommandParse(EmberAfClusterCommand * cmd)
 {
     bool wasHandled = false;
@@ -233,22 +207,6 @@ EmberAfStatus emberAfBasicClusterServerCommandParse(EmberAfClusterCommand * cmd)
             wasHandled = emberAfBasicClusterResetToFactoryDefaultsCallback();
             break;
         }
-        default: {
-            // Unrecognized command ID, error status will apply.
-            break;
-        }
-        }
-    }
-    return status(wasHandled, true, cmd->mfgSpecific);
-}
-EmberAfStatus emberAfColorControlClusterClientCommandParse(EmberAfClusterCommand * cmd)
-{
-    bool wasHandled = false;
-
-    if (!cmd->mfgSpecific)
-    {
-        switch (cmd->commandId)
-        {
         default: {
             // Unrecognized command ID, error status will apply.
             break;
@@ -1635,22 +1593,6 @@ EmberAfStatus emberAfIdentifyClusterServerCommandParse(EmberAfClusterCommand * c
     }
     return status(wasHandled, true, cmd->mfgSpecific);
 }
-EmberAfStatus emberAfLevelControlClusterClientCommandParse(EmberAfClusterCommand * cmd)
-{
-    bool wasHandled = false;
-
-    if (!cmd->mfgSpecific)
-    {
-        switch (cmd->commandId)
-        {
-        default: {
-            // Unrecognized command ID, error status will apply.
-            break;
-        }
-        }
-    }
-    return status(wasHandled, true, cmd->mfgSpecific);
-}
 EmberAfStatus emberAfLevelControlClusterServerCommandParse(EmberAfClusterCommand * cmd)
 {
     bool wasHandled = false;
@@ -1859,22 +1801,6 @@ EmberAfStatus emberAfLevelControlClusterServerCommandParse(EmberAfClusterCommand
             wasHandled = emberAfLevelControlClusterStopWithOnOffCallback();
             break;
         }
-        default: {
-            // Unrecognized command ID, error status will apply.
-            break;
-        }
-        }
-    }
-    return status(wasHandled, true, cmd->mfgSpecific);
-}
-EmberAfStatus emberAfOnOffClusterClientCommandParse(EmberAfClusterCommand * cmd)
-{
-    bool wasHandled = false;
-
-    if (!cmd->mfgSpecific)
-    {
-        switch (cmd->commandId)
-        {
         default: {
             // Unrecognized command ID, error status will apply.
             break;
@@ -2303,22 +2229,6 @@ EmberAfStatus emberAfScenesClusterServerCommandParse(EmberAfClusterCommand * cmd
             wasHandled = emberAfScenesClusterViewSceneCallback(groupId, sceneId);
             break;
         }
-        default: {
-            // Unrecognized command ID, error status will apply.
-            break;
-        }
-        }
-    }
-    return status(wasHandled, true, cmd->mfgSpecific);
-}
-EmberAfStatus emberAfTemperatureMeasurementClusterServerCommandParse(EmberAfClusterCommand * cmd)
-{
-    bool wasHandled = false;
-
-    if (!cmd->mfgSpecific)
-    {
-        switch (cmd->commandId)
-        {
         default: {
             // Unrecognized command ID, error status will apply.
             break;

--- a/examples/lighting-app/lighting-common/gen/af-structs.h
+++ b/examples/lighting-app/lighting-common/gen/af-structs.h
@@ -87,7 +87,7 @@ typedef struct _DebtPayload
 // Struct for DeviceInformationRecord
 typedef struct _DeviceInformationRecord
 {
-    uint8_t * ieeeAddress;
+    uint64_t ieeeAddress;
     chip::EndpointId endpointId;
     uint16_t profileId;
     uint16_t deviceId;
@@ -113,10 +113,9 @@ typedef struct _EndpointInformationRecord
     uint8_t version;
 } EmberAfEndpointInformationRecord;
 
-// Struct for EphemeralData
-typedef struct _EphemeralData
-{
-} EmberAfEphemeralData;
+// Void typedef for EmberAfEphemeralData which is empty.
+// this will result in all the references to the data being as uint8_t*
+typedef uint8_t EmberAfEphemeralData;
 
 // Struct for EventConfigurationPayload
 typedef struct _EventConfigurationPayload
@@ -176,15 +175,14 @@ typedef struct _IasAceZoneStatusResult
     uint16_t zoneStatus;
 } EmberAfIasAceZoneStatusResult;
 
-// Struct for Identity
-typedef struct _Identity
-{
-} EmberAfIdentity;
+// Void typedef for EmberAfIdentity which is empty.
+// this will result in all the references to the data being as uint8_t*
+typedef uint8_t EmberAfIdentity;
 
 // Struct for NeighborInfo
 typedef struct _NeighborInfo
 {
-    uint8_t * neighbor;
+    uint64_t neighbor;
     int16_t x;
     int16_t y;
     int16_t z;
@@ -333,15 +331,13 @@ typedef struct _SeasonEntry
     uint8_t weekIdRef;
 } EmberAfSeasonEntry;
 
-// Struct for Signature
-typedef struct _Signature
-{
-} EmberAfSignature;
+// Void typedef for EmberAfSignature which is empty.
+// this will result in all the references to the data being as uint8_t*
+typedef uint8_t EmberAfSignature;
 
-// Struct for Smac
-typedef struct _Smac
-{
-} EmberAfSmac;
+// Void typedef for EmberAfSmac which is empty.
+// this will result in all the references to the data being as uint8_t*
+typedef uint8_t EmberAfSmac;
 
 // Struct for SnapshotResponsePayload
 typedef struct _SnapshotResponsePayload

--- a/examples/lock-app/lock-common/gen/af-structs.h
+++ b/examples/lock-app/lock-common/gen/af-structs.h
@@ -87,7 +87,7 @@ typedef struct _DebtPayload
 // Struct for DeviceInformationRecord
 typedef struct _DeviceInformationRecord
 {
-    uint8_t * ieeeAddress;
+    uint64_t ieeeAddress;
     chip::EndpointId endpointId;
     uint16_t profileId;
     uint16_t deviceId;
@@ -113,10 +113,9 @@ typedef struct _EndpointInformationRecord
     uint8_t version;
 } EmberAfEndpointInformationRecord;
 
-// Struct for EphemeralData
-typedef struct _EphemeralData
-{
-} EmberAfEphemeralData;
+// Void typedef for EmberAfEphemeralData which is empty.
+// this will result in all the references to the data being as uint8_t*
+typedef uint8_t EmberAfEphemeralData;
 
 // Struct for EventConfigurationPayload
 typedef struct _EventConfigurationPayload
@@ -176,15 +175,14 @@ typedef struct _IasAceZoneStatusResult
     uint16_t zoneStatus;
 } EmberAfIasAceZoneStatusResult;
 
-// Struct for Identity
-typedef struct _Identity
-{
-} EmberAfIdentity;
+// Void typedef for EmberAfIdentity which is empty.
+// this will result in all the references to the data being as uint8_t*
+typedef uint8_t EmberAfIdentity;
 
 // Struct for NeighborInfo
 typedef struct _NeighborInfo
 {
-    uint8_t * neighbor;
+    uint64_t neighbor;
     int16_t x;
     int16_t y;
     int16_t z;
@@ -333,15 +331,13 @@ typedef struct _SeasonEntry
     uint8_t weekIdRef;
 } EmberAfSeasonEntry;
 
-// Struct for Signature
-typedef struct _Signature
-{
-} EmberAfSignature;
+// Void typedef for EmberAfSignature which is empty.
+// this will result in all the references to the data being as uint8_t*
+typedef uint8_t EmberAfSignature;
 
-// Struct for Smac
-typedef struct _Smac
-{
-} EmberAfSmac;
+// Void typedef for EmberAfSmac which is empty.
+// this will result in all the references to the data being as uint8_t*
+typedef uint8_t EmberAfSmac;
 
 // Struct for SnapshotResponsePayload
 typedef struct _SnapshotResponsePayload

--- a/examples/temperature-measurement-app/esp32/main/gen/af-structs.h
+++ b/examples/temperature-measurement-app/esp32/main/gen/af-structs.h
@@ -87,7 +87,7 @@ typedef struct _DebtPayload
 // Struct for DeviceInformationRecord
 typedef struct _DeviceInformationRecord
 {
-    uint8_t * ieeeAddress;
+    uint64_t ieeeAddress;
     chip::EndpointId endpointId;
     uint16_t profileId;
     uint16_t deviceId;
@@ -113,10 +113,9 @@ typedef struct _EndpointInformationRecord
     uint8_t version;
 } EmberAfEndpointInformationRecord;
 
-// Struct for EphemeralData
-typedef struct _EphemeralData
-{
-} EmberAfEphemeralData;
+// Void typedef for EmberAfEphemeralData which is empty.
+// this will result in all the references to the data being as uint8_t*
+typedef uint8_t EmberAfEphemeralData;
 
 // Struct for EventConfigurationPayload
 typedef struct _EventConfigurationPayload
@@ -176,15 +175,14 @@ typedef struct _IasAceZoneStatusResult
     uint16_t zoneStatus;
 } EmberAfIasAceZoneStatusResult;
 
-// Struct for Identity
-typedef struct _Identity
-{
-} EmberAfIdentity;
+// Void typedef for EmberAfIdentity which is empty.
+// this will result in all the references to the data being as uint8_t*
+typedef uint8_t EmberAfIdentity;
 
 // Struct for NeighborInfo
 typedef struct _NeighborInfo
 {
-    uint8_t * neighbor;
+    uint64_t neighbor;
     int16_t x;
     int16_t y;
     int16_t z;
@@ -333,15 +331,13 @@ typedef struct _SeasonEntry
     uint8_t weekIdRef;
 } EmberAfSeasonEntry;
 
-// Struct for Signature
-typedef struct _Signature
-{
-} EmberAfSignature;
+// Void typedef for EmberAfSignature which is empty.
+// this will result in all the references to the data being as uint8_t*
+typedef uint8_t EmberAfSignature;
 
-// Struct for Smac
-typedef struct _Smac
-{
-} EmberAfSmac;
+// Void typedef for EmberAfSmac which is empty.
+// this will result in all the references to the data being as uint8_t*
+typedef uint8_t EmberAfSmac;
 
 // Struct for SnapshotResponsePayload
 typedef struct _SnapshotResponsePayload

--- a/examples/temperature-measurement-app/esp32/main/gen/call-command-handler.cpp
+++ b/examples/temperature-measurement-app/esp32/main/gen/call-command-handler.cpp
@@ -72,7 +72,8 @@ EmberAfStatus emberAfClusterSpecificCommandParse(EmberAfClusterCommand * cmd)
             result = emberAfBasicClusterServerCommandParse(cmd);
             break;
         case ZCL_TEMP_MEASUREMENT_CLUSTER_ID:
-            result = emberAfTemperatureMeasurementClusterServerCommandParse(cmd);
+            // No commands are enabled for cluster Temperature Measurement
+            result = status(false, true, cmd->mfgSpecific);
             break;
         default:
             // Unrecognized cluster ID, error status will apply.
@@ -96,22 +97,6 @@ EmberAfStatus emberAfBasicClusterServerCommandParse(EmberAfClusterCommand * cmd)
             wasHandled = emberAfBasicClusterResetToFactoryDefaultsCallback();
             break;
         }
-        default: {
-            // Unrecognized command ID, error status will apply.
-            break;
-        }
-        }
-    }
-    return status(wasHandled, true, cmd->mfgSpecific);
-}
-EmberAfStatus emberAfTemperatureMeasurementClusterServerCommandParse(EmberAfClusterCommand * cmd)
-{
-    bool wasHandled = false;
-
-    if (!cmd->mfgSpecific)
-    {
-        switch (cmd->commandId)
-        {
         default: {
             // Unrecognized command ID, error status will apply.
             break;

--- a/src/app/zap-templates/helper-chip.js
+++ b/src/app/zap-templates/helper-chip.js
@@ -205,8 +205,8 @@ function asChipUnderlyingType(label, type)
   } else if (zclHelper.isStrEqual(label, "commandId")) {
     return 'chip::CommandId'
   } else {
-    // Might want to use asUnderlyingZclType instead. TBD
-    return cHelper.asUnderlyingType.call(this, type)
+    const options = { 'hash' : {} };
+    return zclHelper.asUnderlyingZclType.call(this, type, options)
   }
 }
 


### PR DESCRIPTION
 #### Problem

The examples `gen/` folders has not been synced when #4006 has landed. It makes it harder to work on `zap-templates` since there are some unrelated changes.

Also this PR has updated `src/app/zap-templates/helper-chip.js` to use `{{asUnderlyingZclType}}` instead of `{{asUnderlyingType}}` into the js helper since this is what `af-structs.zapt` has started to use before #4006 lands. I assume this is a merge issue.

 #### Summary of Changes
* Sync the `gen/` folder with ZAP templates
* Update `helper-chip.js` to use the correct function