### PR TITLE
Receive path cleanup for PacketBufferHandle conversion

### DIFF
--- a/src/inet/InetLayer.cpp
+++ b/src/inet/InetLayer.cpp
@@ -1066,12 +1066,10 @@ chip::System::Error InetLayer::HandleInetLayerEvent(chip::System::Object & aTarg
         static_cast<TCPEndPoint &>(aTarget).HandleIncomingConnection(reinterpret_cast<TCPEndPoint *>(aArgument));
         break;
 
-    case kInetEvent_TCPDataReceived: {
-        chip::System::PacketBufferHandle buf;
-        buf.Adopt(reinterpret_cast<chip::System::PacketBuffer *>(aArgument));
-        static_cast<TCPEndPoint &>(aTarget).HandleDataReceived(std::move(buf));
-    }
-    break;
+    case kInetEvent_TCPDataReceived:
+        static_cast<TCPEndPoint &>(aTarget).HandleDataReceived(
+            System::PacketBufferHandle::Create(reinterpret_cast<chip::System::PacketBuffer *>(aArgument)));
+        break;
 
     case kInetEvent_TCPDataSent:
         static_cast<TCPEndPoint &>(aTarget).HandleDataSent(static_cast<uint16_t>(aArgument));
@@ -1083,21 +1081,17 @@ chip::System::Error InetLayer::HandleInetLayerEvent(chip::System::Object & aTarg
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
 #if INET_CONFIG_ENABLE_RAW_ENDPOINT
-    case kInetEvent_RawDataReceived: {
-        chip::System::PacketBufferHandle buf;
-        buf.Adopt(reinterpret_cast<chip::System::PacketBuffer *>(aArgument));
-        static_cast<RawEndPoint &>(aTarget).HandleDataReceived(std::move(buf));
-    }
-    break;
+    case kInetEvent_RawDataReceived:
+        static_cast<RawEndPoint &>(aTarget).HandleDataReceived(
+            System::PacketBufferHandle::Create(reinterpret_cast<chip::System::PacketBuffer *>(aArgument)));
+        break;
 #endif // INET_CONFIG_ENABLE_RAW_ENDPOINT
 
 #if INET_CONFIG_ENABLE_UDP_ENDPOINT
-    case kInetEvent_UDPDataReceived: {
-        chip::System::PacketBufferHandle buf;
-        buf.Adopt(reinterpret_cast<chip::System::PacketBuffer *>(aArgument));
-        static_cast<UDPEndPoint &>(aTarget).HandleDataReceived(std::move(buf));
-    }
-    break;
+    case kInetEvent_UDPDataReceived:
+        static_cast<UDPEndPoint &>(aTarget).HandleDataReceived(
+            System::PacketBufferHandle::Create(reinterpret_cast<chip::System::PacketBuffer *>(aArgument)));
+        break;
 #endif // INET_CONFIG_ENABLE_UDP_ENDPOINT
 
 #if INET_CONFIG_ENABLE_DNS_RESOLVER

--- a/src/platform/EFR32/BLEManagerImpl.cpp
+++ b/src/platform/EFR32/BLEManagerImpl.cpp
@@ -376,12 +376,8 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 
     case DeviceEventType::kCHIPoBLEWriteReceived: {
         ChipLogProgress(DeviceLayer, "_OnPlatformEvent kCHIPoBLEWriteReceived");
-        {
-            System::PacketBufferHandle data_ForNow;
-            data_ForNow.Adopt(event->CHIPoBLEWriteReceived.Data);
-            HandleWriteReceived(event->CHIPoBLEWriteReceived.ConId, &CHIP_BLE_SVC_ID, &ChipUUID_CHIPoBLEChar_RX,
-                                std::move(data_ForNow));
-        }
+        HandleWriteReceived(event->CHIPoBLEWriteReceived.ConId, &CHIP_BLE_SVC_ID, &ChipUUID_CHIPoBLEChar_RX,
+                            PacketBufferHandle::Create(event->CHIPoBLEWriteReceived.Data));
     }
     break;
 

--- a/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
@@ -248,13 +248,10 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
         HandleUnsubscribeReceived(event->CHIPoBLEUnsubscribe.ConId, &CHIP_BLE_SVC_ID, &ChipUUID_CHIPoBLEChar_TX);
         break;
 
-    case DeviceEventType::kCHIPoBLEWriteReceived: {
-        System::PacketBufferHandle data_ForNow;
-        data_ForNow.Adopt(event->CHIPoBLEWriteReceived.Data);
+    case DeviceEventType::kCHIPoBLEWriteReceived:
         HandleWriteReceived(event->CHIPoBLEWriteReceived.ConId, &CHIP_BLE_SVC_ID, &ChipUUID_CHIPoBLEChar_RX,
-                            std::move(data_ForNow));
-    }
-    break;
+                            PacketBufferHandle::Create(event->CHIPoBLEWriteReceived.Data));
+        break;
 
     case DeviceEventType::kCHIPoBLEIndicateConfirm:
         HandleIndicationConfirmation(event->CHIPoBLEIndicateConfirm.ConId, &CHIP_BLE_SVC_ID, &ChipUUID_CHIPoBLEChar_TX);

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -241,13 +241,10 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
         HandleUnsubscribeReceived(event->CHIPoBLEUnsubscribe.ConId, &CHIP_BLE_SVC_ID, &chipUUID_CHIPoBLEChar_TX);
         break;
 
-    case DeviceEventType::kCHIPoBLEWriteReceived: {
-        System::PacketBufferHandle data_ForNow;
-        data_ForNow.Adopt(event->CHIPoBLEWriteReceived.Data);
+    case DeviceEventType::kCHIPoBLEWriteReceived:
         HandleWriteReceived(event->CHIPoBLEWriteReceived.ConId, &CHIP_BLE_SVC_ID, &chipUUID_CHIPoBLEChar_RX,
-                            std::move(data_ForNow));
-    }
-    break;
+                            PacketBufferHandle::Create(event->CHIPoBLEWriteReceived.Data));
+        break;
 
     case DeviceEventType::kCHIPoBLEIndicateConfirm:
         HandleIndicationConfirmation(event->CHIPoBLEIndicateConfirm.ConId, &CHIP_BLE_SVC_ID, &chipUUID_CHIPoBLEChar_TX);

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -214,13 +214,10 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
         HandleUnsubscribeReceived(event->CHIPoBLEUnsubscribe.ConId, &CHIP_BLE_SVC_ID, &ChipUUID_CHIPoBLEChar_TX);
         break;
 
