### PR TITLE
Fix Mac build breakage from incorrect formats for node ids

### DIFF
--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -99,7 +99,7 @@ CHIP_ERROR SendEchoRequest(void)
 
     gLastEchoTime = chip::System::Timer::GetCurrentEpoch();
 
-    printf("\nSend echo request message to Node: %lu\n", chip::kTestDeviceNodeId);
+    printf("\nSend echo request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
 
     err = gEchoClient.SendEchoRequest(chip::kTestDeviceNodeId, std::move(payloadBuf));
 
@@ -151,8 +151,9 @@ void HandleEchoResponseReceived(chip::NodeId nodeId, chip::System::PacketBufferH
     gWaitingForEchoResp = false;
     gEchoRespCount++;
 
-    printf("Echo Response from node %lu : %" PRIu64 "/%" PRIu64 "(%.2f%%) len=%u time=%.3fms\n", nodeId, gEchoRespCount, gEchoCount,
-           static_cast<double>(gEchoRespCount) * 100 / gEchoCount, payload->DataLength(), static_cast<double>(transitTime) / 1000);
+    printf("Echo Response from node %" PRIu64 ": %" PRIu64 "/%" PRIu64 "(%.2f%%) len=%u time=%.3fms\n", nodeId, gEchoRespCount,
+           gEchoCount, static_cast<double>(gEchoRespCount) * 100 / gEchoCount, payload->DataLength(),
+           static_cast<double>(transitTime) / 1000);
 }
 
 } // namespace

--- a/src/messaging/tests/echo/echo_responder.cpp
+++ b/src/messaging/tests/echo/echo_responder.cpp
@@ -49,7 +49,7 @@ chip::SecurePairingUsingTestSecret gTestPairing;
 // Callback handler when a CHIP EchoRequest is received.
 void HandleEchoRequestReceived(chip::NodeId nodeId, chip::System::PacketBufferHandle payload)
 {
-    printf("Echo Request from node %lu, len=%u ... sending response.\n", nodeId, payload->DataLength());
+    printf("Echo Request from node %" PRIu64 ", len=%u ... sending response.\n", nodeId, payload->DataLength());
 }
 
 } // namespace


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
https://github.com/project-chip/connectedhomeip/pull/3836 introduced code that uses `%lu` to print node ids, which does not compile if `long` is 32 bits.  This breaks at least some Mac builds, as far as I can tell.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Use `PRIu64` as needed.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
