### PR TITLE
Add support to read 'uint64_t' parameters in the ZCL payload

### DIFF
--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -522,6 +522,11 @@ uint8_t emberAfGetAttributeAnalogOrDiscreteType(uint8_t dataType);
 bool emberAfIsTypeSigned(EmberAfAttributeType dataType);
 
 /**
+ * @brief Function that extracts a 64-bit integer from the message buffer
+ */
+uint64_t emberAfGetInt64u(const uint8_t * message, uint16_t currentIndex, uint16_t msgLen);
+
+/**
  * @brief Function that extracts a 32-bit integer from the message buffer
  */
 uint32_t emberAfGetInt32u(const uint8_t * message, uint16_t currentIndex, uint16_t msgLen);

--- a/src/app/util/message.cpp
+++ b/src/app/util/message.cpp
@@ -182,11 +182,11 @@ uint8_t * emberAfPutDateInResp(EmberAfDate * value)
 // buffer)
 // ------------------------------------
 
-// retrieves an uint32_t which contains between 1 and 4 bytes of relevent data
+// retrieves an uint64_t which contains between 1 and 8 bytes of relevant data
 // depending on number of bytes requested.
-uint32_t emberAfGetInt(const uint8_t * message, uint16_t currentIndex, uint16_t msgLen, uint8_t bytes)
+uint64_t emberAfGetInt(const uint8_t * message, uint16_t currentIndex, uint16_t msgLen, uint8_t bytes)
 {
-    uint32_t result = 0;
+    uint64_t result = 0;
     uint8_t i       = bytes;
     if ((currentIndex + bytes) > msgLen)
     {
@@ -200,6 +200,11 @@ uint32_t emberAfGetInt(const uint8_t * message, uint16_t currentIndex, uint16_t 
         i--;
     }
     return result;
+}
+
+uint64_t emberAfGetInt64u(const uint8_t * message, uint16_t currentIndex, uint16_t msgLen)
+{
+    return emberAfGetInt(message, currentIndex, msgLen, 8);
 }
 
 uint32_t emberAfGetInt32u(const uint8_t * message, uint16_t currentIndex, uint16_t msgLen)

--- a/src/app/util/util.h
+++ b/src/app/util/util.h
@@ -165,17 +165,17 @@ bool emberAfProcessMessageIntoZclCmd(EmberApsFrame * apsFrame, EmberIncomingMess
 EmberAfDifferenceType emberAfGetDifference(uint8_t * pData, EmberAfDifferenceType value, uint8_t dataSize);
 
 /**
- * Retrieves an uint32_t from the given Zigbee payload. The integer retrieved
+ * Retrieves an uint64_t from the given Zigbee payload. The integer retrieved
  * may be cast into an integer of the appropriate size depending on the
  * number of bytes requested from the message. In Zigbee, all integers are
  * passed over the air in LSB form. LSB to MSB conversion is
  * done within this function automatically before the integer is returned.
  *
  * Obviously (due to return value) this function can only handle
- * the retrieval of integers between 1 and 4 bytes in length.
+ * the retrieval of integers between 1 and 8 bytes in length.
  *
  */
-uint32_t emberAfGetInt(const uint8_t * message, uint16_t currentIndex, uint16_t msgLen, uint8_t bytes);
+uint64_t emberAfGetInt(const uint8_t * message, uint16_t currentIndex, uint16_t msgLen, uint8_t bytes);
 
 void emberAfClearResponseData(void);
 uint8_t * emberAfPutInt8uInResp(uint8_t value);

--- a/src/app/zap-templates/helper-chip.js
+++ b/src/app/zap-templates/helper-chip.js
@@ -169,6 +169,9 @@ function asReadType(type)
       case 'int32_t':
       case 'uint32_t':
         return 'Int32u';
+      case 'int64_t':
+      case 'uint64_t':
+        return 'Int64u';
       default:
         error = 'Unhandled underlying type ' + zclType + ' for original type ' + type;
         throw error;


### PR DESCRIPTION
 #### Problem

`uint64_t` arguments (as for example a `chip::NodeId`) in the ZCL cluster payload does not work because there `emberAfGetInt64u` does not exists.

 #### Summary of Changes
* Add it