### PR TITLE
Load default configuration for the reporting plugin

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/gen_config.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/gen_config.h
@@ -158,5 +158,5 @@
 // Use this macro to check if Reporting plugin is included
 #define EMBER_AF_PLUGIN_REPORTING
 // User options for plugin Reporting
-#define EMBER_AF_PLUGIN_REPORTING_TABLE_SIZE 5
+#define EMBER_AF_PLUGIN_REPORTING_TABLE_SIZE 20
 #define EMBER_AF_PLUGIN_REPORTING_ENABLE_GROUP_BOUND_REPORTS

--- a/examples/common/chip-app-server/DataModelHandler.cpp
+++ b/examples/common/chip-app-server/DataModelHandler.cpp
@@ -30,6 +30,10 @@
 #include <support/logging/CHIPLogging.h>
 #include <system/SystemPacketBuffer.h>
 
+#ifdef EMBER_AF_GENERATED_PLUGIN_STACK_STATUS_FUNCTION_DECLARATIONS
+EMBER_AF_GENERATED_PLUGIN_STACK_STATUS_FUNCTION_DECLARATIONS
+#endif
+
 using namespace ::chip;
 
 /**
@@ -198,4 +202,9 @@ void InitDataModelHandler()
 {
     emberAfEndpointConfigure();
     emberAfInit();
+
+#ifdef EMBER_AF_GENERATED_PLUGIN_STACK_STATUS_FUNCTION_CALLS
+    EmberStatus status = EMBER_NETWORK_UP;
+    EMBER_AF_GENERATED_PLUGIN_STACK_STATUS_FUNCTION_CALLS
+#endif
 }

--- a/examples/lighting-app/lighting-common/gen/endpoint_config.h
+++ b/examples/lighting-app/lighting-common/gen/endpoint_config.h
@@ -139,11 +139,6 @@
         0                                                                                                                          \
     }
 
-#define EMBER_AF_GENERATED_PLUGIN_STACK_STATUS_FUNCTION_DECLARATIONS                                                               \
-    void emberAfPluginNetworkSteeringStackStatusCallback(EmberStatus status);
-
-#define EMBER_AF_GENERATED_PLUGIN_STACK_STATUS_FUNCTION_CALLS emberAfPluginNetworkSteeringStackStatusCallback(status);
-
 // Generated data for the command discovery
 #define GENERATED_COMMANDS                                                                                                         \
     {                                                                                                                              \

--- a/examples/lighting-app/lighting-common/gen/gen_config.h
+++ b/examples/lighting-app/lighting-common/gen/gen_config.h
@@ -51,5 +51,5 @@
 // Use this macro to check if Reporting plugin is included
 #define EMBER_AF_PLUGIN_REPORTING
 // User options for plugin Reporting
-#define EMBER_AF_PLUGIN_REPORTING_TABLE_SIZE 5
+#define EMBER_AF_PLUGIN_REPORTING_TABLE_SIZE 20
 #define EMBER_AF_PLUGIN_REPORTING_ENABLE_GROUP_BOUND_REPORTS

--- a/examples/lock-app/lock-common/gen/endpoint_config.h
+++ b/examples/lock-app/lock-common/gen/endpoint_config.h
@@ -131,11 +131,6 @@
         0                                                                                                                          \
     }
 
-#define EMBER_AF_GENERATED_PLUGIN_STACK_STATUS_FUNCTION_DECLARATIONS                                                               \
-    void emberAfPluginNetworkSteeringStackStatusCallback(EmberStatus status);
-
-#define EMBER_AF_GENERATED_PLUGIN_STACK_STATUS_FUNCTION_CALLS emberAfPluginNetworkSteeringStackStatusCallback(status);
-
 // Generated data for the command discovery
 #define GENERATED_COMMANDS                                                                                                         \
     {                                                                                                                              \

--- a/examples/lock-app/lock-common/gen/gen_config.h
+++ b/examples/lock-app/lock-common/gen/gen_config.h
@@ -41,5 +41,5 @@
 // Use this macro to check if Reporting plugin is included
 #define EMBER_AF_PLUGIN_REPORTING
 // User options for plugin Reporting
-#define EMBER_AF_PLUGIN_REPORTING_TABLE_SIZE 5
+#define EMBER_AF_PLUGIN_REPORTING_TABLE_SIZE 20
 #define EMBER_AF_PLUGIN_REPORTING_ENABLE_GROUP_BOUND_REPORTS

--- a/examples/temperature-measurement-app/esp32/main/gen/gen_config.h
+++ b/examples/temperature-measurement-app/esp32/main/gen/gen_config.h
@@ -47,5 +47,5 @@
 // Use this macro to check if Reporting plugin is included
 #define EMBER_AF_PLUGIN_REPORTING
 // User options for plugin Reporting
-#define EMBER_AF_PLUGIN_REPORTING_TABLE_SIZE 5
+#define EMBER_AF_PLUGIN_REPORTING_TABLE_SIZE 20
 #define EMBER_AF_PLUGIN_REPORTING_ENABLE_GROUP_BOUND_REPORTS

--- a/src/app/clusters/temperature-measurement-server/temperature-measurement-server.cpp
+++ b/src/app/clusters/temperature-measurement-server/temperature-measurement-server.cpp
@@ -52,6 +52,8 @@ EmberEventControl emberAfPluginTemperatureMeasurementServerReadEventControl;
 // https://github.com/project-chip/connectedhomeip/issues/3619
 void emberAfPluginTemperatureMeasurementServerReadEventHandler() {}
 
+void emberAfPluginTemperatureMeasurementServerStackStatusCallback(EmberStatus status) {}
+
 // -------------------------------------------------------------------------
 // ****** callback section *******
 

--- a/src/app/reporting/reporting-default-configuration.cpp
+++ b/src/app/reporting/reporting-default-configuration.cpp
@@ -58,6 +58,8 @@ void emberAfPluginReportingLoadReportingConfigDefaults(void)
 {
 #if (defined EMBER_AF_GENERATED_REPORTING_CONFIG_DEFAULTS_TABLE_SIZE &&                                                            \
      0 != EMBER_AF_GENERATED_REPORTING_CONFIG_DEFAULTS_TABLE_SIZE)
+    static_assert(EMBER_AF_GENERATED_REPORTING_CONFIG_DEFAULTS_TABLE_SIZE <= EMBER_AF_PLUGIN_REPORTING_TABLE_SIZE,
+                  "Not enough slots to hold EMBER_AF_GENERATED_REPORTING_CONFIG_DEFAULTS");
     for (int i = 0; i < EMBER_AF_GENERATED_REPORTING_CONFIG_DEFAULTS_TABLE_SIZE; i++)
     {
         emAfPluginReportingConditionallyAddReportingEntry((EmberAfPluginReportingEntry *) &generatedReportingConfigDefaults[i]);

--- a/src/app/reporting/reporting.cpp
+++ b/src/app/reporting/reporting.cpp
@@ -49,6 +49,11 @@
 
 using namespace chip;
 
+// TODO: Need to figure out what needs to happen wrt HAL tokens here, but for
+// now define ESZP_HOST to disable it.  See
+// https://github.com/project-chip/connectedhomeip/issues/3275
+#define EZSP_HOST
+
 #ifdef ATTRIBUTE_LARGEST
 #define READ_DATA_SIZE ATTRIBUTE_LARGEST
 #else
@@ -125,11 +130,11 @@ static uint32_t computeStringHash(uint8_t * data, uint8_t length)
 static EmberAfPluginReportingEntry table[REPORT_TABLE_SIZE];
 void emAfPluginReportingGetEntry(uint8_t index, EmberAfPluginReportingEntry * result)
 {
-    MEMMOVE(result, &table[index], sizeof(EmberAfPluginReportingEntry));
+    memmove(result, &table[index], sizeof(EmberAfPluginReportingEntry));
 }
 void emAfPluginReportingSetEntry(uint8_t index, EmberAfPluginReportingEntry * value)
 {
-    MEMMOVE(&table[index], value, sizeof(EmberAfPluginReportingEntry));
+    memmove(&table[index], value, sizeof(EmberAfPluginReportingEntry));
 }
 #else
 void emAfPluginReportingGetEntry(uint8_t index, EmberAfPluginReportingEntry * result)
@@ -802,7 +807,7 @@ static void scheduleTick(void)
     }
     if (delayMs != MAX_INT32U_VALUE)
     {
-        emberAfDebugPrintln("sched report event for: 0x%4x", delayMs);
+        emberAfDebugPrintln("sched report event in %d ms", delayMs);
         emberEventControlSetDelayMS(&emberAfPluginReportingTickEventControl, delayMs);
     }
     else

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -58,11 +58,6 @@
 
 using namespace chip;
 
-// TODO: Need to figure out what needs to happen wrt HAL tokens here, but for
-// now define ESZP_HOST to disable it.  See
-// https://github.com/project-chip/connectedhomeip/issues/3275
-#define EZSP_HOST
-
 //------------------------------------------------------------------------------
 // Forward Declarations
 

--- a/src/app/zap-templates/gen_config.zapt
+++ b/src/app/zap-templates/gen_config.zapt
@@ -59,5 +59,5 @@
 // Use this macro to check if Reporting plugin is included
 #define EMBER_AF_PLUGIN_REPORTING
 // User options for plugin Reporting
-#define EMBER_AF_PLUGIN_REPORTING_TABLE_SIZE 5
+#define EMBER_AF_PLUGIN_REPORTING_TABLE_SIZE 20
 #define EMBER_AF_PLUGIN_REPORTING_ENABLE_GROUP_BOUND_REPORTS


### PR DESCRIPTION
#### Problem
The default configuration for the reporting plugin that is contained in `EMBER_AF_GENERATED_REPORTING_CONFIG_DEFAULTS` is currently not loaded.

There are a few different issues:
 * `EMBER_AF_GENERATED_PLUGIN_STACK_STATUS_FUNCTION_CALLS` which contains some bits of the plugins initialization is never called
 * The dynamically generated `EMBER_AF_GENERATED_REPORTING_CONFIG_DEFAULTS_TABLE_SIZE` is bigger than `EMBER_AF_PLUGIN_REPORTING_TABLE_SIZE`
 * The `EmberAfPluginReportingEntry` has trying to be load/save from the disk, which is not supported yet.
 * Some of the plugins callbacks that are loaded by `EMBER_AF_GENERATED_PLUGIN_STACK_STATUS_FUNCTION_CALLS` does not exists. Either because the plugin is not part of CHIP or because the plugin has been hand crafted and this method was missing.
