### PR TITLE
Convert PacketBuffer::Next() to return a PacketBufferHandle

### DIFF
--- a/src/inet/TCPEndPoint.cpp
+++ b/src/inet/TCPEndPoint.cpp
@@ -1239,7 +1239,7 @@ INET_ERROR TCPEndPoint::DriveSending()
                 unsentOffset = static_cast<uint16_t>(unsentOffset + sendLen);
                 if (unsentOffset == bufDataLen)
                 {
-                    currentUnsentBuf = currentUnsentBuf->Next();
+                    currentUnsentBuf = currentUnsentBuf->Next_ForNow();
                     unsentOffset     = 0;
                 }
 
@@ -1790,7 +1790,7 @@ TCPEndPoint::BufferOffset TCPEndPoint::FindStartOfUnsent()
         {
             // We have more to skip than current packet buffer size.
             // Follow the chain to continue.
-            currentUnsentBuf = currentUnsentBuf->Next();
+            currentUnsentBuf = currentUnsentBuf->Next_ForNow();
             leftToSkip       = static_cast<uint16_t>(leftToSkip - bufDataLen);
         }
         else
@@ -2417,7 +2417,7 @@ void TCPEndPoint::ReceiveData()
     else
     {
         rcvBuf = mRcvQueue.Get_ForNow();
-        for (PacketBuffer * nextBuf = rcvBuf->Next(); nextBuf != nullptr; rcvBuf = nextBuf, nextBuf = nextBuf->Next())
+        for (PacketBuffer * nextBuf = rcvBuf->Next_ForNow(); nextBuf != nullptr; rcvBuf = nextBuf, nextBuf = nextBuf->Next_ForNow())
             ;
 
         if (rcvBuf->AvailableDataLength() == 0)

--- a/src/inet/tests/TestInetLayerCommon.cpp
+++ b/src/inet/tests/TestInetLayerCommon.cpp
@@ -256,7 +256,7 @@ static bool HandleDataReceived(const PacketBufferHandle & aBuffer, TransferStats
     // Walk through each buffer in the packet chain, checking the
     // buffer for the expected pattern, if requested.
 
-    for (const PacketBuffer * lBuffer = aBuffer.Get_ForNow(); lBuffer != nullptr; lBuffer = lBuffer->Next())
+    for (PacketBufferHandle lBuffer = aBuffer.Retain(); !lBuffer.IsNull(); lBuffer.Advance())
     {
         const uint16_t lDataLength = lBuffer->DataLength();
 

--- a/src/lib/core/CHIPTLVReader.cpp
+++ b/src/lib/core/CHIPTLVReader.cpp
@@ -1558,7 +1558,7 @@ CHIP_ERROR TLVReader::GetNextPacketBuffer(TLVReader & reader, uintptr_t & bufHan
     PacketBuffer *& buf = reinterpret_cast<PacketBuffer *&>(bufHandle);
 
     if (buf != nullptr)
-        buf = buf->Next();
+        buf = buf->Next_ForNow();
     if (buf != nullptr)
     {
         bufStart = buf->Start();

--- a/src/lib/core/CHIPTLVWriter.cpp
+++ b/src/lib/core/CHIPTLVWriter.cpp
@@ -1848,12 +1848,15 @@ CHIP_ERROR TLVWriter::GetNewPacketBuffer(TLVWriter & writer, uintptr_t & bufHand
 {
     PacketBuffer * buf = reinterpret_cast<PacketBuffer *>(bufHandle);
 
-    PacketBuffer * newBuf = buf->Next();
+    PacketBuffer * newBuf = buf->Next_ForNow();
     if (newBuf == nullptr)
     {
-        newBuf = PacketBuffer::New(0).Release_ForNow();
-        if (newBuf != nullptr)
-            buf->AddToEnd_ForNow(newBuf);
+        System::PacketBufferHandle newBufHandle = PacketBuffer::New(0);
+        if (!newBufHandle.IsNull())
+        {
+            newBuf = newBufHandle.Get_ForNow();
+            buf->AddToEnd(std::move(newBufHandle));
+        }
     }
 
     if (newBuf != nullptr)

--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -264,7 +264,7 @@ void TestBufferContents(nlTestSuite * inSuite, PacketBuffer * buf, const uint8_t
         expectedVal += len;
         expectedLen -= len;
 
-        buf = buf->Next();
+        buf = buf->Next_ForNow();
     }
 
     NL_TEST_ASSERT(inSuite, expectedLen == 0);

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -586,15 +586,15 @@ public:
         return buffer;
     }
 
-    void Advance()
-    {
-        PacketBuffer * next = mBuffer->Next_ForNow();
-        if (next != nullptr)
-        {
-            next->AddRef();
-        }
-        Adopt(next);
-    }
+    /**
+     * Advance this PacketBufferHandle to the next buffer in a chain.
+     *
+     *  @note This differs from `FreeHead()` in that it does not touch any content in the currently referenced packet buffer;
+     *      it only changes which buffer this handle owns. (Note that this could result in the previous buffer being freed,
+     *      if there is no other.) `Advance()` is designed to be used with an addition handle to traverse a buffer chain,
+     *      whereas `FreeHead()` modifies a chain.
+     */
+    void Advance() { *this = Hold(mBuffer->Next_ForNow()); }
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     /**
@@ -649,7 +649,7 @@ inline PacketBufferHandle PacketBuffer::Next()
 inline PacketBufferHandle PacketBuffer::Last()
 {
     PacketBuffer * p = this;
-    while (p->next != nullptr)
+    while (p->Next_ForNow() != nullptr)
         p = p->Next_ForNow();
     return PacketBufferHandle::Hold(p);
 }

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -1023,7 +1023,7 @@ void PacketBufferTest::CheckNext(nlTestSuite * inSuite, void * inContext)
             {
                 theFirstContext->buf->next = theSecondContext->buf;
 
-                NL_TEST_ASSERT(inSuite, buffer_1->Next() == buffer_2);
+                NL_TEST_ASSERT(inSuite, buffer_1->Next_ForNow() == buffer_2);
             }
             else
             {


### PR DESCRIPTION
#### Problem

Code should use `PacketBufferHandle` rather than `PacketBuffer *`.
`Next()` returned a raw pointer.

#### Summary of Changes

- Return PacketBufferHandle from Next().
- Added PacketBuffer::Last() and PacketBufferHandle::Advance() to
  streamline particular cases.
- Retain Next_ForNow() for a new cases remaining to be converted
  (particularly testing and TLV).

Part of issue #2707 - Figure out a way to express PacketBuffer ownership in the type system
