### PR TITLE
Roll python deps & add pigweed's

### DIFF
--- a/scripts/requirements.in
+++ b/scripts/requirements.in
@@ -13,7 +13,7 @@ pyelftools>=0.22
 requests>=2.24.0
 
 # device controller wheel package
-wheel>=0.34.2
+wheel==0.34.2
 
 # mobly tests
 portpicker
@@ -25,3 +25,9 @@ west>=0.8.0
 # happy tests
 lockfile
 psutil >= 5.7.3
+
+# pigweed
+ipython
+coloredlogs
+watchdog
+protobuf

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -4,33 +4,50 @@
 #
 #    pip-compile requirements.in
 #
-certifi==2020.6.20        # via requests
-cffi==1.14.3              # via cryptography
+backcall==0.2.0           # via ipython
+certifi==2020.12.5        # via requests
+cffi==1.14.4              # via cryptography
 chardet==3.0.4            # via requests
 click==7.1.2              # via -r requirements.in, pip-tools
 colorama==0.4.4           # via west
+coloredlogs==15.0         # via -r requirements.in
 configobj==5.0.6          # via west
-cryptography==3.2.1       # via -r requirements.in
+cryptography==3.3.1       # via -r requirements.in
+decorator==4.4.2          # via ipython
 docopt==0.6.2             # via pykwalify
 future==0.18.2            # via -r requirements.in, mobly
+humanfriendly==9.1        # via coloredlogs
 idna==2.10                # via requests
+ipython-genutils==0.2.0   # via traitlets
+ipython==7.19.0           # via -r requirements.in
+jedi==0.17.2              # via ipython
 lockfile==0.12.2          # via -r requirements.in
 mobly==1.10               # via -r requirements.in
-packaging==20.4           # via west
-pip-tools==5.3.1          # via -r requirements.in
+packaging==20.7           # via west
+parso==0.7.1              # via jedi
+pexpect==4.8.0            # via ipython
+pickleshare==0.7.5        # via ipython
+pip-tools==5.4.0          # via -r requirements.in
 portpicker==1.3.1         # via -r requirements.in, mobly
+prompt-toolkit==3.0.8     # via ipython
+protobuf==3.14.0          # via -r requirements.in
 psutil==5.7.3             # via -r requirements.in, mobly
+ptyprocess==0.6.0         # via pexpect
 pycparser==2.20           # via cffi
-pyelftools==0.26          # via -r requirements.in
+pyelftools==0.27          # via -r requirements.in
+pygments==2.7.3           # via ipython
 pykwalify==1.7.0          # via west
 pyparsing==2.3.1          # via -r requirements.in, packaging
-pyserial==3.4             # via -r requirements.in, mobly
+pyserial==3.5             # via -r requirements.in, mobly
 python-dateutil==2.8.1    # via pykwalify
 pyyaml==5.3.1             # via mobly, pykwalify, west
-requests==2.24.0          # via -r requirements.in
-six==1.15.0               # via configobj, cryptography, packaging, pip-tools, python-dateutil
-timeout-decorator==0.4.1  # via mobly
-urllib3==1.25.10          # via requests
+requests==2.25.0          # via -r requirements.in
+six==1.15.0               # via configobj, cryptography, pip-tools, protobuf, python-dateutil
+timeout-decorator==0.5.0  # via mobly
+traitlets==5.0.5          # via ipython
+urllib3==1.26.2           # via requests
+watchdog==1.0.1           # via -r requirements.in
+wcwidth==0.2.5            # via prompt-toolkit
 west==0.8.0               # via -r requirements.in
 wheel==0.34.2             # via -r requirements.in
 


### PR DESCRIPTION
This will help avoid issues like the one fixed by #4165, where a pip
package used by pigweed updated underneath us and broke.
    
These are gathered from install_requires in setup.py of packages we
install. Currently we don't have a way to fail the build if there's an
unpinned dep; they'll have to be found manually and added to
requirements.in.
