### PR TITLE
Fix build: references to bufbound replaced with bufferwriter

### DIFF
--- a/src/lib/mdns/minimal/Parser.cpp
+++ b/src/lib/mdns/minimal/Parser.cpp
@@ -66,7 +66,7 @@ bool QueryData::Parse(const BytesRange & validData, const uint8_t ** start)
     return true;
 }
 
-bool QueryData::Append(HeaderRef & hdr, chip::BufBound & out) const
+bool QueryData::Append(HeaderRef & hdr, chip::Encoding::BigEndian::BufferWriter & out) const
 {
     if ((hdr.GetAdditionalCount() != 0) || (hdr.GetAnswerCount() != 0) || (hdr.GetAuthorityCount() != 0))
     {
@@ -74,8 +74,8 @@ bool QueryData::Append(HeaderRef & hdr, chip::BufBound & out) const
     }
 
     GetName().Put(out);
-    out.PutBE16(static_cast<uint16_t>(mType));
-    out.PutBE16(static_cast<uint16_t>(mClass) | (mAnswerViaUnicast ? kQClassUnicastAnswerFlag : 0));
+    out.Put16(static_cast<uint16_t>(mType));
+    out.Put16(static_cast<uint16_t>(mClass) | (mAnswerViaUnicast ? kQClassUnicastAnswerFlag : 0));
 
     if (out.Fit())
     {

--- a/src/lib/mdns/minimal/Parser.h
+++ b/src/lib/mdns/minimal/Parser.h
@@ -49,7 +49,7 @@ public:
     bool Parse(const BytesRange & validData, const uint8_t ** start);
 
     /// Write out this query data back into an output buffer.
-    bool Append(HeaderRef & hdr, chip::BufBound & out) const;
+    bool Append(HeaderRef & hdr, chip::Encoding::BigEndian::BufferWriter & out) const;
 
 private:
     QType mType            = QType::ANY;

--- a/src/lib/mdns/minimal/ResponseBuilder.h
+++ b/src/lib/mdns/minimal/ResponseBuilder.h
@@ -97,7 +97,7 @@ public:
             return *this;
         }
 
-        chip::BufBound out(mPacket->Start() + mPacket->DataLength(), mPacket->AvailableDataLength());
+        chip::Encoding::BigEndian::BufferWriter out(mPacket->Start() + mPacket->DataLength(), mPacket->AvailableDataLength());
 
         if (!query.Append(mHeader, out))
         {

--- a/src/lib/mdns/minimal/core/QName.h
+++ b/src/lib/mdns/minimal/core/QName.h
@@ -108,7 +108,7 @@ public:
     bool operator==(const FullQName & other) const;
     bool operator!=(const FullQName & other) const { return !(*this == other); }
 
-    void Put(chip::BufBound & out) const
+    void Put(chip::Encoding::BigEndian::BufferWriter & out) const
     {
         SerializedQNameIterator copy = *this;
         while (copy.Next())


### PR DESCRIPTION
 #### Problem
Merge conflicts broke the build

 #### Summary of Changes
 Fix the build (use Encoding::BigEndian::BufferWriter instead of BufBound in min mdns)