-    case DeviceEventType::kCHIPoBLEWriteReceived: {
-        System::PacketBufferHandle data_ForNow;
-        data_ForNow.Adopt(event->CHIPoBLEWriteReceived.Data);
+    case DeviceEventType::kCHIPoBLEWriteReceived:
         HandleWriteReceived(event->CHIPoBLEWriteReceived.ConId, &CHIP_BLE_SVC_ID, &ChipUUID_CHIPoBLEChar_RX,
-                            std::move(data_ForNow));
-    }
-    break;
+                            PacketBufferHandle::Create(event->CHIPoBLEWriteReceived.Data));
+        break;
 
     case DeviceEventType::kCHIPoBLEIndicateConfirm:
         HandleIndicationConfirmation(event->CHIPoBLEIndicateConfirm.ConId, &CHIP_BLE_SVC_ID, &ChipUUID_CHIPoBLEChar_TX);

--- a/src/platform/Zephyr/GenericBLEManagerImpl_Zephyr.cpp
+++ b/src/platform/Zephyr/GenericBLEManagerImpl_Zephyr.cpp
@@ -480,9 +480,8 @@ CHIP_ERROR GenericBLEManagerImpl_Zephyr<ImplClass>::HandleRXCharWrite(const Chip
     ChipLogDetail(DeviceLayer, "Write request received for CHIPoBLE RX characteristic (ConnId 0x%02" PRIx16 ")",
                   bt_conn_index(c1WriteEvent->BtConn));
 
-    PacketBufferHandle data_ForNow;
-    data_ForNow.Adopt(c1WriteEvent->Data);
-    HandleWriteReceived(c1WriteEvent->BtConn, &CHIP_BLE_SVC_ID, &chipUUID_CHIPoBLEChar_RX, std::move(data_ForNow));
+    HandleWriteReceived(c1WriteEvent->BtConn, &CHIP_BLE_SVC_ID, &chipUUID_CHIPoBLEChar_RX,
+                        PacketBufferHandle::Create(c1WriteEvent->Data));
     bt_conn_unref(c1WriteEvent->BtConn);
 
     return CHIP_NO_ERROR;


### PR DESCRIPTION
#### Problem

Code should use `PacketBufferHandle` rather than `PacketBuffer *`.

#### Summary of Changes

Simplify by using `Create` factory instead of declare-adopt-move.

Part of issue #2707 - Figure out a way to express PacketBuffer ownership in the type system
