### PR TITLE
Purge some unused PacketBuffer declarations.

### DIFF
--- a/src/ble/BleLayer.h
+++ b/src/ble/BleLayer.h
@@ -66,8 +66,6 @@
 namespace chip {
 namespace Ble {
 
-using ::chip::System::PacketBuffer;
-
 /**
  *  @def NUM_SUPPORTED_PROTOCOL_VERSIONS
  *

--- a/src/ble/BlePlatformDelegate.h
+++ b/src/ble/BlePlatformDelegate.h
@@ -34,7 +34,6 @@
 namespace chip {
 namespace Ble {
 
-using ::chip::System::PacketBuffer;
 using ::chip::System::PacketBufferHandle;
 
 // Platform-agnostic BLE interface

--- a/src/controller/java/AndroidBlePlatformDelegate.cpp
+++ b/src/controller/java/AndroidBlePlatformDelegate.cpp
@@ -25,7 +25,6 @@
 #include <stddef.h>
 
 using namespace chip::Ble;
-using chip::System::PacketBuffer;
 
 AndroidBlePlatformDelegate::AndroidBlePlatformDelegate() :
     SendWriteRequestCb(NULL), SubscribeCharacteristicCb(NULL), UnsubscribeCharacteristicCb(NULL), CloseConnectionCb(NULL),

--- a/src/platform/Darwin/BlePlatformDelegateImpl.mm
+++ b/src/platform/Darwin/BlePlatformDelegateImpl.mm
@@ -32,7 +32,7 @@
 
 using namespace ::chip;
 using namespace ::chip::Ble;
-using ::chip::System::PacketBuffer;
+using ::chip::System::PacketBufferHandle;
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/EFR32/CHIPDevicePlatformEvent.h
+++ b/src/platform/EFR32/CHIPDevicePlatformEvent.h
@@ -27,12 +27,6 @@
 #include <platform/CHIPDeviceEvent.h>
 
 namespace chip {
-namespace System {
-class PacketBuffer;
-} // namespace System
-} // namespace chip
-
-namespace chip {
 namespace DeviceLayer {
 
 namespace DeviceEventType {

--- a/src/platform/K32W/CHIPDevicePlatformEvent.h
+++ b/src/platform/K32W/CHIPDevicePlatformEvent.h
@@ -28,12 +28,6 @@
 #include <platform/CHIPDeviceEvent.h>
 
 namespace chip {
-namespace System {
-class PacketBuffer;
-}
-} // namespace chip
-
-namespace chip {
 namespace DeviceLayer {
 
 namespace DeviceEventType {

--- a/src/platform/Linux/CHIPDevicePlatformEvent.h
+++ b/src/platform/Linux/CHIPDevicePlatformEvent.h
@@ -26,12 +26,6 @@
 #include <platform/CHIPDeviceEvent.h>
 
 namespace chip {
-namespace System {
-class PacketBuffer;
-}
-} // namespace chip
-
-namespace chip {
 namespace DeviceLayer {
 
 namespace DeviceEventType {

--- a/src/platform/qpg6100/CHIPDevicePlatformEvent.h
+++ b/src/platform/qpg6100/CHIPDevicePlatformEvent.h
@@ -26,12 +26,6 @@
 #include <platform/CHIPDeviceEvent.h>
 
 namespace chip {
-namespace System {
-class PacketBuffer;
-}
-} // namespace chip
-
-namespace chip {
 namespace DeviceLayer {
 
 namespace DeviceEventType {


### PR DESCRIPTION
#### Problem

Code is being converted to use `PacketBufferHandle`, but some
`PacketBuffer` declarations were left behind.

#### Summary of Changes

Delete and/or rename obsolete `using` declarations.

Part of issue #2707 - Figure out a way to express PacketBuffer ownership in the type system
