### PR TITLE
Use the latest Docker images in the workflows

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -34,7 +34,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build-android:0.4.16
+            image: connectedhomeip/chip-build-android:0.4.18
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/.github/workflows/bloat_check.yaml
+++ b/.github/workflows/bloat_check.yaml
@@ -24,7 +24,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build:0.4.16
+            image: connectedhomeip/chip-build:0.4.18
 
         steps:
             - name: Checkout

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build:0.4.16
+            image: connectedhomeip/chip-build:0.4.18
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
             options:

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -29,7 +29,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build-efr32:0.4.16
+            image: connectedhomeip/chip-build-efr32:0.4.18
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
                 - "/tmp/output_binaries:/tmp/output_binaries"

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -29,7 +29,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build-esp32:0.4.16
+            image: connectedhomeip/chip-build-esp32:0.4.18
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
                 - "/tmp/output_binaries:/tmp/output_binaries"

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -31,7 +31,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build:0.4.16
+            image: connectedhomeip/chip-build:0.4.18
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
                 - "/tmp/output_binaries:/tmp/output_binaries"

--- a/.github/workflows/examples-qpg6100.yaml
+++ b/.github/workflows/examples-qpg6100.yaml
@@ -27,7 +27,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build:0.4.16
+            image: connectedhomeip/chip-build:0.4.18
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
                 - "/tmp/output_binaries:/tmp/output_binaries"

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -28,7 +28,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build-esp32-qemu:0.4.16
+            image: connectedhomeip/chip-build-esp32-qemu:0.4.18
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/.github/workflows/unit_integration_test.yaml
+++ b/.github/workflows/unit_integration_test.yaml
@@ -34,7 +34,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-          image: connectedhomeip/chip-build:0.4.16
+          image: connectedhomeip/chip-build:0.4.18
           volumes:
               - "/tmp/log_output:/tmp/test_logs"
               - "/tmp/happy_test_logs:/tmp/happy_test_logs"

--- a/src/test_driver/happy/README.md
+++ b/src/test_driver/happy/README.md
@@ -18,7 +18,7 @@
               --entrypoint /bin/bash \
               --sysctl "net.ipv6.conf.all.disable_ipv6=0 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1" \
               -it --mount type=bind,source=`pwd`,target=`pwd` \
-              connectedhomeip/chip-build:0.4.16
+              connectedhomeip/chip-build:0.4.18
 
     Mount your checkout to the same path as your local path avoids errors during
     bootstrap.


### PR DESCRIPTION
 #### Problem
Github workflows don't use the latest Docker images (0.4.16 vs 0.4.18).

 #### Summary of Changes
Update the workflows.