### PR TITLE
[exchange] Add echo test to validate exchange manager in Cirque

### DIFF
--- a/examples/chip-tool/Dockerfile
+++ b/examples/chip-tool/Dockerfile
@@ -16,7 +16,7 @@
 #
 
 from chip-cirque-device-base
-RUN apt-get update && apt-get install -y libglib2.0 avahi-daemon libavahi-client3 && rm -rf /var/lib/apt/lists/*
+
 COPY out/debug/chip-tool /usr/bin/
 COPY entrypoint.sh /
 

--- a/examples/lighting-app/linux/Dockerfile
+++ b/examples/lighting-app/linux/Dockerfile
@@ -16,7 +16,7 @@
 #
 
 from chip-cirque-device-base
-RUN apt-get update && apt-get install -y libglib2.0 avahi-daemon libavahi-client3 && rm -rf /var/lib/apt/lists/*
+
 COPY out/debug/chip-tool-server /usr/bin/
 COPY entrypoint.sh /
 

--- a/integrations/docker/images/chip-cirque-device-base/Dockerfile
+++ b/integrations/docker/images/chip-cirque-device-base/Dockerfile
@@ -15,6 +15,7 @@ WORKDIR /app
 
 RUN apt-get update \
   && apt-get install --no-install-recommends -y sudo git ca-certificates psmisc dhcpcd5 wpasupplicant wireless-tools \
+  && apt-get install -y libglib2.0 avahi-daemon libavahi-client3 \
   && ln -fs /usr/share/zoneinfo/UTC /etc/localtime \
   && git clone https://github.com/openthread/ot-br-posix . \
   && git checkout $OT_BR_POSIX_CHECKOUT \

--- a/scripts/tests/cirque_tests.sh
+++ b/scripts/tests/cirque_tests.sh
@@ -25,6 +25,7 @@ LOG_DIR=${LOG_DIR:-$(mktemp -d)}
 
 # Append test name here to add more tests for run_all_tests
 CIRQUE_TESTS=(
+    "EchoTest"
     "OnOffClusterTest"
 )
 

--- a/src/messaging/tests/echo/Dockerfile.requester
+++ b/src/messaging/tests/echo/Dockerfile.requester
@@ -1,5 +1,5 @@
 from chip-cirque-device-base
-RUN apt-get update && apt-get install -y libglib2.0 avahi-daemon libavahi-client3
+
 COPY out/chip-echo-requester /usr/bin/
 COPY entrypoint.sh /
 

--- a/src/messaging/tests/echo/Dockerfile.requester
+++ b/src/messaging/tests/echo/Dockerfile.requester
@@ -1,0 +1,6 @@
+from chip-cirque-device-base
+RUN apt-get update && apt-get install -y libglib2.0 avahi-daemon libavahi-client3
+COPY out/chip-echo-requester /usr/bin/
+COPY entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh", "requester"]

--- a/src/messaging/tests/echo/Dockerfile.responder
+++ b/src/messaging/tests/echo/Dockerfile.responder
@@ -1,5 +1,5 @@
 from chip-cirque-device-base
-RUN apt-get update && apt-get install -y libglib2.0 avahi-daemon libavahi-client3
+
 COPY out/chip-echo-responder /usr/bin/
 COPY entrypoint.sh /
 

--- a/src/messaging/tests/echo/Dockerfile.responder
+++ b/src/messaging/tests/echo/Dockerfile.responder
@@ -1,0 +1,6 @@
+from chip-cirque-device-base
+RUN apt-get update && apt-get install -y libglib2.0 avahi-daemon libavahi-client3
+COPY out/chip-echo-responder /usr/bin/
+COPY entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh", "responder"]

--- a/src/messaging/tests/echo/entrypoint.sh
+++ b/src/messaging/tests/echo/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+service dbus start
+sleep 1
+service avahi-daemon start
+/usr/sbin/otbr-agent -I wpan0 spinel+hdlc+uart:///dev/ttyUSB0 &
+sleep 1
+ot-ctl panid 0x1234
+ot-ctl ifconfig up
+ot-ctl thread start
+
+if [ "$1" = "responder" ]; then
+    chip-echo-responder
+else
+    sleep infinity
+fi

--- a/src/test_driver/linux-cirque/EchoTest.sh
+++ b/src/test_driver/linux-cirque/EchoTest.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e
+
+SOURCE="${BASH_SOURCE[0]}"
+SOURCE_DIR="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
+REPO_DIR="$SOURCE_DIR/../../../"
+
+echo_source=$REPO_DIR/src/messaging/tests/echo
+
+function build_image() {
+    # These files should be successfully compiled elsewhere.
+    source "$REPO_DIR/scripts/activate.sh" >/dev/null
+    set -x
+    cd "$echo_source"
+    gn gen out >/dev/null
+    run_ninja -C out
+    docker build -t chip_echo_requester -f Dockerfile.requester . 2>&1
+    docker build -t chip_echo_responder -f Dockerfile.responder . 2>&1
+}
+
+function main() {
+    pushd .
+    build_image
+    popd
+    python3 "$SOURCE_DIR/test-echo.py"
+}
+
+source "$SOURCE_DIR"/shell-helpers.sh
+main

--- a/src/test_driver/linux-cirque/test-echo.py
+++ b/src/test_driver/linux-cirque/test-echo.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Copyright (c) 2020 Project CHIP Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import logging
+import os
+import time
+import sys
+
+from helper.CHIPTestBase import CHIPVirtualHome
+
+logger = logging.getLogger('CHIPEchoTest')
+logger.setLevel(logging.INFO)
+
+sh = logging.StreamHandler()
+sh.setFormatter(
+    logging.Formatter(
+        '%(asctime)s [%(name)s] %(levelname)s %(message)s'))
+logger.addHandler(sh)
+
+DEVICE_CONFIG = {
+    'device0': {
+        'type': 'CHIP-Echo-Requester',
+        'base_image': 'chip_echo_requester',
+        'capability': ['Thread', 'Interactive'],
+        'rcp_mode': True,
+    },
+    'device1': {
+        'type': 'CHIP-Echo-Responder',
+        'base_image': 'chip_echo_responder',
+        'capability': ['Thread', 'Interactive'],
+        'rcp_mode': True,
+    }
+}
+
+CHIP_PORT = 11097
+
+CIRQUE_URL = "http://localhost:5000"
+
+
+class TestEcho(CHIPVirtualHome):
+    def __init__(self, device_config):
+        super().__init__(CIRQUE_URL, device_config)
+        self.logger = logger
+
+    def setup(self):
+        self.initialize_home()
+        self.connect_to_thread_network()
+
+    def test_routine(self):
+        self.run_data_model_test()
+
+    def run_data_model_test(self):
+        resp_ips = [device['description']['ipv4_addr'] for device in self.non_ap_devices
+                    if device['type'] == 'CHIP-Echo-Responder']
+        req_ids = [device['id'] for device in self.non_ap_devices
+                   if device['type'] == 'CHIP-Echo-Requester']
+
+        req_device_id = req_ids[0]
+
+        command = "chip-echo-requester {}"
+
+        for ip in resp_ips:
+            ret = self.execute_device_cmd(
+                req_device_id, command.format(ip))
+            self.assertEqual(
+                ret['return_code'], '0', "{} failure: {}".format("Echo", ret['output']))
+
+
+if __name__ == "__main__":
+    sys.exit(TestEcho(DEVICE_CONFIG).run_test())


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
We don't have e2e validation for exchange manager.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
1. Add echo test to validate exchange manager in Cirque
2. Extract common packaged used in device images to the base image.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #3757
