### PR TITLE
Use enum class for message types and status codes for secure channel.

### DIFF
--- a/src/protocols/secure_channel/SecureChannelProtocol.h
+++ b/src/protocols/secure_channel/SecureChannelProtocol.h
@@ -42,35 +42,35 @@ namespace SecureChannel {
 /**
  * SecureChannel Protocol Message Types
  */
-enum
+enum class MsgType
 {
     // Message Counter Synchronization Protocol Message Types
-    kMsgType_MsgCounterSyncReq = 0x00,
-    kMsgType_MsgCounterSyncRsp = 0x01,
+    MsgCounterSyncReq = 0x00,
+    MsgCounterSyncRsp = 0x01,
 
     // Reliable Messaging Protocol Message Types
-    kMsgType_StandaloneAck = 0x10,
+    StandaloneAck = 0x10,
 
     // Password-based session establishment Message Types
-    kMsgType_PASE_Spake2pA = 0x20,
-    kMsgType_PASE_Spake2pB = 0x21,
-    kMsgType_PASE_Spake2cA = 0x22,
+    PASE_Spake2pA = 0x20,
+    PASE_Spake2pB = 0x21,
+    PASE_Spake2cA = 0x22,
 
     // Certificate-based session establishment Message Types
-    kMsgType_CASE_SigmaR1  = 0x30,
-    kMsgType_CASE_SigmaR2  = 0x31,
-    kMsgType_CASE_SigmaR3  = 0x32,
-    kMsgType_CASE_SigmaErr = 0x3F,
+    CASE_SigmaR1  = 0x30,
+    CASE_SigmaR2  = 0x31,
+    CASE_SigmaR3  = 0x32,
+    CASE_SigmaErr = 0x3F,
 };
 
 /**
  * SecureChannel Protocol Status Codes
  */
-enum
+enum class StatusCode
 {
-    kStatusCode_AlreadyMemberOfFabric = 1, /**< The recipient is already a member of a fabric. */
-    kStatusCode_NotMemberOfFabric     = 2, /**< The recipient is not a member of a fabric. */
-    kStatusCode_InvalidFabricConfig   = 3  /**< The specified fabric configuration was invalid. */
+    AlreadyMemberOfFabric = 1, /**< The recipient is already a member of a fabric. */
+    NotMemberOfFabric     = 2, /**< The recipient is not a member of a fabric. */
+    InvalidFabricConfig   = 3  /**< The specified fabric configuration was invalid. */
 };
 
 } // namespace SecureChannel


### PR DESCRIPTION
This should give us better type-safety.

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Secure channel message types and status codes are C-style enums, which gives worse type-safety properties than C++ enum classes.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Use enum classes instead.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
