### PR TITLE
Add Binding Server Cluster to src/app

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/BUILD.gn
+++ b/examples/all-clusters-app/all-clusters-common/BUILD.gn
@@ -25,6 +25,7 @@ source_set("all-clusters-common") {
   sources = [
     "${chip_root}/src/app/clusters/barrier-control-server/barrier-control-server.cpp",
     "${chip_root}/src/app/clusters/basic/basic.cpp",
+    "${chip_root}/src/app/clusters/bindings/bindings.cpp",
     "${chip_root}/src/app/clusters/color-control-server/color-control-server.cpp",
     "${chip_root}/src/app/clusters/door-lock-client/door-lock-client.cpp",
     "${chip_root}/src/app/clusters/door-lock-server/door-lock-server-core.cpp",

--- a/examples/all-clusters-app/esp32/main/component.mk
+++ b/examples/all-clusters-app/esp32/main/component.mk
@@ -38,6 +38,7 @@ COMPONENT_SRCDIRS :=                                                            
   ../third_party/connectedhomeip/src/app/clusters/temperature-measurement-server    \
   ../third_party/connectedhomeip/src/app/clusters/scenes                            \
   ../third_party/connectedhomeip/src/app/clusters/basic                             \
+  ../third_party/connectedhomeip/src/app/clusters/bindings                          \
   ../third_party/connectedhomeip/src/app/reporting                                  \
   ../third_party/connectedhomeip/src/app/clusters/door-lock-client                  \
   ../third_party/connectedhomeip/src/app/clusters/door-lock-server                  \

--- a/examples/lighting-app/lighting-common/BUILD.gn
+++ b/examples/lighting-app/lighting-common/BUILD.gn
@@ -23,6 +23,7 @@ config("includes") {
 
 source_set("lighting-common") {
   sources = [
+    "${chip_root}/src/app/clusters/bindings/bindings.cpp",
     "${chip_root}/src/app/clusters/level-control/level-control.cpp",
     "${chip_root}/src/app/clusters/on-off-server/on-off.cpp",
     "${chip_root}/src/app/reporting/reporting-default-configuration.cpp",

--- a/examples/lighting-app/nrfconnect/CMakeLists.txt
+++ b/examples/lighting-app/nrfconnect/CMakeLists.txt
@@ -58,6 +58,7 @@ target_sources(app PRIVATE
                ${CHIP_ROOT}/src/app/util/process-cluster-message.cpp
                ${CHIP_ROOT}/src/app/util/process-global-message.cpp
                ${CHIP_ROOT}/src/app/util/util.cpp
+               ${CHIP_ROOT}/src/app/clusters/bindings/bindings.cpp
                ${CHIP_ROOT}/src/app/clusters/on-off-server/on-off.cpp
                ${CHIP_ROOT}/src/app/clusters/level-control/level-control.cpp
                )

--- a/examples/lock-app/lock-common/BUILD.gn
+++ b/examples/lock-app/lock-common/BUILD.gn
@@ -24,6 +24,7 @@ config("includes") {
 
 source_set("lock-common") {
   sources = [
+    "${chip_root}/src/app/clusters/bindings/bindings.cpp",
     "${chip_root}/src/app/clusters/on-off-server/on-off.cpp",
     "${chip_root}/src/app/reporting/reporting-default-configuration.cpp",
     "${chip_root}/src/app/reporting/reporting.cpp",

--- a/examples/lock-app/nrfconnect/CMakeLists.txt
+++ b/examples/lock-app/nrfconnect/CMakeLists.txt
@@ -58,4 +58,5 @@ target_sources(app PRIVATE
                ${CHIP_ROOT}/src/app/util/process-cluster-message.cpp
                ${CHIP_ROOT}/src/app/util/process-global-message.cpp
                ${CHIP_ROOT}/src/app/util/util.cpp
+               ${CHIP_ROOT}/src/app/clusters/bindings/bindings.cpp
                ${CHIP_ROOT}/src/app/clusters/on-off-server/on-off.cpp)

--- a/examples/temperature-measurement-app/esp32/main/component.mk
+++ b/examples/temperature-measurement-app/esp32/main/component.mk
@@ -28,6 +28,7 @@ COMPONENT_SRCDIRS :=                                                            
   ../third_party/connectedhomeip/src/app/util                                     \
   ../third_party/connectedhomeip/src/app/reporting                                \
   ../third_party/connectedhomeip/src/app/clusters/basic                           \
+  ../third_party/connectedhomeip/src/app/clusters/bindings                        \
   ../third_party/connectedhomeip/src/app/clusters/temperature-measurement-server  \
 
 

--- a/src/app/clusters/bindings/bindings.cpp
+++ b/src/app/clusters/bindings/bindings.cpp
@@ -1,0 +1,140 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/****************************************************************************
+ * @file
+ * @brief Implementation for the Binding Server Cluster
+ ***************************************************************************/
+
+#include "af.h"
+
+#include <app/util/binding-table.h>
+#include <support/logging/CHIPLogging.h>
+
+using namespace chip;
+
+EmberStatus prepareBinding(EmberBindingTableEntry & binding, NodeId nodeId, GroupId groupId, EndpointId endpointId,
+                           ClusterId clusterId)
+{
+    if (groupId && nodeId)
+    {
+        return EMBER_BAD_ARGUMENT;
+    }
+
+    binding.clusterId    = clusterId;
+    binding.local        = emberAfCurrentCommand()->apsFrame->destinationEndpoint;
+    binding.networkIndex = 0;
+
+    if (groupId)
+    {
+        binding.type    = EMBER_MULTICAST_BINDING;
+        binding.groupId = groupId;
+        binding.remote  = 0;
+    }
+    else
+    {
+        binding.type   = EMBER_UNICAST_BINDING;
+        binding.nodeId = nodeId;
+        binding.remote = endpointId;
+    }
+
+    return EMBER_SUCCESS;
+}
+
+EmberStatus getBindingIndex(EmberBindingTableEntry & newEntry, uint8_t * bindingIndex)
+{
+    EmberBindingTableEntry currentEntry;
+    for (uint8_t i = 0; i < EMBER_BINDING_TABLE_SIZE; i++)
+    {
+        emberGetBinding(i, &currentEntry);
+        if (currentEntry.type != EMBER_UNUSED_BINDING && currentEntry == newEntry)
+        {
+            *bindingIndex = i;
+            return EMBER_SUCCESS;
+        }
+    }
+
+    return EMBER_NOT_FOUND;
+}
+
+EmberStatus getUnusedBindingIndex(uint8_t * bindingIndex)
+{
+    EmberBindingTableEntry currentEntry;
+    for (uint8_t i = 0; i < EMBER_BINDING_TABLE_SIZE; i++)
+    {
+        emberGetBinding(i, &currentEntry);
+        if (currentEntry.type == EMBER_UNUSED_BINDING)
+        {
+            *bindingIndex = i;
+            return EMBER_SUCCESS;
+        }
+    }
+
+    return EMBER_NOT_FOUND;
+}
+
+bool emberAfBindingClusterBindCallback(NodeId nodeId, GroupId groupId, EndpointId endpointId, ClusterId clusterId)
+{
+    ChipLogDetail(Zcl, "RX: BindCallback");
+
+    EmberBindingTableEntry bindingEntry;
+    if (prepareBinding(bindingEntry, nodeId, groupId, endpointId, clusterId) != EMBER_SUCCESS)
+    {
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_MALFORMED_COMMAND);
+        return true;
+    }
+
+    uint8_t bindingIndex;
+    if (getBindingIndex(bindingEntry, &bindingIndex) != EMBER_NOT_FOUND)
+    {
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_DUPLICATE_EXISTS);
+        return true;
+    }
+
+    if (getUnusedBindingIndex(&bindingIndex) != EMBER_SUCCESS)
+    {
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INSUFFICIENT_SPACE);
+        return true;
+    }
+
+    emberSetBinding(bindingIndex, &bindingEntry);
+    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    return true;
+}
+
+bool emberAfBindingClusterUnbindCallback(NodeId nodeId, GroupId groupId, EndpointId endpointId, ClusterId clusterId)
+{
+    ChipLogDetail(Zcl, "RX: UnbindCallback");
+
+    EmberBindingTableEntry bindingEntry;
+    if (prepareBinding(bindingEntry, nodeId, groupId, endpointId, clusterId) != EMBER_SUCCESS)
+    {
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_MALFORMED_COMMAND);
+        return true;
+    }
+
+    uint8_t bindingIndex;
+    if (getBindingIndex(bindingEntry, &bindingIndex) != EMBER_SUCCESS)
+    {
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_NOT_FOUND);
+        return true;
+    }
+
+    emberDeleteBinding(bindingIndex);
+    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    return true;
+}

--- a/src/app/util/types_stub.h
+++ b/src/app/util/types_stub.h
@@ -522,7 +522,7 @@ enum
  * cluster ID and either the destination EUI64 (for unicast bindings) or the
  * 64-bit group address (for multicast bindings).
  */
-typedef struct
+struct EmberBindingTableEntry
 {
     /** The type of binding. */
     EmberBindingType type;
@@ -550,7 +550,27 @@ typedef struct
     };
     /** The index of the network the binding belongs to. */
     uint8_t networkIndex;
-} EmberBindingTableEntry;
+
+    bool operator==(EmberBindingTableEntry const & other) const
+    {
+        if (type != other.type)
+        {
+            return false;
+        }
+
+        if (type == EMBER_MULTICAST_BINDING && groupId != other.groupId)
+        {
+            return false;
+        }
+
+        if (type == EMBER_UNICAST_BINDING && nodeId != other.nodeId)
+        {
+            return false;
+        }
+
+        return local == other.local && clusterId == other.clusterId && remote == other.remote && networkIndex == other.networkIndex;
+    }
+};
 
 /**
  * @brief The decision made by the Trust Center when a node attempts to join.


### PR DESCRIPTION
### Problem

This code add a new `Binding Cluster` that contains a `Bind` and `Unbind` method in order to create bindings between devices using the underlying ZCL code.

I have added it to be compile in all the `examples/`, similarly to `reporting` even if it is unused now.
In fact one may noticed that there it no headers for it. This is because the declarations are going to be generated as part of `gen/callbacks.h`.

#### Summary of changes
 * Add `src/app/clusters/bindings/bindings.cpp`
 * Get it to be compiled in all `examples/`