### PR TITLE
Align Spake2 protocol message type definition with spec

### DIFF
--- a/src/protocols/secure_channel/SecureChannelProtocol.h
+++ b/src/protocols/secure_channel/SecureChannelProtocol.h
@@ -52,9 +52,12 @@ enum class MsgType
     StandaloneAck = 0x10,
 
     // Password-based session establishment Message Types
-    PASE_Spake2pA = 0x20,
-    PASE_Spake2pB = 0x21,
-    PASE_Spake2cA = 0x22,
+    PBKDFParamRequest  = 0x20,
+    PBKDFParamResponse = 0x21,
+    PASE_Spake2p1      = 0x22,
+    PASE_Spake2p2      = 0x23,
+    PASE_Spake2p3      = 0x24,
+    PASE_Spake2pError  = 0x2F,
 
     // Certificate-based session establishment Message Types
     CASE_SigmaR1  = 0x30,

--- a/src/transport/SecurePairingSession.h
+++ b/src/transport/SecurePairingSession.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <crypto/CHIPCryptoPAL.h>
+#include <protocols/secure_channel/SecureChannelProtocol.h>
 #include <support/Base64.h>
 #include <system/SystemPacketBuffer.h>
 #include <transport/SecureSession.h>
@@ -232,25 +233,15 @@ private:
     void SendErrorMsg(Spake2pErrorType errorCode);
     void HandleErrorMsg(const PacketHeader & header, const System::PacketBufferHandle & msg);
 
-    CHIP_ERROR AttachHeaderAndSend(uint8_t msgType, System::PacketBufferHandle msgBuf);
+    CHIP_ERROR AttachHeaderAndSend(Protocols::SecureChannel::MsgType msgType, System::PacketBufferHandle msgBuf);
 
     void Clear();
 
     static constexpr size_t kSpake2p_WS_Length = kP256_FE_Length + 8;
 
-    enum Spake2pMsgType : uint8_t
-    {
-        kPBKDFParamRequest  = 0x20,
-        kPBKDFParamResponse = 0x21,
-        kSpake2pMsg1        = 0x22,
-        kSpake2pMsg2        = 0x23,
-        kSpake2pMsg3        = 0x24,
-        kSpake2pMsgError    = 0x2f,
-    };
-
     SecurePairingSessionDelegate * mDelegate = nullptr;
 
-    Spake2pMsgType mNextExpectedMsg = Spake2pMsgType::kSpake2pMsgError;
+    Protocols::SecureChannel::MsgType mNextExpectedMsg = Protocols::SecureChannel::MsgType::PASE_Spake2pError;
 
     Spake2p_P256_SHA256_HKDF_HMAC mSpake2p;
 


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Currently, transport layer still use the internal temporary message type definition for protocol Spake2

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Align Spake2 protocol message type definition with spec 0.7.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
