### PR TITLE
Drop "StartingFrom" from BufferWriter

### DIFF
--- a/src/lib/support/BufferWriter.h
+++ b/src/lib/support/BufferWriter.h
@@ -113,7 +113,6 @@ protected:
     size_t mNeeded;
 
     BufferWriterBase(uint8_t * buf, size_t len) : mBuf(buf), mSize(len), mNeeded(0) {}
-    BufferWriterBase(uint8_t * buf, size_t len, size_t needed) : mBuf(buf), mSize(len), mNeeded(needed) {}
     BufferWriterBase(const BufferWriterBase & other) = default;
     BufferWriterBase & operator=(const BufferWriterBase & other) = default;
 };

--- a/src/lib/support/BufferWriter.h
+++ b/src/lib/support/BufferWriter.h
@@ -137,21 +137,6 @@ public:
         }
         return *this;
     }
-
-    /// Allows treating of a buffer stream to a different endianess.
-    /// If input buffer does not fit, return value will not fit either.
-    template <typename T>
-    static BufferWriter StartingFrom(BufferWriterBase<T> & other)
-    {
-        if (!other.Fit())
-        {
-            return BufferWriter(other.Buffer() + other.Size(), 0, other.Needed() - other.Size());
-        }
-        return BufferWriter(other.Buffer() + other.Needed(), other.Size() - other.Needed());
-    }
-
-private:
-    BufferWriter(uint8_t * buf, size_t len, size_t needed) : BufferWriterBase<BufferWriter>(buf, len, needed) {}
 };
 
 } // namespace LittleEndian
@@ -174,21 +159,6 @@ public:
         }
         return *this;
     }
-
-    /// Allows treating of a buffer stream to a different endianess.
-    /// If input buffer does not fit, return value will not fit either.
-    template <typename T>
-    static BufferWriter StartingFrom(BufferWriterBase<T> & other)
-    {
-        if (!other.Fit())
-        {
-            return BufferWriter(other.Buffer() + other.Size(), 0, other.Needed() - other.Size());
-        }
-        return BufferWriter(other.Buffer() + other.Needed(), other.Size() - other.Needed());
-    }
-
-private:
-    BufferWriter(uint8_t * buf, size_t len, size_t needed) : BufferWriterBase<BufferWriter>(buf, len, needed) {}
 };
 
 } // namespace BigEndian

--- a/src/lib/support/tests/TestBufferWriter.cpp
+++ b/src/lib/support/tests/TestBufferWriter.cpp
@@ -180,55 +180,12 @@ void TestPutBigEndian(nlTestSuite * inSuite, void * inContext)
     }
 }
 
-void TestEndianessSwitch(nlTestSuite * inSuite, void * inContext)
-{
-    BWTest<BigEndian::BufferWriter> bb(6);
-    bb.Put16('i' + 'h' * 256);
-
-    LittleEndian::BufferWriter leWriter = LittleEndian::BufferWriter::StartingFrom(bb);
-    leWriter.Put16('i' + 'h' * 256);
-    bb.Skip(2);
-
-    BigEndian::BufferWriter beWriter = BigEndian::BufferWriter::StartingFrom(leWriter);
-    beWriter.Put16('i' + 'h' * 256);
-    bb.Skip(2);
-
-    NL_TEST_ASSERT(inSuite, bb.expect("hiihhi", 6, 0));
-}
-
-void TestEndianessSwitchFit(nlTestSuite * inSuite, void * inContext)
-{
-    BWTest<BigEndian::BufferWriter> bb(6);
-    bb.Put16(0x1234);
-    bb.Put32(0x12345678);
-
-    NL_TEST_ASSERT(inSuite, bb.Fit());
-
-    bb.Put32(0x1);
-
-    NL_TEST_ASSERT(inSuite, !bb.Fit());
-
-    LittleEndian::BufferWriter leWriter = LittleEndian::BufferWriter::StartingFrom(bb);
-    NL_TEST_ASSERT(inSuite, !leWriter.Fit());
-    NL_TEST_ASSERT(inSuite, leWriter.Size() == 0); // was never able to fit anything to begin with
-    NL_TEST_ASSERT(inSuite, leWriter.Needed() == (bb.Needed() - bb.Size()));
-
-    leWriter.Put16(0x4321);
-    NL_TEST_ASSERT(inSuite, !leWriter.Fit());
-
-    BigEndian::BufferWriter beWriter = BigEndian::BufferWriter::StartingFrom(leWriter);
-    NL_TEST_ASSERT(inSuite, !beWriter.Fit());
-    NL_TEST_ASSERT(inSuite, beWriter.Size() == 0); // was never able to fit anything to begin with
-}
-
 const nlTest sTests[] = {
-    NL_TEST_DEF("TestStringWrite", TestStringWrite),               //
-    NL_TEST_DEF("TestBufferWrite", TestBufferWrite),               //
-    NL_TEST_DEF("TestPutLittleEndian", TestPutLittleEndian),       //
-    NL_TEST_DEF("TestPutBigEndian", TestPutBigEndian),             //
-    NL_TEST_DEF("TestEndianessSwitch", TestEndianessSwitch),       //
-    NL_TEST_DEF("TestEndianessSwitchFit", TestEndianessSwitchFit), //
-    NL_TEST_SENTINEL()                                             //
+    NL_TEST_DEF("TestStringWrite", TestStringWrite),         //
+    NL_TEST_DEF("TestBufferWrite", TestBufferWrite),         //
+    NL_TEST_DEF("TestPutLittleEndian", TestPutLittleEndian), //
+    NL_TEST_DEF("TestPutBigEndian", TestPutBigEndian),       //
+    NL_TEST_SENTINEL()                                       //
 };
 
 } // namespace


### PR DESCRIPTION
 #### Problem
Hard to define Needed() when endianess is switched since several buffers are tracking sizes. 

 #### Summary of Changes
Drop 'StartingFrom' for now. It can be added later if we really need writing different data types and need a simpler way (we can still use normal constructors and 'skip' if really needed for a one-off).
